### PR TITLE
fix: vectorized truncation did not compile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## 0.4.1
+
+Truncation only worked on a scalar outcome. 0.4.0 added truncation and
+tested it on `real y`, which is the one shape that compiled. Every
+vectorized form failed at compile time, and `y ~ normal(mu, sigma)
+T[0, 10]` over a vector is the form models are written in.
+
+Two constructs were missing, one per shape stanc3 emits:
+
+- A scalar location gives a normalizer of `FnLength(y) * log_diff_exp(...)`.
+  `FnLength` is a compiler-internal rather than a stan-library name, so it
+  reached the lowering as an unknown function kind. It answers as
+  `num_elements` does, matching `stan::math::size`, which is what stanc3's
+  own backend maps it to.
+- A container location with a literal scale makes stanc3 loop over the
+  elements and hoist the scale into a temporary it declares
+  `(Unsized UReal)`. The reader only understood sized declarations, and a
+  scalar carries no size expression.
+
+Both are fixed. Five shapes now match CmdStan at 0 ULP on `lp__` and every
+gradient: vector outcome, array outcome, one-sided `T[a, ]` and `T[ , b]`,
+a vector location, and a truncated `_lpmf`. `tests/fixtures/truncvec.stan`
+covers the two that failed, so CI catches this without CmdStan installed.
+
 ## 0.4.0
 
 Coverage. 0.3.0 shipped 46 of Stan's 72 densities and could not compile a

--- a/python/stanli/__init__.py
+++ b/python/stanli/__init__.py
@@ -16,7 +16,7 @@ import numpy as np
 __all__ = ["Model", "__version__"]
 # The one place the version lives. setup.py and the release workflow both
 # read it from here.
-__version__ = "0.4.0"
+__version__ = "0.4.1"
 
 _BIN = pathlib.Path(__file__).parent / "_bin"
 

--- a/runtime/include/stanli/mir_interp.hpp
+++ b/runtime/include/stanli/mir_interp.hpp
@@ -1087,8 +1087,12 @@ class MirInterp {
       a.dims = {(int64_t)std::max(a.r.size(), a.i.size())};
       return a;
     }
