### PR TITLE
docs: the lite lp__ shift has no direction, and no speed cost either

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,7 @@ tagged, so everything below is what changed for anyone upgrading from
     transformed parameter, and generated quantity, is bitwise
     identical.
   - The posterior is the same posterior. `lp__` lands a per-model
-    constant above CmdStan's.
+    constant away from CmdStan's.
 
   Two consequences. Do not compare a browser `lp__` against a CmdStan
   run, and do not feed it to anything that reads log densities as

--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ hand-written derivative instantiates nothing.
 
 **`-DSTANLI_LITE_LP=ON` halves the runtime.** Dropping the propto family
 entirely takes `libstanli` from 14.9 MB to 7.79 MB stripped, at the cost
-of an `lp__` that sits a per-model constant above CmdStan's. Every
+of an `lp__` that differs from CmdStan's by a per-model constant. Every
 gradient stays bit-identical; a pinned seed draws a different but equally
 valid chain, because the sampler adds `lp` to the kinetic energy and a
 shifted `lp` rounds differently there. On by default for the browser
@@ -227,8 +227,8 @@ known model in a browser is the 1.01 MB runtime alone.
 
 **The browser `lp__` is not CmdStan's.** `STANLI_LITE_LP` is what makes
 the numbers above, and it drops the propto instantiations, so `~`
-evaluates the full density and `lp__` lands a per-model constant above
-CmdStan's. Gradients and every `write_array` value stay bitwise
+evaluates the full density and `lp__` differs from CmdStan's by a
+per-model constant. Gradients and every `write_array` value stay bitwise
 identical, and the posterior is the same posterior, but do not compare a
 browser `lp__` against a CmdStan run or feed it to anything reading log
 densities as absolute numbers. The wheels ship the exact build.

--- a/docs/lite-lp.md
+++ b/docs/lite-lp.md
@@ -21,7 +21,7 @@ per distribution, about 630 KB of object for a three-argument one.
 evaluates the *full* normal density. That is still a correct log density
 --
 it just is not the one CmdStan computes, so `lp__` lands a per-model
-constant above CmdStan's.
+constant away from CmdStan's.
 
 ## What it does not drop
 
@@ -39,6 +39,34 @@ every `write_array` value is **bitwise identical** to the exact build, and
 | `lp__` vs CmdStan | bitwise | constant offset |
 | draws for a pinned seed | -- | different chain, same posterior |
 | `stanli_exact_lp()` | 1 | 0 |
+
+### Speed, and what propto is worth at runtime
+
+Nothing measurable. The natural worry about `~` evaluating the full
+density is that it is doing arithmetic the propto form skips, so the
+half-size build should be the slower one. It is not, at any size that
+shows up above the noise floor.
+
+Per-gradient, minimum of five runs of 4000 evaluations each, same
+machine, both builds `-O3`:
+
+| model | exact | lite | |
+|---|---:|---:|---|
+| eight schools (10 params) | 278.9 ns | 288.7 ns | lite 3.5% slower |
+| `arK` (7 params) | 2556 ns | 2591 ns | lite 1.4% slower |
+| `radon_pooled` (3 params, 919 obs) | 4430 ns | 4256 ns | lite 3.9% *faster* |
+
+The sign is not even consistent, which is the tell: this is run-to-run
+variance, not a cost. `STANLI_PROFILE=1` says why. The two builds produce
+the same opcodes with the same counts, because the propto choice is
+internal to a kernel and never changes the graph, and in a profiled run
+the unrelated `OP_ADD` and `OP_MUL` moved by the same 9% as
+`OP_NORMAL_LPDF` did, which is machine noise rather than anything to do
+with densities.
+
+So the trade is half the library against a shifted `lp__`, and not
+against throughput. Do not pick the exact build for speed; pick it
+because you want CmdStan's `lp__`.
 
 ### The draws are not byte-identical, and that is expected
 

--- a/web/index.html
+++ b/web/index.html
@@ -587,7 +587,7 @@ drops stan-math's propto instantiations to halve the download. Those are
 exactly the terms that do not depend on the parameters, so every gradient
 and every generated quantity here is bit-for-bit what CmdStan computes,
 and the posterior you sample from is the same one. What moves is
-<code>lp__</code> itself: it sits a per-model constant above CmdStan's,
+<code>lp__</code> itself: it differs from CmdStan's by a per-model constant,
 so do not compare this page's <code>lp__</code> against a CmdStan run, and
 do not use it for anything that reads log densities as absolute numbers
 (Bayes factors, marginal likelihoods, bridge sampling).</p>


### PR DESCRIPTION
Four places said the browser lp__ sits a per-model constant "above"
CmdStan's. It is below, and the wording was wrong rather than the sign
being interesting: propto drops terms like -0.5*log(2*pi) - log(sigma),
which are negative for any scale above about 0.4, so keeping them pushes
lp down. Measured on eight schools at the shared evaluation point, exact
-4.30791067401904 against lite -44.26266743937529, and summing the
dropped terms across the model's four statements predicts the gap to
five decimals (39.95476 both ways). Since the direction depends on the
scales, all four now say it differs by a per-model constant, which is
what optable.hpp already said.

While checking, measured the thing anyone reading this doc will ask
next: what propto costs at runtime. Nothing. Minimum of five runs of
4000 gradients, eight schools 278.9 exact against 288.7 lite, arK 2556
against 2591, radon_pooled 4430 against 4256, so lite is slower on two
and faster on the third. The two builds emit the same opcodes with the
same counts, and in a profiled run unrelated OP_ADD and OP_MUL moved by
the same 9% as OP_NORMAL_LPDF, which is machine variance. The trade is
size against a shifted lp__, not against throughput.
