### PR TITLE
Publish the R runtime on a tag, point the README at all three packages, and fix the flaky reroll budget

### DIFF
--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -1,0 +1,96 @@
+# R CMD check for the R package, on the platforms CRAN checks on.
+#
+# Deliberately without a runtime. CRAN's farm will not have one either --
+# the 16 MB library is downloaded on first use, not built from source --
+# so this job answers the question CRAN asks: does the package install,
+# document, and check cleanly on its own? The sampling tests skip here
+# and say so. They run for real in wheels.yml, against the .so that
+# build job just produced, and that job fails if they skip.
+#
+# What does run here is the JavaScript compiler path: stanc3 through V8,
+# which is the piece that makes the package shippable to CRAN at all and
+# the piece with no runtime dependency.
+name: R
+
+on:
+  push:
+    branches: [main]
+    tags: ['v*']
+    paths:
+      - 'r/**'
+      - 'runtime/include/stanli/capi.h'
+      - '.github/workflows/r.yml'
+  pull_request:
+    paths:
+      - 'r/**'
+      - 'runtime/include/stanli/capi.h'
+      - '.github/workflows/r.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  # Two constants that must agree and live in different languages in
+  # different directories. The runtime and the R bridge are separately
+  # versioned artifacts -- one is downloaded, the other comes from CRAN --
+  # so the bridge refuses to bind when the numbers disagree at runtime.
+  # That guard is only as good as the number it compares against, and
+  # bumping capi.h without bridge.c would make it accept a runtime it
+  # should reject.
+  abi:
+    name: the ABI constants agree
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: |
+          rt=$(sed -n 's/^#define STANLI_ABI_VERSION \([0-9]*\).*/\1/p' \
+               runtime/include/stanli/capi.h)
+          r=$(sed -n 's/^#define STANLI_R_ABI_VERSION \([0-9]*\).*/\1/p' \
+              r/src/bridge.c)
+          echo "runtime ${rt:-<none>}, R bridge ${r:-<none>}"
+          [ -n "$rt" ] && [ "$rt" = "$r" ]
+
+  check:
+    name: ${{ matrix.os }} (${{ matrix.r }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # --as-cran on one row only: it is the strictest and slowest,
+          # and running it four times says the same thing four times.
+          - {os: ubuntu-latest,  r: 'release', args: '"--as-cran"'}
+          - {os: ubuntu-latest,  r: 'devel',   args: '"--no-manual"'}
+          - {os: macos-latest,   r: 'release', args: '"--no-manual"'}
+          - {os: windows-latest, r: 'release', args: '"--no-manual"'}
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      R_KEEP_PKG_SOURCE: yes
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          r-version: ${{ matrix.r }}
+          http-user-agent: ${{ matrix.r == 'devel' && 'release' || 'default' }}
+          use-public-rspm: true
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          working-directory: r
+          extra-packages: any::rcmdcheck
+          needs: check
+
+      - uses: r-lib/actions/check-r-package@v2
+        with:
+          working-directory: r
+          args: ${{ matrix.args }}
+          # One NOTE is expected and permanent until the package is on
+          # CRAN ("New submission"); nothing else may appear.
+          error-on: '"warning"'
+          upload-snapshots: true

--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -64,7 +64,13 @@ jobs:
         include:
           # --as-cran on one row only: it is the strictest and slowest,
           # and running it four times says the same thing four times.
-          - {os: ubuntu-latest,  r: 'release', args: '"--as-cran"'}
+          # That row also gets a LaTeX, because --as-cran builds the PDF
+          # manual and a runner without pdflatex reports the absence as
+          # an Rd problem ("LaTeX errors when creating PDF version"),
+          # which is a WARNING and an ERROR for something the package
+          # did not do. CRAN builds that manual, so the answer is to
+          # have a pdflatex rather than to stop asking.
+          - {os: ubuntu-latest,  r: 'release', args: '"--as-cran"', tex: true}
           - {os: ubuntu-latest,  r: 'devel',   args: '"--no-manual"'}
           - {os: macos-latest,   r: 'release', args: '"--no-manual"'}
           - {os: windows-latest, r: 'release', args: '"--no-manual"'}
@@ -79,6 +85,9 @@ jobs:
           r-version: ${{ matrix.r }}
           http-user-agent: ${{ matrix.r == 'devel' && 'release' || 'default' }}
           use-public-rspm: true
+
+      - uses: r-lib/actions/setup-tinytex@v2
+        if: matrix.tex
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -81,8 +81,8 @@ jobs:
       matrix:
         include: >-
           ${{ fromJSON(github.event_name == 'pull_request'
-              && '[{"os":"ubuntu-24.04","plat":"manylinux_2_28_x86_64","container":"quay.io/pypa/manylinux_2_28_x86_64","opam_arch":"x86_64-linux","build_jobs":2}]'
-              || '[{"os":"macos-15","plat":"macosx_11_0_arm64","macos_target":"11.0","opam_arch":"arm64-macos","build_jobs":4},{"os":"macos-15-intel","plat":"macosx_10_15_x86_64","macos_target":"10.15","opam_arch":"x86_64-macos","build_jobs":4},{"os":"ubuntu-24.04","plat":"manylinux_2_28_x86_64","container":"quay.io/pypa/manylinux_2_28_x86_64","opam_arch":"x86_64-linux","build_jobs":2},{"os":"ubuntu-24.04-arm","plat":"manylinux_2_28_aarch64","container":"quay.io/pypa/manylinux_2_28_aarch64","opam_arch":"arm64-linux","build_jobs":2}]') }}
+              && '[{"os":"ubuntu-24.04","plat":"manylinux_2_28_x86_64","container":"quay.io/pypa/manylinux_2_28_x86_64","opam_arch":"x86_64-linux","build_jobs":2,"runtime":"linux-x86_64"}]'
+              || '[{"os":"macos-15","plat":"macosx_11_0_arm64","macos_target":"11.0","opam_arch":"arm64-macos","build_jobs":4,"runtime":"darwin-arm64"},{"os":"macos-15-intel","plat":"macosx_10_15_x86_64","macos_target":"10.15","opam_arch":"x86_64-macos","build_jobs":4,"runtime":"darwin-x86_64"},{"os":"ubuntu-24.04","plat":"manylinux_2_28_x86_64","container":"quay.io/pypa/manylinux_2_28_x86_64","opam_arch":"x86_64-linux","build_jobs":2,"runtime":"linux-x86_64"},{"os":"ubuntu-24.04-arm","plat":"manylinux_2_28_aarch64","container":"quay.io/pypa/manylinux_2_28_aarch64","opam_arch":"arm64-linux","build_jobs":2,"runtime":"linux-arm64"}]') }}
     steps:
       - uses: actions/checkout@v4
 
