### PR TITLE
docs: one changelog section for everything since 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,142 +1,147 @@
 # Changelog
 
-## Unreleased
-
-- **Truncation and censoring work.** `y ~ normal(mu, sigma) T[0, 10]` did
-  not compile before: stanc3 rewrites a `T[,]` into the density minus
-  `log_diff_exp` of the bounds' `lcdf`s, and stanli had neither piece.
-  Both land here, along with the whole continuous distribution-function
-  family -- 87 `cdf`/`lcdf`/`lccdf` functions, continuous and count
-  alike, every one 0 ULP against CmdStan.
-
-- **Count distributions**: `neg_binomial`, `neg_binomial_2_log`,
-  `beta_neg_binomial`, `yule_simon`. Coverage is now 46 of Stan's 72
-  densities and 87 of its 105 distribution functions;
-  [docs/coverage.md](docs/coverage.md) lists what is missing and what each
-  gap actually needs.
-
-- **`-DSTANLI_LITE_LP=ON`** halves the runtime -- 14.9 MB to 7.79 MB
-  stripped -- by dropping stan-math's propto instantiations. Every
-  gradient and every `write_array` value stays bitwise identical across
-  the whole corpus; only `lp__` moves, by a per-model constant. The
-  chain a seed produces does change, because lp is added to the kinetic
-  energy and a shifted lp rounds differently there -- the same class of
-  difference as reseeding, not of different math. On by default for the
-  browser build, off for the wheel -- which takes `stanli.wasm` from 6.2
-  MB to 3.40 MB raw, 1.34 MB to 0.99 MB gzipped, while *gaining*
-  truncation and 76 functions. `stanli_exact_lp()`
-  in C, `stanli.exact_lp()` in Python, `fit.exactLp` in JS report which
-  build you have. See [docs/lite-lp.md](docs/lite-lp.md).
-
-- **`stanli_run` is a self-contained native sampler.** Built with the
-  stanc3 embed object it compiles the model in-process: `.stan` and
-  `data.json` in, CmdStan-shaped CSV out, with no toolchain and no
-  separate compiler binary to find. `cmake --install` now places it,
-  `stanli_check`, the shared library and the headers.
-
-- `tools/verify_lite.py` verifies the lite build against the exact one
-  (gradients bitwise, lp shift constant across evaluation points), and
-  `tools/verify_refs.py --no-lp` replays the corpus for a build whose
-  `lp__` is shifted by design.
-
 ## 0.3.0
 
