### PR TITLE
docs: say plainly that the browser lp__ is shifted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,10 +18,45 @@ tagged, so everything below is what changed for anyone upgrading from
   different draws than 0.2.0 did. Any seed is as valid as any other, but
   a run pinned to one will not reproduce byte for byte.
 
-- **The browser build reports a shifted `lp__`** (see the lite build
-  below). Gradients and every `write_array` value are bitwise identical;
-  `lp__` sits a per-model constant above CmdStan's. The wheels are
-  unaffected: they ship the exact build.
+- **The browser build reports a shifted `lp__`.** This is the one
+  number in this release that does not match CmdStan, so it is worth
+  being precise about what does and does not move.
+
+  The browser runtime is built with `STANLI_LITE_LP`, which drops
+  stan-math's propto instantiations. A density is not one function:
+  stan-math decides which terms of a log density to keep by looking at
+  the argument types, so `y ~ normal(mu, sigma)` with data `sigma`
+  drops `-0.5 * log(2*pi)` and is a different instantiation from the
+  one that keeps it. Supporting that exactly costs `4 * 2^N` copies of
+  the template per distribution, about 630 KB each, which is half the
+  library.
+
+  Dropping the propto half means `~` evaluates the full density. The
+  terms it stops removing are exactly the ones that are constant in the
+  active arguments, so they have no derivative to contribute:
+
+  - Every gradient is bitwise identical to the exact build, measured
+    across the whole 119-model corpus.
+  - Every `write_array` value, so every constrained parameter,
+    transformed parameter, and generated quantity, is bitwise
+    identical.
+  - The posterior is the same posterior. `lp__` lands a per-model
+    constant above CmdStan's.
+
+  Two consequences. Do not compare a browser `lp__` against a CmdStan
+  run, and do not feed it to anything that reads log densities as
+  absolute numbers: Bayes factors, marginal likelihoods, bridge
+  sampling. And because NUTS adds `lp` to the kinetic energy, a shifted
+  `lp` rounds differently there, so a pinned seed draws a different
+  chain in the browser than in the wheels. It is an equally valid chain
+  from the same posterior, the same class of difference as reseeding.
+
+  **The PyPI wheels are unaffected.** `STANLI_LITE_LP` is on by default
+  only for emscripten; every wheel ships the exact build and matches
+  CmdStan's `lp__`. `stanli_exact_lp()` in C, `stanli.exact_lp()` in
+  Python, and `fit.exactLp` in JS report which build is loaded, and
+  `tools/verify_lite.py` is what checks the claims above. Full write-up
+  in [docs/lite-lp.md](docs/lite-lp.md).
 
 ### Stan in the browser
 

--- a/web/index.html
+++ b/web/index.html
@@ -54,6 +54,15 @@
   .plots canvas { border: 1px solid #8883; border-radius: 6px;
                   max-width: 100%; }
   .times { font-size: .8rem; opacity: .7; margin-top: .5rem; }
+  footer {
+    margin: 2.5rem 0 1rem; padding: .9rem 1.1rem; font-size: .85rem;
+    border: 1px solid #c96a; border-left: 4px solid #c96;
+    border-radius: 6px; background: #c9630c0a;
+  }
+  footer h2 { font-size: .9rem; margin: 0 0 .4rem; }
+  footer p { margin: .4rem 0 0; }
+  footer code { font-family: ui-monospace, monospace; font-size: .95em; }
+  footer a { color: inherit; }
 </style>
 </head>
 <body>
@@ -492,5 +501,23 @@ $("csv").onclick = () => {
   URL.revokeObjectURL(a.href);
 };
 </script>
+<footer>
+<h2>This page reports a shifted <code>lp__</code></h2>
+<p>The browser runtime is built with <code>STANLI_LITE_LP</code>, which
+drops stan-math's propto instantiations to halve the download. Those are
+exactly the terms that do not depend on the parameters, so every gradient
+and every generated quantity here is bit-for-bit what CmdStan computes,
+and the posterior you sample from is the same one. What moves is
+<code>lp__</code> itself: it sits a per-model constant above CmdStan's,
+so do not compare this page's <code>lp__</code> against a CmdStan run, and
+do not use it for anything that reads log densities as absolute numbers
+(Bayes factors, marginal likelihoods, bridge sampling).</p>
+<p>Because the sampler adds <code>lp</code> to the kinetic energy, a
+pinned seed also draws a different chain here than in the wheels. It is
+an equally valid chain from the same posterior, not different math.</p>
+<p>The PyPI wheels ship the exact build and match CmdStan's
+<code>lp__</code>. Details in
+<a href="https://github.com/seantalts/stanli/blob/main/docs/lite-lp.md">docs/lite-lp.md</a>.</p>
+</footer>
 </body>
 </html>


### PR DESCRIPTION
The browser build ships STANLI_LITE_LP, so its lp__ sits a per-model
constant above CmdStan's while every gradient and every write_array
value stays bitwise identical. That is the one number in 0.3.0 that
does not match CmdStan, and it was a single sentence in the changelog
and nothing at all on the page people actually use.

The release note now says what moves, what does not, and the two things
not to do with a shifted lp__ (compare it to CmdStan, or feed it to
anything reading log densities as absolute numbers: Bayes factors,
marginal likelihoods, bridge sampling), plus why a pinned seed draws a
different chain there. The demo page carries the same warning in a
footer. The wheels are unaffected and both texts say so.
