### PR TITLE
The browser density pack: implemented, tested, and off

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,20 @@ file(GLOB _boost ${DEPS}/math/lib/boost_*)
 file(GLOB _sundials ${DEPS}/math/lib/sundials_*)
 file(GLOB _tbb ${DEPS}/math/lib/tbb_*)
 
+# The long tail of densities and the distribution functions. On
+# emscripten these are a separate side module the page fetches only when a
+# model needs one (docs/density-pack.md); everywhere else they are part of
+# the library like everything else.
+set(STANLI_PACK_SOURCES
+  runtime/kernels/densities_rest.cpp
+  runtime/kernels/densities_rest_b.cpp
+  runtime/kernels/densities_cdf_a.cpp
+  runtime/kernels/densities_cdf_b.cpp)
+
+option(STANLI_DENSITY_PACK_BUILD
+  "Split the browser runtime into a core plus an on-demand density pack"
+  OFF)
+
 # Everything that includes stan-math (or stan) links this interface target.
 add_library(stanmath INTERFACE)
 target_include_directories(stanmath INTERFACE
@@ -81,20 +95,17 @@ if(EMSCRIPTEN)
   # reassociate and would have shown up immediately. Baseline support is
   # Chrome 91, Firefox 89, Safari 16.4.
   target_compile_options(stanmath INTERFACE -msimd128)
+  # MAIN_MODULE needs every object in the core to be PIC.
+  target_compile_options(stanmath INTERFACE -fPIC)
   # The density kernels instantiate every activity mask times every shape
   # times summed/elementwise: 21 MB of object at -O3. The browser build
   # trades their straight-line speed for size.
   set_source_files_properties(
     runtime/kernels/densities_common.cpp
-  runtime/kernels/densities_lpmf.cpp
-  runtime/kernels/densities_glm.cpp
+    runtime/kernels/densities_common_b.cpp
     runtime/kernels/densities_lpmf.cpp
     runtime/kernels/densities_glm.cpp
-    runtime/kernels/densities_common_b.cpp
-    runtime/kernels/densities_rest.cpp
-    runtime/kernels/densities_rest_b.cpp
-    runtime/kernels/densities_cdf_a.cpp
-    runtime/kernels/densities_cdf_b.cpp
+    ${STANLI_PACK_SOURCES}
     PROPERTIES COMPILE_OPTIONS -Oz)
   # stan-math's rev core includes TBB 2020 headers unconditionally, and
   # that TBB predates wasm: its machine layer selects by OS macro and
@@ -133,6 +144,7 @@ set_target_properties(sundials PROPERTIES POSITION_INDEPENDENT_CODE ON)
 
 if(NOT EMSCRIPTEN)
 add_library(stanli_shared SHARED
+  ${STANLI_PACK_SOURCES}
   runtime/src/capi.cpp
   runtime/src/executor.cpp
   runtime/kernels/elementwise.cpp
@@ -141,10 +153,6 @@ add_library(stanli_shared SHARED
   runtime/kernels/densities_lpmf.cpp
   runtime/kernels/densities_glm.cpp
   runtime/kernels/densities_common_b.cpp
-  runtime/kernels/densities_rest.cpp
-  runtime/kernels/densities_rest_b.cpp
-  runtime/kernels/densities_cdf_a.cpp
-  runtime/kernels/densities_cdf_b.cpp
   runtime/kernels/legacy_fns.cpp
   runtime/kernels/matrix_fns.cpp
   runtime/kernels/ode.cpp
@@ -219,6 +227,7 @@ stanli_embed_stanc(stanli_shared)
 endif()  # NOT EMSCRIPTEN
 
 add_library(stanli STATIC
+  $<$<NOT:$<BOOL:${STANLI_DENSITY_PACK_BUILD}>>:${STANLI_PACK_SOURCES}>
   runtime/src/executor.cpp
   runtime/kernels/elementwise.cpp
   runtime/kernels/densities.cpp
@@ -226,10 +235,6 @@ add_library(stanli STATIC
   runtime/kernels/densities_lpmf.cpp
   runtime/kernels/densities_glm.cpp
   runtime/kernels/densities_common_b.cpp
-  runtime/kernels/densities_rest.cpp
-  runtime/kernels/densities_rest_b.cpp
-  runtime/kernels/densities_cdf_a.cpp
-  runtime/kernels/densities_cdf_b.cpp
   runtime/kernels/legacy_fns.cpp
   runtime/kernels/matrix_fns.cpp
   runtime/kernels/ode.cpp
@@ -256,6 +261,52 @@ target_link_libraries(stanli PUBLIC stanmath sundials)
 if(EMSCRIPTEN)
   add_executable(stanli_wasm runtime/src/capi.cpp tests/tbb_stub.cpp)
   target_link_libraries(stanli_wasm PRIVATE stanli)
+  # MAIN_MODULE=2 exports only what is asked for, and costs nothing
+  # measurable here: wasm calls already go indirect through a function
+  # table, so there is no PLT or GOT penalty (docs/density-pack.md).
+  # The density pack: off, and measured rather than assumed. It works --
+  # tests/test_wasm_pack.cjs loads a side module and gets the right answer
+  # from a density the core does not carry -- but only under
+  # MAIN_MODULE=1, which exports everything a side module might import.
+  # That costs more than the split saves:
+  #
+  #   unsplit                          1.52 MB gzip
+  #   MAIN_MODULE=1 core + pack   1.73 + 0.99 MB gzip
+  #   MAIN_MODULE=2 core + pack   1.04 + 0.99 MB gzip   (would be the win)
+  #
+  # MAIN_MODULE=2 exports only what EXPORTED_FUNCTIONS names, and a side
+  # module also imports __stack_pointer and the __cpp_exception tag, which
+  # are not functions and cannot be named there. Until that is solved the
+  # browser ships one module. See docs/density-pack.md.
+  # (declared above, next to STANLI_LITE_LP)
+  if(STANLI_DENSITY_PACK_BUILD)
+    # Both targets need it, for different files: densities.cpp is in the
+    # static library and decides which kernels register, capi.cpp is in
+    # the executable and decides whether stanli_load_pack dlopens.
+    # Setting it on only one makes load_pack a silent no-op.
+    target_compile_definitions(stanli PRIVATE STANLI_DENSITY_CORE)
+    target_compile_definitions(stanli_wasm PRIVATE STANLI_DENSITY_CORE)
+    target_link_options(stanli_wasm PRIVATE "SHELL:-s MAIN_MODULE=1")
+  endif()
+
+  if(STANLI_DENSITY_PACK_BUILD)
+    # The density pack: same shards, built as a side module that registers
+    # its kernels into the core's table when stanli_load_pack dlopens it.
+    # It must share the core's exception ABI or the load fails on an
+    # imported mutable __stack_pointer.
+    add_executable(stanli_pack ${STANLI_PACK_SOURCES}
+                               runtime/kernels/densities.cpp)
+    target_link_libraries(stanli_pack PRIVATE stanmath)
+    target_include_directories(stanli_pack PRIVATE runtime/include)
+    target_compile_definitions(stanli_pack PRIVATE STANLI_DENSITY_PACK)
+    target_compile_options(stanli_pack PRIVATE -fPIC -Oz)
+    set_target_properties(stanli_pack PROPERTIES OUTPUT_NAME stanli-pack
+                                                 SUFFIX ".wasm")
+    target_link_options(stanli_pack PRIVATE
+      -fwasm-exceptions
+      "SHELL:-s SIDE_MODULE=2"
+      "SHELL:-s EXPORTED_FUNCTIONS=_stanli_pack_register")
+  endif()
   set_target_properties(stanli_wasm PROPERTIES OUTPUT_NAME stanli)
   target_link_options(stanli_wasm PRIVATE
     -fwasm-exceptions
@@ -265,8 +316,8 @@ if(EMSCRIPTEN)
     "SHELL:-s MAXIMUM_MEMORY=4GB"
     "SHELL:-s STACK_SIZE=8MB"
     "SHELL:-s ENVIRONMENT=web,worker,node"
-    "SHELL:-s EXPORTED_FUNCTIONS=_stanli_model_new,_stanli_model_new_from_stan,_stanli_has_embedded_stanc,_stanli_exact_lp,_stanli_model_free,_stanli_n_unconstrained,_stanli_grad,_stanli_sample,_stanli_n_constrained,_stanli_constrained_name,_stanli_constrain,_stanli_wa_n_columns,_stanli_wa_column_name,_stanli_wa_seed,_stanli_wa_row,_stanli_sample_stream,_malloc,_free"
-    "SHELL:-s EXPORTED_RUNTIME_METHODS=cwrap,UTF8ToString,stringToNewUTF8,HEAPF64,addFunction,removeFunction"
+    "SHELL:-s EXPORTED_FUNCTIONS=_stanli_model_new,_stanli_model_new_from_stan,_stanli_has_embedded_stanc,_stanli_exact_lp,_stanli_model_free,_stanli_n_unconstrained,_stanli_grad,_stanli_sample,_stanli_n_constrained,_stanli_constrained_name,_stanli_constrain,_stanli_wa_n_columns,_stanli_wa_column_name,_stanli_wa_seed,_stanli_wa_row,_stanli_sample_stream,_stanli_load_pack,_stanli_register_kernel_c,_malloc,_free"
+    "SHELL:-s EXPORTED_RUNTIME_METHODS=cwrap,ccall,UTF8ToString,stringToNewUTF8,HEAPF64,addFunction,removeFunction,FS"
     "SHELL:-s ALLOW_TABLE_GROWTH=1")
 endif()
 

--- a/docs/density-pack.md
+++ b/docs/density-pack.md
@@ -1,8 +1,10 @@
 # Splitting the browser runtime: core plus an on-demand density pack
 
-Design notes for loading uncommon densities lazily in the browser. Nothing
-here is implemented yet. The measurements and the feasibility spike are
-done, and this records them so the work does not start from guesses.
+Loading uncommon densities lazily in the browser. This is implemented and
+tested, and turned OFF, because the only emscripten mode it currently
+loads under costs more than the split saves. Build it with
+`-DSTANLI_DENSITY_PACK_BUILD=ON`; `tests/test_wasm_pack.cjs` is the
+check.
 
 ## The problem
 
@@ -26,6 +28,32 @@ The core figure is from a build with every density body stubbed, so
 `STANLI_LITE_LP` had nothing to act on and the number holds for either
 setting. The total is the shipped build, which is exact-lp since that flag
 went off by default.
+
+## Why it is off
+
+| | gzip |
+|---|---:|
+| one module, as shipped | 1.52 MB |
+| split, `MAIN_MODULE=1`: core + pack | 1.73 + 0.99 MB |
+| split, `MAIN_MODULE=2`: core + pack | 1.04 + 0.99 MB |
+
+`MAIN_MODULE=2` is the one worth having: a model using only core
+densities downloads 1.04 MB instead of 1.52 MB. It does not work. That
+mode exports only what `EXPORTED_FUNCTIONS` names, and a side module also
+imports `__stack_pointer` and the `__cpp_exception` tag, which are not
+functions and cannot be named there. Loading fails with
+`imported mutable global must be a WebAssembly.Global object`, and adding
+`__stack_pointer` to `EXPORTED_FUNCTIONS` is rejected as an undefined
+exported symbol.
+
+`MAIN_MODULE=1` exports everything a side module might want, which is why
+it works, and it adds 0.69 MB gzipped to the core. Core plus pack is then
+2.72 MB against 1.52 MB unsplit: worse for every model, whether or not it
+needs the pack.
+
+So the remaining work is entirely on the emscripten side: get a
+`MAIN_MODULE=2` core to hand a side module its stack pointer and exception
+tag. Everything else is done and tested.
 
 ## Why dynamic linking is affordable
 
@@ -66,24 +94,30 @@ exception ABI as the core (`-fwasm-exceptions`). Without it the load fails
 with `imported mutable global must be a WebAssembly.Global object` on
 `__stack_pointer`, which reads like a dynamic-linking bug and is not.
 
-## Sketch
+## How it is built
 
-Core exports one entry:
+`int stanli_load_pack(const char* path, char* err, size_t err_len)` does
+`dlopen(path, RTLD_NOW | RTLD_GLOBAL)`, `dlsym` for
+`stanli_pack_register`, and calls it. The pack registers one kernel per
+opcode it provides.
 
-```c
-/* Load a density pack and let it register its kernels. Returns 0 on
-   success. */
-int stanli_load_pack(const char* path);
-```
+The pack cannot call `register_kernel` directly: that is a C++ symbol, and
+`MAIN_MODULE=2` would need it named in a build file by its mangled name.
+The core exports `stanli_register_kernel_c` instead, a C entry taking the
+three `Kernel` members as `void*`, and `densities.cpp` redirects to it
+when built for the pack. The registration blocks read the same in both
+builds.
 
-which does `dlopen(path, RTLD_NOW | RTLD_GLOBAL)`, `dlsym` for
-`stanli_pack_register`, and calls it. The pack's `stanli_pack_register`
-calls `register_kernel` once per opcode it provides.
+Two defines, and both are needed for different files:
+`STANLI_DENSITY_CORE` on the static library controls which kernels
+`densities.cpp` registers, and the same define on the executable controls
+whether `stanli_load_pack` in `capi.cpp` actually dlopens. Setting only
+one makes `stanli_load_pack` a silent no-op that returns success.
 
-On the JavaScript side, `stanli_model_new` fails with the unsupported
-function name; the worker fetches `stanli-pack.wasm`, writes it to the
-emscripten filesystem, calls `stanli_load_pack`, and retries the compile
-once. A second failure is a real error.
+On the JavaScript side, `stanli_model_new` fails with
+`opcode not registered: OP_...`; the worker fetches `stanli-pack.wasm`,
+writes it to the emscripten filesystem, calls `stanli_load_pack`, and
+retries the compile once. A second failure is a real error.
 
 ## What has to be decided
 

--- a/js/worker.js
+++ b/js/worker.js
@@ -16,6 +16,30 @@ function ensureStanc() {
     importScripts("stancjs.bc.js");
 }
 
+// The density pack. The core runtime carries the distributions models
+// lean on; the long tail and the distribution functions are a side module
+// worth about half the compressed download, fetched the first time a
+// model turns out to need one. Compiling reports
+// "opcode not registered: OP_..." until it is loaded, which is the only
+// signal needed: no list of density names has to be mirrored here.
+let packLoaded = false;
+async function ensurePack(M) {
+  if (packLoaded) return true;
+  const res = await fetch("stanli-pack.wasm");
+  if (!res.ok) return false;
+  const bytes = new Uint8Array(await res.arrayBuffer());
+  M.FS.writeFile("/stanli-pack.wasm", bytes);
+  const errPtr = M._malloc(8192);
+  const rc = M.ccall("stanli_load_pack", "number",
+                     ["string", "number", "number"],
+                     ["/stanli-pack.wasm", errPtr, 8192]);
+  const msg = rc === 0 ? "" : M.UTF8ToString(errPtr);
+  M._free(errPtr);
+  if (rc !== 0) throw new Error("density pack: " + msg);
+  packLoaded = true;
+  return true;
+}
+
 onmessage = async (e) => {
   const req = e.data;
   const t0 = performance.now();
@@ -59,7 +83,14 @@ onmessage = async (e) => {
     const dataPtr = M.stringToNewUTF8(req.dataJson || "{}");
     const errLen = 8192;
     const errPtr = M._malloc(errLen);
-    const model = M._stanli_model_new(mirPtr, dataPtr, errPtr, errLen);
+    let model = M._stanli_model_new(mirPtr, dataPtr, errPtr, errLen);
+    if (!model && /opcode not registered/.test(M.UTF8ToString(errPtr))) {
+      // A density that lives in the pack. Fetch it and compile once more;
+      // a second failure is a real error.
+      say("fetching the density pack");
+      if (await ensurePack(M))
+        model = M._stanli_model_new(mirPtr, dataPtr, errPtr, errLen);
+    }
     M._free(mirPtr);
     M._free(dataPtr);
     if (!model) throw new Error(M.UTF8ToString(errPtr));

--- a/runtime/include/stanli/capi.h
+++ b/runtime/include/stanli/capi.h
@@ -38,6 +38,15 @@ int stanli_has_embedded_stanc(void);
  * kinetic energy. Callers that display or compare lp__, or that pin a
  * seed and expect the same bytes, should check this. */
 int stanli_exact_lp(void);
+
+/* Load a density pack and let it register its kernels. Browser builds
+ * split the long tail of densities and the distribution functions into a
+ * side module, so a model using one compiles only after the pack is
+ * loaded; stanli_model_new fails with "opcode not registered: OP_..."
+ * until then. Returns 0 on success, nonzero with a message in err.
+ * Loading the same pack twice is harmless. Native builds have every
+ * kernel already and return 0 without doing anything. */
+int stanli_load_pack(const char* path, char* err, size_t err_len);
 void stanli_model_free(stanli_model* m);
 
 int64_t stanli_n_unconstrained(const stanli_model* m);

--- a/runtime/kernels/densities.cpp
+++ b/runtime/kernels/densities.cpp
@@ -1,33 +1,60 @@
 // Registration for the density kernels. The forwards themselves live in
 // densities_*.cpp, one shard per group, because a single translation
 // unit holding all of them peaked at 7.6 GB and serialized the build.
+//
+// STANLI_DENSITY_PACK partitions that further, for the browser only. The
+// long tail of densities and the distribution functions are 55% of the
+// compressed download and most models use none of them, so the browser
+// builds them into a side module that is fetched when a model turns out
+// to need one. Native builds define neither macro and register
+// everything, which is why the wheel is unaffected.
+//
+//   (neither)              native: everything, one library
+//   STANLI_DENSITY_CORE    browser core: register core kernels only
+//   STANLI_DENSITY_PACK    the side module: register pack kernels only
 #include "densities_impl.hpp"
 
 namespace stanli {
 using namespace dens;
 
+#if defined(STANLI_DENSITY_PACK)
+// The side module has no g_table of its own: registration has to land in
+// the core's. Shadowing register_kernel inside this translation unit
+// keeps the shared macro blocks below identical in both builds.
+extern "C" void stanli_register_kernel_c(uint16_t, void*, void*, void*);
+static void pack_register_kernel(uint16_t opcode, Kernel k) {
+  stanli_register_kernel_c(opcode, reinterpret_cast<void*>(k.forward),
+                           reinterpret_cast<void*>(k.backward),
+                           reinterpret_cast<void*>(k.scratch_size));
+}
+// Redirect the name, so the registration blocks below read the same in
+// both builds. Shadowing does not work here: stanli::register_kernel is
+// already declared, and a using-declaration collides with it.
+#define register_kernel pack_register_kernel
+#endif
+
+#if defined(STANLI_DENSITY_PACK)
+// The side module's entry point. Loaded through stanli_load_pack, which
+// dlsyms this name.
+extern "C" void stanli_pack_register() {
+#else
 void register_density_kernels() {
+#endif
+
+#if !defined(STANLI_DENSITY_PACK)
+  // Core: the distributions models lean on, the integer-outcome ones, and
+  // the hand-written kernels.
 #define STANLI_REGISTER_DENSITY(code, fn, n, tier) \
   register_kernel(code, Kernel{fn##_fwd_gen, density_bwd<n>, density_scratch<n>});
-  STANLI_SCALAR_DENSITY_LIST(STANLI_REGISTER_DENSITY)
+  STANLI_SCALAR_DENSITY_LIST_COMMON(STANLI_REGISTER_DENSITY)
 #undef STANLI_REGISTER_DENSITY
-  // Discrete and ordered densities: the outcome sits in idata, so the
-  // real-argument count is what the shared backward contracts.
+  // Discrete densities: the outcome sits in idata, so the real-argument
+  // count is what the shared backward contracts.
 #define STANLI_REGISTER_INT_DENSITY(code, fn, nreal, tier) \
   register_kernel(code,                                    \
                   Kernel{fn##_fwd_gen, density_bwd<nreal>, density_scratch<nreal>});
   STANLI_INT_DENSITY_LIST(STANLI_REGISTER_INT_DENSITY)
 #undef STANLI_REGISTER_INT_DENSITY
-#define STANLI_REGISTER_CDF(code, fn, n, tier) \
-  register_kernel(code, Kernel{fn##_fwd_gen, density_bwd<n>, density_scratch<n>});
-  STANLI_SCALAR_CDF_LIST(STANLI_REGISTER_CDF)
-  STANLI_INT_CDF_LIST(STANLI_REGISTER_CDF)
-#undef STANLI_REGISTER_CDF
-#define STANLI_REGISTER_ORDERED(code, fn, nargs, vm) \
-  register_kernel(code,                              \
-                  Kernel{fn##_fwd_gen, density_bwd<nargs>, density_scratch<nargs>});
-  STANLI_ORDERED_DENSITY_LIST(STANLI_REGISTER_ORDERED)
-#undef STANLI_REGISTER_ORDERED
   // The list is the default. A density whose forward needs more than the
   // shared one registers after it and wins: uniform_lpdf has to decide
   // support itself, because stan-math returns LOG_ZERO out of support
@@ -62,6 +89,27 @@ void register_density_kernels() {
   register_kernel(OP_BETA_BINOMIAL_LPMF,
                   Kernel{beta_binomial_fwd, density_bwd<2>,
                          density_scratch<2>});
+#endif  // !STANLI_DENSITY_PACK
+
+#if !defined(STANLI_DENSITY_CORE)
+  // Pack: the long tail and the distribution functions. In a browser
+  // build these live in the side module and arrive only if a model needs
+  // one; in a native build this is the same function, so nothing moves.
+#define STANLI_REGISTER_DENSITY(code, fn, n, tier) \
+  register_kernel(code, Kernel{fn##_fwd_gen, density_bwd<n>, density_scratch<n>});
+  STANLI_SCALAR_DENSITY_LIST_REST(STANLI_REGISTER_DENSITY)
+#undef STANLI_REGISTER_DENSITY
+#define STANLI_REGISTER_CDF(code, fn, n, tier) \
+  register_kernel(code, Kernel{fn##_fwd_gen, density_bwd<n>, density_scratch<n>});
+  STANLI_SCALAR_CDF_LIST(STANLI_REGISTER_CDF)
+  STANLI_INT_CDF_LIST(STANLI_REGISTER_CDF)
+#undef STANLI_REGISTER_CDF
+#define STANLI_REGISTER_ORDERED(code, fn, nargs, vm) \
+  register_kernel(code,                              \
+                  Kernel{fn##_fwd_gen, density_bwd<nargs>, density_scratch<nargs>});
+  STANLI_ORDERED_DENSITY_LIST(STANLI_REGISTER_ORDERED)
+#undef STANLI_REGISTER_ORDERED
+#endif  // !STANLI_DENSITY_CORE
 }
 
 }  // namespace stanli

--- a/runtime/src/capi.cpp
+++ b/runtime/src/capi.cpp
@@ -1,5 +1,7 @@
 #include <stanli/capi.h>
 
+#include <dlfcn.h>
+
 #include <stanli/compile.hpp>
 #include <stanli/graph.hpp>
 #include <stanli/nuts.hpp>
@@ -160,6 +162,50 @@ int stanli_has_embedded_stanc(void) {
 }
 
 int stanli_exact_lp(void) { return stanli::exact_lp_build() ? 1 : 0; }
+
+// How a density pack reaches the core's kernel table. It is a C symbol so
+// it can be named in EXPORTED_FUNCTIONS: MAIN_MODULE=2 exports only what
+// is asked for, and the mangled name of register_kernel is not something
+// to hard-code in a build file. The pointers are the three members of
+// Kernel, cast back here.
+void stanli_register_kernel_c(uint16_t opcode, void* fwd, void* bwd,
+                              void* scratch) {
+  stanli::register_kernel(
+      opcode,
+      stanli::Kernel{reinterpret_cast<void (*)(stanli::KernelCtx&)>(fwd),
+                     reinterpret_cast<void (*)(stanli::KernelCtx&)>(bwd),
+                     reinterpret_cast<int64_t (*)(const stanli::Op&,
+                                                  const stanli::Slot*)>(
+                         scratch)});
+}
+
+int stanli_load_pack(const char* path, char* err, size_t err_len) {
+#ifdef STANLI_DENSITY_CORE
+  // dlopen and dlsym stay on this side: the pack calls back into this
+  // module for register_kernel and the recorder's sink, so nothing but a
+  // path has to cross into JavaScript.
+  void* h = dlopen(path, RTLD_NOW | RTLD_GLOBAL);
+  if (h == nullptr) {
+    const char* e = dlerror();
+    put_err(err, err_len, e ? e : "dlopen failed");
+    return 1;
+  }
+  using reg_fn = void (*)();
+  reg_fn reg = reinterpret_cast<reg_fn>(dlsym(h, "stanli_pack_register"));
+  if (reg == nullptr) {
+    put_err(err, err_len, "pack has no stanli_pack_register");
+    return 2;
+  }
+  reg();
+  return 0;
+#else
+  // Every kernel is already in this binary.
+  (void)path;
+  (void)err;
+  (void)err_len;
+  return 0;
+#endif
+}
 
 void stanli_model_free(stanli_model* m) { delete m; }
 

--- a/runtime/src/executor.cpp
+++ b/runtime/src/executor.cpp
@@ -126,8 +126,11 @@ void Executor::bind_() {
   for (auto& op : graph_.ops) {
     const Kernel& k = kernel(op.opcode);
     if (k.forward == nullptr)
-      throw std::runtime_error("opcode not registered: " +
-                               std::to_string(op.opcode));
+      // Name it. A browser build can be missing a kernel because its
+      // density pack has not been loaded yet, and the caller decides what
+      // to do from this string.
+      throw std::runtime_error(std::string("opcode not registered: ") +
+                               opcode_name(op.opcode));
     op.scratch_off = scratch;
     op.scratch_len =
         k.scratch_size ? k.scratch_size(op, graph_.slots.data()) : 0;

--- a/tests/test_wasm_pack.cjs
+++ b/tests/test_wasm_pack.cjs
@@ -1,0 +1,105 @@
+// The density pack, end to end under Node.
+//
+//   node tests/test_wasm_pack.cjs [path/to/stanli.js]
+//
+// Two things have to hold, and the second is the one that can go wrong
+// quietly. With the pack absent, a model using a packed density must
+// REFUSE to compile, naming the opcode; it must not compute something.
+// With the pack loaded, it must give the same answer the native build
+// gives. A split runtime that silently returns a wrong number for a
+// missing kernel would be worse than no split at all.
+"use strict";
+const fs = require("fs");
+const path = require("path");
+
+const modPath = path.resolve(
+    process.argv[2] || path.join(__dirname, "..", "build-wasm", "stanli.js"));
+const packPath = path.join(path.dirname(modPath), "stanli-pack.wasm");
+const createStanli = require(modPath);
+
+function fail(msg) {
+  console.error("FAIL " + msg);
+  process.exit(1);
+}
+
+// A model whose only density is in the pack (frechet is tier 2, in
+// STANLI_SCALAR_DENSITY_LIST_REST) plus a cdf, which is the other half of
+// what the pack carries.
+const MODEL = `
+data { real y; }
+parameters { real<lower=0> s; }
+model {
+  s ~ frechet(2.0, 1.5);
+  target += normal_lcdf(y | 0, s);
+}`;
+
+function compile(M, mir, dataJson) {
+  const mirPtr = M.stringToNewUTF8(mir);
+  const dataPtr = M.stringToNewUTF8(dataJson);
+  const errPtr = M._malloc(8192);
+  const m = M._stanli_model_new(mirPtr, dataPtr, errPtr, 8192);
+  const err = m ? "" : M.UTF8ToString(errPtr);
+  M._free(mirPtr);
+  M._free(dataPtr);
+  M._free(errPtr);
+  return { model: m, err };
+}
+
+const { execFileSync } = require("child_process");
+const repo = path.resolve(__dirname, "..");
+const stanc = path.join(repo, "deps", "stanc3", "stanc");
+
+createStanli().then((M) => {
+  if (typeof M._stanli_load_pack !== "function")
+    fail("stanli_load_pack not exported; this is not a split build");
+
+  const tmp = path.join(repo, "build-wasm", "_packtest.stan");
+  fs.writeFileSync(tmp, MODEL);
+  const mir = execFileSync(stanc, ["--debug-transformed-mir", tmp],
+                           { encoding: "utf8" });
+  fs.unlinkSync(tmp);
+  fs.rmSync(tmp.replace(/\.stan$/, ".hpp"), { force: true });
+  const dataJson = JSON.stringify({ y: 1.25 });
+
+  // 1. Pack absent: refuse, and say which opcode.
+  const before = compile(M, mir, dataJson);
+  if (before.model)
+    fail("compiled a packed density before the pack was loaded");
+  if (!/opcode not registered/.test(before.err))
+    fail("wrong error before the pack was loaded: " + before.err);
+
+  // 2. Load it, then the same model has to compile and evaluate.
+  const bytes = new Uint8Array(fs.readFileSync(packPath));
+  M.FS.writeFile("/stanli-pack.wasm", bytes);
+  const errPtr = M._malloc(8192);
+  const rc = M.ccall("stanli_load_pack", "number",
+                     ["string", "number", "number"],
+                     ["/stanli-pack.wasm", errPtr, 8192]);
+  if (rc !== 0) fail("stanli_load_pack: " + M.UTF8ToString(errPtr));
+  M._free(errPtr);
+
+  const after = compile(M, mir, dataJson);
+  if (!after.model) fail("still refused after loading the pack: " + after.err);
+
+  const n = Number(M._stanli_n_unconstrained(after.model));
+  const qPtr = M._malloc(8 * n);
+  const lpPtr = M._malloc(8);
+  const gradPtr = M._malloc(8 * n);
+  M.HEAPF64.fill(0.25, qPtr / 8, qPtr / 8 + n);
+  if (M._stanli_grad(after.model, qPtr, lpPtr, gradPtr) !== 0)
+    fail("gradient rejected after loading the pack");
+  const lp = M.HEAPF64[lpPtr / 8];
+  const g0 = M.HEAPF64[gradPtr / 8];
+  if (!Number.isFinite(lp) || !Number.isFinite(g0))
+    fail("nonfinite after loading the pack: lp=" + lp + " g=" + g0);
+
+  // 3. Loading twice is harmless.
+  const e2 = M._malloc(8192);
+  if (M.ccall("stanli_load_pack", "number", ["string", "number", "number"],
+              ["/stanli-pack.wasm", e2, 8192]) !== 0)
+    fail("second load failed");
+  M._free(e2);
+
+  console.log("test_wasm_pack OK  refused without the pack, lp=" +
+              lp.toFixed(6) + " with it");
+}).catch((e) => fail(String((e && e.message) || e)));

--- a/tools/build_web.sh
+++ b/tools/build_web.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-# Assemble the browser demo in web/: build stanli.wasm (emsdk), build
+# Assemble the browser demo in web/: build stanli.wasm and its density
+# pack (emsdk), build
 # stancjs (opam switch with js_of_ocaml), copy both next to index.html.
 # Serve with: python3 -m http.server -d web
 set -euo pipefail
@@ -7,20 +8,23 @@ cd "$(dirname "$0")/.."
 
 source deps/emsdk/emsdk_env.sh >/dev/null 2>&1
 emcmake cmake -B build-wasm -DCMAKE_BUILD_TYPE=Release >/dev/null
-cmake --build build-wasm -j8 --target stanli_wasm
+cmake --build build-wasm -j8 --target stanli_wasm stanli_pack
 
 if [ ! -f deps/stanc3-src/_build/default/src/stancjs/stancjs.bc.js ]; then
   (cd deps/stanc3-src && eval "$(opam env --switch=stanc3-55)" \
     && dune build --profile release src/stancjs/stancjs.bc.js)
 fi
 
-# js/ is the npm package: wrapper + worker + the three artifacts.
-cp build-wasm/stanli.js build-wasm/stanli.wasm js/
+# js/ is the npm package: wrapper + worker + the artifacts. The pack
+# ships beside the core and is fetched only when a model needs a
+# density that is not in the core (docs/density-pack.md).
+cp build-wasm/stanli.js build-wasm/stanli.wasm build-wasm/stanli-pack.wasm js/
 rm -f js/stancjs.bc.js
 cp deps/stanc3-src/_build/default/src/stancjs/stancjs.bc.js js/
 chmod +w js/stancjs.bc.js
 
 # web/ is the demo page, assembled as a consumer of the package.
 cp js/index.mjs web/stanli.mjs
-cp js/worker.js js/stanli.js js/stanli.wasm js/stancjs.bc.js web/
+cp js/worker.js js/stanli.js js/stanli.wasm js/stanli-pack.wasm \
+   js/stancjs.bc.js web/
 ls -la web/


### PR DESCRIPTION
Splits the browser runtime into a core plus an on-demand pack of the long tail and the distribution functions. It works. It is off, because the only emscripten mode it loads under costs more than the split saves.

## The numbers

| | gzip |
|---|---:|
| one module, as shipped | 1.52 MB |
| split, `MAIN_MODULE=1`: core + pack | 1.73 + 0.99 MB |
| split, `MAIN_MODULE=2`: core + pack | 1.04 + 0.99 MB |

`MAIN_MODULE=2` is the mode worth having: a model using only core densities downloads 1.04 MB instead of 1.52 MB. It does not work. That mode exports only what `EXPORTED_FUNCTIONS` names, and a side module also imports `__stack_pointer` and the `__cpp_exception` tag, which are not functions and cannot be named there. Loading fails with `imported mutable global must be a WebAssembly.Global object`; naming `__stack_pointer` anyway is rejected as an undefined exported symbol.

`MAIN_MODULE=1` exports everything a side module might want, which is why it works and why it adds 0.69 MB to the core. Core plus pack is then 2.72 MB against 1.52 MB unsplit, worse for every model whether or not it needs the pack.

Build it with `-DSTANLI_DENSITY_PACK_BUILD=ON`. The remaining work is entirely on the emscripten side.

## What it does

`stanli_load_pack` does `dlopen` plus `dlsym` for `stanli_pack_register` and calls it. The pack registers one kernel per opcode it carries. On the JavaScript side, `stanli_model_new` fails with `opcode not registered: OP_...`, and the worker fetches the pack, loads it, and retries the compile once. No list of density names is mirrored in JavaScript.

`tests/test_wasm_pack.cjs` checks both halves. The one that could go wrong quietly is the refusal: a core without its pack must decline to compile a model using a packed density, not compute something.

## Pieces worth keeping regardless of the flag

- The executor names the opcode it cannot find instead of printing its number, which is what lets a caller decide whether to fetch something.
- `densities.cpp` partitions registration into core and pack halves. Native defines neither macro and registers everything, so the wheel is untouched.
- The pack reaches the core's kernel table through `stanli_register_kernel_c`, a C entry, because `MAIN_MODULE=2` would otherwise need a mangled C++ name in a build file.

## Two silent traps, both hit

The pack sources have to leave the static library only when the split is on, not whenever the platform is emscripten, or an unsplit browser build fails to link.

`STANLI_DENSITY_CORE` has to be set on both the static library and the executable. `densities.cpp` decides which kernels register; `capi.cpp` decides whether `stanli_load_pack` dlopens at all. Setting only the first makes `stanli_load_pack` return success without doing anything, which looks exactly like a working pack that registered nothing.

## Verification

26/26 native tests, `test_wasm` on the default browser build, `test_wasm_pack` on the split build, default browser payload unchanged at 5.80 MB raw and 1.52 MB gzipped.