### PR TITLE
docs: the PyPI benchmark table renders as a table, and 0.3.0

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -133,7 +133,13 @@ jobs:
           opam --version
 
       - name: Build tooling
-        run: python3 -m pip install --upgrade pip setuptools wheel
+        # readme_renderer is what PyPI itself renders the long
+        # description with, and tools/gen_docs.py --check uses it to
+        # prove the page's tables still come out as tables.
+        run: |
+          python3 -m pip install --upgrade pip setuptools wheel
+          python3 -m pip install "readme_renderer[md]"
+
 
       - name: Vendored dependencies
         run: ./deps/fetch.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,48 @@
 # Changelog
 
-## 0.2.1
+## 0.3.0
+
+- Stan runs in the browser. stanc3 compiled to JavaScript through its
+  own js_of_ocaml target, this runtime compiled to WebAssembly through
+  Emscripten, and nothing on a server: a model is compiled and sampled
+  in the page. 118 of the 120 corpus models replay through the WASM
+  build under Node against the same recorded CmdStan values the native
+  build is checked against, generated-quantities columns included
+  (`nn_rbm1bJ100` is the exception, and it wants more than the 4 GB a
+  wasm32 heap can address). The demo is at
+  [seantalts.github.io/stanli](https://seantalts.github.io/stanli/):
+  presets, chains sampling simultaneously in one worker each, live trace
+  and histogram plots while NUTS runs, split-Rhat and effective sample
+  size, and a CSV of the draws. The payload is 1.34 MB of runtime plus
+  0.43 MB of compiler, gzipped; a page that ships precompiled MIR never
+  loads the compiler at all.
+
+- An npm package, `stanli`, wrapping that: `compile()` and `sample()`
+  over a worker pool sized to the hardware, with an `onLive` callback
+  for streaming draws. Published on `npm-v*` tags through npm trusted
+  publishing.
+
+- A Windows wheel. `win_amd64` joins the four existing platforms, built
+  under mingw-w64 (stan-math does not build under MSVC, which is why
+  RStan ships through RTools), exporting the C ABI through a `.def`
+  file. It bundles the release `stanc.exe` and drives it as a
+  subprocess rather than embedding the compiler, which waits on opam's
+  native Windows support.
+
+- write_array reached the C ABI: `stanli_wa_n_columns`,
+  `stanli_wa_column_name`, `stanli_wa_seed`, `stanli_wa_row`. Every
+  binding gets the columns CmdStan would write, in CmdStan's order,
+  including the models whose generated quantities are interpreted per
+  draw because the graph cannot express them.
+
+- The benchmark table on the PyPI page renders as a table again. The
+  marker that stamps generated numbers into the page shared its line
+  with the table header, and a line opening `<!--` opens a raw HTML
+  block that runs to the `-->`, so PyPI's renderer swallowed the header
+  and printed every row as literal pipes. `tools/gen_docs.py --check`
+  now renders both READMEs with readme_renderer, the library PyPI
+  itself uses, and fails if a table does not come out as one. `twine
+  check` never caught this: the page rendered, it just rendered wrong.
 
 - The sampler draws from CmdStan's generator now. It built
   `boost::ecuyer1988` from the seed while CmdStan builds

--- a/README.md
+++ b/README.md
@@ -236,9 +236,13 @@ ctest --test-dir build
 
 ## Releasing
 
-`.github/workflows/wheels.yml` builds all four wheels (macOS arm64 and
-x86_64, manylinux_2_28 x86_64 and aarch64) on every push and pull request,
-so the release path is the path that is already exercised continuously.
+`.github/workflows/wheels.yml` builds all five wheels (macOS arm64 and
+x86_64, manylinux_2_28 x86_64 and aarch64, Windows x86_64). The first
+four run on every push and pull request, so the release path is the path
+that is already exercised continuously; Windows runs after the merge and
+nightly, because mingw compiles the density kernels slowly enough to set
+the pace of every merge on its own. A release tag runs all five, and the
+publish job waits for them.
 Each build links the embedded stanc3 object (cached, since it takes half
 an hour to produce), runs the test suite, checks that the platform tag
 matches what the library actually requires, and installs the wheel into a

--- a/python/README.md
+++ b/python/README.md
@@ -84,7 +84,8 @@ Full per-model accuracy table:
 Per-gradient latency against CmdStan, same models, same evaluation point,
 both sides `-O3` with FP contraction pinned off:
 
-<!--gen:bench_table_us-->| model | params | stanli | CmdStan | speedup |
+<!--gen:bench_table_us-->
+| model | params | stanli | CmdStan | speedup |
 | --- | ---: | ---: | ---: | ---: |
 | `radon_pooled` | 3 | 52.9 us | 320.9 us | **6.1x** |
 | `arK` | 7 | 2.4 us | 12.5 us | **5.2x** |
@@ -108,7 +109,8 @@ both sides `-O3` with FP contraction pinned off:
 | `hmm_drive_0` | 6 | 173.0 us | 132.8 us | 0.77x |
 | `hmm_example` | 4 | 36.3 us | 27.1 us | 0.75x |
 | `ldaK2` | 7 | 145.9 us | 104.1 us | 0.71x |
-| `iohmm_reg` | 29 | 545.2 us | 320.3 us | 0.59x |<!--/gen-->
+| `iohmm_reg` | 29 | 545.2 us | 320.3 us | 0.59x |
+<!--/gen-->
 
 The wins come from op granularity. CmdStan's var tape allocates, walks, and
 frees one node per scalar operation per leapfrog step; stanli pays a fixed

--- a/python/stanli/__init__.py
+++ b/python/stanli/__init__.py
@@ -16,7 +16,7 @@ import numpy as np
 __all__ = ["Model", "__version__"]
 # The one place the version lives. setup.py and the release workflow both
 # read it from here.
-__version__ = "0.2.1"
+__version__ = "0.3.0"
 
 _BIN = pathlib.Path(__file__).parent / "_bin"
 

--- a/tools/gen_docs.py
+++ b/tools/gen_docs.py
@@ -21,6 +21,7 @@ import json
 import pathlib
 import re
 import sys
+import warnings
 
 REPO = pathlib.Path(__file__).resolve().parent.parent
 TARGETS = [REPO / "README.md", REPO / "python" / "README.md"]
@@ -120,6 +121,44 @@ def compute():
     }
 
 
