### PR TITLE
docs: no em-dashes in the published docs

### DIFF
--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -60,8 +60,8 @@ model's *shape*, not its size:
   gap grows with N. This class is regressions, GLMs, and most
   hierarchical models written with vectorized statements.
 - **Scalar loops the passes can vectorize.** The hierarchical indexing
-  idiom — `y[n] ~ normal(mu[county[n]], sigma)` and loops that fill a
-  vector element by element — arrives unrolled and is re-rolled back
+  idiom -- `y[n] ~ normal(mu[county[n]], sigma)` and loops that fill a
+  vector element by element -- arrives unrolled and is re-rolled back
   into the class above (radon family up to 6.1x, `election88_full`
   3.0x, `dogs` 2.8x). What the passes handle is described below.
 - **Everything, on preparation.** Lowering a model is 4-400 ms against
@@ -70,7 +70,7 @@ model's *shape*, not its size:
 
 **Near parity (0.8-1.2x):**
 
-- **Models dominated by one large dense operation** — a Cholesky, a big
+- **Models dominated by one large dense operation** -- a Cholesky, a big
   matrix product, an eigendecomposition (the GP models). Both engines
   spend their time inside the same stan-math kernel on the same
   contiguous doubles; interpreter overhead is noise on top.
@@ -140,8 +140,8 @@ terms fused into one summed vector density). `radon_pooled` collapses
 from 27,670 ops to 8 (0.91x -> 6.18x) and `arK` from 3,164 to 21 (0.40x
 -> 4.83x). Indexed reads rewrite by shape: the whole base in order needs
 no op at all, a contiguous window becomes an `OP_SLICE`, and an arbitrary
-data-driven index — `alpha[county_idx[n]]`, the hierarchical idiom,
-repeats and all — becomes one `OP_GATHER` whose backward scatter-adds.
+data-driven index -- `alpha[county_idx[n]]`, the hierarchical idiom,
+repeats and all -- becomes one `OP_GATHER` whose backward scatter-adds.
 Anything the pass cannot prove safe it leaves alone, per region:
 cross-lane recurrences, outputs escaping their lane, opcodes outside its
 vocabulary. Set `STANLI_NO_REROLL=1` to disable it, `STANLI_NO_INPLACE=1`
@@ -149,15 +149,16 @@ for the update rules below.
 
 **Element writes: `mu[n] = ...` inside a loop.** This is the other half
 of the hierarchical idiom, and it used to be the worst thing in the
-project. Each write lowered to a *functional update* — copy the whole
-vector into a fresh slot, poke one element — so N writes cost O(N^2) time
+project. Each write lowered to a *functional update* -- copy the whole
+vector into a fresh slot, poke one element -- so N writes cost O(N^2)
+time
 and O(N^2) arena. `radon_county_intercept` (N=12,573) spent 90.5 ms per
 gradient inside 2.58 GB of arena, 207x slower than CmdStan.
 
 Three rules compose to remove it (`runtime/src/inplace.cpp`, plus the
 index rules above). A write may mutate its vector directly when it is the
-**last use** of that vector — not merely its only use, since the
-read-back in the same iteration is an earlier use — and when no earlier
+**last use** of that vector -- not merely its only use, since the
+read-back in the same iteration is an earlier use -- and when no earlier
 reader needs the vector's values during the reverse sweep (`log_sum_exp`
 and the other nested-replay backwards rebuild their tape from the input
 buffer, so they must find it intact). The write and its read-back then
@@ -167,9 +168,10 @@ gather rule vectorizes: **77,960 ops become 9**, 90.5 ms becomes 92 us,
 2.58 GB becomes 42 MB. Seven radon-family models and `rats_model` collapse
 the same way.
 
-That worked when the read-back cancelled the write. When it did not —
+That worked when the read-back cancelled the write. When it did not --
 when the loop fills a vector that something *else* reads, which is what
-`y_hat[n] = a[county[n]]` followed by `y ~ normal(y_hat, sigma)` is — the
+`y_hat[n] = a[county[n]]` followed by `y ~ normal(y_hat, sigma)` is --
+the
 writes survived, one op per element, and the re-roll pass refused the
 region because its outputs escaped the lane. **Write-side fusion** takes
 that case: a run of element writes marching contiguously through one
