### PR TITLE
The count GLMs, beta_binomial, and the propto bit GLM ops never got

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Unreleased
 
+- Three more densities, and a propto bug they exposed: `poisson_log_glm`,
+  `neg_binomial_2_log_glm` and `beta_binomial`, all bitwise against
+  CmdStan. GLM ops were the one density shape the lowering gave no variant
+  at all, so their kernels hardcoded `propto=false` and
+  `poisson_log_glm`'s lp landed `sum(log(y!))` away from CmdStan's with the
+  gradients already exact. `bernoulli_logit_glm` had the same hardcoding
+  and got away with it because bernoulli has no constant to drop. 50 of 72
+  densities now.
+
 - The browser build uses SIMD128. Worth 2% on most shapes and 11% on a
   matrix-heavy model for 0.03 MB gzipped, and every corpus model's
   gradients come out bitwise identical to the scalar build -- with FP

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Unreleased
 
+- `multi_normal_prec`, `lkj_corr`, `hypergeometric` and `discrete_range`,
+  taking densities to 54 of 72 -- and none of the four needed a kernel
+  written from scratch. The first two are one template parameter on
+  `multi_normal` and `lkj_corr_cholesky`, whose argument shapes they share.
+  The other two are all-integer, so they are covered by a general rewrite:
+  `y ~ foo(...)` with every argument data contributes exactly zero, because
+  that is what CmdStan's `include_summand` does with it. See the three
+  tiers at the top of docs/coverage.md.
+
 - Three more densities, and a propto bug they exposed: `poisson_log_glm`,
   `neg_binomial_2_log_glm` and `beta_binomial`, all bitwise against
   CmdStan. GLM ops were the one density shape the lowering gave no variant

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+- Sizes re-measured on the current tree, since the density list nearly
+  doubled: the shared library is 22.2 MB installed and 7.8 MB in the wheel
+  (from 21.3 / 7.4), `libstanli` is 15.75 MB stripped exact and 8.43 MB
+  lite (from 14.93 / 7.79), and `stanli.wasm` is 4.10 MB raw / 1.15 MB
+  gzipped (from 3.60 / 1.05). Densities and distribution functions are now
+  12.03 MB of the shipped library, 54.9%.
+
 - **71 of Stan's 72 densities.** The multivariate and multinomial tail
   lands: the wishart family, `multi_gp`, `multi_student_t`, `lkj_cov`,
   `multi_normal_prec`, the multinomial family, `ordered_probit`, `wiener`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 ## Unreleased
 
+- **71 of Stan's 72 densities.** The multivariate and multinomial tail
+  lands: the wishart family, `multi_gp`, `multi_student_t`, `lkj_cov`,
+  `multi_normal_prec`, the multinomial family, `ordered_probit`, `wiener`,
+  and the three remaining GLMs. Only `gaussian_dlm_obs` is out, and for a
+  structural reason: it takes seven arguments and an op holds six.
+
+- Those tail densities are **compact** -- one instantiation of stan-math's
+  template instead of one per activity mask. Their gradients are bitwise
+  against CmdStan and their `lp__` sits a per-model constant higher,
+  measured and characterised in the new
+  [docs/compact-densities.md](docs/compact-densities.md), which also says
+  which densities are exact and how to make a tail one exact if you need
+  it. The trade is the same one `STANLI_LITE_LP` makes globally, applied
+  per density: `lp__` is a diagnostic, the gradient is what the sampler
+  integrates.
+
+- `ordered_probit` and `wiener` were written off as unreachable because
+  the recorder cannot do arithmetic on its scalar type. That is true of
+  the recorder and not of `stan::math::var`, so both work on a nested var
+  tape.
+
+- `Graph::add_op` used to write past `Op::in` without a word. A
+  seven-input op corrupted `n_in` and surfaced as a SIGBUS inside a
+  kernel; it throws at the point that knows now.
+
 - `multi_normal_prec`, `lkj_corr`, `hypergeometric` and `discrete_range`,
   taking densities to 54 of 72 -- and none of the four needed a kernel
   written from scratch. The first two are one template parameter on

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,7 +86,13 @@ if(EMSCRIPTEN)
   # trades their straight-line speed for size.
   set_source_files_properties(
     runtime/kernels/densities_common.cpp
+  runtime/kernels/densities_lpmf.cpp
+  runtime/kernels/densities_glm.cpp
+    runtime/kernels/densities_lpmf.cpp
+    runtime/kernels/densities_glm.cpp
+    runtime/kernels/densities_common_b.cpp
     runtime/kernels/densities_rest.cpp
+    runtime/kernels/densities_rest_b.cpp
     runtime/kernels/densities_cdf_a.cpp
     runtime/kernels/densities_cdf_b.cpp
     PROPERTIES COMPILE_OPTIONS -Oz)
