### PR TITLE
fix: array-of-container data layout, and vectorized dirichlet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,50 @@
 
 ## 0.4.1
 
-Truncation only worked on a scalar outcome. 0.4.0 added truncation and
-tested it on `real y`, which is the one shape that compiled. Every
-vectorized form failed at compile time, and `y ~ normal(mu, sigma)
-T[0, 10]` over a vector is the form models are written in.
+Three bugs in features 0.4.0 introduced. Two refused to compile, one was
+silent. All three were found by exercising shapes the posteriordb corpus
+does not contain, and all three are covered by fixtures now.
 
-Two constructs were missing, one per shape stanc3 emits:
+### array[N] vector[K] data reached the multivariate densities permuted
+
+`y ~ multi_normal(mu, Sigma)` with `array[N] vector[K] y` as data returned
+wrong gradients. The model compiled and `lp__` stayed plausible, so
+nothing announced it.
+
+Data is stored with the first index fastest, the way a matrix is stored.
+An array of vectors has to reach the kernel with element `n` contiguous in
+`K`, which is where a parameter of the same type already sits, so the data
+path now repacks on the way into the slot. The same slot indexed one
+element at a time was always right, which is why the shape looked healthy.
+
+Affected: `multi_normal`, `multi_normal_cholesky`, `multi_normal_prec`,
+`multi_student_t` and `multi_student_t_cholesky`, only with an
+`array[N] vector[K]` outcome that is data, and only when the whole array
+is passed. All five now match CmdStan at 0 ULP on every gradient. The same
+outcome as a parameter was correct before and still is.
+
+No posteriordb model has this shape, so the corpus never covered it.
+`tests/fixtures/mnarr.stan` does now, with `N` and `K` deliberately
+different, since a square case hides a transpose.
+
+### Vectorized dirichlet did not compile
+
+`p ~ dirichlet(a)` over an array of simplexes, the shape a hierarchical
+Dirichlet is written in, threw at evaluation time. The kernel took one
+theta vector and read the whole slot as it, so the vectorized form reached
+stan-math as a single simplex of `N*K` and failed the length check against
+alpha. Only the explicit `for (n in 1:N) p[n] ~ dirichlet(a)` worked.
+
+The kernel splits the slot now. A single dirichlet needs theta and alpha
+the same length, so a longer theta is unambiguously the vectorized form.
+Data and parameter outcomes both match CmdStan at 0 ULP.
+
+### Vectorized truncation did not compile
+
+0.4.0 added truncation and tested it on `real y`, which is the one shape
+that compiled. Every vectorized form failed at compile time, and
+`y ~ normal(mu, sigma) T[0, 10]` over a vector is the form models are
+written in. Two constructs were missing, one per shape stanc3 emits:
 
 - A scalar location gives a normalizer of `FnLength(y) * log_diff_exp(...)`.
   `FnLength` is a compiler-internal rather than a stan-library name, so it