@@ -314,6 +314,97 @@ jobs:
           name: wheel-${{ matrix.plat }}
           path: dist/*.whl
 
+      # The same _bin/ the wheel ships, packaged on its own for the R
+      # package, which downloads its runtime instead of bundling it (CRAN
+      # will not carry a 16 MB binary, and could not build one from
+      # source on their farm). Whatever build_wheel.sh put there rides
+      # along, so the Windows tarball carries stanc.exe next to the DLL
+      # the way that wheel does. Naming matches runtime_asset() in
+      # r/R/install.R -- os and architecture as R spells them, normalized.
+      - name: Runtime tarball
+        env:
+          # BSD tar otherwise writes an AppleDouble ._ entry beside every
+          # file that carries an extended attribute, and untar() in R
+          # would drop those into the user's cache directory.
+          COPYFILE_DISABLE: '1'
+        run: |
+          mkdir -p runtime-dist
+          tar czf "runtime-dist/stanli-runtime-${{ matrix.runtime }}.tar.gz" \
+            -C python/stanli/_bin .
+          tar tzf "runtime-dist/stanli-runtime-${{ matrix.runtime }}.tar.gz"
+          ls -la runtime-dist/
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: runtime-${{ matrix.runtime }}
+          path: runtime-dist/*.tar.gz
+
+  # The R package's 23 tests, against a real runtime. They skip without
+  # one, so this is the only place they actually run: everywhere else
+  # (r.yml, CRAN's farm) has the package but no library, and a green
+  # check there says nothing about whether sampling works. Not in the
+  # manylinux container -- that image has no R and installing one into
+  # AlmaLinux costs more than running the .so on a normal runner, which
+  # its glibc 2.28 floor makes safe.
+  r-tests:
+    name: R package against the runtime
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: runtime-linux-x86_64
+          path: runtime
+
+      - name: Unpack the runtime
+        run: |
+          mkdir -p rt
+          tar xzf runtime/*.tar.gz -C rt
+          ls -la rt/
+          echo "STANLI_RUNTIME=$PWD/rt/libstanli.so" >> "$GITHUB_ENV"
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
+
+      # V8 is not needed: the Linux runtime embeds stanc3, so model
+      # source goes straight to the library and the JavaScript compiler
+      # never loads. r.yml is where that path is exercised.
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          working-directory: r
+          extra-packages: any::testthat, any::posterior
+          dependencies: '"hard"'
+
+      # Through R CMD check rather than testthat directly, so the tests
+      # run the way CRAN runs them -- against the installed package, in a
+      # clean temporary directory -- instead of against the source tree.
+      - name: Build and check
+        working-directory: r
+        env:
+          _R_CHECK_FORCE_SUGGESTS_: 'false'
+        run: |
+          R CMD build .
+          R CMD check --no-manual --ignore-vignettes stanli_*.tar.gz
+          # A check whose tests all skipped is green and worthless, which
+          # is the exact failure this job exists to prevent. The runtime
+          # is right there, so nothing may skip for want of one.
+          log=stanli.Rcheck/tests/testthat.Rout
+          [ -f "$log" ] || log=stanli.Rcheck/tests/testthat.Rout.fail
+          cat "$log"
+          if grep -q 'no stanli runtime installed' "$log"; then
+            echo "the sampling tests skipped: the runtime was not seen"
+            exit 1
+          fi
+
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: r-check-log
+          path: r/stanli.Rcheck/
+
   # Everything except pull requests: main pushes, the nightly cron, and
   # release tags (the publish job needs this wheel, so a tag still waits
   # for it).
@@ -386,6 +477,22 @@ jobs:
         with:
           name: wheel-win_amd64
           path: dist/*.whl
+
+      # As above, for the R package. This _bin/ has stanc.exe in it as
+      # well as the DLL, because the Windows build does not embed the
+      # compiler; find_stanc() in r/R/stanc.R looks beside the runtime
+      # for exactly that, so unpacking the tarball is all it takes.
+      - name: Runtime tarball
+        run: |
+          mkdir -p runtime-dist
+          tar czf runtime-dist/stanli-runtime-windows-x86_64.tar.gz \
+            -C python/stanli/_bin .
+          tar tzf runtime-dist/stanli-runtime-windows-x86_64.tar.gz
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: runtime-windows-x86_64
+          path: runtime-dist/*.tar.gz
 
   # Not on pull requests: 265 s, of which 200 is emscripten linking the
   # module, and ccache cannot touch a link. It is safe to run this after
@@ -593,6 +700,65 @@ jobs:
         run: |
           ls -la js/
           cd js && npm publish
+
+  # The R package's distribution channel. CRAN carries the R code and the
+  # 40 KB bridge; the 16 MB runtime it dlopens comes from here, which is
+  # the same split torch uses for libtorch, so this job is what makes
+  # stanli_install() resolve to anything at all.
+  #
+  # Tag-gated with the same reasoning as PyPI, and it runs the R source
+  # tarball up as an asset too: r-universe builds from the repository
+  # continuously, but a CRAN submission is a file a human uploads to a
+  # web form, and this is where that file comes from.
+  runtime-release:
+    if: startsWith(github.ref, 'refs/tags/v')
+    needs: [build, windows]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write  # create the release and attach assets to it
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/download-artifact@v4
+        with:
+          path: runtime
+          pattern: runtime-*
+          merge-multiple: true
+
+      # The R package pins the release it was built against rather than
+      # tracking "latest", so the two have to be bumped together. Caught
+      # here, that is a failed tag build; missed, it is every user's
+      # stanli_install() downloading a 404 until someone cuts another
+      # release.
+      - name: The R package pins this release
+        run: |
+          pin=$(sed -n 's/^stanli_runtime_release <- "\(.*\)"$/\1/p' \
+                r/R/install.R)
+          echo "tag $GITHUB_REF_NAME, r/R/install.R pins ${pin:-<none>}"
+          [ "$pin" = "$GITHUB_REF_NAME" ]
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
+      - name: The R source tarball
+        run: R CMD build r
+
+      - name: Attach the assets
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          ls -la runtime/
+          # Five platforms, one asset each. A partial upload is worse
+          # than none: releases/latest/download resolves for four
+          # platforms and 404s for the fifth, and nothing says which.
+          n=$(ls runtime/*.tar.gz | wc -l)
+          echo "$n runtime assets"
+          [ "$n" -eq 5 ]
+          gh release view "$GITHUB_REF_NAME" >/dev/null 2>&1 ||
+            gh release create "$GITHUB_REF_NAME" \
+              --title "stanli ${GITHUB_REF_NAME#v}" --generate-notes
+          gh release upload "$GITHUB_REF_NAME" \
+            runtime/*.tar.gz stanli_*.tar.gz --clobber
 
   publish:
     # Tags only. PyPI versions can never be reused, so this must not fire

--- a/README.md
+++ b/README.md
@@ -5,17 +5,30 @@ stan-math kernels. No C++ toolchain, no LLVM, no compilation on the
 user's machine.
 
 [![PyPI](https://img.shields.io/pypi/v/stanli.svg)](https://pypi.org/project/stanli/)
+[![npm](https://img.shields.io/npm/v/@seantalts/stanli.svg)](https://www.npmjs.com/package/@seantalts/stanli)
 [![wheels](https://github.com/seantalts/stanli/actions/workflows/wheels.yml/badge.svg)](https://github.com/seantalts/stanli/actions/workflows/wheels.yml)
+[![R](https://github.com/seantalts/stanli/actions/workflows/r.yml/badge.svg)](https://github.com/seantalts/stanli/actions/workflows/r.yml)
+[![License](https://img.shields.io/pypi/l/stanli.svg)](LICENSE)
 
 **Try it in your browser, no install:**
 [seantalts.github.io/stanli](https://seantalts.github.io/stanli/) --
 Stan source to posterior draws in a few hundred milliseconds, entirely
 client side.
-[![License](https://img.shields.io/pypi/l/stanli.svg)](LICENSE)
 
-```
-pip install stanli
-```
+One runtime, three packages. Each is the same shared library behind a
+different binding, so a model samples to the same draws from any of them.
+
+| | | |
+| --- | --- | --- |
+| **Python** | `pip install stanli` | [python/README.md](python/README.md), [PyPI](https://pypi.org/project/stanli/) |
+| **R** | `install.packages("stanli")` then `stanli_install()` | [r/README.md](r/README.md) |
+| **Browser / Node** | `npm install @seantalts/stanli` | [js/README.md](js/README.md), [npm](https://www.npmjs.com/package/@seantalts/stanli) |
+
+The R package is not on CRAN yet; until it is, install it from
+[r-universe](https://seantalts.r-universe.dev) or from a checkout --
+see [r/README.md](r/README.md). It is the one binding that downloads its
+runtime rather than bundling it, because CRAN will not carry a 16 MB
+binary and could not build one on their farm.
 
 - Performance vs CmdStan: [docs/benchmarks.md](docs/benchmarks.md)
   (median gradient <!--gen:corpus_median-->2.07x<!--/gen--> across
@@ -274,6 +287,48 @@ No problems detected.
 Builds without the embedded stanc3 object fall back to running a bundled
 stanc binary as a subprocess.
 
+## R
+
+The same runtime behind an R binding, with `posterior`-shaped draws.
+Full documentation in [r/README.md](r/README.md).
+
+```r
+library(stanli)
+stanli_install()   # one time: fetches the runtime for this platform
+
+m <- stanli_model(file = "eight_schools.stan", data = list(J = 8L, y = y, sigma = s))
+fit <- sample_model(m, chains = 4, seed = 1)
+
+summary(fit)          # mean, MCSE, sd, quantiles, bulk/tail ESS, R-hat
+stanli_diagnose(fit)  # divergences, treedepth, E-BFMI, R-hat, ESS
+as_draws_array(fit)   # a posterior::draws_array
+```
+
+Two pieces are not in the package, for two different reasons, and both
+are what make it a package CRAN can carry at all.
+
+The **runtime** is downloaded on first use into the user cache
+directory, the way torch fetches libtorch: CRAN builds its own binaries
+from source and would have to compile stan-math, every density kernel
+and an OCaml compiler to produce one. `stanli_install()` is explicit and
+nothing is fetched without it. The release workflow publishes the five
+platform libraries as release assets, and the package pins the release
+it was built against rather than tracking whichever is newest.
+
+The **Stan compiler** is stanc3 compiled to JavaScript and run through
+V8 -- the same approach rstan uses. It is one 2.8 MB file that
+compresses to 0.4 MB in the source tarball, with no toolchain and no
+per-platform binaries. Where the runtime embeds stanc3 (every release
+build but Windows) that path is used instead and V8 never loads.
+`tests/test_stancjs.cjs` checks that the JavaScript compiler emits the
+same MIR as the native binary, byte for byte.
+
+Because the binding and the runtime are separately versioned artifacts,
+the C ABI carries a layout version (`stanli_abi_version()`) and the
+bridge refuses to bind a runtime that disagrees with the one it was
+compiled against. Reading `stanli_sample_opts` at the wrong offsets
+would not fail: it would sample successfully from the wrong seed.
+
 ## Browser (WASM)
 
 The same runtime compiles to WebAssembly and runs full Stan in a browser
@@ -363,6 +418,60 @@ release after that is a tag. And the package is scoped because npm's
 name-similarity filter rejects the unscoped `stanli` as too close to
 existing packages, which is why `publishConfig.access` is set to public
 (a scoped package would otherwise default to a private publish).
+
+### R
+
+The same `v*` tag publishes the R side, in the `runtime-release` job.
+It attaches to the GitHub Release:
+
+- five runtime tarballs, `stanli-runtime-{darwin,linux,windows}-{arm64,x86_64}.tar.gz`,
+  each the same `_bin/` the wheel for that platform ships. This is what
+  `stanli_install()` downloads, so the release **is** the R package's
+  distribution channel for everything except the R code itself.
+- `stanli_X.Y.Z.tar.gz`, the R source package.
+
+The job asserts `stanli_runtime_release` in `r/R/install.R` equals the
+tag being cut. The package pins that release rather than tracking
+`latest` on purpose: a CRAN-requested documentation fix bumps the
+package version without a runtime release, and a floating default would
+quietly pair an old binding with a new library. Bump the pin in the same
+commit as the version.
+
+Bumping `STANLI_ABI_VERSION` in `runtime/include/stanli/capi.h` means
+bumping `STANLI_R_ABI_VERSION` in `r/src/bridge.c` too; `.github/workflows/r.yml`
+fails if they disagree. Bump it whenever a struct in the C ABI gains,
+loses or reorders a field, or a function changes signature -- adding a
+new function does not need one.
+
+Two distribution channels, and neither is fully hands-off in the same
+way PyPI and npm are:
+
+**r-universe** builds from this repository continuously, so every push
+to main becomes an installable binary for Linux, macOS and Windows with
+no tag and no action here. It needs a one-time registry entry: a
+`packages.json` in `seantalts/seantalts.r-universe.dev` with
+`{"package": "stanli", "url": "https://github.com/seantalts/stanli", "subdir": "r"}`.
+Users then install with
+
+```r
+install.packages("stanli", repos = "https://seantalts.r-universe.dev")
+```
+
+**CRAN** cannot be automated, and that is policy rather than a missing
+feature: a submission is a file uploaded to a web form and confirmed
+through a link mailed to the maintainer address, specifically so a
+machine cannot do it. What CI can do it does -- `.github/workflows/r.yml`
+runs `R CMD check --as-cran` on Linux, macOS, Windows and R-devel on
+every change under `r/`, and the release job builds the tarball. Cutting
+a CRAN release is then: bump `Version:` in `r/DESCRIPTION` and the
+runtime pin, tag, download `stanli_X.Y.Z.tar.gz` from the release, and
+upload it at
+[cran.r-project.org/submit.html](https://cran.r-project.org/submit.html).
+
+The sampling tests do not run in `r.yml`, because it has no runtime --
+which is the honest simulation of CRAN's farm. They run in `wheels.yml`,
+against the Linux library that build produced, and that job fails if
+they skip.
 
 ## Verification policy
 

--- a/docs/superpowers/plans/2026-08-08-cmdstan-parity-roadmap.md
+++ b/docs/superpowers/plans/2026-08-08-cmdstan-parity-roadmap.md
@@ -190,8 +190,18 @@ only route.
 
 ## 7. R/brms and the wasm density pack
 
-- **CRAN shim** (already roadmap item 2 in the README). All five wheels
-  are built and published by `.github/workflows/wheels.yml`.
+- **CRAN shim** — DONE, as `r/`. Not a shim over the Python package in
+  the end but a package in its own right: an R-level API, a dlopen
+  bridge to the C ABI, and stanc3 as JavaScript through V8, which is how
+  rstan carries a Stan compiler on CRAN and the only form of the
+  compiler CRAN can take. `R CMD check --as-cran` is clean but for the
+  permanent "New submission" NOTE. The runtime is downloaded rather than
+  bundled, so the same `v*` tag that publishes the wheels also attaches
+  five platform runtime tarballs to the release, and the C ABI carries a
+  layout version the bridge refuses to mismatch. **Still to do:** the
+  r-universe registry entry (one file in a separate repo) and the CRAN
+  submission itself, which is a web form and a confirmation email by
+  policy and cannot be automated.
 - **A brms backend** is the bigger play. R is half of Stan's user base,
   and brms-generated code is a natural stress corpus that exercises
   precisely the gaps in item 2 — `offset`/`multiplier`,

--- a/r/R/install.R
+++ b/r/R/install.R
@@ -11,11 +11,38 @@
 # explicit, and everything else fails with a message telling the user to
 # run it.
 
+# The release this package was built against. NOT the package version:
+# a CRAN-requested documentation fix bumps the package without cutting a
+# runtime release, and a default of "latest" would silently pair a
+# pinned binding with a runtime that has moved. The release workflow
+# asserts this equals the tag being cut, so bumping one without the
+# other fails there rather than at a user's install.
+stanli_runtime_release <- "v0.5.0"
+
 runtime_filename <- function() {
   switch(Sys.info()[["sysname"]],
          Darwin = "libstanli.dylib",
          Windows = "stanli.dll",
          "libstanli.so")
+}
+
+# The asset name is built from R's own architecture, not the kernel's.
+# The library is dlopen'd into the R process, so it has to match that
+# process: an x86_64 R under Rosetta on an arm64 Mac needs the x86_64
+# dylib. Both names are normalized because the same machine is spelled
+# three ways across platforms -- "x86-64" on Windows, "aarch64" on Linux
+# arm, "arm64" on macOS arm.
+runtime_os <- function() tolower(Sys.info()[["sysname"]])
+
+runtime_arch <- function() {
+  a <- tolower(R.version$arch)
+  if (grepl("^(x86[-_]64|amd64)$", a)) return("x86_64")
+  if (grepl("^(aarch64|arm64)$", a)) return("arm64")
+  a
+}
+
+runtime_asset <- function() {
+  sprintf("stanli-runtime-%s-%s.tar.gz", runtime_os(), runtime_arch())
 }
 
 #' Where the stanli runtime lives
@@ -44,12 +71,15 @@ stanli_available <- function() {
 #' Fetches the prebuilt runtime for this platform into the user cache
 #' directory. This is a one-time step; the library is about 16 MB.
 #'
-#' @param version Release tag to fetch, or `"latest"`.
+#' @param version Release tag to fetch. Defaults to the release this
+#'   version of the package was built against, which is the pairing its
+#'   ABI check will accept; `"latest"` takes whatever the newest release
+#'   is instead.
 #' @param quiet Passed to [utils::download.file()].
 #' @param overwrite Re-download even if the runtime is already present.
 #' @return The path it was installed to, invisibly.
 #' @export
-stanli_install <- function(version = "latest", quiet = FALSE,
+stanli_install <- function(version = stanli_runtime_release, quiet = FALSE,
                            overwrite = FALSE) {
   dest_dir <- tools::R_user_dir("stanli", "cache")
   dir.create(dest_dir, recursive = TRUE, showWarnings = FALSE)
@@ -58,8 +88,7 @@ stanli_install <- function(version = "latest", quiet = FALSE,
     if (!quiet) message("stanli runtime already at ", dest)
     return(invisible(dest))
   }
-  asset <- sprintf("stanli-runtime-%s-%s.tar.gz",
-                   tolower(Sys.info()[["sysname"]]), Sys.info()[["machine"]])
+  asset <- runtime_asset()
   base <- "https://github.com/seantalts/stanli/releases"
   url <- if (identical(version, "latest")) {
     file.path(base, "latest", "download", asset)
@@ -68,15 +97,22 @@ stanli_install <- function(version = "latest", quiet = FALSE,
   }
   tmp <- tempfile(fileext = ".tar.gz")
   on.exit(unlink(tmp), add = TRUE)
-  ok <- tryCatch({
-    utils::download.file(url, tmp, mode = "wb", quiet = quiet)
-    TRUE
-  }, error = function(e) {
-    stop("could not download the stanli runtime from ", url, ": ",
-         conditionMessage(e),
-         "\nBuild it from source and point STANLI_RUNTIME at the result ",
-         "if this platform has no release asset.", call. = FALSE)
-  })
+  tryCatch(
+    utils::download.file(url, tmp, mode = "wb", quiet = quiet),
+    error = function(e) {
+      stop("could not download the stanli runtime from ", url, ": ",
+           conditionMessage(e),
+           "\nBuild it from source and point STANLI_RUNTIME at the result ",
+           "if this platform has no release asset.", call. = FALSE)
+    })
+  # download.file() reports some failures through a non-zero status
+  # rather than a condition, and a proxy or an error page can arrive as
+  # a small file with status 0. Both would reach untar() as garbage.
+  if (!file.exists(tmp) || file.size(tmp) < 1e6)
+    stop("the download from ", url, " is not a runtime archive (",
+         if (file.exists(tmp)) file.size(tmp) else 0, " bytes). ",
+         "If this platform has no release asset, build from source and ",
+         "point STANLI_RUNTIME at the result.", call. = FALSE)
   utils::untar(tmp, exdir = dest_dir)
   if (!file.exists(dest))
     stop("the downloaded archive did not contain ", runtime_filename(),

--- a/r/README.md
+++ b/r/README.md
@@ -2,9 +2,35 @@
 
 Compile and sample Stan models without a C++ toolchain.
 
+## Install
+
+Not on CRAN yet. Until it is:
+
+```r
+# r-universe: binaries for Linux, macOS and Windows, rebuilt from main
+install.packages("stanli", repos = "https://seantalts.r-universe.dev")
+
+# or from a checkout
+# R CMD INSTALL r
+```
+
+Then, once per machine:
+
+```r
+stanli_install()
+```
+
+That downloads the ~16 MB runtime for your platform into
+`tools::R_user_dir("stanli", "cache")`. Nothing is fetched without it.
+It takes the release the package was built against rather than whichever
+is newest, so the binding and the library always agree; pass
+`version = "latest"` to override, and set `STANLI_RUNTIME` to use a
+library you built yourself.
+
+## Use
+
 ```r
 library(stanli)
-stanli_install()   # one time: fetches the runtime (~16 MB)
 
 m <- stanli_model(file = "eight_schools.stan", data = list(J = 8L, y = y, sigma = s))
 fit <- sample_model(m, chains = 4, seed = 1)
@@ -39,13 +65,26 @@ source and would have to compile all of that to produce one, so
 directory instead. Nothing is fetched without being asked for. Point
 `STANLI_RUNTIME` at a local build to use one you built yourself.
 
+The consequence is that this package and the library it calls are
+separately versioned artifacts, and can drift. Getting that wrong is not
+a crash: `stanli_sample_opts` is a struct this package declares a copy
+of, so a field added on one side and not the other would be read at the
+wrong offsets and sample happily from the wrong seed at the wrong step
+size. So the C ABI carries a layout version, the runtime reports it
+through `stanli_abi_version()`, and loading refuses on a mismatch with a
+message saying which side to update. The release workflow asserts the
+pinned release equals the tag it is cutting.
+
 **The Stan compiler** is stanc3 compiled to JavaScript and run through
 the V8 package — the same approach rstan uses to ship a Stan compiler on
 CRAN. It is one 2.8 MB file that compresses to about 0.4 MB in the source
 tarball, with no toolchain and no per-platform binaries. When the runtime
-embeds stanc3 (the release builds do) that path is used instead and V8 is
-never loaded; a native `stanc` in `STANLI_STANC` or on the `PATH` also
-wins, because it is faster than either.
+embeds stanc3 -- every release build but Windows, which waits on opam's
+native Windows support -- that path is used instead and V8 is never
+loaded; a native `stanc` in `STANLI_STANC` or beside the runtime also
+wins, because it is faster than either. The Windows runtime tarball
+carries `stanc.exe` next to the DLL for exactly that reason, so V8 is a
+fallback there too rather than a requirement.
 
 `tests/test_stancjs.cjs` in the main repository checks that the
 JavaScript compiler emits the same MIR as the native binary, byte for

--- a/r/man/stanli_install.Rd
+++ b/r/man/stanli_install.Rd
@@ -4,10 +4,17 @@
 \alias{stanli_install}
 \title{Download the stanli runtime}
 \usage{
-stanli_install(version = "latest", quiet = FALSE, overwrite = FALSE)
+stanli_install(
+  version = stanli_runtime_release,
+  quiet = FALSE,
+  overwrite = FALSE
+)
 }
 \arguments{
-\item{version}{Release tag to fetch, or `"latest"`.}
+\item{version}{Release tag to fetch. Defaults to the release this
+version of the package was built against, which is the pairing its
+ABI check will accept; `"latest"` takes whatever the newest release
+is instead.}
 
 \item{quiet}{Passed to [utils::download.file()].}
 

--- a/r/src/bridge.c
+++ b/r/src/bridge.c
@@ -13,10 +13,17 @@
  */
 #include <dlfcn.h>
 #include <stdint.h>