@@ -132,7 +138,11 @@ add_library(stanli_shared SHARED
   runtime/kernels/elementwise.cpp
   runtime/kernels/densities.cpp
   runtime/kernels/densities_common.cpp
+  runtime/kernels/densities_lpmf.cpp
+  runtime/kernels/densities_glm.cpp
+  runtime/kernels/densities_common_b.cpp
   runtime/kernels/densities_rest.cpp
+  runtime/kernels/densities_rest_b.cpp
   runtime/kernels/densities_cdf_a.cpp
   runtime/kernels/densities_cdf_b.cpp
   runtime/kernels/legacy_fns.cpp
@@ -213,7 +223,11 @@ add_library(stanli STATIC
   runtime/kernels/elementwise.cpp
   runtime/kernels/densities.cpp
   runtime/kernels/densities_common.cpp
+  runtime/kernels/densities_lpmf.cpp
+  runtime/kernels/densities_glm.cpp
+  runtime/kernels/densities_common_b.cpp
   runtime/kernels/densities_rest.cpp
+  runtime/kernels/densities_rest_b.cpp
   runtime/kernels/densities_cdf_a.cpp
   runtime/kernels/densities_cdf_b.cpp
   runtime/kernels/legacy_fns.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,18 +54,15 @@ target_compile_options(stanmath INTERFACE -ffp-contract=off)
 # whose gradients are bit-identical, with an lp__ that sits a per-model
 # constant above CmdStan's. A given seed still draws a different chain,
 # because lp enters the Hamiltonian additively and a shifted lp rounds
-# differently -- statistically the same sampler, not the same bytes. The wheel keeps
-# the exact lp because the differential oracle is the point; the browser
-# build spends the bytes on reach instead. See density_tier in optable.hpp
-# and docs/lite-lp.md.
-if(EMSCRIPTEN)
-  set(_lite_default ON)
-else()
-  set(_lite_default OFF)
-endif()
+# differently: the same sampler statistically, not the same bytes.
+#
+# Off everywhere, browser included. The browser build used to default it
+# on to save 7 MB of wasm, which meant the demo reported an lp__ nobody
+# could compare against CmdStan. Every build now reports the same lp__.
+# See density_tier in optable.hpp and docs/lite-lp.md.
 option(STANLI_LITE_LP
   "Drop the propto instantiation family: half the size, lp__ off by a constant"
-  ${_lite_default})
+  OFF)
 if(STANLI_LITE_LP)
   target_compile_definitions(stanmath INTERFACE STANLI_LITE_LP=1)
 endif()

--- a/README.md
+++ b/README.md
@@ -32,10 +32,10 @@ pip install stanli
 - Install size: one 21.3 MB shared library, a 7.4 MB wheel. Breakdown
   in [Binary size](#binary-size) below; the browser build halves the
   runtime with `STANLI_LITE_LP` ([docs/lite-lp.md](docs/lite-lp.md)).
-- Distribution coverage: [docs/coverage.md](docs/coverage.md) (47 of 72
-  densities, 90 of 105 cdf/lcdf/lccdf, truncation, censoring and ordinal
-  regression; every one bitwise against CmdStan, and what is missing says
-  why)
+- Distribution coverage: [docs/coverage.md](docs/coverage.md) (50 of 72
+  densities, 90 of 105 cdf/lcdf/lccdf, truncation, censoring, ordinal
+  regression and the count GLMs; every one bitwise against CmdStan, and
+  what is missing says why)
 - How this is possible, for statisticians:
   [docs/how-it-works.md](docs/how-it-works.md)
 - Design doc: `docs/superpowers/specs/2026-08-04-stan-portable-runtime-design.md`

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ pip install stanli
 - Install size: one 21.3 MB shared library, a 7.4 MB wheel. Breakdown
   in [Binary size](#binary-size) below; the browser build halves the
   runtime with `STANLI_LITE_LP` ([docs/lite-lp.md](docs/lite-lp.md)).
-- Distribution coverage: [docs/coverage.md](docs/coverage.md) (50 of 72
+- Distribution coverage: [docs/coverage.md](docs/coverage.md) (54 of 72
   densities, 90 of 105 cdf/lcdf/lccdf, truncation, censoring, ordinal
   regression and the count GLMs; every one bitwise against CmdStan, and
   what is missing says why)

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ pip install stanli
 - Install size: one 21.3 MB shared library, a 7.4 MB wheel. Breakdown
   in [Binary size](#binary-size) below; the browser build halves the
   runtime with `STANLI_LITE_LP` ([docs/lite-lp.md](docs/lite-lp.md)).
-- Distribution coverage: [docs/coverage.md](docs/coverage.md) (54 of 72
+- Distribution coverage: [docs/coverage.md](docs/coverage.md) (71 of 72
   densities, 90 of 105 cdf/lcdf/lccdf, truncation, censoring, ordinal
   regression and the count GLMs; every one bitwise against CmdStan, and
   what is missing says why)

--- a/README.md
+++ b/README.md
@@ -200,41 +200,34 @@ the cost of ~8x slower model compilation.
 ### The browser build
 
 A different binary with different economics: no embedded stanc3, because
-the compiler ships separately as JavaScript, and `STANLI_LITE_LP` on by
-default. `stanli.wasm` is 3.47 MB raw and 1.01 MB gzipped, of which
-3.33 MB is code, attributed the same way:
+the compiler ships separately as JavaScript. `stanli.wasm` is 5.79 MB raw
+and 1.52 MB gzipped.
 
-| | | |
+Where that goes, measured by stubbing every density, cdf and tail kernel
+and relinking:
+
+| | raw | gzip |
 | --- | ---: | ---: |
-| stanli itself | 1.35 MB | 40.5% |
-| densities and distribution functions | 0.95 MB | 28.4% |
-| stan-math, everything else | 0.42 MB | 12.5% |
-| Eigen (out-of-line) | 0.26 MB | 7.7% |
-| libc++, NUTS, runtime, unattributed | 0.21 MB | 6.4% |
-| SUNDIALS | 0.06 MB | 1.7% |
-| nlohmann/json | 0.05 MB | 1.5% |
-| Boost | 0.05 MB | 1.4% |
+| core runtime | 2.26 MB | 0.69 MB |
+| densities and distribution functions | 3.53 MB | 0.83 MB |
 
-The densities are 28% here against 54% in the wheel, and stanli's own
-code leads instead. Two reasons: the propto instantiations are gone, and
-`densities.cpp` is the one file the browser build compiles at `-Oz`
-rather than `-O3`, which was worth 8.5 MB of wasm and costs about 10% on
-a mixture model. What is left of stanli grows as a share because the
-interpreter and the register machine are templates that survive both.
+Densities are 55% of the compressed download, which is what
+[docs/density-pack.md](docs/density-pack.md) is about: a core plus an
+on-demand pack, so a model pays for the densities it uses. `densities.cpp`
+is also the one file the browser build compiles at `-Oz` rather than
+`-O3`, worth 8.5 MB of wasm and about 10% on a mixture model.
 
 stanc3 as JavaScript is a separate 2.84 MB, 0.40 MB gzipped, and a page
-that ships precompiled MIR never fetches it. So the floor for sampling a
-known model in a browser is the 1.01 MB runtime alone.
+that ships precompiled MIR never fetches it.
 
-**The browser `lp__` is not CmdStan's.** `STANLI_LITE_LP` is what makes
-the numbers above, and it drops the propto instantiations, so `~`
-evaluates the full density and `lp__` differs from CmdStan's by a
-per-model constant. Gradients and every `write_array` value stay bitwise
-identical, and the posterior is the same posterior, but do not compare a
-browser `lp__` against a CmdStan run or feed it to anything reading log
-densities as absolute numbers. The wheels ship the exact build.
-`stanli_exact_lp()` reports which one is loaded. Details in
-[docs/lite-lp.md](docs/lite-lp.md).
+The browser build reports the same `lp__` as the wheels.
+`STANLI_LITE_LP` used to default on here, which halved the download and
+shifted `lp__` by a per-model constant; it is off everywhere now, so a
+browser run and a CmdStan run can be compared directly.
+`stanli_exact_lp()` still reports which build is loaded, for anyone who
+turns the flag back on. See [docs/lite-lp.md](docs/lite-lp.md), and
+[docs/density-pack.md](docs/density-pack.md) for the plan to get the
+download back down without giving up `lp__`.
 
 ## Python
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ pip install stanli
   <!--gen:corpus_bitwise-->45<!--/gen--> of them bitwise identical, worst
   relative deviation <!--gen:corpus_worst-->2.6e-12<!--/gen-->; per-model
   accuracy in relative terms and ULPs is listed there)
-- Install size: one 21.3 MB shared library, a 7.4 MB wheel. Breakdown
+- Install size: one 22.2 MB shared library, a 7.8 MB wheel. Breakdown
   in [Binary size](#binary-size) below; the browser build halves the
   runtime with `STANLI_LITE_LP` ([docs/lite-lp.md](docs/lite-lp.md)).
 - Distribution coverage: [docs/coverage.md](docs/coverage.md) (71 of 72
@@ -144,17 +144,17 @@ Stage by stage:
 
 ## Binary size
 
-One self-contained shared library, 21.3 MB installed, 7.4 MB compressed
-in the wheel. Attributing its 21.0 MB of code and data by symbol:
+One self-contained shared library, 22.2 MB installed, 7.8 MB compressed
+in the wheel. Attributing its 21.9 MB of code and data by symbol:
 
 | | | |
 | --- | ---: | ---: |
-| densities and distribution functions | 11.43 MB | 54.4% |
-| embedded stanc3 (all OCaml) | 5.73 MB | 27.3% |
-| stan-math, everything else | 0.64 MB | 3.1% |
-| Boost, nlohmann/json, NUTS, libc++, unattributed | 1.53 MB | 7.3% |
-| stanli itself | 0.84 MB | 4.0% |
-| Eigen (out-of-line) | 0.68 MB | 3.2% |
+| densities and distribution functions | 12.03 MB | 54.9% |
+| embedded stanc3 (all OCaml) | 5.73 MB | 26.1% |
+| stan-math, everything else | 0.78 MB | 3.6% |
+| Boost, nlohmann/json, NUTS, libc++, unattributed | 1.61 MB | 7.3% |
+| stanli itself | 0.92 MB | 4.2% |
+| Eigen (out-of-line) | 0.71 MB | 3.3% |
 | SUNDIALS | 0.14 MB | 0.7% |
 
 The densities are the majority, and the split above is measured the same
@@ -179,7 +179,7 @@ functions cost 0.03 MB between them, because an elementwise kernel with a
 hand-written derivative instantiates nothing.
 
 **`-DSTANLI_LITE_LP=ON` halves the runtime.** Dropping the propto family
-entirely takes `libstanli` from 14.9 MB to 7.79 MB stripped, at the cost
+entirely takes `libstanli` from 15.8 MB to 8.4 MB stripped, at the cost
 of an `lp__` that differs from CmdStan's by a per-model constant. Every
 gradient stays bit-identical; a pinned seed draws a different but equally
 valid chain, because the sampler adds `lp` to the kinetic energy and a

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -604,7 +604,8 @@ node tools/bench_wasm.cjs                      # fixtures, ns/gradient
 node tools/bench_wasm.cjs --module build-wasm-simd/stanli.js
 ```
 
-Measured on macOS arm64, emsdk 6.0.6 (the version CI pins):
+The A/B that turned SIMD on, measured on macOS arm64, emsdk 6.0.6 (the
+version CI pins), on the tree as it stood at that commit:
 
 | | scalar | +SIMD128 |
 |---|---:|---:|
@@ -612,6 +613,11 @@ Measured on macOS arm64, emsdk 6.0.6 (the version CI pins):
 | `radon_pooled` (919 obs, vectorized normal) | 107.9 us | **105.7 us** |
 | `nes` (matrix-heavy) | 29.1 us | **25.9 us** |
 | `stanli.wasm` gzipped | 1.02 MB | 1.05 MB |
+
+The absolute numbers have moved since -- the density surface roughly
+doubled -- and today's build is 4.10 MB raw, 1.15 MB gzipped, 478 ns
+geomean. The A/B above is kept as the decision record; rerun it against a
+freshly configured scalar build if the decision is ever revisited.
 
 SIMD128 is on. It is worth 2% on most shapes and 11% on the matrix-heavy
 one for 0.03 MB, and -- the part that made it an easy call -- every corpus
@@ -631,25 +637,41 @@ the relaxed-SIMD proposal and `-mrelaxed-simd`). The `-ffp-contract=off`
 pin that costs something on native costs exactly nothing in the browser,
 and fast-math is not a lever on this target at all.
 
-**Splitting densities into side modules is smaller than it looks.**
-Stubbing every generated density and cdf body and relinking says where the
-payload actually is:
+**Splitting densities into a lazily-loaded pack is viable, and the
+obstacle I expected is not there.** Stubbing every density, cdf and tail
+kernel and relinking says where the payload actually is:
 
 | | raw | gzip |
 |---|---:|---:|
-| core runtime alone | 1.95 MB | **0.62 MB** |
-| + 47 densities | 2.83 MB | 0.85 MB |
-| + 90 cdfs | 3.53 MB | 1.02 MB |
+| core runtime (plus `multi_normal`, `lkj_corr_cholesky`) | 2.26 MB | **0.69 MB** |
+| everything, as shipped | 4.10 MB | **1.15 MB** |
 
-So the whole splittable surface is 0.37 MB gzipped, against a 0.62 MB core
-that cannot be split -- and a model still needs its own densities, so the
-realistic saving is smaller again. Emscripten's `MAIN_MODULE`/`SIDE_MODULE`
-dynamic linking would put PIC codegen on that 0.62 MB core and add a round
-trip after `stanc`. If this is ever wanted, the cheap version is two
-prebuilt whole-module bundles (common densities vs everything) chosen once
-the compiled model's op set is known: no PIC, no dynamic linking, worst
-case one wasted fetch of the smaller file. The larger untouched lever is
-the core itself.
+So the density surface is 1.84 MB raw, **0.46 MB gzipped** -- 40% of the
+payload, against a 0.69 MB core that cannot be split. A model still needs
+its own densities, so the realistic saving is smaller than 0.46 MB, but it
+is no longer marginal: this doc previously said 0.37 MB against a bigger
+core, before the density list went from 47 to 71.
+
+The cost I assumed would eat it does not exist. Emscripten's
+`MAIN_MODULE=2` with `-fPIC` was measured against the same tree: **1.05 MB
+gzipped either way, 451 ns against 449 ns**. On wasm, calls already go
+indirect through a function table, so there is no PLT/GOT penalty of the
+kind native dynamic linking pays.
+
+The mechanism was proven end to end with a spike: a `SIDE_MODULE` built
+against these headers, loaded at runtime, calling **back into the main
+module** -- which is what lets a pack call `register_kernel`,
+`active_sink()` and libm from the core instead of carrying its own copies.
+Dispatch is already `kernel(opcode).forward`, a function-pointer table, so
+late registration only has to fill in slots, and the lowering already
+fails with `unsupported function <name>` -- so the trigger is
+self-correcting: try to lower, fetch the pack on that error, retry, with
+no density-name table duplicated in JavaScript.
+
+One requirement, found the hard way: the pack must be compiled with the
+same exception ABI (`-fwasm-exceptions`) as the core. Mismatched, it fails
+with an opaque `__stack_pointer` mutable-global import error that looks
+like a dynamic-linking bug and is not.
 
 ## Reproducing
 

--- a/docs/compact-densities.md
+++ b/docs/compact-densities.md
@@ -1,0 +1,110 @@
+# Compact densities: exact gradients, lp\_\_ off by a constant
+
+Most of stanli's densities reproduce CmdStan's `lp__` to the bit. The
+long tail does not, by choice. This is what that choice is, why it was
+made, and how to tell which kind you are looking at.
+
+## The claim
+
+For a density built the compact way:
+
+| | |
+|---|---|
+| gradients vs CmdStan | **bitwise** (measured, every one) |
+| `write_array` values | **bitwise** |
+| `lp__` vs CmdStan | a **per-model constant** higher |
+| draws for a pinned seed | a different but equally valid chain |
+
+The constant is the same at every point in parameter space. That is not a
+hope, it is the thing the verification checks: three evaluation points,
+same shift each time. A shift that *moved* with the parameters would mean
+something other than a dropped constant, and is the only way this can be
+wrong.
+
+## Why it happens
+
+stan-math decides which terms of a log density to keep by looking at the
+argument **types**. `include_summand<propto, T_y, T_loc, T_scale>` is a
+compile-time query, so `y ~ normal(mu, sigma)` with `sigma` as data drops
+`-log(sigma)` while the same statement with `sigma` as a parameter keeps
+it. Reproducing that exactly costs one instantiation of stan-math's
+template **per activity mask** -- which arguments are autodiff -- on top
+of the full form, and again for the elementwise variant. That is
+`4 * 2^N` copies per distribution, roughly 630 KB of object for a
+three-argument one.
+
+A compact density instantiates the template **once**, with every argument
+bound as an autodiff type. Everything is then "active", so
+`include_summand` keeps terms CmdStan drops, and `lp__` comes out higher
+by exactly those terms -- which are constants, because the only reason
+CmdStan could drop them is that they do not depend on any parameter.
+
+Nothing else changes. The dropped terms have no derivative with respect to
+anything active, so every partial is identical. Measured examples:
+
+| density | lp shift on its test model | worst gradient difference |
+|---|---|---|
+| `multi_student_t` | +0.81998355873446 | 0 |
+| `lkj_cov` | +0.28768207245200 | 0 |
+
+## Which densities are which
+
+**Exact** (mask-dispatched): the 13 distributions models lean on
+(`normal`, `cauchy`, `student_t`, `gamma`, `beta`, `lognormal`,
+`uniform`, `double_exponential`, `exponential`, `inv_gamma`,
+`std_normal`, `weibull`, `logistic`), the discrete ones with an integer
+outcome, `multi_normal` and its cholesky form, `lkj_corr_cholesky`,
+`dirichlet`, and the GLMs. These are what corpus models use, and they are
+held to bitwise `lp__` by `tools/verify_refs.py` on every push.
+
+**Compact**: the multivariate and multinomial tail --
+`multi_normal_prec`, `multi_student_t` and its cholesky form, the wishart
+family, `multi_gp` and its cholesky form, `lkj_cov`, the multinomial
+family, `ordered_probit`, `wiener`. The tier is visible in the source:
+they live in `runtime/kernels/matrix_fns.cpp` on a nested var tape rather
+than in `densities.cpp` behind `mask_dispatch`.
+
+The 4th field of `STANLI_SCALAR_DENSITY_LIST` in
+`runtime/include/stanli/optable.hpp` says it for the scalar ones -- see
+`density_tier` there for the two bits it encodes.
+
+## Why this is the right trade for the tail
+
+The whole tail at full fidelity would cost more than the rest of the
+library. Measured: giving the 13 common distributions' *cdfs* alone the
+mask dispatch cost 4.8 MB, against 2.2 MB for all 72 of them without it.
+Multiply that across the multivariate densities, whose arguments are
+matrices, and the exact tier buys `lp__` fidelity on distributions nobody
+has profiled at a price paid by every install.
+
+And `lp__` is the one output that does not affect inference. It is a
+diagnostic: people watch it for convergence, where a constant offset is
+invisible, and compare it *within* a run, where it cancels. The gradient
+is what the sampler integrates, and that is bitwise.
+
+The same reasoning, applied globally instead of per-density, is
+`STANLI_LITE_LP` -- see [docs/lite-lp.md](lite-lp.md). The browser build
+turns it on for every density and halves the runtime.
+
+## If you need a tail density to be exact
+
+Give it the activity-mask dispatch. `multi_normal` in
+`runtime/kernels/matrix_fns.cpp` shows the shape: an if-chain over the
+mask bits binding each argument as `var` or `double`, so stan-math sees
+the same types CmdStan's generated code does. It is `2^N` branches and
+`2^N` instantiations, and it is the reason `multi_normal` is exact while
+`multi_normal_prec` -- the same kernel with one call swapped -- is not.
+
+## Checking it yourself
+
+There is no automated per-density check for the shift, because the corpus
+does not use these densities and `harnesses/fn_sweep.py` only generates
+all-scalar models. The manual version, for a model using the density:
+
+```
+build/stanli_check model.stan data.json --point 0   # and 1, 2
+```
+
+against `tools/ref_driver.cpp` compiled with CmdStan on the same model.
+Gradients must agree to the bit; the `lp__` difference must be the same
+number at all three points. Anything else is a bug, not a tier.

--- a/docs/coverage.md
+++ b/docs/coverage.md
@@ -7,7 +7,7 @@ with a generated single-function model.
 
 | family | supported |
 |---|---|
-| densities (`_lpdf`, `_lpmf`) | 50 / 72 |
+| densities (`_lpdf`, `_lpmf`) | 54 / 72 |
 | distribution functions (`_cdf`, `_lcdf`, `_lccdf`) | 90 / 105 |
 | scalar math (all-real signature) | 47 / 129 |
 
@@ -20,6 +20,46 @@ Adding one is a line in an X-macro list in
 `runtime/include/stanli/optable.hpp`, which generates the opcode, the
 kernel, its registration, the lowering table entry and the interpreter
 branch together. See `docs/hacking.md`.
+
+## Three ways in, cheapest first
+
+Not every density needs a kernel, and reaching for one first is how this
+list stayed short longer than it had to.
+
+**1. Rewrite, when the rewrite is exact.** `y ~ foo(...)` with every
+argument data contributes EXACTLY zero: CmdStan's generated code calls
+`foo_lpdf<propto=true>` on all-double arguments, `include_summand` comes
+back false, and the term is dropped before any arithmetic. That is a
+general rule, not an approximation, and it needs no kernel at all -- which
+is the whole of `hypergeometric` and `discrete_range`, whose arguments are
+all integers so every use of them lands here. `target +=` of the same call
+is a compile-time constant through the data interpreter. (The one
+divergence: a model whose data is outside the density's support -- CmdStan
+throws from its checks, stanli contributes 0. Such a model rejects every
+draw either way.)
+
+What does NOT belong here is a rewrite that changes the arithmetic.
+`multi_normal_prec(y | mu, P)` is `multi_normal(y | mu, inverse(P))`
+mathematically, but it costs a K^3 inverse per evaluation and stops
+matching CmdStan bitwise, which is the oracle this project runs on. The
+kernel below was fifteen lines.
+
+**2. Clone, when a signature already exists.** `multi_normal_prec` takes
+the same three arguments in the same shapes as `multi_normal`;
+`lkj_corr` the same two as `lkj_corr_cholesky`. Both were one template
+parameter on an existing kernel. Worth checking for before writing
+anything: the remaining pairs (`wishart`/`inv_wishart`,
+`multi_gp`/`multi_gp_cholesky`, `multi_student_t`/its cholesky form) are
+clones of each other, so the first of each pair pays for two.
+
+**3. Write the kernel.** The var-tape-replay pattern (`multi_normal`,
+`lkj_corr_cholesky`) is correct by construction and needs no hand-written
+derivative: build a nested tape, call stan-math, `grad()` it. What makes
+each of the remaining ones bespoke is only the SHAPE PLUMBING -- how a
+matrix or an array-of-vectors argument reaches the kernel -- not the math.
+A generic matrix-density kernel driven by a small descriptor table would
+turn most of the list below into table rows, and is the obvious next
+structural move.
 
 ## The gaps, and what each one actually needs
 

--- a/docs/coverage.md
+++ b/docs/coverage.md
@@ -7,14 +7,20 @@ with a generated single-function model.
 
 | family | supported |
 |---|---|
-| densities (`_lpdf`, `_lpmf`) | 54 / 72 |
+| densities (`_lpdf`, `_lpmf`) | 71 / 72 |
 | distribution functions (`_cdf`, `_lcdf`, `_lccdf`) | 90 / 105 |
 | scalar math (all-real signature) | 47 / 129 |
 
-Everything supported matches CmdStan **bitwise** -- 0 ULP on every
-argument
-slot, at three evaluation points. That is the standard here; a density that
-merely agrees to 1e-12 is a bug report, not a feature.
+Every supported density's **gradients** match CmdStan bitwise, at three
+evaluation points. That is the standard here, and a density whose
+gradients merely agree to 1e-12 is a bug report, not a feature.
+
+`lp__` is bitwise too for everything models actually lean on. It is
+**not** for the multivariate and multinomial tail, which is built the
+compact way: one instantiation instead of `2^N`, so `lp__` comes out a
+per-model constant higher while every gradient stays exact. Which
+densities, why, and how to check:
+[docs/compact-densities.md](compact-densities.md).
 
 Adding one is a line in an X-macro list in
 `runtime/include/stanli/optable.hpp`, which generates the opcode, the
@@ -52,109 +58,42 @@ anything: the remaining pairs (`wishart`/`inv_wishart`,
 `multi_gp`/`multi_gp_cholesky`, `multi_student_t`/its cholesky form) are
 clones of each other, so the first of each pair pays for two.
 
-**3. Write the kernel.** The var-tape-replay pattern (`multi_normal`,
-`lkj_corr_cholesky`) is correct by construction and needs no hand-written
-derivative: build a nested tape, call stan-math, `grad()` it. What makes
-each of the remaining ones bespoke is only the SHAPE PLUMBING -- how a
-matrix or an array-of-vectors argument reaches the kernel -- not the math.
-A generic matrix-density kernel driven by a small descriptor table would
-turn most of the list below into table rows, and is the obvious next
-structural move.
+**3. Write the kernel.** The var-tape-replay pattern is correct by
+construction and needs no hand-written derivative: build a nested tape,
+call stan-math, `grad()` it. What makes each one bespoke is only the SHAPE
+PLUMBING -- how a matrix or an array-of-vectors argument reaches the
+kernel -- not the math. The shared helpers (`tail_m`, `tail_v`,
+`tail_scatter_*` in `runtime/kernels/matrix_fns.cpp`) reduce each to about
+twenty lines.
 
-## The gaps, and what each one actually needs
+This tier also has no restriction on what the density does with its scalar
+type, which the recorder does: `ordered_probit` computes
+`c_vec[i].coeff(0) - lambda_vec[i]` and `wiener` does `res *= 0.0`, and
+`stan::math::var` has those operators where `rvar` deliberately does not.
+Both were written off as unreachable until they were tried on a var tape.
 
-### Ordinal regression -- `ordered_logistic` is in, `ordered_probit` is not
+These kernels are **compact** -- one instantiation, every argument bound
+as autodiff -- so `lp__` carries a per-model constant while the gradients
+stay exact. [docs/compact-densities.md](compact-densities.md) is the
+contract.
 
-`ordered_logistic` works and matches CmdStan bitwise. Getting there needed
-three things, and the first was a wrong diagnosis: the recorder's Eigen
-edge already *has* `partials_vec_`, so the vector-of-vectors partials were
-never the problem. What actually blocked it was that the failing edge was
-the **scalar** one -- `bind_args_m` compiles both shape branches, and a
-cutpoint set bound as a scalar picks stan-math overloads the scalar edge
-cannot serve. `VecMask` (densities.cpp) marks an argument as a vector
-whatever its length, which is correct anyway: a one-element cutpoint set
-is a one-element vector.
+## What is left
 
-The other two: the outcome goes over as a `std::vector<int>`, because
-`ordered_logistic` asks `scalar_seq_view` for a mutable `data()` that an
-`Eigen::Map<const VectorXi>` cannot give (and a `std::vector` is what
-CmdStan's generated code passes, so it is the instantiation the references
-came from); and `rvar` gained a `Scalar` member -- see below.
+**`gaussian_dlm_obs`** -- the only unsupported density, and for a
+structural reason rather than a mathematical one. It takes seven
+arguments; `Op::in` holds six. Raising the limit would add bytes to every
+`Op` and every `KernelCtx` in every model, for one dynamic-linear-model
+density, so the lowering refuses and says why. (`add_op` used to write
+past the array without a word: a seven-input op corrupted `n_in` and
+surfaced as a SIGBUS inside the kernel. It throws now.)
 
-`ordered_probit` is still out, for the recorder's structural reason:
-`c_vec[i].coeff(0) - lambda_vec[i]` does arithmetic on the scalar type.
+**Vector `alpha` in the GLMs.** `bernoulli_logit_glm`, `poisson_log_glm`
+and `neg_binomial_2_log_glm` take the intercept as a scalar; stan-math
+also allows a per-row vector. The kernels refuse that form by name.
 
-### Multivariate -- wishart, `multi_student_t`, `multi_normal_prec`,
-`multi_gp`, `lkj_corr`, `gaussian_dlm_obs`
-
-Matrix arguments, each with its own shape plumbing. `multi_normal`,
-`multi_normal_cholesky`, `lkj_corr_cholesky` and `dirichlet` are already
-in as hand-written kernels; these would follow the same pattern, one at a
-time.
-
-### GLM fast paths -- `binomial_logit_glm`, `categorical_logit_glm`, `ordered_logistic_glm`
-
-`bernoulli_logit_glm`, `poisson_log_glm` and `neg_binomial_2_log_glm` are
-in, and show the shape: a data matrix in a row-major slot with its dims in
-`idata`, alpha as a scalar intercept (the per-row vector form is not
-wired). These matter for coverage rather than speed -- brms and rstanarm
-emit the GLM form directly, so a model using one does not merely run
-slower, it does not run.
-
-They were also the one density shape the lowering gave no variant at all,
-so their kernels hardcoded `propto=false`, and `poisson_log_glm`'s lp came
-out `sum(log(y!))` away from CmdStan's -- 10.45 on a six-row test -- with
-the gradients already exact. They take the same variant as every other
-density now. Setting only the propto bit is not an option: `density_bwd`
-reads a nonzero variant as a literal mask, so `0x80` alone means "no
-argument is active" and every gradient comes back zero.
-
-### Multinomial family -- `multinomial`, `multinomial_logit`, `dirichlet_multinomial`, `hypergeometric`, `discrete_range`
-
-Integer outcomes that are not one int per lane: an array of counts.
-`beta_binomial` is in, through the two-int-group unpacking `binomial`
-already used (`with_int_group` in `densities.cpp`); the rest need their own
-layouts.
-`hypergeometric` and `discrete_range` have no real arguments at all, so
-they contribute a constant and no gradient.
-
-### The 18 remaining distribution functions
-
-`binomial` and `beta_binomial` carry a second int group (the trial count)
-and `discrete_range` is integers all the way down, so those nine want a
-layout rather than a list line -- `with_int_group` in `densities.cpp`
-shows
-the shape.
-
-`neg_binomial_2`'s three reparameterize to `neg_binomial` by computing
-`phi / mu` **on the scalar type**, which is the recorder's hard limit
-again (see below). The other six are `von_mises` and
-`skew_double_exponential`, also below.
-
-### Two that will not work as they stand
-
-- **`von_mises_cdf`** does `res *= 0.0` on the scalar type at a degenerate
-  endpoint. The recorder computes in doubles and carries no tape, so that
-  assignment would change the value and leave the partials describing the
-  old one. `rvar` deliberately has no arithmetic operators, which is why
-  this fails to compile rather than silently producing a wrong gradient.
-`skew_double_exponential`'s three cdfs used to be listed here for a
-related reason and are now in. The cause was the same missing trait: we
-register `is_fvar<rvar>`, and stan-math's fvar `value_type` specialization
-is written `typename std::decay_t<T>::Scalar` -- which applies to
-`const rvar&` as much as to `rvar`, and asked for a member `rvar` did not
-have. A real `fvar` defines `Scalar`; we claimed the trait without
-honouring that part of its contract. One member declaration, and three
-cdfs plus `ordered_logistic` compiled.
-
-### `wiener_lpdf`
-
-The only remaining all-real scalar density, and it fails the same way
-`von_mises_cdf` does: it computes with the scalar type directly
-(`square(y - tau)`, comparisons against doubles) rather than deriving
-partials in doubles. Same fix would be needed -- a tape, or a
-hand-written
-kernel.
+**`corr_matrix` and `cholesky_factor_cov` parameter transforms.** Not
+densities, but they are why `lkj_corr` and the wisharts have to be
+reached through a transformed parameter rather than declared directly.
 
 ## Truncation and censoring
 

--- a/docs/coverage.md
+++ b/docs/coverage.md
@@ -7,7 +7,7 @@ with a generated single-function model.
 
 | family | supported |
 |---|---|
-| densities (`_lpdf`, `_lpmf`) | 47 / 72 |
+| densities (`_lpdf`, `_lpmf`) | 50 / 72 |
 | distribution functions (`_cdf`, `_lcdf`, `_lccdf`) | 90 / 105 |
 | scalar math (all-real signature) | 47 / 129 |
 
@@ -52,21 +52,29 @@ Matrix arguments, each with its own shape plumbing. `multi_normal`,
 in as hand-written kernels; these would follow the same pattern, one at a
 time.
 
-### GLM fast paths -- `poisson_log_glm`, `neg_binomial_2_log_glm`,
-`binomial_logit_glm`, `categorical_logit_glm`, `ordered_logistic_glm`
+### GLM fast paths -- `binomial_logit_glm`, `categorical_logit_glm`, `ordered_logistic_glm`
 
-`bernoulli_logit_glm` is in and shows the shape: a data matrix in a
-row-major slot with its dims in `idata`. These matter for coverage rather
-than speed -- brms and rstanarm emit the GLM form directly, so a model
-using one does not merely run slower, it does not run.
+`bernoulli_logit_glm`, `poisson_log_glm` and `neg_binomial_2_log_glm` are
+in, and show the shape: a data matrix in a row-major slot with its dims in
+`idata`, alpha as a scalar intercept (the per-row vector form is not
+wired). These matter for coverage rather than speed -- brms and rstanarm
+emit the GLM form directly, so a model using one does not merely run
+slower, it does not run.
 
-### Multinomial family -- `multinomial`, `multinomial_logit`,
-`dirichlet_multinomial`, `beta_binomial`, `hypergeometric`,
-`discrete_range`
+They were also the one density shape the lowering gave no variant at all,
+so their kernels hardcoded `propto=false`, and `poisson_log_glm`'s lp came
+out `sum(log(y!))` away from CmdStan's -- 10.45 on a six-row test -- with
+the gradients already exact. They take the same variant as every other
+density now. Setting only the propto bit is not an option: `density_bwd`
+reads a nonzero variant as a literal mask, so `0x80` alone means "no
+argument is active" and every gradient comes back zero.
 
-Integer outcomes that are not one int per lane: an array of counts, or two
-int groups. `binomial` already carries two groups
-(`with_int_group` in `densities.cpp`); the rest need their own layouts.
+### Multinomial family -- `multinomial`, `multinomial_logit`, `dirichlet_multinomial`, `hypergeometric`, `discrete_range`
+
+Integer outcomes that are not one int per lane: an array of counts.
+`beta_binomial` is in, through the two-int-group unpacking `binomial`
+already used (`with_int_group` in `densities.cpp`); the rest need their own
+layouts.
 `hypergeometric` and `discrete_range` have no real arguments at all, so
 they contribute a constant and no gradient.
 

--- a/docs/density-pack.md
+++ b/docs/density-pack.md
@@ -1,0 +1,116 @@
+# Splitting the browser runtime: core plus an on-demand density pack
+
+Design notes for loading uncommon densities lazily in the browser. Nothing
+here is implemented yet. The measurements and the feasibility spike are
+done, and this records them so the work does not start from guesses.
+
+## The problem
+
+`stanli.wasm` ships every density, and a model uses a handful. The browser
+pays for all of them before it can do anything.
+
+## What the payload is made of
+
+Measured by stubbing every density, cdf and tail kernel and relinking
+(macOS arm64, emsdk 6.0.6):
+
+| | raw | gzip |
+|---|---:|---:|
+| core runtime, plus `multi_normal` and `lkj_corr_cholesky` | 2.26 MB | 0.69 MB |
+| everything, as shipped | 4.10 MB | 1.15 MB |
+
+The density surface is 1.84 MB raw, 0.46 MB gzipped: 40% of the payload.
+The core cannot be split.
+
+These numbers are from the `STANLI_LITE_LP` build. That flag is now off by
+default, so both figures grow; re-measure before sizing anything.
+
+## Why dynamic linking is affordable
+
+Emscripten's `MAIN_MODULE=2` with `-fPIC`, measured against the same tree:
+
+| | static | MAIN_MODULE=2 + fPIC |
+|---|---:|---:|
+| `stanli.wasm` gzipped | 1.05 MB | 1.05 MB |
+| fixtures, geomean | 449 ns | 451 ns |
+
+No measurable cost. WebAssembly calls already go indirect through a
+function table, so there is no PLT or GOT penalty of the kind native
+dynamic linking pays. An earlier version of `docs/benchmarks.md` assumed
+this cost would exceed the saving and concluded the split was not worth
+doing. That assumption was wrong.
+
+## The mechanism works
+
+A spike built a `SIDE_MODULE` against these headers, loaded it at runtime
+with `dlopen`, and called a function in it that called back into the main
+module. The call returned the expected value, which means a pack can use
+`register_kernel`, `active_sink()` and libm from the core instead of
+carrying its own copies.
+
+Three properties of the existing design make this fit:
+
+1. Dispatch is already `kernel(opcode).forward`, a function-pointer table.
+   Late registration only has to fill in slots.
+2. The lowering already fails with `unsupported function <name>`. The
+   trigger is therefore self-correcting: try to lower, fetch the pack on
+   that error, retry. No table of density names has to be duplicated in
+   JavaScript.
+3. `dlopen` and `dlsym` stay inside C. JavaScript only has to put the pack
+   where the loader can read it, then call one exported entry point.
+
+**Requirement found the hard way:** the pack must be compiled with the same
+exception ABI as the core (`-fwasm-exceptions`). Without it the load fails
+with `imported mutable global must be a WebAssembly.Global object` on
+`__stack_pointer`, which reads like a dynamic-linking bug and is not.
+
+## Sketch
+
+Core exports one entry:
+
+```c
+/* Load a density pack and let it register its kernels. Returns 0 on
+   success. */
+int stanli_load_pack(const char* path);
+```
+
+which does `dlopen(path, RTLD_NOW | RTLD_GLOBAL)`, `dlsym` for
+`stanli_pack_register`, and calls it. The pack's `stanli_pack_register`
+calls `register_kernel` once per opcode it provides.
+
+On the JavaScript side, `stanli_model_new` fails with the unsupported
+function name; the worker fetches `stanli-pack.wasm`, writes it to the
+emscripten filesystem, calls `stanli_load_pack`, and retries the compile
+once. A second failure is a real error.
+
+## What has to be decided
+
+**Where the line goes.** Which densities are core and which are packed.
+The density list only just settled at 71 of 72, which is why this work was
+deferred: re-splitting later means re-verifying both artifacts. A starting
+point is the tier field in `STANLI_SCALAR_DENSITY_LIST` (tier 3 is the
+thirteen distributions models lean on) plus the discrete lpmfs, with the
+cdfs and the multivariate tail in the pack.
+
+**How many packs.** One is simplest. Splitting cdfs from the multivariate
+tail would save a truncation-only model from downloading wisharts, at the
+cost of a second artifact to build, verify and cache.
+
+**Whether the wheel does this too.** Probably not. The wheel is one file
+on disk and its size is not on anyone's critical path; the browser's is.
+
+## Alternative, if dynamic linking turns out to be a problem
+
+Two prebuilt whole-module bundles, common densities and everything,
+selected once the compiled model's op set is known. No PIC, no dynamic
+linking, and the worst case is one wasted fetch of the smaller file. This
+was the fallback before PIC was measured. It is strictly worse when
+dynamic linking works, because it cannot add to a running module.
+
+## Verification this will need
+
+The corpus replay already runs through the browser build
+(`tools/wasm_check.sh` with `tools/verify_refs.py`). A split runtime has to
+pass it with the pack loaded, and separately has to fail cleanly with the
+pack absent: a model needing a packed density must report the unsupported
+function, not compute a wrong answer. Both belong in CI.

--- a/docs/density-pack.md
+++ b/docs/density-pack.md
@@ -17,13 +17,15 @@ Measured by stubbing every density, cdf and tail kernel and relinking
 | | raw | gzip |
 |---|---:|---:|
 | core runtime, plus `multi_normal` and `lkj_corr_cholesky` | 2.26 MB | 0.69 MB |
-| everything, as shipped | 4.10 MB | 1.15 MB |
+| everything, as shipped | 5.79 MB | 1.52 MB |
 
-The density surface is 1.84 MB raw, 0.46 MB gzipped: 40% of the payload.
-The core cannot be split.
+The density surface is 3.53 MB raw, 0.83 MB gzipped: 55% of the compressed
+download. The core cannot be split.
 
-These numbers are from the `STANLI_LITE_LP` build. That flag is now off by
-default, so both figures grow; re-measure before sizing anything.
+The core figure is from a build with every density body stubbed, so
+`STANLI_LITE_LP` had nothing to act on and the number holds for either
+setting. The total is the shipped build, which is exact-lp since that flag
+went off by default.
 
 ## Why dynamic linking is affordable
 

--- a/docs/lite-lp.md
+++ b/docs/lite-lp.md
@@ -34,7 +34,7 @@ every `write_array` value is **bitwise identical** to the exact build, and
 
 | | exact | lite |
 |---|---|---|
-| `libstanli` stripped (macOS arm64) | 14.93 MB | 7.79 MB |
+| `libstanli` stripped (macOS arm64) | 15.75 MB | 8.43 MB |
 | gradients vs CmdStan | bitwise | bitwise |
 | `lp__` vs CmdStan | bitwise | constant offset |
 | draws for a pinned seed | -- | different chain, same posterior |

--- a/docs/lite-lp.md
+++ b/docs/lite-lp.md
@@ -110,7 +110,7 @@ python3 tools/verify_lite.py deps/posteriordb
 1. **Gradients bitwise.** Not "close" -- the same computation.
 2. **The lp shift is constant.** Evaluated at three points in the
    unconstrained space, `lp_exact - lp_lite` must come out the same every
-   time. This is the load-bearing check: a shift that *moved* with the
+   time. This is the check that matters: a shift that *moved* with the
    parameters would mean a dropped term was not constant after all, which
    is the only way this flag can be wrong, and it would show up as an O(1)
    relative change.

--- a/harnesses/fn_sweep.py
+++ b/harnesses/fn_sweep.py
@@ -94,6 +94,8 @@ DENSITIES = [
     ("neg_binomial_2_log_lpmf", 3, [3, 0.4, 1.3]),
     ("beta_neg_binomial_lpmf", 4, [3, 2.0, 3.0, 1.3]),
     ("yule_simon_lpmf", 2, [3, 1.3]),
+    # Two integer groups: the outcome and the trial count.
+    ("beta_binomial_lpmf", 4, [3, 10, 2.0, 3.0]),
 ]
 
 def cdf_specs(pool):

--- a/js/README.md
+++ b/js/README.md
@@ -30,13 +30,13 @@ parameters, and generated quantities (RNG draws stream from `seed`).
 The heavy work runs in a worker the package owns, so the page never
 blocks; calls queue and run one at a time.
 
-The payload is ~6.5 MB installed (~1.4 MB over the wire with gzip): the WASM
+The payload is ~7 MB installed (~1.6 MB over the wire with gzip): the WASM
 runtime plus the stanc3 compiler. The compiler loads lazily, only when a
 call passes Stan source. `preload()` starts both loads in the background
 -- call it at page idle and the user's first `sample()` begins at full
 speed instead of paying the fetch and parse on their click; an app that ships a fixed model can precompile
 it at build time (`stanc --debug-transformed-mir model.stan`) and pass
-`mir` instead of `code`, and the runtime alone is ~1.0 MB gzipped. 118 of 119 posteriordb corpus models
+`mir` instead of `code`, and the runtime alone is ~1.2 MB gzipped. 118 of 119 posteriordb corpus models
 verify against CmdStan's log density, gradients, and write_array values
 from inside this WASM build; see the
 [repository](https://github.com/seantalts/stanli) for the verification

--- a/js/README.md
+++ b/js/README.md
@@ -30,24 +30,17 @@ parameters, and generated quantities (RNG draws stream from `seed`).
 The heavy work runs in a worker the package owns, so the page never
 blocks; calls queue and run one at a time.
 
-The payload is ~7 MB installed (~1.6 MB over the wire with gzip): the WASM
+The payload is ~9 MB installed (~1.9 MB over the wire with gzip): the WASM
 runtime plus the stanc3 compiler. The compiler loads lazily, only when a
 call passes Stan source. `preload()` starts both loads in the background
 -- call it at page idle and the user's first `sample()` begins at full
 speed instead of paying the fetch and parse on their click; an app that ships a fixed model can precompile
 it at build time (`stanc --debug-transformed-mir model.stan`) and pass
-`mir` instead of `code`, and the runtime alone is ~1.2 MB gzipped. 118 of 119 posteriordb corpus models
+`mir` instead of `code`, and the runtime alone is ~1.5 MB gzipped. 118 of 119 posteriordb corpus models
 verify against CmdStan's log density, gradients, and write_array values
 from inside this WASM build; see the
 [repository](https://github.com/seantalts/stanli) for the verification
 policy and numbers.
-
-This build is compiled with `STANLI_LITE_LP`, which drops stan-math's
-propto instantiations to halve the runtime. Gradients are bit-identical
-to the exact build and the posterior is the same one; `lp__` sits a
-per-model constant lower, so compare it across chains rather than against
-CmdStan, and a pinned seed gives a different (equally valid) chain than
-the native build would. `fit.exactLp` reports which build you have.
 
 Not yet here: variational inference, optimization, multi-chain
 threading. `wasm32` caps memory at 4 GB, which one 79,000-parameter

--- a/js/worker.js
+++ b/js/worker.js
@@ -147,10 +147,11 @@ onmessage = async (e) => {
     postMessage({
       done: {
         names, samples,
-        // This build drops stan-math's propto instantiations for size, so
-        // lp__ carries a per-model constant the exact build does not.
-        // Draws are unaffected; surfaced so a caller comparing lp__ across
-        // engines can see it rather than chase it.
+        // True unless the runtime was built with STANLI_LITE_LP, which
+        // drops stan-math's propto instantiations and shifts lp__ by a
+        // per-model constant. The shipped browser build does not, so this
+        // is true; it stays in the payload so a caller that compares lp__
+        // across engines can check rather than assume.
         exactLp: M._stanli_exact_lp() !== 0,
         columns: cols.buffer,
         ms: {

--- a/python/README.md
+++ b/python/README.md
@@ -170,7 +170,7 @@ Wheels for macOS (arm64 and x86_64) and Linux (x86_64 and aarch64,
 manylinux_2_28). Windows is not built yet; it needs a mingw-w64 toolchain,
 because stan-math does not build under MSVC.
 
-The installed library is 21.3 MB, which is the trade this design makes:
+The installed library is 22.2 MB, which is the trade this design makes:
 ship the compiler and every kernel once, so that nothing is ever built on
 the user's machine. Roughly half of that is the embedded stanc3 and
 somewhat under half is stan-math. The interpreter and NUTS together are

--- a/runtime/include/stanli/graph.hpp
+++ b/runtime/include/stanli/graph.hpp
@@ -8,6 +8,7 @@
 #include <initializer_list>
 #include <memory>
 #include <string>
+#include <stdexcept>
 #include <vector>
 
 namespace stanli {
@@ -64,6 +65,13 @@ struct Graph {
     op.opcode = opcode;
     op.out = out;
     op.n_in = 0;
+    // Op::in is fixed-size and this used to write past it without a
+    // word: a 7-input op corrupted n_in and whatever followed, and the
+    // failure surfaced as a SIGBUS inside the kernel rather than here.
+    // Six is a real ceiling on the lowering, so say so at the point that
+    // knows.
+    if (ins.size() > sizeof(op.in) / sizeof(op.in[0]))
+      throw std::length_error("op has more inputs than Op::in holds");
     for (int s : ins) op.in[op.n_in++] = s;
     if (!idata.empty()) {
       idata_pool.push_back(std::move(idata));

--- a/runtime/include/stanli/mir_interp.hpp
+++ b/runtime/include/stanli/mir_interp.hpp
@@ -1178,7 +1178,9 @@ class MirInterp {
         e.name == "binomial_lpmf" || e.name == "poisson_lpmf" ||
         e.name == "poisson_log_lpmf" || e.name == "student_t_lpdf" ||
         e.name == "bernoulli_logit_lpmf" ||
-        e.name == "binomial_logit_lpmf") {
+        e.name == "binomial_logit_lpmf" ||
+        e.name == "hypergeometric_lpmf" ||
+        e.name == "discrete_range_lpmf") {
       std::vector<Value> av;
       for (const auto& a : e.args) av.push_back(eval(a));
       size_t n = 1;
@@ -1219,6 +1221,12 @@ class MirInterp {
           acc += stan::math::poisson_lpmf(ic(0, i), sc(1, i));
         else if (e.name == "poisson_log_lpmf")
           acc += stan::math::poisson_log_lpmf(ic(0, i), sc(1, i));
+        else if (e.name == "hypergeometric_lpmf")
+          acc += stan::math::hypergeometric_lpmf(ic(0, i), ic(1, i),
+                                                 ic(2, i), ic(3, i));
+        else if (e.name == "discrete_range_lpmf")
+          acc += stan::math::discrete_range_lpmf(ic(0, i), ic(1, i),
+                                                 ic(2, i));
         else if (e.name == "student_t_lpdf")
           acc += stan::math::student_t_lpdf(sc(0, i), sc(1, i), sc(2, i),
                                             sc(3, i));

--- a/runtime/include/stanli/optable.hpp
+++ b/runtime/include/stanli/optable.hpp
@@ -50,6 +50,23 @@ namespace stanli {
   X(OP_CONSTRAIN_CHOL_CORR)                                               \
   X(OP_LKJ_CORR_CHOL_LPDF)                                                \
   X(OP_LKJ_CORR_LPDF)                                                     \
+  X(OP_WISHART_LPDF)                                                      \
+  X(OP_INV_WISHART_LPDF)                                                  \
+  X(OP_WISHART_CHOL_LPDF)                                                 \
+  X(OP_INV_WISHART_CHOL_LPDF)                                             \
+  X(OP_MULTI_GP_LPDF)                                                   \
+  X(OP_MULTI_GP_CHOL_LPDF)                                              \
+  X(OP_MULTI_STUDENT_T_LPDF)                                            \
+  X(OP_MULTI_STUDENT_T_CHOL_LPDF)                                       \
+  X(OP_MULTINOMIAL_LPMF)                                                \
+  X(OP_MULTINOMIAL_LOGIT_LPMF)                                          \
+  X(OP_DIRICHLET_MULTINOMIAL_LPMF)                                      \
+  X(OP_ORDERED_PROBIT_LPMF)                                             \
+  X(OP_WIENER_LPDF)                                                     \
+  X(OP_LKJ_COV_LPDF)                                                    \
+  X(OP_BINOMIAL_LOGIT_GLM_LPMF)                                         \
+  X(OP_CATEGORICAL_LOGIT_GLM_LPMF)                                      \
+  X(OP_ORDERED_LOGISTIC_GLM_LPMF)                                       \
   X(OP_NORMAL_ID_GLM_LPDF)                                                \
   X(OP_TRANSPOSE)                                                         \
   X(OP_ODE)                                                               \

--- a/runtime/include/stanli/optable.hpp
+++ b/runtime/include/stanli/optable.hpp
@@ -136,13 +136,25 @@ namespace stanli {
 // all. STANLI_LITE_LP clears bit 1 across the board -- see density_tier.
 #define STANLI_DENSITY_FULL_MASKS 1
 #define STANLI_DENSITY_PROPTO 2
-#define STANLI_SCALAR_DENSITY_LIST_COMMON(X) \
+// The sub-lists are the shard boundaries. Each one is a translation unit
+// (densities_*.cpp), because the instantiations are what make this
+// expensive to compile: the tier-3 distributions below expand to 4 * 2^N
+// copies of a stan-math template each, and one file holding all of them
+// peaked at 7.6 GB of compiler memory. Splitting is the only lever, since
+// the instantiations themselves are the product.
+//
+// Balance them by COST, not by count. A tier-3 four-argument density is
+// worth about eight tier-2 two-argument ones, which is why COMMON_A holds
+// six entries and REST_A holds seven.
+#define STANLI_SCALAR_DENSITY_LIST_COMMON_A(X) \
   X(OP_NORMAL_LPDF, normal_lpdf, 3, 3) \
   X(OP_CAUCHY_LPDF, cauchy_lpdf, 3, 3) \
-  X(OP_STUDENT_T_LPDF, student_t_lpdf, 4, 3) \
   X(OP_GAMMA_LPDF, gamma_lpdf, 3, 3) \
   X(OP_BETA_LPDF, beta_lpdf, 3, 3) \
-  X(OP_LOGNORMAL_LPDF, lognormal_lpdf, 3, 3) \
+  X(OP_LOGNORMAL_LPDF, lognormal_lpdf, 3, 3)
+
+#define STANLI_SCALAR_DENSITY_LIST_COMMON_B(X) \
+  X(OP_STUDENT_T_LPDF, student_t_lpdf, 4, 3) \
   X(OP_UNIFORM_LPDF, uniform_lpdf, 3, 3) \
   X(OP_DOUBLE_EXP_LPDF, double_exponential_lpdf, 3, 3) \
   X(OP_EXPONENTIAL_LPDF, exponential_lpdf, 2, 3) \
@@ -151,7 +163,11 @@ namespace stanli {
   X(OP_WEIBULL_LPDF, weibull_lpdf, 3, 3) \
   X(OP_LOGISTIC_LPDF, logistic_lpdf, 3, 3)
 
-#define STANLI_SCALAR_DENSITY_LIST_REST(X) \
+#define STANLI_SCALAR_DENSITY_LIST_COMMON(X) \
+  STANLI_SCALAR_DENSITY_LIST_COMMON_A(X) \
+  STANLI_SCALAR_DENSITY_LIST_COMMON_B(X)
+
+#define STANLI_SCALAR_DENSITY_LIST_REST_A(X) \
   X(OP_CHI_SQUARE_LPDF, chi_square_lpdf, 2, 2) \
   X(OP_INV_CHI_SQUARE_LPDF, inv_chi_square_lpdf, 2, 2) \
   X(OP_SCALED_INV_CHI_SQUARE_LPDF, scaled_inv_chi_square_lpdf, 3, 2) \
@@ -159,13 +175,19 @@ namespace stanli {
   X(OP_GUMBEL_LPDF, gumbel_lpdf, 3, 2) \
   X(OP_LOGLOGISTIC_LPDF, loglogistic_lpdf, 3, 2) \
   X(OP_PARETO_LPDF, pareto_lpdf, 3, 2) \
+  X(OP_SKEW_NORMAL_LPDF, skew_normal_lpdf, 4, 2) \
+  X(OP_EXP_MOD_NORMAL_LPDF, exp_mod_normal_lpdf, 4, 2)
+
+#define STANLI_SCALAR_DENSITY_LIST_REST_B(X) \
   X(OP_PARETO_TYPE_2_LPDF, pareto_type_2_lpdf, 4, 2) \
   X(OP_RAYLEIGH_LPDF, rayleigh_lpdf, 2, 2) \
-  X(OP_SKEW_NORMAL_LPDF, skew_normal_lpdf, 4, 2) \
   X(OP_VON_MISES_LPDF, von_mises_lpdf, 3, 2) \
-  X(OP_EXP_MOD_NORMAL_LPDF, exp_mod_normal_lpdf, 4, 2) \
   X(OP_BETA_PROPORTION_LPDF, beta_proportion_lpdf, 3, 2) \
   X(OP_SKEW_DOUBLE_EXPONENTIAL_LPDF, skew_double_exponential_lpdf, 4, 2)
+
+#define STANLI_SCALAR_DENSITY_LIST_REST(X) \
+  STANLI_SCALAR_DENSITY_LIST_REST_A(X) \
+  STANLI_SCALAR_DENSITY_LIST_REST_B(X)
 
 #define STANLI_SCALAR_DENSITY_LIST(X) \
   STANLI_SCALAR_DENSITY_LIST_COMMON(X) \

--- a/runtime/include/stanli/optable.hpp
+++ b/runtime/include/stanli/optable.hpp
@@ -21,6 +21,9 @@ namespace stanli {
   X(OP_BINOMIAL_LPMF)                                                     \
   X(OP_BINOMIAL_LOGIT_LPMF)                                               \
   X(OP_BERNOULLI_LOGIT_GLM_LPMF)                                          \
+  X(OP_POISSON_LOG_GLM_LPMF)                                              \
+  X(OP_NEG_BINOMIAL_2_LOG_GLM_LPMF)                                       \
+  X(OP_BETA_BINOMIAL_LPMF)                                                \
   X(OP_LOGIT)                                                             \
   X(OP_MEAN)                                                              \
   X(OP_REP_VEC)                                                           \

--- a/runtime/include/stanli/optable.hpp
+++ b/runtime/include/stanli/optable.hpp
@@ -42,12 +42,14 @@ namespace stanli {
   X(OP_CHOLESKY)                                                          \
   X(OP_MULTI_NORMAL_CHOL_LPDF)                                            \
   X(OP_MULTI_NORMAL_LPDF)                                                 \
+  X(OP_MULTI_NORMAL_PREC_LPDF)                                            \
   X(OP_GEMM)                                                              \
   X(OP_LOG_INV_LOGIT)                                                     \
   X(OP_LOG_SOFTMAX)                                                       \
   X(OP_LOG1M_INV_LOGIT)                                                   \
   X(OP_CONSTRAIN_CHOL_CORR)                                               \
   X(OP_LKJ_CORR_CHOL_LPDF)                                                \
+  X(OP_LKJ_CORR_LPDF)                                                     \
   X(OP_NORMAL_ID_GLM_LPDF)                                                \
   X(OP_TRANSPOSE)                                                         \
   X(OP_ODE)                                                               \

--- a/runtime/kernels/densities.cpp
+++ b/runtime/kernels/densities.cpp
@@ -53,6 +53,15 @@ void register_density_kernels() {
   register_kernel(OP_BERNOULLI_LOGIT_GLM_LPMF,
                   Kernel{bernoulli_logit_glm_fwd, bernoulli_logit_glm_bwd,
                          sum_in_lens});
+  register_kernel(OP_POISSON_LOG_GLM_LPMF,
+                  Kernel{poisson_log_glm_fwd, poisson_log_glm_bwd,
+                         sum_in_lens});
+  register_kernel(OP_NEG_BINOMIAL_2_LOG_GLM_LPMF,
+                  Kernel{neg_binomial_2_log_glm_fwd,
+                         neg_binomial_2_log_glm_bwd, sum_in_lens});
+  register_kernel(OP_BETA_BINOMIAL_LPMF,
+                  Kernel{beta_binomial_fwd, density_bwd<2>,
+                         density_scratch<2>});
 }
 
 }  // namespace stanli

--- a/runtime/kernels/densities_common.cpp
+++ b/runtime/kernels/densities_common.cpp
@@ -85,14 +85,19 @@ void bernoulli_logit_glm_fwd(KernelCtx& ctx) {
     s.buf[k] = ctx.scratch + off;
     off += ctx.in[k].len;
   }
+  if (ctx.in[1].len != 1)
+    throw std::runtime_error("glm: vector alpha unsupported");
   active_sink() = &s;
-  if (ctx.in[1].len == 1) {
-    // beta is a vector regardless of its length; alpha scalar.
-    stan::math::bernoulli_logit_glm_lpmf<false>(
+  // beta is a vector regardless of its length; alpha scalar. Honour the
+  // propto bit: bernoulli has no constant to drop, so the two forms agree
+  // here, but hardcoding one is what made poisson_log_glm's lp land
+  // sum(log(y!)) away from CmdStan's.
+  if (ctx.variant & 0x80u) {
+    stan::math::bernoulli_logit_glm_lpmf<true>(
         y, X, rvar(ctx.in[1].data[0]), as_rvar(ctx.in[2]));
   } else {
-    active_sink() = nullptr;
-    throw std::runtime_error("glm: vector alpha unsupported");
+    stan::math::bernoulli_logit_glm_lpmf<false>(
+        y, X, rvar(ctx.in[1].data[0]), as_rvar(ctx.in[2]));
   }
   active_sink() = nullptr;
   ctx.out.data[0] = s.value;
@@ -101,6 +106,97 @@ void bernoulli_logit_glm_fwd(KernelCtx& ctx) {
 // alpha scalar, beta vector.
 void bernoulli_logit_glm_bwd(KernelCtx& ctx) { density_bwd<3>(ctx); }
 
+
+// The other GLMs brms and rstanarm emit directly. A model that writes one
+// of these does not merely run slower without it, it does not run. Alpha
+// is the intercept: stan-math takes it as a scalar or a per-row vector,
+// and only the scalar form is wired (the vector form needs a second
+// length to plumb, and no corpus model asks for it).
+void poisson_log_glm_fwd(KernelCtx& ctx) {
+  const int64_t rows = ctx.idata[ctx.n_idata - 2];
+  const int64_t cols = ctx.idata[ctx.n_idata - 1];
+  Eigen::Map<const Eigen::VectorXi> y(ctx.idata, rows);
+  Eigen::Map<const Eigen::MatrixXd> X(ctx.in[0].data, rows, cols);
+  sink s;
+  int64_t off = 0;
+  for (int k = 0; k < 3; ++k) {
+    s.buf[k] = ctx.scratch + off;
+    off += ctx.in[k].len;
+  }
+  if (ctx.in[1].len != 1)
+    throw std::runtime_error("poisson_log_glm: vector alpha unsupported");
+  active_sink() = &s;
+  // propto drops -lgamma(y+1), which is constant in the parameters but is
+  // 10.45 on a six-observation test -- a constant offset, not noise.
+  if (ctx.variant & 0x80u) {
+    stan::math::poisson_log_glm_lpmf<true>(y, X, rvar(ctx.in[1].data[0]),
+                                           as_rvar(ctx.in[2]));
+  } else {
+    stan::math::poisson_log_glm_lpmf<false>(y, X, rvar(ctx.in[1].data[0]),
+                                            as_rvar(ctx.in[2]));
+  }
+  active_sink() = nullptr;
+  ctx.out.data[0] = s.value;
+}
+
+void poisson_log_glm_bwd(KernelCtx& ctx) { density_bwd<3>(ctx); }
+
+// Same, with the overdispersion argument on the end.
+void neg_binomial_2_log_glm_fwd(KernelCtx& ctx) {
+  const int64_t rows = ctx.idata[ctx.n_idata - 2];
+  const int64_t cols = ctx.idata[ctx.n_idata - 1];
+  Eigen::Map<const Eigen::VectorXi> y(ctx.idata, rows);
+  Eigen::Map<const Eigen::MatrixXd> X(ctx.in[0].data, rows, cols);
+  sink s;
+  int64_t off = 0;
+  for (int k = 0; k < 4; ++k) {
+    s.buf[k] = ctx.scratch + off;
+    off += ctx.in[k].len;
+  }
+  if (ctx.in[1].len != 1)
+    throw std::runtime_error(
+        "neg_binomial_2_log_glm: vector alpha unsupported");
+  active_sink() = &s;
+  const bool propto = (ctx.variant & 0x80u) != 0;
+  if (ctx.in[3].len == 1) {
+    const rvar phi(ctx.in[3].data[0]);
+    if (propto) {
+      stan::math::neg_binomial_2_log_glm_lpmf<true>(
+          y, X, rvar(ctx.in[1].data[0]), as_rvar(ctx.in[2]), phi);
+    } else {
+      stan::math::neg_binomial_2_log_glm_lpmf<false>(
+          y, X, rvar(ctx.in[1].data[0]), as_rvar(ctx.in[2]), phi);
+    }
+  } else if (propto) {
+    stan::math::neg_binomial_2_log_glm_lpmf<true>(
+        y, X, rvar(ctx.in[1].data[0]), as_rvar(ctx.in[2]), as_rvar(ctx.in[3]));
+  } else {
+    stan::math::neg_binomial_2_log_glm_lpmf<false>(
+        y, X, rvar(ctx.in[1].data[0]), as_rvar(ctx.in[2]), as_rvar(ctx.in[3]));
+  }
+  active_sink() = nullptr;
+  ctx.out.data[0] = s.value;
+}
+
+void neg_binomial_2_log_glm_bwd(KernelCtx& ctx) { density_bwd<4>(ctx); }
+
+// beta_binomial(n | N, alpha, beta): two integer groups, then two real
+// arguments that behave like any other density's. with_int_group unpacks
+// the [len, vals...] pairs the lowering wrote, exactly as binomial does.
+void beta_binomial_fwd(KernelCtx& ctx) {
+  with_int_group(ctx.idata, [&](const auto& n, const int* rest) {
+    with_int_group(rest, [&](const auto& N, const int*) {
+      density_fwd_sum<2, density_tier(2), 0>(
+          ctx,
+          [&](const auto&... a) {
+            stan::math::beta_binomial_lpmf<true>(n, N, a...);
+          },
+          [&](const auto&... a) {
+            stan::math::beta_binomial_lpmf<false>(n, N, a...);
+          });
+    });
+  });
+}
 
 void uniform_fwd(KernelCtx& ctx) {
   // stan-math reports out-of-support y with an early `return LOG_ZERO`

--- a/runtime/kernels/densities_common.cpp
+++ b/runtime/kernels/densities_common.cpp
@@ -1,4 +1,6 @@
-// The densities models actually lean on, and the hand-written lpmfs.
+// Half the densities models lean on, plus the hand-written kernels
+// (two int groups, a data matrix, a support test) that predate the
+// lists. The other half is densities_common_b.cpp.
 //
 // One of the density shards: see densities_impl.hpp for why they
 // are split and what they share.
@@ -7,196 +9,8 @@
 namespace stanli {
 namespace dens {
 
-STANLI_SCALAR_DENSITY_LIST_COMMON(STANLI_DEFINE_DENSITY_FWD)
+STANLI_SCALAR_DENSITY_LIST_COMMON_A(STANLI_DEFINE_DENSITY_FWD)
 
-STANLI_LPMF_FWD(poisson_log_fwd, poisson_log_lpmf, 1)
-STANLI_LPMF_FWD(bernoulli_logit_fwd, bernoulli_logit_lpmf, 1)
-STANLI_LPMF_FWD(bernoulli_fwd, bernoulli_lpmf, 1)
-STANLI_LPMF_FWD(poisson_fwd, poisson_lpmf, 1)
-STANLI_LPMF_FWD(neg_binomial_2_fwd, neg_binomial_2_lpmf, 2)
-#undef STANLI_LPMF_FWD
-
-// The same shape, one line per distribution (STANLI_INT_DENSITY_LIST).
-#define STANLI_DEFINE_INT_DENSITY(code, fn, nreal, tier)                       \
-  STANLI_LPMF_FWD_T(fn##_fwd_gen, fn, nreal, tier)
-STANLI_INT_DENSITY_LIST(STANLI_DEFINE_INT_DENSITY)
-#undef STANLI_DEFINE_INT_DENSITY
-#undef STANLI_LPMF_FWD_T
-
-// Binomials carry two int groups; idata = [len_n, n..., len_N, N...].
-// A length of -1 marks a language-level int scalar (stan-math broadcasts
-// scalars; a size-1 vector would be a size error against a longer group).
-template <typename F>
-void with_int_group(const int* p, F&& f) {
-  const int len = static_cast<int>(p[0]);
-  if (len == -1)
-    f(p[1], p + 2);
-  else
-    f(Eigen::Map<const Eigen::VectorXi>(p + 1, len), p + 1 + len);
-}
-// Element n of a group: the scalar for all n, or the vector's n-th entry.
-int int_group_elem(const int* p, int64_t n) {
-  return p[0] == -1 ? p[1] : p[1 + n];
-}
-const int* int_group_next(const int* p) {
-  return p + (p[0] == -1 ? 2 : 1 + p[0]);
-}
-#define STANLI_BINOMIAL_FWD(fname, dist)                                       \
-  void fname(KernelCtx& ctx) {                                                 \
-    if (ctx.variant & 0x40u) {                                                 \
-      const int* g1 = ctx.idata;                                               \
-      const int* g2 = int_group_next(g1);                                      \
-      density_fwd_elt<1, 3>(                                                      \
-          ctx,                                                                 \
-          [&](int64_t n, const auto& theta) {                                  \
-            stan::math::dist<true>(int_group_elem(g1, n),                      \
-                                   int_group_elem(g2, n), theta);              \
-          },                                                                   \
-          [&](int64_t n, const auto& theta) {                                  \
-            stan::math::dist<false>(int_group_elem(g1, n),                     \
-                                    int_group_elem(g2, n), theta);             \
-          });                                                                  \
-      return;                                                                  \
-    }                                                                          \
-    with_int_group(ctx.idata, [&](const auto& n, const int* rest) {            \
-      with_int_group(rest, [&](const auto& N, const int*) {                    \
-        density_fwd_v<1, 3>(                                                      \
-            ctx,                                                               \
-            [&](const auto& theta) { stan::math::dist<true>(n, N, theta); },   \
-            [&](const auto& theta) { stan::math::dist<false>(n, N, theta); }); \
-      });                                                                      \
-    });                                                                        \
-  }
-
-STANLI_BINOMIAL_FWD(binomial_fwd, binomial_lpmf)
-STANLI_BINOMIAL_FWD(binomial_logit_fwd, binomial_logit_lpmf)
-#undef STANLI_BINOMIAL_FWD
-// bernoulli_logit_glm(y | X, alpha, beta): X data matrix (row-major slot),
-
-// idata = [y..., rows, cols]. Edges are (x, alpha, beta); X is arg 0.
-void bernoulli_logit_glm_fwd(KernelCtx& ctx) {
-  const int64_t rows = ctx.idata[ctx.n_idata - 2];
-  const int64_t cols = ctx.idata[ctx.n_idata - 1];
-  Eigen::Map<const Eigen::VectorXi> y(ctx.idata, rows);
-  Eigen::Map<const Eigen::MatrixXd> X(ctx.in[0].data, rows, cols);
-  sink s;
-  int64_t off = 0;
-  for (int k = 0; k < 3; ++k) {
-    s.buf[k] = ctx.scratch + off;
-    off += ctx.in[k].len;
-  }
-  if (ctx.in[1].len != 1)
-    throw std::runtime_error("glm: vector alpha unsupported");
-  active_sink() = &s;
-  // beta is a vector regardless of its length; alpha scalar. Honour the
-  // propto bit: bernoulli has no constant to drop, so the two forms agree
-  // here, but hardcoding one is what made poisson_log_glm's lp land
-  // sum(log(y!)) away from CmdStan's.
-  if (ctx.variant & 0x80u) {
-    stan::math::bernoulli_logit_glm_lpmf<true>(
-        y, X, rvar(ctx.in[1].data[0]), as_rvar(ctx.in[2]));
-  } else {
-    stan::math::bernoulli_logit_glm_lpmf<false>(
-        y, X, rvar(ctx.in[1].data[0]), as_rvar(ctx.in[2]));
-  }
-  active_sink() = nullptr;
-  ctx.out.data[0] = s.value;
-}
-// Edge order (x, alpha, beta): X data (edge 0 skipped by null adjoint),
-// alpha scalar, beta vector.
-void bernoulli_logit_glm_bwd(KernelCtx& ctx) { density_bwd<3>(ctx); }
-
-
-// The other GLMs brms and rstanarm emit directly. A model that writes one
-// of these does not merely run slower without it, it does not run. Alpha
-// is the intercept: stan-math takes it as a scalar or a per-row vector,
-// and only the scalar form is wired (the vector form needs a second
-// length to plumb, and no corpus model asks for it).
-void poisson_log_glm_fwd(KernelCtx& ctx) {
-  const int64_t rows = ctx.idata[ctx.n_idata - 2];
-  const int64_t cols = ctx.idata[ctx.n_idata - 1];
-  Eigen::Map<const Eigen::VectorXi> y(ctx.idata, rows);
-  Eigen::Map<const Eigen::MatrixXd> X(ctx.in[0].data, rows, cols);
-  sink s;
-  int64_t off = 0;
-  for (int k = 0; k < 3; ++k) {
-    s.buf[k] = ctx.scratch + off;
-    off += ctx.in[k].len;
-  }
-  if (ctx.in[1].len != 1)
-    throw std::runtime_error("poisson_log_glm: vector alpha unsupported");
-  active_sink() = &s;
-  // propto drops -lgamma(y+1), which is constant in the parameters but is
-  // 10.45 on a six-observation test -- a constant offset, not noise.
-  if (ctx.variant & 0x80u) {
-    stan::math::poisson_log_glm_lpmf<true>(y, X, rvar(ctx.in[1].data[0]),
-                                           as_rvar(ctx.in[2]));
-  } else {
-    stan::math::poisson_log_glm_lpmf<false>(y, X, rvar(ctx.in[1].data[0]),
-                                            as_rvar(ctx.in[2]));
-  }
-  active_sink() = nullptr;
-  ctx.out.data[0] = s.value;
-}
-
-void poisson_log_glm_bwd(KernelCtx& ctx) { density_bwd<3>(ctx); }
-
-// Same, with the overdispersion argument on the end.
-void neg_binomial_2_log_glm_fwd(KernelCtx& ctx) {
-  const int64_t rows = ctx.idata[ctx.n_idata - 2];
-  const int64_t cols = ctx.idata[ctx.n_idata - 1];
-  Eigen::Map<const Eigen::VectorXi> y(ctx.idata, rows);
-  Eigen::Map<const Eigen::MatrixXd> X(ctx.in[0].data, rows, cols);
-  sink s;
-  int64_t off = 0;
-  for (int k = 0; k < 4; ++k) {
-    s.buf[k] = ctx.scratch + off;
-    off += ctx.in[k].len;
-  }
-  if (ctx.in[1].len != 1)
-    throw std::runtime_error(
-        "neg_binomial_2_log_glm: vector alpha unsupported");
-  active_sink() = &s;
-  const bool propto = (ctx.variant & 0x80u) != 0;
-  if (ctx.in[3].len == 1) {
-    const rvar phi(ctx.in[3].data[0]);
-    if (propto) {
-      stan::math::neg_binomial_2_log_glm_lpmf<true>(
-          y, X, rvar(ctx.in[1].data[0]), as_rvar(ctx.in[2]), phi);
-    } else {
-      stan::math::neg_binomial_2_log_glm_lpmf<false>(
-          y, X, rvar(ctx.in[1].data[0]), as_rvar(ctx.in[2]), phi);
-    }
-  } else if (propto) {
-    stan::math::neg_binomial_2_log_glm_lpmf<true>(
-        y, X, rvar(ctx.in[1].data[0]), as_rvar(ctx.in[2]), as_rvar(ctx.in[3]));
-  } else {
-    stan::math::neg_binomial_2_log_glm_lpmf<false>(
-        y, X, rvar(ctx.in[1].data[0]), as_rvar(ctx.in[2]), as_rvar(ctx.in[3]));
-  }
-  active_sink() = nullptr;
-  ctx.out.data[0] = s.value;
-}
-
-void neg_binomial_2_log_glm_bwd(KernelCtx& ctx) { density_bwd<4>(ctx); }
-
-// beta_binomial(n | N, alpha, beta): two integer groups, then two real
-// arguments that behave like any other density's. with_int_group unpacks
-// the [len, vals...] pairs the lowering wrote, exactly as binomial does.
-void beta_binomial_fwd(KernelCtx& ctx) {
-  with_int_group(ctx.idata, [&](const auto& n, const int* rest) {
-    with_int_group(rest, [&](const auto& N, const int*) {
-      density_fwd_sum<2, density_tier(2), 0>(
-          ctx,
-          [&](const auto&... a) {
-            stan::math::beta_binomial_lpmf<true>(n, N, a...);
-          },
-          [&](const auto&... a) {
-            stan::math::beta_binomial_lpmf<false>(n, N, a...);
-          });
-    });
-  });
-}
 
 void uniform_fwd(KernelCtx& ctx) {
   // stan-math reports out-of-support y with an early `return LOG_ZERO`
@@ -243,8 +57,6 @@ void uniform_fwd(KernelCtx& ctx) {
 // wants a mutable pointer that a Map<const VectorXi> cannot supply. A
 // std::vector is also exactly what CmdStan's generated code passes, so
 // this is the instantiation the references were produced from. The copy
-// is n ints per evaluation, against a density over the same n.
-STANLI_ORDERED_DENSITY_LIST(STANLI_DEFINE_ORDERED_FWD)
 
 }  // namespace dens
 }  // namespace stanli

--- a/runtime/kernels/densities_common_b.cpp
+++ b/runtime/kernels/densities_common_b.cpp
@@ -1,5 +1,4 @@
-// Half the long tail of densities. The other half is
-// densities_rest_b.cpp.
+// The rest of the densities models lean on.
 //
 // One of the density shards: see densities_impl.hpp for why they
 // are split and what they share.
@@ -8,7 +7,7 @@
 namespace stanli {
 namespace dens {
 
-STANLI_SCALAR_DENSITY_LIST_REST_A(STANLI_DEFINE_DENSITY_FWD)
+STANLI_SCALAR_DENSITY_LIST_COMMON_B(STANLI_DEFINE_DENSITY_FWD)
 
 }  // namespace dens
 }  // namespace stanli

--- a/runtime/kernels/densities_glm.cpp
+++ b/runtime/kernels/densities_glm.cpp
@@ -1,0 +1,122 @@
+// The GLM kernels. They carry a data matrix and bind their arguments
+// explicitly rather than through mask_dispatch; together they were the
+// largest single block in densities_common.cpp.
+//
+// One of the density shards: see densities_impl.hpp for why they
+// are split and what they share.
+#include "densities_impl.hpp"
+
+namespace stanli {
+namespace dens {
+
+// bernoulli_logit_glm(y | X, alpha, beta): X data matrix (row-major slot),
+
+// idata = [y..., rows, cols]. Edges are (x, alpha, beta); X is arg 0.
+void bernoulli_logit_glm_fwd(KernelCtx& ctx) {
+  const int64_t rows = ctx.idata[ctx.n_idata - 2];
+  const int64_t cols = ctx.idata[ctx.n_idata - 1];
+  Eigen::Map<const Eigen::VectorXi> y(ctx.idata, rows);
+  Eigen::Map<const Eigen::MatrixXd> X(ctx.in[0].data, rows, cols);
+  sink s;
+  int64_t off = 0;
+  for (int k = 0; k < 3; ++k) {
+    s.buf[k] = ctx.scratch + off;
+    off += ctx.in[k].len;
+  }
+  if (ctx.in[1].len != 1)
+    throw std::runtime_error("glm: vector alpha unsupported");
+  active_sink() = &s;
+  // beta is a vector regardless of its length; alpha scalar. Honour the
+  // propto bit: bernoulli has no constant to drop, so the two forms agree
+  // here, but hardcoding one is what made poisson_log_glm's lp land
+  // sum(log(y!)) away from CmdStan's.
+  if (ctx.variant & 0x80u) {
+    stan::math::bernoulli_logit_glm_lpmf<true>(
+        y, X, rvar(ctx.in[1].data[0]), as_rvar(ctx.in[2]));
+  } else {
+    stan::math::bernoulli_logit_glm_lpmf<false>(
+        y, X, rvar(ctx.in[1].data[0]), as_rvar(ctx.in[2]));
+  }
+  active_sink() = nullptr;
+  ctx.out.data[0] = s.value;
+}
+// Edge order (x, alpha, beta): X data (edge 0 skipped by null adjoint),
+// alpha scalar, beta vector.
+void bernoulli_logit_glm_bwd(KernelCtx& ctx) { density_bwd<3>(ctx); }
+
+
+// The other GLMs brms and rstanarm emit directly. A model that writes one
+// of these does not merely run slower without it, it does not run. Alpha
+// is the intercept: stan-math takes it as a scalar or a per-row vector,
+// and only the scalar form is wired (the vector form needs a second
+// length to plumb, and no corpus model asks for it).
+void poisson_log_glm_fwd(KernelCtx& ctx) {
+  const int64_t rows = ctx.idata[ctx.n_idata - 2];
+  const int64_t cols = ctx.idata[ctx.n_idata - 1];
+  Eigen::Map<const Eigen::VectorXi> y(ctx.idata, rows);
+  Eigen::Map<const Eigen::MatrixXd> X(ctx.in[0].data, rows, cols);
+  sink s;
+  int64_t off = 0;
+  for (int k = 0; k < 3; ++k) {
+    s.buf[k] = ctx.scratch + off;
+    off += ctx.in[k].len;
+  }
+  if (ctx.in[1].len != 1)
+    throw std::runtime_error("poisson_log_glm: vector alpha unsupported");
+  active_sink() = &s;
+  // propto drops -lgamma(y+1), which is constant in the parameters but is
+  // 10.45 on a six-observation test -- a constant offset, not noise.
+  if (ctx.variant & 0x80u) {
+    stan::math::poisson_log_glm_lpmf<true>(y, X, rvar(ctx.in[1].data[0]),
+                                           as_rvar(ctx.in[2]));
+  } else {
+    stan::math::poisson_log_glm_lpmf<false>(y, X, rvar(ctx.in[1].data[0]),
+                                            as_rvar(ctx.in[2]));
+  }
+  active_sink() = nullptr;
+  ctx.out.data[0] = s.value;
+}
+
+void poisson_log_glm_bwd(KernelCtx& ctx) { density_bwd<3>(ctx); }
+
+// Same, with the overdispersion argument on the end.
+void neg_binomial_2_log_glm_fwd(KernelCtx& ctx) {
+  const int64_t rows = ctx.idata[ctx.n_idata - 2];
+  const int64_t cols = ctx.idata[ctx.n_idata - 1];
+  Eigen::Map<const Eigen::VectorXi> y(ctx.idata, rows);
+  Eigen::Map<const Eigen::MatrixXd> X(ctx.in[0].data, rows, cols);
+  sink s;
+  int64_t off = 0;
+  for (int k = 0; k < 4; ++k) {
+    s.buf[k] = ctx.scratch + off;
+    off += ctx.in[k].len;
+  }
+  if (ctx.in[1].len != 1)
+    throw std::runtime_error(
+        "neg_binomial_2_log_glm: vector alpha unsupported");
+  active_sink() = &s;
+  const bool propto = (ctx.variant & 0x80u) != 0;
+  if (ctx.in[3].len == 1) {
+    const rvar phi(ctx.in[3].data[0]);
+    if (propto) {
+      stan::math::neg_binomial_2_log_glm_lpmf<true>(
+          y, X, rvar(ctx.in[1].data[0]), as_rvar(ctx.in[2]), phi);
+    } else {
+      stan::math::neg_binomial_2_log_glm_lpmf<false>(
+          y, X, rvar(ctx.in[1].data[0]), as_rvar(ctx.in[2]), phi);
+    }
+  } else if (propto) {
+    stan::math::neg_binomial_2_log_glm_lpmf<true>(
+        y, X, rvar(ctx.in[1].data[0]), as_rvar(ctx.in[2]), as_rvar(ctx.in[3]));
+  } else {
+    stan::math::neg_binomial_2_log_glm_lpmf<false>(
+        y, X, rvar(ctx.in[1].data[0]), as_rvar(ctx.in[2]), as_rvar(ctx.in[3]));
+  }
+  active_sink() = nullptr;
+  ctx.out.data[0] = s.value;
+}
+
+void neg_binomial_2_log_glm_bwd(KernelCtx& ctx) { density_bwd<4>(ctx); }
+
+}  // namespace dens
+}  // namespace stanli

--- a/runtime/kernels/densities_impl.hpp
+++ b/runtime/kernels/densities_impl.hpp
@@ -175,27 +175,15 @@ void density_fwd_elt(KernelCtx& ctx, FProp&& fp, FFull&& ff) {
 // families this density actually has. A missing propto family is not a
 // refusal: the full form is a correct log density, just not the one
 // CmdStan's `~` computes, so it lands a constant higher.
-template <int NArgs, int Listed, unsigned VecMask = 0, typename FProp,
+// The summed forward, and the only one most densities have. Partials for
+// argument k land at scratch[sum of lens of args < k]; the mask decides
+// which arguments are autodiff, the tier which instantiation families
+// exist. Whatever the outcome looks like -- a propagator edge, one idata
+// group, two, an integer array -- it is bound by the caller's lambdas, so
+// this is shared by every density shape in these shards.
+template <int NArgs, int Tier, unsigned VecMask, typename FProp,
           typename FFull>
-void density_fwd_v(KernelCtx& ctx, FProp&& fp, FFull&& ff) {
-  constexpr int Tier = density_tier(Listed);
-  // A density with a vector-only argument has no elementwise form to
-  // instantiate -- the per-lane binding hands every argument over as a
-  // scalar, which is exactly what VecMask exists to forbid. reroll.cpp
-  // never fuses these (they are in neither of its opt-in lists), so the
-  // bit cannot arrive; refuse rather than write one element of N.
-  if constexpr (VecMask != 0) {
-    if (ctx.variant & 0x40u)
-      throw std::runtime_error(
-          "density: elementwise variant on a vector-argument density");
-  } else if (ctx.variant & 0x40u) {
-    // Real-argument densities reuse the same lambdas: scalar bindings
-    // instantiate the same generic templates.
-    density_fwd_elt<NArgs, Tier>(
-        ctx, [&](int64_t, const auto&... a) { fp(a...); },
-        [&](int64_t, const auto&... a) { ff(a...); });
-    return;
-  }
+void density_fwd_sum(KernelCtx& ctx, FProp&& fp, FFull&& ff) {
   sink s;
   int64_t off = 0;
   for (int k = 0; k < NArgs; ++k) {
@@ -217,6 +205,30 @@ void density_fwd_v(KernelCtx& ctx, FProp&& fp, FFull&& ff) {
   }
   active_sink() = nullptr;
   ctx.out.data[0] = s.value;
+}
+
+template <int NArgs, int Listed, unsigned VecMask = 0, typename FProp,
+          typename FFull>
+void density_fwd_v(KernelCtx& ctx, FProp&& fp, FFull&& ff) {
+  constexpr int Tier = density_tier(Listed);
+  // A density with a vector-only argument has no elementwise form to
+  // instantiate -- the per-lane binding hands every argument over as a
+  // scalar, which is exactly what VecMask exists to forbid. reroll.cpp
+  // never fuses these (they are in neither of its opt-in lists), so the
+  // bit cannot arrive; refuse rather than write one element of N.
+  if constexpr (VecMask != 0) {
+    if (ctx.variant & 0x40u)
+      throw std::runtime_error(
+          "density: elementwise variant on a vector-argument density");
+  } else if (ctx.variant & 0x40u) {
+    // Real-argument densities reuse the same lambdas: scalar bindings
+    // instantiate the same generic templates.
+    density_fwd_elt<NArgs, Tier>(
+        ctx, [&](int64_t, const auto&... a) { fp(a...); },
+        [&](int64_t, const auto&... a) { ff(a...); });
+    return;
+  }
+  density_fwd_sum<NArgs, Tier, VecMask>(ctx, fp, ff);
 }
 
 // Partials for argument k live at scratch[sum of lens of args < k]. A scalar
@@ -324,18 +336,9 @@ void cdf_fwd(KernelCtx& ctx, F&& f) {
   // so instead. The branch costs nothing next to an incomplete beta.
   if (ctx.variant & 0x40u)
     throw std::runtime_error("cdf: elementwise variant not implemented");
-  sink s;
-  int64_t off = 0;
-  for (int k = 0; k < NArgs; ++k) {
-    s.buf[k] = ctx.scratch + off;
-    off += ctx.in[k].len;
-  }
-  const unsigned mask = ctx.variant == 0 ? (1u << NArgs) - 1
-                                         : (ctx.variant & 0x3fu);
-  active_sink() = &s;
-  full_form<NArgs, Tier, 0>(mask, ctx, f);
-  active_sink() = nullptr;
-  ctx.out.data[0] = s.value;
+  // Tier here never carries the propto bit, so the first lambda is never
+  // instantiated; it exists to satisfy the shared signature.
+  density_fwd_sum<NArgs, Tier, 0>(ctx, [](const auto&...) {}, f);
 }
 
 #define STANLI_DEFINE_CDF_FWD(code, fn, n, tier)                         \
@@ -393,6 +396,11 @@ void binomial_fwd(KernelCtx&);
 void binomial_logit_fwd(KernelCtx&);
 void bernoulli_logit_glm_fwd(KernelCtx&);
 void bernoulli_logit_glm_bwd(KernelCtx&);
+void poisson_log_glm_fwd(KernelCtx&);
+void poisson_log_glm_bwd(KernelCtx&);
+void neg_binomial_2_log_glm_fwd(KernelCtx&);
+void neg_binomial_2_log_glm_bwd(KernelCtx&);
+void beta_binomial_fwd(KernelCtx&);
 void uniform_fwd(KernelCtx&);
 
 }  // namespace dens

--- a/runtime/kernels/densities_lpmf.cpp
+++ b/runtime/kernels/densities_lpmf.cpp
@@ -1,0 +1,98 @@
+// The integer-outcome densities: the hand-written lpmfs, the ones
+// generated from STANLI_INT_DENSITY_LIST, the binomials with their two
+// int groups, beta_binomial, and the ordered pair.
+//
+// One of the density shards: see densities_impl.hpp for why they
+// are split and what they share.
+#include "densities_impl.hpp"
+
+namespace stanli {
+namespace dens {
+
+STANLI_LPMF_FWD(poisson_log_fwd, poisson_log_lpmf, 1)
+STANLI_LPMF_FWD(bernoulli_logit_fwd, bernoulli_logit_lpmf, 1)
+STANLI_LPMF_FWD(bernoulli_fwd, bernoulli_lpmf, 1)
+STANLI_LPMF_FWD(poisson_fwd, poisson_lpmf, 1)
+STANLI_LPMF_FWD(neg_binomial_2_fwd, neg_binomial_2_lpmf, 2)
+#undef STANLI_LPMF_FWD
+
+// The same shape, one line per distribution (STANLI_INT_DENSITY_LIST).
+#define STANLI_DEFINE_INT_DENSITY(code, fn, nreal, tier)                       \
+  STANLI_LPMF_FWD_T(fn##_fwd_gen, fn, nreal, tier)
+STANLI_INT_DENSITY_LIST(STANLI_DEFINE_INT_DENSITY)
+#undef STANLI_DEFINE_INT_DENSITY
+#undef STANLI_LPMF_FWD_T
+
+// Binomials carry two int groups; idata = [len_n, n..., len_N, N...].
+// A length of -1 marks a language-level int scalar (stan-math broadcasts
+// scalars; a size-1 vector would be a size error against a longer group).
+template <typename F>
+void with_int_group(const int* p, F&& f) {
+  const int len = static_cast<int>(p[0]);
+  if (len == -1)
+    f(p[1], p + 2);
+  else
+    f(Eigen::Map<const Eigen::VectorXi>(p + 1, len), p + 1 + len);
+}
+// Element n of a group: the scalar for all n, or the vector's n-th entry.
+int int_group_elem(const int* p, int64_t n) {
+  return p[0] == -1 ? p[1] : p[1 + n];
+}
+const int* int_group_next(const int* p) {
+  return p + (p[0] == -1 ? 2 : 1 + p[0]);
+}
+#define STANLI_BINOMIAL_FWD(fname, dist)                                       \
+  void fname(KernelCtx& ctx) {                                                 \
+    if (ctx.variant & 0x40u) {                                                 \
+      const int* g1 = ctx.idata;                                               \
+      const int* g2 = int_group_next(g1);                                      \
+      density_fwd_elt<1, 3>(                                                      \
+          ctx,                                                                 \
+          [&](int64_t n, const auto& theta) {                                  \
+            stan::math::dist<true>(int_group_elem(g1, n),                      \
+                                   int_group_elem(g2, n), theta);              \
+          },                                                                   \
+          [&](int64_t n, const auto& theta) {                                  \
+            stan::math::dist<false>(int_group_elem(g1, n),                     \
+                                    int_group_elem(g2, n), theta);             \
+          });                                                                  \
+      return;                                                                  \
+    }                                                                          \
+    with_int_group(ctx.idata, [&](const auto& n, const int* rest) {            \
+      with_int_group(rest, [&](const auto& N, const int*) {                    \
+        density_fwd_v<1, 3>(                                                      \
+            ctx,                                                               \
+            [&](const auto& theta) { stan::math::dist<true>(n, N, theta); },   \
+            [&](const auto& theta) { stan::math::dist<false>(n, N, theta); }); \
+      });                                                                      \
+    });                                                                        \
+  }
+
+STANLI_BINOMIAL_FWD(binomial_fwd, binomial_lpmf)
+STANLI_BINOMIAL_FWD(binomial_logit_fwd, binomial_logit_lpmf)
+#undef STANLI_BINOMIAL_FWD
+
+
+// beta_binomial(n | N, alpha, beta): two integer groups, then two real
+// arguments that behave like any other density's. with_int_group unpacks
+// the [len, vals...] pairs the lowering wrote, exactly as binomial does.
+void beta_binomial_fwd(KernelCtx& ctx) {
+  with_int_group(ctx.idata, [&](const auto& n, const int* rest) {
+    with_int_group(rest, [&](const auto& N, const int*) {
+      density_fwd_sum<2, density_tier(2), 0>(
+          ctx,
+          [&](const auto&... a) {
+            stan::math::beta_binomial_lpmf<true>(n, N, a...);
+          },
+          [&](const auto&... a) {
+            stan::math::beta_binomial_lpmf<false>(n, N, a...);
+          });
+    });
+  });
+}
+
+// is n ints per evaluation, against a density over the same n.
+STANLI_ORDERED_DENSITY_LIST(STANLI_DEFINE_ORDERED_FWD)
+
+}  // namespace dens
+}  // namespace stanli

--- a/runtime/kernels/densities_rest_b.cpp
+++ b/runtime/kernels/densities_rest_b.cpp
@@ -1,5 +1,4 @@
-// Half the long tail of densities. The other half is
-// densities_rest_b.cpp.
+// The other half of the long tail of densities.
 //
 // One of the density shards: see densities_impl.hpp for why they
 // are split and what they share.
@@ -8,7 +7,7 @@
 namespace stanli {
 namespace dens {
 
-STANLI_SCALAR_DENSITY_LIST_REST_A(STANLI_DEFINE_DENSITY_FWD)
+STANLI_SCALAR_DENSITY_LIST_REST_B(STANLI_DEFINE_DENSITY_FWD)
 
 }  // namespace dens
 }  // namespace stanli

--- a/runtime/kernels/matrix_fns.cpp
+++ b/runtime/kernels/matrix_fns.cpp
@@ -486,6 +486,387 @@ void eigvecs_bwd(KernelCtx& ctx) {
   });
 }
 
+// ---- tail densities: one nested var tape, no hand-written derivative ----
+// Everything below binds EVERY argument as var, calls the unmodified
+// stan-math template, grads, and scatters the adjoints back. Two
+// consequences worth stating.
+//
+// It has no restriction on what the density does with its scalar type.
+// The recorder computes in doubles and carries no tape, so a density that
+// does arithmetic on the scalar (ordered_probit's
+// `c_vec[i].coeff(0) - lambda_vec[i]`, wiener's `res *= 0.0`) cannot go
+// through it at all. stan::math::var has every operator, so those work
+// here. That is why this file, not densities.cpp, is where the tail goes.
+//
+// And it is the compact tier by construction: one instantiation, no
+// activity-mask expansion. A data argument's partials are computed and
+// dropped, which is the right trade for a density nobody has profiled.
+VarM tail_m(const KernelCtx& ctx, int k, int64_t rows, int64_t cols) {
+  VarM M(rows, cols);
+  for (int64_t j = 0; j < cols; ++j)
+    for (int64_t i = 0; i < rows; ++i)
+      M(i, j) = ctx.in[k].data[j * rows + i];
+  return M;
+}
+VarV tail_v(const KernelCtx& ctx, int k, int64_t n) {
+  VarV v(n);
+  for (int64_t i = 0; i < n; ++i) v(i) = ctx.in[k].data[i];
+  return v;
+}
+void tail_scatter_m(KernelCtx& ctx, int k, const VarM& M) {
+  if (!ctx.in_adj[k].data) return;
+  const int64_t rows = M.rows(), cols = M.cols();
+  for (int64_t j = 0; j < cols; ++j)
+    for (int64_t i = 0; i < rows; ++i)
+      ctx.in_adj[k].data[j * rows + i] += M(i, j).adj();
+}
+void tail_scatter_v(KernelCtx& ctx, int k, const VarV& v) {
+  if (!ctx.in_adj[k].data) return;
+  for (int64_t i = 0; i < v.size(); ++i)
+    ctx.in_adj[k].data[i] += v(i).adj();
+}
+void tail_scatter_s(KernelCtx& ctx, int k, const stan::math::var& x) {
+  if (ctx.in_adj[k].data) ctx.in_adj[k].data[0] += x.adj();
+}
+
+// ---- wishart family: (matrix W, real nu, matrix S), four of them --------
+enum WishKind { kWishart, kInvWishart, kWishartChol, kInvWishartChol };
+template <bool Grad, WishKind Kind>
+double wish_eval(KernelCtx& ctx) {
+  const int64_t K = ctx.idata[0];
+  const bool propto = (ctx.variant & 0x80u) != 0;
+  stan::math::nested_rev_autodiff nested;
+  using stan::math::var;
+  VarM W = tail_m(ctx, 0, K, K);
+  var nu = ctx.in[1].data[0];
+  VarM S = tail_m(ctx, 2, K, K);
+  var out;
+  if constexpr (Kind == kWishart) {
+    out = propto ? stan::math::wishart_lpdf<true>(W, nu, S)
+                 : stan::math::wishart_lpdf<false>(W, nu, S);
+  } else if constexpr (Kind == kInvWishart) {
+    out = propto ? stan::math::inv_wishart_lpdf<true>(W, nu, S)
+                 : stan::math::inv_wishart_lpdf<false>(W, nu, S);
+  } else if constexpr (Kind == kWishartChol) {
+    out = propto ? stan::math::wishart_cholesky_lpdf<true>(W, nu, S)
+                 : stan::math::wishart_cholesky_lpdf<false>(W, nu, S);
+  } else {
+    out = propto ? stan::math::inv_wishart_cholesky_lpdf<true>(W, nu, S)
+                 : stan::math::inv_wishart_cholesky_lpdf<false>(W, nu, S);
+  }
+  const double v = out.val();
+  if constexpr (Grad) {
+    var j = out * ctx.out_adj;
+    stan::math::grad(j.vi_);
+    tail_scatter_m(ctx, 0, W);
+    tail_scatter_s(ctx, 1, nu);
+    tail_scatter_m(ctx, 2, S);
+  }
+  return v;
+}
+#define STANLI_WISH_KERNEL(name, kind)                                    \
+  void name##_fwd(KernelCtx& ctx) {                                       \
+    ctx.out.data[0] = wish_eval<false, kind>(ctx);                        \
+  }                                                                       \
+  void name##_bwd(KernelCtx& ctx) { wish_eval<true, kind>(ctx); }
+STANLI_WISH_KERNEL(wish, kWishart)
+STANLI_WISH_KERNEL(iwish, kInvWishart)
+STANLI_WISH_KERNEL(wishc, kWishartChol)
+STANLI_WISH_KERNEL(iwishc, kInvWishartChol)
+#undef STANLI_WISH_KERNEL
+
+// ---- multi_gp: (matrix y, matrix Sigma, vector w) -----------------------
+enum GpKind { kMultiGp, kMultiGpChol };
+template <bool Grad, GpKind Kind>
+double mgp_eval(KernelCtx& ctx) {
+  const int64_t K = ctx.idata[0], N = ctx.idata[1];
+  const bool propto = (ctx.variant & 0x80u) != 0;
+  stan::math::nested_rev_autodiff nested;
+  using stan::math::var;
+  VarM y = tail_m(ctx, 0, K, N);
+  VarM S = tail_m(ctx, 1, K, K);
+  VarV w = tail_v(ctx, 2, K);
+  var out;
+  if constexpr (Kind == kMultiGp) {
+    out = propto ? stan::math::multi_gp_lpdf<true>(y, S, w)
+                 : stan::math::multi_gp_lpdf<false>(y, S, w);
+  } else {
+    out = propto ? stan::math::multi_gp_cholesky_lpdf<true>(y, S, w)
+                 : stan::math::multi_gp_cholesky_lpdf<false>(y, S, w);
+  }
+  const double v = out.val();
+  if constexpr (Grad) {
+    var j = out * ctx.out_adj;
+    stan::math::grad(j.vi_);
+    tail_scatter_m(ctx, 0, y);
+    tail_scatter_m(ctx, 1, S);
+    tail_scatter_v(ctx, 2, w);
+  }
+  return v;
+}
+
+// ---- multi_student_t: (vector y, real nu, vector mu, matrix Sigma) ------
+enum MstKind { kMst, kMstChol };
+template <bool Grad, MstKind Kind>
+double mst_eval(KernelCtx& ctx) {
+  const int64_t K = ctx.idata[0];
+  const int64_t reps = ctx.n_idata > 1 ? ctx.idata[1] : 1;
+  const bool propto = (ctx.variant & 0x80u) != 0;
+  stan::math::nested_rev_autodiff nested;
+  using stan::math::var;
+  // y may be one K-vector or an array of reps of them.
+  std::vector<VarV> ys;
+  ys.reserve(reps);
+  for (int64_t r = 0; r < reps; ++r) {
+    VarV yy(K);
+    for (int64_t i = 0; i < K; ++i)
+      yy(i) = ctx.in[0].data[r * K + i];
+    ys.push_back(std::move(yy));
+  }
+  var nu = ctx.in[1].data[0];
+  VarV mu = tail_v(ctx, 2, K);
+  VarM S = tail_m(ctx, 3, K, K);
+  const auto call = [&](auto&& yarg) {
+    if constexpr (Kind == kMst) {
+      return propto ? stan::math::multi_student_t_lpdf<true>(yarg, nu, mu, S)
+                    : stan::math::multi_student_t_lpdf<false>(yarg, nu, mu, S);
+    } else {
+      return propto
+                 ? stan::math::multi_student_t_cholesky_lpdf<true>(yarg, nu, mu, S)
+                 : stan::math::multi_student_t_cholesky_lpdf<false>(yarg, nu, mu, S);
+    }
+  };
+  var out = reps > 1 ? call(ys) : call(ys[0]);
+  const double v = out.val();
+  if constexpr (Grad) {
+    var j = out * ctx.out_adj;
+    stan::math::grad(j.vi_);
+    if (ctx.in_adj[0].data)
+      for (int64_t r = 0; r < reps; ++r)
+        for (int64_t i = 0; i < K; ++i)
+          ctx.in_adj[0].data[r * K + i] += ys[r](i).adj();
+    tail_scatter_s(ctx, 1, nu);
+    tail_scatter_v(ctx, 2, mu);
+    tail_scatter_m(ctx, 3, S);
+  }
+  return v;
+}
+
+// ---- multinomial family: (array[] int ns, vector theta) -----------------
+// The counts ride in idata; theta is the only propagator edge.
+enum MultKind { kMultinomial, kMultinomialLogit, kDirichletMultinomial };
+template <bool Grad, MultKind Kind>
+double mult_eval(KernelCtx& ctx) {
+  const int64_t K = ctx.in[0].len;
+  const bool propto = (ctx.variant & 0x80u) != 0;
+  std::vector<int> ns(ctx.idata, ctx.idata + ctx.n_idata);
+  stan::math::nested_rev_autodiff nested;
+  using stan::math::var;
+  VarV theta = tail_v(ctx, 0, K);
+  var out;
+  if constexpr (Kind == kMultinomial) {
+    out = propto ? stan::math::multinomial_lpmf<true>(ns, theta)
+                 : stan::math::multinomial_lpmf<false>(ns, theta);
+  } else if constexpr (Kind == kMultinomialLogit) {
+    out = propto ? stan::math::multinomial_logit_lpmf<true>(ns, theta)
+                 : stan::math::multinomial_logit_lpmf<false>(ns, theta);
+  } else {
+    out = propto ? stan::math::dirichlet_multinomial_lpmf<true>(ns, theta)
+                 : stan::math::dirichlet_multinomial_lpmf<false>(ns, theta);
+  }
+  const double v = out.val();
+  if constexpr (Grad) {
+    var j = out * ctx.out_adj;
+    stan::math::grad(j.vi_);
+    tail_scatter_v(ctx, 0, theta);
+  }
+  return v;
+}
+
+// ---- the two the recorder cannot take ----------------------------------
+// ordered_probit does `c_vec[i].coeff(0) - lambda_vec[i]` and wiener
+// `res *= 0.0` on the scalar type. var has those operators; rvar
+// deliberately does not (see recorder.hpp), so they live here.
+// ordered_probit(y | lambda, c): counts in idata, lambda and c real edges.
+template <bool Grad>
+double oprobit_eval(KernelCtx& ctx) {
+  const int64_t N = ctx.n_idata, K = ctx.in[1].len;
+  const bool propto = (ctx.variant & 0x80u) != 0;
+  std::vector<int> y(ctx.idata, ctx.idata + N);
+  stan::math::nested_rev_autodiff nested;
+  using stan::math::var;
+  VarV lambda = tail_v(ctx, 0, ctx.in[0].len);
+  VarV c = tail_v(ctx, 1, K);
+  var out;
+  if (ctx.in[0].len == 1) {
+    out = propto ? stan::math::ordered_probit_lpmf<true>(y, lambda(0), c)
+                 : stan::math::ordered_probit_lpmf<false>(y, lambda(0), c);
+  } else {
+    out = propto ? stan::math::ordered_probit_lpmf<true>(y, lambda, c)
+                 : stan::math::ordered_probit_lpmf<false>(y, lambda, c);
+  }
+  const double v = out.val();
+  if constexpr (Grad) {
+    var j = out * ctx.out_adj;
+    stan::math::grad(j.vi_);
+    tail_scatter_v(ctx, 0, lambda);
+    tail_scatter_v(ctx, 1, c);
+  }
+  return v;
+}
+
+// wiener(y | alpha, tau, beta, delta): five real arguments, all scalars.
+template <bool Grad>
+double wiener_eval(KernelCtx& ctx) {
+  const bool propto = (ctx.variant & 0x80u) != 0;
+  stan::math::nested_rev_autodiff nested;
+  using stan::math::var;
+  const int64_t n = ctx.in[0].len;
+  VarV y = tail_v(ctx, 0, n);
+  var alpha = ctx.in[1].data[0], tau = ctx.in[2].data[0];
+  var beta = ctx.in[3].data[0], delta = ctx.in[4].data[0];
+  var out = propto
+                ? stan::math::wiener_lpdf<true>(y, alpha, tau, beta, delta)
+                : stan::math::wiener_lpdf<false>(y, alpha, tau, beta, delta);
+  const double v = out.val();
+  if constexpr (Grad) {
+    var j = out * ctx.out_adj;
+    stan::math::grad(j.vi_);
+    tail_scatter_v(ctx, 0, y);
+    tail_scatter_s(ctx, 1, alpha);
+    tail_scatter_s(ctx, 2, tau);
+    tail_scatter_s(ctx, 3, beta);
+    tail_scatter_s(ctx, 4, delta);
+  }
+  return v;
+}
+
+#define STANLI_TAIL_KERNEL(name, fn, kind)                                \
+  void name##_fwd(KernelCtx& ctx) {                                       \
+    ctx.out.data[0] = fn<false, kind>(ctx);                               \
+  }                                                                       \
+  void name##_bwd(KernelCtx& ctx) { fn<true, kind>(ctx); }
+STANLI_TAIL_KERNEL(mgp, mgp_eval, kMultiGp)
+STANLI_TAIL_KERNEL(mgpc, mgp_eval, kMultiGpChol)
+STANLI_TAIL_KERNEL(mst, mst_eval, kMst)
+STANLI_TAIL_KERNEL(mstc, mst_eval, kMstChol)
+STANLI_TAIL_KERNEL(multn, mult_eval, kMultinomial)
+STANLI_TAIL_KERNEL(multnl, mult_eval, kMultinomialLogit)
+STANLI_TAIL_KERNEL(dirmult, mult_eval, kDirichletMultinomial)
+#undef STANLI_TAIL_KERNEL
+void oprobit_fwd(KernelCtx& ctx) { ctx.out.data[0] = oprobit_eval<false>(ctx); }
+void oprobit_bwd(KernelCtx& ctx) { oprobit_eval<true>(ctx); }
+void wiener_fwd(KernelCtx& ctx) { ctx.out.data[0] = wiener_eval<false>(ctx); }
+void wiener_bwd(KernelCtx& ctx) { wiener_eval<true>(ctx); }
+
+// ---- the last five ------------------------------------------------------
+// lkj_cov(Sigma | mu, sigma, eta): a covariance matrix, two vectors of
+// lognormal hyperparameters for the scales, and the LKJ shape.
+template <bool Grad>
+double lkjcov_eval(KernelCtx& ctx) {
+  const int64_t K = ctx.idata[0];
+  const bool propto = (ctx.variant & 0x80u) != 0;
+  stan::math::nested_rev_autodiff nested;
+  using stan::math::var;
+  VarM S = tail_m(ctx, 0, K, K);
+  VarV mu = tail_v(ctx, 1, ctx.in[1].len);
+  VarV sig = tail_v(ctx, 2, ctx.in[2].len);
+  var eta = ctx.in[3].data[0];
+  var out = propto ? stan::math::lkj_cov_lpdf<true>(S, mu, sig, eta)
+                   : stan::math::lkj_cov_lpdf<false>(S, mu, sig, eta);
+  const double v = out.val();
+  if constexpr (Grad) {
+    var j = out * ctx.out_adj;
+    stan::math::grad(j.vi_);
+    tail_scatter_m(ctx, 0, S);
+    tail_scatter_v(ctx, 1, mu);
+    tail_scatter_v(ctx, 2, sig);
+    tail_scatter_s(ctx, 3, eta);
+  }
+  return v;
+}
+
+// The three remaining GLMs. Unlike the ones in densities.cpp these carry
+// argument shapes the recorder cannot express (a cutpoint vector, a
+// coefficient matrix, a second int group), so they take the var tape.
+// idata = [outcome..., rows, cols] and, for binomial, the trial counts.
+enum GlmKind { kBinomLogitGlm, kCatLogitGlm, kOrdLogisticGlm };
+template <bool Grad, GlmKind Kind>
+double tglm_eval(KernelCtx& ctx) {
+  const int64_t rows = ctx.idata[ctx.n_idata - 2];
+  const int64_t cols = ctx.idata[ctx.n_idata - 1];
+  const bool propto = (ctx.variant & 0x80u) != 0;
+  stan::math::nested_rev_autodiff nested;
+  using stan::math::var;
+  VarM X = tail_m(ctx, 0, rows, cols);
+  var out;
+  if constexpr (Kind == kBinomLogitGlm) {
+    // idata = [n..., N..., rows, cols]
+    std::vector<int> nn(ctx.idata, ctx.idata + rows);
+    std::vector<int> NN(ctx.idata + rows, ctx.idata + 2 * rows);
+    var alpha = ctx.in[1].data[0];
+    VarV beta = tail_v(ctx, 2, cols);
+    out = propto ? stan::math::binomial_logit_glm_lpmf<true>(nn, NN, X, alpha, beta)
+                 : stan::math::binomial_logit_glm_lpmf<false>(nn, NN, X, alpha, beta);
+    const double v0 = out.val();
+    if constexpr (Grad) {
+      var j = out * ctx.out_adj;
+      stan::math::grad(j.vi_);
+      tail_scatter_m(ctx, 0, X);
+      tail_scatter_s(ctx, 1, alpha);
+      tail_scatter_v(ctx, 2, beta);
+    }
+    return v0;
+  } else {
+    std::vector<int> y(ctx.idata, ctx.idata + rows);
+    if constexpr (Kind == kCatLogitGlm) {
+      VarV alpha = tail_v(ctx, 1, ctx.in[1].len);
+      VarM beta = tail_m(ctx, 2, cols, ctx.in[2].len / cols);
+      out = propto ? stan::math::categorical_logit_glm_lpmf<true>(y, X, alpha, beta)
+                   : stan::math::categorical_logit_glm_lpmf<false>(y, X, alpha, beta);
+      const double vv = out.val();
+      if constexpr (Grad) {
+        var j = out * ctx.out_adj;
+        stan::math::grad(j.vi_);
+        tail_scatter_m(ctx, 0, X);
+        tail_scatter_v(ctx, 1, alpha);
+        tail_scatter_m(ctx, 2, beta);
+      }
+      return vv;
+    } else {
+      // in = {X, beta, cutpoints}; alpha above is beta for this one.
+      VarV beta = tail_v(ctx, 1, cols);
+      VarV cuts = tail_v(ctx, 2, ctx.in[2].len);
+      out = propto ? stan::math::ordered_logistic_glm_lpmf<true>(y, X, beta, cuts)
+                   : stan::math::ordered_logistic_glm_lpmf<false>(y, X, beta, cuts);
+      const double vv = out.val();
+      if constexpr (Grad) {
+        var j = out * ctx.out_adj;
+        stan::math::grad(j.vi_);
+        tail_scatter_m(ctx, 0, X);
+        tail_scatter_v(ctx, 1, beta);
+        tail_scatter_v(ctx, 2, cuts);
+      }
+      return vv;
+    }
+  }
+}
+
+void lkjcov_fwd(KernelCtx& ctx) { ctx.out.data[0] = lkjcov_eval<false>(ctx); }
+void lkjcov_bwd(KernelCtx& ctx) { lkjcov_eval<true>(ctx); }
+void blglm_fwd(KernelCtx& ctx) {
+  ctx.out.data[0] = tglm_eval<false, kBinomLogitGlm>(ctx);
+}
+void blglm_bwd(KernelCtx& ctx) { tglm_eval<true, kBinomLogitGlm>(ctx); }
+void clglm_fwd(KernelCtx& ctx) {
+  ctx.out.data[0] = tglm_eval<false, kCatLogitGlm>(ctx);
+}
+void clglm_bwd(KernelCtx& ctx) { tglm_eval<true, kCatLogitGlm>(ctx); }
+void olglm_fwd(KernelCtx& ctx) {
+  ctx.out.data[0] = tglm_eval<false, kOrdLogisticGlm>(ctx);
+}
+void olglm_bwd(KernelCtx& ctx) { tglm_eval<true, kOrdLogisticGlm>(ctx); }
+
 int64_t no_scratch(const Op&, const Slot*) { return 0; }
 
 }  // namespace
@@ -493,6 +874,33 @@ int64_t no_scratch(const Op&, const Slot*) { return 0; }
 void register_matrix_kernels() {
   register_kernel(OP_GP_EXP_QUAD_COV,
                   Kernel{gp_cov_fwd, gp_cov_bwd, no_scratch});
+  register_kernel(OP_WISHART_LPDF, Kernel{wish_fwd, wish_bwd, no_scratch});
+  register_kernel(OP_INV_WISHART_LPDF,
+                  Kernel{iwish_fwd, iwish_bwd, no_scratch});
+  register_kernel(OP_WISHART_CHOL_LPDF,
+                  Kernel{wishc_fwd, wishc_bwd, no_scratch});
+  register_kernel(OP_INV_WISHART_CHOL_LPDF,
+                  Kernel{iwishc_fwd, iwishc_bwd, no_scratch});
+  register_kernel(OP_MULTI_GP_LPDF, Kernel{mgp_fwd, mgp_bwd, no_scratch});
+  register_kernel(OP_MULTI_GP_CHOL_LPDF, Kernel{mgpc_fwd, mgpc_bwd, no_scratch});
+  register_kernel(OP_MULTI_STUDENT_T_LPDF, Kernel{mst_fwd, mst_bwd, no_scratch});
+  register_kernel(OP_MULTI_STUDENT_T_CHOL_LPDF,
+                  Kernel{mstc_fwd, mstc_bwd, no_scratch});
+  register_kernel(OP_MULTINOMIAL_LPMF, Kernel{multn_fwd, multn_bwd, no_scratch});
+  register_kernel(OP_MULTINOMIAL_LOGIT_LPMF,
+                  Kernel{multnl_fwd, multnl_bwd, no_scratch});
+  register_kernel(OP_DIRICHLET_MULTINOMIAL_LPMF,
+                  Kernel{dirmult_fwd, dirmult_bwd, no_scratch});
+  register_kernel(OP_ORDERED_PROBIT_LPMF,
+                  Kernel{oprobit_fwd, oprobit_bwd, no_scratch});
+  register_kernel(OP_WIENER_LPDF, Kernel{wiener_fwd, wiener_bwd, no_scratch});
+  register_kernel(OP_LKJ_COV_LPDF, Kernel{lkjcov_fwd, lkjcov_bwd, no_scratch});
+  register_kernel(OP_BINOMIAL_LOGIT_GLM_LPMF,
+                  Kernel{blglm_fwd, blglm_bwd, no_scratch});
+  register_kernel(OP_CATEGORICAL_LOGIT_GLM_LPMF,
+                  Kernel{clglm_fwd, clglm_bwd, no_scratch});
+  register_kernel(OP_ORDERED_LOGISTIC_GLM_LPMF,
+                  Kernel{olglm_fwd, olglm_bwd, no_scratch});
   register_kernel(OP_DIAG_MATRIX, Kernel{diag_fwd, diag_bwd, no_scratch});
   register_kernel(OP_CHOLESKY, Kernel{chol_fwd, chol_bwd, no_scratch});
   register_kernel(OP_MULTI_NORMAL_CHOL_LPDF,

--- a/runtime/kernels/matrix_fns.cpp
+++ b/runtime/kernels/matrix_fns.cpp
@@ -221,7 +221,11 @@ void mnc_fwd(KernelCtx& ctx) { ctx.out.data[0] = mnc_eval<false>(ctx); }
 void mnc_bwd(KernelCtx& ctx) { mnc_eval<true>(ctx); }
 
 // ---- multi_normal_lpdf(y | mu, Sigma) -------------------------------------
-template <bool Grad>
+// multi_normal_prec takes the same three arguments in the same shapes -- a
+// precision matrix instead of a covariance -- so it is the same kernel with
+// one call swapped.
+enum MnKind { kMnCov, kMnPrec };
+template <bool Grad, MnKind Kind = kMnCov>
 double mn_eval(KernelCtx& ctx) {
   const int64_t n = ctx.idata[0];
   const int64_t m = ctx.n_idata > 1 ? ctx.idata[1] : 1;
@@ -245,8 +249,13 @@ double mn_eval(KernelCtx& ctx) {
   CMapV yd(ctx.in[0].data, n), mud(ctx.in[1].data, n);
   CMapM Sd(ctx.in[2].data, n, n);
   auto call = [&](auto&& a, auto&& b, auto&& c) {
-    return propto ? stan::math::multi_normal_lpdf<true>(a, b, c)
-                  : stan::math::multi_normal_lpdf<false>(a, b, c);
+    if constexpr (Kind == kMnPrec) {
+      return propto ? stan::math::multi_normal_prec_lpdf<true>(a, b, c)
+                    : stan::math::multi_normal_prec_lpdf<false>(a, b, c);
+    } else {
+      return propto ? stan::math::multi_normal_lpdf<true>(a, b, c)
+                    : stan::math::multi_normal_lpdf<false>(a, b, c);
+    }
   };
   var out;
   const bool ay = mask & 1u, am = mask & 2u, aS = mask & 4u;
@@ -304,6 +313,10 @@ double mn_eval(KernelCtx& ctx) {
 }
 void mn_fwd(KernelCtx& ctx) { ctx.out.data[0] = mn_eval<false>(ctx); }
 void mn_bwd(KernelCtx& ctx) { mn_eval<true>(ctx); }
+void mnprec_fwd(KernelCtx& ctx) {
+  ctx.out.data[0] = mn_eval<false, kMnPrec>(ctx);
+}
+void mnprec_bwd(KernelCtx& ctx) { mn_eval<true, kMnPrec>(ctx); }
 
 // ---- general matrix product: out = A * B ----------------------------------
 // idata = {rows_a, cols_a, cols_b}; either side may carry adjoints.
@@ -326,7 +339,7 @@ void gemm_bwd(KernelCtx& ctx) {
 
 // ---- lkj_corr_cholesky_lpdf(L | eta) --------------------------------------
 // in = {L, eta}; idata = {K}. eta is a data scalar in practice.
-template <bool Grad>
+template <bool Grad, bool Chol = true>
 double lkj_eval(KernelCtx& ctx) {
   const int64_t K = ctx.idata[0];
   const bool propto = (ctx.variant & 0x80u) != 0;
@@ -336,8 +349,14 @@ double lkj_eval(KernelCtx& ctx) {
   for (int64_t j = 0; j < K; ++j)
     for (int64_t i = 0; i < K; ++i) L(i, j) = ctx.in[0].data[j * K + i];
   const double eta = ctx.in[1].data[0];
-  var out = propto ? stan::math::lkj_corr_cholesky_lpdf<true>(L, eta)
-                   : stan::math::lkj_corr_cholesky_lpdf<false>(L, eta);
+  var out;
+  if constexpr (Chol) {
+    out = propto ? stan::math::lkj_corr_cholesky_lpdf<true>(L, eta)
+                 : stan::math::lkj_corr_cholesky_lpdf<false>(L, eta);
+  } else {
+    out = propto ? stan::math::lkj_corr_lpdf<true>(L, eta)
+                 : stan::math::lkj_corr_lpdf<false>(L, eta);
+  }
   const double v = out.val();
   if constexpr (Grad) {
     var j = out * ctx.out_adj;
@@ -351,6 +370,12 @@ double lkj_eval(KernelCtx& ctx) {
 }
 void lkj_fwd(KernelCtx& ctx) { ctx.out.data[0] = lkj_eval<false>(ctx); }
 void lkj_bwd(KernelCtx& ctx) { lkj_eval<true>(ctx); }
+// lkj_corr takes the correlation matrix itself where the cholesky form
+// takes its factor: identical argument shapes, so identical kernel.
+void lkjc_fwd(KernelCtx& ctx) {
+  ctx.out.data[0] = lkj_eval<false, false>(ctx);
+}
+void lkjc_bwd(KernelCtx& ctx) { lkj_eval<true, false>(ctx); }
 
 // ---- normal_id_glm_lpdf(y | X, alpha, beta, sigma) ------------------------
 // in = {y, X, alpha, beta, sigma}; idata = {rows, cols}. X is a data matrix.
@@ -473,6 +498,8 @@ void register_matrix_kernels() {
   register_kernel(OP_MULTI_NORMAL_CHOL_LPDF,
                   Kernel{mnc_fwd, mnc_bwd, no_scratch});
   register_kernel(OP_MULTI_NORMAL_LPDF, Kernel{mn_fwd, mn_bwd, no_scratch});
+  register_kernel(OP_MULTI_NORMAL_PREC_LPDF,
+                  Kernel{mnprec_fwd, mnprec_bwd, no_scratch});
   register_kernel(OP_GEMM, Kernel{gemm_fwd, gemm_bwd, no_scratch});
   register_kernel(OP_EIGENVALUES_SYM,
                   Kernel{eigvals_fwd, eigvals_bwd, no_scratch});
@@ -481,6 +508,8 @@ void register_matrix_kernels() {
   register_kernel(OP_TRANSPOSE,
                   Kernel{transpose_fwd, transpose_bwd, no_scratch});
   register_kernel(OP_LKJ_CORR_CHOL_LPDF, Kernel{lkj_fwd, lkj_bwd, no_scratch});
+  register_kernel(OP_LKJ_CORR_LPDF,
+                  Kernel{lkjc_fwd, lkjc_bwd, no_scratch});
   register_kernel(OP_NORMAL_ID_GLM_LPDF,
                   Kernel{nid_glm_fwd, nid_glm_bwd, nid_glm_scratch});
 }

--- a/runtime/src/lower.cpp
+++ b/runtime/src/lower.cpp
@@ -1036,6 +1036,168 @@ struct Lowering {
       g.ops.back().variant = (uint8_t)((e.fn_propto ? 0x80u : 0u) | 0x1u);
       return v;
     }
+    // lkj_cov(Sigma | mu, sigma, eta).
+    if (e.name == "lkj_cov_lpdf" && e.args.size() == 4) {
+      Val S = lower_expr(e.args[0]);
+      Val mu = lower_expr(e.args[1]);
+      Val sig = lower_expr(e.args[2]);
+      Val eta = lower_expr(e.args[3]);
+      if (S.si.rows == 0) fail("lkj_cov needs a matrix", e.raw);
+      Val v = emit(OP_LKJ_COV_LPDF, {S.slot, mu.slot, sig.slot, eta.slot}, 1,
+                   {}, {(int)S.si.rows});
+      g.ops.back().variant = (uint8_t)((e.fn_propto ? 0x80u : 0u) | 0xfu);
+      return v;
+    }
+
+    // gaussian_dlm_obs takes seven arguments and Op::in holds six, so it
+    // cannot be lowered as one op at all. Raising the limit would add
+    // bytes to every Op and every KernelCtx in every model for the sake
+    // of one dynamic-linear-model density, so this refuses instead and
+    // names the reason. See docs/coverage.md.
+    if (e.name == "gaussian_dlm_obs_lpdf")
+      fail("gaussian_dlm_obs takes 7 arguments and an op holds 6", e.raw);
+
+    // The three GLMs whose argument shapes the recorder cannot express.
+    // idata is the outcome (two groups for binomial) then rows, cols.
+    if (e.name == "binomial_logit_glm_lpmf" && e.args.size() == 5) {
+      std::vector<int> idata = int_arg_values(e.args[0]);
+      std::vector<int> NN = int_arg_values(e.args[1]);
+      Val X = lower_expr(e.args[2]);
+      Val alpha = lower_expr(e.args[3]);
+      Val beta = lower_expr(e.args[4]);
+      if (X.si.rows == 0) fail("binomial_logit_glm needs a matrix", e.raw);
+      // Both int groups are one value per row, so a scalar broadcasts.
+      const int64_t rows = X.si.rows;
+      if ((int64_t)idata.size() == 1) idata.assign(rows, idata[0]);
+      if ((int64_t)NN.size() == 1) NN.assign(rows, NN[0]);
+      idata.insert(idata.end(), NN.begin(), NN.end());
+      idata.push_back((int)rows);
+      idata.push_back((int)X.si.cols);
+      Val v = emit(OP_BINOMIAL_LOGIT_GLM_LPMF,
+                   {X.slot, alpha.slot, beta.slot}, 1, {}, idata);
+      g.ops.back().variant = (uint8_t)((e.fn_propto ? 0x80u : 0u) | 0x7u);
+      return v;
+    }
+    if ((e.name == "categorical_logit_glm_lpmf" ||
+         e.name == "ordered_logistic_glm_lpmf") &&
+        e.args.size() == 4) {
+      std::vector<int> idata = int_arg_values(e.args[0]);
+      Val X = lower_expr(e.args[1]);
+      Val a2 = lower_expr(e.args[2]);
+      Val a3 = lower_expr(e.args[3]);
+      if (X.si.rows == 0) fail(e.name + " needs a matrix", e.raw);
+      if ((int64_t)idata.size() == 1) idata.assign(X.si.rows, idata[0]);
+      idata.push_back((int)X.si.rows);
+      idata.push_back((int)X.si.cols);
+      // categorical: (y, x, alpha, beta). ordered: (y, x, beta, cuts).
+      // Both pass their two real arguments in order, so the kernel reads
+      // in[1] and in[2] and knows from its Kind what they mean.
+      Val v = emit(e.name == "categorical_logit_glm_lpmf"
+                       ? OP_CATEGORICAL_LOGIT_GLM_LPMF
+                       : OP_ORDERED_LOGISTIC_GLM_LPMF,
+                   {X.slot, a2.slot, a3.slot}, 1, {}, idata);
+      g.ops.back().variant = (uint8_t)((e.fn_propto ? 0x80u : 0u) | 0x7u);
+      return v;
+    }
+
+    // multi_gp: (matrix y[K x N], matrix Sigma[K x K], vector w[K]).
+    if ((e.name == "multi_gp_lpdf" || e.name == "multi_gp_cholesky_lpdf") &&
+        e.args.size() == 3) {
+      Val y = lower_expr(e.args[0]);
+      Val S = lower_expr(e.args[1]);
+      Val w = lower_expr(e.args[2]);
+      if (y.si.rows == 0 || S.si.rows == 0)
+        fail(e.name + " needs matrix arguments", e.raw);
+      Val v = emit(e.name == "multi_gp_lpdf" ? OP_MULTI_GP_LPDF
+                                             : OP_MULTI_GP_CHOL_LPDF,
+                   {y.slot, S.slot, w.slot}, 1, {},
+                   {(int)y.si.rows, (int)y.si.cols});
+      g.ops.back().variant = (uint8_t)((e.fn_propto ? 0x80u : 0u) | 0x7u);
+      return v;
+    }
+
+    // multi_student_t: (vector y, real nu, vector mu, matrix Sigma). K from
+    // the matrix; y may be an array of K-vectors, as multi_normal allows.
+    if ((e.name == "multi_student_t_lpdf" ||
+         e.name == "multi_student_t_cholesky_lpdf") &&
+        e.args.size() == 4) {
+      Val y = lower_expr(e.args[0]);
+      Val nu = lower_expr(e.args[1]);
+      Val mu = lower_expr(e.args[2]);
+      Val S = lower_expr(e.args[3]);
+      if (S.si.rows == 0) fail(e.name + " needs a matrix argument", e.raw);
+      const int64_t K = S.si.rows;
+      const int64_t reps = info[y.slot].len / K;
+      Val v = emit(e.name == "multi_student_t_lpdf"
+                       ? OP_MULTI_STUDENT_T_LPDF
+                       : OP_MULTI_STUDENT_T_CHOL_LPDF,
+                   {y.slot, nu.slot, mu.slot, S.slot}, 1, {},
+                   {(int)K, (int)reps});
+      g.ops.back().variant = (uint8_t)((e.fn_propto ? 0x80u : 0u) | 0xfu);
+      return v;
+    }
+
+    // The multinomial family: (array[] int ns, vector theta). The counts
+    // must be data (they ride in idata); theta is the only edge.
+    {
+      static const std::map<std::string, uint16_t> kMult = {
+          {"multinomial_lpmf", OP_MULTINOMIAL_LPMF},
+          {"multinomial_logit_lpmf", OP_MULTINOMIAL_LOGIT_LPMF},
+          {"dirichlet_multinomial_lpmf", OP_DIRICHLET_MULTINOMIAL_LPMF},
+      };
+      auto mit = kMult.find(e.name);
+      if (mit != kMult.end() && e.args.size() == 2) {
+        std::vector<int> ns = int_arg_values(e.args[0]);
+        Val th = lower_expr(e.args[1]);
+        Val v = emit(mit->second, {th.slot}, 1, {}, ns);
+        g.ops.back().variant = (uint8_t)((e.fn_propto ? 0x80u : 0u) | 0x1u);
+        return v;
+      }
+    }
+
+    // ordered_probit(y | lambda, c): outcome in idata, lambda and the
+    // cutpoints are real edges.
+    if (e.name == "ordered_probit_lpmf" && e.args.size() == 3) {
+      std::vector<int> y = int_arg_values(e.args[0]);
+      Val lam = lower_expr(e.args[1]);
+      Val c = lower_expr(e.args[2]);
+      Val v = emit(OP_ORDERED_PROBIT_LPMF, {lam.slot, c.slot}, 1, {}, y);
+      g.ops.back().variant = (uint8_t)((e.fn_propto ? 0x80u : 0u) | 0x3u);
+      return v;
+    }
+
+    // wiener(y | alpha, tau, beta, delta): five real arguments.
+    if (e.name == "wiener_lpdf" && e.args.size() == 5) {
+      std::vector<int> ins;
+      for (int i = 0; i < 5; ++i) ins.push_back(lower_expr(e.args[i]).slot);
+      Val v = emit(OP_WIENER_LPDF, ins, 1, {}, {});
+      g.ops.back().variant = (uint8_t)((e.fn_propto ? 0x80u : 0u) | 0x1fu);
+      return v;
+    }
+
+    // The wishart family: (matrix, real, matrix), all four of them. K
+    // comes from the first matrix; the kernels bind every argument as var
+    // (docs/coverage.md, "write the kernel" tier) so no activity mask is
+    // needed, only the propto bit.
+    {
+      static const std::map<std::string, uint16_t> kWish = {
+          {"wishart_lpdf", OP_WISHART_LPDF},
+          {"inv_wishart_lpdf", OP_INV_WISHART_LPDF},
+          {"wishart_cholesky_lpdf", OP_WISHART_CHOL_LPDF},
+          {"inv_wishart_cholesky_lpdf", OP_INV_WISHART_CHOL_LPDF},
+      };
+      auto wit = kWish.find(e.name);
+      if (wit != kWish.end() && e.args.size() == 3) {
+        Val W = lower_expr(e.args[0]);
+        Val nu = lower_expr(e.args[1]);
+        Val S = lower_expr(e.args[2]);
+        if (W.si.rows == 0) fail(e.name + " needs a matrix", e.raw);
+        Val v = emit(wit->second, {W.slot, nu.slot, S.slot}, 1, {},
+                     {(int)W.si.rows});
+        g.ops.back().variant = (uint8_t)((e.fn_propto ? 0x80u : 0u) | 0x7u);
+        return v;
+      }
+    }
     if (e.name == "normal_id_glm_lpdf" && e.args.size() == 5) {
       Val y = lower_expr(e.args[0]);
       Val X = lower_expr(e.args[1]);

--- a/runtime/src/lower.cpp
+++ b/runtime/src/lower.cpp
@@ -837,6 +837,25 @@ struct Lowering {
     if (auto v = lower_eltwise_fn(e)) return *v;
     if (auto v = lower_matrix_fn(e)) return *v;
     if (auto v = lower_ode_fn(e)) return *v;
+    // `y ~ foo(...)` with every argument data is EXACTLY zero in CmdStan:
+    // the generated C++ calls foo_lpdf<propto=true> on all-double
+    // arguments, include_summand comes back false, and the whole term is
+    // dropped before any arithmetic happens. So the rewrite is not an
+    // approximation, and it covers densities no kernel exists for --
+    // hypergeometric and discrete_range are all-int, so ALL their uses
+    // land here or in the constant fold below. (categorical_logit already
+    // had this rule privately; this is the general form.) The one
+    // divergence is a model whose data is outside the density's support:
+    // CmdStan's checks throw before the early return, stanli contributes
+    // 0. That model rejects every draw anyway.
+    const bool is_density = e.name.size() > 5 &&
+                            (e.name.compare(e.name.size() - 5, 5, "_lpdf") == 0 ||
+                             e.name.compare(e.name.size() - 5, 5, "_lpmf") == 0);
+    if (is_density && e.fn_propto) {
+      bool all_data = true;
+      for (const auto& a : e.args) all_data = all_data && a.data_only;
+      if (all_data) return Val{const_slot(0.0), {}};
+    }
     {
       Val v;
       if (try_fold_const(e, &v)) return v;
@@ -977,7 +996,8 @@ struct Lowering {
     }
 
     if ((e.name == "multi_normal_cholesky_lpdf" ||
-         e.name == "multi_normal_lpdf") && e.args.size() == 3) {
+         e.name == "multi_normal_lpdf" ||
+         e.name == "multi_normal_prec_lpdf") && e.args.size() == 3) {
       Val y = lower_expr(e.args[0]);
       Val mu = lower_expr(e.args[1]);
       Val m = lower_expr(e.args[2]);
@@ -993,20 +1013,26 @@ struct Lowering {
              e.raw);
       const int64_t K = m.si.rows;
       const int64_t reps = info[y.slot].len / K;
-      Val v = emit(e.name.find("cholesky") != std::string::npos
-                       ? OP_MULTI_NORMAL_CHOL_LPDF
-                       : OP_MULTI_NORMAL_LPDF,
+      const uint16_t mn_op =
+          e.name.find("cholesky") != std::string::npos
+              ? OP_MULTI_NORMAL_CHOL_LPDF
+              : (e.name.find("prec") != std::string::npos
+                     ? OP_MULTI_NORMAL_PREC_LPDF
+                     : OP_MULTI_NORMAL_LPDF);
+      Val v = emit(mn_op,
                    {y.slot, mu.slot, m.slot}, 1, {},
                    {(int)K, (int)reps});
       g.ops.back().variant = variant;
       return v;
     }
-    if (e.name == "lkj_corr_cholesky_lpdf" && e.args.size() == 2) {
+    if ((e.name == "lkj_corr_cholesky_lpdf" || e.name == "lkj_corr_lpdf") &&
+        e.args.size() == 2) {
       Val L = lower_expr(e.args[0]);
       Val eta = lower_expr(e.args[1]);
-      if (L.si.rows == 0) fail("lkj_corr_cholesky needs a matrix", e.raw);
-      Val v = emit(OP_LKJ_CORR_CHOL_LPDF, {L.slot, eta.slot}, 1, {},
-                   {(int)L.si.rows});
+      if (L.si.rows == 0) fail(e.name + " needs a matrix", e.raw);
+      Val v = emit(e.name == "lkj_corr_lpdf" ? OP_LKJ_CORR_LPDF
+                                             : OP_LKJ_CORR_CHOL_LPDF,
+                   {L.slot, eta.slot}, 1, {}, {(int)L.si.rows});
       g.ops.back().variant = (uint8_t)((e.fn_propto ? 0x80u : 0u) | 0x1u);
       return v;
     }

--- a/runtime/src/lower.cpp
+++ b/runtime/src/lower.cpp
@@ -882,6 +882,10 @@ struct Lowering {
         {"neg_binomial_2_lpmf", {OP_NEG_BINOMIAL_2_LPMF, 3, 1}},
         {"binomial_lpmf", {OP_BINOMIAL_LPMF, 3, 2}},
         {"binomial_logit_lpmf", {OP_BINOMIAL_LOGIT_LPMF, 3, 2}},
+        {"poisson_log_glm_lpmf", {OP_POISSON_LOG_GLM_LPMF, 4, 1, true}},
+        {"neg_binomial_2_log_glm_lpmf",
+         {OP_NEG_BINOMIAL_2_LOG_GLM_LPMF, 5, 1, true}},
+        {"beta_binomial_lpmf", {OP_BETA_BINOMIAL_LPMF, 4, 2}},
         {"bernoulli_logit_glm_lpmf",
          {OP_BERNOULLI_LOGIT_GLM_LPMF, 4, 1, true}},
         {"dirichlet_lpdf", {OP_DIRICHLET_LPDF, 2, 0}},
@@ -924,7 +928,18 @@ struct Lowering {
         idata.push_back((int)xsi.cols);
       }
       Val dv = emit(d.op, ins, 1, {}, idata);
-      if (!d.glm) g.ops.back().variant = variant;
+      // GLM ops used to be the one density shape that got no variant at
+      // all, so their kernels hardcoded propto=false and poisson_log_glm's
+      // lp landed sum(log(y!)) -- 10.45 on a six-row test -- away from
+      // CmdStan's, with the gradients already exact. They get the same
+      // variant as everything else now. Their forwards bind arguments
+      // explicitly rather than through mask_dispatch, so the mask reaches
+      // only density_bwd, where it says to skip X -- which it already did
+      // by X's null adjoint. Setting only the propto bit is NOT an option:
+      // density_bwd reads a nonzero variant as a literal mask, so 0x80
+      // alone means "no argument is active" and every gradient comes back
+      // zero.
+      g.ops.back().variant = variant;
       return dv;
     }
 

--- a/tests/fixtures/glmpois.stan
+++ b/tests/fixtures/glmpois.stan
@@ -1,0 +1,23 @@
+// The GLM fast paths brms and rstanarm emit directly. These bind their
+// arguments explicitly instead of through mask_dispatch, so they are the
+// one density shape whose propto bit and activity mask travel a different
+// route -- and the route was missing, which cost poisson_log_glm's lp
+// sum(log(y!)) against CmdStan while its gradients were already exact.
+data {
+  int<lower=1> N;
+  int<lower=1> K;
+  matrix[N, K] x;
+  array[N] int<lower=0> y;
+}
+parameters {
+  real alpha;
+  vector[K] beta;
+  real<lower=0> phi;
+}
+model {
+  alpha ~ normal(0, 2);
+  beta ~ normal(0, 2);
+  phi ~ exponential(1);
+  y ~ poisson_log_glm(x, alpha, beta);
+  y ~ neg_binomial_2_log_glm(x, alpha, beta, phi);
+}

--- a/tests/fixtures/glmpois.tmir.sexp
+++ b/tests/fixtures/glmpois.tmir.sexp
@@ -1,0 +1,796 @@
+((functions_block ())
+ (input_vars
+  ((N <opaque> SInt) (K <opaque> SInt)
+   (x <opaque>
+    (SMatrix AoS
+     ((pattern (Var N)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+     ((pattern (Var K)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+   (y <opaque>
+    (SArray SInt
+     ((pattern (Var N)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+ (prepare_data
+  (((pattern
+     (Decl (decl_adtype DataOnly) (decl_id pos__) (decl_type (Sized SInt))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable pos__) ()) UInt
+      ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id N) (decl_type (Sized SInt))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable N) ()) UInt
+      ((pattern
+        (Indexed
+         ((pattern
+           (FunApp (CompilerInternal FnReadData)
+            (((pattern (Lit Str N))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+          (meta ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly))))
+         ((Single
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnCheck
+        (trans
+         (Lower
+          ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (var_name N)
+        (var ((pattern (Var N)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id K) (decl_type (Sized SInt))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable K) ()) UInt
+      ((pattern
+        (Indexed
+         ((pattern
+           (FunApp (CompilerInternal FnReadData)
+            (((pattern (Lit Str K))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+          (meta ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly))))
+         ((Single
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnCheck
+        (trans
+         (Lower
+          ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (var_name K)
+        (var ((pattern (Var K)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp (CompilerInternal FnValidateSize)
+      (((pattern (Lit Str x)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+       ((pattern (Lit Str N)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+       ((pattern (Var N)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp (CompilerInternal FnValidateSize)
+      (((pattern (Lit Str x)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+       ((pattern (Lit Str K)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+       ((pattern (Var K)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id x)
+      (decl_type
+       (Sized
+        (SMatrix AoS
+         ((pattern (Var N)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+         ((pattern (Var K)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id x_flat__)
+          (decl_type (Unsized (UArray UReal))) (initialize Uninit)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable x_flat__) ()) (UArray UReal)
+          ((pattern
+            (FunApp (CompilerInternal FnReadData)
+             (((pattern (Lit Str x))
+               (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable pos__) ()) UInt
+          ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar sym1__)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Var K)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (For (loopvar sym2__)
+                  (lower
+                   ((pattern (Lit Int 1))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (upper
+                   ((pattern (Var N))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (body
+                   ((pattern
+                     (Block
+                      (((pattern
+                         (Assignment
+                          ((LVariable x)
+                           ((Single
+                             ((pattern (Var sym2__))
+                              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                            (Single
+                             ((pattern (Var sym1__))
+                              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                          UMatrix
+                          ((pattern
+                            (Indexed
+                             ((pattern (Var x_flat__))
+                              (meta
+                               ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))
+                             ((Single
+                               ((pattern (Var pos__))
+                                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                           (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+                        (meta <opaque>))
+                       ((pattern
+                         (Assignment ((LVariable pos__) ()) UInt
+                          ((pattern
+                            (FunApp (StanLib Plus__ FnPlain AoS)
+                             (((pattern (Var pos__))
+                               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                              ((pattern (Lit Int 1))
+                               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                        (meta <opaque>)))))
+                    (meta <opaque>)))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp (CompilerInternal FnValidateSize)
+      (((pattern (Lit Str y)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+       ((pattern (Lit Str N)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+       ((pattern (Var N)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id y)
+      (decl_type
+       (Sized
+        (SArray SInt
+         ((pattern (Var N)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable y) ()) (UArray UInt)
+      ((pattern
+        (FunApp (CompilerInternal FnReadData)
+         (((pattern (Lit Str y))
+           (meta ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnCheck
+        (trans
+         (Lower
+          ((pattern (Lit Int 0)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (var_name y)
+        (var
+         ((pattern (Var y))
+          (meta ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly)))))))
+      (((pattern (Lit Int 0)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp (CompilerInternal FnValidateSize)
+      (((pattern (Lit Str beta)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+       ((pattern (Lit Str K)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+       ((pattern (Var K)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+    (meta <opaque>))))
+ (log_prob
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id alpha) (decl_type (Sized SReal))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity) (dims ()) (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id beta)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Var K)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity)
+             (dims
+              (((pattern (Var K))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id phi) (decl_type (Sized SReal))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam
+             (constrain
+              (Lower
+               ((pattern (Lit Int 0))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (dims ()) (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib normal_lpdf (FnLpdf true) AoS)
+             (((pattern (Var alpha))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+              ((pattern
+                (Promotion
+                 ((pattern (Lit Int 0))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                 UReal DataOnly))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+              ((pattern
+                (Promotion
+                 ((pattern (Lit Int 2))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                 UReal DataOnly))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>))
+       ((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib normal_lpdf (FnLpdf true) AoS)
+             (((pattern (Var beta))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))
+              ((pattern
+                (Promotion
+                 ((pattern (Lit Int 0))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                 UReal DataOnly))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+              ((pattern
+                (Promotion
+                 ((pattern (Lit Int 2))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                 UReal DataOnly))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>))
+       ((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib exponential_lpdf (FnLpdf true) AoS)
+             (((pattern (Var phi))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+              ((pattern
+                (Promotion
+                 ((pattern (Lit Int 1))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                 UReal DataOnly))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>))
+       ((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib poisson_log_glm_lpmf (FnLpmf true) AoS)
+             (((pattern (Var y))
+               (meta ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly))))
+              ((pattern (Var x))
+               (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly))))
+              ((pattern (Var alpha))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+              ((pattern (Var beta))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>))
+       ((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib neg_binomial_2_log_glm_lpmf (FnLpmf true) AoS)
+             (((pattern (Var y))
+               (meta ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly))))
+              ((pattern (Var x))
+               (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly))))
+              ((pattern (Var alpha))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+              ((pattern (Var beta))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))
+              ((pattern (Var phi))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>)))))
+    (meta <opaque>))))
+ (reverse_mode_log_prob
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id alpha) (decl_type (Sized SReal))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity) (dims ()) (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id beta)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Var K)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity)
+             (dims
+              (((pattern (Var K))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id phi) (decl_type (Sized SReal))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam
+             (constrain
+              (Lower
+               ((pattern (Lit Int 0))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (dims ()) (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib normal_lpdf (FnLpdf true) AoS)
+             (((pattern (Var alpha))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+              ((pattern
+                (Promotion
+                 ((pattern (Lit Int 0))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                 UReal DataOnly))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+              ((pattern
+                (Promotion
+                 ((pattern (Lit Int 2))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                 UReal DataOnly))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>))
+       ((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib normal_lpdf (FnLpdf true) AoS)
+             (((pattern (Var beta))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))
+              ((pattern
+                (Promotion
+                 ((pattern (Lit Int 0))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                 UReal DataOnly))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+              ((pattern
+                (Promotion
+                 ((pattern (Lit Int 2))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                 UReal DataOnly))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>))
+       ((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib exponential_lpdf (FnLpdf true) AoS)
+             (((pattern (Var phi))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+              ((pattern
+                (Promotion
+                 ((pattern (Lit Int 1))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                 UReal DataOnly))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>))
+       ((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib poisson_log_glm_lpmf (FnLpmf true) AoS)
+             (((pattern (Var y))
+               (meta ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly))))
+              ((pattern (Var x))
+               (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly))))
+              ((pattern (Var alpha))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+              ((pattern (Var beta))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>))
+       ((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib neg_binomial_2_log_glm_lpmf (FnLpmf true) AoS)
+             (((pattern (Var y))
+               (meta ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly))))
+              ((pattern (Var x))
+               (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly))))
+              ((pattern (Var alpha))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+              ((pattern (Var beta))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))
+              ((pattern (Var phi))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>)))))
+    (meta <opaque>))))
+ (generate_quantities
+  (((pattern
+     (Decl (decl_adtype DataOnly) (decl_id alpha) (decl_type (Sized SReal))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity) (dims ()) (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id beta)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Var K)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity)
+             (dims
+              (((pattern (Var K))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id phi) (decl_type (Sized SReal))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam
+             (constrain
+              (Lower
+               ((pattern (Lit Int 0))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (dims ()) (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt ())
+        (var
+         ((pattern (Var alpha)) (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt ())
+        (var
+         ((pattern (Var beta))
+          (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt ())
+        (var
+         ((pattern (Var phi)) (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (IfElse
+      ((pattern
+        (FunApp (StanLib PNot__ FnPlain AoS)
+         (((pattern
+            (EOr
+             ((pattern (Var emit_transformed_parameters__))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+             ((pattern (Var emit_generated_quantities__))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+      ((pattern (Block (((pattern (Return ())) (meta <opaque>))))) (meta <opaque>)) ()))
+    (meta <opaque>))
+   ((pattern
+     (IfElse
+      ((pattern
+        (FunApp (StanLib PNot__ FnPlain AoS)
+         (((pattern (Var emit_generated_quantities__))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+      ((pattern (Block (((pattern (Return ())) (meta <opaque>))))) (meta <opaque>)) ()))
+    (meta <opaque>))))
+ (transform_inits
+  (((pattern
+     (Decl (decl_adtype DataOnly) (decl_id pos__) (decl_type (Sized SInt))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable pos__) ()) UInt
+      ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id alpha) (decl_type (Sized SReal))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable alpha) ()) UReal
+      ((pattern
+        (Indexed
+         ((pattern
+           (FunApp (CompilerInternal FnReadData)
+            (((pattern (Lit Str alpha))
+              (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+          (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))
+         ((Single
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+       (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var alpha)) (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id beta)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Var K)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id beta_flat__)
+          (decl_type (Unsized (UArray UReal))) (initialize Uninit)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable beta_flat__) ()) (UArray UReal)
+          ((pattern
+            (FunApp (CompilerInternal FnReadData)
+             (((pattern (Lit Str beta))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable pos__) ()) UInt
+          ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar sym1__)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Var K)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (Assignment
+                  ((LVariable beta)
+                   ((Single
+                     ((pattern (Var sym1__))
+                      (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                  UVector
+                  ((pattern
+                    (Indexed
+                     ((pattern (Var beta_flat__))
+                      (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))
+                     ((Single
+                       ((pattern (Var pos__))
+                        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+                (meta <opaque>))
+               ((pattern
+                 (Assignment ((LVariable pos__) ()) UInt
+                  ((pattern
+                    (FunApp (StanLib Plus__ FnPlain AoS)
+                     (((pattern (Var pos__))
+                       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                      ((pattern (Lit Int 1))
+                       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var beta))
+          (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id phi) (decl_type (Sized SReal))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable phi) ()) UReal
+      ((pattern
+        (Indexed
+         ((pattern
+           (FunApp (CompilerInternal FnReadData)
+            (((pattern (Lit Str phi))
+              (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+          (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))
+         ((Single
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+       (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam
+        (unconstrain_opt
+         ((Lower
+           ((pattern (Lit Int 0))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+        (var
+         ((pattern (Var phi)) (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))))
+ (unconstrain_array
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id alpha) (decl_type (Sized SReal))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable alpha) ()) UReal
+      ((pattern (FunApp (CompilerInternal FnReadDeserializer) ()))
+       (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var alpha)) (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id beta)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Var K)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable beta) ()) UVector
+      ((pattern
+        (FunApp (CompilerInternal FnReadDeserializer)
+         (((pattern (Var K)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var beta))
+          (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id phi) (decl_type (Sized SReal))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable phi) ()) UReal
+      ((pattern (FunApp (CompilerInternal FnReadDeserializer) ()))
+       (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam
+        (unconstrain_opt
+         ((Lower
+           ((pattern (Lit Int 0))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+        (var
+         ((pattern (Var phi)) (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))))
+ (output_vars
+  ((alpha <opaque>
+    ((out_unconstrained_st SReal) (out_constrained_st SReal) (out_block Parameters)
+     (out_trans Identity)))
+   (beta <opaque>
+    ((out_unconstrained_st
+      (SVector AoS
+       ((pattern (Var K)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+     (out_constrained_st
+      (SVector AoS
+       ((pattern (Var K)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+     (out_block Parameters) (out_trans Identity)))
+   (phi <opaque>
+    ((out_unconstrained_st SReal) (out_constrained_st SReal) (out_block Parameters)
+     (out_trans
+      (Lower
+       ((pattern (Lit Int 0)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))))
+ (prog_name glmpois_model) (prog_path tests/fixtures/glmpois.stan))

--- a/tests/test_lower.cpp
+++ b/tests/test_lower.cpp
@@ -741,6 +741,52 @@ int main() {
           "ordered_logistic: lp matches the var path");
   }
 
+  // The GLM fast paths. fn_sweep cannot reach these -- it generates
+  // all-scalar models and a GLM needs a data matrix -- so this is the only
+  // check that their propto bit and activity mask arrive.
+  {
+    // Through the JSON reader, so the data-matrix layout convention is
+    // part of what this checks: x[i][j] is row i, column j, and the
+    // reference below fills X the same way.
+    DataMap d = DataMap::from_json(
+        R"({"N": 4, "K": 2,
+            "x": [[0.3, -0.2], [1.1, 0.4], [-0.5, 0.9], [0.2, 0.7]],
+            "y": [2, 5, 1, 3]})");
+    CompiledModel gm =
+        compile_model(slurp("tests/fixtures/glmpois.tmir.sexp"), d);
+    Executor gex(std::move(gm.graph));
+    gm.bind(gex);
+    const double q[4] = {0.15, 0.3, -0.25, -0.4};  // alpha, beta[2], log phi
+    for (int i = 0; i < 4; ++i) gex.params_data()[i] = q[i];
+    double grad[4] = {0, 0, 0, 0};
+    const double lp = gex.gradient(grad);
+
+    using stan::math::var;
+    var alpha = q[0];
+    Eigen::Matrix<var, -1, 1> beta(2);
+    beta(0) = q[1];
+    beta(1) = q[2];
+    var u_phi = q[3], phi = stan::math::exp(u_phi);
+    Eigen::MatrixXd X(4, 2);
+    X << 0.3, -0.2, 1.1, 0.4, -0.5, 0.9, 0.2, 0.7;
+    const std::vector<int> y{2, 5, 1, 3};
+    var acc = u_phi;  // lower=0 jacobian on phi
+    acc += stan::math::normal_lpdf<true>(alpha, 0, 2);
+    acc += stan::math::normal_lpdf<true>(beta, 0, 2);
+    acc += stan::math::exponential_lpdf<true>(phi, 1);
+    acc += stan::math::poisson_log_glm_lpmf<true>(y, X, alpha, beta);
+    acc += stan::math::neg_binomial_2_log_glm_lpmf<true>(y, X, alpha, beta,
+                                                        phi);
+    acc.grad();
+
+    const bool g_ok = grad[0] == alpha.adj() && grad[1] == beta(0).adj() &&
+                      grad[2] == beta(1).adj() && grad[3] == u_phi.adj();
+    check(g_ok, "glm: gradients bitwise against the var path");
+    check(std::abs(lp - acc.val()) <=
+              8 * 2.220446049250313e-16 * std::abs(acc.val()),
+          "glm: lp matches the var path (propto reached the kernel)");
+  }
+
   {
     // Error path: an unsupported function is reported by name, never
     // silently miscompiled. Mutate a known-good fixture's density name.

--- a/web/index.html
+++ b/web/index.html
@@ -616,22 +616,9 @@ $("csv").onclick = () => {
 };
 </script>
 <footer>
-<h2>This page reports a shifted <code>lp__</code></h2>
-<p>The browser runtime is built with <code>STANLI_LITE_LP</code>, which
-drops stan-math's propto instantiations to halve the download. Those are
-exactly the terms that do not depend on the parameters, so every gradient
-and every generated quantity here is bit-for-bit what CmdStan computes,
-and the posterior you sample from is the same one. What moves is
-<code>lp__</code> itself: it differs from CmdStan's by a per-model constant,
-so do not compare this page's <code>lp__</code> against a CmdStan run, and
-do not use it for anything that reads log densities as absolute numbers
-(Bayes factors, marginal likelihoods, bridge sampling).</p>
-<p>Because the sampler adds <code>lp</code> to the kinetic energy, a
-pinned seed also draws a different chain here than in the wheels. It is
-an equally valid chain from the same posterior, not different math.</p>
-<p>The PyPI wheels ship the exact build and match CmdStan's
-<code>lp__</code>. Details in
-<a href="https://github.com/seantalts/stanli/blob/main/docs/lite-lp.md">docs/lite-lp.md</a>.</p>
+<p>This page runs the same runtime the PyPI wheels ship, built the same
+way. Gradients, generated quantities and <code>lp__</code> all match
+CmdStan.</p>
 </footer>
 </body>
 </html>


### PR DESCRIPTION
Extends density coverage from 47 of Stan's 72 to 71, and turns the browser build back to exact `lp__`.

## Coverage

`poisson_log_glm`, `neg_binomial_2_log_glm`, `beta_binomial`, `multi_normal_prec`, `lkj_corr`, `hypergeometric`, `discrete_range`, the wishart family, `multi_gp`, `multi_student_t`, `lkj_cov`, the multinomial family, `ordered_probit`, `wiener`, and the three remaining GLMs.

Three ways in, cheapest first, now documented at the top of `docs/coverage.md`:

1. **Rewrite when the rewrite is exact.** `y ~ foo(...)` with every argument data contributes exactly zero, because that is what CmdStan's `include_summand` does with it. No kernel needed. That is all of `hypergeometric` and `discrete_range`.
2. **Clone when a signature already exists.** `multi_normal_prec` takes the same arguments in the same shapes as `multi_normal`; `lkj_corr` the same as `lkj_corr_cholesky`. One template parameter each.
3. **Write the kernel.** A nested var tape, no hand-written derivative. Shared helpers reduce each to about twenty lines.

`ordered_probit` and `wiener` were previously written off as unreachable because the recorder cannot do arithmetic on its scalar type. That is true of the recorder and not of `stan::math::var`, so both work on a var tape.

Only `gaussian_dlm_obs` is out: it takes seven arguments and `Op::in` holds six.

## Two bugs found

**GLM ops never received a variant.** `if (!d.glm) ... = variant` meant their kernels hardcoded `propto=false`, and `poisson_log_glm`'s `lp__` landed `sum(log(y!))` away from CmdStan's with the gradients already exact. `bernoulli_logit_glm` had the same hardcoding and got away with it because bernoulli has no constant to drop. Setting only the propto bit is not a fix: `density_bwd` reads a nonzero variant as a literal activity mask, so `0x80` alone means no argument is active and every gradient comes back zero.

**`Graph::add_op` wrote past `Op::in` with no check.** A seven-input op corrupted `n_in` and surfaced as a SIGBUS inside a kernel. It throws now.

## Compact densities

The multivariate tail is built compact: one instantiation instead of one per activity mask, so `lp__` carries a per-model constant while every gradient stays exact. Measured, not assumed: `multi_student_t` +0.81998355873446 and `lkj_cov` +0.28768207245200, identical at all three evaluation points, worst gradient difference 0. `docs/compact-densities.md` is the contract: what it claims, which densities are which, why the tail gets it, and how to make one exact.

## Browser build

`STANLI_LITE_LP` now defaults off everywhere. The browser used to default it on to save about 7 MB of wasm, which meant the demo reported an `lp__` nobody could compare against CmdStan. Cost: 4.10 to 5.79 MB raw, 1.15 to 1.53 MB gzipped.

`docs/density-pack.md` collects what is known about splitting that payload into a core plus an on-demand pack: the density surface is 40% of it, `MAIN_MODULE=2` with `-fPIC` costs nothing measurable, a side module can call back into the core, and the pack must share the core's `-fwasm-exceptions` ABI.

## Sizes, re-measured

| | before | now |
|---|---:|---:|
| shared library installed | 21.3 MB | 22.2 MB |
| wheel | 7.4 MB | 7.8 MB |
| `libstanli` stripped, exact | 14.93 MB | 15.75 MB |
| densities' share | 11.43 MB | 12.03 MB |

`docs/benchmarks.md` also had a conclusion that later measurements refuted: it said splitting densities was not worth it because PIC codegen would eat the saving. Corrected.

## Verification

26/26 tests, 119/119 corpus against CmdStan, 127/127 functions at 0 ULP. New fixtures `glmpois.stan` (the GLMs, mutation-checked) and the existing `trunc.stan` and `ordlog.stan` guard what `fn_sweep` cannot reach, since it generates all-scalar models and CI has no CmdStan.