### PR TITLE
js: preload() warms the compiler and runtime before the first click

### DIFF
--- a/js/README.md
+++ b/js/README.md
@@ -32,7 +32,9 @@ blocks; calls queue and run one at a time.
 
 The payload is ~9 MB installed (~2 MB over the wire with gzip): the WASM
 runtime plus the stanc3 compiler. The compiler loads lazily, only when a
-call passes Stan source; an app that ships a fixed model can precompile
+call passes Stan source. `preload()` starts both loads in the background
+-- call it at page idle and the user's first `sample()` begins at full
+speed instead of paying the fetch and parse on their click; an app that ships a fixed model can precompile
 it at build time (`stanc --debug-transformed-mir model.stan`) and pass
 `mir` instead of `code`, and the runtime alone is ~1.3 MB gzipped. 118 of 119 posteriordb corpus models
 verify against CmdStan's log density, gradients, and write_array values

--- a/js/index.mjs
+++ b/js/index.mjs
@@ -70,6 +70,24 @@ function request(msg, opts) {
   });
 }
 
+/** Load the heavy artifacts before they are needed. Resolves when one
+ * worker holds the parsed stanc3 compiler and `chains - 1` more hold the
+ * instantiated wasm runtime, so a later compile() or sample() starts at
+ * full speed instead of paying the fetch+parse on the user's click.
+ * Safe to call more than once; the pool reuses warmed workers.
+ * @param {object} [opts]
+ * @param {number} [opts.chains=2] Workers to warm (first gets stanc3).
+ * @param {function} [opts.onProgress]
+ */
+export function preload(opts) {
+  const o = opts || {};
+  const n = Math.max(1, Math.min(MAX_WORKERS, o.chains || 2));
+  const jobs = [request({ cmd: "preload", stanc: true }, o)];
+  for (let k = 1; k < n; ++k)
+    jobs.push(request({ cmd: "preload", stanc: false }, o));
+  return Promise.all(jobs);
+}
+
 /** Compile Stan source to transformed MIR (one worker loads stanc3).
  * @returns {Promise<{mir: string, ms: {stanc: number}}>} */
 export function compile(opts) {

--- a/js/worker.js
+++ b/js/worker.js
@@ -21,6 +21,17 @@ onmessage = async (e) => {
   const t0 = performance.now();
   const say = (status) => postMessage({ status });
   try {
+    if (req.cmd === "preload") {
+      // Warm the worker before anyone needs it: instantiate the wasm
+      // runtime and, when asked, parse the 2.8 MB compiler. Sent by the
+      // page at idle so the first Run pays neither load.
+      if (req.stanc) ensureStanc();
+      await ready;
+      postMessage({ done: { warmed: true,
+                            stanc: typeof globalThis.stanc === "function",
+                            ms: { preload: performance.now() - t0 } } });
+      return;
+    }
     if (req.cmd === "compile") {
       // Compile once here, sample everywhere: chain workers take the MIR
       // and never load the compiler.

--- a/web/index.html
+++ b/web/index.html
@@ -96,8 +96,27 @@ everything below happens in this tab.
 <div class="times" id="times"></div>
 
 <script type="module">
-import { compile, sample } from "./stanli.mjs";
+import { compile, preload, sample } from "./stanli.mjs";
 const $ = (id) => document.getElementById(id);
+
+// ---- background warm-up ----------------------------------------------------
+// Fetch and parse the heavy artifacts (2.8 MB compiler, wasm runtime)
+// while the user is still reading the page, so the first Run starts at
+// full speed. requestIdleCallback keeps it off the first paint; the
+// promise is awaited nowhere -- if the user beats it to the button, the
+// pool simply hands them the half-warmed worker and the load finishes in
+// line, exactly as it would have without the warm-up.
+const warm = () => preload({ chains: 2 }).then(() => {
+  if (!$("status").textContent) {
+    $("status").textContent = "compiler loaded";
+    setTimeout(() => {
+      if ($("status").textContent === "compiler loaded")
+        $("status").textContent = "";
+    }, 2000);
+  }
+}).catch(() => {});  // a failed warm-up is just a cold first click
+if ("requestIdleCallback" in window) requestIdleCallback(warm);
+else setTimeout(warm, 0);
 
 // ---- presets ---------------------------------------------------------------
 // Synthetic data comes from a fixed linear congruential stream so the

--- a/web/index.mjs
+++ b/web/index.mjs
@@ -70,6 +70,24 @@ function request(msg, opts) {
   });
 }
 
+/** Load the heavy artifacts before they are needed. Resolves when one
+ * worker holds the parsed stanc3 compiler and `chains - 1` more hold the
+ * instantiated wasm runtime, so a later compile() or sample() starts at
+ * full speed instead of paying the fetch+parse on the user's click.
+ * Safe to call more than once; the pool reuses warmed workers.
+ * @param {object} [opts]
+ * @param {number} [opts.chains=2] Workers to warm (first gets stanc3).
+ * @param {function} [opts.onProgress]
+ */
+export function preload(opts) {
+  const o = opts || {};
+  const n = Math.max(1, Math.min(MAX_WORKERS, o.chains || 2));
+  const jobs = [request({ cmd: "preload", stanc: true }, o)];
+  for (let k = 1; k < n; ++k)
+    jobs.push(request({ cmd: "preload", stanc: false }, o));
+  return Promise.all(jobs);
+}
+
 /** Compile Stan source to transformed MIR (one worker loads stanc3).
  * @returns {Promise<{mir: string, ms: {stanc: number}}>} */
 export function compile(opts) {


### PR DESCRIPTION
Nothing loaded until the user pressed Run: the worker spawned on the first request, the wasm runtime instantiated then, and the 2.8 MB compiled-OCaml stanc3 parsed after that, all inside the click. `preload()` sends a warm-up through the same worker protocol — the first worker loads stanc3 and the runtime, the rest just the runtime — and the demo page calls it at `requestIdleCallback`, so by the time a human has read the model and found the button, the click starts at lowering.

The promise is deliberately awaited nowhere on the Run path: a user who beats the warm-up to the button gets the half-warmed worker and the load finishes in line, exactly as cold as it would have been anyway. A failed warm-up is likewise just a cold first click.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R8ghYJNY67ZudxxuV8Y6xx