@@ -186,8 +188,8 @@ each. 57 of the 120 corpus models now change under the passes, against 28
 before.
 
 Three follow-ons closed the `dogs` family (0.65x -> 2.8x, 12,751 ops ->
-261). A **strided** run — indices advancing by the matrix's row count,
-`p[j, t]` filled down columns — fuses into `OP_SET_SLICE_STRIDED`, and
+261). A **strided** run -- indices advancing by the matrix's row count,
+`p[j, t]` filled down columns -- fuses into `OP_SET_SLICE_STRIDED`, and
 interleaved runs over one vector chain block by block: each block's store
 output becomes the vector every later reference, read or write, is
 renamed to, so the next block fuses onto it in turn. **Per-lane integer
@@ -213,18 +215,18 @@ elementwise, widens the consuming `log_mix`, and swaps the N per-lane
 target terms for one `OP_SUM_VEC`. `low_dim_gauss_mix` drops from 7,208
 ops to 16 and crosses parity (0.78x -> 1.07x); `normal_mixture` lands at
 13 ops, 1.09x. A density whose inputs are all lane-invariant hoists to
-one scalar op instead of widening — a len-N output over all-scalar
+one scalar op instead of widening -- a len-N output over all-scalar
 inputs is exactly the miscompile shape the corpus A/B caught once
 already (`losscurve_sislob`).
 
 **Tape islands: the irreducible residue.** After every other pass has
 run, whatever scalar residue survives is, by construction, what no
-vectorizer can help — cross-lane recurrences, where step t reads step
+vectorizer can help -- cross-lane recurrences, where step t reads step
 t-1's parameter-dependent result. The island pass
 (`runtime/src/island.cpp`, `STANLI_NO_ISLAND=1` to disable) compiles
 each maximal run of compilable ops into a flat register program executed
 by ONE op: forward runs it on plain doubles; backward replays it under
-stan-math's nested autodiff and harvests the live-ins' adjoints — the
+stan-math's nested autodiff and harvests the live-ins' adjoints -- the
 same var arithmetic CmdStan's generated code runs for the same
 statements, so gradients match by construction. Per-lane data constants
 absorb into the program as immediates; dead copy-then-modify chains
@@ -260,14 +262,14 @@ backwards it replaced. `iohmm_reg` is different for a reason that has
 nothing to do with dispatch: its steps copy a 1,500-element state
 vector each, 1.6M elements of traffic per gradient, and the island's
 registers make those copies disappear. `bones_model` is the same
-mechanism inverted — 36 ops behind a 4,024-register file, rebuilt as
+mechanism inverted -- 36 ops behind a 4,024-register file, rebuilt as
 vars 77 times per gradient.
 
 So the pass estimates both sides before committing: what the ops move
 (an in-place element update moves one element, not a vector) against
 the register file, weighted 4x because it is built twice per call and
-once as vars. The estimate separates the fourteen exactly — `iohmm_reg`
-1.6M against 435k, every other region 4-20x the wrong way — and the
+once as vars. The estimate separates the fourteen exactly -- `iohmm_reg`
+1.6M against 435k, every other region 4-20x the wrong way -- and the
 thirteen it now leaves alone are bitwise identical to the passes-off
 baseline again. `STANLI_ISLAND_ALWAYS=1` skips the estimate, which is
 how to ask why a region was left alone.
@@ -403,7 +405,8 @@ attribute one).
 That harness earns its keep. An earlier version of the in-place rule
 allowed a destructive write whenever it was the last use of its vector,
 which is wrong for any earlier reader that rebuilds its var tape from the
-buffer during the reverse sweep — `log_sum_exp`, `softmax`, every legacy
+buffer during the reverse sweep -- `log_sum_exp`, `softmax`, every
+legacy
 nested-replay backward. Eight HMM/LDA/mixture models were silently wrong
 by up to 1.7e+05 relative **with their op counts unchanged**, so nothing
 structural would have caught it. Only ops whose backward purely routes

