### PR TITLE
ci: say when the peak RSS number means nothing

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -211,7 +211,16 @@ jobs:
             /usr/bin/time -v cmake --build build-rel \
               -j ${{ matrix.build_jobs }} 2>/tmp/build.err ||
               { cat /tmp/build.err; exit 1; }
-            grep -i "maximum resident" /tmp/build.err
+            # A cache-hit build compiles nothing and reports a peak of
+            # about 170 MB, which is not headroom and must not be read as
+            # any. Qualify the number with the miss count so nobody
+            # raises -j off a run that never ran the compiler.
+            kb=$(awk '/[Mm]aximum resident/ {print $NF}' /tmp/build.err)
+            miss=$(ccache -s | awk '/^ *Misses:/ {print $2; exit}')
+            echo "peak RSS $(( kb / 1024 )) MB on the largest single" \
+                 "compile, over ${miss:-?} ccache misses" \
+                 "$([ "${miss:-0}" -lt 20 ] && echo '(cached build:' \
+                 'this peak is not a memory ceiling)')"
           else
             cmake --build build-rel -j ${{ matrix.build_jobs }}
           fi


### PR DESCRIPTION
The build prints the largest single compile's resident set size so that
-j can be set from a measurement instead of a guess. On the first green
run after that landed it printed 171 MB, which is not headroom: every
object came from ccache and the compiler never ran. Read as a ceiling it
would invite -j8 and another exit 137.

The line now carries the miss count and says outright when the build was
cached. The number is only a ceiling on a run that actually compiled,
which in practice means a run that touched the density kernels.