+def render_problems(path):
+    """Markdown tables that PyPI would not render as tables.
+
+    PyPI renders the long description with readme_renderer, which is
+    stricter than GitHub about one thing that bit this file: a line
+    starting with `<!--` opens a raw HTML block, and everything up to
+    the `-->` is HTML, not markdown. A generated-value marker sitting on
+    the same line as a table header therefore swallowed the header, and
+    the delimiter row plus every data row rendered as literal pipes.
+    twine check does not catch it: the page renders, it just renders
+    wrong. Returns [] when readme_renderer[md] is not installed, so this
+    is a CI check that a local run without it simply skips.
+    """
+    try:
+        import readme_renderer.markdown
+    except ImportError:
+        return []
+    text = path.read_text(encoding="utf-8")
+    # A delimiter row, which is what makes the block above it a table:
+    # every cell is dashes, optionally colon-anchored.
+    delim = re.compile(r"\s*\|(\s*:?-+:?\s*\|)+\s*$")
+    want = sum(1 for line in text.splitlines() if delim.match(line))
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        html = readme_renderer.markdown.render(text)
+    if html is None:
+        # readme_renderer is present but its markdown extra is not, so
+        # it renders nothing at all. Not a finding about the docs.
+        return []
+    got = html.count("<table")
+    if got >= want:
+        return []
+    rel = path.relative_to(REPO)
+    return [f"{rel}: {want} markdown table(s), "
+            f"{got} rendered by readme_renderer (PyPI would show "
+            f"literal pipes)"]
+
+
 def main():
     check = "--check" in sys.argv
     stats = compute()
@@ -132,15 +171,29 @@ def main():
             key = m.group(2)
             if key not in stats:
                 raise SystemExit(f"{rel}: unknown marker gen:{key}")
-            if m.group(3) != stats[key]:
-                short = (stats[key][:40] + "...") \
-                    if len(stats[key]) > 40 else stats[key]
-                stale.append(f"{rel}: {key}: {m.group(3)[:40]!r} -> {short!r}")
-            return m.group(1) + stats[key] + m.group(4)
+            value = stats[key]
+            # A multi-line value is a markdown block, and a block cannot
+            # begin on the marker's own line: `<!--` opens a raw HTML
+            # block that runs through the `-->`, so a table header
+            # sharing that line is eaten as HTML and the rows below it
+            # render as literal pipes (see render_problems).
+            block = "\n" in value
+            had = m.group(3).strip("\n") if block else m.group(3)
+            if had != value:
+                short = (value[:40] + "...") if len(value) > 40 else value
+                stale.append(f"{rel}: {key}: {had[:40]!r} -> {short!r}")
+            body = f"\n{value}\n" if block else value
+            return m.group(1) + body + m.group(4)
 
         new = MARK.sub(sub, text)
         if not check and new != text:
             path.write_text(new)
+    broken = [p for path in TARGETS for p in render_problems(path)]
+    if broken:
+        print("the rendered page would be wrong:")
+        for b in broken:
+            print(" ", b)
+        return 1
     if check and stale:
         print("docs disagree with the measured artifacts "
               "(run tools/gen_docs.py):")


### PR DESCRIPTION
The generated-value marker shared its line with the table header:

  <!--gen:bench_table_us-->| model | params | stanli | CmdStan | speedup |

A line that opens `<!--` opens a raw HTML block running through the
`-->`, so PyPI's renderer took the header row as HTML, stripped it, and
printed the delimiter row and all 23 data rows as literal pipes.
GitHub's renderer is looser and showed a table, which is why this
survived two releases. `twine check --strict` passes on it: the page
renders, it just renders wrong.

gen_docs.py now puts a multi-line value on its own lines, and
--check renders both READMEs through readme_renderer, the library PyPI
itself uses, failing if a markdown table does not come out as a
<table>. Verified against the description inside the built wheel: one
table, zero leftover pipe rows. The check skips when the markdown
extra is absent, so a local run without it is unaffected; the build
jobs install it.

Version 0.3.0, not 0.2.1: since 0.2.0 this gained a browser build, an
npm package, and a Windows wheel, and the sampler moved to CmdStan's
RNG stream, so a pinned seed no longer reproduces 0.2.0's draws.