+    // FnLength is the compiler-internal stanc3 emits for the observation
+    // count in a vectorized `T[,]` normalizer. Its backend spelling is
+    // stan::math::size, which counts every element, so it answers as
+    // num_elements does rather than as size does.
     if (e.name == "rows" || e.name == "cols" || e.name == "size" ||
-        e.name == "num_elements") {
+        e.name == "num_elements" || e.name == "FnLength") {
       Value a = eval(e.args[0]);
       long v = 0;
       if (e.name == "rows")
@@ -1098,7 +1102,7 @@ class MirInterp {
       else
         v = a.dims.empty() ? (long)std::max(a.r.size(), a.i.size())
                            : (long)a.dims[0];
-      if (e.name == "num_elements")
+      if (e.name == "num_elements" || e.name == "FnLength")
         v = (long)std::max(a.r.size(), a.i.size());
       r.is_int = true;
       r.i = {(int)v};

--- a/runtime/src/lower.cpp
+++ b/runtime/src/lower.cpp
@@ -154,7 +154,7 @@ struct Lowering {
         // Shape queries on slot-bound values (e.g. rows(v) on an inlined
         // UDF's vector argument) answer from the slot's SlotInfo.
         if ((e.name == "rows" || e.name == "cols" || e.name == "size" ||
-             e.name == "num_elements") &&
+             e.name == "num_elements" || e.name == "FnLength") &&
             e.args.size() == 1 && e.args[0].kind == mir::Expr::Var) {
           auto sit = scope.find(e.args[0].name);
           if (sit != scope.end()) {

--- a/runtime/src/mir_reader.cpp
+++ b/runtime/src/mir_reader.cpp
@@ -235,7 +235,19 @@ Stmt read_stmt(const Node& n) {
     if (const Node* dt = field(p, "decl_type")) {
       const Node& t = (*dt)[1];  // (Sized ST) or (Unsized T)
       s.decl_type = t.head_is("Sized") ? read_sized(t[1]) : SizedType{};
-      if (!t.head_is("Sized")) s.decl_type.raw = dump(t);
+      if (!t.head_is("Sized")) {
+        s.decl_type.raw = dump(t);
+        // stanc3 declares scalar temporaries unsized. A vectorized `T[,]`
+        // whose location is a container loops over the elements and hoists
+        // the scale into one of these. A scalar carries no size
+        // expression, so give it the sized spelling. Unsized containers
+        // still reach the failure in sized_len, which is where their
+        // missing size belongs.
+        if (t.size() > 1 && t[1].is_atom()) {
+          if (t[1].atom == "UReal") s.decl_type.base = "SReal";
+          else if (t[1].atom == "UInt") s.decl_type.base = "SInt";
+        }
+      }
     }
     if (const Node* init = field(p, "initialize")) {
       const Node& iv = (*init)[1];

--- a/tests/fixtures/truncvec.stan
+++ b/tests/fixtures/truncvec.stan
@@ -1,0 +1,24 @@
+// Vectorized truncation, which the scalar trunc.stan fixture does not
+// reach. stanc3 writes the two forms differently, and each one used a
+// construct the reader rejected:
+//
+//   scalar location: the normalizer is FnLength(y) * log_diff_exp(...),
+//     and FnLength is a compiler-internal, not a stan-library name.
+//   container location with a literal scale: stanc3 loops over the
+//     elements and hoists the scale into a temporary it declares
+//     (Unsized UReal), which carries no size expression.
+//
+// Neither shape compiled before 0.4.1. Both are covered here.
+data {
+  int N;
+  vector[N] y;
+}
+parameters {
+  real mu;
+  vector[N] theta;
+  real<lower=0> sigma;
+}
+model {
+  y ~ normal(mu, sigma) T[0, 10];
+  y ~ normal(theta, 1) T[0, 10];
+}

--- a/tests/fixtures/truncvec.tmir.sexp
+++ b/tests/fixtures/truncvec.tmir.sexp
@@ -1,0 +1,1118 @@
+((functions_block ())
+ (input_vars
+  ((N <opaque> SInt)
+   (y <opaque>
+    (SVector AoS
+     ((pattern (Var N)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+ (prepare_data
+  (((pattern
+     (Decl (decl_adtype DataOnly) (decl_id pos__) (decl_type (Sized SInt))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable pos__) ()) UInt
+      ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id N) (decl_type (Sized SInt))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable N) ()) UInt
+      ((pattern
+        (Indexed
+         ((pattern
+           (FunApp (CompilerInternal FnReadData)
+            (((pattern (Lit Str N))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+          (meta ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly))))
+         ((Single
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp (CompilerInternal FnValidateSize)
+      (((pattern (Lit Str y)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+       ((pattern (Lit Str N)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+       ((pattern (Var N)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id y)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Var N)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id y_flat__)
+          (decl_type (Unsized (UArray UReal))) (initialize Uninit)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable y_flat__) ()) (UArray UReal)
+          ((pattern
+            (FunApp (CompilerInternal FnReadData)
+             (((pattern (Lit Str y))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable pos__) ()) UInt
+          ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar sym1__)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Var N)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (Assignment
+                  ((LVariable y)
+                   ((Single
+                     ((pattern (Var sym1__))
+                      (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                  UVector
+                  ((pattern
+                    (Indexed
+                     ((pattern (Var y_flat__))
+                      (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))
+                     ((Single
+                       ((pattern (Var pos__))
+                        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+                (meta <opaque>))
+               ((pattern
+                 (Assignment ((LVariable pos__) ()) UInt
+                  ((pattern
+                    (FunApp (StanLib Plus__ FnPlain AoS)
+                     (((pattern (Var pos__))
+                       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                      ((pattern (Lit Int 1))
+                       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp (CompilerInternal FnValidateSize)
+      (((pattern (Lit Str theta))
+        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+       ((pattern (Lit Str N)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+       ((pattern (Var N)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+    (meta <opaque>))))
+ (log_prob
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id mu) (decl_type (Sized SReal))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity) (dims ()) (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id theta)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Var N)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity)
+             (dims
+              (((pattern (Var N))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id sigma) (decl_type (Sized SReal))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam
+             (constrain
+              (Lower
+               ((pattern (Lit Int 0))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (dims ()) (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib normal_lpdf (FnLpdf true) AoS)
+             (((pattern (Var y))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly))))
+              ((pattern (Var mu))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+              ((pattern (Var sigma))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>))
+       ((pattern
+         (IfElse
+          ((pattern
+            (FunApp (StanLib Less__ FnPlain AoS)
+             (((pattern
+                (FunApp (StanLib min FnPlain AoS)
+                 (((pattern (Var y))
+                   (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+              ((pattern (Lit Int 0))
+               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+          ((pattern
+            (Block
+             (((pattern
+                (TargetPE
+                 ((pattern (FunApp (CompilerInternal FnNegInf) ()))
+                  (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+               (meta <opaque>)))))
+           (meta <opaque>))
+          (((pattern
+             (Block
+              (((pattern
+                 (IfElse
+                  ((pattern
+                    (FunApp (StanLib Greater__ FnPlain AoS)
+                     (((pattern
+                        (FunApp (StanLib max FnPlain AoS)
+                         (((pattern (Var y))
+                           (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+                       (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+                      ((pattern (Lit Int 10))
+                       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                  ((pattern
+                    (Block
+                     (((pattern
+                        (TargetPE
+                         ((pattern (FunApp (CompilerInternal FnNegInf) ()))
+                          (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+                       (meta <opaque>)))))
+                   (meta <opaque>))
+                  (((pattern
+                     (Block
+                      (((pattern
+                         (TargetPE
+                          ((pattern
+                            (FunApp (StanLib PMinus__ FnPlain AoS)
+                             (((pattern
+                                (FunApp (StanLib Times__ FnPlain AoS)
+                                 (((pattern
+                                    (FunApp (StanLib log_diff_exp FnPlain AoS)
+                                     (((pattern
+                                        (FunApp (StanLib normal_lcdf FnPlain AoS)
+                                         (((pattern
+                                            (Promotion
+                                             ((pattern (Lit Int 10))
+                                              (meta
+                                               ((type_ UInt) (loc <opaque>)
+                                                (adlevel DataOnly))))
+                                             UReal DataOnly))
+                                           (meta
+                                            ((type_ UReal) (loc <opaque>)
+                                             (adlevel DataOnly))))
+                                          ((pattern (Var mu))
+                                           (meta
+                                            ((type_ UReal) (loc <opaque>)
+                                             (adlevel AutoDiffable))))
+                                          ((pattern (Var sigma))
+                                           (meta
+                                            ((type_ UReal) (loc <opaque>)
+                                             (adlevel AutoDiffable)))))))
+                                       (meta
+                                        ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                                      ((pattern
+                                        (FunApp (StanLib normal_lcdf FnPlain AoS)
+                                         (((pattern
+                                            (Promotion
+                                             ((pattern (Lit Int 0))
+                                              (meta
+                                               ((type_ UInt) (loc <opaque>)
+                                                (adlevel DataOnly))))
+                                             UReal DataOnly))
+                                           (meta
+                                            ((type_ UReal) (loc <opaque>)
+                                             (adlevel DataOnly))))
+                                          ((pattern (Var mu))
+                                           (meta
+                                            ((type_ UReal) (loc <opaque>)
+                                             (adlevel AutoDiffable))))
+                                          ((pattern (Var sigma))
+                                           (meta
+                                            ((type_ UReal) (loc <opaque>)
+                                             (adlevel AutoDiffable)))))))
+                                       (meta
+                                        ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                                   (meta
+                                    ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                                  ((pattern
+                                    (FunApp (CompilerInternal FnLength)
+                                     (((pattern (Var y))
+                                       (meta
+                                        ((type_ UVector) (loc <opaque>)
+                                         (adlevel DataOnly)))))))
+                                   (meta
+                                    ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+                               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                        (meta <opaque>)))))
+                    (meta <opaque>)))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>))
+       ((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib normal_lpdf (FnLpdf true) AoS)
+             (((pattern (Var y))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly))))
+              ((pattern (Var theta))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))
+              ((pattern
+                (Promotion
+                 ((pattern (Lit Int 1))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                 UReal DataOnly))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>))
+       ((pattern
+         (IfElse
+          ((pattern
+            (FunApp (StanLib Less__ FnPlain AoS)
+             (((pattern
+                (FunApp (StanLib min FnPlain AoS)
+                 (((pattern (Var y))
+                   (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+              ((pattern (Lit Int 0))
+               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+          ((pattern
+            (Block
+             (((pattern
+                (TargetPE
+                 ((pattern (FunApp (CompilerInternal FnNegInf) ()))
+                  (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+               (meta <opaque>)))))
+           (meta <opaque>))
+          (((pattern
+             (Block
+              (((pattern
+                 (IfElse
+                  ((pattern
+                    (FunApp (StanLib Greater__ FnPlain AoS)
+                     (((pattern
+                        (FunApp (StanLib max FnPlain AoS)
+                         (((pattern (Var y))
+                           (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+                       (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+                      ((pattern (Lit Int 10))
+                       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                  ((pattern
+                    (Block
+                     (((pattern
+                        (TargetPE
+                         ((pattern (FunApp (CompilerInternal FnNegInf) ()))
+                          (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+                       (meta <opaque>)))))
+                   (meta <opaque>))
+                  (((pattern
+                     (Block
+                      (((pattern
+                         (Decl (decl_adtype DataOnly) (decl_id sym1__)
+                          (decl_type (Unsized UReal)) (initialize Default)))
+                        (meta <opaque>))
+                       ((pattern
+                         (Assignment ((LVariable sym1__) ()) UReal
+                          ((pattern
+                            (Promotion
+                             ((pattern (Lit Int 1))
+                              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                             UReal DataOnly))
+                           (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+                        (meta <opaque>))
+                       ((pattern
+                         (For (loopvar sym3__)
+                          (lower
+                           ((pattern (Lit Int 1))
+                            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                          (upper
+                           ((pattern
+                             (FunApp (CompilerInternal FnLength)
+                              (((pattern (Var theta))
+                                (meta
+                                 ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+                            (meta ((type_ UInt) (loc <opaque>) (adlevel AutoDiffable)))))
+                          (body
+                           ((pattern
+                             (Block
+                              (((pattern
+                                 (TargetPE
+                                  ((pattern
+                                    (FunApp (StanLib PMinus__ FnPlain AoS)
+                                     (((pattern
+                                        (FunApp (StanLib log_diff_exp FnPlain AoS)
+                                         (((pattern
+                                            (FunApp (StanLib normal_lcdf FnPlain AoS)
+                                             (((pattern
+                                                (Promotion
+                                                 ((pattern (Lit Int 10))
+                                                  (meta
+                                                   ((type_ UInt) (loc <opaque>)
+                                                    (adlevel DataOnly))))
+                                                 UReal DataOnly))
+                                               (meta
+                                                ((type_ UReal) (loc <opaque>)
+                                                 (adlevel DataOnly))))
+                                              ((pattern
+                                                (Indexed
+                                                 ((pattern (Var theta))
+                                                  (meta
+                                                   ((type_ UVector) (loc <opaque>)
+                                                    (adlevel AutoDiffable))))
+                                                 ((Single
+                                                   ((pattern (Var sym3__))
+                                                    (meta
+                                                     ((type_ UInt) (loc <opaque>)
+                                                      (adlevel DataOnly))))))))
+                                               (meta
+                                                ((type_ UReal) (loc <opaque>)
+                                                 (adlevel AutoDiffable))))
+                                              ((pattern (Var sym1__))
+                                               (meta
+                                                ((type_ UReal) (loc <opaque>)
+                                                 (adlevel DataOnly)))))))
+                                           (meta
+                                            ((type_ UInt) (loc <opaque>)
+                                             (adlevel DataOnly))))
+                                          ((pattern
+                                            (FunApp (StanLib normal_lcdf FnPlain AoS)
+                                             (((pattern
+                                                (Promotion
+                                                 ((pattern (Lit Int 0))
+                                                  (meta
+                                                   ((type_ UInt) (loc <opaque>)
+                                                    (adlevel DataOnly))))
+                                                 UReal DataOnly))
+                                               (meta
+                                                ((type_ UReal) (loc <opaque>)
+                                                 (adlevel DataOnly))))
+                                              ((pattern
+                                                (Indexed
+                                                 ((pattern (Var theta))
+                                                  (meta
+                                                   ((type_ UVector) (loc <opaque>)
+                                                    (adlevel AutoDiffable))))
+                                                 ((Single
+                                                   ((pattern (Var sym3__))
+                                                    (meta
+                                                     ((type_ UInt) (loc <opaque>)
+                                                      (adlevel DataOnly))))))))
+                                               (meta
+                                                ((type_ UReal) (loc <opaque>)
+                                                 (adlevel AutoDiffable))))
+                                              ((pattern (Var sym1__))
+                                               (meta
+                                                ((type_ UReal) (loc <opaque>)
+                                                 (adlevel DataOnly)))))))
+                                           (meta
+                                            ((type_ UInt) (loc <opaque>)
+                                             (adlevel DataOnly)))))))
+                                       (meta
+                                        ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                                   (meta
+                                    ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                                (meta <opaque>)))))
+                            (meta <opaque>)))))
+                        (meta <opaque>)))))
+                    (meta <opaque>)))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))))
+ (reverse_mode_log_prob
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id mu) (decl_type (Sized SReal))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity) (dims ()) (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id theta)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Var N)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity)
+             (dims
+              (((pattern (Var N))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id sigma) (decl_type (Sized SReal))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam
+             (constrain
+              (Lower
+               ((pattern (Lit Int 0))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (dims ()) (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib normal_lpdf (FnLpdf true) AoS)
+             (((pattern (Var y))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly))))
+              ((pattern (Var mu))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+              ((pattern (Var sigma))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>))
+       ((pattern
+         (IfElse
+          ((pattern
+            (FunApp (StanLib Less__ FnPlain AoS)
+             (((pattern
+                (FunApp (StanLib min FnPlain AoS)
+                 (((pattern (Var y))
+                   (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+              ((pattern (Lit Int 0))
+               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+          ((pattern
+            (Block
+             (((pattern
+                (TargetPE
+                 ((pattern (FunApp (CompilerInternal FnNegInf) ()))
+                  (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+               (meta <opaque>)))))
+           (meta <opaque>))
+          (((pattern
+             (Block
+              (((pattern
+                 (IfElse
+                  ((pattern
+                    (FunApp (StanLib Greater__ FnPlain AoS)
+                     (((pattern
+                        (FunApp (StanLib max FnPlain AoS)
+                         (((pattern (Var y))
+                           (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+                       (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+                      ((pattern (Lit Int 10))
+                       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                  ((pattern
+                    (Block
+                     (((pattern
+                        (TargetPE
+                         ((pattern (FunApp (CompilerInternal FnNegInf) ()))
+                          (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+                       (meta <opaque>)))))
+                   (meta <opaque>))
+                  (((pattern
+                     (Block
+                      (((pattern
+                         (TargetPE
+                          ((pattern
+                            (FunApp (StanLib PMinus__ FnPlain AoS)
+                             (((pattern
+                                (FunApp (StanLib Times__ FnPlain AoS)
+                                 (((pattern
+                                    (FunApp (StanLib log_diff_exp FnPlain AoS)
+                                     (((pattern
+                                        (FunApp (StanLib normal_lcdf FnPlain AoS)
+                                         (((pattern
+                                            (Promotion
+                                             ((pattern (Lit Int 10))
+                                              (meta
+                                               ((type_ UInt) (loc <opaque>)
+                                                (adlevel DataOnly))))
+                                             UReal DataOnly))
+                                           (meta
+                                            ((type_ UReal) (loc <opaque>)
+                                             (adlevel DataOnly))))
+                                          ((pattern (Var mu))
+                                           (meta
+                                            ((type_ UReal) (loc <opaque>)
+                                             (adlevel AutoDiffable))))
+                                          ((pattern (Var sigma))
+                                           (meta
+                                            ((type_ UReal) (loc <opaque>)
+                                             (adlevel AutoDiffable)))))))
+                                       (meta
+                                        ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                                      ((pattern
+                                        (FunApp (StanLib normal_lcdf FnPlain AoS)
+                                         (((pattern
+                                            (Promotion
+                                             ((pattern (Lit Int 0))
+                                              (meta
+                                               ((type_ UInt) (loc <opaque>)
+                                                (adlevel DataOnly))))
+                                             UReal DataOnly))
+                                           (meta
+                                            ((type_ UReal) (loc <opaque>)
+                                             (adlevel DataOnly))))
+                                          ((pattern (Var mu))
+                                           (meta
+                                            ((type_ UReal) (loc <opaque>)
+                                             (adlevel AutoDiffable))))
+                                          ((pattern (Var sigma))
+                                           (meta
+                                            ((type_ UReal) (loc <opaque>)
+                                             (adlevel AutoDiffable)))))))
+                                       (meta
+                                        ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                                   (meta
+                                    ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                                  ((pattern
+                                    (FunApp (CompilerInternal FnLength)
+                                     (((pattern (Var y))
+                                       (meta
+                                        ((type_ UVector) (loc <opaque>)
+                                         (adlevel DataOnly)))))))
+                                   (meta
+                                    ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+                               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                        (meta <opaque>)))))
+                    (meta <opaque>)))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>))
+       ((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib normal_lpdf (FnLpdf true) AoS)
+             (((pattern (Var y))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly))))
+              ((pattern (Var theta))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))
+              ((pattern
+                (Promotion
+                 ((pattern (Lit Int 1))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                 UReal DataOnly))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>))
+       ((pattern
+         (IfElse
+          ((pattern
+            (FunApp (StanLib Less__ FnPlain AoS)
+             (((pattern
+                (FunApp (StanLib min FnPlain AoS)
+                 (((pattern (Var y))
+                   (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+              ((pattern (Lit Int 0))
+               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+          ((pattern
+            (Block
+             (((pattern
+                (TargetPE
+                 ((pattern (FunApp (CompilerInternal FnNegInf) ()))
+                  (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+               (meta <opaque>)))))
+           (meta <opaque>))
+          (((pattern
+             (Block
+              (((pattern
+                 (IfElse
+                  ((pattern
+                    (FunApp (StanLib Greater__ FnPlain AoS)
+                     (((pattern
+                        (FunApp (StanLib max FnPlain AoS)
+                         (((pattern (Var y))
+                           (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+                       (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+                      ((pattern (Lit Int 10))
+                       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                  ((pattern
+                    (Block
+                     (((pattern
+                        (TargetPE
+                         ((pattern (FunApp (CompilerInternal FnNegInf) ()))
+                          (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+                       (meta <opaque>)))))
+                   (meta <opaque>))
+                  (((pattern
+                     (Block
+                      (((pattern
+                         (Decl (decl_adtype DataOnly) (decl_id sym1__)
+                          (decl_type (Unsized UReal)) (initialize Default)))
+                        (meta <opaque>))
+                       ((pattern
+                         (Assignment ((LVariable sym1__) ()) UReal
+                          ((pattern
+                            (Promotion
+                             ((pattern (Lit Int 1))
+                              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                             UReal DataOnly))
+                           (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+                        (meta <opaque>))
+                       ((pattern
+                         (For (loopvar sym3__)
+                          (lower
+                           ((pattern (Lit Int 1))
+                            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                          (upper
+                           ((pattern
+                             (FunApp (CompilerInternal FnLength)
+                              (((pattern (Var theta))
+                                (meta
+                                 ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+                            (meta ((type_ UInt) (loc <opaque>) (adlevel AutoDiffable)))))
+                          (body
+                           ((pattern
+                             (Block
+                              (((pattern
+                                 (TargetPE
+                                  ((pattern
+                                    (FunApp (StanLib PMinus__ FnPlain AoS)
+                                     (((pattern
+                                        (FunApp (StanLib log_diff_exp FnPlain AoS)
+                                         (((pattern
+                                            (FunApp (StanLib normal_lcdf FnPlain AoS)
+                                             (((pattern
+                                                (Promotion
+                                                 ((pattern (Lit Int 10))
+                                                  (meta
+                                                   ((type_ UInt) (loc <opaque>)
+                                                    (adlevel DataOnly))))
+                                                 UReal DataOnly))
+                                               (meta
+                                                ((type_ UReal) (loc <opaque>)
+                                                 (adlevel DataOnly))))
+                                              ((pattern
+                                                (Indexed
+                                                 ((pattern (Var theta))
+                                                  (meta
+                                                   ((type_ UVector) (loc <opaque>)
+                                                    (adlevel AutoDiffable))))
+                                                 ((Single
+                                                   ((pattern (Var sym3__))
+                                                    (meta
+                                                     ((type_ UInt) (loc <opaque>)
+                                                      (adlevel DataOnly))))))))
+                                               (meta
+                                                ((type_ UReal) (loc <opaque>)
+                                                 (adlevel AutoDiffable))))
+                                              ((pattern (Var sym1__))
+                                               (meta
+                                                ((type_ UReal) (loc <opaque>)
+                                                 (adlevel DataOnly)))))))
+                                           (meta
+                                            ((type_ UInt) (loc <opaque>)
+                                             (adlevel DataOnly))))
+                                          ((pattern
+                                            (FunApp (StanLib normal_lcdf FnPlain AoS)
+                                             (((pattern
+                                                (Promotion
+                                                 ((pattern (Lit Int 0))
+                                                  (meta
+                                                   ((type_ UInt) (loc <opaque>)
+                                                    (adlevel DataOnly))))
+                                                 UReal DataOnly))
+                                               (meta
+                                                ((type_ UReal) (loc <opaque>)
+                                                 (adlevel DataOnly))))
+                                              ((pattern
+                                                (Indexed
+                                                 ((pattern (Var theta))
+                                                  (meta
+                                                   ((type_ UVector) (loc <opaque>)
+                                                    (adlevel AutoDiffable))))
+                                                 ((Single
+                                                   ((pattern (Var sym3__))
+                                                    (meta
+                                                     ((type_ UInt) (loc <opaque>)
+                                                      (adlevel DataOnly))))))))
+                                               (meta
+                                                ((type_ UReal) (loc <opaque>)
+                                                 (adlevel AutoDiffable))))
+                                              ((pattern (Var sym1__))
+                                               (meta
+                                                ((type_ UReal) (loc <opaque>)
+                                                 (adlevel DataOnly)))))))
+                                           (meta
+                                            ((type_ UInt) (loc <opaque>)
+                                             (adlevel DataOnly)))))))
+                                       (meta
+                                        ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                                   (meta
+                                    ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                                (meta <opaque>)))))
+                            (meta <opaque>)))))
+                        (meta <opaque>)))))
+                    (meta <opaque>)))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))))
+ (generate_quantities
+  (((pattern
+     (Decl (decl_adtype DataOnly) (decl_id mu) (decl_type (Sized SReal))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity) (dims ()) (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id theta)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Var N)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity)
+             (dims
+              (((pattern (Var N))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id sigma) (decl_type (Sized SReal))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam
+             (constrain
+              (Lower
+               ((pattern (Lit Int 0))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (dims ()) (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt ())
+        (var
+         ((pattern (Var mu)) (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt ())
+        (var
+         ((pattern (Var theta))
+          (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt ())
+        (var
+         ((pattern (Var sigma)) (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (IfElse
+      ((pattern
+        (FunApp (StanLib PNot__ FnPlain AoS)
+         (((pattern
+            (EOr
+             ((pattern (Var emit_transformed_parameters__))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+             ((pattern (Var emit_generated_quantities__))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+      ((pattern (Block (((pattern (Return ())) (meta <opaque>))))) (meta <opaque>)) ()))
+    (meta <opaque>))
+   ((pattern
+     (IfElse
+      ((pattern
+        (FunApp (StanLib PNot__ FnPlain AoS)
+         (((pattern (Var emit_generated_quantities__))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+      ((pattern (Block (((pattern (Return ())) (meta <opaque>))))) (meta <opaque>)) ()))
+    (meta <opaque>))))
+ (transform_inits
+  (((pattern
+     (Decl (decl_adtype DataOnly) (decl_id pos__) (decl_type (Sized SInt))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable pos__) ()) UInt
+      ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id mu) (decl_type (Sized SReal))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable mu) ()) UReal
+      ((pattern
+        (Indexed
+         ((pattern
+           (FunApp (CompilerInternal FnReadData)
+            (((pattern (Lit Str mu))
+              (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+          (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))
+         ((Single
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+       (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var mu)) (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id theta)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Var N)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id theta_flat__)
+          (decl_type (Unsized (UArray UReal))) (initialize Uninit)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable theta_flat__) ()) (UArray UReal)
+          ((pattern
+            (FunApp (CompilerInternal FnReadData)
+             (((pattern (Lit Str theta))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable pos__) ()) UInt
+          ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar sym1__)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Var N)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (Assignment
+                  ((LVariable theta)
+                   ((Single
+                     ((pattern (Var sym1__))
+                      (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                  UVector
+                  ((pattern
+                    (Indexed
+                     ((pattern (Var theta_flat__))
+                      (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))
+                     ((Single
+                       ((pattern (Var pos__))
+                        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+                (meta <opaque>))
+               ((pattern
+                 (Assignment ((LVariable pos__) ()) UInt
+                  ((pattern
+                    (FunApp (StanLib Plus__ FnPlain AoS)
+                     (((pattern (Var pos__))
+                       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                      ((pattern (Lit Int 1))
+                       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var theta))
+          (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id sigma) (decl_type (Sized SReal))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable sigma) ()) UReal
+      ((pattern
+        (Indexed
+         ((pattern
+           (FunApp (CompilerInternal FnReadData)
+            (((pattern (Lit Str sigma))
+              (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+          (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))
+         ((Single
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+       (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam
+        (unconstrain_opt
+         ((Lower
+           ((pattern (Lit Int 0))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+        (var
+         ((pattern (Var sigma)) (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))))
+ (unconstrain_array
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id mu) (decl_type (Sized SReal))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable mu) ()) UReal
+      ((pattern (FunApp (CompilerInternal FnReadDeserializer) ()))
+       (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var mu)) (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id theta)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Var N)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable theta) ()) UVector
+      ((pattern
+        (FunApp (CompilerInternal FnReadDeserializer)
+         (((pattern (Var N)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var theta))
+          (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id sigma) (decl_type (Sized SReal))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable sigma) ()) UReal
+      ((pattern (FunApp (CompilerInternal FnReadDeserializer) ()))
+       (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam
+        (unconstrain_opt
+         ((Lower
+           ((pattern (Lit Int 0))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+        (var
+         ((pattern (Var sigma)) (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))))
+ (output_vars
+  ((mu <opaque>
+    ((out_unconstrained_st SReal) (out_constrained_st SReal) (out_block Parameters)
+     (out_trans Identity)))
+   (theta <opaque>
+    ((out_unconstrained_st
+      (SVector AoS
+       ((pattern (Var N)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+     (out_constrained_st
+      (SVector AoS
+       ((pattern (Var N)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+     (out_block Parameters) (out_trans Identity)))
+   (sigma <opaque>
+    ((out_unconstrained_st SReal) (out_constrained_st SReal) (out_block Parameters)
+     (out_trans
+      (Lower
+       ((pattern (Lit Int 0)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))))
+ (prog_name truncvec_model) (prog_path tests/fixtures/truncvec.stan))

--- a/tests/test_lower.cpp
+++ b/tests/test_lower.cpp
@@ -697,6 +697,58 @@ int main() {
     }
   }
 
+  // Vectorized truncation. The fixture above truncates a scalar, which is
+  // the shape that kept working while both vectorized forms failed to
+  // compile at all: one needs the FnLength compiler-internal, the other a
+  // decl stanc3 leaves unsized. Checked against CmdStan at 0 ULP on lp and
+  // every gradient when this went in; the var path is what CI can run.
+  {
+    const std::vector<double> yv = {0.5, 1.75, 2.25};
+    DataMap d;
+    d.set_int("N", 3);
+    d.set_real_array("y", yv);
+    CompiledModel tm = compile_model(slurp("tests/fixtures/truncvec.tmir.sexp"),
+                                     d);
+    Executor tex(std::move(tm.graph));
+    tm.bind(tex);
+    // Declaration order: mu, theta[3], sigma.
+    const double pts[2][5] = {{0.6, -0.2, 0.35, 0.1, -0.3},
+                              {-0.25, 0.4, -0.15, 0.5, 0.2}};
+    for (int c = 0; c < 2; ++c) {
+      for (int i = 0; i < 5; ++i) tex.params_data()[i] = pts[c][i];
+      double grad[5] = {0, 0, 0, 0, 0};
+      const double lp = tex.gradient(grad);
+
+      using stan::math::var;
+      var u_mu = pts[c][0], u_sig = pts[c][4];
+      Eigen::Matrix<var, Eigen::Dynamic, 1> theta(3);
+      for (int i = 0; i < 3; ++i) theta(i) = pts[c][1 + i];
+      var mu = u_mu, sigma = stan::math::exp(u_sig);
+      Eigen::VectorXd y = Eigen::Map<const Eigen::VectorXd>(yv.data(), 3);
+
+      var acc = u_sig;  // lower=0 jacobian
+      // Scalar location: one log_diff_exp scaled by the element count.
+      acc += stan::math::normal_lpdf<true>(y, mu, sigma);
+      acc -= 3.0 * stan::math::log_diff_exp(
+                       stan::math::normal_lcdf(10.0, mu, sigma),
+                       stan::math::normal_lcdf(0.0, mu, sigma));
+      // Container location: one log_diff_exp per element, accumulated.
+      acc += stan::math::normal_lpdf<true>(y, theta, 1.0);
+      for (int i = 0; i < 3; ++i)
+        acc -= stan::math::log_diff_exp(
+            stan::math::normal_lcdf(10.0, theta(i), 1.0),
+            stan::math::normal_lcdf(0.0, theta(i), 1.0));
+      acc.grad();
+
+      bool gok = grad[0] == u_mu.adj() && grad[4] == u_sig.adj();
+      for (int i = 0; i < 3; ++i) gok = gok && grad[1 + i] == theta(i).adj();
+      check(gok, "truncvec: gradients bitwise against the var path");
+      const double tol = 8 * 2.220446049250313e-16 * std::abs(acc.val());
+      check(std::abs(lp - acc.val()) <= tol,
+            "truncvec: lp matches the var path");
+    }
+  }
+
   // Ordinal regression, against an independent var-path reference. Same
   // reason as the truncation case: CI has no CmdStan, and this is the one
   // density whose cutpoint argument is a shared vector rather than a


### PR DESCRIPTION
`y ~ normal(mu, sigma) T[0, 10]` over a vector failed to compile in 0.4.0.

0.4.0 shipped truncation and tested it on `real y`. That is the one shape
that worked. Every vectorized form, which is how models are actually
written, failed at compile time. `tests/fixtures/trunc.stan` truncates a
scalar, so nothing caught it.

## Two constructs were missing

stanc3 emits a different shape depending on the location argument.

**Scalar location.** The normalizer is `FnLength(y) * log_diff_exp(...)`.
`FnLength` is a compiler-internal, not a stan-library name, so it reached
the lowering as an unknown function kind and constant folding declined it.
It now answers as `num_elements` does, which is what stanc3's own backend
maps it to (`stan::math::size`).

**Container location with a literal scale.** stanc3 loops over the elements
and hoists the scale into a temporary it declares `(Unsized UReal)`. The
reader only understood sized declarations. Scalars carry no size
expression, so the two unsized scalar spellings now map to their sized
ones. Unsized containers still fail in `sized_len`, where a missing size
belongs.

## Verification

Five shapes checked against CmdStan, compiled from the same source with
`-ffp-contract=off`, at four evaluation points each. All 0 ULP on `lp__`
and on every gradient:

| shape | worst |
|---|---:|
| vector outcome, `T[0, 10]` | 0 ULP |
| array outcome, `T[0, 10]` | 0 ULP |
| one-sided `T[0, ]` | 0 ULP |
| one-sided `T[ , 10]` | 0 ULP |
| vector location | 0 ULP |
| truncated `_lpmf` (`poisson`) | 0 ULP |

`tests/fixtures/truncvec.stan` covers both failing shapes in one model and
is checked against a var-path reference, so CI catches a regression without
CmdStan installed. Reverting either fix aborts that test with the original
error.

26/26 tests pass and the corpus stays 119/119, worst `hmm_gaussian` at
3.63e-12, unchanged.

Version bumped to 0.4.1 so the tag is one step. This is a fix to a headline
0.4.0 feature, so it is worth releasing rather than holding.