--- a/runtime/kernels/legacy_fns.cpp
+++ b/runtime/kernels/legacy_fns.cpp
@@ -49,6 +49,48 @@ double dirichlet_eval(KernelCtx& ctx) {
   Eigen::Map<const Eigen::VectorXd> alpha_d(ctx.in[1].data, ctx.in[1].len);
   var lp;
   const bool a0 = (mask & 1u) != 0, a1 = (mask & 2u) != 0;
+
+  // `p ~ dirichlet(a)` over an array of simplexes. A single dirichlet needs
+  // theta and alpha the same length, so a longer theta is unambiguously the
+  // vectorized form: reps simplexes of K, element n contiguous in K.
+  // stan-math reads both through vector_seq_view, so the only work here is
+  // splitting the slot.
+  const int64_t K = ctx.in[1].len;
+  const int64_t reps = K > 0 ? ctx.in[0].len / K : 1;
+  if (reps > 1) {
+    std::vector<Eigen::Matrix<var, -1, 1>> th(reps,
+                                              Eigen::Matrix<var, -1, 1>(K));
+    std::vector<Eigen::VectorXd> thd(reps, Eigen::VectorXd(K));
+    for (int64_t r = 0; r < reps; ++r)
+      for (int64_t i = 0; i < K; ++i) {
+        th[r](i) = ctx.in[0].data[r * K + i];
+        thd[r](i) = ctx.in[0].data[r * K + i];
+      }
+    var lpv;
+    if (propto) {
+      if (a0 && a1) lpv = stan::math::dirichlet_lpdf<true>(th, alpha);
+      else if (a0) lpv = stan::math::dirichlet_lpdf<true>(th, alpha_d);
+      else if (a1) lpv = stan::math::dirichlet_lpdf<true>(thd, alpha);
+      else lpv = 0.0;
+    } else {
+      if (a0 && a1) lpv = stan::math::dirichlet_lpdf<false>(th, alpha);
+      else if (a0) lpv = stan::math::dirichlet_lpdf<false>(th, alpha_d);
+      else if (a1) lpv = stan::math::dirichlet_lpdf<false>(thd, alpha);
+      else lpv = stan::math::dirichlet_lpdf<false>(thd, alpha_d);
+    }
+    if constexpr (Grad) {
+      var j = lpv * ctx.out_adj;
+      stan::math::grad(j.vi_);
+      if (a0 && ctx.in_adj[0].data)
+        for (int64_t r = 0; r < reps; ++r)
+          for (int64_t i = 0; i < K; ++i)
+            ctx.in_adj[0].data[r * K + i] += th[r](i).adj();
+      if (a1 && ctx.in_adj[1].data)
+        for (int64_t i = 0; i < K; ++i)
+          ctx.in_adj[1].data[i] += alpha(i).adj();
+    }
+    return lpv.val();
+  }
   if (propto) {
     if (a0 && a1) lp = stan::math::dirichlet_lpdf<true>(theta, alpha);
     else if (a0) lp = stan::math::dirichlet_lpdf<true>(theta, alpha_d);

--- a/runtime/src/lower.cpp
+++ b/runtime/src/lower.cpp
@@ -197,10 +197,23 @@ struct Lowering {
     fail("unsupported sized type " + t.base, t.raw);
   }
 
+  // Data declared `array[N] vector[K]` (or row_vector). The interpreter
+  // stores every 2-D value with the first index fastest, the way it stores
+  // a matrix. The graph wants an array of containers laid out the way
+  // parameters of the same type are: element n contiguous in K. env_slot
+  // repacks these on the way out.
+  std::set<std::string> array_of_container;
+
   void bind_data(const mir::Program& p) {
     for (const auto& [name, type] : p.input_vars) {
       (void)type;
       if (data.has(name)) td.env()[name] = data.at(name);
+    }
+    for (const auto& st : p.prepare_data) {
+      if (st.kind == mir::Stmt::Decl && st.decl_type.base == "SArray" &&
+          st.decl_type.dims.size() == 2 &&
+          (st.decl_type.raw == "SVector" || st.decl_type.raw == "SRowVector"))
+        array_of_container.insert(st.decl_id);
     }
     for (const auto& st : p.prepare_data) td.exec(st);
     for (auto& [name, e] : td.env()) {
@@ -225,13 +238,25 @@ struct Lowering {
     if (en->r.empty()) return -1;
     SlotInfo si;
     si.data_like = true;
-    if (en->dims.size() == 2) {
+    // An array of containers is not a matrix, so it gets no rows/cols: the
+    // kernels that take one read element n from n*K, which is where the
+    // repack below puts it, and which is where a parameter of the same
+    // type already sits.
+    const bool aoc = array_of_container.count(name) > 0 &&
+                     en->dims.size() == 2;
+    if (en->dims.size() == 2 && !aoc) {
       si.rows = en->dims[0];
       si.cols = en->dims[1];
     }
-    const int s = add_slot((int64_t)en->r.size(), false, si);
-    out.fills.emplace_back(s, en->r);
-    slot_values[s] = en->r;
+    std::vector<double> vals = en->r;
+    if (aoc) {
+      const int64_t N = en->dims[0], K = en->dims[1];
+      for (int64_t i = 0; i < N; ++i)
+        for (int64_t k = 0; k < K; ++k) vals[i * K + k] = en->r[k * N + i];
+    }
+    const int s = add_slot((int64_t)vals.size(), false, si);
+    out.fills.emplace_back(s, vals);
+    slot_values[s] = vals;
     scope[name] = s;
     return s;
   }

--- a/tests/fixtures/dirvec.stan
+++ b/tests/fixtures/dirvec.stan
@@ -1,0 +1,22 @@
+// `p ~ dirichlet(a)` over an array of simplexes, the shape a hierarchical
+// Dirichlet is written in.
+//
+// The kernel took one theta vector and read the whole slot as it, so the
+// vectorized form reached stan-math as a single simplex of N*K and threw
+// on the length mismatch against alpha. It failed loudly, but it failed:
+// only the explicit `for (n in 1:N) p[n] ~ dirichlet(a)` worked.
+//
+// The outcome is data here so the reference stays a plain lpdf call. That
+// also pins the array[N] vector[K] data layout, which mnarr.stan covers
+// for multi_normal. N and K differ on purpose.
+data {
+  int N;
+  int K;
+  array[N] vector[K] p;
+}
+parameters {
+  vector<lower=0>[K] a;
+}
+model {
+  p ~ dirichlet(a);
+}

--- a/tests/fixtures/dirvec.tmir.sexp
+++ b/tests/fixtures/dirvec.tmir.sexp
@@ -1,0 +1,411 @@
+((functions_block ())
+ (input_vars
+  ((N <opaque> SInt) (K <opaque> SInt)
+   (p <opaque>
+    (SArray
+     (SVector AoS
+      ((pattern (Var K)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+     ((pattern (Var N)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+ (prepare_data
+  (((pattern
+     (Decl (decl_adtype DataOnly) (decl_id pos__) (decl_type (Sized SInt))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable pos__) ()) UInt
+      ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id N) (decl_type (Sized SInt))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable N) ()) UInt
+      ((pattern
+        (Indexed
+         ((pattern
+           (FunApp (CompilerInternal FnReadData)
+            (((pattern (Lit Str N))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+          (meta ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly))))
+         ((Single
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id K) (decl_type (Sized SInt))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable K) ()) UInt
+      ((pattern
+        (Indexed
+         ((pattern
+           (FunApp (CompilerInternal FnReadData)
+            (((pattern (Lit Str K))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+          (meta ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly))))
+         ((Single
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp (CompilerInternal FnValidateSize)
+      (((pattern (Lit Str p)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+       ((pattern (Lit Str N)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+       ((pattern (Var N)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp (CompilerInternal FnValidateSize)
+      (((pattern (Lit Str p)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+       ((pattern (Lit Str K)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+       ((pattern (Var K)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id p)
+      (decl_type
+       (Sized
+        (SArray
+         (SVector AoS
+          ((pattern (Var K)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+         ((pattern (Var N)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id p_flat__)
+          (decl_type (Unsized (UArray UReal))) (initialize Uninit)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable p_flat__) ()) (UArray UReal)
+          ((pattern
+            (FunApp (CompilerInternal FnReadData)
+             (((pattern (Lit Str p))
+               (meta ((type_ (UArray UVector)) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable pos__) ()) UInt
+          ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar sym1__)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Var K)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (For (loopvar sym2__)
+                  (lower
+                   ((pattern (Lit Int 1))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (upper
+                   ((pattern (Var N))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (body
+                   ((pattern
+                     (Block
+                      (((pattern
+                         (Assignment
+                          ((LVariable p)
+                           ((Single
+                             ((pattern (Var sym2__))
+                              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                            (Single
+                             ((pattern (Var sym1__))
+                              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                          (UArray UVector)
+                          ((pattern
+                            (Indexed
+                             ((pattern (Var p_flat__))
+                              (meta
+                               ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))
+                             ((Single
+                               ((pattern (Var pos__))
+                                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                           (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+                        (meta <opaque>))
+                       ((pattern
+                         (Assignment ((LVariable pos__) ()) UInt
+                          ((pattern
+                            (FunApp (StanLib Plus__ FnPlain AoS)
+                             (((pattern (Var pos__))
+                               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                              ((pattern (Lit Int 1))
+                               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                        (meta <opaque>)))))
+                    (meta <opaque>)))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp (CompilerInternal FnValidateSize)
+      (((pattern (Lit Str a)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+       ((pattern (Lit Str K)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+       ((pattern (Var K)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+    (meta <opaque>))))
+ (log_prob
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id a)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Var K)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam
+             (constrain
+              (Lower
+               ((pattern (Lit Int 0))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (dims
+              (((pattern (Var K))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib dirichlet_lpdf (FnLpdf true) AoS)
+             (((pattern (Var p))
+               (meta ((type_ (UArray UVector)) (loc <opaque>) (adlevel DataOnly))))
+              ((pattern (Var a))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>)))))
+    (meta <opaque>))))
+ (reverse_mode_log_prob
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id a)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Var K)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam
+             (constrain
+              (Lower
+               ((pattern (Lit Int 0))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (dims
+              (((pattern (Var K))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib dirichlet_lpdf (FnLpdf true) AoS)
+             (((pattern (Var p))
+               (meta ((type_ (UArray UVector)) (loc <opaque>) (adlevel DataOnly))))
+              ((pattern (Var a))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>)))))
+    (meta <opaque>))))
+ (generate_quantities
+  (((pattern
+     (Decl (decl_adtype DataOnly) (decl_id a)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Var K)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam
+             (constrain
+              (Lower
+               ((pattern (Lit Int 0))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (dims
+              (((pattern (Var K))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt ())
+        (var
+         ((pattern (Var a)) (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (IfElse
+      ((pattern
+        (FunApp (StanLib PNot__ FnPlain AoS)
+         (((pattern
+            (EOr
+             ((pattern (Var emit_transformed_parameters__))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+             ((pattern (Var emit_generated_quantities__))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+      ((pattern (Block (((pattern (Return ())) (meta <opaque>))))) (meta <opaque>)) ()))
+    (meta <opaque>))
+   ((pattern
+     (IfElse
+      ((pattern
+        (FunApp (StanLib PNot__ FnPlain AoS)
+         (((pattern (Var emit_generated_quantities__))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+      ((pattern (Block (((pattern (Return ())) (meta <opaque>))))) (meta <opaque>)) ()))
+    (meta <opaque>))))
+ (transform_inits
+  (((pattern
+     (Decl (decl_adtype DataOnly) (decl_id pos__) (decl_type (Sized SInt))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable pos__) ()) UInt
+      ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id a)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Var K)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id a_flat__)
+          (decl_type (Unsized (UArray UReal))) (initialize Uninit)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable a_flat__) ()) (UArray UReal)
+          ((pattern
+            (FunApp (CompilerInternal FnReadData)
+             (((pattern (Lit Str a))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable pos__) ()) UInt
+          ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar sym1__)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Var K)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (Assignment
+                  ((LVariable a)
+                   ((Single
+                     ((pattern (Var sym1__))
+                      (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                  UVector
+                  ((pattern
+                    (Indexed
+                     ((pattern (Var a_flat__))
+                      (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))
+                     ((Single
+                       ((pattern (Var pos__))
+                        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+                (meta <opaque>))
+               ((pattern
+                 (Assignment ((LVariable pos__) ()) UInt
+                  ((pattern
+                    (FunApp (StanLib Plus__ FnPlain AoS)
+                     (((pattern (Var pos__))
+                       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                      ((pattern (Lit Int 1))
+                       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam
+        (unconstrain_opt
+         ((Lower
+           ((pattern (Lit Int 0))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+        (var
+         ((pattern (Var a)) (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))))
+ (unconstrain_array
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id a)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Var K)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable a) ()) UVector
+      ((pattern
+        (FunApp (CompilerInternal FnReadDeserializer)
+         (((pattern (Var K)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam
+        (unconstrain_opt
+         ((Lower
+           ((pattern (Lit Int 0))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+        (var
+         ((pattern (Var a)) (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))))
+ (output_vars
+  ((a <opaque>
+    ((out_unconstrained_st
+      (SVector AoS
+       ((pattern (Var K)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+     (out_constrained_st
+      (SVector AoS
+       ((pattern (Var K)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+     (out_block Parameters)
+     (out_trans
+      (Lower
+       ((pattern (Lit Int 0)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))))
+ (prog_name dirvec_model) (prog_path tests/fixtures/dirvec.stan))

--- a/tests/fixtures/mnarr.stan
+++ b/tests/fixtures/mnarr.stan
@@ -1,0 +1,24 @@
+// `array[N] vector[K]` data into a vectorized multivariate density.
+//
+// The interpreter stores every 2-D value with the first index fastest, the
+// way it stores a matrix. An array of vectors has to reach the kernel with
+// element n contiguous in K, which is where a parameter of the same type
+// already sits, so the data path has to repack on the way into the slot.
+//
+// Getting this wrong permutes the observations against the components. It
+// is silent: the model compiles, lp__ stays plausible, and every gradient
+// is wrong. No posteriordb model has this shape, so the corpus does not
+// cover it. N and K differ here on purpose; a square case hides the
+// transpose.
+data {
+  int N;
+  int K;
+  array[N] vector[K] y;
+  matrix[K, K] Sigma;
+}
+parameters {
+  vector[K] mu;
+}
+model {
+  y ~ multi_normal(mu, Sigma);
+}

--- a/tests/fixtures/mnarr.tmir.sexp
+++ b/tests/fixtures/mnarr.tmir.sexp
@@ -1,0 +1,493 @@
+((functions_block ())
+ (input_vars
+  ((N <opaque> SInt) (K <opaque> SInt)
+   (y <opaque>
+    (SArray
+     (SVector AoS
+      ((pattern (Var K)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+     ((pattern (Var N)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+   (Sigma <opaque>
+    (SMatrix AoS
+     ((pattern (Var K)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+     ((pattern (Var K)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+ (prepare_data
+  (((pattern
+     (Decl (decl_adtype DataOnly) (decl_id pos__) (decl_type (Sized SInt))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable pos__) ()) UInt
+      ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id N) (decl_type (Sized SInt))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable N) ()) UInt
+      ((pattern
+        (Indexed
+         ((pattern
+           (FunApp (CompilerInternal FnReadData)
+            (((pattern (Lit Str N))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+          (meta ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly))))
+         ((Single
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id K) (decl_type (Sized SInt))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable K) ()) UInt
+      ((pattern
+        (Indexed
+         ((pattern
+           (FunApp (CompilerInternal FnReadData)
+            (((pattern (Lit Str K))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+          (meta ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly))))
+         ((Single
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp (CompilerInternal FnValidateSize)
+      (((pattern (Lit Str y)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+       ((pattern (Lit Str N)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+       ((pattern (Var N)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp (CompilerInternal FnValidateSize)
+      (((pattern (Lit Str y)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+       ((pattern (Lit Str K)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+       ((pattern (Var K)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id y)
+      (decl_type
+       (Sized
+        (SArray
+         (SVector AoS
+          ((pattern (Var K)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+         ((pattern (Var N)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id y_flat__)
+          (decl_type (Unsized (UArray UReal))) (initialize Uninit)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable y_flat__) ()) (UArray UReal)
+          ((pattern
+            (FunApp (CompilerInternal FnReadData)
+             (((pattern (Lit Str y))
+               (meta ((type_ (UArray UVector)) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable pos__) ()) UInt
+          ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar sym1__)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Var K)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (For (loopvar sym2__)
+                  (lower
+                   ((pattern (Lit Int 1))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (upper
+                   ((pattern (Var N))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (body
+                   ((pattern
+                     (Block
+                      (((pattern
+                         (Assignment
+                          ((LVariable y)
+                           ((Single
+                             ((pattern (Var sym2__))
+                              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                            (Single
+                             ((pattern (Var sym1__))
+                              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                          (UArray UVector)
+                          ((pattern
+                            (Indexed
+                             ((pattern (Var y_flat__))
+                              (meta
+                               ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))
+                             ((Single
+                               ((pattern (Var pos__))
+                                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                           (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+                        (meta <opaque>))
+                       ((pattern
+                         (Assignment ((LVariable pos__) ()) UInt
+                          ((pattern
+                            (FunApp (StanLib Plus__ FnPlain AoS)
+                             (((pattern (Var pos__))
+                               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                              ((pattern (Lit Int 1))
+                               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                        (meta <opaque>)))))
+                    (meta <opaque>)))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp (CompilerInternal FnValidateSize)
+      (((pattern (Lit Str Sigma))
+        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+       ((pattern (Lit Str K)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+       ((pattern (Var K)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp (CompilerInternal FnValidateSize)
+      (((pattern (Lit Str Sigma))
+        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+       ((pattern (Lit Str K)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+       ((pattern (Var K)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id Sigma)
+      (decl_type
+       (Sized
+        (SMatrix AoS
+         ((pattern (Var K)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+         ((pattern (Var K)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id Sigma_flat__)
+          (decl_type (Unsized (UArray UReal))) (initialize Uninit)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable Sigma_flat__) ()) (UArray UReal)
+          ((pattern
+            (FunApp (CompilerInternal FnReadData)
+             (((pattern (Lit Str Sigma))
+               (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable pos__) ()) UInt
+          ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar sym1__)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Var K)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (For (loopvar sym2__)
+                  (lower
+                   ((pattern (Lit Int 1))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (upper
+                   ((pattern (Var K))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (body
+                   ((pattern
+                     (Block
+                      (((pattern
+                         (Assignment
+                          ((LVariable Sigma)
+                           ((Single
+                             ((pattern (Var sym2__))
+                              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                            (Single
+                             ((pattern (Var sym1__))
+                              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                          UMatrix
+                          ((pattern
+                            (Indexed
+                             ((pattern (Var Sigma_flat__))
+                              (meta
+                               ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))
+                             ((Single
+                               ((pattern (Var pos__))
+                                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                           (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+                        (meta <opaque>))
+                       ((pattern
+                         (Assignment ((LVariable pos__) ()) UInt
+                          ((pattern
+                            (FunApp (StanLib Plus__ FnPlain AoS)
+                             (((pattern (Var pos__))
+                               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                              ((pattern (Lit Int 1))
+                               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                        (meta <opaque>)))))
+                    (meta <opaque>)))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp (CompilerInternal FnValidateSize)
+      (((pattern (Lit Str mu)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+       ((pattern (Lit Str K)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+       ((pattern (Var K)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+    (meta <opaque>))))
+ (log_prob
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id mu)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Var K)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity)
+             (dims
+              (((pattern (Var K))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib multi_normal_lpdf (FnLpdf true) AoS)
+             (((pattern (Var y))
+               (meta ((type_ (UArray UVector)) (loc <opaque>) (adlevel DataOnly))))
+              ((pattern (Var mu))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))
+              ((pattern (Var Sigma))
+               (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>)))))
+    (meta <opaque>))))
+ (reverse_mode_log_prob
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id mu)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Var K)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity)
+             (dims
+              (((pattern (Var K))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib multi_normal_lpdf (FnLpdf true) AoS)
+             (((pattern (Var y))
+               (meta ((type_ (UArray UVector)) (loc <opaque>) (adlevel DataOnly))))
+              ((pattern (Var mu))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))
+              ((pattern (Var Sigma))
+               (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>)))))
+    (meta <opaque>))))
+ (generate_quantities
+  (((pattern
+     (Decl (decl_adtype DataOnly) (decl_id mu)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Var K)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity)
+             (dims
+              (((pattern (Var K))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt ())
+        (var
+         ((pattern (Var mu)) (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (IfElse
+      ((pattern
+        (FunApp (StanLib PNot__ FnPlain AoS)
+         (((pattern
+            (EOr
+             ((pattern (Var emit_transformed_parameters__))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+             ((pattern (Var emit_generated_quantities__))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+      ((pattern (Block (((pattern (Return ())) (meta <opaque>))))) (meta <opaque>)) ()))
+    (meta <opaque>))
+   ((pattern
+     (IfElse
+      ((pattern
+        (FunApp (StanLib PNot__ FnPlain AoS)
+         (((pattern (Var emit_generated_quantities__))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+      ((pattern (Block (((pattern (Return ())) (meta <opaque>))))) (meta <opaque>)) ()))
+    (meta <opaque>))))
+ (transform_inits
+  (((pattern
+     (Decl (decl_adtype DataOnly) (decl_id pos__) (decl_type (Sized SInt))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable pos__) ()) UInt
+      ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id mu)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Var K)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id mu_flat__)
+          (decl_type (Unsized (UArray UReal))) (initialize Uninit)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable mu_flat__) ()) (UArray UReal)
+          ((pattern
+            (FunApp (CompilerInternal FnReadData)
+             (((pattern (Lit Str mu))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable pos__) ()) UInt
+          ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar sym1__)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Var K)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (Assignment
+                  ((LVariable mu)
+                   ((Single
+                     ((pattern (Var sym1__))
+                      (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                  UVector
+                  ((pattern
+                    (Indexed
+                     ((pattern (Var mu_flat__))
+                      (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))
+                     ((Single
+                       ((pattern (Var pos__))
+                        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+                (meta <opaque>))
+               ((pattern
+                 (Assignment ((LVariable pos__) ()) UInt
+                  ((pattern
+                    (FunApp (StanLib Plus__ FnPlain AoS)
+                     (((pattern (Var pos__))
+                       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                      ((pattern (Lit Int 1))
+                       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var mu)) (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))))
+ (unconstrain_array
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id mu)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Var K)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable mu) ()) UVector
+      ((pattern
+        (FunApp (CompilerInternal FnReadDeserializer)
+         (((pattern (Var K)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var mu)) (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))))
+ (output_vars
+  ((mu <opaque>
+    ((out_unconstrained_st
+      (SVector AoS
+       ((pattern (Var K)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+     (out_constrained_st
+      (SVector AoS
+       ((pattern (Var K)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+     (out_block Parameters) (out_trans Identity)))))
+ (prog_name mnarr_model) (prog_path tests/fixtures/mnarr.stan))

--- a/tests/test_lower.cpp
+++ b/tests/test_lower.cpp
@@ -749,6 +749,96 @@ int main() {
     }
   }
 
+  // array[N] vector[K] data into a vectorized multivariate density. See
+  // tests/fixtures/mnarr.stan: the data path stores this shape the way it
+  // stores a matrix, and the kernel wants each element contiguous, so the
+  // slot has to be repacked. Wrong is silent, and no corpus model has the
+  // shape.
+  {
+    // Logical y = {{1,2},{3,4},{5,6}}, stored first index fastest, which
+    // is what the JSON reader produces for [[1,2],[3,4],[5,6]].
+    DataMap d;
+    d.set_int("N", 3);
+    d.set_int("K", 2);
+    d.set_real_array("y", {1, 3, 5, 2, 4, 6}, {3, 2});
+    d.set_real_array("Sigma", {2.0, 0.5, 0.5, 1.0}, {2, 2});
+    CompiledModel am = compile_model(slurp("tests/fixtures/mnarr.tmir.sexp"),
+                                     d);
+    Executor aex(std::move(am.graph));
+    am.bind(aex);
+    const double pts[2][2] = {{0.4, -0.7}, {-0.3, 0.9}};
+    for (int c = 0; c < 2; ++c) {
+      aex.params_data()[0] = pts[c][0];
+      aex.params_data()[1] = pts[c][1];
+      double grad[2] = {0, 0};
+      const double lp = aex.gradient(grad);
+
+      using stan::math::var;
+      // y and Sigma are data, mu is a parameter: the same instantiation
+      // the kernel picks, so this is exact rather than merely close.
+      std::vector<Eigen::VectorXd> ys(3, Eigen::VectorXd(2));
+      ys[0] << 1, 2;
+      ys[1] << 3, 4;
+      ys[2] << 5, 6;
+      Eigen::MatrixXd Sd(2, 2);
+      Sd << 2.0, 0.5, 0.5, 1.0;
+      Eigen::Matrix<var, Eigen::Dynamic, 1> mu(2);
+      mu(0) = pts[c][0];
+      mu(1) = pts[c][1];
+      var acc = stan::math::multi_normal_lpdf<true>(ys, mu, Sd);
+      acc.grad();
+
+      check(grad[0] == mu(0).adj() && grad[1] == mu(1).adj(),
+            "mnarr: gradients bitwise against the var path");
+      const double tol = 8 * 2.220446049250313e-16 * std::abs(acc.val());
+      check(std::abs(lp - acc.val()) <= tol,
+            "mnarr: lp matches the var path");
+    }
+  }
+
+  // `p ~ dirichlet(a)` over an array of simplexes. See
+  // tests/fixtures/dirvec.stan: the kernel read the whole slot as one
+  // theta, so the vectorized form threw on a length mismatch and only the
+  // explicit loop worked.
+  {
+    // Logical p = {{0.3,0.7},{0.4,0.6},{0.2,0.8}}, first index fastest.
+    DataMap d;
+    d.set_int("N", 3);
+    d.set_int("K", 2);
+    d.set_real_array("p", {0.3, 0.4, 0.2, 0.7, 0.6, 0.8}, {3, 2});
+    CompiledModel dm = compile_model(slurp("tests/fixtures/dirvec.tmir.sexp"),
+                                     d);
+    Executor dex(std::move(dm.graph));
+    dm.bind(dex);
+    const double pts[2][2] = {{0.3, -0.4}, {-0.6, 0.8}};
+    for (int c = 0; c < 2; ++c) {
+      dex.params_data()[0] = pts[c][0];
+      dex.params_data()[1] = pts[c][1];
+      double grad[2] = {0, 0};
+      const double lp = dex.gradient(grad);
+
+      using stan::math::var;
+      var u0 = pts[c][0], u1 = pts[c][1];
+      Eigen::Matrix<var, Eigen::Dynamic, 1> alpha(2);
+      alpha(0) = stan::math::exp(u0);
+      alpha(1) = stan::math::exp(u1);
+      std::vector<Eigen::VectorXd> th(3, Eigen::VectorXd(2));
+      th[0] << 0.3, 0.7;
+      th[1] << 0.4, 0.6;
+      th[2] << 0.2, 0.8;
+      // lower=0 jacobian on both elements of a, then the vectorized lpdf.
+      var acc = u0 + u1;
+      acc += stan::math::dirichlet_lpdf<true>(th, alpha);
+      acc.grad();
+
+      check(grad[0] == u0.adj() && grad[1] == u1.adj(),
+            "dirvec: gradients bitwise against the var path");
+      const double tol = 8 * 2.220446049250313e-16 * std::abs(acc.val());
+      check(std::abs(lp - acc.val()) <= tol,
+            "dirvec: lp matches the var path");
+    }
+  }
+
   // Ordinal regression, against an independent var-path reference. Same
   // reason as the truncation case: CI has no CmdStan, and this is the one
   // density whose cutpoint argument is a shared vector rather than a


### PR DESCRIPTION
Two more shapes 0.4.0 got wrong, both found by exercising the published
wheel on shapes posteriordb does not contain. One was silent.

## array[N] vector[K] data reached the multivariate densities permuted

`y ~ multi_normal(mu, Sigma)` with that outcome as **data** returned wrong
gradients. The model compiled, `lp__` stayed plausible, and nothing
announced it.

Data is stored with the first index fastest, the way a matrix is stored.
An array of vectors has to reach the kernel with element `n` contiguous in
`K`, which is where a **parameter** of the same type already sits, so the
kernel and the parameter path agreed with each other and only the data
path disagreed. `env_slot` repacks these now, and stops claiming
`rows`/`cols` for a type that is not a matrix.

The same data indexed one element at a time was always right, because that
path folds through the interpreter rather than the slot. That is why the
shape looked healthy.

| density | before | after |
|---|---|---|
| `multi_normal` | wrong gradients | 0 ULP |
| `multi_normal_cholesky` | wrong gradients | 0 ULP |
| `multi_normal_prec` | wrong gradients | 0 ULP |
| `multi_student_t` | wrong gradients | 0 ULP |
| `multi_student_t_cholesky` | wrong gradients | 0 ULP |

Concretely, with `y = [[1,2],[3,4],[5,6]]` and identity covariance the
gradient at `mu = 0` is `sum_n y_n = [9, 12]`. 0.4.0 returned `[10, 11]`.

Verified unaffected: the same outcome as a parameter (0 ULP before and
after), a single `vector` outcome, `array[N, M] real`, `matrix`,
`array[N] row_vector[K]`, `multi_gp`.

## Vectorized dirichlet threw

`p ~ dirichlet(a)` over an array of simplexes, the shape a hierarchical
Dirichlet is written in, failed at evaluation time:

```
dirichlet_lpdf: probabilities has size = 6, but prior sample sizes has size 2
```

The kernel took one theta vector and read the whole slot as it. It splits
the slot now: a single dirichlet needs theta and alpha the same length, so
a longer theta is unambiguously the vectorized form. Data and parameter
outcomes are both 0 ULP. The explicit loop form, which was the only one
that worked, still is.

## Why the corpus missed both

No posteriordb model has either shape, so 119/119 stayed green throughout.
`tests/fixtures/mnarr.stan` and `tests/fixtures/dirvec.stan` cover them
now, checked against var-path references so CI catches a regression
without CmdStan installed. `N` and `K` differ in both, since a square case
hides a transpose. Reverting either fix fails its test.

## Verification

26/26 tests, corpus 119/119 unchanged (worst `hmm_gaussian` 3.63e-12).
Every shape above checked against CmdStan compiled from the same source
with `-ffp-contract=off`, at four evaluation points each.