-- Stan runs in the browser. stanc3 compiled to JavaScript through its
-  own js_of_ocaml target, this runtime compiled to WebAssembly through
-  Emscripten, and nothing on a server: a model is compiled and sampled
-  in the page. 118 of the 120 corpus models replay through the WASM
-  build under Node against the same recorded CmdStan values the native
-  build is checked against, generated-quantities columns included
-  (`nn_rbm1bJ100` is the exception, and it wants more than the 4 GB a
-  wasm32 heap can address). The demo is at
-  [seantalts.github.io/stanli](https://seantalts.github.io/stanli/):
-  presets, chains sampling simultaneously in one worker each, live trace
-  and histogram plots while NUTS runs, split-Rhat and effective sample
-  size, and a CSV of the draws. The payload is 1.34 MB of runtime plus
-  0.43 MB of compiler, gzipped; a page that ships precompiled MIR never
-  loads the compiler at all.
+The releases in between never shipped: 0.2.1 was written up but never
+tagged, so everything below is what changed for anyone upgrading from
+0.2.0.
 
-- An npm package, `stanli`, wrapping that: `compile()` and `sample()`
-  over a worker pool sized to the hardware, with an `onLive` callback
-  for streaming draws. Published on `npm-v*` tags through npm trusted
-  publishing.
+### Two things change results
 
-- A Windows wheel. `win_amd64` joins the four existing platforms, built
-  under mingw-w64 (stan-math does not build under MSVC, which is why
-  RStan ships through RTools), exporting the C ABI through a `.def`
-  file. It bundles the release `stanc.exe` and drives it as a
-  subprocess rather than embedding the compiler, which waits on opam's
-  native Windows support.
-
-- write_array reached the C ABI: `stanli_wa_n_columns`,
-  `stanli_wa_column_name`, `stanli_wa_seed`, `stanli_wa_row`. Every
-  binding gets the columns CmdStan would write, in CmdStan's order,
-  including the models whose generated quantities are interpreted per
-  draw because the graph cannot express them.
-
-- The benchmark table on the PyPI page renders as a table again. The
-  marker that stamps generated numbers into the page shared its line
-  with the table header, and a line opening `<!--` opens a raw HTML
-  block that runs to the `-->`, so PyPI's renderer swallowed the header
-  and printed every row as literal pipes. `tools/gen_docs.py --check`
-  now renders both READMEs with readme_renderer, the library PyPI
-  itself uses, and fails if a table does not come out as one. `twine
-  check` never caught this: the page rendered, it just rendered wrong.
-
-## 0.2.1
-
-- The sampler draws from CmdStan's generator now. It built
+- **The sampler draws from CmdStan's generator.** It built
   `boost::ecuyer1988` from the seed while CmdStan builds
   `boost::random::mixmax` as `(0, 1, seed, chain)`, so the same seed
   named unrelated streams and any sampling comparison was comparing two
   different draws as much as two engines. `run_nuts` calls
   `stan::services::util::create_rng` and draws the initial point the way
-  `stan::io::random_var_context` does. Note that a given seed now
-  produces different draws than 0.2.0 did; any seed is as valid as any
-  other, but a run pinned to a seed will not reproduce byte for byte.
+  `stan::io::random_var_context` does. A given seed now produces
+  different draws than 0.2.0 did. Any seed is as valid as any other, but
+  a run pinned to one will not reproduce byte for byte.
 
-- Initial points are accepted the way CmdStan accepts them, which fixes
-  `lotka_volterra`'s sampling timeout. CmdStan checks a candidate by
-  evaluating the log density on doubles and then its gradient; we only
-  ever ran the second. That matters for an ODE model, because the value
-  path solves the states alone while the gradient path solves the coupled
-  state-plus-sensitivity system, and at a solution grazing zero the two
-  disagree in sign (measured on the point in question: -1.81e-05 against
-  +5.33e-06, so log(z) is NaN for one and finite for the other). We were
-  accepting starting points CmdStan rejects, and at the corpus seed that
-  meant a chain that never left a bad region -- lp -1260 against a
-  typical set near -14, and 87x the leapfrogs, which is the whole
-  timeout. `Executor::forward_value_only()` is the double path, and
-  OP_ODE is the one kernel that does less work in it.
+- **The browser build reports a shifted `lp__`** (see the lite build
+  below). Gradients and every `write_array` value are bitwise identical;
+  `lp__` sits a per-model constant above CmdStan's. The wheels are
+  unaffected: they ship the exact build.
 
-- A draw whose generated quantities throw is written as nan and sampling
-  continues, which is what CmdStan does. `stanli_run` used to abort and
-  print nothing, so one bad `lognormal_rng` on a marginal ODE solution
-  discarded every draw of an otherwise good chain.
+### Stan in the browser
 
-- 34 scalar math functions and 14 more distributions. `lgamma`, `log1p`,
-  `Phi`, `inv_Phi`, `erf`, `expm1`, `digamma`, the trig and hyperbolic
-  families, `floor`/`ceil`/`round`, `inv`/`inv_sqrt`/`inv_square` and the
-  rest now work on the parameter path and in transformed data and
-  generated quantities, taking coverage of stanc3's scalar function list
-  from 13 of 103 to 47 of 103. The distributions are `chi_square`,
-  `inv_chi_square`, `scaled_inv_chi_square`, `frechet`, `gumbel`,
-  `loglogistic`, `pareto`, `pareto_type_2`, `rayleigh`, `skew_normal`,
-  `von_mises`, `exp_mod_normal`, `beta_proportion` and
-  `skew_double_exponential`. Every one is bitwise identical to CmdStan,
-  checked by `harnesses/fn_sweep.py`, which generates a model per
-  function from stanc3's own signature list and compares against the
+- stanc3 compiled to JavaScript through its own js_of_ocaml target, this
+  runtime compiled to WebAssembly through Emscripten, and nothing on a
+  server: a model is compiled and sampled in the page. 118 of the 120
+  corpus models replay through the WASM build under Node against the
+  same recorded CmdStan values the native build is checked against,
+  generated-quantities columns included (`nn_rbm1bJ100` is the
+  exception, and it wants more than the 4 GB a wasm32 heap can address).
+
+- The demo is at
+  [seantalts.github.io/stanli](https://seantalts.github.io/stanli/):
+  presets, chains sampling simultaneously in one worker each, live trace
+  and histogram plots while NUTS runs, split-Rhat and effective sample
+  size, and a CSV of the draws.
+
+- An npm package, `stanli`: `compile()` and `sample()` over a worker
+  pool sized to the hardware, with an `onLive` callback for streaming
+  draws and `preload()` to warm the compiler and runtime before the
+  first click. Published on `npm-v*` tags through npm trusted
+  publishing.
+
+- The payload is 0.99 MB of runtime plus 0.43 MB of compiler, gzipped. A
+  page that ships precompiled MIR never loads the compiler at all.
+
+### A Windows wheel
+
+- `win_amd64` joins the four existing platforms, built under mingw-w64
+  (stan-math does not build under MSVC, which is why RStan ships through
+  RTools), exporting the C ABI through a `.def` file. It bundles the
+  release `stanc.exe` and drives it as a subprocess rather than
+  embedding the compiler, which waits on opam's native Windows support.
+
+### What the language covers
+
+- **Truncation and censoring work.** `y ~ normal(mu, sigma) T[0, 10]`
+  did not compile before: stanc3 rewrites a `T[,]` into the density
+  minus `log_diff_exp` of the bounds' `lcdf`s, and stanli had neither
+  piece. Both land here, along with the whole distribution-function
+  family: 87 `cdf`/`lcdf`/`lccdf` functions, continuous and count alike,
+  every one 0 ULP against CmdStan.
+
+- **34 scalar math functions**: `lgamma`, `log1p`, `Phi`, `inv_Phi`,
+  `erf`, `expm1`, `digamma`, the trig and hyperbolic families,
+  `floor`/`ceil`/`round`, `inv`/`inv_sqrt`/`inv_square` and the rest,
+  on the parameter path and in transformed data and generated
+  quantities.
+
+- **18 more distributions**: `chi_square`, `inv_chi_square`,
+  `scaled_inv_chi_square`, `frechet`, `gumbel`, `loglogistic`,
+  `pareto`, `pareto_type_2`, `rayleigh`, `skew_normal`, `von_mises`,
+  `exp_mod_normal`, `beta_proportion`, `skew_double_exponential`,
+  `neg_binomial`, `neg_binomial_2_log`, `beta_neg_binomial`, and
+  `yule_simon`.
+
+- Coverage is now 46 of Stan's 72 densities, 87 of its 105 distribution
+  functions, and 47 of 129 scalar functions, counted against
+  `stanc --dump-stan-math-signatures` rather than a table someone typed
+  here. [docs/coverage.md](docs/coverage.md) lists what is missing and
+  what each gap needs. Every supported function is bitwise identical to
+  CmdStan, checked by `harnesses/fn_sweep.py`, which generates a model
+  per function from stanc3's own signature list and compares against the
   same reference driver the corpus uses.
 
-- The library is 19.1 MB installed, up from 13.8. Distributions are what
-  cost: each is instantiated once per activity mask, twice for propto and
-  again for the elementwise form, about 630 KB apiece, which is what a
-  precompiled library pays so that no model has to be compiled. The long
-  tail of them now takes a smaller form -- with propto off no terms are
-  dropped, so one binding covers every mask -- which returned 4.4 MB of
-  the 10.5 the additions cost, and leaves the distributions models
-  actually use running exactly as fast as before. The 34 scalar
-  functions cost 0.03 MB between them.
+- The wheel is bigger for it: 21.3 MB installed, 7.4 MB compressed, up
+  from 13.8 MB in 0.2.0. Each distribution is instantiated once per
+  activity mask, twice for propto and again for the elementwise form,
+  about 630 KB apiece, which is what a precompiled library pays so that
+  no model has to be compiled. The long tail of them takes a smaller
+  form now, which returned 4.4 MB, and the distributions models actually
+  use run exactly as fast as before. The 34 scalar functions cost
+  0.03 MB between them.
+
+### Half the library, if you want it
+
+- **`-DSTANLI_LITE_LP=ON`** takes the runtime from 14.9 MB to 7.79 MB
+  stripped by dropping stan-math's propto instantiations. A density is
+  instantiated once per activity mask, twice over for propto, and again
+  for the elementwise variant; dropping the propto half costs only terms
+  that are constant in the active arguments, which is why no gradient
+  moves. On by default for the browser build, off for the wheels, which
+  is what took `stanli.wasm` from 6.2 MB to 3.40 MB raw while *gaining*
+  truncation and 76 functions. `stanli_exact_lp()` in C,
+  `stanli.exact_lp()` in Python, and `fit.exactLp` in JS report which
+  build you have. See [docs/lite-lp.md](docs/lite-lp.md).
+
+### Sampling and generated quantities
+
+- **Initial points are accepted the way CmdStan accepts them**, which
+  fixes `lotka_volterra`'s sampling timeout. CmdStan checks a candidate
+  by evaluating the log density on doubles and then its gradient; we
+  only ever ran the second. That matters for an ODE model, because the
+  value path solves the states alone while the gradient path solves the
+  coupled state-plus-sensitivity system, and at a solution grazing zero
+  the two disagree in sign (measured on the point in question: -1.81e-05
+  against +5.33e-06, so log(z) is NaN for one and finite for the other).
+  We were accepting starting points CmdStan rejects, and at the corpus
+  seed that meant a chain that never left a bad region: lp -1260 against
+  a typical set near -14, and 87x the leapfrogs, which is the whole
+  timeout.
+
+- **A draw whose generated quantities throw is written as nan and
+  sampling continues**, which is what CmdStan does. `stanli_run` used to
+  abort and print nothing, so one bad `lognormal_rng` on a marginal ODE
+  solution discarded every draw of an otherwise good chain.
+
+- **write_array reached the C ABI**: `stanli_wa_n_columns`,
+  `stanli_wa_column_name`, `stanli_wa_seed`, `stanli_wa_row`. Every
+  binding gets the columns CmdStan would write, in CmdStan's order,
+  including the models whose generated quantities are interpreted per
+  draw because the graph cannot express them.
+
+- **`stanli_run` is a self-contained native sampler.** Built with the
+  stanc3 embed object it compiles the model in-process: `.stan` and
+  `data.json` in, CmdStan-shaped CSV out, with no toolchain and no
+  separate compiler binary to find. `cmake --install` now places it,
+  `stanli_check`, the shared library, and the headers.
+
+### Faster
 
 - Two kernels stopped doing twice the work. `normal_id_glm_lpdf` built a
   var tape in the forward, threw it away, and built it again in the
@@ -160,10 +165,32 @@
   precompiled kernel is half to nine-tenths of the gradient. Measured
   and rejected along the way: Eigen's gemv (fastest, but reassociates
   and costs 1-2 ULP against stan-math on every model with a matrix),
-  cache-blocking the accumulator, swapping the loop nesting (both
-  slower than what they replaced), and the same partial-stashing on
+  cache-blocking the accumulator, swapping the loop nesting (both slower
+  than what they replaced), and the same partial-stashing on
   `multi_normal_cholesky_lpdf` (a wash, and it would have cost n^2
   doubles of scratch per op).
+
+### Fixed
+
+- The benchmark table on the PyPI page renders as a table again. The
+  marker that stamps generated numbers into the page shared its line
+  with the table header, and a line opening `<!--` opens a raw HTML
+  block that runs to the `-->`, so PyPI's renderer swallowed the header
+  and printed every row as literal pipes. `tools/gen_docs.py --check`
+  now renders both READMEs with readme_renderer, the library PyPI itself
+  uses, and fails if a table does not come out as one. `twine check`
+  never caught this: the page rendered, it just rendered wrong.
+
+### Verification and tooling
+
+- `tools/verify_lite.py` verifies the lite build against the exact one
+  (gradients bitwise, lp shift constant across evaluation points), and
+  `tools/verify_refs.py --no-lp` replays the corpus for a build whose
+  `lp__` is shifted by design.
+
+- `harnesses/fn_sweep.py` takes its function list from stanc3's own
+  signature dump, so a function stanli claims and Stan does not offer,
+  or the reverse, shows up as a gap rather than as agreement.
 
 ## 0.2.0
 


### PR DESCRIPTION
PyPI has 0.1.0 and 0.2.0. The 0.2.1 section was written but never
tagged, and the Unreleased section on top of it is the truncation and
lite-lp work, so a reader upgrading from the last published release was
looking at three headings for one diff. They are now one 0.3.0 section,
grouped by what a reader is looking for, and it leads with the two
changes that move results: the RNG stream, and the browser build's
shifted lp__.

Reconciled while merging: the browser payload figure was pre-lite (1.34
MB gzipped, now 0.99), the distribution list was 14 and is 18 with the
count distributions, and the coverage counts now come from
stanc --dump-stan-math-signatures rather than a hand-kept table. Added
the installed size, which grew to 21.3 MB and had no entry at all.
