### PR TITLE
reroll: replace the quadratic use-list scans with binary search (19x at n=32,000, 9x on ldaK5)

### DIFF
--- a/runtime/src/reroll.cpp
+++ b/runtime/src/reroll.cpp
@@ -214,6 +214,44 @@ RerollStats reroll(Graph& g,
     if (g.ops[u].out2 >= 0) writers[g.ops[u].out2].push_back(u);
   }
 
+  // Both lists are built by walking u upwards, so each one is sorted, and
+  // every question asked of them below is a range question: is anything
+  // in [lo, hi), is anything at or past hi. Answering those by scanning
+  // the whole list is what made this pass quadratic in TIME long after
+  // the lazy renaming below made it linear in space -- ldaK5 refills one
+  // shared gamma vector from every one of its N iterations, so that
+  // slot's lists are N long and every one of the N regions walked all of
+  // both. Measured at N=32,000: 11.3 billion list steps, against 3.6
+  // million for everything else in the pass put together.
+  //
+  // Binary search asks the same questions of the same lists and gets the
+  // same answers; it just does not read the entries that cannot matter.
+  // Entries actually inside a region are still visited, but regions are
+  // disjoint, so that total is bounded by the list sizes: O(n log n).
+  const auto first_at_or_after = [](const std::vector<size_t>& v, size_t x) {
+    return std::lower_bound(v.begin(), v.end(), x);
+  };
+  // Is any entry of `v` in [lo, hi) not accepted by `ours`? `ours` names
+  // the region's own ops, which are allowed to touch the slot.
+  const auto any_in_range_but = [&](const std::vector<size_t>* v, size_t lo,
+                                    size_t hi, auto&& ours) {
+    if (v == nullptr) return false;
+    for (auto it = first_at_or_after(*v, lo); it != v->end() && *it < hi; ++it)
+      if (!ours(*it)) return true;
+    return false;
+  };
+  // Is any entry of `v` at or after `x`?
+  const auto any_at_or_after = [&](const std::vector<size_t>* v, size_t x) {
+    return v != nullptr && first_at_or_after(*v, x) != v->end();
+  };
+  // The list for a slot, or null when it has none.
+  const auto list_for = [](const std::unordered_map<int,
+                                                    std::vector<size_t>>& m,
+                           int slot) -> const std::vector<size_t>* {
+    const auto it = m.find(slot);
+    return it == m.end() ? nullptr : &it->second;
+  };
+
   std::unordered_set<int> term_set(target_terms.begin(), target_terms.end());
 
   // Write-fusion renaming, done lazily. When a store region is fused, every