--- a/docs/coverage.md
+++ b/docs/coverage.md
@@ -11,7 +11,8 @@ with a generated single-function model.
 | distribution functions (`_cdf`, `_lcdf`, `_lccdf`) | 87 / 105 |
 | scalar math (all-real signature) | 47 / 129 |
 
-Everything supported matches CmdStan **bitwise** — 0 ULP on every argument
+Everything supported matches CmdStan **bitwise** -- 0 ULP on every
+argument
 slot, at three evaluation points. That is the standard here; a density that
 merely agrees to 1e-12 is a bug report, not a feature.
 
@@ -22,29 +23,34 @@ branch together. See `docs/hacking.md`.
 
 ## The gaps, and what each one actually needs
 
-### Ordinal regression — `ordered_logistic`, `ordered_probit`
+### Ordinal regression -- `ordered_logistic`, `ordered_probit`
 
 The largest real-world gap. Their cutpoint argument is a whole vector per
 observation, and stan-math reaches its partials through
-`partials_vec<1>(ops_partials)` — a vector-of-vectors edge. The recorder
+`partials_vec<1>(ops_partials)` -- a vector-of-vectors edge. The
+recorder
 (`runtime/include/stanli/recorder.hpp`) implements scalar and vector edges
 only, so this needs a recorder extension, not a list entry.
 
-### Multivariate — wishart, `multi_student_t`, `multi_normal_prec`, `multi_gp`, `lkj_corr`, `gaussian_dlm_obs`
+### Multivariate -- wishart, `multi_student_t`, `multi_normal_prec`,
+`multi_gp`, `lkj_corr`, `gaussian_dlm_obs`
 
 Matrix arguments, each with its own shape plumbing. `multi_normal`,
 `multi_normal_cholesky`, `lkj_corr_cholesky` and `dirichlet` are already
 in as hand-written kernels; these would follow the same pattern, one at a
 time.
 
-### GLM fast paths — `poisson_log_glm`, `neg_binomial_2_log_glm`, `binomial_logit_glm`, `categorical_logit_glm`, `ordered_logistic_glm`
+### GLM fast paths -- `poisson_log_glm`, `neg_binomial_2_log_glm`,
+`binomial_logit_glm`, `categorical_logit_glm`, `ordered_logistic_glm`
 
 `bernoulli_logit_glm` is in and shows the shape: a data matrix in a
 row-major slot with its dims in `idata`. These matter for coverage rather
-than speed — brms and rstanarm emit the GLM form directly, so a model
+than speed -- brms and rstanarm emit the GLM form directly, so a model
 using one does not merely run slower, it does not run.
 
-### Multinomial family — `multinomial`, `multinomial_logit`, `dirichlet_multinomial`, `beta_binomial`, `hypergeometric`, `discrete_range`
+### Multinomial family -- `multinomial`, `multinomial_logit`,
+`dirichlet_multinomial`, `beta_binomial`, `hypergeometric`,
+`discrete_range`
 
 Integer outcomes that are not one int per lane: an array of counts, or two
 int groups. `binomial` already carries two groups
@@ -56,7 +62,8 @@ they contribute a constant and no gradient.
 
 `binomial` and `beta_binomial` carry a second int group (the trial count)
 and `discrete_range` is integers all the way down, so those nine want a
-layout rather than a list line — `with_int_group` in `densities.cpp` shows
+layout rather than a list line -- `with_int_group` in `densities.cpp`
+shows
 the shape.
 
 `neg_binomial_2`'s three reparameterize to `neg_binomial` by computing
@@ -81,7 +88,8 @@ again (see below). The other six are `von_mises` and
 The only remaining all-real scalar density, and it fails the same way
 `von_mises_cdf` does: it computes with the scalar type directly
 (`square(y - tau)`, comparisons against doubles) rather than deriving
-partials in doubles. Same fix would be needed — a tape, or a hand-written
+partials in doubles. Same fix would be needed -- a tape, or a
+hand-written
 kernel.
 
 ## Truncation and censoring