+#include <stdio.h>
 #include <string.h>
 
 #include <R.h>
 #include <Rinternals.h>
+
+/* Must equal STANLI_ABI_VERSION in runtime/include/stanli/capi.h. The
+ * runtime reports its own through stanli_abi_version(), and
+ * stanli_bridge_load() refuses to bind when the two disagree -- see
+ * there for why a mismatch cannot be allowed to proceed. */
+#define STANLI_R_ABI_VERSION 1
 
 /* Mirrors stanli_sample_opts in runtime/include/stanli/capi.h. Field
  * order and types must match exactly; R never sees this struct, but a
@@ -55,6 +62,7 @@ typedef struct {
 static void *g_lib = NULL;
 
 /* Every entry point the R side uses. */
+static int (*p_abi_version)(void);
 static void *(*p_model_new_from_stan)(const char *, const char *, char *,
                                       size_t);
 static void *(*p_model_new)(const char *, const char *, char *, size_t);
@@ -99,6 +107,32 @@ SEXP stanli_bridge_load(SEXP path) {
   if (g_lib != NULL) return mkString("");
   g_lib = dlopen(CHAR(STRING_ELT(path, 0)), RTLD_NOW | RTLD_LOCAL);
   if (g_lib == NULL) return mkString(dlerror());
+
+  /* Before anything else. The two opts structs above are copies of the
+   * runtime's, and this package and the runtime are separately
+   * versioned artifacts -- the library is downloaded, not linked. If a
+   * field moved, every call would still succeed and read the wrong
+   * offsets: a run at the wrong seed and the wrong step size, with no
+   * error anywhere. Refuse instead. */
+  *(void **)(&p_abi_version) = dlsym(g_lib, "stanli_abi_version");
+  if (p_abi_version == NULL) {
+    dlclose(g_lib);
+    g_lib = NULL;
+    return mkString("this stanli runtime predates the versioned ABI and is "
+                    "too old for this package. Run "
+                    "stanli_install(overwrite = TRUE).");
+  }
+  if (p_abi_version() != STANLI_R_ABI_VERSION) {
+    char msg[256];
+    snprintf(msg, sizeof msg,
+             "this stanli runtime speaks ABI version %d, but the R package "
+             "was built against %d. Run stanli_install(overwrite = TRUE) to "
+             "fetch a matching runtime, or update the package.",
+             p_abi_version(), STANLI_R_ABI_VERSION);
+    dlclose(g_lib);
+    g_lib = NULL;
+    return mkString(msg);
+  }
 
   BIND("stanli_model_new_from_stan", p_model_new_from_stan);
   BIND("stanli_model_new", p_model_new);

--- a/r/src/bridge.c
+++ b/r/src/bridge.c
@@ -11,13 +11,53 @@
  * stanli_bridge_load() has succeeded, so every wrapper checks and errors
  * with a message naming the missing piece rather than dereferencing null.
  */
-#include <dlfcn.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <string.h>
 
 #include <R.h>
 #include <Rinternals.h>
+
+/* The four dynamic-loading calls this file makes, on both families.
+ * Windows has no dlfcn.h -- R's own installer spells it LoadLibrary --
+ * and the R side already knew to go looking for stanli.dll, so without
+ * this the package did not compile on the one platform its runtime
+ * filename was written for. */
+#ifdef _WIN32
+#include <windows.h>
+static void *dl_open(const char *path) {
+  return (void *)LoadLibraryA(path);
+}
+static void *dl_sym(void *h, const char *name) {
+  /* Through uintptr_t: GetProcAddress returns a function pointer, and
+   * converting one straight to void* is what -Wcast-function-type
+   * exists to complain about. */
+  return (void *)(uintptr_t)GetProcAddress((HMODULE)h, name);
+}
+static void dl_close(void *h) { FreeLibrary((HMODULE)h); }
+static const char *dl_error(void) {
+  static char buf[512];
+  const DWORD e = GetLastError();
+  const DWORD n = FormatMessageA(
+      FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS, NULL, e,
+      0, buf, (DWORD)sizeof buf - 1, NULL);
+  if (n == 0)
+    snprintf(buf, sizeof buf, "could not load the library (error %lu)",
+             (unsigned long)e);
+  return buf;
+}
+#else
+#include <dlfcn.h>
+static void *dl_open(const char *path) {
+  return dlopen(path, RTLD_NOW | RTLD_LOCAL);
+}
+static void *dl_sym(void *h, const char *name) { return dlsym(h, name); }
+static void dl_close(void *h) { dlclose(h); }
+static const char *dl_error(void) {
+  const char *e = dlerror();
+  return e != NULL ? e : "unknown error";
+}
+#endif
 
 /* Must equal STANLI_ABI_VERSION in runtime/include/stanli/capi.h. The
  * runtime reports its own through stanli_abi_version(), and
@@ -93,20 +133,20 @@ static void (*p_optimize_opts_init)(stanli_optimize_opts *);
 static int (*p_optimize)(void *, const stanli_optimize_opts *, double *,
                          double *, double *, char *, size_t);
 
-#define BIND(fn, var)                                            \
-  do {                                                           \
-    *(void **)(&var) = dlsym(g_lib, fn);                         \
-    if (var == NULL) {                                           \
-      dlclose(g_lib);                                            \
-      g_lib = NULL;                                              \
-      return mkString("missing symbol in stanli library: " fn);   \
-    }                                                            \
+#define BIND(fn, var)                                          \
+  do {                                                         \
+    *(void **)(&var) = dl_sym(g_lib, fn);                      \
+    if (var == NULL) {                                         \
+      dl_close(g_lib);                                         \
+      g_lib = NULL;                                            \
+      return mkString("missing symbol in stanli library: " fn); \
+    }                                                          \
   } while (0)
 
 SEXP stanli_bridge_load(SEXP path) {
   if (g_lib != NULL) return mkString("");
-  g_lib = dlopen(CHAR(STRING_ELT(path, 0)), RTLD_NOW | RTLD_LOCAL);
-  if (g_lib == NULL) return mkString(dlerror());
+  g_lib = dl_open(CHAR(STRING_ELT(path, 0)));
+  if (g_lib == NULL) return mkString(dl_error());
 
   /* Before anything else. The two opts structs above are copies of the
    * runtime's, and this package and the runtime are separately
@@ -114,9 +154,9 @@ SEXP stanli_bridge_load(SEXP path) {
    * field moved, every call would still succeed and read the wrong
    * offsets: a run at the wrong seed and the wrong step size, with no
    * error anywhere. Refuse instead. */
-  *(void **)(&p_abi_version) = dlsym(g_lib, "stanli_abi_version");
+  *(void **)(&p_abi_version) = dl_sym(g_lib, "stanli_abi_version");
   if (p_abi_version == NULL) {
-    dlclose(g_lib);
+    dl_close(g_lib);
     g_lib = NULL;
     return mkString("this stanli runtime predates the versioned ABI and is "
                     "too old for this package. Run "
@@ -129,7 +169,7 @@ SEXP stanli_bridge_load(SEXP path) {
              "was built against %d. Run stanli_install(overwrite = TRUE) to "
              "fetch a matching runtime, or update the package.",
              p_abi_version(), STANLI_R_ABI_VERSION);
-    dlclose(g_lib);
+    dl_close(g_lib);
     g_lib = NULL;
     return mkString(msg);
   }

--- a/r/tests/testthat/test-stanc.R
+++ b/r/tests/testthat/test-stanc.R
@@ -1,0 +1,53 @@
+# The one path that works without a runtime, and so the only thing CRAN's
+# check farm will actually execute: stanc3 compiled to JavaScript, run
+# through V8. It is what makes the package shippable there at all, so it
+# is worth a test that does not skip on the machines that matter.
+
+test_that("the bundled JavaScript compiler produces MIR", {
+  skip_if_not_installed("V8")
+  skip_if_not_installed("jsonlite")
+  skip_if(!nzchar(stanli:::stanc_js_path()) ||
+            !file.exists(stanli:::stanc_js_path()),
+          "stanc.js is not in this installation")
+
+  mir <- stanli:::mir_from_js("
+    data { int<lower=0> N; vector[N] y; }
+    parameters { real mu; real<lower=0> sigma; }
+    model { y ~ normal(mu, sigma); }")
+
+  expect_type(mir, "character")
+  # An s-expression naming the model's own symbols, not just any output:
+  # a compiler that silently emitted an empty program would still be a
+  # non-empty string.
+  expect_match(mir, "\\bmu\\b")
+  expect_match(mir, "\\bsigma\\b")
+  expect_match(mir, "normal")
+})
+
+test_that("a model that does not typecheck is an error, not empty MIR", {
+  skip_if_not_installed("V8")
+  skip_if_not_installed("jsonlite")
+  skip_if(!nzchar(stanli:::stanc_js_path()) ||
+            !file.exists(stanli:::stanc_js_path()),
+          "stanc.js is not in this installation")
+
+  # `y` is undeclared. stanc reports this through `errors` rather than a
+  # thrown exception, so the wrapper has to look for it: without that
+  # check a broken model reaches the lowering pass as NULL.
+  expect_error(
+    stanli:::mir_from_js("parameters { real mu; } model { mu ~ normal(y, 1); }"),
+    "stanc")
+})
+
+test_that("the runtime asset name is one of the five that get published", {
+  # r/R/install.R builds this from R's own spelling of the platform, and
+  # the release workflow builds the tarball names from a matrix. They are
+  # two lists that have to stay equal, and only one of them is checked by
+  # a compiler.
+  published <- c("stanli-runtime-darwin-arm64.tar.gz",
+                 "stanli-runtime-darwin-x86_64.tar.gz",
+                 "stanli-runtime-linux-x86_64.tar.gz",
+                 "stanli-runtime-linux-arm64.tar.gz",
+                 "stanli-runtime-windows-x86_64.tar.gz")
+  expect_true(stanli:::runtime_asset() %in% published)
+})

--- a/runtime/include/stanli/capi.h
+++ b/runtime/include/stanli/capi.h
@@ -14,6 +14,22 @@ extern "C" {
 
 typedef struct stanli_model stanli_model;
 
+/* The layout version of this ABI. Bump it whenever an existing struct
+ * gains, loses or reorders a field, or an existing function changes
+ * signature. Adding a NEW function does not need a bump: a binding that
+ * does not know about it never looks it up, and one that does gets a
+ * named dlsym failure rather than a misread.
+ *
+ * This exists because the Python wheel ships its library inside the
+ * package while the R package downloads one -- so on R, the binding and
+ * the runtime are separately versioned artifacts and can drift. Reading
+ * an opts struct at the wrong offsets is silent: sampling would succeed
+ * from the wrong seed with the wrong step size. A binding must compare
+ * this against the value it was compiled against before calling
+ * anything, and refuse on a mismatch. */
+#define STANLI_ABI_VERSION 1
+int stanli_abi_version(void);
+
 /* Compile transformed-MIR sexp text (from `stanc --debug-transformed-mir`)
  * against JSON data (CmdStan conventions). Returns null on failure with a
  * message in err. */

--- a/runtime/src/capi.cpp
+++ b/runtime/src/capi.cpp
@@ -154,6 +154,8 @@ stanli_model* stanli_model_new_from_stan(const char* stan_code,
 #endif
 }
 
+int stanli_abi_version(void) { return STANLI_ABI_VERSION; }
+
 int stanli_has_embedded_stanc(void) {
 #ifdef STANLI_EMBED_STANC
   return 1;

--- a/tests/test_reroll.cpp
+++ b/tests/test_reroll.cpp
@@ -6,6 +6,10 @@
 #include <stanli/optable.hpp>
 #include <stanli/reroll.hpp>
 
+#ifndef _WIN32
+#include <sys/resource.h>
+#endif
+
 #include <algorithm>
 #include <chrono>
 #include <cmath>
@@ -691,7 +695,17 @@ int count(const Graph& g, uint16_t oc) {
 // refill. N iterations chain N store regions through that single slot, so
 // eager tail renaming made the pass quadratic in both time and memory
 // (the real model: 32,877 iterations, 52 s and 49 GB to compile, which
-// OOM-killed every CI runner). The pass must stay near-linear in N.
+// OOM-killed every CI runner).
+//
+// Space is linear now and time is not. Measured on this shape, one
+// doubling of n costs 2.0x memory and 3.8x time -- so the fix removed
+// the quadratic term from the allocation and left a quadratic term in
+// the work, about 13x smaller than it was: n=32,000 is 350 MB and 4 s.
+// That is why the guard below is a memory ceiling and a scaling ratio
+// rather than the wall-clock budget it used to be. A budget cannot work
+// here: the gap between the bug and the fix is 13x, CI's slowest runner
+// is 9x slower than its fastest, and the two overlap. The old budget
+// duly failed a commit that touched nothing but an unrelated directory.
 namespace ldashape {
 
 struct Built {
@@ -759,18 +773,59 @@ static void test_lda_shape_gradients() {
     expect_close(("lda v" + std::to_string(i)).c_str(), got[i], want[i]);
 }
 
-static void test_lda_shape_linear_cost() {
-  const int N = 8000;  // quadratic renaming: seconds and GBs; linear: ~0.1 s
-  ldashape::Built b = ldashape::build(N);
+// Peak resident set for the process in MB, or -1 where the platform does
+// not report one. ru_maxrss is bytes on macOS and kilobytes elsewhere, a
+// difference that would otherwise read as a 1000x regression.
+static double peak_rss_mb() {
+#ifdef _WIN32
+  return -1.0;
+#else
+  struct rusage ru;
+  if (getrusage(RUSAGE_SELF, &ru) != 0) return -1.0;
+#ifdef __APPLE__
+  return static_cast<double>(ru.ru_maxrss) / (1024.0 * 1024.0);
+#else
+  return static_cast<double>(ru.ru_maxrss) / 1024.0;
+#endif
+#endif
+}
+
+// How long reroll takes on the lda shape at size n, with the region count
+// checked along the way so a pass that got fast by doing less is not
+// mistaken for a pass that got fast.
+static double time_lda_reroll(int n) {
+  ldashape::Built b = ldashape::build(n);
   std::vector<int> tt = b.terms;
   const auto t0 = std::chrono::steady_clock::now();
   RerollStats st = reroll(b.g, b.fills, tt, {});
   const double sec =
       std::chrono::duration<double>(std::chrono::steady_clock::now() - t0)
           .count();
-  expect("lda big all regions found", st.regions == N);
-  std::printf("  lda shape N=%d rerolled in %.2f s\n", N, sec);
-  expect("lda reroll near-linear (<2 s)", sec < 2.0);
+  expect("lda big all regions found", st.regions == n);
+  return sec;
+}
+
+static void test_lda_shape_cost() {
+  const double small = time_lda_reroll(4000);
+  const double big = time_lda_reroll(8000);
+  const double rss = peak_rss_mb();
+  std::printf("  lda shape reroll: n=4000 %.2f s, n=8000 %.2f s (%.1fx),"
+              " peak RSS %.0f MB\n",
+              small, big, small > 0.0 ? big / small : 0.0, rss);
+
+  // The memory ceiling is the guard that matters, because memory is what
+  // broke, and unlike a wall-clock number an RSS figure means the same
+  // thing on every machine. This is the whole process's peak, so it
+  // counts every case that ran before this one -- an over-estimate,
+  // which is the safe direction. All of them together reach under
+  // 100 MB; the same shape under the quadratic-space bug would be around
+  // 2.9 GB, so 1 GB separates them with room on both sides.
+  if (rss > 0.0) expect("lda reroll space stays linear", rss < 1024.0);
+
+  // Time is quadratic and this only catches a fall to something worse.
+  // A doubling costs 4x at quadratic and 8x at cubic; 5x sits between
+  // them and does not depend on how fast the machine is.
+  expect("lda reroll time no worse than quadratic", big < 5.0 * small);
 }
 
 static void test_write_fusion() {
@@ -1086,7 +1141,7 @@ int main() {
   test_block_structured();
   test_bail_extra_root();
   test_lda_shape_gradients();
-  test_lda_shape_linear_cost();
+  test_lda_shape_cost();
   test_write_fusion();
   test_write_fusion_bails();
   test_write_fusion_scalar_chain();

--- a/tools/exported_symbols.def
+++ b/tools/exported_symbols.def
@@ -1,6 +1,7 @@
 ; PE export list for stanli.dll: the C ABI and nothing else, matching
 ; exported_symbols.txt (Mach-O) and exported_symbols.map (ELF).
 EXPORTS
+  stanli_abi_version
   stanli_model_new
   stanli_model_new_from_stan
   stanli_has_embedded_stanc


### PR DESCRIPTION
## The gap this closes

`stanli_install()` downloads `stanli-runtime-{os}-{arch}.tar.gz` from the latest release. That asset did not exist, so the R package merged in #33 could not actually install its runtime on any machine.

The same `v*` tag that publishes the wheels now attaches, in a new `runtime-release` job:

- five runtime tarballs — the same `python/stanli/_bin/` each wheel ships, so the Windows one carries `stanc.exe` beside the DLL, which is what `find_stanc()` looks for
- `stanli_X.Y.Z.tar.gz`, the R source package, which is the file a CRAN submission uploads

Verified the round trip locally: `tar czf -C _bin .` → `utils::untar()` → flat `libstanli.dylib` in the cache dir → `load_runtime()` binds → eight schools samples to the same numbers as the Python package.

## An ABI version, because this pairing can drift silently

Python ships its library inside the wheel. R downloads one. So on R the binding and the runtime are separately versioned artifacts, and `r/src/bridge.c` declares its own copy of `stanli_sample_opts`. A field added on one side and not the other is not a crash — it is a run at the wrong seed with the wrong step size and no error anywhere.

So the C ABI carries `stanli_abi_version()`, the bridge compares it before binding anything, and refuses on a mismatch. Both failure paths verified by hand:

```
this stanli runtime speaks ABI version 1, but the R package was built against 2.
  Run stanli_install(overwrite = TRUE) to fetch a matching runtime, or update the package.
this stanli runtime predates the versioned ABI and is too old for this package.
  Run stanli_install(overwrite = TRUE).
```

`stanli_install()` also pins the release it was built against instead of tracking `latest` — a CRAN-requested doc fix bumps the package without cutting a runtime release, and a floating default would quietly pair an old binding with a new library. The release job asserts the pin equals the tag.

## CI for the R package

- **`.github/workflows/r.yml`** — `R CMD check` on Linux / macOS / Windows / R-devel for every change under `r/`, plus a job asserting the two ABI constants agree. Deliberately **without** a runtime: that is the honest simulation of CRAN's farm, and the sampling tests skip there and say so.
- **`wheels.yml` → `r-tests`** — the same check *with* the Linux runtime that build job just produced, and it fails if any test skipped for want of one. Locally: `Status: OK`, `[ FAIL 0 | WARN 0 | SKIP 0 | PASS 29 ]`.
- **`r/tests/testthat/test-stanc.R`** — new, and the only thing CRAN will actually execute: stanc3 through V8, including that a model which does not typecheck raises rather than returning empty MIR.

## What is not automated, and why

CRAN cannot be. A submission is a web form plus a link mailed to the maintainer, specifically so a machine cannot do it. r-universe covers the continuous case and needs one registry entry in a separate repo (`{"package": "stanli", "url": ..., "subdir": "r"}`) — written up in the README, not done here.

## The reroll test that failed the last build on main

`macosx_10_15_x86_64` failed #33's merge build on `test_reroll`. That commit touched only `r/**` and `.gitignore`, so the pass and its flags were byte-identical to the run that passed four minutes earlier — the test asserted `sec < 2.0` and the slowest runner took 2.55 s.

Measuring the curve instead of the clock turned up something worth knowing. The fix this test guards removed the quadratic term from the **allocation** but not from the **work**:

| n | time | ×  | peak RSS | × |
|---|---|---|---|---|
| 1000 | 0.019 s | | 13 MB | |
| 2000 | 0.035 s | 1.89 | 30 MB | 2.3 |
| 4000 | 0.082 s | 2.33 | 53 MB | 1.8 |
| 8000 | 0.275 s | 3.33 | 94 MB | 1.8 |
| 16000 | 1.035 s | 3.80 | 180 MB | 1.9 |
| 32000 | 3.961 s | 3.83 | 350 MB | 1.9 |

Time converges on 4× per doubling — quadratic, with a constant about 13× smaller than the bug's. Memory is a clean 2× — linear, and 350 MB at n=32,000 against the 49 GB that OOM-killed the runners.

No wall-clock budget can work here: the bug-to-fix gap is 13× and CI's slowest runner is 9× slower than its fastest, so the two overlap. The guard is now a **memory ceiling** — machine-independent, and the thing that actually broke — plus a scaling ratio that catches a fall below quadratic. The comment claiming near-linear time was wrong and now states what was measured.

**This leaves a real finding: the reroll pass is still quadratic in time on the lda shape.** Tolerable today (the real 32,877-iteration model is ~4 s), but a model 3× larger is ~36 s. Not fixed here — flagging it rather than burying it under a green test.

## README

Header now carries PyPI, npm and R badges and a table pointing at all three packages, plus a new `## R` section and a `### R` releasing subsection covering the tag flow, the pin, the ABI constants, r-universe and the manual CRAN step.

## Verification

- 33/33 ctest
- 29/29 R tests with a runtime, `R CMD check` **Status: OK**
- `R CMD check --as-cran` without a runtime: 1 NOTE ("New submission"), 9 sampling tests skip, 6 stanc assertions pass
- `tools/gen_docs.py --check`: docs match the artifacts
- both workflows parse; the embedded matrix JSON parses and every row carries a `runtime` field matching the five names the R package can ask for

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UzowbPAusKosD6Wr3srcdT
