### PR TITLE
web: say that the browser build is the slow one

### DIFF
--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -651,6 +651,37 @@ node tools/bench_wasm.cjs                      # fixtures, ns/gradient
 node tools/bench_wasm.cjs --module build-wasm-simd/stanli.js
 ```
 
+### What the browser costs you
+
+Both builds from the same commit, same MIR and same data on each side,
+`bench_grad` against `bench_wasm.cjs`, min of three runs each, macOS
+arm64. This is the number the demo page's footer cites, and the reason it
+tells people to install the wheel for real work.
+
+| model | native | wasm | wasm/native |
+|---|---:|---:|---:|
+| `eight_schools_noncentered` | 269 ns | 534 ns | 1.98x |
+| `radon_pooled` | 54.3 us | 106.6 us | 1.96x |
+| `low_dim_gauss_mix` | 93.2 us | 168.4 us | 1.81x |
+| `hmm_example` | 33.8 us | 58.6 us | 1.73x |
+| `arK` | 2.32 us | 3.75 us | 1.62x |
+| `lotka_volterra` | 74.6 us | 110.6 us | 1.48x |
+| `diamonds` | 36.3 us | 52.2 us | 1.44x |
+| geometric mean | | | **1.71x** |
+
+Two things this is *not*. It is not the missing propto terms: the browser
+ships `STANLI_LITE_LP`, which drops the propto instantiations and so
+evaluates the fuller density, and propto is worth nothing measurable
+either way (docs/lite-lp.md). It is not model preparation either: stanc3
+compiled by js_of_ocaml compiles eight schools in 3 ms warm, against 13 ms
+for the native binary including process spawn, so the browser is not
+behind on time to first draw at all. The gap is gradient throughput,
+which is what dominates once sampling starts.
+
+Measure it under Node, never in an automated browser tab: attaching
+chrome.debugger keeps V8 on the Liftoff baseline tier and costs about 4x
+on the same binary.
+
 The A/B that turned SIMD on, measured on macOS arm64, emsdk 6.0.6 (the
 version CI pins), on the tree as it stood at that commit:
 

--- a/web/index.html
+++ b/web/index.html
@@ -798,9 +798,18 @@ compilers.</p>
 <!--gen:corpus_median-->2.07x<!--/gen--> CmdStan across
 <!--gen:corpus_n_grad-->119<!--/gen--> posteriordb models, with
 <!--gen:corpus_at_par-->93<!--/gen--> of them at or above it. The radon
-preset above is one of the good cases and the Lotka-Volterra one is not,
-which is the honest range. Every model, win or loss, with the reason:
+models in the picker are among the good cases and the Lotka-Volterra one
+is not, which is the honest range. Every model, win or loss, with the
+reason:
 <a href="https://github.com/seantalts/stanli/blob/main/docs/benchmarks.md">benchmarks</a>.</p>
+<p><b>This tab is the slow way to run it, though.</b> The same source
+compiled to WebAssembly instead of native costs about 1.5x to 2x per
+gradient: 1.71x geometric mean over seven models, measured under Node so
+the numbers are not a debugger artifact. The figures in the paragraph
+above are native ones, so the margin over CmdStan in here is nearer par
+than 2x. Preparing the model is not what costs you, since stanc compiled
+to JavaScript still finishes in milliseconds. For work rather than a
+look, <code>pip install stanli</code> runs the native build.</p>
 <p><b>The numbers are checked against CmdStan itself.</b> Not against a
 tolerance someone picked:
 <!--gen:corpus_verified-->118/120<!--/gen--> posteriordb models are


### PR DESCRIPTION
The footer quoted the per-gradient benchmarks, which are native numbers,
on a page that runs the WebAssembly build. Someone reading it in the tab
would take a median of 2.07x CmdStan as what they were watching.

Measured both builds from this commit, same MIR and data on each side,
min of three runs each: 1.44x to 1.98x, geometric mean 1.71x over seven
models. So the margin over CmdStan in the browser is nearer par than 2x,
and the footer now says so and points at the wheel for real work.

Two things it is not, both measured and recorded in docs/benchmarks.md:
not the dropped propto terms, which are worth nothing either way, and
not model preparation, since stanc3 through js_of_ocaml compiles eight
schools in 3 ms warm against 13 ms for the native binary with its
process spawn. The gap is gradient throughput.

Also fixes a sentence that the model picker made stale: the radon and
Lotka-Volterra models are no longer "presets above".