--- a/docs/lite-lp.md
+++ b/docs/lite-lp.md
@@ -7,8 +7,9 @@ for emscripten and off everywhere else.
 ## What it drops
 
 A density is not one function. stan-math decides which terms of a log
-density to keep by looking at the argument *types* — `include_summand<propto,
-T_y, T_loc, T_scale>` is a compile-time query — so a `~` statement that
+density to keep by looking at the argument *types* --
+`include_summand<propto,
+T_y, T_loc, T_scale>` is a compile-time query -- so a `~` statement that
 drops `-0.5 * log(2π)` because `sigma` is data is a *different
 instantiation* from one that keeps it. Supporting `~` exactly therefore
 costs one instantiation per activity mask, on top of the full form, twice
@@ -17,7 +18,8 @@ per distribution, about 630 KB of object for a three-argument one.
 
 `STANLI_LITE_LP` clears the propto half of that (`density_tier()` in
 `runtime/include/stanli/optable.hpp`). `y ~ normal(mu, sigma)` then
-evaluates the *full* normal density. That is still a correct log density —
+evaluates the *full* normal density. That is still a correct log density
+--
 it just is not the one CmdStan computes, so `lp__` lands a per-model
 constant above CmdStan's.
 
@@ -35,14 +37,14 @@ every `write_array` value is **bitwise identical** to the exact build, and
 | `libstanli` stripped (macOS arm64) | 14.93 MB | 7.79 MB |
 | gradients vs CmdStan | bitwise | bitwise |
 | `lp__` vs CmdStan | bitwise | constant offset |
-| draws for a pinned seed | — | different chain, same posterior |
+| draws for a pinned seed | -- | different chain, same posterior |
 | `stanli_exact_lp()` | 1 | 0 |
 
 ### The draws are not byte-identical, and that is expected
 
 It is tempting to reason: the constant cancels in every Hamiltonian
-*difference* NUTS looks at — the Metropolis ratio, the multinomial
-weights, the divergence test — so the trajectory must be identical. In
+*difference* NUTS looks at -- the Metropolis ratio, the multinomial
+weights, the divergence test -- so the trajectory must be identical. In
 exact arithmetic that is true. In floating point it is not: the sampler
 forms `H = -lp + kinetic`, and adding a shifted `lp` to the kinetic energy
 **rounds differently**. The difference starts at one ULP and NUTS is
@@ -58,7 +60,8 @@ Measured on eight schools, same seed, exact against lite:
 
 Both chains start from the identical initial point and take the identical
 number of gradient evaluations; they separate purely by amplification.
-This is the same class of difference as changing the seed — every draw is
+This is the same class of difference as changing the seed -- every draw
+is
 from the same posterior, and no draw is byte-comparable. If you need a run
 that reproduces another run byte for byte, both must be the same build.
 0.2.1 carries the same caveat for a different reason (the RNG change).
@@ -76,7 +79,7 @@ cmake --build build-lite --target stanli_check -j8
 python3 tools/verify_lite.py deps/posteriordb
 ```
 
-1. **Gradients bitwise.** Not "close" — the same computation.
+1. **Gradients bitwise.** Not "close" -- the same computation.
 2. **The lp shift is constant.** Evaluated at three points in the
    unconstrained space, `lp_exact - lp_lite` must come out the same every
    time. This is the load-bearing check: a shift that *moved* with the
@@ -87,7 +90,7 @@ python3 tools/verify_lite.py deps/posteriordb
 The gate on the shift is relative to `lp`, not to the shift. Dropping a
 term reassociates the sum after it, so the residue lives on `lp`'s rounding
 scale: `rats_model`'s `lp` is -4.7e6 (one ULP is 9.3e-10) and its shift
-moves by 4.7e-10 — half an ULP of the number it was subtracted from.
+moves by 4.7e-10 -- half an ULP of the number it was subtracted from.
 Normalizing against the shift's own magnitude instead would flag that as a
 failure and teach everyone to ignore the tool.
 


### PR DESCRIPTION
House style, and these three had 38 between them. Substitution is
same-line only, so no paragraph reflows and no table cell moves.