@@ -467,10 +505,8 @@ RerollStats reroll(Graph& g,
               const Pos& prod = pos[(size_t)ap.ins[1].producer_pos];
               if (prod.index_elision) {
                 const int base = op_at(ap.ins[1].producer_pos, 0).in[0];
-                auto wit = writers.find(base);
-                if (wit != writers.end())
-                  for (size_t u : wit->second)
-                    if (u >= region_end) written_after = true;
+                if (any_at_or_after(list_for(writers, base), region_end))
+                  written_after = true;
               }
             }
             if (clean) {
@@ -480,18 +516,13 @@ RerollStats reroll(Graph& g,
                 return u >= i && u < region_end &&
                        (u - i) % (size_t)P == (size_t)p;
               };
-              auto uit = uses.find(vec);
-              if (uit != uses.end())
-                for (size_t u : uit->second)
-                  if (u >= i && u < region_end && !in_region_write(u))
-                    clean = false;
-              auto wit = writers.find(vec);
-              if (wit != writers.end())
-                for (size_t u : wit->second) {
-                  if (u >= i && u < region_end && !in_region_write(u))
-                    clean = false;
-                  if (u >= region_end) written_after = true;
-                }
+              const std::vector<size_t>* vec_uses = list_for(uses, vec);
+              const std::vector<size_t>* vec_writers = list_for(writers, vec);
+              if (any_in_range_but(vec_uses, i, region_end, in_region_write) ||
+                  any_in_range_but(vec_writers, i, region_end, in_region_write))
+                clean = false;
+              if (any_at_or_after(vec_writers, region_end))
+                written_after = true;
             }
             if (!clean || br_run < Luse) {
               ok = false;

--- a/tests/test_reroll.cpp
+++ b/tests/test_reroll.cpp
@@ -697,15 +697,19 @@ int count(const Graph& g, uint16_t oc) {
 // (the real model: 32,877 iterations, 52 s and 49 GB to compile, which
 // OOM-killed every CI runner).
 //
-// Space is linear now and time is not. Measured on this shape, one
-// doubling of n costs 2.0x memory and 3.8x time -- so the fix removed
-// the quadratic term from the allocation and left a quadratic term in
-// the work, about 13x smaller than it was: n=32,000 is 350 MB and 4 s.
-// That is why the guard below is a memory ceiling and a scaling ratio
-// rather than the wall-clock budget it used to be. A budget cannot work
-// here: the gap between the bug and the fix is 13x, CI's slowest runner
-// is 9x slower than its fastest, and the two overlap. The old budget
-// duly failed a commit that touched nothing but an unrelated directory.
+// Both are linear now, but they were fixed in two separate goes: the
+// lazy renaming took the quadratic term out of the allocation and left
+// one in the work, which stood for a while because nothing measured it
+// (n=32,000 was 350 MB and 4 s). Binary search over the sorted use and
+// writer lists in reroll.cpp took out the second: 0.2 s at that size.
+//
+// The guards below are a memory ceiling and a scaling ratio rather than
+// the wall-clock budget this test used to carry. A budget cannot work
+// here. The gap between a regression and a fix is around 13x, CI's
+// slowest runner is 9x slower than its fastest, and those two overlap --
+// the old budget duly failed a commit that touched nothing but an
+// unrelated directory. A ratio and an RSS figure mean the same thing on
+// every machine.
 namespace ldashape {
 
 struct Built {
@@ -806,10 +810,10 @@ static double time_lda_reroll(int n) {
 }
 
 static void test_lda_shape_cost() {
-  const double small = time_lda_reroll(4000);
-  const double big = time_lda_reroll(8000);
+  const double small = time_lda_reroll(8000);
+  const double big = time_lda_reroll(16000);
   const double rss = peak_rss_mb();
-  std::printf("  lda shape reroll: n=4000 %.2f s, n=8000 %.2f s (%.1fx),"
+  std::printf("  lda shape reroll: n=8000 %.2f s, n=16000 %.2f s (%.1fx),"
               " peak RSS %.0f MB\n",
               small, big, small > 0.0 ? big / small : 0.0, rss);
 
@@ -818,14 +822,15 @@ static void test_lda_shape_cost() {
   // thing on every machine. This is the whole process's peak, so it
   // counts every case that ran before this one -- an over-estimate,
   // which is the safe direction. All of them together reach under
-  // 100 MB; the same shape under the quadratic-space bug would be around
-  // 2.9 GB, so 1 GB separates them with room on both sides.
+  // 200 MB; the same shape under the quadratic-space bug would be around
+  // 12 GB at n=16000, so 1 GB separates them with room on both sides.
   if (rss > 0.0) expect("lda reroll space stays linear", rss < 1024.0);
 
-  // Time is quadratic and this only catches a fall to something worse.
-  // A doubling costs 4x at quadratic and 8x at cubic; 5x sits between
-  // them and does not depend on how fast the machine is.
-  expect("lda reroll time no worse than quadratic", big < 5.0 * small);
+  // Time is linear with a log factor: a doubling measures about 2.1x
+  // here and 2.0x asymptotically, against 4x for the quadratic scan this
+  // replaced. 3x sits between them, and being a ratio it does not depend
+  // on how fast the machine is.
+  expect("lda reroll time stays near-linear", big < 3.0 * small);
 }
 
 static void test_write_fusion() {


### PR DESCRIPTION
Follow-up to #35, which found that this pass was still quadratic in time and said so rather than burying it.

## Finding the term

Every scrap of the pass's work, counted against n. Each counter doubles exactly when n doubles — except one, which quadruples:

| n | position | period | lanestep | match | classify | **uselist** |
|---|---|---|---|---|---|---|
| 1000 | 2,002 | 38,015 | 32,004 | 111,854 | 1,002 | **11,075,935** |
| 2000 | 4,002 | 76,015 | 64,004 | 223,854 | 2,002 | **44,151,935** |
| 4000 | 8,002 | 152,015 | 128,004 | 447,854 | 4,002 | **176,303,935** |
| 8000 | 16,002 | 304,015 | 256,004 | 895,854 | 8,002 | **704,607,935** |
| 16000 | 32,002 | 608,015 | 512,004 | 1,791,854 | 16,002 | **2,817,215,935** |
| 32000 | 64,002 | 1,216,015 | 1,024,004 | 3,583,854 | 32,002 | **11,266,431,935** |

11.3 **billion** list steps at n=32,000, against 3.6 million for the scanner, matcher and classifier put together. Not the region-finding logic at all — I had assumed the matcher, and the counters said otherwise.

## The cause

Three scans over `uses[vec]`, `writers[vec]` and `writers[base]`. `ldaK5` refills one shared gamma vector from every one of its N iterations, so those lists are N long, and each of the N regions walked all of both. The lazy renaming that this pass is famous for took the quadratic term out of the **allocation** and left this one in the **work**, where nothing measured it.

## The fix

Every question asked of those lists is a range question — *is anything in `[i, region_end)`*, *is anything at or past `region_end`* — and both lists are built by walking op indices upwards, so both are **already sorted**. Binary search answers the same questions from the same lists and reaches the same decisions; it just stops reading entries that cannot matter. In-range entries are still visited, but regions are disjoint, so that total is bounded by the list sizes.

O(n²) → O(n log n), and it is 20 lines.

## Measured

| n | before | after | |
|---|---|---|---|
| 8000 | 0.275 s | 0.047 s | |
| 16000 | 1.035 s | 0.094 s | |
| 32000 | 3.961 s | 0.205 s | **19×** |
| 64000 | (~16 s) | 0.435 s | |
| ratio/doubling | 3.83 | 2.1 | |

On the real model — `ldaK5` over posteriordb's `prideprejudice_chapter`, compile through gradient — **4.54–4.92 s → 0.49–0.51 s, about 9×**.

## Nothing it decides changes

The corpus oracle is the evidence: **119/119 models still within 1e-9 of the CmdStan references, worst case identical to the digit** (`hmm_gaussian` 3.63e-12, 35180 ulp). Same number before and after, not merely a passing threshold. 33/33 ctest.

## The test now asserts the truth

`test_lda_shape_cost` previously said "no worse than quadratic" at a 5× ratio, because quadratic was the truth. It now asserts near-linear at 3×, which sits between this pass's 2.1× and the 4× it replaced. Measured at 8000/16000 rather than 4000/8000: the numbers are big enough there that timer noise does not move the ratio (six consecutive runs gave 2.3× on the nose).

The memory ceiling is unchanged and still the primary guard — memory is what OOM-killed CI runners originally, and an RSS figure means the same thing on every machine where a wall-clock budget does not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UzowbPAusKosD6Wr3srcdT
