### PR TITLE
docs: the PyPI page still said Windows was not built

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -166,9 +166,13 @@ parameter, named the way CmdStan names them, so `theta` declared as
 
 ## Platforms
 
-Wheels for macOS (arm64 and x86_64) and Linux (x86_64 and aarch64,
-manylinux_2_28). Windows is not built yet; it needs a mingw-w64 toolchain,
-because stan-math does not build under MSVC.
+Wheels for macOS (arm64 and x86_64), Linux (x86_64 and aarch64,
+manylinux_2_28) and Windows (x86_64). The Windows wheel is built under
+mingw-w64, because stan-math does not build under MSVC, which is the same
+reason RStan ships through RTools. It bundles `stanc.exe` and runs it as
+a subprocess instead of embedding the compiler, which waits on opam's
+native Windows support; `Model("model.stan", data)` works the same way
+either way.
 
 The installed library is 22.2 MB, which is the trade this design makes:
 ship the compiler and every kernel once, so that nothing is ever built on


### PR DESCRIPTION
0.3.0 shipped stanli-0.3.0-py3-none-win_amd64.whl, and the project page
told anyone who looked that Windows "is not built yet". The wheel is on
PyPI now and carries stanli.dll and stanc.exe, which is what the section
should have described in the first place.

Says what the Windows build actually is: mingw-w64 rather than MSVC, a
bundled stanc.exe driven as a subprocess rather than the embedded
compiler, and the same Model(...) call either way, so nobody has to
guess whether the Python API differs there.

This reaches pypi.org only on the next release; the wheel it describes
has been downloadable since 0.3.0.
