### PR TITLE
ci: Windows runs after the merge, not as a merge gate

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -11,7 +11,14 @@
 # Windows builds under mingw-w64 (stan-math does not build under MSVC,
 # which is why RStan ships through RTools), exports the C ABI through a
 # .def file, and bundles the release stanc.exe as a subprocess: the
-# embedded compiler waits on opam's native Windows support.
+# embedded compiler waits on opam's native Windows support. That job
+# does not run on pull requests: mingw compiles the density kernels an
+# order of magnitude slower than every other platform (110 minutes for
+# that one translation unit against ~7 for the other 140 targets), so
+# gating merges on it means waiting hours for a signal that has never
+# caught a bug the other five platforms missed. It runs after the merge
+# instead, nightly, and on release tags, where a failure is a bug report
+# rather than a roadblock. Publishing still waits for it.
 name: wheels
 
 on:
@@ -19,6 +26,9 @@ on:
     branches: [main]
     tags: ['v*', 'npm-v*']
   pull_request:
+  schedule:
+    # 08:00 UTC daily, which is overnight in US time zones.
+    - cron: '0 8 * * *'
   workflow_dispatch:
 
 permissions:
@@ -246,8 +256,12 @@ jobs:
           name: wheel-${{ matrix.plat }}
           path: dist/*.whl
 
+  # Everything except pull requests: main pushes, the nightly cron, and
+  # release tags (the publish job needs this wheel, so a tag still waits
+  # for it).
   windows:
     name: win_amd64
+    if: github.event_name != 'pull_request'
     runs-on: windows-2022
     defaults:
       run:

--- a/docs/hacking.md
+++ b/docs/hacking.md
@@ -265,7 +265,7 @@ python3 tools/verify_refs.py deps/posteriordb --check build-rel/stanli_check --j
 
 The second line replays all 119 corpus models against recorded CmdStan
 values and is the strongest oracle in the project; it also runs in CI on
-every push, on all five wheel platforms, and
+every push, on each of the four wheel platforms it is gated on, and
 [`tools/wasm_check.sh`](../tools/wasm_check.sh) drives the same replay
 through the WASM build under Node. Compiler changes that claim to be pure
 refactors should leave its worst-deviation line untouched. For sampler
@@ -276,9 +276,10 @@ harnesses and the current numbers).
 
 ## Landing a change
 
-`main` is protected: the five wheel platforms and the WASM build must
-pass before anything merges, admins included, so direct pushes are
-rejected. The flow is a branch and an auto-merged PR:
+`main` is protected: the four wheel platforms that build at a reasonable
+speed, plus the WASM build, must pass before anything merges, admins
+included, so direct pushes are rejected. The flow is a branch and an
+auto-merged PR:
 
 ```
 git checkout -b my-change
@@ -290,5 +291,18 @@ gh pr merge --auto --rebase
 The merge happens on its own when CI goes green (rebase-merge keeps the
 history linear). Release tags (`v*`, `npm-v*`) are not gated by this;
 they point at commits that already passed on main.
+
+Windows is the exception. mingw compiles the density kernels an order of
+magnitude slower than any other platform, so that job would set the pace
+for every merge on its own; it runs after the merge, nightly at 08:00
+UTC, and on release tags instead of on pull requests. A red Windows run
+on main is a bug to fix forward, and a tag will not publish until it
+passes. If a change plausibly touches Windows (build files, the C ABI
+surface, anything under `tools/exported_symbols.def`), run the job on the
+branch before merging:
+
+```
+gh workflow run wheels.yml --ref my-change
+```
 
 Release process and CI layout live in [`README.md`](../README.md) under "Releasing".


### PR DESCRIPTION
mingw compiles runtime/kernels/densities.cpp an order of magnitude
slower than any other platform: in the last run the other 140 ninja
targets finished in 7 minutes and that single translation unit took
110, which made Windows the pace of every merge and put a two-hour
required check in front of one-line changes. It has never been the job
that caught a bug; the four wheel platforms and the WASM build run the
same tests, and the corpus oracle runs on all four.

So the job now skips pull requests and runs on main pushes, on a
nightly cron, and on release tags. A red Windows run on main is a bug
to fix forward instead of a roadblock, and publishing is unchanged:
the publish job still needs it, so no tag ships a wheel set that
Windows has not built. Branches that touch the build or the ABI can
still ask for it with `gh workflow run wheels.yml --ref <branch>`.

Branch protection has been updated to match; win_amd64 is no longer a
required status check.
