### PR TITLE
Scope the npm package so the tag flow can publish

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -488,8 +488,9 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
+          # Scoped, so npm pack writes seantalts-stanli-<version>.tgz.
           name: npm-package
-          path: stanli-*.tgz
+          path: "*stanli-*.tgz"
 
       - uses: actions/upload-pages-artifact@v3
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -242,7 +242,7 @@ tagged, so everything below is what changed for anyone upgrading from
   and histogram plots while NUTS runs, split-Rhat and effective sample
   size, and a CSV of the draws.
 
-- An npm package, `stanli`: `compile()` and `sample()` over a worker
+- An npm package, `@seantalts/stanli`: `compile()` and `sample()` over a worker
   pool sized to the hardware, with an `onLive` callback for streaming
   draws and `preload()` to warm the compiler and runtime before the
   first click. Published on `npm-v*` tags through npm trusted

--- a/README.md
+++ b/README.md
@@ -316,6 +316,27 @@ No sdist is published. Building from source needs a 30-minute OCaml
 toolchain step, so an sdist would only turn "no wheel for your platform"
 into a confusing build failure.
 
+The npm package `@seantalts/stanli` ships the same way on its own tag
+series. Bump `version` in `js/package.json`, add the `CHANGELOG.md` entry,
+then tag `npm-vX.Y.Z`. The `npm-publish` job asserts the tag agrees with
+`package.json`, takes the `stanli.wasm` the `wasm` job built for that
+commit plus the cached release stancjs, and publishes through npm trusted
+publishing, again with no token anywhere; the `npm` deployment environment
+is restricted to `npm-v*` tags.
+
+```
+git tag -a npm-v0.1.0 -m "stanli npm 0.1.0" && git push origin npm-v0.1.0
+```
+
+Two things about npm differ from PyPI and are worth knowing before the
+next name or the next first release. npm has no pending publisher: a
+trusted publisher attaches only to a package that already exists, so the
+first version of a package goes out by hand with `npm publish` and every
+release after that is a tag. And the package is scoped because npm's
+name-similarity filter rejects the unscoped `stanli` as too close to
+existing packages, which is why `publishConfig.access` is set to public
+(a scoped package would otherwise default to a private publish).
+
 ## Verification policy
 
 Nothing ships on "looks close". Kernel gradients are bitwise-tested

--- a/js/README.md
+++ b/js/README.md
@@ -8,7 +8,7 @@ server, no C++ toolchain, everything in the tab. Live demo:
 <https://seantalts.github.io/stanli/>.
 
 ```js
-import { sample } from "stanli";
+import { sample } from "@seantalts/stanli";
 
 const fit = await sample({
   code: `

--- a/js/index.mjs
+++ b/js/index.mjs
@@ -3,7 +3,7 @@
 // op graph and runs NUTS. Everything happens client side, off the main
 // thread, in workers this module owns.
 //
-//   import { compile, sample } from "stanli";
+//   import { compile, sample } from "@seantalts/stanli";
 //   const { mir } = await compile({ code });
 //   const fits = await Promise.all([1, 2, 3, 4].map((c) =>
 //       sample({ mir, data, seed: c })));

--- a/js/package.json
+++ b/js/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "stanli",
+  "name": "@seantalts/stanli",
   "version": "0.1.0",
   "description": "Full Stan in the browser: stanc3 compiles the model in JS, a WASM runtime lowers it to an op graph and runs NUTS. No server, no C++ toolchain.",
   "type": "module",
@@ -22,6 +22,9 @@
   },
   "homepage": "https://seantalts.github.io/stanli/",
   "license": "BSD-3-Clause",
+  "publishConfig": {
+    "access": "public"
+  },
   "keywords": [
     "stan",
     "bayesian",

--- a/web/index.html
+++ b/web/index.html
@@ -75,7 +75,7 @@
 lowers it to an op graph and runs NUTS. No server, no C++ toolchain;
 everything below happens in this tab.
 <a href="https://github.com/seantalts/stanli">github.com/seantalts/stanli</a>
-&middot; <a href="https://www.npmjs.com/package/stanli">npm</a>
+&middot; <a href="https://www.npmjs.com/package/@seantalts/stanli">npm</a>
 &middot; <a href="https://pypi.org/project/stanli/">PyPI</a></p>
 
 <div class="cols">

--- a/web/index.mjs
+++ b/web/index.mjs
@@ -3,7 +3,7 @@
 // op graph and runs NUTS. Everything happens client side, off the main
 // thread, in workers this module owns.
 //
-//   import { compile, sample } from "stanli";
+//   import { compile, sample } from "@seantalts/stanli";
 //   const { mir } = await compile({ code });
 //   const fits = await Promise.all([1, 2, 3, 4].map((c) =>
 //       sample({ mir, data, seed: c })));


### PR DESCRIPTION
npm's name-similarity filter refuses the unscoped name (too close to
vanli and stable), so nothing can be published under it and the
npm-v* job would fail the same way a laptop does. Take the scoped
name npm itself suggests and set publishConfig.access to public,
since a scoped package publishes private by default and the job runs
a bare npm publish.

npm pack now writes seantalts-stanli-<version>.tgz, so the artifact
glob in the pages job has to match that too.

README documents the npm side of releasing next to the PyPI side,
including the part that has no PyPI equivalent: npm has no pending
publisher, so a trusted publisher can only attach to a package that
already exists and the first version goes out by hand.
