### PR TITLE
L-BFGS optimization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,38 @@ TBB's scheduler-entry hook does it for every worker -- and this build
 stubs TBB out. Raw `std::thread`s segfaulted inside `start_nested()`
 until `run_nuts_chains` did it itself.
 
+### Optimization
+
+`Model.optimize()` runs L-BFGS -- stan's own, the one behind CmdStan's
+`optimize` -- over the same gradient the sampler uses, and returns the
+mode as every CSV column plus the unconstrained point. That point is
+what `sample(inits=...)` takes, which is the reason to have it.
+
+**It returns the posterior MODE, and refuses CmdStan's default.**
+CmdStan's `optimize` defaults to `jacobian=0`, the penalized maximum
+likelihood. stanli folds the change-of-variables Jacobian into the graph
+at lowering time and the model adapter ignores the template flag
+entirely, so `jacobian=False` raises rather than quietly returning the
+other quantity under that name -- they differ for any constrained
+parameter, which is most models. Excluding the Jacobian is possible in
+principle (`lower.cpp` already collects `jac_slots` separately) and is
+what the fix would be.
+
+`ExecutorModel` grew the rest of the stan model concept to get here:
+`log_prob` in its `std::vector` form as well as its Eigen one,
+`constrained_param_names` (which APPENDS -- the services push their own
+columns first), `write_array` in both forms, `get_dims`, and a
+`transform_inits` that throws, because unconstraining a user's starting
+values needs the INVERSE parameter transforms and only the forward ones
+exist.
+
+**Pathfinder is not here.** The adapter is now complete enough that
+stan's service compiles and runs against it, but the draws come back
+empty -- the parameter writer is never called -- and an entry point that
+silently returns nothing is worse than none. Multi-path additionally
+needs real TBB, which this build stubs out, so its `tbb::parallel_for`
+does not link at all.
+
 ### The modern ODE interface
 
 `ode_rk45`, `ode_bdf`, `ode_adams`, `ode_ckrk` and their `_tol` forms.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -195,6 +195,7 @@ add_library(stanli_shared SHARED
   runtime/src/island.cpp
   runtime/src/nuts.cpp
   runtime/src/diagnose.cpp
+  runtime/src/estimate.cpp
   runtime/src/mir_reader.cpp
   runtime/src/lower.cpp
   runtime/src/wa_interp.cpp
@@ -282,6 +283,7 @@ add_library(stanli STATIC
   runtime/src/island.cpp
   runtime/src/nuts.cpp
   runtime/src/diagnose.cpp
+  runtime/src/estimate.cpp
   runtime/src/mir_reader.cpp
   runtime/src/lower.cpp
   runtime/src/wa_interp.cpp
@@ -388,4 +390,5 @@ stanli_add_test(test_multichain)
 stanli_add_test(test_newtrans)
 stanli_add_test(test_rejectprint)
 stanli_add_test(test_odevariadic)
+stanli_add_test(test_estimate)
 endif()  # NOT EMSCRIPTEN

--- a/docs/superpowers/plans/2026-08-08-cmdstan-parity-roadmap.md
+++ b/docs/superpowers/plans/2026-08-08-cmdstan-parity-roadmap.md
@@ -113,7 +113,22 @@ Same shape, same machinery: `algebra_solver`/`solve_newton`/
 
 ---
 
-## 4. Pathfinder, optimize, laplace
+## 4. Pathfinder, optimize, laplace — PARTIAL
+
+**L-BFGS landed** (`Model.optimize()`), verified against a posterior
+whose mode is known in closed form. It returns the posterior MODE and
+refuses CmdStan's `jacobian=0` default rather than returning the wrong
+quantity under that name -- stanli folds the Jacobian into the graph at
+lowering time. `lower.cpp` already collects `jac_slots` separately, so
+making that flag real is the next piece.
+
+**Pathfinder is not landed.** `ExecutorModel` now satisfies enough of
+the model concept that stan's single-path service compiles and runs,
+but its parameter writer is never called and the draws come back empty;
+that is one debugging session, not a design problem. Multi-path is a
+harder blocker: it uses `tbb::parallel_for` and this build stubs TBB
+out, so it does not link. **laplace_sample** and standalone
+**generate_quantities** are untouched.
 
 `deps/stan/src/stan/services/` ships `pathfinder/`, `optimize/`,
 `laplace_sample`, and `diagnose/`. They are drivers over a model's

--- a/python/README.md
+++ b/python/README.md
@@ -29,6 +29,25 @@ fit.draws("mu")         # (chains, draws), for a trace plot
 Model preparation takes milliseconds, so the first draw arrives about 20x
 sooner than a toolchain that compiles C++ per model.
 
+## The mode, and where to start
+
+```python
+r = model.optimize(seed=1)
+r["mu"], r.lp          # every CSV column at the mode, and the lp there
+r.unconstrained        # the point on the sampler's scale
+
+fit = model.sample(inits=r.unconstrained)   # start the chains there
+```
+
+L-BFGS -- stan's own, the one behind CmdStan's `optimize`.
+
+It returns the posterior **mode**. CmdStan's `optimize` defaults to
+`jacobian=0`, the penalized maximum likelihood, and stanli cannot offer
+that: the change-of-variables Jacobian is folded into the graph when the
+model is lowered. `jacobian=False` raises rather than quietly handing
+back the other quantity, since the two differ for any constrained
+parameter.
+
 ## Chains and convergence
 
 Four chains by default, run in parallel, because R-hat needs more than one

--- a/python/stanli/__init__.py
+++ b/python/stanli/__init__.py
@@ -14,7 +14,8 @@ import sys
 
 import numpy as np
 
-__all__ = ["Model", "Fit", "Summary", "exact_lp", "thread_safe",
+__all__ = ["Model", "Fit", "Summary", "OptimizeResult",
+           "exact_lp", "thread_safe",
            "SAMPLER_COLUMNS", "__version__"]
 # The one place the version lives. setup.py and the release workflow both
 # read it from here.
@@ -31,6 +32,25 @@ _N_SAMPLER_COLS = len(SAMPLER_COLUMNS)
 _SUMMARY_STATS = ("mean", "mcse_mean", "sd", "mcse_sd", "q5", "q50", "q95",
                   "ess_bulk", "ess_tail", "r_hat")
 _N_SUMMARY_STATS = len(_SUMMARY_STATS)
+
+
+class _OptimizeOpts(ctypes.Structure):
+    """Mirrors stanli_optimize_opts in runtime/include/stanli/capi.h."""
+    _fields_ = [
+        ("seed", ctypes.c_uint32),
+        ("chain_id", ctypes.c_int),
+        ("iter", ctypes.c_int),
+        ("jacobian", ctypes.c_int),
+        ("init_alpha", ctypes.c_double),
+        ("tol_obj", ctypes.c_double),
+        ("tol_rel_obj", ctypes.c_double),
+        ("tol_grad", ctypes.c_double),
+        ("tol_rel_grad", ctypes.c_double),
+        ("tol_param", ctypes.c_double),
+        ("history_size", ctypes.c_int),
+        ("init_radius", ctypes.c_double),
+        ("init", ctypes.POINTER(ctypes.c_double)),
+    ]
 
 
 class _SampleOpts(ctypes.Structure):
@@ -116,6 +136,14 @@ def _load_lib():
                                          ctypes.c_int64, ctypes.c_int64,
                                          ctypes.c_int64,
                                          ctypes.POINTER(ctypes.c_double)]
+    lib.stanli_optimize_opts_init.argtypes = [ctypes.POINTER(_OptimizeOpts)]
+    lib.stanli_optimize.restype = ctypes.c_int
+    lib.stanli_optimize.argtypes = [ctypes.c_void_p,
+                                    ctypes.POINTER(_OptimizeOpts),
+                                    ctypes.POINTER(ctypes.c_double),
+                                    ctypes.POINTER(ctypes.c_double),
+                                    ctypes.POINTER(ctypes.c_double),
+                                    ctypes.c_char_p, ctypes.c_size_t]
     lib.stanli_diagnose_text.restype = ctypes.c_int64
     lib.stanli_diagnose_text.argtypes = [ctypes.POINTER(ctypes.c_double),
                                          ctypes.c_int64, ctypes.c_int64,
@@ -397,6 +425,16 @@ class Fit:
                 f"{len(self.names)} columns>")
 
 
+class OptimizeResult(dict):
+    """The mode, by column name, plus where it is on the sampler's scale.
+
+    A dict so `result["mu"]` reads the way a draw does, with the
+    unconstrained point and lp attached for handing to `sample(inits=)`.
+    """
+    unconstrained = None
+    lp = None
+
+
 class Model:
     """A compiled (model, data) pair."""
 
@@ -461,6 +499,58 @@ class Model:
             return [_lib.stanli_wa_column_name(self._m, i).decode()
                     for i in range(n_wa)], True
         return list(self.constrained_names), False
+
+    def optimize(self, *, seed=1, iter=2000, jacobian=True, init=None,
+                 init_radius=2.0):
+        """The mode by L-BFGS -- the same optimizer CmdStan's `optimize` runs.
+
+        Returns an OptimizeResult: a {name: float} of every CSV column at
+        the mode, matching one draw of what `sample()` returns, with the
+        unconstrained point and lp attached. `.unconstrained` is what
+        `sample(inits=...)` takes.
+
+        Returns the posterior MODE. CmdStan's `optimize` defaults to
+        `jacobian=0`, the penalized maximum likelihood, which stanli
+        cannot offer: the Jacobian terms are folded into the graph at
+        lowering time. `jacobian=False` raises rather than quietly
+        returning the other quantity -- the two differ for any
+        constrained parameter, which is most models.
+        """
+        if not jacobian:
+            raise NotImplementedError(
+                "stanli folds the Jacobian into the graph at lowering "
+                "time, so the penalized maximum likelihood (CmdStan's "
+                "jacobian=0) is not available; optimize() returns the "
+                "posterior mode")
+        opts = _OptimizeOpts()
+        _lib.stanli_optimize_opts_init(ctypes.byref(opts))
+        opts.seed = seed
+        opts.iter = int(iter)
+        opts.jacobian = 1 if jacobian else 0
+        opts.init_radius = float(init_radius)
+        init_arr = None
+        if init is not None:
+            init_arr = np.ascontiguousarray(init, dtype=np.float64)
+            if init_arr.shape != (self.n_unconstrained,):
+                raise ValueError(
+                    f"init must be ({self.n_unconstrained},) on the "
+                    f"unconstrained scale, got {init_arr.shape}")
+            opts.init = _dptr(init_arr)
+
+        names, _ = self._column_names()
+        q = np.empty(self.n_unconstrained)
+        vals = np.empty(len(names))
+        lp = ctypes.c_double()
+        err = ctypes.create_string_buffer(4096)
+        rc = _lib.stanli_optimize(self._m, ctypes.byref(opts), _dptr(q),
+                                  _dptr(vals), ctypes.byref(lp), err, len(err))
+        del init_arr
+        if rc != 0:
+            raise RuntimeError(f"optimize failed: {err.value.decode()}")
+        out = OptimizeResult({n: vals[i] for i, n in enumerate(names)})
+        out.unconstrained = q
+        out.lp = lp.value
+        return out
 
     def sample(self, *, chains=4, seed=1, warmup=1000, samples=1000,
                delta=0.8, max_depth=10, thin=1, save_warmup=False,

--- a/runtime/include/stanli/capi.h
+++ b/runtime/include/stanli/capi.h
@@ -174,6 +174,45 @@ int64_t stanli_diagnose_text(const double* draws, int64_t n_chains,
                              const char* const* names, const double* stats,
                              int max_depth, char* out, size_t out_len);
 
+/* ---- optimization --------------------------------------------------------
+ *
+ * L-BFGS, the same one CmdStan's `optimize` runs, over the same gradient
+ * the sampler uses. */
+
+typedef struct {
+  uint32_t seed;
+  int chain_id;
+  int iter;
+  int jacobian;        /* include the change-of-variables Jacobian, making
+                        * this the posterior MODE rather than the penalized
+                        * maximum likelihood. CmdStan defaults it off. */
+  double init_alpha;
+  double tol_obj;
+  double tol_rel_obj;
+  double tol_grad;
+  double tol_rel_grad;
+  double tol_param;
+  int history_size;
+  double init_radius;
+  const double* init;  /* unconstrained, or null for a random start */
+} stanli_optimize_opts;
+
+/* CmdStan's defaults. Call before setting fields, for the same reason
+ * stanli_sample_opts_init exists. */
+void stanli_optimize_opts_init(stanli_optimize_opts* o);
+
+/* Writes the mode to `unconstrained` (n_unconstrained doubles) and, when
+ * `values` is non-null, every CSV column there (stanli_wa_n_columns, or
+ * n_constrained when the model has no generated quantities). *lp receives
+ * the log density at the mode.
+ *
+ * Returns 0 when the optimizer converged, nonzero otherwise with a
+ * message in err -- and in that case the buffers still hold the last
+ * point it reached, which is usually what a user wants to look at. */
+int stanli_optimize(stanli_model* m, const stanli_optimize_opts* opts,
+                    double* unconstrained, double* values, double* lp,
+                    char* err, size_t err_len);
+
 /* Constrained view: flattened parameter values for one unconstrained q.
  * n_constrained gives the output length; names are "mu", "theta.1", ... */
 int64_t stanli_n_constrained(const stanli_model* m);

--- a/runtime/include/stanli/estimate.hpp
+++ b/runtime/include/stanli/estimate.hpp
@@ -1,0 +1,75 @@
+// Point estimates and variational draws: L-BFGS, Laplace, and Pathfinder.
+//
+// All three are stan's own services (stan/services/optimize/,
+// stan/services/pathfinder/) driven through the same ExecutorModel the
+// sampler uses. They are algorithms over a log density and its gradient,
+// which the executor already provides, so nothing here reimplements a
+// method -- it supplies the model concept the services expect and
+// collects what they write.
+//
+// Pathfinder matters twice: as a deliverable, and as the modern answer to
+// "where should the chains start", which is what NutsConfig::init takes.
+#ifndef STANLI_ESTIMATE_HPP
+#define STANLI_ESTIMATE_HPP
+
+#include <stanli/graph.hpp>
+#include <stanli/model_adapter.hpp>
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace stanli {
+
+struct OptimizeConfig {
+  uint32_t seed = 1;
+  int chain_id = 1;
+  int iter = 2000;
+  // MUST be true, and it is checked rather than assumed.
+  //
+  // CmdStan's `optimize` defaults to jacobian=0 -- the penalized maximum
+  // likelihood -- and stanli cannot offer that. The Jacobian terms are
+  // folded into the graph at lowering time and the adapter's log_prob
+  // ignores the template flag entirely (see model_adapter.hpp), so a
+  // `false` here would silently return the posterior MODE while claiming
+  // to be the other thing. The two differ for any constrained parameter,
+  // which is most models.
+  //
+  // Excluding them is possible in principle -- lower.cpp already collects
+  // jac_slots separately -- and would be the fix; until then this refuses.
+  bool jacobian = true;
+  double init_alpha = 0.001;
+  double tol_obj = 1e-12;
+  double tol_rel_obj = 1e4;
+  double tol_grad = 1e-8;
+  double tol_rel_grad = 1e7;
+  double tol_param = 1e-8;
+  int history_size = 5;
+  double init_radius = 2.0;
+  const double* init = nullptr;  // unconstrained, or null for random
+};
+
+struct OptimizeResult {
+  double lp = 0;
+  std::vector<double> unconstrained;  // the mode, on the sampler's scale
+  std::vector<double> values;         // every CSV column at that point
+  std::vector<std::string> names;
+  int return_code = 0;                // 0 = converged
+  std::string message;
+};
+
+// L-BFGS, the same one CmdStan's `optimize` runs.
+OptimizeResult run_optimize(Executor& ex, const WriteArray* wa,
+                            const OptimizeConfig& cfg);
+
+// Pathfinder is NOT here yet, deliberately. ExecutorModel now satisfies
+// enough of the model concept for stan's service to compile and run
+// against it, but the draws come back empty -- the parameter writer is
+// never called -- and shipping an entry point that silently returns
+// nothing is worse than not shipping one. Multi-path additionally needs
+// real TBB, which this build stubs out (tests/tbb_stub.cpp), so its
+// tbb::parallel_for does not link at all.
+
+}  // namespace stanli
+
+#endif

--- a/runtime/include/stanli/model_adapter.hpp
+++ b/runtime/include/stanli/model_adapter.hpp
@@ -14,16 +14,34 @@
 
 #include <stan/math.hpp>
 
+#include <functional>
 #include <limits>
 #include <ostream>
+#include <stdexcept>
+#include <string>
 #include <vector>
 
 namespace stanli {
 
+// The CSV side of the model concept, supplied by whoever built the
+// write_array graph (or its interpreter fallback). The samplers never
+// need this; the optimizers and Pathfinder do, because they report a
+// point rather than a stream of draws and have to name and constrain it.
+//
+// Kept as a callback rather than a second Executor inside the adapter so
+// that the two write_array paths -- compiled graph and per-draw
+// interpreter -- stay where they already are, in compile.hpp and capi.
+struct WriteArray {
+  std::vector<std::string> names;  // flattened, CmdStan's column order
+  // q holds num_params_r() unconstrained values; out receives
+  // names.size() doubles.
+  std::function<void(const double* q, double* out)> row;
+};
+
 class ExecutorModel {
  public:
-  explicit ExecutorModel(Executor& ex)
-      : ex_(&ex), grad_(static_cast<size_t>(ex.n_params())) {}
+  explicit ExecutorModel(Executor& ex, const WriteArray* wa = nullptr)
+      : ex_(&ex), grad_(static_cast<size_t>(ex.n_params())), wa_(wa) {}
 
   size_t num_params_r() const { return static_cast<size_t>(ex_->n_params()); }
 
@@ -54,9 +72,112 @@ class ExecutorModel {
     }
   }
 
+  // The std::vector form of the same call. stan::model::log_prob_grad and
+  // log_prob_propto each have two overloads and the optimizers reach for
+  // this one; forwarding keeps a single definition of what log_prob means.
+  template <bool propto, bool jacobian, typename T>
+  T log_prob(std::vector<T>& params_r, std::vector<int>& /*params_i*/,
+             std::ostream* msgs) const {
+    Eigen::Matrix<T, -1, 1> q =
+        Eigen::Map<Eigen::Matrix<T, -1, 1>>(params_r.data(),
+                                            (Eigen::Index)params_r.size());
+    return log_prob<propto, jacobian, T>(q, msgs);
+  }
+
+  // ---- the CSV side, for the point-estimate services -------------------
+  // include_tp / include_gq are ignored: the write_array graph is built
+  // once, whole, and there is no cheaper prefix of it to serve. That
+  // matches what these callers want (both pass true, true) and it is
+  // stated rather than silently assumed.
+  // APPENDS. Pathfinder pushes lp_approx__ and lp__ first and then calls
+  // this to add the model's own columns, so assigning here would wipe
+  // them and leave every row two values wider than its header.
+  void constrained_param_names(std::vector<std::string>& names,
+                               bool /*include_tp*/ = true,
+                               bool /*include_gq*/ = true) const {
+    if (wa_ != nullptr) {
+      names.insert(names.end(), wa_->names.begin(), wa_->names.end());
+      return;
+    }
+    // No write_array graph: the unconstrained parameters are all there is
+    // to name, and they are what write_array returns in that case too.
+    std::vector<std::string> q;
+    unconstrained_param_names(q);
+    names.insert(names.end(), q.begin(), q.end());
+  }
+  void unconstrained_param_names(std::vector<std::string>& names,
+                                 bool /*include_tp*/ = true,
+                                 bool /*include_gq*/ = true) const {
+    for (int64_t i = 0; i < ex_->n_params(); ++i)
+      names.push_back("q." + std::to_string(i + 1));
+  }
+
+  template <typename RNG>
+  void write_array(RNG& /*rng*/, std::vector<double>& params_r,
+                   std::vector<int>& /*params_i*/,
+                   std::vector<double>& values, bool /*include_tp*/ = true,
+                   bool /*include_gq*/ = true,
+                   std::ostream* /*msgs*/ = nullptr) const {
+    if (wa_ == nullptr) {
+      values.assign(params_r.begin(), params_r.end());
+      return;
+    }
+    values.assign(wa_->names.size(), 0.0);
+    wa_->row(params_r.data(), values.data());
+  }
+
+  // Pathfinder's Eigen form of the same call.
+  template <typename RNG>
+  void write_array(RNG& /*rng*/, Eigen::Matrix<double, -1, 1>& params_r,
+                   Eigen::Matrix<double, -1, 1>& values,
+                   bool /*include_tp*/ = true, bool /*include_gq*/ = true,
+                   std::ostream* /*msgs*/ = nullptr) const {
+    if (wa_ == nullptr) {
+      values = params_r;
+      return;
+    }
+    values.setZero((Eigen::Index)wa_->names.size());
+    wa_->row(params_r.data(), values.data());
+  }
+
+  // Every unconstrained parameter is a scalar as far as a random init is
+  // concerned, so each gets an empty dimension list.
+  void get_dims(std::vector<std::vector<size_t>>& dims,
+                bool /*include_tp*/ = true,
+                bool /*include_gq*/ = true) const {
+    dims.assign((size_t)ex_->n_params(), std::vector<size_t>{});
+  }
+
+  // stan::services::util::initialize wants these. get_param_names names
+  // the parameters in an initialization failure message.
+  void get_param_names(std::vector<std::string>& names,
+                       bool /*include_tp*/ = true,
+                       bool /*include_gq*/ = true) const {
+    unconstrained_param_names(names);
+  }
+
+  // Constrained-scale inits, which stanli cannot express: unconstraining
+  // a user's starting values needs the INVERSE parameter transforms, and
+  // only the forward ones exist. Callers here always pass an empty
+  // context (initialize then draws at random and never reaches this), so
+  // throwing is the honest way to say the one case that is missing --
+  // quietly returning zeros would start the run somewhere the user did
+  // not ask for.
+  template <typename Context>
+  void transform_inits(const Context& /*context*/,
+                       std::vector<int>& /*params_i*/,
+                       std::vector<double>& /*params_r*/,
+                       std::ostream* /*msgs*/ = nullptr) const {
+    throw std::runtime_error(
+        "stanli cannot take inits on the constrained scale: it has the "
+        "forward parameter transforms but not their inverses. Pass an "
+        "unconstrained init instead.");
+  }
+
  private:
   Executor* ex_;
   mutable std::vector<double> grad_;
+  const WriteArray* wa_ = nullptr;
 };
 
 }  // namespace stanli

--- a/runtime/src/capi.cpp
+++ b/runtime/src/capi.cpp
@@ -3,6 +3,7 @@
 
 #include <stanli/compile.hpp>
 #include <stanli/diagnose.hpp>
+#include <stanli/estimate.hpp>
 #include <stanli/graph.hpp>
 #include <stanli/nuts.hpp>
 #include <stanli/wa_interp.hpp>
@@ -393,6 +394,77 @@ int64_t stanli_diagnose_text(const double* draws, int64_t n_chains,
     return (int64_t)text.size() + 1;
   } catch (const std::exception&) {
     return 0;
+  }
+}
+
+void stanli_optimize_opts_init(stanli_optimize_opts* o) {
+  if (o == nullptr) return;
+  *o = stanli_optimize_opts{};
+  const stanli::OptimizeConfig d;
+  o->seed = d.seed;
+  o->chain_id = d.chain_id;
+  o->iter = d.iter;
+  o->jacobian = d.jacobian ? 1 : 0;
+  o->init_alpha = d.init_alpha;
+  o->tol_obj = d.tol_obj;
+  o->tol_rel_obj = d.tol_rel_obj;
+  o->tol_grad = d.tol_grad;
+  o->tol_rel_grad = d.tol_rel_grad;
+  o->tol_param = d.tol_param;
+  o->history_size = d.history_size;
+  o->init_radius = d.init_radius;
+  o->init = nullptr;
+}
+
+int stanli_optimize(stanli_model* m, const stanli_optimize_opts* opts,
+                    double* unconstrained, double* values, double* lp,
+                    char* err, size_t err_len) {
+  try {
+    if (opts == nullptr) {
+      put_err(err, err_len, "null options");
+      return 1;
+    }
+    stanli::OptimizeConfig cfg;
+    cfg.seed = opts->seed;
+    cfg.chain_id = opts->chain_id > 0 ? opts->chain_id : 1;
+    cfg.iter = opts->iter > 0 ? opts->iter : 2000;
+    cfg.jacobian = opts->jacobian != 0;
+    cfg.init_alpha = opts->init_alpha;
+    cfg.tol_obj = opts->tol_obj;
+    cfg.tol_rel_obj = opts->tol_rel_obj;
+    cfg.tol_grad = opts->tol_grad;
+    cfg.tol_rel_grad = opts->tol_rel_grad;
+    cfg.tol_param = opts->tol_param;
+    cfg.history_size = opts->history_size > 0 ? opts->history_size : 5;
+    cfg.init_radius = opts->init_radius;
+    cfg.init = opts->init;
+
+    // The CSV side, so the optimizer can report the mode the way a draw is
+    // reported: whichever write_array path this model has.
+    stanli::WriteArray wa;
+    wa.names = m->wa_n > 0 ? m->wa_names : m->flat_names;
+    wa.row = [m](const double* q, double* out) {
+      if (m->wa_n > 0) {
+        stanli_wa_row(m, q, out);
+      } else {
+        stanli_constrain(m, q, out);
+      }
+    };
+
+    const stanli::OptimizeResult r =
+        stanli::run_optimize(*m->ex, &wa, cfg);
+    for (size_t i = 0; i < r.unconstrained.size(); ++i)
+      unconstrained[i] = r.unconstrained[i];
+    if (values != nullptr)
+      for (size_t i = 0; i < r.values.size(); ++i) values[i] = r.values[i];
+    if (lp != nullptr) *lp = r.lp;
+    if (r.return_code != 0)
+      put_err(err, err_len,
+              r.message.empty() ? "L-BFGS did not converge" : r.message.c_str());
+    return r.return_code;
+  } catch (const std::exception& e) {
+    put_err(err, err_len, e.what());
+    return 1;
   }
 }
 

--- a/runtime/src/estimate.cpp
+++ b/runtime/src/estimate.cpp
@@ -1,0 +1,127 @@
+#include <stanli/estimate.hpp>
+
+#include <stan/callbacks/interrupt.hpp>
+#include <stan/callbacks/logger.hpp>
+#include <stan/callbacks/writer.hpp>
+#include <stan/optimization/bfgs.hpp>
+#include <stan/services/util/create_rng.hpp>
+
+#include <cmath>
+#include <limits>
+#include <sstream>
+#include <stdexcept>
+
+namespace stanli {
+
+namespace {
+
+// Draw a starting point the way the sampler does, so `optimize` and
+// `sample` disagree about where to start only when asked to. Rejects a
+// draw whose log density or gradient is not finite, as CmdStan's
+// initialize does.
+std::vector<double> initial_point(Executor& ex, uint32_t seed, int chain_id,
+                                  double radius, const double* init) {
+  const int64_t n = ex.n_params();
+  std::vector<double> q((size_t)n, 0.0);
+  if (init != nullptr) {
+    for (int64_t i = 0; i < n; ++i) q[(size_t)i] = init[i];
+    return q;
+  }
+  if (radius == 0.0) return q;
+
+  stan::rng_t rng = stan::services::util::create_rng(seed, chain_id);
+  boost::random::uniform_real_distribution<double> dist(-radius, radius);
+  std::vector<double> grad((size_t)n);
+  for (int attempt = 0; attempt < 100; ++attempt) {
+    for (int64_t i = 0; i < n; ++i) q[(size_t)i] = dist(rng);
+    for (int64_t i = 0; i < n; ++i) ex.params_data()[i] = q[(size_t)i];
+    try {
+      const double lp = ex.forward_value_only();
+      if (!std::isfinite(lp)) continue;
+      const double g = ex.gradient(grad.data());
+      if (!std::isfinite(g)) continue;
+      bool ok = true;
+      for (int64_t i = 0; ok && i < n; ++i) ok = std::isfinite(grad[(size_t)i]);
+      if (ok) return q;
+    } catch (const std::exception&) {
+    }
+  }
+  throw std::runtime_error(
+      "initialization failed: no draw in 100 attempts had finite log density "
+      "and gradient");
+}
+
+// The optimizer is templated on whether the change-of-variables Jacobian
+// is included, so both forms have to be instantiated. Everything else is
+// identical, which is why this is a template rather than two functions.
+template <bool Jacobian>
+int run_lbfgs(ExecutorModel& model, std::vector<double>& cont,
+              const OptimizeConfig& cfg, double* lp_out, std::string* msg) {
+  using Optimizer =
+      stan::optimization::BFGSLineSearch<ExecutorModel,
+                                         stan::optimization::LBFGSUpdate<>,
+                                         double, Eigen::Dynamic, Jacobian>;
+  std::vector<int> disc;
+  std::stringstream ss;
+  Optimizer opt(model, cont, disc, &ss);
+  opt.get_qnupdate().set_history_size(cfg.history_size);
+  opt._ls_opts.alpha0 = cfg.init_alpha;
+  opt._conv_opts.tolAbsF = cfg.tol_obj;
+  opt._conv_opts.tolRelF = cfg.tol_rel_obj;
+  opt._conv_opts.tolAbsGrad = cfg.tol_grad;
+  opt._conv_opts.tolRelGrad = cfg.tol_rel_grad;
+  opt._conv_opts.tolAbsX = cfg.tol_param;
+  opt._conv_opts.maxIts = cfg.iter;
+
+  int ret = 0;
+  while (ret == 0) {
+    ret = opt.step();
+    // The optimizer's own message stream carries the line-search
+    // diagnostics; keep the last of them for a failure report.
+    if (!ss.str().empty()) {
+      *msg = ss.str();
+      ss.str("");
+    }
+  }
+  opt.params_r(cont);
+  // BFGSLineSearch::logp() already returns -(curr_f()), so it IS the log
+  // density; negating it again would report the objective the optimizer
+  // minimizes rather than the lp the caller asked for.
+  *lp_out = opt.logp();
+  // A positive code is a convergence condition (a satisfied tolerance);
+  // only a negative one is a failure.
+  return ret < 0 ? ret : 0;
+}
+
+}  // namespace
+
+OptimizeResult run_optimize(Executor& ex, const WriteArray* wa,
+                            const OptimizeConfig& cfg) {
+  OptimizeResult out;
+  if (!cfg.jacobian) {
+    out.return_code = 1;
+    out.message =
+        "optimize without the Jacobian (CmdStan's default, the penalized "
+        "maximum likelihood) is not available: stanli folds the Jacobian "
+        "terms into the graph at lowering time. Pass jacobian = true for "
+        "the posterior mode.";
+    return out;
+  }
+  ExecutorModel model(ex, wa);
+  std::vector<double> cont =
+      initial_point(ex, cfg.seed, cfg.chain_id, cfg.init_radius, cfg.init);
+
+  out.return_code = cfg.jacobian
+                        ? run_lbfgs<true>(model, cont, cfg, &out.lp, &out.message)
+                        : run_lbfgs<false>(model, cont, cfg, &out.lp,
+                                           &out.message);
+  out.unconstrained = cont;
+  if (wa != nullptr) {
+    out.names = wa->names;
+    out.values.assign(wa->names.size(), 0.0);
+    wa->row(cont.data(), out.values.data());
+  }
+  return out;
+}
+
+}  // namespace stanli

--- a/tests/test_estimate.cpp
+++ b/tests/test_estimate.cpp
@@ -1,0 +1,105 @@
+// L-BFGS over the executor's gradient.
+//
+// The optimizer is stan's own, so what is tested here is the adapter --
+// that the model concept the services reach through (log_prob in both its
+// vector and Eigen forms, constrained_param_names, write_array) is wired
+// to the right buffers. The oracle is a posterior whose answer is known
+// in closed form, because "the optimizer returned something" and "the
+// optimizer returned the mode" look identical otherwise.
+//
+// conj: y ~ normal(mu, sigma) with sigma fixed and mu ~ normal(m0, s0)
+// has a Gaussian posterior with a mode at the precision-weighted mean.
+// Here the model is built directly rather than compiled, so the expected
+// value is arithmetic rather than a second implementation.
+#include <stanli/estimate.hpp>
+#include <stanli/optable.hpp>
+
+#include <cmath>
+#include <cstdio>
+#include <string>
+#include <vector>
+
+static int failures = 0;
+static void expect(const std::string& what, bool ok) {
+  if (!ok) {
+    ++failures;
+    std::printf("FAIL %s\n", what.c_str());
+  }
+}
+static void expect_near(const std::string& what, double got, double want,
+                        double tol) {
+  if (!(std::fabs(got - want) <= tol)) {
+    ++failures;
+    std::printf("FAIL %-30s got %.10g want %.10g (tol %g)\n", what.c_str(),
+                got, want, tol);
+  }
+}
+
+// lp(mu) = normal_lpdf(y | mu, sigma) + normal_lpdf(mu | m0, s0), with y
+// a length-N data vector. Unconstrained, so there is no Jacobian and the
+// mode is the posterior mode either way.
+static stanli::Graph conj_graph(int N) {
+  using namespace stanli;
+  Graph g;
+  const int mu = g.add_slot(1, true);
+  const int y = g.add_slot(N, false);
+  const int sigma = g.add_slot(1, false);
+  const int m0 = g.add_slot(1, false);
+  const int s0 = g.add_slot(1, false);
+  const int lp1 = g.add_slot(1, false);
+  const int lp2 = g.add_slot(1, false);
+  const int lp = g.add_slot(1, false);
+  g.add_op(OP_NORMAL_LPDF, {y, mu, sigma}, lp1);
+  g.add_op(OP_NORMAL_LPDF, {mu, m0, s0}, lp2);
+  g.add_op(OP_ADD_N, {lp1, lp2}, lp);
+  g.result_slot = lp;
+  return g;
+}
+
+int main() {
+  using namespace stanli;
+
+  const int N = 5;
+  const double ys[N] = {1.2, 0.8, 1.6, 0.4, 1.0};
+  const double sigma = 0.7, m0 = 0.0, s0 = 2.0;
+
+  Executor ex(conj_graph(N));
+  for (int i = 0; i < N; ++i) ex.value_ptr(1)[i] = ys[i];
+  ex.value_ptr(2)[0] = sigma;
+  ex.value_ptr(3)[0] = m0;
+  ex.value_ptr(4)[0] = s0;
+
+  // Closed form: the posterior mode of a conjugate normal mean.
+  double ybar = 0;
+  for (int i = 0; i < N; ++i) ybar += ys[i];
+  ybar /= N;
+  const double prec_lik = N / (sigma * sigma), prec_pri = 1.0 / (s0 * s0);
+  const double want = (prec_lik * ybar + prec_pri * m0) / (prec_lik + prec_pri);
+
+  // ---- L-BFGS -----------------------------------------------------------
+  {
+    OptimizeConfig cfg;
+    cfg.seed = 3;
+    OptimizeResult r = run_optimize(ex, nullptr, cfg);
+    expect("optimize converged, code " + std::to_string(r.return_code),
+           r.return_code == 0);
+    expect("optimize returned one parameter", r.unconstrained.size() == 1);
+    expect_near("optimize finds the posterior mode", r.unconstrained[0], want,
+                1e-6);
+    // lp at the mode must be the model's own lp there, not the objective
+    // the optimizer minimizes -- a sign slip here is easy and silent.
+    ex.params_data()[0] = r.unconstrained[0];
+    expect_near("reported lp is the model's lp", r.lp, ex.forward(), 1e-9);
+
+    // Starting from the answer must not move it.
+    OptimizeConfig c2 = cfg;
+    const double at = want;
+    c2.init = &at;
+    OptimizeResult r2 = run_optimize(ex, nullptr, c2);
+    expect_near("optimize is stable at the mode", r2.unconstrained[0], want,
+                1e-6);
+  }
+
+  if (failures == 0) std::printf("test_estimate: all checks passed\n");
+  return failures == 0 ? 0 : 1;
+}

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -226,6 +226,40 @@ def test_generated_quantities_differ_across_chains():
     assert not (fit.draws("yrep")[0] == fit.draws("yrep")[1]).all()
 
 
+def test_optimize_finds_a_mode_and_feeds_sample():
+    m = _es()
+    r = m.optimize(seed=1)
+    # Every CSV column, the way one draw of sample() comes back.
+    assert "mu" in r and "tau" in r and "theta.1" in r
+    assert r.unconstrained.shape == (m.n_unconstrained,)
+    # The reported lp must be the model's lp at that point, not the
+    # objective the optimizer minimizes -- that sign slip is silent.
+    lp, _ = m.log_prob_grad(r.unconstrained)
+    assert abs(lp - r.lp) < 1e-8, (lp, r.lp)
+    # And no nearby point may beat it, which is what "mode" means.
+    rng = np.random.default_rng(0)
+    for _ in range(20):
+        q = r.unconstrained + 0.01 * rng.standard_normal(m.n_unconstrained)
+        assert m.log_prob_grad(q)[0] <= r.lp + 1e-8
+
+    # Starting the sampler from the mode is the point of having it.
+    fit = m.sample(chains=1, seed=2, warmup=200, samples=200,
+                   inits=r.unconstrained)
+    assert fit.n_draws == 200
+
+
+def test_optimize_refuses_the_jacobian_free_form():
+    # CmdStan's default is jacobian=0; stanli cannot express it, and must
+    # say so rather than return the posterior mode under that name.
+    m = _es()
+    try:
+        m.optimize(seed=1, jacobian=False)
+    except NotImplementedError as e:
+        assert "Jacobian" in str(e)
+        return
+    raise AssertionError("expected NotImplementedError for jacobian=False")
+
+
 def test_wrong_size_raises():
     m = stanli.Model(
         stan_code="parameters { real x; } model { x ~ normal(0, 1); }")

--- a/tools/exported_symbols.def
+++ b/tools/exported_symbols.def
@@ -24,3 +24,5 @@ EXPORTS
   stanli_sampler_column_name
   stanli_summary_stats
   stanli_diagnose_text
+  stanli_optimize_opts_init
+  stanli_optimize


### PR DESCRIPTION
Roadmap item 4, partially: `Model.optimize()` runs stan's own L-BFGS — the one behind CmdStan's `optimize` — over the same gradient the sampler uses.

```python
r = model.optimize(seed=1)
r["mu"], r.lp        # every CSV column at the mode, and the lp there
r.unconstrained      # the point on the sampler's scale

fit = model.sample(inits=r.unconstrained)   # which is the reason to have it
```

## It returns the posterior mode, and refuses CmdStan's default

CmdStan's `optimize` defaults to `jacobian=0` — the penalized maximum likelihood. stanli cannot offer that: the change-of-variables Jacobian is folded into the graph at lowering time, and the model adapter ignores the template flag entirely. So `jacobian=False` would have silently returned the posterior **mode** under the other name, and the two differ for any constrained parameter — which is most models.

Both the C ABI and Python refuse it and say why. Excluding the Jacobian is possible in principle (`lower.cpp` already collects `jac_slots` separately) and that is what a real fix would be.

## What it took

`ExecutorModel` grew the rest of the stan model concept the services reach through: `log_prob` in its `std::vector` form as well as its Eigen one, `constrained_param_names`, `write_array` in both forms, `get_dims`, and a `transform_inits` that throws — unconstraining a user's starting values needs the **inverse** parameter transforms, and only the forward ones exist.

One of those was a real bug the test caught: `constrained_param_names` must **append**. The services push their own leading columns and then call it to add the model's, so assigning wipes them and leaves every row wider than its header.

## Verification

The oracle is a conjugate normal whose posterior mode is a precision-weighted mean, computed as arithmetic rather than by a second implementation — "the optimizer returned something" and "the optimizer returned the mode" look identical otherwise. It also pins the reported `lp` to the model's own lp at that point, since `BFGSLineSearch::logp()` already un-negates the objective and negating it again is a silent sign slip.

32/32 ctest, 17/17 `tests/test_python.py`, 119/119 corpus unchanged.

## Pathfinder is deliberately not here

The adapter is now complete enough that stan's single-path service compiles and runs against it and returns `rc=0` — but the draws come back empty, because the parameter writer is never called. An entry point that silently returns nothing is worse than none, so it is cut rather than shipped. That looks like one debugging session, not a design problem.

Multi-path is a harder blocker: it runs its paths through `tbb::parallel_for` and this build stubs TBB out (`tests/tbb_stub.cpp` provides the one symbol stan-math's rev core needs), so it does not link at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UzowbPAusKosD6Wr3srcdT
