### PR TITLE
docs: shorten and simplify, fix stale claims

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,46 +25,41 @@ different binding, so a model samples to the same draws from any of them.
 | **Browser / Node** | `npm install @seantalts/stanli` | [js/README.md](js/README.md), [npm](https://www.npmjs.com/package/@seantalts/stanli) |
 
 The R package is not on CRAN yet; until it is, install it from
-[r-universe](https://seantalts.r-universe.dev) or from a checkout --
-see [r/README.md](r/README.md). It is the one binding that downloads its
-runtime rather than bundling it, because CRAN will not carry a 16 MB
-binary and could not build one on their farm.
+[r-universe](https://seantalts.r-universe.dev) or from a checkout (see
+[r/README.md](r/README.md)). It downloads its runtime on first use
+rather than bundling it, because CRAN will not carry a 16 MB binary and
+could not build one on their farm.
 
-- Performance vs CmdStan: [docs/benchmarks.md](docs/benchmarks.md)
-  (median gradient <!--gen:corpus_median-->2.07x<!--/gen--> across
+- Performance vs CmdStan: [docs/benchmarks.md](docs/benchmarks.md).
+  Median gradient <!--gen:corpus_median-->2.07x<!--/gen--> across
   <!--gen:corpus_n_grad-->119<!--/gen--> posteriordb models,
   <!--gen:corpus_at_par-->93<!--/gen--> of them at or above CmdStan;
-  <!--gen:bench_span-->1.0x-6.1x<!--/gen--> on the vectorized shapes that
-  suit it best; time-to-first-draw ~20x faster)
-- Model coverage: [docs/corpus-status.md](docs/corpus-status.md)
-  (<!--gen:corpus_verified-->118/120<!--/gen--> posteriordb models
-  differentially verified against CmdStan's log_prob and full gradient,
-  <!--gen:corpus_bitwise-->45<!--/gen--> of them bitwise identical, worst
-  relative deviation <!--gen:corpus_worst-->2.6e-12<!--/gen-->; per-model
-  accuracy in relative terms and ULPs is listed there)
-- Install size: one 22.2 MB shared library, a 7.8 MB wheel. Breakdown
-  in [Binary size](#binary-size) below; the browser build halves the
-  runtime with `STANLI_LITE_LP` ([docs/lite-lp.md](docs/lite-lp.md)).
-- Distribution coverage: [docs/coverage.md](docs/coverage.md) (71 of 72
+  <!--gen:bench_span-->1.0x-6.1x<!--/gen--> on vectorized shapes;
+  time-to-first-draw about 20x faster.
+- Model coverage: [docs/corpus-status.md](docs/corpus-status.md).
+  <!--gen:corpus_verified-->118/120<!--/gen--> posteriordb models
+  verified against CmdStan's log density and full gradient,
+  <!--gen:corpus_bitwise-->45<!--/gen--> of them bitwise identical,
+  worst relative deviation <!--gen:corpus_worst-->2.6e-12<!--/gen-->.
+- Distribution coverage: [docs/coverage.md](docs/coverage.md). 71 of 72
   densities, 90 of 105 cdf/lcdf/lccdf, truncation, censoring, ordinal
-  regression and the count GLMs; every one bitwise against CmdStan, and
-  what is missing says why)
+  regression and the count GLMs, each bitwise against CmdStan.
+- Install size: one 22.2 MB shared library, a 7.8 MB wheel. Breakdown in
+  [Binary size](#binary-size).
 - How this is possible, for statisticians:
   [docs/how-it-works.md](docs/how-it-works.md)
+- Contributor map: [docs/hacking.md](docs/hacking.md)
 - Design doc: `docs/superpowers/specs/2026-08-04-stan-portable-runtime-design.md`
 
 ## Architecture
 
-For a contributor's file-by-file map and the how-to-add-a-function
-recipe, see [docs/hacking.md](docs/hacking.md).
-
 The premise: a Stan model does not need machine code generated for it.
 Every model is a composition of a fixed vocabulary of operations
-(densities, constraint transforms, linear algebra, elementwise math), so
-stanli ships those operations precompiled and turns each model into data:
-a static graph of ops over flat buffers, built at load time and executed
-by a small interpreter. There is no JIT and no C++ codegen; "compiling" a
-model takes milliseconds.
+(densities, constraint transforms, linear algebra, elementwise math).
+stanli ships those operations precompiled and turns each model into
+data: a static graph of ops over flat buffers, built at load time and
+run by a small interpreter. There is no JIT and no C++ codegen;
+"compiling" a model takes milliseconds.
 
 ```
 model.stan + data.json
@@ -79,213 +74,130 @@ op graph + preallocated value/adjoint arenas
 NUTS (stan::mcmc::adapt_diag_e_nuts) -> draws
 ```
 
-Stage by stage:
+1. **stanc3, in process.** The official Stan compiler (OCaml) is built
+   as a self-contained object and linked into the shared library. It
+   parses, typechecks, and optimizes the model; stanli consumes its
+   transformed MIR. Full language fidelity without a subprocess or a
+   reimplemented parser.
 
-1. **stanc3, in process.** The real Stan compiler (OCaml) is compiled to
-   a self-contained object (`-output-complete-obj`) and linked into the
-   shared library. It parses, typechecks, and optimizes the model, and
-   stanli consumes its transformed MIR directly. Full language fidelity
-   without a subprocess or a vendored parser rewrite.
-
-2. **Lowering** (`runtime/src/lower.cpp`). A compile-time interpreter
-   walks the MIR against the actual data: transformed data is evaluated
+2. **Lowering** (`runtime/src/lower.cpp`). Transformed data is evaluated
    eagerly, loops with data-known bounds are unrolled, and the model
-   block flattens into a linear sequence of ops reading and writing
-   preallocated arenas. `~` statements lower to the same propto +
-   per-argument-activity instantiations CmdStan's generated C++ uses, so
-   dropped constants and skipped data partials match exactly. The one
-   user function that cannot be inlined is an ODE right-hand side --
-   the integrator picks the times, so it has to stay callable at
-   runtime -- and that compiles instead into a flat register machine
-   (`runtime/src/ode_prog.cpp`), which is worth 29-39x on the models
-   that use one.
+   block flattens into a linear op sequence over preallocated arenas.
+   `~` statements lower to the same propto and per-argument-activity
+   instantiations CmdStan's generated C++ uses, so dropped constants
+   match exactly. The one user function that cannot be inlined is an ODE
+   right-hand side (the integrator picks the times), and it compiles
+   into a flat register machine (`runtime/src/ode_prog.cpp`) instead.
 
-3. **Graph passes** (`runtime/src/reroll.cpp` and friends; a
-   plain-language guide to all of them is in
-   [runtime/src/OPTIMIZATIONS.md](runtime/src/OPTIMIZATIONS.md)).
-   Unrolling is what makes
-   the graph concrete, but a model written as a per-observation loop
-   arrives as N copies of one small op template, and the interpreter's
-   cost is per op. This pass finds those periodic regions and rewrites
-   them into the vectorized ops the kernels already support: constant
-   vectors materialized from the const pool, invariant ops hoisted,
-   elementwise lanes widened, index progressions collapsed into their
-   base vector, and N scalar density terms fused into one summed vector
-   density. `radon_pooled` goes from 27,670 ops to 8. Whatever the pass
-   cannot prove safe it leaves alone, one region at a time.
-   `STANLI_NO_REROLL=1` disables it.
+3. **Graph passes** (`runtime/src/reroll.cpp` and friends; plain-language
+   guide in [runtime/src/OPTIMIZATIONS.md](runtime/src/OPTIMIZATIONS.md)).
+   A model written as a per-observation loop arrives as N copies of one
+   small op template, and the interpreter's cost is per op. The passes
+   rewrite those regions into the vectorized ops the kernels already
+   support: constants become vectors, invariant ops hoist, indexed reads
+   become gathers, and N scalar density terms fuse into one summed
+   vector density. `radon_pooled` goes from 27,670 ops to 8. Anything a
+   pass cannot prove safe it leaves alone. `STANLI_NO_REROLL=1` disables
+   the main pass.
 
 4. **Execution** (`runtime/src/executor.cpp`). The op graph is the AD
    tape. The forward sweep computes the log density and stashes each
-   op's partials in per-op scratch; the reverse sweep runs the ops
-   backward, contracting adjoints. Steady-state gradient evaluation
-   performs zero allocation, which is where the speedup over the
-   pointer-chasing var tape comes from.
+   op's partials; the reverse sweep runs the ops backward, contracting
+   adjoints. Steady-state gradient evaluation allocates no memory.
 
 5. **Kernels** (`runtime/kernels/`). Two tiers behind one interface.
-   Native kernels are hand-written forward/backward pairs that mirror
-   the exact Eigen expressions of stan-math's rev overloads, so
-   gradients match CmdStan bitwise (FP contraction pinned off
-   project-wide). Everything else runs as a "legacy" op: a recorder
-   scalar (`rvar`, a registered stan-math scalar type) or a nested var
-   tape replay drives unmodified stan-math prim/prob templates and
-   deposits values and partials into the caller's buffers. Legacy ops
-   make the whole library expressible; native kernels make the hot path
-   fast. Both are compiled once, when the stanli binary is built.
+   Native kernels mirror the exact Eigen expressions of stan-math's rev
+   overloads, so gradients match CmdStan bitwise (FP contraction pinned
+   off project-wide). Everything else runs as a "legacy" op: a recorder
+   scalar or a nested var tape drives unmodified stan-math templates.
+   Legacy ops make the whole library expressible; native kernels make
+   the hot path fast. Both compile once, when stanli is built.
 
 6. **Sampling** (`runtime/src/nuts.cpp`). Stan's own NUTS with
-   diagonal-metric adaptation, driven through a thin model adapter that
-   returns one precomputed-gradients vari per evaluation.
+   diagonal-metric adaptation, driven through a thin model adapter.
 
-7. **Writing draws.** The log_prob graph deliberately does not compute
-   transformed parameters the target never reads, and never sees
-   generated quantities at all, so a second graph does: the MIR's
-   `generate_quantities` section lowers, through the same machinery and
-   the same passes, into a forward-only graph that takes an unconstrained
-   draw and produces every CSV column CmdStan would write, in CmdStan's
-   order and under CmdStan's naming (`theta.1.1` for array elements,
-   column-major for matrices). 93 of the 119 compiling corpus models get
-   theirs in full; the rest stop at an RNG call or at generated
-   quantities that branch on a parameter, and emit the prefix that did
-   lower along with the reason they stopped
-   (`harnesses/wa_coverage.py`, `harnesses/wa_header_check.py`).
+7. **Writing draws.** A second, forward-only graph lowers the MIR's
+   `generate_quantities` section and produces every CSV column CmdStan
+   would write, in CmdStan's order and under CmdStan's naming. Models
+   the graph cannot express (RNG draws, branches on draw-computed
+   values) run through a per-draw interpreter instead
+   (`runtime/src/wa_interp.cpp`), so all 119 compiling corpus models
+   produce their full columns.
 
-8. **Distribution.** Everything above sits behind a C ABI
-   (`runtime/include/stanli/capi.h`) in one shared library; the Python
-   package is a ctypes wrapper around it. A platform wheel is one .whl
-   containing one dylib.
+8. **Distribution.** Everything sits behind a C ABI
+   (`runtime/include/stanli/capi.h`) in one shared library. Each binding
+   is a thin wrapper over it; a platform wheel is one .whl containing
+   one dylib.
 
 ## Binary size
 
 One self-contained shared library, 22.2 MB installed, 7.8 MB compressed
-in the wheel. Attributing its 21.9 MB of code and data by symbol:
+in the wheel. Attributed by demangled symbol:
 
 | | | |
 | --- | ---: | ---: |
 | densities and distribution functions | 12.03 MB | 54.9% |
 | embedded stanc3 (all OCaml) | 5.73 MB | 26.1% |
-| stan-math, everything else | 0.78 MB | 3.6% |
 | Boost, nlohmann/json, NUTS, libc++, unattributed | 1.61 MB | 7.3% |
 | stanli itself | 0.92 MB | 4.2% |
+| stan-math, everything else | 0.78 MB | 3.6% |
 | Eigen (out-of-line) | 0.71 MB | 3.3% |
 | SUNDIALS | 0.14 MB | 0.7% |
 
-The densities are the majority, and the split above is measured the same
-way as the rest of the table: by demangled symbol, with everything
-matching a `_lpdf`, `_lpmf`, `cdf`, `lcdf`, `lccdf` or `_rng` name
-counted against the first row rather than against stan-math generally.
-A distribution is instantiated once per activity mask -- which arguments
-are autodiff -- twice for propto and again for the elementwise form, so
-4 * 2^N templates per distribution, about 630 KB of object each. That is
-the standing cost of shipping precompiled math: CmdStan instantiates
-only the combination your model uses, and pays for it with a per-model
-compile.
+The densities dominate. A distribution is instantiated once per activity
+mask (which arguments are autodiff), twice for propto, and again for the
+elementwise form: `4 * 2^N` templates per distribution, about 630 KB of
+object each. That is the standing cost of shipping precompiled math;
+CmdStan instantiates only the combination your model uses and pays for
+it with a per-model compile. Each density chooses how much of that
+ladder to instantiate (`STANLI_SCALAR_DENSITY_LIST` in optable.hpp): the
+thirteen distributions models lean on take all of it, the long tail
+takes less, and the 72 distribution functions take one instantiation
+each.
 
-Each density picks how much of that ladder to instantiate
-(`STANLI_SCALAR_DENSITY_LIST` in optable.hpp). The thirteen distributions
-models lean on take the whole thing; the long tail takes less. The 72
-distribution functions (`cdf`/`lcdf`/`lccdf`, which is what truncation
-runs on) take the least -- one instantiation each -- and that choice was
-measured: giving the common ones the mask dispatch cost 4.8 MB on its
-own, against 2.2 MB for the whole family without it. The 34 scalar math
-functions cost 0.03 MB between them, because an elementwise kernel with a
-hand-written derivative instantiates nothing.
+`-DSTANLI_LITE_LP=ON` drops the propto family: the library is 48%
+smaller and every gradient stays bitwise, but `lp__` differs from
+CmdStan's by a per-model constant. It is **off by default in every
+build, browser included**, so any run can be compared against CmdStan
+directly; `stanli_exact_lp()` reports which build is loaded. See
+[docs/lite-lp.md](docs/lite-lp.md).
 
-**`-DSTANLI_LITE_LP=ON` halves the runtime.** Dropping the propto family
-entirely takes `libstanli` from 15.8 MB to 8.4 MB stripped, at the cost
-of an `lp__` that differs from CmdStan's by a per-model constant. Every
-gradient stays bit-identical; a pinned seed draws a different but equally
-valid chain, because the sampler adds `lp` to the kinetic energy and a
-shifted `lp` rounds differently there. On by default for the browser
-build, off for the wheel, which keeps the exact `lp__` the differential
-oracle compares against. See [docs/lite-lp.md](docs/lite-lp.md).
-
-The interpreter and NUTS together are about 410 KB. Nearly all of the
-rest is the Stan compiler and the math library, which is the trade the
-design makes: ship every kernel and the compiler once so that nothing is
-built on the user's machine.
-
-Shrinking it further has been measured and declined: dead-code stripping
-cannot reach inside the OCaml object (96.4% of it is reachable from its
-entry points anyway), and compiling stanc3 to bytecode saves 3.7 MB at
-the cost of ~8x slower model compilation.
+The interpreter and NUTS together are about 410 KB. Shrinking further
+was measured and declined: dead-code stripping cannot reach inside the
+OCaml object, and compiling stanc3 to bytecode saves 3.7 MB at the cost
+of about 8x slower model compilation.
 
 ### The browser build
 
-A different binary with different economics: no embedded stanc3, because
-the compiler ships separately as JavaScript. `stanli.wasm` is 5.79 MB raw
-and 1.52 MB gzipped.
-
-Where that goes, measured by stubbing every density, cdf and tail kernel
-and relinking:
-
-| | raw | gzip |
-| --- | ---: | ---: |
-| core runtime | 2.26 MB | 0.69 MB |
-| densities and distribution functions | 3.53 MB | 0.83 MB |
-
-Densities are 55% of the compressed download. Loading the uncommon ones
-on demand was built and removed; the measurements and the one emscripten
-limitation that blocks it are in
-[docs/density-pack.md](docs/density-pack.md). `densities.cpp` is also the
-one file the browser build compiles at `-Oz` rather than `-O3`, worth
-8.5 MB of wasm and about 10% on a mixture model.
-
-stanc3 as JavaScript is a separate 2.84 MB, 0.40 MB gzipped, and a page
-that ships precompiled MIR never fetches it.
-
-The browser build reports the same `lp__` as the wheels.
-`STANLI_LITE_LP` used to default on here, which halved the download and
-shifted `lp__` by a per-model constant; it is off everywhere now, so a
-browser run and a CmdStan run can be compared directly.
-`stanli_exact_lp()` still reports which build is loaded, for anyone who
-turns the flag back on. See [docs/lite-lp.md](docs/lite-lp.md).
+A different binary: no embedded stanc3, because the compiler ships
+separately as JavaScript (2.84 MB, 0.40 MB gzipped; a page that ships
+precompiled MIR never fetches it). `stanli.wasm` is 5.79 MB raw and
+1.52 MB gzipped, and densities are 55% of the compressed payload
+(measured by stubbing every density kernel and relinking). Loading the
+uncommon densities on demand was built and removed; the measurements and
+the emscripten limitation that blocks it are in
+[docs/density-pack.md](docs/density-pack.md).
 
 ## Python
 
-A ctypes wrapper over the same shared library, published to PyPI as one
-platform wheel per platform.
-
-```
-pip install stanli                 # or: ./tools/build_wheel.sh
-```
+A ctypes wrapper over the shared library, published to PyPI as one
+platform wheel per platform. Full documentation in
+[python/README.md](python/README.md).
 
 ```python
 import stanli
 m = stanli.Model(stan_file="model.stan", data={"J": 8, "y": y, "sigma": s})
 fit = m.sample(seed=1, chains=4, warmup=1000, samples=1000)
 fit["mu"].mean()          # every draw, chains concatenated
-fit.draws("mu")           # (chains, draws), for a trace plot
 print(fit.summary())      # stansummary's table
 print(fit.diagnose())     # the convergence checks, in words
-fit.to_arviz()            # if you have arviz
 ```
 
-Four chains by default, run in parallel, because R-hat needs more than
-one and a single-chain run cannot be checked for convergence at all.
-Eight schools takes about 70 ms for all four. Threading changes nothing
-about the answer: each chain owns its executor and its RNG stream, so
-the draws are byte-identical to a sequential run.
-
-`summary()` reports rank-normalized split-R-hat with bulk and tail ESS
-and MCSE -- stan's own estimators, so the numbers agree with
-`stansummary`. `diagnose()` runs the checks a Bayesian workflow actually
-turns on: divergent transitions, max-treedepth saturation, **E-BFMI**,
-R-hat, and bulk/tail ESS, each either confirmed or reported with the
-number that failed and what to do about it.
-
-```
-No divergent transitions.
-No transitions saturated the maximum treedepth of 10.
-E-BFMI is above 0.3 in every chain.
-R-hat is below 1.01 for every parameter (worst 1.002, theta.6).
-Bulk ESS is at least 100 per chain for every parameter (worst 2160, tau).
-Tail ESS is at least 100 per chain for every parameter (worst 1874, tau).
-No problems detected.
-```
-
-Builds without the embedded stanc3 object fall back to running a bundled
-stanc binary as a subprocess.
+Four chains by default, run in parallel. Threading does not change the
+answer: each chain owns its executor and its RNG stream, so the draws
+are byte-identical to a sequential run. Builds without the embedded
+stanc3 object fall back to running a bundled stanc binary as a
+subprocess.
 
 ## R
 
@@ -298,55 +210,34 @@ stanli_install()   # one time: fetches the runtime for this platform
 
 m <- stanli_model(file = "eight_schools.stan", data = list(J = 8L, y = y, sigma = s))
 fit <- sample_model(m, chains = 4, seed = 1)
-
 summary(fit)          # mean, MCSE, sd, quantiles, bulk/tail ESS, R-hat
-stanli_diagnose(fit)  # divergences, treedepth, E-BFMI, R-hat, ESS
-as_draws_array(fit)   # a posterior::draws_array
 ```
 
-Two pieces are not in the package, for two different reasons, and both
-are what make it a package CRAN can carry at all.
-
-The **runtime** is downloaded on first use into the user cache
-directory, the way torch fetches libtorch: CRAN builds its own binaries
-from source and would have to compile stan-math, every density kernel
-and an OCaml compiler to produce one. `stanli_install()` is explicit and
-nothing is fetched without it. The release workflow publishes the five
-platform libraries as release assets, and the package pins the release
-it was built against rather than tracking whichever is newest.
-
-The **Stan compiler** is stanc3 compiled to JavaScript and run through
-V8 -- the same approach rstan uses. It is one 2.8 MB file that
-compresses to 0.4 MB in the source tarball, with no toolchain and no
-per-platform binaries. Where the runtime embeds stanc3 (every release
-build but Windows) that path is used instead and V8 never loads.
-`tests/test_stancjs.cjs` checks that the JavaScript compiler emits the
-same MIR as the native binary, byte for byte.
-
-Because the binding and the runtime are separately versioned artifacts,
-the C ABI carries a layout version (`stanli_abi_version()`) and the
-bridge refuses to bind a runtime that disagrees with the one it was
-compiled against. Reading `stanli_sample_opts` at the wrong offsets
-would not fail: it would sample successfully from the wrong seed.
+The runtime is downloaded on first use because CRAN cannot build or
+carry it; `stanli_install()` is explicit and pins the release the
+package was built against. The Stan compiler is stanc3 compiled to
+JavaScript, run through V8 (rstan's approach) when the runtime does not
+embed it. Because binding and runtime are separately versioned, the C
+ABI carries a layout version (`stanli_abi_version()`) and the bridge
+refuses a runtime that disagrees; reading the options struct at wrong
+offsets would not crash, it would sample from the wrong seed.
 
 ## Browser (WASM)
 
 The same runtime compiles to WebAssembly and runs full Stan in a browser
-tab with no server: **[seantalts.github.io/stanli](https://seantalts.github.io/stanli/)**.
-stanc3's js_of_ocaml build compiles the model to MIR in JS, and
-stanli.wasm lowers it and samples. Eight schools goes from
-Stan source to 1,000 posterior draws in about 120 ms in-tab. 118 of the
-119 compiling corpus models replay against the CmdStan references from
-inside WASM (`tools/wasm_check.sh` adapts `verify_refs.py`; the one
-exception is `nn_rbm1bJ100`, whose compile does not fit in wasm32's 4 GB).
+tab with no server:
+**[seantalts.github.io/stanli](https://seantalts.github.io/stanli/)**.
+stanc3's js_of_ocaml build compiles the model to MIR in JS; stanli.wasm
+lowers it and samples. Eight schools goes from source to 1,000 draws in
+about 120 ms in-tab. 118 of the 119 compiling corpus models replay
+against the CmdStan references from inside WASM (`tools/wasm_check.sh`;
+the exception is `nn_rbm1bJ100`, whose compile does not fit in wasm32's
+4 GB).
 
 ```
 ./tools/build_web.sh              # emsdk + opam builds, assembled in web/
 python3 -m http.server -d web     # then open http://localhost:8000
 ```
-
-Needs `deps/emsdk` (see tools/build_web.sh) and, for the stanc side, the
-same opam switch that builds the embedded compiler.
 
 ## Build
 
@@ -372,162 +263,110 @@ ctest --test-dir build
 
 `.github/workflows/wheels.yml` builds all five wheels (macOS arm64 and
 x86_64, manylinux_2_28 x86_64 and aarch64, Windows x86_64). The first
-four run on every push and pull request, so the release path is the path
-that is already exercised continuously; Windows runs after the merge and
-nightly, because mingw compiles the density kernels slowly enough to set
-the pace of every merge on its own. A release tag runs all five, and the
-publish job waits for them.
-Each build links the embedded stanc3 object (cached, since it takes half
-an hour to produce), runs the test suite, checks that the platform tag
-matches what the library actually requires, and installs the wheel into a
-clean venv to sample eight schools.
+four run on every push and pull request; Windows runs after the merge
+and nightly, because mingw compiles the density kernels slowly enough to
+set the pace of every merge. A release tag runs all five, and the
+publish job waits for them. Each build links the cached embedded stanc3
+object, runs the test suite, checks the platform tag, and samples eight
+schools from the installed wheel in a clean venv.
 
 To cut a release: bump `__version__` in `python/stanli/__init__.py` (the
-one place it lives; `setup.py` and the workflow both read it from there),
-add the entry to `CHANGELOG.md`, then tag. The publish job fires only on
-`refs/tags/v*`, asserts the tag agrees with the packaged version, and
-uploads through PyPI trusted publishing, so no API token exists anywhere
-in the repo or its secrets. The `pypi` deployment environment is
-restricted to `v*` tags as a second lock on that.
+one place it lives), add a `CHANGELOG.md` entry, then tag. The publish
+job fires only on `refs/tags/v*`, asserts the tag matches the packaged
+version, and uploads through PyPI trusted publishing; no API token
+exists anywhere in the repo. The `pypi` deployment environment is
+restricted to `v*` tags as a second lock.
 
 ```
 git tag -a v0.1.0 -m "stanli 0.1.0" && git push origin v0.1.0
 ```
 
-No sdist is published. Building from source needs a 30-minute OCaml
+No sdist is published: building from source needs a 30-minute OCaml
 toolchain step, so an sdist would only turn "no wheel for your platform"
 into a confusing build failure.
 
 The npm package `@seantalts/stanli` ships the same way on its own tag
-series. Bump `version` in `js/package.json`, add the `CHANGELOG.md` entry,
-then tag `npm-vX.Y.Z`. The `npm-publish` job asserts the tag agrees with
-`package.json`, takes the `stanli.wasm` the `wasm` job built for that
-commit plus the cached release stancjs, and publishes through npm trusted
-publishing, again with no token anywhere; the `npm` deployment environment
-is restricted to `npm-v*` tags.
-
-```
-git tag -a npm-v0.1.0 -m "stanli npm 0.1.0" && git push origin npm-v0.1.0
-```
-
-Two things about npm differ from PyPI and are worth knowing before the
-next name or the next first release. npm has no pending publisher: a
-trusted publisher attaches only to a package that already exists, so the
-first version of a package goes out by hand with `npm publish` and every
-release after that is a tag. And the package is scoped because npm's
-name-similarity filter rejects the unscoped `stanli` as too close to
-existing packages, which is why `publishConfig.access` is set to public
-(a scoped package would otherwise default to a private publish).
+series: bump `version` in `js/package.json`, add the changelog entry,
+tag `npm-vX.Y.Z`. The `npm-publish` job asserts the tag matches
+`package.json` and publishes through npm trusted publishing. Two npm
+quirks worth knowing: a trusted publisher attaches only to a package
+that already exists, so a package's first version goes out by hand with
+`npm publish`; and the package is scoped because npm's name-similarity
+filter rejects unscoped `stanli`, which is why `publishConfig.access` is
+set to public.
 
 ### R
 
-The same `v*` tag publishes the R side, in the `runtime-release` job.
-It attaches to the GitHub Release:
-
-- five runtime tarballs, `stanli-runtime-{darwin,linux,windows}-{arm64,x86_64}.tar.gz`,
-  each the same `_bin/` the wheel for that platform ships. This is what
-  `stanli_install()` downloads, so the release **is** the R package's
-  distribution channel for everything except the R code itself.
-- `stanli_X.Y.Z.tar.gz`, the R source package.
-
-The job asserts `stanli_runtime_release` in `r/R/install.R` equals the
-tag being cut. The package pins that release rather than tracking
-`latest` on purpose: a CRAN-requested documentation fix bumps the
-package version without a runtime release, and a floating default would
-quietly pair an old binding with a new library. Bump the pin in the same
-commit as the version.
+The same `v*` tag publishes the R side (`runtime-release` job). It
+attaches to the GitHub Release five runtime tarballs
+(`stanli-runtime-{darwin,linux,windows}-{arm64,x86_64}.tar.gz`, what
+`stanli_install()` downloads) plus `stanli_X.Y.Z.tar.gz`, the R source
+package. The job asserts `stanli_runtime_release` in `r/R/install.R`
+equals the tag: the package pins its runtime release on purpose, so bump
+the pin in the same commit as the version.
 
 Bumping `STANLI_ABI_VERSION` in `runtime/include/stanli/capi.h` means
-bumping `STANLI_R_ABI_VERSION` in `r/src/bridge.c` too; `.github/workflows/r.yml`
-fails if they disagree. Bump it whenever a struct in the C ABI gains,
-loses or reorders a field, or a function changes signature -- adding a
-new function does not need one.
+bumping `STANLI_R_ABI_VERSION` in `r/src/bridge.c` too; `r.yml` fails if
+they disagree. Bump it when a C ABI struct changes layout or a function
+changes signature; adding a function does not need one.
 
-Two distribution channels, and neither is fully hands-off in the same
-way PyPI and npm are:
+Two R distribution channels:
 
-**r-universe** builds from this repository continuously, so every push
-to main becomes an installable binary for Linux, macOS and Windows with
-no tag and no action here. It needs a one-time registry entry: a
-`packages.json` in `seantalts/seantalts.r-universe.dev` with
-`{"package": "stanli", "url": "https://github.com/seantalts/stanli", "subdir": "r"}`.
-Users then install with
+- **r-universe** builds from this repository continuously; every push to
+  main becomes an installable binary with no tag. It needs a one-time
+  registry entry in `seantalts/seantalts.r-universe.dev`.
+- **CRAN** cannot be automated by policy: a submission is a web-form
+  upload confirmed by email. `r.yml` runs `R CMD check --as-cran` on
+  every change under `r/`; a CRAN release is then bump `Version:` in
+  `r/DESCRIPTION` plus the runtime pin, tag, download the tarball from
+  the release, and upload it at
+  [cran.r-project.org/submit.html](https://cran.r-project.org/submit.html).
 
-```r
-install.packages("stanli", repos = "https://seantalts.r-universe.dev")
-```
-
-**CRAN** cannot be automated, and that is policy rather than a missing
-feature: a submission is a file uploaded to a web form and confirmed
-through a link mailed to the maintainer address, specifically so a
-machine cannot do it. What CI can do it does -- `.github/workflows/r.yml`
-runs `R CMD check --as-cran` on Linux, macOS, Windows and R-devel on
-every change under `r/`, and the release job builds the tarball. Cutting
-a CRAN release is then: bump `Version:` in `r/DESCRIPTION` and the
-runtime pin, tag, download `stanli_X.Y.Z.tar.gz` from the release, and
-upload it at
-[cran.r-project.org/submit.html](https://cran.r-project.org/submit.html).
-
-The sampling tests do not run in `r.yml`, because it has no runtime --
-which is the honest simulation of CRAN's farm. They run in `wheels.yml`,
-against the Linux library that build produced, and that job fails if
-they skip.
+The R sampling tests run in `wheels.yml` against the Linux library that
+build produced (and fail if skipped); `r.yml` has no runtime, which is
+an honest simulation of CRAN's farm.
 
 ## Verification policy
 
 Nothing ships on "looks close". Kernel gradients are bitwise-tested
 against stan-math's var path at fixed points; whole models are
-differentially verified against CmdStan (same generated model, same
-deterministic evaluation point, `tools/verify_sample.py`). The corpus
-scoreboard (`tools/corpus.py`) tracks which posteriordb models compile,
-evaluate, and verify. Details in
-[docs/corpus-status.md](docs/corpus-status.md).
+differentially verified against CmdStan at the same deterministic
+evaluation point (`tools/verify_sample.py`). The corpus scoreboard
+(`tools/corpus.py`) tracks which posteriordb models compile, evaluate,
+and verify. Details in [docs/corpus-status.md](docs/corpus-status.md).
 
 ## Status
 
-26/26 tests green, built and tested in CI on macOS (arm64, x86_64) and
-manylinux (x86_64, aarch64). 119/120 posteriordb models compile and
-evaluate, <!--gen:corpus_verified_n-->118<!--/gen--> of them
-CmdStan-verified. Of the two that are not: `sir`'s
-ODE solution dips ~1e-9 below a declared lower bound at every shared
-evaluation point and CmdStan rejects it there too, and `kronecker_gp`
-matches on lp and 436 of 438 gradients but differs on the two that flow
-through eigenvectors of a nearly degenerate covariance (see the note in
-the corpus status).
+Built and tested in CI on macOS (arm64, x86_64) and manylinux (x86_64,
+aarch64). 119/120 posteriordb models compile and evaluate,
+<!--gen:corpus_verified_n-->118<!--/gen--> of them CmdStan-verified. Of
+the two that are not: `sir`'s ODE solution dips about 1e-9 below a
+declared lower bound at every shared evaluation point and CmdStan
+rejects it there too, and `kronecker_gp` matches on lp and 436 of 438
+gradients, differing on the two that flow through eigenvectors of a
+nearly degenerate covariance (see the note in the corpus status).
 
 ## Roadmap
 
-What it would take to displace CmdStan rather than out-run it on a
-corpus, in order, is written up in
+The path to displacing CmdStan rather than out-running it on a corpus is
+written up in
 [docs/superpowers/plans/2026-08-08-cmdstan-parity-roadmap.md](docs/superpowers/plans/2026-08-08-cmdstan-parity-roadmap.md):
 multi-chain and diagnostics (done), the missing parameter transforms
 (done), the modern `ode_*` and solver interfaces, Pathfinder and
 optimize, a native adjoint program for the sequential tail
 ([design](docs/superpowers/plans/2026-08-08-native-adjoint-program.md)),
-`reduce_sum`, and the R/brms and browser packaging. The engine-level
-items below are the ones that predate it.
+`reduce_sum`, and the R/brms and browser packaging.
 
-1. Fusing adjacent elementwise chains into one pass over the arena --
-   the follow-on now that the re-roll pass covers the mixture shape
-   (density lanes feeding `log_mix`/`log_sum_exp` instead of the target
-   fuse into an elementwise-lp density variant plus batched mixture
-   kernels) and tape islands compile the leftover scalar residue into
-   single ops where that is measurably cheaper than the ops.
-2. A CRAN shim package. All five wheels (macOS arm64/x86_64, Linux
-   x86_64/aarch64, Windows x86_64) are built and published by
-   `.github/workflows/wheels.yml` on a version tag. The Windows wheel is
-   built under mingw-w64 (stan-math does not build under MSVC) and
-   bundles the release `stanc.exe` as a subprocess instead of the
-   embedded compiler, which waits on opam's native Windows support.
+Engine-level items that predate it:
+
+1. Fusing adjacent elementwise chains into one pass over the arena, now
+   that the re-roll pass covers the mixture shape and tape islands
+   compile the leftover scalar residue.
+2. A CRAN shim package.
 3. Vectorized kernels via stan-math's varmat (SoA) overloads. Today the
    kernels mirror CmdStan's default AoS arithmetic, which is scalar for
-   transcendentals and reductions (strided var access defeats Eigen's
-   packet math). stan-math's `var_value<Matrix>` overloads compute over
-   contiguous doubles and vectorize, and `stanc --O1` already emits them
-   variable-by-variable where every use is varmat-compatible. The plan
-   follows the same shape: switch kernels to mirror the varmat
-   expressions function-by-function where the overload exists
-   (constrains, elementwise, matvec, the common densities), verify
-   differentially against `stanc --O1` CmdStan builds, and keep AoS
-   parity for the rest. Profile a large-N model first to size the win;
-   graph-level fusion of elementwise chains is the follow-on.
+   transcendentals and reductions. The plan: switch kernels to mirror
+   the varmat expressions function-by-function where the overload
+   exists, verify differentially against `stanc --O1` CmdStan builds,
+   and keep AoS parity for the rest. Profile a large-N model first to
+   size the win.

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -4,10 +4,10 @@
 -ffp-contract=off, single-threaded. Both engines evaluate the sampling
 gradient (propto + jacobian) at the same deterministic unconstrained
 point. stanli runs `tools/bench_grad.cpp`; CmdStan runs
-`tools/bench_cmdstan_grad.cpp` compiled against the stanc-generated
-header, looping the same fresh-vars + grad + recover_memory cycle
-`stan::model::gradient` performs per leapfrog step. Reproduce the whole
-table with `tools/bench_models.py deps/cmdstan deps/posteriordb`.
+`tools/bench_cmdstan_grad.cpp`, looping the same fresh-vars + grad +
+recover_memory cycle `stan::model::gradient` performs per leapfrog
+step. Reproduce the whole table with
+`tools/bench_models.py deps/cmdstan deps/posteriordb`.
 
 ## Per-gradient latency
 
@@ -40,203 +40,99 @@ this page.
 | `ldaK2` | 7 | 145,916 | 104,059 | 0.71x | 0.165 s |
 | `iohmm_reg` | 29 | 545,184 | 320,335 | 0.59x | 0.441 s |
 
-(The table has changed shape twice: `radon_county`, `election88_full`
-and `dogs` moved up with the write-fusion and constant-folding work, the
-mixtures crossed parity with the elementwise-lp fusion, and `iohmm_reg`
-climbed from 0.21x on the island pass. All three are described below.)
-
 ## Which models are faster, which are slower, and why
 
 Across the full corpus (`docs/corpus-bench.tsv`, 119 models with both
-gradients) the median per-gradient speedup is 2.07x and 93 of 119 models
-are at or above parity. The ratio is almost entirely predicted by the
-model's *shape*, not its size:
+gradients) the median per-gradient speedup is 2.07x and 93 of 119
+models are at or above parity. The ratio is predicted almost entirely
+by the model's *shape*, not its size.
 
 **Faster (most of the corpus, typically 1.5-6x):**
 
-- **Vectorized-statement models.** A `y ~ normal(X * beta, sigma)` or a
-  vectorized GLM over N observations is a handful of ops here; CmdStan
-  builds and walks N var-tape nodes per statement per leapfrog step. The
-  gap grows with N. This class is regressions, GLMs, and most
-  hierarchical models written with vectorized statements.
+- **Vectorized-statement models.** A `y ~ normal(X * beta, sigma)` over
+  N observations is a handful of ops here; CmdStan builds and walks N
+  var-tape nodes per statement per leapfrog step. The gap grows with N.
+  This class is regressions, GLMs, and most hierarchical models.
 - **Scalar loops the passes can vectorize.** The hierarchical indexing
-  idiom -- `y[n] ~ normal(mu[county[n]], sigma)` and loops that fill a
-  vector element by element -- arrives unrolled and is re-rolled back
-  into the class above (radon family up to 6.1x, `election88_full`
-  3.0x, `dogs` 2.8x). What the passes handle is described below.
-- **Everything, on preparation.** Lowering a model is 4-400 ms against
-  a ~7 s CmdStan compile, so short runs and iterative model development
+  idiom (`y[n] ~ normal(mu[county[n]], sigma)` and loops that fill a
+  vector element by element) arrives unrolled and is re-rolled back
+  into the class above: the radon family up to 6.1x, `election88_full`
+  3.0x, `dogs` 2.8x.
+- **Everything, on preparation.** Lowering takes 4-400 ms against a
+  ~7 s CmdStan compile, so short runs and iterative model development
   are dominated by this regardless of gradient speed.
 
-**Near parity (0.8-1.2x):**
-
-- **Models dominated by one large dense operation** -- a Cholesky, a big
-  matrix product, an eigendecomposition (the GP models). Both engines
-  spend their time inside the same stan-math kernel on the same
-  contiguous doubles; interpreter overhead is noise on top.
+**Near parity (0.8-1.2x):** models dominated by one large dense
+operation (a Cholesky, a big matrix product, the GP models). Both
+engines spend their time inside the same stan-math kernel; interpreter
+overhead is noise on top.
 
 **Slower (a shrinking tail, mostly 0.5-0.8x):**
 
-- **Sequential models.** HMM forward recursions, state-space and
-  ARMA/GARCH-style updates: each step reads the previous step's
-  parameter-dependent result, so re-rolling correctly refuses
-  (vectorizing a recurrence would change the math). The island pass
-  (below) compiles such a region into one op, but only helps when the
-  region's ops move real data: `iohmm_reg` copies a 1,500-element state
-  vector per step and went 0.21x to 0.59x, while on the scalar
-  recurrences the compiled form measured slower than the ops and the
-  pass now declines it. What is left for them is per-op dispatch
-  against CmdStan's inlined scalar code, and a native adjoint program
-  is what would change that.
-- **Mixture-shape models with K > 2 components** (`ldaK2`/`ldaK5`):
-  their inner `log_sum_exp` runs over K-vectors built per document, a
-  row-wise reduction the elementwise-lp fusion (below) does not yet
-  express. The binary-mixture case is closed.
-- **ODE models** were the extreme case (0.015x) when the right-hand
-  side was interpreted per call; with it compiled (below) they sit at
-  ~0.6x, the residue being our per-call dispatch against CmdStan's
-  fully inlined right-hand side inside the same CVODES solver.
-- **`Mtbh_model` (0.45x)**, now the slowest model, spends **36%** in
-  `OP_SET_SLICE_STRIDED`: 146 calls moving 106,580 elements, most of it
-  in the backward. The in-place rule below rewrites element writes
-  (`OP_SET_INDEX`) but not slice writes, so a model that fills a matrix
-  column by column still copies the whole matrix per column. Open.
+- **Sequential models.** HMM recursions and state-space/ARMA/GARCH
+  updates read the previous step's parameter-dependent result, so
+  re-rolling correctly refuses (vectorizing a recurrence would change
+  the math). What is left is per-op dispatch against CmdStan's inlined
+  scalar code; a native adjoint program is what would change that.
+- **Mixture models with K > 2 components** (`ldaK2`/`ldaK5`): their
+  inner `log_sum_exp` runs over K-vectors built per document, a
+  row-wise reduction the elementwise-lp fusion does not yet express.
+  The binary-mixture case is closed.
+- **ODE models**, at about 0.6x: our per-call dispatch of the compiled
+  right-hand side against CmdStan's fully inlined one inside the same
+  CVODES solver. (They were 0.015x before the right-hand side compiled;
+  see below.)
+- **`Mtbh_model` (0.45x)**, the slowest model, spends 36% in
+  `OP_SET_SLICE_STRIDED`. The in-place rule rewrites element writes but
+  not slice writes, so a model that fills a matrix column by column
+  still copies the whole matrix per column. Open.
 
-A profile of every sub-parity model (`STANLI_PROFILE=1`, one gradient
-each) is what the last two kernel changes came from, and it says the
-remaining tail is mostly not a graph problem: in seven of those models a
-single precompiled kernel is half to nine-tenths of the gradient.
-`diamonds` was the extreme -- 90.9% in `OP_NORMAL_ID_GLM_LPDF`, whose
-"native" kernel built a var tape in the forward, threw it away, and
-built it again in the backward to call grad(). Differentiating once and
-stashing the partials took it from 0.48x to 0.89x. `prophet` was 82% in
-`OP_MATVEC`, where the accumulation was one serial dependency chain;
-four independent accumulators took it from 0.67x to 1.23x, bitwise
-unchanged. What is left in that class: `Mt_model` (62% in a scalar
-`bernoulli_lpmf`), `gp_regr` (55% in `multi_normal_cholesky_lpdf`, where
-the same partial-stashing measured a wash), `kronecker_gp` (38% in an
-eigendecomposition).
+A profile of every sub-parity model (`STANLI_PROFILE=1`) says the
+remaining tail is mostly not a graph problem: in seven of those models
+a single precompiled kernel is half to nine-tenths of the gradient.
+`diamonds` was the extreme, 90.9% in one GLM kernel that rebuilt a var
+tape in both sweeps; differentiating once and stashing the partials
+took it 0.48x -> 0.89x. `prophet` was 82% in `OP_MATVEC` with one
+serial accumulation chain; four independent accumulators took it 0.67x
+-> 1.23x, bitwise unchanged.
 
-**Where the wins come from: op granularity.** The interpreter's cost is
-per op, not per element: ~17-20 ns for a scalar density op forward +
-backward, measured as ~9.5 ns executor (dispatch + context assembly) plus
-~9 ns recorder/sink inside the kernel, against ~0.9 ns for the actual
+## Where the wins come from
+
+The interpreter's cost is per op, not per element: ~17-20 ns for a
+scalar density op forward + backward, against ~0.9 ns for the actual
 math (`tools/bench_opcost.cpp`). A vectorized statement over N elements
 amortizes that to nothing and runs precompiled stan-math on contiguous
-doubles, while CmdStan pays its var-tape cost per scalar per evaluation:
-one tape node allocated, walked, and freed per leapfrog step, with
-AoS-strided access. Vectorized models therefore win (2-6x, growing with
-N), and models that were stuck as unrolled scalar loops used to lose
-(0.4-0.9x before the re-roll pass).
+doubles, while CmdStan pays its var-tape cost per scalar per
+evaluation. Vectorized models therefore win, and models stuck as
+unrolled scalar loops used to lose (0.4-0.9x) until the graph passes
+closed the gap. The passes themselves are described in
+[runtime/src/OPTIMIZATIONS.md](../runtime/src/OPTIMIZATIONS.md); the
+headline measurements:
 
-**The re-roll pass** (`runtime/src/reroll.cpp`) closes that gap at the
-graph level. Lowering unrolls data-bound loops, so a scalar-loop model
-arrives as N consecutive copies of a small op template; the pass detects
-these periodic regions and rewrites them into the vectorized ops the
-kernels already support (constant vectors materialized from the const
-pool, invariant ops hoisted, elementwise lanes widened, INDEX
-progressions collapsed into their base vector, and N scalar density
-terms fused into one summed vector density). `radon_pooled` collapses
-from 27,670 ops to 8 (0.91x -> 6.18x) and `arK` from 3,164 to 21 (0.40x
--> 4.83x). Indexed reads rewrite by shape: the whole base in order needs
-no op at all, a contiguous window becomes an `OP_SLICE`, and an arbitrary
-data-driven index -- `alpha[county_idx[n]]`, the hierarchical idiom,
-repeats and all -- becomes one `OP_GATHER` whose backward scatter-adds.
-Anything the pass cannot prove safe it leaves alone, per region:
-cross-lane recurrences, outputs escaping their lane, opcodes outside its
-vocabulary. Set `STANLI_NO_REROLL=1` to disable it, `STANLI_NO_INPLACE=1`
-for the update rules below.
+- **Re-rolling** (scalar loops back to vector ops): `radon_pooled`
+  27,670 ops -> 8 (0.91x -> 6.18x), `arK` 3,164 -> 21 (0.40x -> 4.83x).
+- **In-place updates + store-to-load forwarding** (the element-write
+  idiom): `radon_county_intercept` went from 90.5 ms per gradient in
+  2.58 GB of arena (207x slower than CmdStan) to 92 us in 42 MB, 77,960
+  ops -> 9. Seven radon-family models and `rats_model` collapse the
+  same way.
+- **Write-side fusion** (loops that fill a vector something else
+  reads): `radon_county` 25,152 ops -> 10 (0.36x -> 0.98x),
+  `election88_full` 289,165 -> 65 (0.39x -> 2.97x). Strided-run and
+  integer-outcome fusion closed the `dogs` family (0.65x -> 2.8x).
+  57 of the 120 corpus models change under the passes, against 28
+  before write-side fusion.
+- **Elementwise-lp fusion** (the mixture idiom): `low_dim_gauss_mix`
+  7,208 ops -> 16, crossing parity (0.78x -> 1.07x); `normal_mixture`
+  13 ops, 1.09x.
 
-**Element writes: `mu[n] = ...` inside a loop.** This is the other half
-of the hierarchical idiom, and it used to be the worst thing in the
-project. Each write lowered to a *functional update* -- copy the whole
-vector into a fresh slot, poke one element -- so N writes cost O(N^2)
-time
-and O(N^2) arena. `radon_county_intercept` (N=12,573) spent 90.5 ms per
-gradient inside 2.58 GB of arena, 207x slower than CmdStan.
+## Tape islands, measured
 
-Three rules compose to remove it (`runtime/src/inplace.cpp`, plus the
-index rules above). A write may mutate its vector directly when it is the
-**last use** of that vector -- not merely its only use, since the
-read-back in the same iteration is an earlier use -- and when no earlier
-reader needs the vector's values during the reverse sweep (`log_sum_exp`
-and the other nested-replay backwards rebuild their tape from the input
-buffer, so they must find it intact). The write and its read-back then
-cancel outright, and when nothing else reads the vector its writes are
-dead and swept. What is left is plain per-lane arithmetic, which the
-gather rule vectorizes: **77,960 ops become 9**, 90.5 ms becomes 92 us,
-2.58 GB becomes 42 MB. Seven radon-family models and `rats_model` collapse
-the same way.
-
-That worked when the read-back cancelled the write. When it did not --
-when the loop fills a vector that something *else* reads, which is what
-`y_hat[n] = a[county[n]]` followed by `y ~ normal(y_hat, sigma)` is --
-the
-writes survived, one op per element, and the re-roll pass refused the
-region because its outputs escaped the lane. **Write-side fusion** takes
-that case: a run of element writes marching contiguously through one
-vector becomes a single vector store, and no store at all when the run
-covers the vector, since the vectorized values can simply *be* it. Later
-readers are redirected to the fused value. The conditions are what make
-the redirection sound rather than what makes it possible: the vector must
-be the same one every lane, no one else may read it while it is
-half-written, nothing may write it after the run, and it must not be read
-from outside the graph. `radon_county` goes from 25,152 ops to **10**
-(0.36x -> 0.98x of CmdStan) and `election88_full` from 289,165 to **65**
-(0.39x -> 2.97x). Eleven more radon-family variants collapse to 10-22 ops
-each. 57 of the 120 corpus models now change under the passes, against 28
-before.
-
-Three follow-ons closed the `dogs` family (0.65x -> 2.8x, 12,751 ops ->
-261). A **strided** run -- indices advancing by the matrix's row count,
-`p[j, t]` filled down columns -- fuses into `OP_SET_SLICE_STRIDED`, and
-interleaved runs over one vector chain block by block: each block's store
-output becomes the vector every later reference, read or write, is
-renamed to, so the next block fuses onto it in turn. **Per-lane integer
-outcomes** fuse too: an lpmf lane carries its observation as an
-immediate, so the lanes match as a template up to that immediate and the
-fused vector op's outcome array is just their concatenation (the vector
-kernels already take outcomes exactly that way). And the **unary math
-ops** (exp, log, inv_logit, sqrt, ...) joined the widening vocabulary,
-since their kernels were already shape-dispatching on `out.len`.
-
-**Mixture fusion: the elementwise-lp variant.** A mixture model's
-per-observation shape is `log_mix(theta, normal_lpdf(y[n]|...),
-normal_lpdf(y[n]|...))`: the density outputs feed an op instead of the
-target, so the summed-density fusion above cannot apply. Three pieces
-close it. Densities gained a variant bit meaning *elementwise*: the
-fused op's output is a vector holding each lane's own lp, computed by
-the same per-element recorder call the scalar lanes used (bit-identical,
-stan-math computing every value and partial). `log_mix` and the
-two-argument `log_sum_exp` kernels batch over lanes with the usual
-broadcast shape dispatch. And the re-roll pass classifies a density
-whose lane outputs are consumed only inside their own lanes as
-elementwise, widens the consuming `log_mix`, and swaps the N per-lane
-target terms for one `OP_SUM_VEC`. `low_dim_gauss_mix` drops from 7,208
-ops to 16 and crosses parity (0.78x -> 1.07x); `normal_mixture` lands at
-13 ops, 1.09x. A density whose inputs are all lane-invariant hoists to
-one scalar op instead of widening -- a len-N output over all-scalar
-inputs is exactly the miscompile shape the corpus A/B caught once
-already (`losscurve_sislob`).
-
-**Tape islands: the irreducible residue.** After every other pass has
-run, whatever scalar residue survives is, by construction, what no
-vectorizer can help -- cross-lane recurrences, where step t reads step
-t-1's parameter-dependent result. The island pass
-(`runtime/src/island.cpp`, `STANLI_NO_ISLAND=1` to disable) compiles
-each maximal run of compilable ops into a flat register program executed
-by ONE op: forward runs it on plain doubles; backward replays it under
-stan-math's nested autodiff and harvests the live-ins' adjoints -- the
-same var arithmetic CmdStan's generated code runs for the same
-statements, so gradients match by construction. Per-lane data constants
-absorb into the program as immediates; dead copy-then-modify chains
-reuse their base's registers (on `iohmm_reg` that is the difference
-between 1.6M registers and 94k).
-
-The op collapse is dramatic on every model that has such a region, and
-the time follows on exactly one. Measured with `STANLI_NO_ISLAND=1` as
-the baseline, same build, same point, on all fourteen corpus models that
-compile a region:
+The island pass compiles irreducible scalar residue (recurrences) into
+one register-machine op. The op collapse is dramatic on every model
+that has such a region; the time follows on exactly one. Measured with
+`STANLI_NO_ISLAND=1` as the baseline, same build, same point, on all
+fourteen corpus models that compile a region:
 
 | model | islanded | ops off | ns/grad off -> on | |
 | --- | ---: | ---: | ---: | ---: |
@@ -255,57 +151,29 @@ compile a region:
 | `arma11` | | 1,198 | 6,882 -> 10,570 | 0.65x |
 | `bones_model` | 77 islands | 4,955 | 52,774 -> 1,005,148 | 0.05x |
 
-The op count was never the cost. A dispatch is ~5 ns and the scalar
-kernels around it are cheap; a var replay of the same operations costs
-what CmdStan costs for them, which is more than the scratch-partials
-backwards it replaced. `iohmm_reg` is different for a reason that has
-nothing to do with dispatch: its steps copy a 1,500-element state
-vector each, 1.6M elements of traffic per gradient, and the island's
-registers make those copies disappear. `bones_model` is the same
-mechanism inverted -- 36 ops behind a 4,024-register file, rebuilt as
-vars 77 times per gradient.
+The op count was never the cost: a dispatch is ~5 ns and the scalar
+kernels around it are cheap, while a var replay of the same operations
+costs what CmdStan costs for them. `iohmm_reg` wins because its steps
+copy a 1,500-element state vector each (1.6M elements of traffic per
+gradient) and the island's registers make the copies disappear;
+`bones_model` is the same mechanism inverted, a 4,024-register file
+rebuilt as vars 77 times per gradient. The pass now estimates both
+sides before committing; the estimate separates the fourteen exactly,
+and the thirteen it leaves alone are bitwise identical to the
+passes-off baseline. What would move the rest of this class is a native
+adjoint program, generated alongside the forward one instead of
+replayed under nested autodiff.
 
-So the pass estimates both sides before committing: what the ops move
-(an in-place element update moves one element, not a vector) against
-the register file, weighted 4x because it is built twice per call and
-once as vars. The estimate separates the fourteen exactly -- `iohmm_reg`
-1.6M against 435k, every other region 4-20x the wrong way -- and the
-thirteen it now leaves alone are bitwise identical to the passes-off
-baseline again. `STANLI_ISLAND_ALWAYS=1` skips the estimate, which is
-how to ask why a region was left alone.
+## ODE models
 
-What would move the rest of this class is not fewer dispatches but a
-cheaper backward: a native adjoint program, generated alongside the
-forward one instead of replayed under nested autodiff. Beyond the
-estimate, islands also refuse propto densities (their term-dropping
-depends on argument types, which the island's uniform binding cannot
-reproduce), runs under 32 ops, and regions producing target terms.
-
-**Dispatch, measured to its floor.** The executor's sweeps resolve their
-function pointers at bind time and run 4x-unrolled
-(`tools/bench_dispatch.cpp` holds the comparison: a musttail-chained
-alternative measured slower and noisier than the unrolled loop, so it
-was declined). After those, per-op cost is bound by the context loads,
-not the dispatch branch: the remaining lever for op-heavy graphs is
-fewer ops, which is what the passes above are.
-
-**ODE models: the right-hand side was an interpreter.** Every user function
-is inlined at lowering time except one -- an ODE right-hand side has to stay
-callable at runtime, because the integrator picks the times. It was evaluated
-by a tree-walking interpreter over the MIR, at a `std::map` lookup per
-variable reference and a `std::vector` allocation per intermediate: 5.8 us per
-call for lotka_volterra's two-line right-hand side, ~500 calls per gradient,
-**97% of the model's gradient time**. It also solved the system twice per
-gradient, once for the values and again for the derivatives.
-
-Both are gone. The right-hand side compiles once, at lowering time, into a
-flat register machine (`runtime/src/ode_prog.cpp`): names become indices,
-loops over the states unroll, data-only conditions fold, conditions on the
-solve time become branches, and a call is a switch over a contiguous
-instruction array with no allocation. And the forward sweep, which has to
-solve the coupled state-plus-sensitivity system anyway to match CmdStan's
-step control, now keeps the sensitivities instead of throwing them away, so
-the backward is a matrix-vector product.
+Every user function is inlined at lowering time except an ODE
+right-hand side, which the integrator calls at times of its choosing.
+It used to be evaluated by a tree-walking interpreter: 5.8 us per call,
+~500 calls per gradient, 97% of the model's gradient time, and the
+system was solved twice per gradient (values, then derivatives). Both
+are gone: the right-hand side compiles once into a flat register
+machine, and the forward sweep keeps the sensitivities it already
+computes, so the backward is a matrix-vector product.
 
 | model | before | after | speedup | vs CmdStan |
 | --- | ---: | ---: | ---: | ---: |
@@ -314,57 +182,22 @@ the backward is a matrix-vector product.
 | `one_comp_mm_elim_abs` | 18,873,857 ns | 653,181 ns | 28.9x | 0.025x -> 0.74x |
 
 Gradients are unchanged to the bit where they were before, and
-`lotka_volterra` moved from 4 ULP to bitwise identical to CmdStan: reading the
-jacobian out of the same solve that produced the values removes a second,
-independently stepped solve. All four corpus models that call
-`integrate_ode_*` compile their right-hand side. Anything the compiler cannot
-express -- a `return` out of a branch on the solve time, say -- keeps the
-interpreter, so coverage never shrinks; `STANLI_DEBUG_ODE=1` reports when that
-happens, since a silent 30x is worth a line.
+`lotka_volterra` moved from 4 ULP to bitwise identical to CmdStan:
+reading the jacobian out of the same solve that produced the values
+removes a second, independently stepped solve. Anything the compiler
+cannot express keeps the interpreter, so coverage never shrinks;
+`STANLI_DEBUG_ODE=1` reports when that happens.
 
-(`one_comp_mm_elim_abs` has a CmdStan number here for the first time.
-It is the only corpus model calling `integrate_ode_bdf`, which reaches
-CVODES, and the gradient driver linked only TBB -- so the comparison
-failed to build and the row went blank with nothing to say why. The
-harness now links the CVODES archives and names the failure if a driver
-still will not build or run.)
+Preparation scales too: the largest corpus model (`nn_rbm1bJ100`,
+MNIST, 60,000 rows, 79,411 parameters) lowers to a 192,030-op graph in
+20.7 s and evaluates its gradient in 0.43 s. Lowering used to be
+quadratic in data size (the transformed-data interpreter copied an
+indexed expression's whole base per read). Overall, stanli lowers a
+model in 4-200 ms against a 6.2-7.6 s CmdStan compile (warm precompiled
+header, after a multi-minute one-time `make build`); that gap is what
+time-to-first-draw is made of.
 
-Model preparation scales too: the largest model in the corpus
-(`nn_rbm1bJ100`, MNIST, 60,000 rows, 79,411 parameters) lowers to a
-192,030-op graph in 20.7 s and evaluates its gradient in 0.43 s. That
-number used to be unbounded: the transformed-data interpreter evaluated
-an indexed expression by copying its base, so reading `y[n]` in a loop
-copied the whole array each time and lowering was quadratic in the data
-size.
-
-Preparation time is the other axis: stanli lowers a model in 4-200 ms,
-against a 6.2-7.6 s CmdStan compile (with a warm precompiled header, and
-after a multi-minute one-time `make build`). That gap is what
-time-to-first-draw is made of. Re-rolling also cut preparation time on
-loop-heavy models (radon_pooled 0.39 s -> 0.08 s): the executor binds
-and sizes 8 ops instead of 27,670.
-
-## End to end: eight schools, model.stan + data.json -> 1000 warmup + 1000 draws
-
-An earlier revision of these sampling numbers was measured with a
-defective max tree depth of 5 (`stan::mcmc::base_nuts` defaults to 5;
-CmdStan sets 10, and `run_nuts` never called `set_max_depth`), capping
-trajectories at 31 leapfrogs and understating any model that needs deep
-trees. The sampling columns in `docs/corpus-bench.tsv` and the full
-table below have since been re-measured at the correct depth; treat them
-as indicative rather than controlled, since adaptation trajectories
-legitimately differ between engines at matched seeds.
-
-They were also unequal work in a second way: stanli computed no
-transformed parameters and no generated quantities, so on the models with
-a generated quantities block (`diamonds`, `accel_splines`,
-`covid19imperial_v2` among the biggest apparent sampling wins) CmdStan
-was doing per-draw work stanli skipped. That gap is closed for all 119
-compiling models: the write_array graph covers 95, and the 24 the graph
-cannot express (RNG draws, branches on draw-computed values) run through
-a per-draw interpreter (`harnesses/wa_coverage.py` is the sweep). The
-sampling columns for those 24 predate the interpreted fallback, so they
-still understate CmdStan's side there.
+## End to end: eight schools, 1000 warmup + 1000 draws
 
 | engine | stage | time |
 | --- | --- | --- |
@@ -375,21 +208,22 @@ still understate CmdStan's side there.
 | CmdStan | NUTS 1000+1000 (self-reported total) | 0.044 s |
 | CmdStan | build + run wall time | ~4.98 s |
 
-Time-to-first-draw is ~20x faster (0.24 s vs ~4.98 s). Sampling-phase
-times are dominated by gradient cost, and adaptation trajectories differ
-between engines (CmdStan took 9,654 post-warmup leapfrogs here), so treat
-the sampling rows as indicative; the controlled comparison is the
-per-gradient table.
+Time-to-first-draw is ~20x faster (0.24 s vs ~4.98 s). Treat sampling
+times as indicative rather than controlled: adaptation trajectories
+legitimately differ between engines at matched seeds, so they measure
+the whole run, not the gradient. (An earlier revision of the sampling
+numbers was measured with a defective max tree depth of 5; the columns
+in `docs/corpus-bench.tsv` and the table below have been re-measured at
+the correct depth. The sampling columns for the 24 models whose
+generated quantities run through the per-draw interpreter predate that
+fallback, so they still understate CmdStan's side there.)
 
 ## Parallel chains, and what STAN_THREADS costs
 
-Chains run in threads, one executor each. The question worth measuring
-was not the speedup but the tax: stan-math's autodiff stack is a plain
-static unless `STAN_THREADS` is defined, in which case it becomes
-thread-local (`__thread` on gcc/clang), and that indirection lands on
-every var operation. So the model to worry about is not a vectorized one
--- native kernels never touch the var stack -- but one dominated by the
-nested-tape path.
+Chains run in threads, one executor each. The tax worth measuring:
+stan-math's autodiff stack becomes thread-local under `STAN_THREADS`,
+and that indirection lands on every var operation, so the model to
+worry about is one dominated by the nested-tape path.
 
 | model | plain | `STAN_THREADS` |
 | --- | ---: | ---: |
@@ -398,98 +232,65 @@ nested-tape path.
 | `ar1` | 228.9 ns | 224.1 ns |
 | `conj` | 142.2 ns | 141.1 ns |
 
-Best of three each. The tax is noise, in both directions, including on
-the model built specifically to expose it. Against that, eight chains of
-that same model:
+The tax is noise, in both directions, including on the model built to
+expose it. Against that, eight chains of that model:
 
 | threads | 1 | 2 | 4 | 8 |
 | --- | ---: | ---: | ---: | ---: |
 | 8 chains, wall clock | 2.89 s | 1.59 s | 0.86 s | 0.49 s |
 
-So it is on by default for native builds, and off under Emscripten (wasm
-threads need `-pthread` and a cross-origin-isolated page; the browser
-build runs one chain per worker instead).
+So it is on by default for native builds, and off under Emscripten
+(wasm threads need a cross-origin-isolated page; the browser runs one
+chain per worker instead).
 
-**Threading does not change the answer.** Each chain owns its executor --
-its own arena, its own contexts -- and its own RNG stream, so a parallel
-run is byte-identical to a sequential one. Checked as a CSV `cmp` across
-four models (eight schools, the `ordered_logistic` recurrence, `ar1`, and
-`conj` with its generated quantities), 8 chains x 300 draws each, and
-asserted in `tests/test_multichain.cpp` and `tests/test_python.py` in a
-form that holds on a single-threaded build too.
+**Threading does not change the answer.** Each chain owns its executor
+and its RNG stream, so a parallel run is byte-identical to a sequential
+one. Checked as a CSV `cmp` across four models at 8 chains x 300 draws,
+and asserted in `tests/test_multichain.cpp` and `tests/test_python.py`.
 
-**One trap, worth naming because it is invisible from the outside.**
+One trap, worth naming because it is invisible from the outside:
 stan-math's AD stack pointer is thread-local under `STAN_THREADS` and
-starts **null** in every new thread; each child thread must instantiate a
-`ChainableStack` before touching the AD system, which stan-math's own
-header documents and which CmdStan never has to write because TBB's
-scheduler-entry hook (`ad_tape_observer`) does it for every worker. This
-build stubs TBB out, so raw `std::thread`s dereferenced null inside
-`start_nested()` on the first legacy op. A segfault rather than a wrong
-number, which is the good version of this bug.
+starts **null** in every new thread. CmdStan never has to handle this
+because TBB's scheduler hook instantiates a `ChainableStack` per
+worker; this build stubs TBB out, so raw `std::thread`s must do it
+themselves or segfault on the first legacy op.
 
 ## Numerical parity
 
 Every model in the passing set is differentially verified against
 CmdStan's `log_prob_propto_jacobian` and full gradient at the shared
-point: 118/120 verified, 44 of them bitwise identical, worst relative
-deviation 2.6e-12 (`tools/verify_sample.py`, `docs/corpus-status.md`).
-For the 20 models whose generated quantities are deterministic
-(kronecker_gp sits out with its documented eigenvector deviation), the
-same oracle also replays CmdStan's write_array values (every CSV column at the
-same point); recording those caught two interpreter bugs on its first
-run, an uninitialized-value semantic and a transposed batched-simplex
-read, both invisible to structural coverage checks.
+point: 118/120 verified, 45 of them bitwise identical, worst relative
+deviation 2.6e-12 (`tools/verify_sample.py`,
+`docs/corpus-status.md`). For the 20 models whose generated quantities
+are deterministic, the same oracle also replays CmdStan's write_array
+values (every CSV column at the same point); recording those caught two
+interpreter bugs invisible to structural coverage checks.
+
 Transformed models change summation order relative to CmdStan's scalar
-loop, so they verify at tolerance rather than bitwise: across the corpus
-the passes now change 66 models and the worst gradient deviation any of
-them introduces vs the untransformed graph is 6.0e-13 relative --
-`iohmm_reg`, whose entire forward algorithm replays through one island
-(`harnesses/ab_corpus.py` compares every corpus model passes-on vs
-passes-off and flags any divergence; `--disable` one variable to
-attribute one).
-
-That harness earns its keep. An earlier version of the in-place rule
-allowed a destructive write whenever it was the last use of its vector,
-which is wrong for any earlier reader that rebuilds its var tape from the
-buffer during the reverse sweep -- `log_sum_exp`, `softmax`, every
-legacy
-nested-replay backward. Eight HMM/LDA/mixture models were silently wrong
-by up to 1.7e+05 relative **with their op counts unchanged**, so nothing
-structural would have caught it. Only ops whose backward purely routes
-adjoints may now precede a destructive write.
-
-All six were then re-run through the CmdStan rig directly rather than
-resting on that transitive argument, and all six still verify:
-`radon_pooled` 2.1e-14 (140 ulp, against 135 before the pass), `arK`
-9.6e-16 (5 ulp, against 1), `rats_model` 2.4e-16 (2 ulp),
-`soil_incubation` 1.3e-16 (1 ulp), and both `covid19imperial` variants
-8.2e-16 (7 ulp), unchanged.
+loop, so they verify at tolerance rather than bitwise: the passes
+change 66 corpus models, and the worst gradient deviation any of them
+introduces vs the untransformed graph is 6.0e-13 relative
+(`harnesses/ab_corpus.py` compares every model passes-on vs passes-off
+and flags any divergence). That harness caught an in-place rule that
+made eight models silently wrong by up to 1.7e+05 relative with their
+op counts unchanged; the six models most affected by the passes were
+then also re-run through the CmdStan rig directly, and all six verify
+(e.g. `radon_pooled` 2.1e-14, `arK` 9.6e-16, `rats_model` 2.4e-16).
 
 ## Full corpus
 
-Every posteriordb model, sorted by per-gradient speedup. The columns are
-CmdStan's absolute numbers and stanli's ratio against them: the ratio is
-what the table is read for, and stanli's own time is the ratio applied to
-the column beside it. Sampling is 1000 warmup + 1000 draws at matched
-seeds, indicative rather than controlled -- the two samplers take
-different trajectories, so it measures the whole run, not the gradient.
-Where the two columns disagree sharply, the two engines sampled
-different modes. `ldaK2` has two (mean lp about -596 and about -696) and
-the second is five times more expensive to explore -- adapted stepsize
-0.09 against 0.48. Over five seeds through `tools/sampler_trace.py` the
-engines picked the same mode in four and the corpus seed is the fifth,
-where stanli drew the expensive mode and CmdStan the cheap one. That is
-the whole of its 0.25x sampling column against a 0.71x gradient, and it
-is a property of the posterior, not of either sampler. `hmm_gaussian`
-(0.69x per gradient, 0.03x sampling) is the same shape with a sharper
-edge: at that seed CmdStan's run has *every* post-warmup draw divergent,
-so its 18.75 s is a chain that is not sampling at all. Read the sampling
-column as indicative and the gradient column as the measurement. (It is
-also older than the gradient column in one way: it was measured before
-the sampler moved to CmdStan's generator, so the seed that produced each
-row's draws is not the seed that would produce them today.)
-Regenerate with `python3 tools/corpus_table.py docs/corpus-bench.tsv`.
+Every posteriordb model, sorted by per-gradient speedup. The columns
+are CmdStan's absolute numbers and stanli's ratio against them.
+Sampling is 1000 warmup + 1000 draws at matched seeds, indicative
+rather than controlled; where the two columns disagree sharply, the two
+engines sampled different modes. (`ldaK2` has two modes and the corpus
+seed is the one seed of five where the engines split, stanli drawing
+the mode that is five times more expensive to explore; that is the
+whole of its 0.25x sampling column against a 0.71x gradient.
+`hmm_gaussian`'s CmdStan run at that seed has every post-warmup draw
+divergent, so its 18.75 s is a chain that is not sampling at all.) Read
+the gradient column as the measurement. Regenerate with
+`python3 tools/corpus_table.py docs/corpus-bench.tsv`.
 
 | model | params | CmdStan ns/grad | grad speedup | CmdStan sample | sample speedup |
 | --- | ---: | ---: | ---: | ---: | ---: |
@@ -613,50 +414,32 @@ Regenerate with `python3 tools/corpus_table.py docs/corpus-bench.tsv`.
 
 ### The models the run could not complete
 
-A missing number is not a slow number, so these sort below the table
-rather than inside it.
+A missing number is not a slow number, so these sort below the table.
 
 | model | params | CmdStan ns/grad | grad speedup | what stopped it |
 | --- | ---: | ---: | ---: | --- |
-| `ldaK5` | 7714 | 5,580,314 | 1.10x | stanli sampling hit the 900 s cap; CmdStan sampling hit the 900 s cap |
-| `nn_rbm1bJ100` | 79411 | 434,981,254 | 1.07x | stanli sampling hit the 900 s cap; CmdStan sampling hit the 900 s cap |
-| `kronecker_gp` | 438 | 217,990 | 0.70x | stanli sampling hit the 900 s cap |
-| `lotka_volterra` | 8 | 41,313 | 0.61x | stanli sampling hit the 900 s cap |
-| `sir` |  | - | - | stanli's gradient probe threw at the benchmark point; no stanli gradient |
+| `ldaK5` | 7714 | 5,580,314 | 1.10x | both engines hit the 900 s sampling cap |
+| `nn_rbm1bJ100` | 79411 | 434,981,254 | 1.07x | both engines hit the 900 s sampling cap |
+| `kronecker_gp` | 438 | 217,990 | 0.70x | stanli sampling hit the 900 s cap (CmdStan takes 451 s) |
+| `lotka_volterra` | 8 | 41,313 | 0.61x | stanli sampling hit the 900 s cap; untraced (CmdStan samples it in 6.2 s, so 0.61x per gradient should fit; `tools/sampler_trace.py` is the tool) |
+| `sir` |  | - | - | the benchmark's fixed evaluation point is invalid: the ODE solution dips to -4.4e-10 and `poisson_lpmf` rejects the negative rate. CmdStan has no gradient number here either; the model samples fine. |
 
-- `ldaK5` and `nn_rbm1bJ100` are the two largest models in the corpus
-  (7,714 and 79,411 parameters; CmdStan itself needs 435 ms per gradient
-  on the second one). Neither engine finishes 2000 iterations inside the
-  cap. Their per-gradient numbers are measured and stand.
-- `kronecker_gp` is 0.70x per gradient and CmdStan takes 451 s, so the
-  same run does not fit in 900 s.
-- `lotka_volterra` is the honest puzzle left: CmdStan samples it in
-  6.2 s and stanli is 0.61x per gradient, so the cap should be nowhere
-  near. The mode explanation above covers `ldaK2` and `hmm_gaussian`;
-  this one has not been traced yet. `tools/sampler_trace.py` is the tool.
-- `sir` throws at the benchmark's fixed evaluation point: the ODE
-  solution dips to -4.4e-10 and `poisson_lpmf` rejects a negative rate.
-  CmdStan has no gradient number here either. The model samples fine
-  (38.7 s in CmdStan), so this is the probe point, not the model.
+`ldaK5` and `nn_rbm1bJ100` are the two largest models in the corpus;
+their per-gradient numbers are measured and stand.
 
 ## The browser build
 
-Different compiler, different libm, and until now no SIMD, so none of the
-numbers above carry over. `tools/bench_wasm.cjs` measures it under Node
-against the same MIR fixtures the tests use (no stanc, no posteriordb
-needed); `--mir`/`--data` point it at a bigger model.
-
-```
-node tools/bench_wasm.cjs                      # fixtures, ns/gradient
-node tools/bench_wasm.cjs --module build-wasm-simd/stanli.js
-```
+Different compiler, different libm, so none of the numbers above carry
+over. `tools/bench_wasm.cjs` measures it under Node against the same
+MIR fixtures the tests use; `--mir`/`--data` point it at a bigger
+model. Measure under Node, never in an automated browser tab: attaching
+chrome.debugger keeps V8 on its baseline tier and costs about 4x.
 
 ### What the browser costs you
 
-Both builds from the same commit, same MIR and same data on each side,
-`bench_grad` against `bench_wasm.cjs`, min of three runs each, macOS
-arm64. This is the number the demo page's footer cites, and the reason it
-tells people to install the wheel for real work.
+Both builds from the same commit, same MIR and data, min of three runs,
+macOS arm64. This is the number the demo page's footer cites, and the
+reason it tells people to install the wheel for real work.
 
 | model | native | wasm | wasm/native |
 |---|---:|---:|---:|
@@ -669,21 +452,16 @@ tells people to install the wheel for real work.
 | `diamonds` | 36.3 us | 52.2 us | 1.44x |
 | geometric mean | | | **1.71x** |
 
-Two things this is *not*. It is not the missing propto terms: the browser
-ships `STANLI_LITE_LP`, which drops the propto instantiations and so
-evaluates the fuller density, and propto is worth nothing measurable
-either way (docs/lite-lp.md). It is not model preparation either: stanc3
-compiled by js_of_ocaml compiles eight schools in 3 ms warm, against 13 ms
-for the native binary including process spawn, so the browser is not
-behind on time to first draw at all. The gap is gradient throughput,
-which is what dominates once sampling starts.
+The gap is gradient throughput, which is what dominates once sampling
+starts. It is not model preparation: stanc3 compiled by js_of_ocaml
+compiles eight schools in 3 ms warm, against 13 ms for the native
+binary including process spawn.
 
-Measure it under Node, never in an automated browser tab: attaching
-chrome.debugger keeps V8 on the Liftoff baseline tier and costs about 4x
-on the same binary.
+### SIMD
 
-The A/B that turned SIMD on, measured on macOS arm64, emsdk 6.0.6 (the
-version CI pins), on the tree as it stood at that commit:
+SIMD128 is on. The A/B that decided it (macOS arm64, emsdk 6.0.6, on
+the tree as it stood then; sizes have grown since as the density
+surface roughly doubled):
 
 | | scalar | +SIMD128 |
 |---|---:|---:|
@@ -692,64 +470,19 @@ version CI pins), on the tree as it stood at that commit:
 | `nes` (matrix-heavy) | 29.1 us | **25.9 us** |
 | `stanli.wasm` gzipped | 1.02 MB | 1.05 MB |
 
-The absolute numbers have moved since -- the density surface roughly
-doubled -- and today's build is 4.10 MB raw, 1.15 MB gzipped, 478 ns
-geomean. The A/B above is kept as the decision record; rerun it against a
-freshly configured scalar build if the decision is ever revisited.
+2% on most shapes and 11% on the matrix-heavy one for 0.03 MB, and
+(the part that made it an easy call) every corpus model's gradients are
+**bitwise identical** to the scalar build. With `-ffp-contract=off` in
+force the vectorization Eigen takes is elementwise, and elementwise is
+order-preserving; a vectorized reduction would have shown up as a
+deviation immediately.
 
-SIMD128 is on. It is worth 2% on most shapes and 11% on the matrix-heavy
-one for 0.03 MB, and -- the part that made it an easy call -- every corpus
-model's gradients come out **bitwise identical** to the scalar build
-(`tools/wasm_check.sh` against the CmdStan references, plus a direct
-comparison on `radon_pooled` and `nes` at three points each). With
-`-ffp-contract=off` still in force the vectorization Eigen takes is
-elementwise, and elementwise is order-preserving. A vectorized reduction
-would reassociate, and would have shown up as a deviation immediately.
-
-### Two things not worth doing, measured
-
-**`-ffp-contract=fast` is a no-op here.** Not "not worth it" -- it produces
-a **byte-identical** `stanli.wasm`. Baseline WebAssembly has no FMA
-instruction, so there is nothing to contract (`f64x2.relaxed_madd` needs
-the relaxed-SIMD proposal and `-mrelaxed-simd`). The `-ffp-contract=off`
-pin that costs something on native costs exactly nothing in the browser,
-and fast-math is not a lever on this target at all.
-
-**Splitting densities into a lazily-loaded pack is viable, and the
-obstacle I expected is not there.** Stubbing every density, cdf and tail
-kernel and relinking says where the payload actually is:
-
-| | raw | gzip |
-|---|---:|---:|
-| core runtime (plus `multi_normal`, `lkj_corr_cholesky`) | 2.26 MB | **0.69 MB** |
-| everything, as shipped | 4.10 MB | **1.15 MB** |
-
-So the density surface is 1.84 MB raw, **0.46 MB gzipped** -- 40% of the
-payload, against a 0.69 MB core that cannot be split. A model still needs
-its own densities, so the realistic saving is smaller than 0.46 MB, but it
-is no longer marginal: this doc previously said 0.37 MB against a bigger
-core, before the density list went from 47 to 71.
-
-The cost I assumed would eat it does not exist. Emscripten's
-`MAIN_MODULE=2` with `-fPIC` was measured against the same tree: **1.05 MB
-gzipped either way, 451 ns against 449 ns**. On wasm, calls already go
-indirect through a function table, so there is no PLT/GOT penalty of the
-kind native dynamic linking pays.
-
-The mechanism was proven end to end with a spike: a `SIDE_MODULE` built
-against these headers, loaded at runtime, calling **back into the main
-module** -- which is what lets a pack call `register_kernel`,
-`active_sink()` and libm from the core instead of carrying its own copies.
-Dispatch is already `kernel(opcode).forward`, a function-pointer table, so
-late registration only has to fill in slots, and the lowering already
-fails with `unsupported function <name>` -- so the trigger is
-self-correcting: try to lower, fetch the pack on that error, retry, with
-no density-name table duplicated in JavaScript.
-
-One requirement, found the hard way: the pack must be compiled with the
-same exception ABI (`-fwasm-exceptions`) as the core. Mismatched, it fails
-with an opaque `__stack_pointer` mutable-global import error that looks
-like a dynamic-linking bug and is not.
+Two related results, measured: `-ffp-contract=fast` produces a
+byte-identical `stanli.wasm`, because baseline WebAssembly has no FMA
+instruction to contract to, so fast-math is not a lever on this target.
+And splitting the densities into a lazily-loaded pack is viable but
+blocked by one emscripten limitation; the measurements and traps are in
+[docs/density-pack.md](density-pack.md).
 
 ## Reproducing
 
@@ -758,5 +491,5 @@ like a dynamic-linking bug and is not.
 cmake -B build-rel -DCMAKE_BUILD_TYPE=Release
 cmake --build build-rel -j
 python3 tools/bench_models.py deps/cmdstan deps/posteriordb
-python3 harnesses/ab_corpus.py deps/posteriordb   # re-roll A/B over the corpus
+python3 harnesses/ab_corpus.py deps/posteriordb   # passes A/B over the corpus
 ```

--- a/docs/compact-densities.md
+++ b/docs/compact-densities.md
@@ -1,8 +1,8 @@
 # Compact densities: exact gradients, lp\_\_ off by a constant
 
 Most of stanli's densities reproduce CmdStan's `lp__` to the bit. The
-long tail does not, by choice. This is what that choice is, why it was
-made, and how to tell which kind you are looking at.
+long tail does not, by choice. This is what that choice is and how to
+tell which kind you are looking at.
 
 ## The claim
 
@@ -15,37 +15,29 @@ For a density built the compact way:
 | `lp__` vs CmdStan | a **per-model constant** higher |
 | draws for a pinned seed | a different but equally valid chain |
 
-The constant is the same at every point in parameter space. That is not a
-hope, it is the thing the verification checks: three evaluation points,
-same shift each time. A shift that *moved* with the parameters would mean
-something other than a dropped constant, and is the only way this can be
-wrong.
+The constant is the same at every point in parameter space, and the
+verification checks exactly that: three evaluation points, same shift
+each time. A shift that moved with the parameters is the only way this
+can be wrong.
 
 ## Why it happens
 
-stan-math decides which terms of a log density to keep by looking at the
-argument **types**. `include_summand<propto, T_y, T_loc, T_scale>` is a
-compile-time query, so `y ~ normal(mu, sigma)` with `sigma` as data drops
-`-log(sigma)` while the same statement with `sigma` as a parameter keeps
-it. Reproducing that exactly costs one instantiation of stan-math's
-template **per activity mask** -- which arguments are autodiff -- on top
-of the full form, and again for the elementwise variant. That is
-`4 * 2^N` copies per distribution, roughly 630 KB of object for a
-three-argument one.
+stan-math decides which terms of a log density to keep by looking at
+the argument **types**: `y ~ normal(mu, sigma)` with `sigma` as data
+drops `-log(sigma)`, while the same statement with `sigma` as a
+parameter keeps it. Reproducing that exactly costs one template
+instantiation per activity mask (which arguments are autodiff), on top
+of the full form and again for the elementwise variant: `4 * 2^N`
+copies per distribution, roughly 630 KB of object for a three-argument
+one.
 
-A compact density instantiates the template **once**, with every argument
-bound as an autodiff type. Everything is then "active", so
-`include_summand` keeps terms CmdStan drops, and `lp__` comes out higher
-by exactly those terms -- which are constants, because the only reason
-CmdStan could drop them is that they do not depend on any parameter.
-
-Nothing else changes. The dropped terms have no derivative with respect to
-anything active, so every partial is identical. Measured examples:
-
-| density | lp shift on its test model | worst gradient difference |
-|---|---|---|
-| `multi_student_t` | +0.81998355873446 | 0 |
-| `lkj_cov` | +0.28768207245200 | 0 |
+A compact density instantiates the template **once**, with every
+argument bound as autodiff. Everything is then "active", so stan-math
+keeps terms CmdStan drops, and `lp__` comes out higher by exactly those
+terms. They are constants (that is the only reason CmdStan could drop
+them), so every partial is identical. Measured: `multi_student_t`
+shifts lp by +0.81998355873446 with zero gradient difference; `lkj_cov`
+by +0.28768207245200, also zero.
 
 ## Which densities are which
 
@@ -54,37 +46,30 @@ anything active, so every partial is identical. Measured examples:
 `uniform`, `double_exponential`, `exponential`, `inv_gamma`,
 `std_normal`, `weibull`, `logistic`), the discrete ones with an integer
 outcome, `multi_normal` and its cholesky form, `lkj_corr_cholesky`,
-`dirichlet`, and the GLMs. These are what corpus models use, and they are
-held to bitwise `lp__` by `tools/verify_refs.py` on every push.
+`dirichlet`, and the GLMs. These are what corpus models use, and
+`tools/verify_refs.py` holds them to bitwise `lp__` on every push.
 
-**Compact**: the multivariate and multinomial tail --
-`multi_normal_prec`, `multi_student_t` and its cholesky form, the wishart
-family, `multi_gp` and its cholesky form, `lkj_cov`, the multinomial
-family, `ordered_probit`, `wiener`. The tier is visible in the source:
-they live in `runtime/kernels/matrix_fns.cpp` on a nested var tape rather
-than in `densities.cpp` behind `mask_dispatch`.
-
-The 4th field of `STANLI_SCALAR_DENSITY_LIST` in
-`runtime/include/stanli/optable.hpp` says it for the scalar ones -- see
-`density_tier` there for the two bits it encodes.
+**Compact**: the multivariate and multinomial tail
+(`multi_normal_prec`, `multi_student_t` and its cholesky form, the
+wishart family, `multi_gp` and its cholesky form, `lkj_cov`, the
+multinomial family, `ordered_probit`, `wiener`). The tier is visible in
+the source: compact kernels live in `runtime/kernels/matrix_fns.cpp` on
+a nested var tape rather than in `densities.cpp` behind
+`mask_dispatch`; for scalar densities, the 4th field of
+`STANLI_SCALAR_DENSITY_LIST` in `optable.hpp` encodes it.
 
 ## Why this is the right trade for the tail
 
-The whole tail at full fidelity would cost more than the rest of the
-library. Measured: giving the 13 common distributions' *cdfs* alone the
-mask dispatch cost 4.8 MB, against 2.2 MB for all 72 of them without it.
-Multiply that across the multivariate densities, whose arguments are
-matrices, and the exact tier buys `lp__` fidelity on distributions nobody
-has profiled at a price paid by every install.
-
-And `lp__` is the one output that does not affect inference. It is a
-diagnostic: people watch it for convergence, where a constant offset is
-invisible, and compare it *within* a run, where it cancels. The gradient
-is what the sampler integrates, and that is bitwise.
-
-The same reasoning, applied globally instead of per-density, is
-`STANLI_LITE_LP` -- see [docs/lite-lp.md](lite-lp.md). The browser build
-turns it on for every density and halves the runtime.
+Full fidelity for the tail would cost more than the rest of the
+library: giving just the 13 common distributions' *cdfs* the mask
+dispatch measured 4.8 MB, against 2.2 MB for all 72 distribution
+functions without it, and the multivariate densities take matrix
+arguments. And `lp__` is the one output that does not affect inference:
+people watch it for convergence, where a constant offset is invisible.
+The gradient is what the sampler integrates, and that is bitwise. The
+same reasoning applied globally is `STANLI_LITE_LP`
+([docs/lite-lp.md](lite-lp.md)), which makes every density compact and
+halves the runtime.
 
 ## If you need a tail density to be exact
 
@@ -92,14 +77,15 @@ Give it the activity-mask dispatch. `multi_normal` in
 `runtime/kernels/matrix_fns.cpp` shows the shape: an if-chain over the
 mask bits binding each argument as `var` or `double`, so stan-math sees
 the same types CmdStan's generated code does. It is `2^N` branches and
-`2^N` instantiations, and it is the reason `multi_normal` is exact while
-`multi_normal_prec` -- the same kernel with one call swapped -- is not.
+`2^N` instantiations, and it is why `multi_normal` is exact while
+`multi_normal_prec`, the same kernel with one call swapped, is not.
 
 ## Checking it yourself
 
-There is no automated per-density check for the shift, because the corpus
-does not use these densities and `harnesses/fn_sweep.py` only generates
-all-scalar models. The manual version, for a model using the density:
+There is no automated per-density check for the shift, because the
+corpus does not use these densities and `harnesses/fn_sweep.py` only
+generates all-scalar models. The manual version, for a model using the
+density:
 
 ```
 build/stanli_check model.stan data.json --point 0   # and 1, 2

--- a/docs/coverage.md
+++ b/docs/coverage.md
@@ -1,9 +1,9 @@
 # Distribution coverage
 
 What stanli lowers, what it does not, and why. Counts are against
-`stanc --dump-stan-math-signatures`, which is what the Stan language
-actually offers rather than what someone typed into a table here; `harnesses/fn_sweep.py` checks each one against CmdStan
-with a generated single-function model.
+`stanc --dump-stan-math-signatures`, so they track what the Stan
+language actually offers; `harnesses/fn_sweep.py` checks each function
+against CmdStan with a generated single-function model.
 
 | family | supported |
 |---|---|
@@ -12,88 +12,70 @@ with a generated single-function model.
 | scalar math (all-real signature) | 47 / 129 |
 
 Every supported density's **gradients** match CmdStan bitwise, at three
-evaluation points. That is the standard here, and a density whose
-gradients merely agree to 1e-12 is a bug report, not a feature.
+evaluation points. That is the standard here: a density whose gradients
+merely agree to 1e-12 is a bug report, not a feature.
 
-`lp__` is bitwise too for everything models actually lean on. It is
-**not** for the multivariate and multinomial tail, which is built the
-compact way: one instantiation instead of `2^N`, so `lp__` comes out a
-per-model constant higher while every gradient stays exact. Which
-densities, why, and how to check:
+`lp__` is bitwise too for everything models commonly use. It is not for
+the multivariate and multinomial tail, which is built the compact way:
+one instantiation instead of `2^N`, so `lp__` comes out a per-model
+constant higher while every gradient stays exact. See
 [docs/compact-densities.md](compact-densities.md).
 
-Adding one is a line in an X-macro list in
-`runtime/include/stanli/optable.hpp`, which generates the opcode, the
-kernel, its registration, the lowering table entry and the interpreter
-branch together. See `docs/hacking.md`.
+Adding a function is one line in an X-macro list in
+`runtime/include/stanli/optable.hpp`; see `docs/hacking.md`.
 
 ## Three ways in, cheapest first
 
-Not every density needs a kernel, and reaching for one first is how this
-list stayed short longer than it had to.
+Not every density needs a kernel.
 
 **1. Rewrite, when the rewrite is exact.** `y ~ foo(...)` with every
-argument data contributes EXACTLY zero: CmdStan's generated code calls
-`foo_lpdf<propto=true>` on all-double arguments, `include_summand` comes
-back false, and the term is dropped before any arithmetic. That is a
-general rule, not an approximation, and it needs no kernel at all -- which
-is the whole of `hypergeometric` and `discrete_range`, whose arguments are
-all integers so every use of them lands here. `target +=` of the same call
-is a compile-time constant through the data interpreter. (The one
-divergence: a model whose data is outside the density's support -- CmdStan
-throws from its checks, stanli contributes 0. Such a model rejects every
-draw either way.)
+argument data contributes exactly zero: CmdStan calls
+`foo_lpdf<propto=true>` on all-double arguments and drops the term
+before any arithmetic. That rule needs no kernel and is the whole of
+`hypergeometric` and `discrete_range`, whose arguments are all
+integers. (One divergence: on data outside the density's support,
+CmdStan throws from its checks and stanli contributes 0. Such a model
+rejects every draw either way.) A rewrite that changes arithmetic does
+not belong here: `multi_normal_prec(y | mu, P)` equals
+`multi_normal(y | mu, inverse(P))` mathematically, but the inverse
+costs K^3 per evaluation and stops matching CmdStan bitwise. The kernel
+was fifteen lines.
 
-What does NOT belong here is a rewrite that changes the arithmetic.
-`multi_normal_prec(y | mu, P)` is `multi_normal(y | mu, inverse(P))`
-mathematically, but it costs a K^3 inverse per evaluation and stops
-matching CmdStan bitwise, which is the oracle this project runs on. The
-kernel below was fifteen lines.
-
-**2. Clone, when a signature already exists.** `multi_normal_prec` takes
-the same three arguments in the same shapes as `multi_normal`;
-`lkj_corr` the same two as `lkj_corr_cholesky`. Both were one template
-parameter on an existing kernel. Worth checking for before writing
-anything: the remaining pairs (`wishart`/`inv_wishart`,
-`multi_gp`/`multi_gp_cholesky`, `multi_student_t`/its cholesky form) are
-clones of each other, so the first of each pair pays for two.
+**2. Clone, when a signature already exists.** `multi_normal_prec`
+takes the same argument shapes as `multi_normal`; `lkj_corr` the same
+as `lkj_corr_cholesky`. Both were one template parameter on an existing
+kernel. The remaining pairs (`wishart`/`inv_wishart`,
+`multi_gp`/`multi_gp_cholesky`, `multi_student_t`/its cholesky form)
+are clones of each other, so the first of each pair pays for two.
 
 **3. Write the kernel.** The var-tape-replay pattern is correct by
 construction and needs no hand-written derivative: build a nested tape,
-call stan-math, `grad()` it. What makes each one bespoke is only the SHAPE
-PLUMBING -- how a matrix or an array-of-vectors argument reaches the
-kernel -- not the math. The shared helpers (`tail_m`, `tail_v`,
-`tail_scatter_*` in `runtime/kernels/matrix_fns.cpp`) reduce each to about
-twenty lines.
-
-This tier also has no restriction on what the density does with its scalar
-type, which the recorder does: `ordered_probit` computes
-`c_vec[i].coeff(0) - lambda_vec[i]` and `wiener` does `res *= 0.0`, and
-`stan::math::var` has those operators where `rvar` deliberately does not.
-Both were written off as unreachable until they were tried on a var tape.
-
-These kernels are **compact** -- one instantiation, every argument bound
-as autodiff -- so `lp__` carries a per-model constant while the gradients
-stay exact. [docs/compact-densities.md](compact-densities.md) is the
+call stan-math, `grad()` it. Only the shape plumbing is bespoke, and
+the shared helpers (`tail_m`, `tail_v`, `tail_scatter_*` in
+`runtime/kernels/matrix_fns.cpp`) reduce each kernel to about twenty
+lines. Unlike the recorder, this tier has no restriction on what the
+density does with its scalar type: `ordered_probit` and `wiener` use
+operators `rvar` deliberately lacks, and both work on a var tape. These
+kernels are **compact** (one instantiation, every argument bound as
+autodiff), so `lp__` carries a per-model constant while gradients stay
+exact; [docs/compact-densities.md](compact-densities.md) is the
 contract.
 
 ## What is left
 
-**`gaussian_dlm_obs`** -- the only unsupported density, and for a
-structural reason rather than a mathematical one. It takes seven
-arguments; `Op::in` holds six. Raising the limit would add bytes to every
-`Op` and every `KernelCtx` in every model, for one dynamic-linear-model
-density, so the lowering refuses and says why. (`add_op` used to write
-past the array without a word: a seven-input op corrupted `n_in` and
-surfaced as a SIGBUS inside the kernel. It throws now.)
+**`gaussian_dlm_obs`**, the only unsupported density, for a structural
+reason: it takes seven arguments and `Op::in` holds six. Raising the
+limit would grow every `Op` and `KernelCtx` in every model for one
+density, so the lowering refuses and says why.
 
-**Vector `alpha` in the GLMs.** `bernoulli_logit_glm`, `poisson_log_glm`
-and `neg_binomial_2_log_glm` take the intercept as a scalar; stan-math
-also allows a per-row vector. The kernels refuse that form by name.
+**Vector `alpha` in the GLMs.** `bernoulli_logit_glm`,
+`poisson_log_glm` and `neg_binomial_2_log_glm` take the intercept as a
+scalar; stan-math also allows a per-row vector, and the kernels refuse
+that form by name.
 
 ## Parameter transforms
 
-All of them, and every one bitwise against CmdStan:
+All of them, every one bitwise against CmdStan:
 
 | transform | unconstrained size |
 |---|---|
@@ -108,51 +90,42 @@ All of them, and every one bitwise against CmdStan:
 | `cholesky_factor_corr[K]` | K(K-1)/2 |
 | `cholesky_factor_cov[M, N]` | N(N+1)/2 + (M-N)N |
 
-`offset`/`multiplier` is the one that matters most in practice -- it is
-how a modern model writes a non-centered parameterization, and how brms
-generates one -- and its offset and multiplier may themselves be
-parameters, scalar or per-element.
+`offset`/`multiplier` matters most in practice: it is how a modern
+model writes a non-centered parameterization, and its offset and
+multiplier may themselves be parameters, scalar or per-element.
+`corr_matrix` and `cholesky_factor_cov` are what let `lkj_corr` and the
+wisharts be *declared* rather than reached through a transformed
+parameter.
 
-`corr_matrix` and `cholesky_factor_cov` landing here is also what lets
-`lkj_corr` and the wisharts be *declared* rather than reached through a
-transformed parameter.
-
-`harnesses/transform_sweep.py deps/cmdstan` is the oracle: one model per
-transform, compared to a CmdStan build of the same model at three
-deterministic points. It needs a CmdStan checkout, so CI runs
-`tests/test_newtrans.cpp` instead, which checks the unconstrained size by
-hand, the gradient against central finite differences, and each
-transform's defining property (a unit_vector has norm 1, a correlation
-matrix has unit diagonal, a Cholesky factor has a positive one).
+`harnesses/transform_sweep.py deps/cmdstan` is the oracle: one model
+per transform against a CmdStan build at three deterministic points. It
+needs a CmdStan checkout, so CI runs `tests/test_newtrans.cpp` instead,
+which checks the unconstrained size, the gradient against central
+finite differences, and each transform's defining property.
 
 ## reject and print
 
-Both supported, in both places they can appear. `reject` throws
-`std::domain_error` -- the same exception CmdStan's generated code
-throws, so the sampler counts it as a rejected proposal rather than a
-failed run -- and `print` writes to stdout.
+Both supported, in both places they can appear
+(`tests/test_rejectprint.cpp`). `reject` throws `std::domain_error`,
+the same exception CmdStan's generated code throws, so the sampler
+counts a rejected proposal rather than a failed run; `print` writes to
+stdout. In `transformed data` the statement runs at lowering time, so a
+taken `reject` fails the compile, which is CmdStan failing to construct
+the model. In the model block it lowers to an op and throws during the
+forward sweep.
 
-The two placements are different machinery and both are covered
-(`tests/test_rejectprint.cpp`). In `transformed data` the statement runs
-in the MIR interpreter at lowering time, so a taken `reject` fails the
-compile, which is CmdStan failing to construct the model. In the model
-block it lowers to an op and throws during the forward sweep, once per
-evaluation.
-
-What is still missing is a `reject` under a condition on a *parameter*,
-because the condition is what stanli cannot lower yet, not the reject:
+Still missing: `reject` under a condition on a *parameter*, because
 `lower.cpp` refuses boolean operators on parameters. That is the same
-gap as parameter-dependent control flow generally, and the path to it is
-island v2 -- the register program already has the branch instructions.
+gap as parameter-dependent control flow generally; the register program
+already has the branch instructions.
 
 ## Truncation and censoring
 
-Supported. `y ~ foo(...) T[l, u]` is rewritten by stanc3 into the density
-minus `log_diff_exp` of the bounds' `lcdf`s, and both pieces are in.
-Gradients are bitwise against CmdStan; `lp__` comes out 1 ULP off, because
-the rewrite accumulates its terms in a different order than CmdStan's
-`lp_accum__` does. `tests/fixtures/trunc.stan` guards this in CI, where
-there is no CmdStan for `fn_sweep` to compare against.
+Supported. `y ~ foo(...) T[l, u]` is rewritten by stanc3 into the
+density minus `log_diff_exp` of the bounds' `lcdf`s, and both pieces
+are in. Gradients are bitwise against CmdStan; `lp__` is 1 ULP off
+because the rewrite accumulates in a different order than CmdStan's
+`lp_accum__`. `tests/fixtures/trunc.stan` guards this in CI.
 
 ## Checking this yourself
 

--- a/docs/density-pack.md
+++ b/docs/density-pack.md
@@ -1,15 +1,14 @@
 # Splitting the browser runtime: what was tried and why it is not in
 
-Densities are 55% of the compressed browser download and most models use a
-handful, so loading the uncommon ones on demand is an obvious idea. It was
-built, it worked, and it was removed. This records what was measured, so
-that a second attempt starts from the one thing that actually blocks it.
+Densities are 55% of the compressed browser download and most models
+use a handful, so loading the uncommon ones on demand is an obvious
+idea. It was built, it worked, and it was removed. This records what
+was measured, so a second attempt starts from the one thing that
+actually blocks it. The code is in the history: the commit that added
+`stanli_load_pack`, `stanli_register_kernel_c` and
+`tests/test_wasm_pack.cjs`, and the one that removed them.
 
-The code is in the history: the commit that added `stanli_load_pack`,
-`stanli_register_kernel_c` and `tests/test_wasm_pack.cjs`, and the one
-that removed them.
-
-## What the payload is made of
+## The payload
 
 Measured by stubbing every density, cdf and tail kernel and relinking
 (macOS arm64, emsdk 6.0.6):
@@ -30,64 +29,49 @@ split.
 | split, `MAIN_MODULE=1`: core + pack | 1.73 + 0.99 MB |
 | split, `MAIN_MODULE=2`: core + pack | 1.04 + 0.99 MB |
 
-`MAIN_MODULE=2` is the mode worth having: a model using only core
-densities downloads 1.04 MB instead of 1.52 MB. It does not load a side
-module. That mode exports only what `EXPORTED_FUNCTIONS` names, and a side
-module also imports `__stack_pointer` and the `__cpp_exception` tag, which
-are not functions and cannot be named there. The load fails with
-`imported mutable global must be a WebAssembly.Global object`, and adding
-`__stack_pointer` to `EXPORTED_FUNCTIONS` is rejected as an undefined
-exported symbol.
-
-`MAIN_MODULE=1` exports everything a side module might want, which is why
-it works and why it adds 0.69 MB gzipped to the core. Core plus pack is
-then 2.72 MB against 1.52 MB unsplit: worse for every model, whether or
-not it needs the pack.
-
-The whole question is therefore on the emscripten side. Everything else
-worked.
+`MAIN_MODULE=2` is the mode worth having (a core-only model downloads
+1.04 MB instead of 1.52 MB), and it cannot load a side module: it
+exports only what `EXPORTED_FUNCTIONS` names, and a side module also
+needs `__stack_pointer` and the `__cpp_exception` tag, which are not
+functions and cannot be named there. The load fails with
+`imported mutable global must be a WebAssembly.Global object`.
+`MAIN_MODULE=1` exports everything, which is why it works and why it
+adds 0.69 MB gzipped: core plus pack is then 2.72 MB against 1.52 MB
+unsplit, worse for every model. The blocker is entirely on the
+emscripten side; everything else worked.
 
 ## What did work, and is worth reusing
 
-**Dynamic linking is free here.** `MAIN_MODULE=2` with `-fPIC`, measured
-against the same tree: 1.05 MB gzipped either way, 449 against 451
-ns/gradient. WebAssembly calls already go indirect through a function
-table, so there is no PLT or GOT penalty of the kind native dynamic
-linking pays. An earlier version of `docs/benchmarks.md` assumed this cost
-would exceed the saving; that was wrong.
-
-**A side module can call back into the core.** A spike loaded one with
-`dlopen` and called a function in it that called a function in the main
-module. A pack can use the core's `register_kernel` and libm rather than
-carrying its own copies.
-
-**The design fits the runtime as it stands.** Dispatch is already
-`kernel(opcode).forward`, a function-pointer table, so late registration
-only fills in slots. The lowering already fails with
-`opcode not registered: OP_...`, so the trigger is self-correcting: try to
-compile, fetch the pack on that error, retry once. No list of density
-names has to be mirrored in JavaScript.
+- **Dynamic linking is free here.** `MAIN_MODULE=2` with `-fPIC`
+  measured 1.05 MB gzipped either way and 449 vs 451 ns/gradient: wasm
+  calls already go indirect through a function table, so there is no
+  PLT/GOT penalty.
+- **A side module can call back into the core** (proven with a `dlopen`
+  spike), so a pack can use the core's `register_kernel` and libm
+  rather than carrying copies.
+- **The trigger is self-correcting.** Dispatch is already a
+  function-pointer table, and lowering already fails with
+  `opcode not registered: OP_...`: try to compile, fetch the pack on
+  that error, retry once. No density-name table mirrored in JavaScript.
 
 ## Traps, if this is attempted again
 
-- The pack must be compiled with the same exception ABI as the core
-  (`-fwasm-exceptions`). Without it the load fails on `__stack_pointer`
-  in a way that looks like a dynamic-linking bug and is not.
-- `dlfcn.h` does not exist on mingw. Anything that includes it has to be
-  guarded, or the Windows wheel stops building. That job runs after the
-  merge rather than as a gate, so it fails on `main`.
-- A define that selects which kernels register has to reach both the
-  static library, where `densities.cpp` lives, and the executable, where
-  the loader lives. Setting only the first makes the loader a silent
-  no-op that returns success.
+- The pack must use the same exception ABI as the core
+  (`-fwasm-exceptions`); mismatched, the load fails on
+  `__stack_pointer` in a way that looks like a dynamic-linking bug.
+- `dlfcn.h` does not exist on mingw; guard any include of it or the
+  Windows wheel stops building, after the merge, on `main`.
+- A define selecting which kernels register must reach both the static
+  library and the executable; setting only the first makes the loader a
+  silent no-op.
 - The pack sources must leave the static library only when the split is
-  on, not whenever the platform is emscripten, or an unsplit browser build
-  fails to link.
+  on, not whenever the platform is emscripten, or an unsplit browser
+  build fails to link.
 
 ## The alternative that needs no dynamic linking
 
 Two prebuilt whole-module bundles, common densities and everything,
 selected once the compiled model's op set is known. No PIC, no side
-modules, and the worst case is one wasted fetch of the smaller file. It
-cannot add to a running module, so a model needing one uncommon density
-downloads the whole large bundle, but it has no emscripten blocker.
+modules, and the worst case is one wasted fetch of the smaller file. A
+model needing one uncommon density downloads the whole large bundle,
+but there is no emscripten blocker.

--- a/docs/hacking.md
+++ b/docs/hacking.md
@@ -1,60 +1,47 @@
 # Hacking on stanli
 
-A map for contributors: which file owns what, how a gradient actually
-gets computed, and the recipes for the two most common changes.
-[`docs/how-it-works.md`](how-it-works.md) explains why the design is what it is;
-[`runtime/src/OPTIMIZATIONS.md`](../runtime/src/OPTIMIZATIONS.md) explains the graph passes in plain
-language; [`docs/benchmarks.md`](benchmarks.md) has the measurements.
+A map for contributors: which file owns what, how a gradient gets
+computed, and the recipes for the most common changes.
+[`docs/how-it-works.md`](how-it-works.md) explains why the design is
+what it is; [`runtime/src/OPTIMIZATIONS.md`](../runtime/src/OPTIMIZATIONS.md)
+explains the graph passes in plain language;
+[`docs/benchmarks.md`](benchmarks.md) has the measurements.
 
-If you are reading only one section, read "Where the silent wrongness
-lives" -- it is the shape of every bug this project has shipped.
+If you read only one section, read "Where the silent wrongness lives".
+It is the shape of every bug this project has shipped.
 
 ## Layout
 
 | Path | Owns |
 |---|---|
-| [`runtime/include/stanli/`](../runtime/include/stanli/) | All public headers. [`graph.hpp`](../runtime/include/stanli/graph.hpp) is the IR: `Slot` + `Op` over flat arenas. |
-| [`runtime/src/lower.cpp`](../runtime/src/lower.cpp) | The compiler: transformed MIR in, op graph out. `lower_expr`/`lower_stmt` walk statements; function calls dispatch through `lower_density_fn`, `lower_eltwise_fn`, `lower_matrix_fn`, `lower_ode_fn`. `lower_read_param` builds the constrain ops and the parameter views. |
-| [`runtime/src/mir_reader.cpp`](../runtime/src/mir_reader.cpp), [`sexp.hpp`](../runtime/include/stanli/sexp.hpp), [`mir.hpp`](../runtime/include/stanli/mir.hpp) | Parse stanc3's `--debug-transformed-mir` s-expressions into the C++ MIR structs. Anything unrecognized is preserved as raw text and fails loudly if reached. |
-| [`runtime/src/inplace.cpp`](../runtime/src/inplace.cpp), [`constfold.cpp`](../runtime/src/constfold.cpp), [`reroll.cpp`](../runtime/src/reroll.cpp) | The graph passes, in pipeline order (with [`island.cpp`](../runtime/src/island.cpp), below, closing it). Each has an env switch to turn it off (see [OPTIMIZATIONS.md](../runtime/src/OPTIMIZATIONS.md)). |
-| [`runtime/src/executor.cpp`](../runtime/src/executor.cpp) | Runs the op list: forward for the log density, reverse for the gradient. `STANLI_PROFILE=1` prints per-opcode accounting. |
-| [`runtime/kernels/`](../runtime/kernels/) | Op implementations. [`densities.cpp`](../runtime/kernels/densities.cpp) instantiates unmodified stan-math prim templates; [`elementwise.cpp`](../runtime/kernels/elementwise.cpp)/[`eltwise_expr.cpp`](../runtime/kernels/eltwise_expr.cpp) the vector math; [`constrain.cpp`](../runtime/kernels/constrain.cpp) the transforms; [`matrix_fns.cpp`](../runtime/kernels/matrix_fns.cpp) and [`legacy_fns.cpp`](../runtime/kernels/legacy_fns.cpp) wrap stan-math functions that have no native port (see [`legacy.hpp`](../runtime/include/stanli/legacy.hpp) for the mechanism). |
-| [`runtime/include/stanli/mir_interp.hpp`](../runtime/include/stanli/mir_interp.hpp) | The one MIR interpreter, templated on the scalar. Three users: the lowering (transformed data and every data-only expression, on `double`), the ODE kernels (right-hand sides the compiled path cannot handle, on `double` and `var`), and the interpreted write_array. |
-| [`runtime/src/wa_interp.cpp`](../runtime/src/wa_interp.cpp) | `WaInterp`: per-draw interpreted generated quantities for models whose write_array graph cannot be built (RNG calls, draw-dependent branches). Owns the RNG stream and the FnReadParam/FnWriteParam statement hooks. |
-| [`runtime/src/island.cpp`](../runtime/src/island.cpp) | The tape-island carver and its cost estimate, plus the graph-op front end to the register machine. Runs last in the pipeline. |
-| [`runtime/include/stanli/program.hpp`](../runtime/include/stanli/program.hpp), [`mir_prog.hpp`](../runtime/include/stanli/mir_prog.hpp) | The register machine: one instruction set with one runner templated on the scalar ([`program.hpp`](../runtime/include/stanli/program.hpp)), and the MIR front end both callers compile through ([`mir_prog.hpp`](../runtime/include/stanli/mir_prog.hpp)). [`ode_prog.cpp`](../runtime/src/ode_prog.cpp) is the ODE entry, [`island.cpp`](../runtime/src/island.cpp) the graph-op entry, [`lower.cpp`](../runtime/src/lower.cpp) the parameter-conditional entry. |
-| [`runtime/src/nuts.cpp`](../runtime/src/nuts.cpp) | The sampler: stan's own `adapt_diag_e_nuts` driven through [`model_adapter.hpp`](../runtime/include/stanli/model_adapter.hpp). Also owns CmdStan parity of the RNG stream and of which initial points are accepted. |
-| [`runtime/src/capi.cpp`](../runtime/src/capi.cpp), [`capi.h`](../runtime/include/stanli/capi.h) | The C ABI the shared library exports, write_array included. [`python/stanli/__init__.py`](../python/stanli/__init__.py) is a thin ctypes wrapper over it. |
-| [`runtime/src/stanc_embed_c.cpp`](../runtime/src/stanc_embed_c.cpp), [`tools/stanc_embed/`](../tools/stanc_embed/) | The in-process stanc3: the OCaml compiler built with `-output-complete-obj` and linked into the shared library. |
-| [`js/`](../js/) | The npm package: [`index.mjs`](../js/index.mjs) is the one-call `sample()` API over [`worker.js`](../js/worker.js), which runs stancjs (stanc3 as JavaScript) and the WASM build of this runtime off the main thread. |
-| [`web/`](../web/) | The demo page at [seantalts.github.io/stanli](https://seantalts.github.io/stanli/), assembled from [`js/`](../js/) by [`tools/build_web.sh`](../tools/build_web.sh) so the package and the page cannot drift. |
-| [`tools/`](../tools/) | [`stanli_check`](../tools/stanli_check.cpp) (one deterministic gradient evaluation, machine-readable), [`stanli_run`](../tools/stanli_run.cpp) (full CSV sampling run), [`dump_ops`](../tools/dump_ops.cpp) (print a model's lowered op list), [`verify_refs.py`](../tools/verify_refs.py) (corpus replay against recorded CmdStan values, runs in CI), [`verify_sample.py`](../tools/verify_sample.py) (records those references, needs CmdStan), [`sampler_trace.py`](../tools/sampler_trace.py) (sampler-column diff vs CmdStan), [`gen_docs.py`](../tools/gen_docs.py) (stamps measured numbers into the READMEs), [`wasm_check.sh`](../tools/wasm_check.sh) (the corpus replay through the WASM build, under Node). |
-| [`harnesses/`](../harnesses/) | Corpus sweeps that need a local posteriordb: [`wa_coverage.py`](../harnesses/wa_coverage.py) (how much of each model's generated quantities we produce), [`wa_header_check.py`](../harnesses/wa_header_check.py) (CSV headers vs CmdStan), benchmarks. |
-| [`tests/`](../tests/) | One `test_*.cpp` per subsystem, plus [`fixtures/`](../tests/fixtures/) with `.stan` sources and their pinned `.tmir.sexp` MIR (regenerate with [`tools/gen_fixtures.sh`](../tools/gen_fixtures.sh)). |
+| [`runtime/include/stanli/`](../runtime/include/stanli/) | Public headers. [`graph.hpp`](../runtime/include/stanli/graph.hpp) is the IR: `Slot` + `Op` over flat arenas. |
+| [`runtime/src/lower.cpp`](../runtime/src/lower.cpp) | The compiler: transformed MIR in, op graph out. |
+| [`runtime/src/mir_reader.cpp`](../runtime/src/mir_reader.cpp) | Parses stanc3's s-expressions into MIR structs. Unrecognized input fails loudly if reached. |
+| [`runtime/src/inplace.cpp`](../runtime/src/inplace.cpp), [`constfold.cpp`](../runtime/src/constfold.cpp), [`reroll.cpp`](../runtime/src/reroll.cpp), [`island.cpp`](../runtime/src/island.cpp) | The graph passes, in pipeline order, each with an off switch (see [OPTIMIZATIONS.md](../runtime/src/OPTIMIZATIONS.md)). |
+| [`runtime/src/executor.cpp`](../runtime/src/executor.cpp) | Runs the op list. `STANLI_PROFILE=1` prints per-opcode accounting. |
+| [`runtime/kernels/`](../runtime/kernels/) | Op implementations: [`densities.cpp`](../runtime/kernels/densities.cpp), [`elementwise.cpp`](../runtime/kernels/elementwise.cpp), [`constrain.cpp`](../runtime/kernels/constrain.cpp), plus [`matrix_fns.cpp`](../runtime/kernels/matrix_fns.cpp)/[`legacy_fns.cpp`](../runtime/kernels/legacy_fns.cpp) wrapping stan-math functions without a native port ([`legacy.hpp`](../runtime/include/stanli/legacy.hpp) is the mechanism). |
+| [`runtime/include/stanli/mir_interp.hpp`](../runtime/include/stanli/mir_interp.hpp) | The one MIR interpreter, templated on the scalar: transformed data at lowering time, uncompiled ODE right-hand sides, interpreted write_array. |
+| [`runtime/src/wa_interp.cpp`](../runtime/src/wa_interp.cpp) | Per-draw interpreted generated quantities when the write_array graph cannot be built (RNG calls, draw-dependent branches). |
+| [`runtime/include/stanli/program.hpp`](../runtime/include/stanli/program.hpp), [`mir_prog.hpp`](../runtime/include/stanli/mir_prog.hpp) | The register machine and its MIR front end. |
+| [`runtime/src/nuts.cpp`](../runtime/src/nuts.cpp) | The sampler: stan's own `adapt_diag_e_nuts`. Owns CmdStan parity of the RNG stream and initial-point acceptance. |
+| [`runtime/src/capi.cpp`](../runtime/src/capi.cpp), [`capi.h`](../runtime/include/stanli/capi.h) | The C ABI. [`python/stanli/__init__.py`](../python/stanli/__init__.py) is a thin ctypes wrapper over it. |
+| [`runtime/src/stanc_embed_c.cpp`](../runtime/src/stanc_embed_c.cpp), [`tools/stanc_embed/`](../tools/stanc_embed/) | The in-process stanc3 (OCaml, `-output-complete-obj`). |
+| [`js/`](../js/), [`web/`](../web/) | The npm package (a one-call `sample()` over a worker) and the demo page, assembled from it by [`tools/build_web.sh`](../tools/build_web.sh) so they cannot drift. |
+| [`tools/`](../tools/) | [`stanli_check`](../tools/stanli_check.cpp) (one deterministic gradient), [`stanli_run`](../tools/stanli_run.cpp) (full CSV run), [`dump_ops`](../tools/dump_ops.cpp) (print a model's op list), [`verify_refs.py`](../tools/verify_refs.py) (corpus replay against recorded CmdStan values; runs in CI), [`verify_sample.py`](../tools/verify_sample.py) (records the references; needs CmdStan), [`sampler_trace.py`](../tools/sampler_trace.py), [`gen_docs.py`](../tools/gen_docs.py), [`wasm_check.sh`](../tools/wasm_check.sh). |
+| [`harnesses/`](../harnesses/) | Corpus sweeps needing a local posteriordb: [`wa_coverage.py`](../harnesses/wa_coverage.py), [`ab_corpus.py`](../harnesses/ab_corpus.py), benchmarks. |
+| [`tests/`](../tests/) | One `test_*.cpp` per subsystem, plus [`fixtures/`](../tests/fixtures/) with `.stan` sources and pinned MIR (regenerate with [`tools/gen_fixtures.sh`](../tools/gen_fixtures.sh)). |
 
-## The shape of the thing
+About 11,500 lines of runtime against 5,800 lines of tests. The biggest
+files: [`lower.cpp`](../runtime/src/lower.cpp) (1,935 lines, the
+compiler, most likely what you are looking for),
+[`mir_interp.hpp`](../runtime/include/stanli/mir_interp.hpp) (1,284),
+[`reroll.cpp`](../runtime/src/reroll.cpp) (860). The kernels are
+repetitive by design: read one and you can read them all. There are 82
+opcodes ([`optable.hpp`](../runtime/include/stanli/optable.hpp)).
 
-About 11,500 lines of runtime against 5,800 lines of tests. Where the
-weight sits:
-
-| | lines | |
-|---|---:|---|
-| [`lower.cpp`](../runtime/src/lower.cpp) | 1,935 | The compiler. Biggest file, and the one most likely to be what you are looking for. |
-| [`mir_interp.hpp`](../runtime/include/stanli/mir_interp.hpp) | 1,284 | The MIR interpreter, templated on the scalar. |
-| [`reroll.cpp`](../runtime/src/reroll.cpp) | 860 | The vectorizing pass. Dense, but self-contained. |
-| [`mir_prog.hpp`](../runtime/include/stanli/mir_prog.hpp) | 536 | MIR to register program. |
-| [`island.cpp`](../runtime/src/island.cpp) | 528 | The island carver. |
-| [`matrix_fns.cpp`](../runtime/kernels/matrix_fns.cpp), [`densities.cpp`](../runtime/kernels/densities.cpp) | 488, 455 | Kernels. Repetitive by design; read one, you can read them all. |
-| [`mir_reader.cpp`](../runtime/src/mir_reader.cpp) | 374 | S-expressions to MIR structs. |
-| [`executor.cpp`](../runtime/src/executor.cpp) | 320 | Runs the op list. Small on purpose. |
-| [`inplace.cpp`](../runtime/src/inplace.cpp), [`constfold.cpp`](../runtime/src/constfold.cpp) | 204, 186 | The other two passes. |
-| [`nuts.cpp`](../runtime/src/nuts.cpp) | 133 | The sampler is thin: Stan's classes do the work. |
-
-There are 82 opcodes ([`optable.hpp`](../runtime/include/stanli/optable.hpp)). Adding one is a small, well-worn
-change; the recipe is below. The difficulty in this codebase is almost
-never in writing new code -- it is in not breaking the numerical
-agreement with CmdStan that everything else rests on, which is what the
-"silent wrongness" section is about.
+The difficulty in this codebase is almost never writing new code. It is
+not breaking the numerical agreement with CmdStan that everything else
+rests on.
 
 ## Life of a gradient
 
@@ -65,7 +52,7 @@ model.stan + data.json
 mir_reader.cpp
   |  parsed into mir::Stmt / mir::Expr
   v
-lower.cpp                       <- the compiler; ~everything hard lives here
+lower.cpp
   |  transformed data evaluated eagerly (mir_interp.hpp, on double)
   |  data-bound loops unrolled, `~` lowered with CmdStan's propto and
   |  per-argument activity, parameter-conditional regions compiled to
@@ -80,50 +67,45 @@ graph passes, in this order (lower.cpp's run()):
   |  reduce_terms              target terms -> one result slot
   v
 Executor::bind_()
-  |  slot offsets assigned, three arenas sized (values, adjoints,
-  |  scratch), one KernelCtx built per op, dispatch tables resolved
+  |  slot offsets assigned, arenas sized, one KernelCtx built per op,
+  |  dispatch tables resolved
   v
 forward sweep   = log density, each kernel stashing its partials
 reverse sweep   = gradient, each kernel contracting them
 ```
 
-Two things follow from that picture and are worth internalizing.
-
-**The graph is the autodiff tape.** There is no tape being built at
-evaluation time; the op list *is* the tape, fixed when the model loads.
-That is why control flow that depends on a parameter cannot be ops (it
-becomes an island instead), and why a steady-state gradient allocates
-nothing.
-
-**Lowering happens once, evaluation happens millions of times.** A
-compile-time cost of 200 ms to save 10 ns per gradient is a trade this
-project takes every time.
+Two things to internalize. **The graph is the autodiff tape**: no tape
+is built at evaluation time, which is why parameter-dependent control
+flow cannot be ops (it becomes an island) and why a steady-state
+gradient allocates nothing. **Lowering happens once, evaluation happens
+millions of times**: a compile-time cost of 200 ms to save 10 ns per
+gradient is a trade this project takes every time.
 
 ## The IR
 
-Four types in [`graph.hpp`](../runtime/include/stanli/graph.hpp), and they are deliberately dull:
+Four types in [`graph.hpp`](../runtime/include/stanli/graph.hpp),
+deliberately dull:
 
-- `Slot` -- a value: an offset into the arenas, a length, and whether it
-  is a parameter. Parameters come first, in declaration order, so the
+- `Slot`: a value. An arena offset, a length, and whether it is a
+  parameter. Parameters come first, in declaration order, so the
   gradient vector is contiguous.
-- `Op` -- an opcode, up to six input slots, one output (rarely two),
-  integer immediates (`idata`), an opaque payload (`udata`, for ODE
-  specs and island programs), and a scratch window.
-- `Graph` -- the slots, the ops, and the pools that own `idata`/`udata`.
-- `KernelCtx` -- what a kernel actually sees: raw `double*` + length for
-  each input, output, and adjoint, plus its scratch. Assembled once at
-  bind, never rebuilt.
+- `Op`: an opcode, up to six input slots, one output (rarely two),
+  integer immediates (`idata`), an opaque payload (`udata`), and a
+  scratch window.
+- `Graph`: the slots, the ops, and the pools that own `idata`/`udata`.
+- `KernelCtx`: what a kernel sees. Raw `double*` + length per input,
+  output, and adjoint, plus scratch. Assembled once at bind.
 
-The `variant` byte on `Op` is worth reading twice, because it encodes
-the CmdStan semantics a density has to reproduce: bits 0-5 are
-per-argument activity (which arguments are autodiff), bit 6 means the
-output is elementwise (one lp per element rather than the sum), and bit
-7 is propto. Get it wrong and the gradient stays perfect while the log
-density is off by a constant.
+The `variant` byte on `Op` encodes the CmdStan semantics a density must
+reproduce: bits 0-5 are per-argument activity (which arguments are
+autodiff), bit 6 is elementwise output, bit 7 is propto. Get it wrong
+and the gradient stays perfect while the log density is off by a
+constant.
 
 ## The kernel contract
 
-A kernel is three function pointers ([`optable.hpp`](../runtime/include/stanli/optable.hpp)):
+A kernel is three function pointers
+([`optable.hpp`](../runtime/include/stanli/optable.hpp)):
 
 ```cpp
 struct Kernel {
@@ -133,143 +115,133 @@ struct Kernel {
 };
 ```
 
-The rules, all of which have been learned the hard way:
+The rules, each learned the hard way:
 
 - **The forward computes partials; the backward only contracts them.**
-  Not the other way around. A backward that recomputes the forward pays
-  twice per gradient -- that was 90% of `diamonds`, and fixing it was
-  worth 1.8x on the model.
-- **`in_adj[k].data` may be null.** That means the input is data and its
-  adjoint must not be touched.
-- **Accumulate in the order the reference does.** Several kernels sum in
-  a deliberate direction (descending, or per-element rather than
-  blocked) to stay bitwise identical to the stan-math var path they are
-  checked against. If you reorder a reduction you will usually still
-  pass the corpus oracle at 1e-9 and still break [`test_matvec`](../tests/test_matvec.cpp) at 1 ULP,
-  and the ULP is the thing worth keeping.
-- **Scratch is yours alone**, sized at bind and never touched by another
-  op -- which is what makes an in-place write safe in front of you.
+  A backward that recomputes the forward pays twice per gradient; that
+  was 90% of `diamonds`, and fixing it was worth 1.8x.
+- **`in_adj[k].data` may be null.** The input is data; do not touch its
+  adjoint.
+- **Accumulate in the order the reference does.** Several kernels sum
+  in a deliberate direction to stay bitwise identical to the stan-math
+  var path they are checked against. A reordered reduction usually
+  still passes the corpus oracle at 1e-9 and still breaks
+  [`test_matvec`](../tests/test_matvec.cpp) at 1 ULP, and the ULP is
+  the thing worth keeping.
+- **Scratch is yours alone**, sized at bind and never touched by
+  another op.
 
 ## The register machine
 
-Some code cannot be ops. An ODE right-hand side has to stay callable
+Some code cannot be ops. An ODE right-hand side must stay callable
 because the integrator picks the times; a region whose control flow
-depends on a parameter has to pick its arm at evaluation time. Both
+depends on a parameter must pick its arm at evaluation time. Both
 compile to the same flat instruction list over a register file
-([`program.hpp`](../runtime/include/stanli/program.hpp)), run by one `run_program<T>` templated on the scalar --
-`double` for values, `var` where stan-math's autodiff needs to see the
-arithmetic.
-
-Three front ends produce one:
-
-| Entry | Source | Who runs it |
-|---|---|---|
-| `compile_rhs` ([`ode_prog.cpp`](../runtime/src/ode_prog.cpp)) | a MIR function body | the ODE kernel, per integrator step |
-| `carve_islands` ([`island.cpp`](../runtime/src/island.cpp)) | a run of graph ops | `OP_ISLAND`, once per evaluation |
-| `lower_param_ifelse` / `lower_param_ternary` ([`lower.cpp`](../runtime/src/lower.cpp)) | a MIR statement or expression | `OP_ISLAND`, once per evaluation |
-
-The first two are optimizations and can be declined -- the carver keeps
-an island only when it estimates the ops cost more (see
-[OPTIMIZATIONS.md](../runtime/src/OPTIMIZATIONS.md);
-`STANLI_NO_ISLAND=1` turns the pass off, `STANLI_ISLAND_ALWAYS=1` skips
-the estimate when you want to know why a region was left alone). The
-third is not: without it the model does not compile, so no switch
-reaches it.
+([`program.hpp`](../runtime/include/stanli/program.hpp)), run by one
+`run_program<T>`: `double` for values, `var` where stan-math's autodiff
+needs to see the arithmetic. Three front ends produce one: `compile_rhs`
+([`ode_prog.cpp`](../runtime/src/ode_prog.cpp)) for ODE right-hand
+sides, `carve_islands` ([`island.cpp`](../runtime/src/island.cpp)) for
+runs of graph ops, and `lower_param_ifelse`/`lower_param_ternary`
+([`lower.cpp`](../runtime/src/lower.cpp)) for parameter-conditional
+statements. The first two are optimizations and can be declined
+(`STANLI_NO_ISLAND=1` turns the pass off; `STANLI_ISLAND_ALWAYS=1`
+skips the cost estimate). The third is not: without it the model does
+not compile.
 
 ## The sampler
 
-[`nuts.cpp`](../runtime/src/nuts.cpp) is 133 lines because Stan's own `adapt_diag_e_nuts` does the
-sampling; the file's real job is matching CmdStan's *configuration*,
-which is invisible to any pointwise gradient test. Three things it has
-to keep in step, each of which was wrong at some point:
-
-- The max tree depth, which defaults to 5 in the base class and 10 in
-  CmdStan.
-- The RNG stream: `stan::services::util::create_rng(seed, chain)`, the
-  same engine seeded the same way, drawing the initial point in the same
-  order. Different engines mean the same seed names different starting
-  points, and every sampler comparison silently compares two draws.
-- Which initial points are accepted: CmdStan evaluates the log density
-  on doubles *and then* its gradient, rejecting on either. Those two can
-  disagree for an ODE model, so `Executor::forward_value_only()` exists
-  to be the double path.
-
-[`tools/sampler_trace.py`](../tools/sampler_trace.py) is the oracle for all of this: same model, same
-seed, compare the sampler columns distributionally.
+[`nuts.cpp`](../runtime/src/nuts.cpp) is 133 lines because Stan's own
+classes do the sampling; the file's real job is matching CmdStan's
+*configuration*, which no pointwise gradient test can see. Three things
+it keeps in step, each of which was wrong at some point: the max tree
+depth (5 in the base class, 10 in CmdStan); the RNG stream
+(`stan::services::util::create_rng(seed, chain)`, drawing the initial
+point in the same order); and which initial points are accepted
+(CmdStan evaluates the log density on doubles *and then* its gradient,
+rejecting on either, and the two can disagree for an ODE model, which
+is why `Executor::forward_value_only()` exists).
+[`tools/sampler_trace.py`](../tools/sampler_trace.py) is the oracle:
+same model, same seed, compare the sampler columns distributionally.
 
 ## Where the silent wrongness lives
 
-Every bug this project has shipped has been of one kind: the graph
-changed shape, every test passed, and the numbers were wrong. The
-classes, with the case that taught each:
+Every bug this project has shipped has one shape: the graph changed,
+every test passed, and the numbers were wrong. The classes, with the
+case that taught each:
 
 - **A destructive write in front of a backward that re-reads its
   inputs.** The in-place pass may only write over a value when every
   earlier op's backward is pure adjoint routing
-  (`backward_ignores_input_values`, pinned by [`test_pass_safety.cpp`](../tests/test_pass_safety.cpp)).
-  Getting this wrong made eight models wrong by up to 1.7e+05 relative
-  with their op counts unchanged.
-- **Propto and argument types.** Which constants a density drops depends
-  on which arguments are autodiff. Anything that binds arguments
-  uniformly (the register machine) cannot reproduce it, which is why
-  `~` inside a parameter-conditional region is refused rather than
-  approximated -- it had a perfect gradient and an lp off by exactly
-  log(2*pi)/2.
-- **Aliasing a slot that is both read and written by the same region.**
-  An island's live-in that is also a live-out needs a fresh slot, or the
-  producer's adjoint is counted twice (measured: off by exactly 1.0).
+  (`backward_ignores_input_values`, pinned by
+  [`test_pass_safety.cpp`](../tests/test_pass_safety.cpp)). Getting
+  this wrong made eight models wrong by up to 1.7e+05 relative with
+  their op counts unchanged.
+- **Propto and argument types.** Which constants a density drops
+  depends on which arguments are autodiff. The register machine binds
+  arguments uniformly and cannot reproduce that, which is why `~`
+  inside a parameter-conditional region is refused rather than
+  approximated: the bug it prevents had a perfect gradient and an lp
+  off by exactly log(2*pi)/2.
+- **Aliasing a slot that a region both reads and writes.** An island's
+  live-in that is also a live-out needs a fresh slot, or the producer's
+  adjoint is counted twice (measured: off by exactly 1.0).
 - **Reassociation.** See the kernel contract. Cheap to do by accident,
   invisible in the corpus oracle, visible in the ULP tests.
 - **Modes that skip work.** `forward_value_only()` lets a kernel skip
   partials; it is safe only because `gradient()` always runs a full
-  forward first. If you add a mode like that, say out loud why the
-  skipped work cannot survive into a reverse sweep.
+  forward first. If you add a mode like that, document why the skipped
+  work cannot survive into a reverse sweep.
 
 The practice that catches these is mutation testing, and it is expected
-of a change that claims a safety property: break the thing on purpose,
-watch the test fail, put it back. If the test passes with the guard
-removed, the test is not testing the guard. (Delete the object file and
-`touch` the source first -- make's mtime granularity will happily hand
+of any change that claims a safety property: break the guard on
+purpose, watch the test fail, put it back. If the test passes with the
+guard removed, the test is not testing the guard. (Delete the object
+file and `touch` the source first; make's mtime granularity will hand
 you a stale binary and a green run.)
 
 ## Adding a stan-math function
 
-Decide where it runs. Anything the log density touches needs to be an op;
-functions that only appear in transformed data, ODE right-hand sides, or
-generated quantities only need the interpreter.
+Decide where it runs. Anything the log density touches needs to be an
+op. Functions that appear only in transformed data, ODE right-hand
+sides, or generated quantities need only the interpreter: add a branch
+in [`mir_interp.hpp`](../runtime/include/stanli/mir_interp.hpp)'s
+`eval_fun`, or for RNG draws in
+[`wa_interp.cpp`](../runtime/src/wa_interp.cpp)'s `rng_fun`. Both fail
+loudly on anything unhandled;
+`python3 harnesses/wa_coverage.py deps/posteriordb` shows what is
+missing.
 
-Interpreter vocabulary: add a branch in [`mir_interp.hpp`](../runtime/include/stanli/mir_interp.hpp)'s `eval_fun`
-(deterministic math, templated on the scalar) or, for RNG draws, in
-[`wa_interp.cpp`](../runtime/src/wa_interp.cpp)'s `rng_fun`. Both fail loudly on anything unhandled, so
-the corpus tells you what is missing:
-`python3 harnesses/wa_coverage.py deps/posteriordb`.
+A density, distribution function, or scalar math function is one line
+in an X-macro list in
+[`optable.hpp`](../runtime/include/stanli/optable.hpp)
+(`STANLI_SCALAR_DENSITY_LIST` and friends), which generates the opcode,
+kernel, registration and lowering entry together so they cannot drift.
+Then check it: `harnesses/fn_sweep.py deps/cmdstan --filter yourfn`
+generates a one-function model, compiles it with CmdStan, and reports
+the worst ULP. The bar is 0.
 
-A density, a distribution function or a scalar math function is one line
-in an X-macro list in [`optable.hpp`](../runtime/include/stanli/optable.hpp)
--- `STANLI_SCALAR_DENSITY_LIST`, `STANLI_INT_DENSITY_LIST`,
-`STANLI_SCALAR_CDF_LIST`, `STANLI_SCALAR_UNARY_LIST` -- which generates the
-opcode, the name, the kernel, its registration and the lowering entry
-together, so none of them can drift out of step. Then check it:
-`harnesses/fn_sweep.py deps/cmdstan --filter yourfn`, which generates a
-one-function model, compiles it with CmdStan, and reports the worst ULP.
-The bar is 0.
-
-Not everything fits: the recorder computes in doubles and carries no tape,
-so a stan-math function that does arithmetic on the scalar type
-(`von_mises_cdf`, `wiener_lpdf`) fails to compile rather than silently
-losing partials. [`docs/coverage.md`](coverage.md) lists which and why.
+Not everything fits: the recorder computes in doubles, so a stan-math
+function that does arithmetic on the scalar type (`von_mises_cdf`,
+`wiener_lpdf`) fails to compile rather than silently losing partials.
+[`docs/coverage.md`](coverage.md) lists which and why.
 
 Anything else takes four steps:
 
-1. Opcode in [`optable.hpp`](../runtime/include/stanli/optable.hpp), kernel in [`runtime/kernels/`](../runtime/kernels/). For a stan-math
-   function without a native port, wrap it with the mechanism in
-   [`legacy.hpp`](../runtime/include/stanli/legacy.hpp) (examples all over [`matrix_fns.cpp`](../runtime/kernels/matrix_fns.cpp)); it is correct by
-   construction and can be replaced by a native kernel when it shows up
-   in profiles.
-2. Lowering branch in the matching `lower_*_fn` group in [`lower.cpp`](../runtime/src/lower.cpp).
+1. Opcode in [`optable.hpp`](../runtime/include/stanli/optable.hpp),
+   kernel in [`runtime/kernels/`](../runtime/kernels/). For a stan-math
+   function without a native port, wrap it with
+   [`legacy.hpp`](../runtime/include/stanli/legacy.hpp) (examples in
+   [`matrix_fns.cpp`](../runtime/kernels/matrix_fns.cpp)); it is
+   correct by construction and can be replaced by a native kernel when
+   it shows up in profiles.
+2. Lowering branch in the matching `lower_*_fn` group in
+   [`lower.cpp`](../runtime/src/lower.cpp).
 3. A test in the matching `tests/test_*.cpp`, asserting parity against
-   the same stan-math call on `var` (house pattern in [`test_lower.cpp`](../tests/test_lower.cpp)).
-4. `build-rel/dump_ops model.stan data.json` shows what actually lowered.
+   the same stan-math call on `var` (house pattern in
+   [`test_lower.cpp`](../tests/test_lower.cpp)).
+4. `build-rel/dump_ops model.stan data.json` shows what actually
+   lowered.
 
 ## Verifying a change
 
@@ -278,9 +250,15 @@ cmake --build build-rel -j8 && (cd build-rel && ctest)
 python3 tools/verify_refs.py deps/posteriordb --check build-rel/stanli_check --jobs 8
 ```
 
-If you touched a density tier, `density_tier`, or anything about propto,
-also check the lite build -- CI does not, because it would mean a second
-full stan-math compile:
+The corpus replay runs all 119 models against recorded CmdStan values
+and is the strongest oracle in the project. It also runs in CI on every
+push, and [`tools/wasm_check.sh`](../tools/wasm_check.sh) drives the
+same replay through the WASM build. Compiler changes that claim to be
+pure refactors should leave its worst-deviation line untouched.
+
+If you touched a density tier or anything about propto, also check the
+lite build (CI does not, because it would mean a second full stan-math
+compile):
 
 ```
 cmake -B build-lite -DCMAKE_BUILD_TYPE=Release -DSTANLI_LITE_LP=ON
@@ -289,28 +267,18 @@ python3 tools/verify_lite.py deps/posteriordb
 python3 tools/verify_refs.py deps/posteriordb --check build-lite/stanli_check --no-lp
 ```
 
-The first replays both builds and holds gradients to the bit while
-requiring the lp shift to be the same at every evaluation point; the
-second checks the lite build's gradients against CmdStan directly.
-[`docs/lite-lp.md`](lite-lp.md) explains what the flag trades.
-
-The corpus replay above runs all 119 models against recorded CmdStan
-values and is the strongest oracle in the project; it also runs in CI on
-every push, on each of the four wheel platforms it is gated on, and
-[`tools/wasm_check.sh`](../tools/wasm_check.sh) drives the same replay
-through the WASM build under Node. Compiler changes that claim to be pure
-refactors should leave its worst-deviation line untouched. For sampler
-changes use [`tools/sampler_trace.py`](../tools/sampler_trace.py); for generated-quantities coverage,
-[`harnesses/wa_coverage.py`](../harnesses/wa_coverage.py); for performance claims, measure with
-`STANLI_PROFILE=1` before and after ([`docs/benchmarks.md`](benchmarks.md) has the
-harnesses and the current numbers).
+For sampler changes use
+[`tools/sampler_trace.py`](../tools/sampler_trace.py); for
+generated-quantities coverage,
+[`harnesses/wa_coverage.py`](../harnesses/wa_coverage.py); for
+performance claims, measure with `STANLI_PROFILE=1` before and after
+([`docs/benchmarks.md`](benchmarks.md) has the harnesses).
 
 ## Landing a change
 
-`main` is protected: the four wheel platforms that build at a reasonable
-speed, plus the WASM build, must pass before anything merges, admins
-included, so direct pushes are rejected. The flow is a branch and an
-auto-merged PR:
+`main` is protected: the four fast wheel platforms plus the WASM build
+must pass before anything merges, admins included. The flow is a branch
+and an auto-merged PR:
 
 ```
 git checkout -b my-change
@@ -319,21 +287,19 @@ gh pr create --fill
 gh pr merge --auto --rebase
 ```
 
-The merge happens on its own when CI goes green (rebase-merge keeps the
-history linear). Release tags (`v*`, `npm-v*`) are not gated by this;
-they point at commits that already passed on main.
+The merge happens when CI goes green. Release tags (`v*`, `npm-v*`) are
+not gated by this; they point at commits that already passed on main.
 
-Windows is the exception. mingw compiles the density kernels an order of
-magnitude slower than any other platform, so that job would set the pace
-for every merge on its own; it runs after the merge, nightly at 08:00
-UTC, and on release tags instead of on pull requests. A red Windows run
-on main is a bug to fix forward, and a tag will not publish until it
-passes. If a change plausibly touches Windows (build files, the C ABI
-surface, anything under `tools/exported_symbols.def`), run the job on the
-branch before merging:
+Windows is the exception: mingw compiles the density kernels an order
+of magnitude slower than any other platform, so its job runs after the
+merge, nightly, and on release tags. A red Windows run on main is a bug
+to fix forward, and a tag will not publish until it passes. If a change
+plausibly touches Windows (build files, the C ABI surface,
+`tools/exported_symbols.def`), run the job on the branch first:
 
 ```
 gh workflow run wheels.yml --ref my-change
 ```
 
-Release process and CI layout live in [`README.md`](../README.md) under "Releasing".
+Release process and CI layout: [`README.md`](../README.md) under
+"Releasing".

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -1,20 +1,16 @@
 # How stanli works, and why an interpreter can outrun a compiler
 
-stanli runs Stan models with no C++ compiler on your machine, and on many
-models it evaluates gradients faster than the natively compiled model
-CmdStan produces. Both halves of that sentence sound wrong. This document
-explains why they are not, for readers who know Stan well and C++ a
-little.
+stanli runs Stan models with no C++ compiler on your machine, and on
+many models it evaluates gradients faster than the natively compiled
+model CmdStan produces. Both halves of that sentence sound wrong. This
+document explains why they are not.
 
 ## What "compiling a model" actually does
 
-When CmdStan builds your model, two things happen. First `stanc`
-translates your Stan program into a C++ file. Second, a C++ compiler
-spends several seconds (and, the first time, several minutes of library
-building) turning that file into machine code.
-
-It is worth looking at what is in that generated C++ file, because it is
-less than you might think. Your model block
+When CmdStan builds your model, `stanc` translates it into a C++ file,
+and a C++ compiler spends several seconds turning that into machine
+code. But the generated file contains less than you might think. Your
+model block
 
 ```stan
 y ~ normal(mu + tau * theta_tilde, sigma);
@@ -26,27 +22,22 @@ becomes, in essence,
 lp += normal_lpdf(y, mu + tau * theta_tilde, sigma);
 ```
 
-where `normal_lpdf`, the vectorized arithmetic, the constraint
-transforms, and everything else your model touches are calls into
-stan-math, a library that was written, tested, and could have been
-compiled long before your model existed. The generated code contributes
-no new math. It contributes an *arrangement*: which library operations to
-call, in what order, wired to which variables.
+where `normal_lpdf` and everything else your model touches are calls
+into stan-math, a library that could have been compiled long before
+your model existed. The generated code contributes no new math, only an
+*arrangement*: which library operations to call, in what order, wired
+to which variables.
 
-That observation is the whole trick. A Stan model is a composition drawn
-from a fixed vocabulary of operations: density functions, constraint
-transforms, matrix algebra, elementwise math. The vocabulary is closed,
-because it is exactly the Stan function library. New models do not add
-operations; they arrange existing ones. And an arrangement does not need
-a compiler. An arrangement is data.
+That is the whole trick. The vocabulary of operations is closed, because
+it is exactly the Stan function library. New models do not add
+operations; they arrange existing ones. And an arrangement does not
+need a compiler. An arrangement is data.
 
 ## The op graph
 
-So stanli ships every operation precompiled, once, inside one shared
-library, and turns your model into a data structure: a flat list of
-operations, each one an opcode plus indexes into a big preallocated
-array of doubles. For the eight schools model block above, the list
-looks roughly like
+stanli ships every operation precompiled inside one shared library and
+turns your model into a flat list of operations, each an opcode plus
+indexes into a preallocated array of doubles:
 
 ```
 op 0: MUL          tau, theta_tilde   -> t0        (vector scale)
@@ -55,133 +46,92 @@ op 2: NORMAL_LPDF  y, theta, sigma    -> target    (summed vector density)
 ```
 
 Evaluating the log density means walking the list and calling each
-opcode's precompiled function. There is no machine code anywhere that is
-specific to your model, in the same way that a spreadsheet does not
-recompile Excel when you type a new formula.
+opcode's precompiled function. No machine code is specific to your
+model, in the same way a spreadsheet does not recompile Excel when you
+type a new formula. Two things make this more than a toy:
 
-Two things make this more than a toy.
+- **The compiler is the real compiler.** The official `stanc` (OCaml)
+  is linked into the library and runs in-process, so your model is
+  parsed, typechecked, and optimized by the same code CmdStan uses.
+- **The kernels are the real kernels.** The precompiled operations are
+  stan-math, the same library CmdStan calls, compiled with the same
+  floating point settings. That is why stanli agrees with CmdStan to
+  the last bit on 45 of the 120 posteriordb test models, and to within
+  2.6e-12 relative on the worst.
 
-**The compiler is the real compiler.** The official `stanc` (an OCaml
-program) is linked into the library and runs in-process. Your model is
-parsed, typechecked, and optimized by the same code CmdStan uses, and
-stanli consumes its output. The Stan language you get is the Stan
-language, not a reimplementation of most of it.
-
-**The kernels are the real kernels.** The precompiled operations are
-stan-math, the same library CmdStan's generated code calls, compiled with
-the same floating point settings. This is why stanli's answers agree with
-CmdStan's to the last bit on 45 of the 120 posteriordb test models, and
-to within 2.6e-12 relative on the worst one: it is mostly running the
-same instructions on the same numbers, just dispatched differently.
-
-Because nothing is compiled at model load, "compiling" a model takes
-milliseconds. That alone changes how the tool feels: the time from
-`model.stan` to a first draw is about twenty times shorter than
-CmdStan's, essentially all of which is the C++ compiler stanli does not
-run.
+Because nothing is compiled at model load, "compiling" takes
+milliseconds, and the time from `model.stan` to a first draw is about
+twenty times shorter than CmdStan's.
 
 ## Gradients without code generation
 
-HMC needs the gradient of the log density, and Stan gets gradients from
-reverse-mode automatic differentiation. Reverse mode has a simple shape:
-run the computation forward, remember what you did, then walk the record
-*backward* applying the chain rule to accumulate derivatives. The record
-is traditionally called a tape.
-
-In CmdStan, the tape is built dynamically. Every scalar operation on a
-parameter, every add and multiply and log inside every density, creates a
-small object on an arena recording what happened, with a virtual method
-that knows how to push derivatives backward. Evaluate the gradient once
-and the tape is built, walked backward, and torn down. Evaluate it a
-thousand times per iteration (which HMC does; each leapfrog step needs a
-fresh gradient) and this construction and teardown happens a thousand
-times.
+Stan gets gradients from reverse-mode automatic differentiation: run
+the computation forward, remember what you did, walk the record (the
+"tape") backward applying the chain rule. In CmdStan the tape is built
+dynamically: every scalar operation on a parameter creates a small heap
+object with a virtual method, and each gradient evaluation builds the
+tape, walks it, and tears it down. HMC evaluates the gradient once per
+leapfrog step, thousands of times per run.
 
 stanli does not build a tape, because it already has one. The op list
-*is* the record of the computation: to differentiate, walk the same list
-backward and call each opcode's derivative function, which each kernel
-carries alongside its forward function. The tape is constructed once, at
-model load, and steady-state gradient evaluation allocates no memory at
-all. The entire autodiff engine in stanli is about 150 lines: a forward
-loop, a backward loop, and an array of derivative accumulators.
+*is* the record of the computation: to differentiate, walk it backward
+and call each opcode's derivative function. The tape is constructed
+once, at model load, and steady-state gradient evaluation allocates no
+memory at all.
 
 ## How an interpreter can win
 
-Interpreters are supposed to be slow, and the intuition behind that is
-right: there is a fixed overhead, some tens of nanoseconds, for every
+Interpreters have a fixed overhead, some tens of nanoseconds per
 operation dispatched. The question is what that overhead is amortized
-over, and here the two designs pay their costs at different granularity.
+over.
 
-**stanli pays per operation. CmdStan pays per scalar.**
+**stanli pays per operation. CmdStan pays per scalar.** Executing
+`NORMAL_LPDF` over a thousand observations, stanli pays its dispatch
+overhead once, then runs precompiled vectorized code over a flat array;
+divided by a thousand elements the overhead vanishes, the same reason
+vectorized R and NumPy are fast. CmdStan has no dispatch overhead, but
+each observation allocates a tape node, and the backward pass walks a
+thousand heap objects through virtual calls, every leapfrog step. Its
+autodiff matrices also store pointers to tape nodes, so values sit
+scattered in memory, which defeats SIMD; stanli's values live in flat
+contiguous arrays. On vectorized models both effects point the same
+way, and stanli evaluates gradients two to six times faster, with the
+gap growing with data size.
 
-When stanli executes `NORMAL_LPDF` over a thousand observations, it pays
-its interpreter overhead once, then runs precompiled vectorized code over
-a flat array of doubles. The overhead is real (roughly 20ns against 1ns
-of arithmetic for a single scalar density) but divided by a thousand
-elements it vanishes. This is the same reason vectorized R and NumPy are
-fast: the interpreter only touches the outside of the loop.
-
-CmdStan's generated code is native, so it has no dispatch overhead at
-all, but its autodiff cost scales with scalars, not statements. Each of
-the thousand observations allocates its tape node, and the backward pass
-walks a thousand heap objects through virtual calls, every leapfrog step.
-There is a second, subtler cost: CmdStan's autodiff matrices store
-pointers to their tape nodes, so the actual values sit scattered in
-memory. Reading them is indirect and strided, which defeats the SIMD
-units modern CPUs rely on. stanli's values live in flat contiguous
-arrays, because the graph, not the scalar type, carries the derivative
-structure.
-
-On a model written with vectorized statements, both effects point the
-same way, and stanli evaluates gradients two to six times faster than the
-compiled model, with the gap growing with data size. Not because it does
-less math, but because it does less bookkeeping around the same math.
-
-**The graph is a persistent artifact, and that means it can be
-optimized.**
-
-There is a deeper advantage hiding here. CmdStan's tape lives for one
-gradient evaluation, so there is no opportunity to optimize it; it is
-gone before anything could look at it. stanli's graph is built once and
-reused millions of times, so it is worth running compiler-style passes
-over it before the first evaluation.
-
-The clearest example: models written as explicit loops,
+**The graph persists, so it can be optimized.** CmdStan's tape lives
+for one gradient evaluation; stanli's graph is built once and reused
+millions of times, so it is worth running compiler-style passes over
+it. A model written as an explicit loop,
 
 ```stan
 for (n in 1:N)
   y[n] ~ normal(alpha[county[n]], sigma);
 ```
 
-initially lower to N copies of a small handful of scalar operations,
-and at scalar granularity the interpreter overhead really does hurt; early
-versions of stanli lost to CmdStan on every model shaped like this. But
-the N copies are sitting right there in a list, visibly periodic. A pass
-detects the repetition and rewrites it: gathers become one vector index
+lowers to N copies of a few scalar operations, where the interpreter
+overhead really does hurt. But the copies sit in a list, visibly
+periodic, and a pass rewrites them: gathers become one vector index
 operation, N scalar densities become one summed vector density. One
-radon model drops from 27,670 operations to 8, and goes from slightly
+radon model drops from 27,670 operations to 8 and goes from slightly
 losing against CmdStan to beating it six-fold. The statistician did not
-vectorize the model; the runtime did, once, at load time, which is a
-thing you can only do to a computation that exists as an inspectable
-data structure.
+vectorize the model; the runtime did, once, at load time. You can only
+do that to a computation that exists as an inspectable data structure.
 
 ## Where the compiled model still wins
 
-Honesty requires the other column. Two benchmark models still lose:
-`low_dim_gauss_mix` (0.78x) computes `log_mix` per observation, a shape
-the rewriting passes do not yet know how to vectorize, and `dogs` (0.65x)
-writes a matrix down its columns in strides the store-fusion pass cannot
-yet express. ODE models run at about 0.6x: the right-hand side of an ODE
-is the one place Stan requires calling back into user code at times
-chosen by the solver, and stanli evaluates it through a compact bytecode
-program where CmdStan runs natively compiled code. All three gaps are
-engineering rather than anything fundamental, but today they are real.
+Sequential models lose: HMM recursions and state-space updates read the
+previous step's parameter-dependent result, which nothing can
+vectorize, so the work is scalar on both sides and CmdStan's compiled
+scalar code is faster (typically 0.6-0.8x). ODE models run at about
+0.6x: the right-hand side must stay callable at solver-chosen times,
+and stanli runs it through a compact register machine where CmdStan
+runs native code. These gaps are engineering, not anything fundamental,
+but today they are real.
 
-The other cost is size, and it is the deliberate trade at the center of
-the design: the wheel is about 5 MB because it carries the entire Stan
-compiler and every operation in the math library, whether your model
-uses them or not. In exchange, nothing is ever built on your machine,
-and `pip install stanli` is the entire installation.
+The other cost is size, the deliberate trade at the center of the
+design: the wheel is 7.8 MB because it carries the entire Stan compiler
+and every operation in the math library, whether your model uses them
+or not. In exchange, `pip install stanli` is the entire installation.
 
 ## The one-paragraph version
 
@@ -189,8 +139,8 @@ Stan models are arrangements of a fixed library of operations, and an
 arrangement is data, not code. Ship the library precompiled, turn the
 model into a graph of operations over flat arrays, and the graph is
 simultaneously the program, the autodiff tape, and an optimizable
-artifact. Interpreting at vector granularity costs almost nothing; never
-rebuilding the tape saves what CmdStan spends every leapfrog step; and
-optimizing the persistent graph recovers the vectorization that loops in
-the source hide. That is how there is no compiler, and why its absence is
-sometimes a speedup.
+artifact. Interpreting at vector granularity costs almost nothing;
+never rebuilding the tape saves what CmdStan spends every leapfrog
+step; and optimizing the persistent graph recovers the vectorization
+that loops in the source hide. That is how there is no compiler, and
+why its absence is sometimes a speedup.

--- a/docs/lite-lp.md
+++ b/docs/lite-lp.md
@@ -1,36 +1,35 @@
 # The lite build: half the library, lp__ off by a constant
 
 `-DSTANLI_LITE_LP=ON` builds a runtime that is 48% smaller and samples
-from the same posterior with bit-identical gradients. It is on by default
-for emscripten and off everywhere else.
+from the same posterior with bit-identical gradients. It is **off by
+default in every build, browser included**, so that any run's `lp__`
+can be compared against CmdStan directly. `stanli_exact_lp()` (Python
+`stanli.exact_lp()`, JS `fit.exactLp`) reports which build is loaded.
 
 ## What it drops
 
 A density is not one function. stan-math decides which terms of a log
-density to keep by looking at the argument *types* --
-`include_summand<propto,
-T_y, T_loc, T_scale>` is a compile-time query -- so a `~` statement that
-drops `-0.5 * log(2π)` because `sigma` is data is a *different
-instantiation* from one that keeps it. Supporting `~` exactly therefore
-costs one instantiation per activity mask, on top of the full form, twice
-over for the elementwise variant: `4 * 2^N` copies of stan-math's template
-per distribution, about 630 KB of object for a three-argument one.
+density to keep by looking at the argument *types*, so a `~` statement
+that drops `-0.5 * log(2*pi)` because `sigma` is data is a different
+instantiation from one that keeps it. Supporting `~` exactly costs one
+instantiation per activity mask on top of the full form, twice over for
+the elementwise variant: `4 * 2^N` copies of stan-math's template per
+distribution.
 
 `STANLI_LITE_LP` clears the propto half of that (`density_tier()` in
 `runtime/include/stanli/optable.hpp`). `y ~ normal(mu, sigma)` then
-evaluates the *full* normal density. That is still a correct log density
---
-it just is not the one CmdStan computes, so `lp__` lands a per-model
-constant away from CmdStan's.
+evaluates the *full* normal density. That is still a correct log
+density; it just is not the one CmdStan computes, so `lp__` lands a
+per-model constant away from CmdStan's.
 
 ## What it does not drop
 
 Every gradient. The terms propto removes are exactly the ones that are
-constant in the active arguments, so they have no derivative to contribute.
-
-Measured over the whole 119-model posteriordb corpus: every gradient and
-every `write_array` value is **bitwise identical** to the exact build, and
-`lp__` differs by a constant at every evaluation point.
+constant in the active arguments, so they have no derivative to
+contribute. Measured over the whole 119-model posteriordb corpus: every
+gradient and every `write_array` value is **bitwise identical** to the
+exact build, and `lp__` differs by a constant at every evaluation
+point.
 
 | | exact | lite |
 |---|---|---|
@@ -40,64 +39,29 @@ every `write_array` value is **bitwise identical** to the exact build, and
 | draws for a pinned seed | -- | different chain, same posterior |
 | `stanli_exact_lp()` | 1 | 0 |
 
-### Speed, and what propto is worth at runtime
+Speed is not part of the trade in either direction. Per-gradient
+differences between the builds measure under 4% with inconsistent sign,
+which is run-to-run variance: the propto choice is internal to a
+kernel and never changes the graph. Do not pick the exact build for
+speed; pick it because you want CmdStan's `lp__`.
 
-Nothing measurable. The natural worry about `~` evaluating the full
-density is that it is doing arithmetic the propto form skips, so the
-half-size build should be the slower one. It is not, at any size that
-shows up above the noise floor.
+## The draws are not byte-identical, and that is expected
 
-Per-gradient, minimum of five runs of 4000 evaluations each, same
-machine, both builds `-O3`:
-
-| model | exact | lite | |
-|---|---:|---:|---|
-| eight schools (10 params) | 278.9 ns | 288.7 ns | lite 3.5% slower |
-| `arK` (7 params) | 2556 ns | 2591 ns | lite 1.4% slower |
-| `radon_pooled` (3 params, 919 obs) | 4430 ns | 4256 ns | lite 3.9% *faster* |
-
-The sign is not even consistent, which is the tell: this is run-to-run
-variance, not a cost. `STANLI_PROFILE=1` says why. The two builds produce
-the same opcodes with the same counts, because the propto choice is
-internal to a kernel and never changes the graph, and in a profiled run
-the unrelated `OP_ADD` and `OP_MUL` moved by the same 9% as
-`OP_NORMAL_LPDF` did, which is machine noise rather than anything to do
-with densities.
-
-So the trade is half the library against a shifted `lp__`, and not
-against throughput. Do not pick the exact build for speed; pick it
-because you want CmdStan's `lp__`.
-
-### The draws are not byte-identical, and that is expected
-
-It is tempting to reason: the constant cancels in every Hamiltonian
-*difference* NUTS looks at -- the Metropolis ratio, the multinomial
-weights, the divergence test -- so the trajectory must be identical. In
-exact arithmetic that is true. In floating point it is not: the sampler
-forms `H = -lp + kinetic`, and adding a shifted `lp` to the kinetic energy
-**rounds differently**. The difference starts at one ULP and NUTS is
-chaotic, so it grows.
-
-Measured on eight schools, same seed, exact against lite:
-
-| warmup iterations | relative difference in `mu` |
-|---|---|
-| 5 | 2.0e-15 |
-| 20 | 6.3e-13 |
-| 50 | 1.3e-09 |
-
-Both chains start from the identical initial point and take the identical
-number of gradient evaluations; they separate purely by amplification.
-This is the same class of difference as changing the seed -- every draw
-is
-from the same posterior, and no draw is byte-comparable. If you need a run
-that reproduces another run byte for byte, both must be the same build.
-0.2.1 carries the same caveat for a different reason (the RNG change).
+In exact arithmetic a constant lp shift cancels in every Hamiltonian
+difference NUTS looks at. In floating point it does not: the sampler
+forms `H = -lp + kinetic`, and adding a shifted `lp` rounds
+differently. The difference starts at one ULP and NUTS is chaotic, so
+it grows: on eight schools at the same seed, `mu` differs by 2.0e-15
+after 5 warmup iterations, 6.3e-13 after 20, and 1.3e-09 after 50. This
+is the same class of difference as changing the seed; every draw is
+from the same posterior, and no draw is byte-comparable. A run that
+must reproduce another run byte for byte needs both to be the same
+build.
 
 ## How the claim is checked
 
-`tools/verify_lite.py` is the oracle. It replays both builds over the
-corpus and enforces the two things the flag actually promises:
+`tools/verify_lite.py` replays both builds over the corpus and enforces
+the two things the flag promises:
 
 ```
 cmake -B build     -DCMAKE_BUILD_TYPE=Release
@@ -107,32 +71,24 @@ cmake --build build-lite --target stanli_check -j8
 python3 tools/verify_lite.py deps/posteriordb
 ```
 
-1. **Gradients bitwise.** Not "close" -- the same computation.
-2. **The lp shift is constant.** Evaluated at three points in the
-   unconstrained space, `lp_exact - lp_lite` must come out the same every
-   time. This is the check that matters: a shift that *moved* with the
-   parameters would mean a dropped term was not constant after all, which
-   is the only way this flag can be wrong, and it would show up as an O(1)
-   relative change.
+1. **Gradients bitwise.** Not "close": the same computation.
+2. **The lp shift is constant.** At three points in the unconstrained
+   space, `lp_exact - lp_lite` must be the same number. A shift that
+   moved with the parameters would mean a dropped term was not constant
+   after all, which is the only way this flag can be wrong.
 
-The gate on the shift is relative to `lp`, not to the shift. Dropping a
-term reassociates the sum after it, so the residue lives on `lp`'s rounding
-scale: `rats_model`'s `lp` is -4.7e6 (one ULP is 9.3e-10) and its shift
-moves by 4.7e-10 -- half an ULP of the number it was subtracted from.
-Normalizing against the shift's own magnitude instead would flag that as a
-failure and teach everyone to ignore the tool.
+The gate on the shift is relative to `lp`, not to the shift itself:
+dropping a term reassociates the sum after it, so the residue lives on
+`lp`'s rounding scale (half an ULP of `lp` on the worst model).
+Normalizing against the shift's own magnitude would flag that rounding
+as failure and teach everyone to ignore the tool.
 
-## When to use which
+## When to turn it on
 
-**The Python wheel is exact and should stay that way.** The differential
-oracle against CmdStan is the project's whole claim to correctness, and it
-needs an `lp__` to compare.
-
-**The browser build is lite.** The runtime has to be downloaded before
-anything happens, nobody is diffing a browser demo's `lp__` against
-CmdStan, and the posterior is the same one.
-
-Callers can ask: `stanli_exact_lp()` in C, `stanli.exact_lp()` in Python,
-`fit.exactLp` in JS. Check it if you display or compare `lp__` across
-engines, or if you pin a seed and expect the same bytes back. Anything
-that just wants draws from the posterior can ignore it.
+When download or install size matters more than an `lp__` comparable
+to CmdStan's: an embedded target, or a size-critical web deployment
+(it roughly halves the wasm payload). The published wheels and the demo
+page both ship exact, because the differential oracle against CmdStan
+is the project's whole claim to correctness and it needs an `lp__` to
+compare. Check `stanli_exact_lp()` if you display or compare `lp__`
+across engines, or pin a seed and expect the same bytes back.

--- a/js/README.md
+++ b/js/README.md
@@ -1,11 +1,11 @@
 # stanli
 
 Full [Stan](https://mc-stan.org) in the browser. stanc3 (the real Stan
-compiler, compiled to JavaScript) turns Stan source into its intermediate
-representation; a WebAssembly build of the stanli runtime lowers it to an
-op graph over precompiled stan-math kernels and samples with NUTS. No
-server, no C++ toolchain, everything in the tab. Live demo:
-<https://seantalts.github.io/stanli/>.
+compiler, compiled to JavaScript) turns Stan source into its
+intermediate representation; a WebAssembly build of the stanli runtime
+lowers it to an op graph over precompiled stan-math kernels and samples
+with NUTS. No server, no C++ toolchain, everything in the tab. Live
+demo: <https://seantalts.github.io/stanli/>.
 
 ```js
 import { sample } from "@seantalts/stanli";
@@ -30,17 +30,18 @@ parameters, and generated quantities (RNG draws stream from `seed`).
 The heavy work runs in a worker the package owns, so the page never
 blocks; calls queue and run one at a time.
 
-The payload is ~9 MB installed (~1.9 MB over the wire with gzip): the WASM
-runtime plus the stanc3 compiler. The compiler loads lazily, only when a
-call passes Stan source. `preload()` starts both loads in the background
--- call it at page idle and the user's first `sample()` begins at full
-speed instead of paying the fetch and parse on their click; an app that ships a fixed model can precompile
-it at build time (`stanc --debug-transformed-mir model.stan`) and pass
-`mir` instead of `code`, and the runtime alone is ~1.5 MB gzipped. 118 of 119 posteriordb corpus models
-verify against CmdStan's log density, gradients, and write_array values
-from inside this WASM build; see the
-[repository](https://github.com/seantalts/stanli) for the verification
-policy and numbers.
+The payload is ~9 MB installed, ~1.9 MB over the wire with gzip: the
+WASM runtime plus the stanc3 compiler. The compiler loads lazily, only
+when a call passes Stan source. `preload()` starts both loads in the
+background; call it at page idle so the first `sample()` skips the
+fetch and parse. An app that ships a fixed model can precompile it at
+build time (`stanc --debug-transformed-mir model.stan`) and pass `mir`
+instead of `code`; the runtime alone is ~1.5 MB gzipped.
+
+118 of 119 posteriordb corpus models verify against CmdStan's log
+density, gradients, and write_array values from inside this WASM build;
+see the [repository](https://github.com/seantalts/stanli) for the
+verification policy and numbers.
 
 Not yet here: variational inference, optimization, multi-chain
 threading. `wasm32` caps memory at 4 GB, which one 79,000-parameter

--- a/python/README.md
+++ b/python/README.md
@@ -12,9 +12,11 @@ C++ toolchain on the machine.
 pip install stanli
 ```
 
-That is the whole install. No compiler, no `make`, no CmdStan checkout, no
-multi-minute first-run build. One wheel, one shared library, under seven
-megabytes.
+That is the whole install. No compiler, no `make`, no CmdStan checkout,
+no multi-minute first-run build. One wheel, one shared library, under
+eight megabytes. Model preparation takes milliseconds, so the first
+draw arrives about 20x sooner than a toolchain that compiles C++ per
+model.
 
 ```python
 import stanli
@@ -26,35 +28,13 @@ fit["mu"].mean()        # every draw of a column, chains concatenated
 fit.draws("mu")         # (chains, draws), for a trace plot
 ```
 
-Model preparation takes milliseconds, so the first draw arrives about 20x
-sooner than a toolchain that compiles C++ per model.
-
-## The mode, and where to start
-
-```python
-r = model.optimize(seed=1)
-r["mu"], r.lp          # every CSV column at the mode, and the lp there
-r.unconstrained        # the point on the sampler's scale
-
-fit = model.sample(inits=r.unconstrained)   # start the chains there
-```
-
-L-BFGS -- stan's own, the one behind CmdStan's `optimize`.
-
-It returns the posterior **mode**. CmdStan's `optimize` defaults to
-`jacobian=0`, the penalized maximum likelihood, and stanli cannot offer
-that: the change-of-variables Jacobian is folded into the graph when the
-model is lowered. `jacobian=False` raises rather than quietly handing
-back the other quantity, since the two differ for any constrained
-parameter.
-
 ## Chains and convergence
 
-Four chains by default, run in parallel, because R-hat needs more than one
-and a single-chain run cannot be checked for convergence at all. Eight
-schools does all four in about 70 ms. Threading changes nothing about the
-answer: each chain owns its executor and its RNG stream, so the draws come
-out byte-identical to a sequential run.
+Four chains by default, run in parallel, because R-hat needs more than
+one and a single-chain run cannot be checked for convergence at all.
+Eight schools does all four in about 70 ms. Threading changes nothing
+about the answer: each chain owns its executor and its RNG stream, so
+the draws come out byte-identical to a sequential run.
 
 ```python
 print(fit.summary())
@@ -66,9 +46,9 @@ mu                4.4600     0.0532     3.1705    -0.7414     4.5519     9.5384 
 tau               3.4752     0.0635     3.1612     0.2192     2.6680     9.6313       2160       1874      1.001
 ```
 
-R-hat is rank-normalized split-R-hat and ESS is the bulk/tail pair, both
-Vehtari et al. 2021, computed by stan's own estimators -- so the numbers
-agree with `stansummary` rather than approximating it.
+R-hat is rank-normalized split-R-hat and ESS is the bulk/tail pair
+(Vehtari et al. 2021), computed by stan's own estimators, so the
+numbers agree with `stansummary` rather than approximating it.
 
 ```python
 print(fit.diagnose())
@@ -85,45 +65,42 @@ No problems detected.
 ```
 
 Those are the checks a Bayesian workflow actually turns on, including
-**E-BFMI** -- the one that catches a badly explored heavy tail, which
-R-hat and ESS are both blind to. Each check either confirms or reports the
-number that failed and what to do about it.
+E-BFMI, the one that catches a badly explored heavy tail, which R-hat
+and ESS are both blind to. The pieces are reachable individually too:
+`fit.divergences`, `fit.max_treedepth_hits`, `fit.stepsize` and
+`fit.ebfmi()` are per-chain arrays, and `fit.to_arviz()` hands off an
+InferenceData with the sampler stats attached.
 
-The pieces are reachable individually too: `fit.divergences`,
-`fit.max_treedepth_hits`, `fit.stepsize` and `fit.ebfmi()` are per-chain
-arrays, `fit.summary().r_hat` is the whole column, and `fit.to_arviz()`
-hands off an InferenceData with the sampler stats attached.
+## The mode, and where to start
+
+```python
+r = model.optimize(seed=1)
+r["mu"], r.lp          # every CSV column at the mode, and the lp there
+r.unconstrained        # the point on the sampler's scale
+
+fit = model.sample(inits=r.unconstrained)   # start the chains there
+```
+
+L-BFGS, stan's own, the one behind CmdStan's `optimize`. It returns the
+posterior **mode**. CmdStan's `optimize` defaults to `jacobian=0`, the
+penalized maximum likelihood, and stanli cannot offer that: the
+change-of-variables Jacobian is folded into the graph when the model is
+lowered. `jacobian=False` raises rather than quietly handing back the
+other quantity.
 
 ## How it works
 
 Every Stan model is a composition of a fixed vocabulary of operations:
-densities, constraint transforms, linear algebra, elementwise math. stanli
-ships those precompiled and turns each model into *data*, a static graph of
-ops over flat preallocated buffers, instead of generating and compiling C++
-per model.
-
-```
-model.stan + data.json
-  |  stanc3, the official OCaml compiler, linked into the library
-  v
-transformed MIR
-  |  lowering: transformed data evaluated eagerly, data-bound loops unrolled,
-  |            then periodic regions re-rolled back into vectorized ops
-  v
-op graph over preallocated value/adjoint arenas
-  |  forward sweep = log density, reverse sweep = gradient
-  v
-NUTS with diagonal-metric adaptation -> draws
-```
-
-The graph doubles as the autodiff tape, so a reverse sweep is a backwards
-loop over an array rather than a walk through a pointer-chasing tape, and
-steady-state gradient evaluation allocates nothing.
+densities, constraint transforms, linear algebra, elementwise math.
+stanli ships those precompiled and turns each model into *data*, a
+static graph of ops over flat preallocated buffers, instead of
+generating and compiling C++ per model. The graph doubles as the
+autodiff tape, so a reverse sweep is a backwards loop over an array,
+and steady-state gradient evaluation allocates nothing.
 
 Two things are not reimplemented, which is what makes the results
-trustworthy: the compiler is the real stanc3, linked in-process, so the
-Stan language behaves as the official toolchain makes it behave; and the
-math is unmodified stan-math, the same code CmdStan runs.
+trustworthy: the compiler is the real stanc3, linked in-process, and
+the math is unmodified stan-math, the same code CmdStan runs.
 
 ## Correctness
 
@@ -136,19 +113,19 @@ component. **<!--gen:corpus_bitwise-->45<!--/gen--> agree bitwise.** The
 worst deviation across the entire corpus is
 **<!--gen:corpus_worst-->2.6e-12<!--/gen--> relative**.
 
-The two exceptions are documented rather than hidden. `sir`'s ODE solution
-dips about 1e-9 below a declared lower bound at the shared evaluation point,
-where CmdStan rejects it too; `kronecker_gp` matches on the log density and
-436 of 438 gradients, differing on the two that flow through eigenvectors of
-a nearly degenerate covariance matrix.
+The two exceptions are documented rather than hidden. `sir`'s ODE
+solution dips about 1e-9 below a declared lower bound at the shared
+evaluation point, where CmdStan rejects it too; `kronecker_gp` matches
+on the log density and 436 of 438 gradients, differing on the two that
+flow through eigenvectors of a nearly degenerate covariance matrix.
 
 Full per-model accuracy table:
 [docs/corpus-status.md](https://github.com/seantalts/stanli/blob/main/docs/corpus-status.md)
 
 ## Performance
 
-Per-gradient latency against CmdStan, same models, same evaluation point,
-both sides `-O3` with FP contraction pinned off:
+Per-gradient latency against CmdStan, same models, same evaluation
+point, both sides `-O3` with FP contraction pinned off:
 
 <!--gen:bench_table_us-->
 | model | params | stanli | CmdStan | speedup |
@@ -178,29 +155,21 @@ both sides `-O3` with FP contraction pinned off:
 | `iohmm_reg` | 29 | 545.2 us | 320.3 us | 0.59x |
 <!--/gen-->
 
-The wins come from op granularity. CmdStan's var tape allocates, walks, and
-frees one node per scalar operation per leapfrog step; stanli pays a fixed
-cost per *op*, and a vectorized statement over N elements amortizes that to
-nothing. Across the whole posteriordb corpus the median is
-<!--gen:corpus_median-->2.07x<!--/gen--> and
+The wins come from op granularity. CmdStan's var tape allocates, walks,
+and frees one node per scalar operation per leapfrog step; stanli pays
+a fixed cost per *op*, and a vectorized statement over N elements
+amortizes that to nothing. Across the whole posteriordb corpus the
+median is <!--gen:corpus_median-->2.07x<!--/gen--> and
 <!--gen:corpus_at_par-->93<!--/gen--> of
 <!--gen:corpus_n_grad-->119<!--/gen--> models are at or above CmdStan.
 
-The losses are honest and understood, and they are all one shape: a
-recurrence. `hmm_*`, `garch11` and `arma11` step through time with each
-step reading the last one's parameter-dependent result, which nothing can
-vectorize, so the work is scalar on both sides and CmdStan's generated C++
-is the faster way to run scalar work. `ldaK2` is a mixture over more than
-two components, which the fusion pass does not yet widen.
-
-ODE models are the other place stanli is still behind. An ODE right-hand
-side is the one user function that cannot be inlined at lowering time,
-since the integrator picks the times; it now compiles into a flat register
-machine instead of being tree-walked, and the forward sweep keeps the
-sensitivities it was already computing instead of solving twice. Together
-that is 29x to 39x faster than the tree-walking interpreter it replaces,
-which puts `lotka_volterra` and `soil_incubation` at 0.58x and 0.63x of
-CmdStan rather than 0.015x.
+The losses are understood, and they are all one shape: a recurrence.
+`hmm_*`, `garch11` and `arma11` step through time with each step
+reading the last one's parameter-dependent result, which nothing can
+vectorize, so the work is scalar on both sides and CmdStan's generated
+C++ runs scalar work faster. ODE models sit around 0.6x for a similar
+reason: the right-hand side runs through a compact register machine
+where CmdStan runs native code.
 
 Method and full table:
 [docs/benchmarks.md](https://github.com/seantalts/stanli/blob/main/docs/benchmarks.md)
@@ -221,46 +190,47 @@ model.constrained_names             # ['mu', 'tau', 'theta.1', ...]
 
 lp, grad = model.log_prob_grad(q)   # sampling log density and its gradient
 
-draws = model.sample(seed=1, warmup=1000, samples=1000, delta=0.8)
-draws["mu"]                         # ndarray of length `samples`
+fit = model.sample(seed=1, warmup=1000, samples=1000, delta=0.8)
+fit["theta.1"]                      # ndarray, chains concatenated
 ```
 
-`data` accepts a path to a JSON file or a dict of Python scalars, lists, and
-numpy arrays. `sample` returns one array of constrained draws per scalar
-parameter, named the way CmdStan names them, so `theta` declared as
-`vector[8]` arrives as `theta.1` through `theta.8`.
+`data` accepts a path to a JSON file or a dict of Python scalars,
+lists, and numpy arrays. `sample` returns every column CmdStan's CSV
+would carry (constrained parameters, transformed parameters, generated
+quantities, with RNG draws streamed per chain), named the way CmdStan
+names them, so `theta` declared as `vector[8]` arrives as `theta.1`
+through `theta.8`. Sampler columns (`lp__`, `divergent__`, ...) are
+reachable by name too.
 
 ## Platforms
 
 Wheels for macOS (arm64 and x86_64), Linux (x86_64 and aarch64,
 manylinux_2_28) and Windows (x86_64). The Windows wheel is built under
-mingw-w64, because stan-math does not build under MSVC, which is the same
-reason RStan ships through RTools. It bundles `stanc.exe` and runs it as
-a subprocess instead of embedding the compiler, which waits on opam's
-native Windows support; `Model("model.stan", data)` works the same way
-either way.
+mingw-w64, because stan-math does not build under MSVC (the same reason
+RStan ships through RTools), and bundles `stanc.exe` as a subprocess
+instead of embedding the compiler; the API works the same way either
+way.
 
-The installed library is 22.2 MB, which is the trade this design makes:
-ship the compiler and every kernel once, so that nothing is ever built on
-the user's machine. Roughly half of that is the embedded stanc3 and
-somewhat under half is stan-math. The interpreter and NUTS together are
-about 410 KB.
+The installed library is 22.2 MB: over half of it is the density
+kernels, about a quarter the embedded stanc3, and the interpreter and
+NUTS together are about 410 KB. That is the trade this design makes:
+ship the compiler and every kernel once, so nothing is ever built on
+the user's machine.
 
-## Status
+## Limits
 
-Early, and deliberately narrow. The sampler is Stan's own NUTS with
-diagonal-metric adaptation. Known limits, stated plainly:
+Stated plainly:
 
-- `sample()` returns declared parameters only. Transformed parameters and
-  generated quantities are computed by the runtime and written by the
-  command line tool, but are not exposed through the Python API yet, so
-  the non-centered eight schools gives you `mu`, `tau`, and
-  `theta_tilde`, not `theta`.
-- No variational inference, no optimization, no multi-chain threading.
-- No convergence diagnostics. Pair it with ArviZ or similar for now.
+- The sampler is Stan's own NUTS with diagonal-metric adaptation, and
+  `optimize()` is Stan's L-BFGS. No variational inference or Pathfinder
+  yet.
+- `inits` are on the unconstrained scale. Constrained inits would need
+  the inverse parameter transforms, which do not exist here yet.
+- `optimize(jacobian=False)` (CmdStan's default penalized maximum
+  likelihood) raises; see above.
 
-What is here is verified against CmdStan model by model, and every number
-on this page is reproducible from the repository.
+What is here is verified against CmdStan model by model, and every
+number on this page is reproducible from the repository.
 
 - Source, issues, and roadmap:
   [github.com/seantalts/stanli](https://github.com/seantalts/stanli)

--- a/r/README.md
+++ b/r/README.md
@@ -22,8 +22,8 @@ stanli_install()
 
 That downloads the ~16 MB runtime for your platform into
 `tools::R_user_dir("stanli", "cache")`. Nothing is fetched without it.
-It takes the release the package was built against rather than whichever
-is newest, so the binding and the library always agree; pass
+It takes the release the package was built against rather than
+whichever is newest, so the binding and the library always agree; pass
 `version = "latest"` to override, and set `STANLI_RUNTIME` to use a
 library you built yourself.
 
@@ -40,19 +40,21 @@ stanli_diagnose(fit)  # divergences, treedepth, E-BFMI, R-hat, ESS
 as_draws_array(fit)   # a posterior::draws_array
 ```
 
-Four chains of eight schools — 8000 draws, full summary and diagnostics —
+Four chains of eight schools (8000 draws, full summary and diagnostics)
 take about 70 ms, because the model is lowered to a graph over
 precompiled kernels rather than translated to C++ and compiled.
 
-`summary()` reports rank-normalized split R-hat with bulk and tail
-effective sample size and MCSE. Those are stan's own estimators, so the
-numbers agree with `stansummary` rather than approximating it.
+`summary()` uses stan's own estimators (rank-normalized split R-hat,
+bulk/tail ESS, MCSE), so the numbers agree with `stansummary`.
 `stanli_diagnose()` runs the checks a Bayesian workflow turns on,
-including **E-BFMI** — the one that catches a badly explored heavy tail,
-which R-hat and ESS are both blind to.
-
+including E-BFMI, the one that catches a badly explored heavy tail.
 `optimize_model()` finds the posterior mode by L-BFGS, and its
 `$unconstrained` element is what `sample_model(init = )` takes.
+
+Chains run in parallel by default. Threading does not change the
+answer: each chain owns its executor and its RNG stream, so a parallel
+run is byte-identical to a sequential one, which the test suite
+asserts.
 
 ## How it is put together
 
@@ -60,50 +62,33 @@ Two pieces are not in the package, for two different reasons.
 
 **The runtime** is a ~16 MB shared library holding stan-math, every
 density kernel, and the interpreter. CRAN builds its own binaries from
-source and would have to compile all of that to produce one, so
-`stanli_install()` downloads the prebuilt library into the user cache
-directory instead. Nothing is fetched without being asked for. Point
-`STANLI_RUNTIME` at a local build to use one you built yourself.
-
-The consequence is that this package and the library it calls are
-separately versioned artifacts, and can drift. Getting that wrong is not
-a crash: `stanli_sample_opts` is a struct this package declares a copy
-of, so a field added on one side and not the other would be read at the
-wrong offsets and sample happily from the wrong seed at the wrong step
-size. So the C ABI carries a layout version, the runtime reports it
-through `stanli_abi_version()`, and loading refuses on a mismatch with a
-message saying which side to update. The release workflow asserts the
-pinned release equals the tag it is cutting.
+source and would have to compile all of that, so `stanli_install()`
+downloads the prebuilt library instead. Because the package and the
+library are separately versioned, they can drift, and drift here would
+not crash: `stanli_sample_opts` is a struct this package declares a
+copy of, so mismatched layouts would read fields at the wrong offsets
+and sample happily from the wrong seed. So the C ABI carries a layout
+version (`stanli_abi_version()`) and loading refuses on a mismatch with
+a message saying which side to update.
 
 **The Stan compiler** is stanc3 compiled to JavaScript and run through
-the V8 package — the same approach rstan uses to ship a Stan compiler on
-CRAN. It is one 2.8 MB file that compresses to about 0.4 MB in the source
-tarball, with no toolchain and no per-platform binaries. When the runtime
-embeds stanc3 -- every release build but Windows, which waits on opam's
-native Windows support -- that path is used instead and V8 is never
-loaded; a native `stanc` in `STANLI_STANC` or beside the runtime also
-wins, because it is faster than either. The Windows runtime tarball
-carries `stanc.exe` next to the DLL for exactly that reason, so V8 is a
-fallback there too rather than a requirement.
-
-`tests/test_stancjs.cjs` in the main repository checks that the
-JavaScript compiler emits the same MIR as the native binary, byte for
-byte.
-
-## Sampling in parallel
-
-Chains run in parallel by default. Threading does not change the answer:
-each chain owns its executor and its RNG stream, so a parallel run is
-byte-identical to a sequential one, which the test suite asserts in a
-form that holds on a single-threaded build too.
+the V8 package, the same approach rstan uses to ship a compiler on
+CRAN: one 2.8 MB file, no toolchain, no per-platform binaries. When the
+runtime embeds stanc3 (every release build but Windows), that path is
+used instead and V8 never loads; a native `stanc` in `STANLI_STANC` or
+beside the runtime also wins, because it is faster than either. The
+Windows runtime tarball carries `stanc.exe` next to the DLL for exactly
+that reason. `tests/test_stancjs.cjs` in the main repository checks
+that the JavaScript compiler emits the same MIR as the native binary,
+byte for byte.
 
 ## What is not here yet
 
-`init` is on the **unconstrained** scale. Unconstraining a user's
+`init` is on the **unconstrained** scale: unconstraining a user's
 starting values needs the inverse parameter transforms, and stanli has
 only the forward ones.
 
 `optimize_model()` returns the posterior **mode**. CmdStan's `optimize`
-defaults to `jacobian=0`, the penalized maximum likelihood, which stanli
-cannot offer: the change-of-variables Jacobian is folded into the graph
-when the model is lowered.
+defaults to `jacobian=0`, the penalized maximum likelihood, which
+stanli cannot offer: the change-of-variables Jacobian is folded into
+the graph when the model is lowered.

--- a/runtime/src/OPTIMIZATIONS.md
+++ b/runtime/src/OPTIMIZATIONS.md
@@ -1,26 +1,24 @@
 # Graph optimizations and performance work
 
-This file describes the optimizations stanli applies to a model before
-running it, and a few performance details of the runtime itself. It is
-written for people who have not worked on compilers. Each section says
-what the problem is, what we do about it, and how to turn the fix off
-when debugging.
+What stanli does to a model's op graph before running it, written for
+people who have not worked on compilers. Each section says what the
+problem is, what the pass does, and how to turn it off when debugging.
+Measurements are in [`docs/benchmarks.md`](../../docs/benchmarks.md).
 
-## Background: what the graph is and why op count matters
+## Background: why op count matters
 
 stanli turns a Stan model into a list of operations ("ops"). Each op
-reads some buffers, computes something, and writes a buffer. Evaluating
-the log density means running the list top to bottom. Computing the
-gradient means running it again bottom to top.
+reads some buffers, computes something, and writes a buffer. The log
+density is the list run top to bottom; the gradient is the list run
+bottom to top.
 
-Running one op has a fixed cost of roughly 15-20 nanoseconds, no matter
-how small the computation inside it is. An op that adds two single
-numbers pays the same fixed cost as an op that adds two vectors of
-10,000 numbers. So the main way to make a model faster is to make the
-list shorter: replace many small ops with few big ones.
+Running one op costs roughly 15-20 nanoseconds regardless of how small
+the computation inside it is. An op that adds two numbers pays the same
+fixed cost as an op that adds two vectors of 10,000 numbers. So the
+main way to make a model faster is to make the list shorter: replace
+many small ops with few big ones.
 
-The problem is that lowering (the step that builds the list from the
-compiler's output) unrolls loops. A model with
+The problem is that lowering unrolls loops. A model with
 
 ```stan
 for (n in 1:1000) {
@@ -28,351 +26,248 @@ for (n in 1:1000) {
 }
 ```
 
-becomes several thousand single-number ops: one read of `mu`, one
-density evaluation, and so on, a thousand times over. The optimizations
-below exist to undo that, without changing the numbers the model
-computes.
-
-The passes run in this order, in `lower.cpp`:
+becomes several thousand single-number ops. The passes below undo that
+without changing the numbers the model computes. They run in this
+order, from `lower.cpp`:
 
 1. in-place updates (`inplace.cpp`)
 2. store-to-load forwarding (`inplace.cpp`)
 3. constant folding (`constfold.cpp`)
 4. loop re-rolling (`reroll.cpp`)
+5. tape islands (`island.cpp`)
 
 ## In-place updates (`inplace.cpp`, disable: `STANLI_NO_INPLACE=1`)
 
-Writing one element of a vector, like `mu[n] = x;` inside a loop, is
-lowered as a "functional update": copy the whole vector into a new
-buffer, then change one element. This keeps every intermediate version
-of the vector around, which the gradient step sometimes needs. But it
-means N writes into a vector of length N copy about N*N/2 numbers in
-total. One real model (radon_county_intercept, N = 12,573) spent 90
-milliseconds per gradient and 2.6 GB of memory this way.
+Writing one element of a vector, like `mu[n] = x;` in a loop, lowers as
+a "functional update": copy the whole vector into a new buffer, then
+change one element. N writes into a length-N vector then copy about
+N*N/2 numbers. One real model (radon_county_intercept, N = 12,573)
+spent 90 ms per gradient and 2.6 GB of memory this way.
 
 The fix: if nothing ever looks at the old version of the vector again,
-skip the copy and change the element directly in the existing buffer.
+change the element directly in the existing buffer. "Nothing looks at
+it again" has two parts:
 
-"Nothing looks at it again" has two parts:
-
-- No later op reads the old version. The write must be the last use of
-  that buffer.
+- No later op reads the old version; the write is the last use of that
+  buffer.
 - No earlier op needs the old values during the gradient step. Some
-  ops (for example `log_sum_exp` before it got its own kernel)
-  recompute their derivative from their input buffer when the gradient
-  runs. The gradient runs after all the writes have happened, so if we
-  destroyed the buffer, those ops would read wrong numbers. Only ops
-  whose gradient step just moves numbers around, without re-reading
-  input values, are safe to have before an in-place write. There is an
-  explicit list of those ops (`backward_ignores_input_values`), and a
-  test that checks every op on the list really has that property.
+  ops recompute their derivative from their input buffer when the
+  gradient runs, which happens after all the writes. Only ops whose
+  gradient step just moves numbers around, without re-reading input
+  values, may sit before an in-place write. There is an explicit list
+  of those ops (`backward_ignores_input_values`) and a test that checks
+  each one really has that property.
 
-We found the need for the second condition the hard way: an earlier
-version of this pass got eight models silently wrong by large amounts,
-with nothing visibly different about the graphs. The full-corpus
-comparison described at the end of this file is what caught it.
+The second condition was learned the hard way: without it, eight models
+were silently wrong by large amounts with nothing visibly different
+about their graphs. The full-corpus comparison at the end of this file
+is what caught it.
 
 ## Store-to-load forwarding (`inplace.cpp`, same switch)
 
-A very common pattern is: write `mu[n]`, then read `mu[n]` back in the
-same loop iteration. After lowering, that is a write op immediately
-followed by a read op on the same element. The pass deletes the read
-and hands the value straight to whoever wanted it. If, after this,
-nobody reads the vector at all anymore, the writes are deleted too.
-
-This matters because it turns "loop that fills a vector" into "loop
-that just does arithmetic", which the re-rolling pass below knows how
-to vectorize.
+A common pattern: write `mu[n]`, then read `mu[n]` back in the same
+iteration. After lowering that is a write op immediately followed by a
+read op on the same element. The pass deletes the read and hands the
+value straight to its consumer. If nobody reads the vector at all after
+this, the writes are deleted too. This turns "loop that fills a vector"
+into "loop that does arithmetic", which re-rolling knows how to
+vectorize.
 
 ## Constant folding (`constfold.cpp`, disable: `STANLI_NO_CONSTFOLD=1`)
 
-Some parts of a model do not depend on the parameters at all. For
-example, `dogs` builds two 25x30 matrices purely out of its data in the
-`transformed parameters` block. Those ops compute the same numbers on
-every single gradient evaluation, thousands of times during sampling.
+Some parts of a model do not depend on the parameters, but still lower
+to ops that recompute the same numbers on every gradient evaluation.
+The pass finds every op no parameter can influence, runs those ops
+once, saves the results, and deletes the ops.
 
-The pass finds every op that no parameter can influence, runs those ops
-once, saves the resulting numbers, and deletes the ops. The saved
-numbers are loaded into the buffers when the model is set up, the same
-way data is.
-
-To run the ops "once", the pass builds a small temporary graph out of
-just the constant ops and runs it through the normal executor. This is
-deliberate: the kernel that implements an op is the only definition of
-what that op computes. If this pass had its own evaluation code, the
-two could disagree.
+To run them "once", the pass builds a small temporary graph from just
+the constant ops and runs it through the normal executor. This is
+deliberate: the kernel is the only definition of what an op computes,
+and a separate evaluation path could disagree with it.
 
 One ordering rule: folding replaces a buffer with its final contents.
-If some surviving op reads a buffer at a moment when it held earlier,
-different contents (this happens with the in-place write chains, which
-reuse one buffer), that buffer cannot be folded, and anything computed
-from it cannot be folded either.
+If a surviving op reads the buffer at a moment when it held different,
+earlier contents (this happens with in-place write chains), that buffer
+cannot be folded, and nothing computed from it can be either.
 
 ## Loop re-rolling (`reroll.cpp`, disable: `STANLI_NO_REROLL=1`)
 
-This is the main pass. An unrolled loop shows up in the op list as the
-same short pattern repeated many times: for example
-"read element, multiply, add, evaluate density" over and over, once per
-data point. The pass looks for such repeats. Each repetition is called
-a lane. If it can prove the lanes are independent of each other, it
-replaces all of them with a handful of vector ops.
+The main pass. An unrolled loop shows up as the same short op pattern
+repeated once per data point; each repetition is called a lane. If the
+pass can prove the lanes independent, it replaces them with a handful
+of vector ops. To do that it works out how each input varies from lane
+to lane:
 
-To do that, it has to work out, for each input of the pattern, how that
-input varies from lane to lane:
+- Same buffer every lane: keep it; the vector kernels broadcast a
+  scalar across elements.
+- A different constant every lane: collect the constants into a new
+  vector loaded at setup time.
+- The output of an earlier op in the same lane: use that op's
+  vectorized output.
 
-- Same buffer every lane: keep it as is. The vector kernels accept a
-  single number where a vector is expected and reuse it for every
-  element ("broadcasting").
-- A different small constant every lane: collect the constants into a
-  new vector, load it at setup time, use that.
-- The output of an earlier op in the same lane: use the vectorized
-  version of that op's output.
+Element reads and writes get special handling:
 
-Reads and writes of vector elements get special handling:
-
-- Reading `v[0], v[1], v[2], ...` across lanes, one element per lane,
-  in order, covering the whole vector: no op needed at all. The
-  consumers can just read `v` directly.
-- Reading the same element every lane: keep one copy of the read
-  ("hoisting" it out of the loop).
+- Reading `v[0], v[1], ...` in order across the whole vector: no op at
+  all; consumers read `v` directly.
+- Reading the same element every lane: one hoisted copy.
 - Reading a contiguous range: one slice op.
-- Reading arbitrary elements, like `mu[county[n]]`: one gather op that
-  reads all the requested elements. Its gradient step adds each
-  element's contribution back to the right place, including when the
-  same element is read by many lanes.
-- Writing `v[0], v[1], v[2], ...` across lanes: one store op that
-  writes the whole range, or no op at all if the writes cover the whole
-  vector (the computed vector simply becomes `v`). Writes that step by
-  a fixed amount bigger than 1 (filling a matrix column by column) use
-  a strided store op. When several write runs take turns filling one
-  vector, each run's store output becomes the vector that everything
-  afterwards refers to, so the runs chain together and each one can be
-  vectorized on its own.
-- A whole run of writes that all write the same value (this happens
-  when every varying input of the value's computation turned out to be
-  hoisted): the computation is kept as a single scalar and one
-  broadcast op copies it across the range. Widening it blindly was a
-  bug: the kernels would have read only the first element.
+- Reading arbitrary elements, like `mu[county[n]]`: one gather op. Its
+  gradient step adds each element's contribution back to the right
+  place, including repeated elements.
+- Writing `v[0], v[1], ...` across lanes: one store op, or no op when
+  the writes cover the whole vector (the computed vector simply becomes
+  `v`). Writes stepping by a fixed stride (filling a matrix column by
+  column) use a strided store. When several write runs take turns
+  filling one vector, each run's store output becomes the vector
+  everything later refers to, so the runs chain and each vectorizes on
+  its own.
+- A run of writes that all write the same value: keep the computation
+  scalar and broadcast it across the range.
 
-Densities get two more tricks, depending on where their results go.
+Densities get two more rewrites, depending on where their results go.
+If every lane's density result goes straight into the target, N scalar
+density ops become one vector density op (the vector kernels already
+return the summed density). Discrete densities carry their integer
+outcome as an attached immediate; lanes fuse by concatenating those
+immediates, the form the vector kernel expects. If instead every lane's
+density result feeds another op in the same lane (the mixture idiom,
+where two densities feed a `log_mix`), the N scalar ops become one
+*elementwise* density op whose output holds each lane's own log
+density, computed by the same per-element call the scalar ops used, so
+the results are bit-identical. The consumers (`log_mix`,
+two-argument `log_sum_exp`, ordinary arithmetic) then vectorize as
+usual, and one summing op replaces the N per-lane target entries. A
+density whose inputs are the same buffer in every lane stays one scalar
+op instead.
 
-If every lane's density result goes straight into the target (the
-running log-density total), the N scalar density ops become one vector
-density op. The vector kernels already return the sum of the element
-densities, so this also removes N additions from the target total.
-Discrete densities like `bernoulli_logit` carry their integer outcome
-(the observed 0 or 1) as a small attached integer rather than as a
-buffer; those fuse by concatenating the attached integers of all lanes
-into one array, which is exactly the form the vector kernel expects.
+Anything the pass cannot prove safe it leaves alone. The common
+reasons: a lane reads a result computed by the previous lane (a
+recurrence involving parameters), a lane's intermediate is used outside
+the loop, or an op it has no rule for. When a pattern only partly
+qualifies, the pass rewrites the longest qualifying prefix of lanes and
+tries again on the rest, which handles data that comes in blocks.
 
-If instead every lane's density result feeds another op in the same
-lane -- the mixture-model idiom, where two densities per observation
-feed a `log_mix` -- the N scalar density ops become one *elementwise*
-density op: its output is a vector holding each lane's own log density,
-not the sum. The kernel computes each element with the same
-per-element call the scalar ops used, so the results are identical bit
-for bit. The consumers (`log_mix`, `log_sum_exp` of two arguments, and
-the ordinary arithmetic ops) then vectorize as usual. When those
-consumers' results are what goes into the target, the pass adds one
-summing op over the vector and the N per-lane target entries become
-that single sum. A density whose inputs are all the same buffer in
-every lane is kept as one scalar op instead (each lane would compute
-the same number, and the consumers can reuse it).
+Scale: `radon_pooled` drops from 27,670 ops to 8, `radon_county` from
+25,152 to 10, `election88_full` from 289,165 to 65, `dogs` from 12,751
+to 261, `low_dim_gauss_mix` to 16.
 
-Anything the pass cannot prove safe, it leaves alone. The common
-reasons to leave a region alone:
+## Control flow that depends on a parameter (`lower.cpp`, `mir_prog.hpp`)
 
-- One lane reads a result computed by the previous lane (a recurrence,
-  like an AR model's state update, when it involves parameters).
-- A lane's intermediate result is used outside the loop.
-- An op the pass does not have a rule for.
+`if (theta > 0) ...` cannot become ops: the op list is fixed at load
+time, and this statement picks its branch anew at every evaluation. The
+region (just the conditional, not the model around it) is translated
+into the same instruction list the ODE right-hand sides use, and one op
+runs it: on plain numbers for the value, and again under stan-math's
+own autodiff for the derivatives, which are the derivatives of
+whichever branch ran. That is what CmdStan's generated C++ does for the
+same statement. This is not an optimization and no switch turns it off;
+without it the model does not run.
 
-When a repeated pattern only partly qualifies, the pass rewrites the
-longest prefix of lanes that does qualify and tries again on the rest.
-This is what handles data that comes in blocks (for example
-observations sorted by time period): each block vectorizes separately.
-
-Results, to give a sense of scale: `radon_pooled` drops from 27,670 ops
-to 8, `radon_county` from 25,152 to 10, `election88_full` from 289,165
-to 65, `dogs` from 12,751 to 261, `low_dim_gauss_mix` (a mixture model,
-using the elementwise density form) to 16.
-
-## Control flow that depends on a parameter (`lower.cpp`, `mir_prog.cpp`)
-
-`if (theta > 0) ...` cannot become operations. The list of operations is
-built when the model is loaded and does not change afterwards, and this
-statement picks its branch every time the model is evaluated, from a
-value that is different every time.
-
-Until recently that was a compile error. Now the region -- just the
-conditional, not the model around it -- is translated into the same
-instruction list the ODE right-hand sides use, and one operation runs
-it: on plain numbers to get the value, and again under stan-math's own
-autodiff to get the derivatives, which are the derivatives of whichever
-branch actually ran. That is what the generated C++ does for the same
-statement, because it is the same autodiff over the same arithmetic.
-
-Values the region reads from outside come in as inputs, values it
-assigns come out and replace the old ones for the statements that
-follow. This is not an optimization and `STANLI_NO_ISLAND` does not turn
-it off: without it the model does not run at all.
-
-One thing it refuses. Writing `y ~ normal(mu, 1)` inside such a region
-is rejected with a message saying to write
-`target += normal_lpdf(y | mu, 1)` instead. The `~` form drops the terms
-that do not depend on the parameters, and *which* terms those are
-depends on which arguments are parameters -- a distinction the
-instruction list cannot make, because it treats every value the same
-way. Getting it wrong would leave the gradient perfect and the log
-density off by a constant, which is the kind of error that survives a
-long time, so it is refused instead of approximated.
+One refusal: `y ~ normal(mu, 1)` inside such a region is rejected with
+a message saying to write `target += normal_lpdf(y | mu, 1)` instead.
+The `~` form drops terms based on which arguments are parameters, a
+distinction the instruction list cannot make because it binds every
+value the same way. Getting it wrong would leave the gradient perfect
+and the log density off by a constant, so it is refused rather than
+approximated.
 
 ## Tape islands (`island.cpp`, disable: `STANLI_NO_ISLAND=1`)
 
-Some code cannot be vectorized by anyone. A hidden Markov model's
-forward algorithm computes step t from step t-1, and every step depends
-on the parameters; the same is true of GARCH and ARMA state updates.
-Re-rolling correctly refuses these, because running the steps in
-parallel would change the arithmetic.
+Some code cannot be vectorized by anyone: an HMM's forward recursion
+computes step t from step t-1, and every step depends on parameters.
+Re-rolling correctly refuses these. This pass runs last, so what it
+sees is by construction what nothing else could help. It compiles each
+long stretch of leftover scalar ops into a single instruction list run
+by one op. Forward runs it on plain numbers; backward re-executes it
+under stan-math's autodiff on a scratch tape and reads the derivatives
+out, the same arithmetic CmdStan performs for those statements, so the
+derivatives agree by construction.
 
-This pass runs last, after all the others, so what it sees is by
-construction the code nothing else could help. It takes each long
-stretch of leftover scalar work and compiles it into a single
-instruction list -- the same idea as the ODE right-hand sides below,
-with a different instruction set -- run by one op instead of thousands.
-Values are numbered cells again, and a data array the region reads is
-copied into the program as constants rather than being read from the
-graph.
+Collapsing thousands of ops into one sounds like it must be faster, and
+mostly it is not: measured on all fourteen corpus models with a big
+enough region, it was faster on one, a wash on four, and up to 20x
+slower on nine. The op count was never the cost; scalar ops are about
+as cheap as the arithmetic inside them, and replaying under autodiff
+costs what CmdStan costs, which is more. The one model that wins
+(`iohmm_reg`, 2.6x) copies a 1,500-element state vector per step, and
+the island's register file makes those copies disappear.
 
-Running it forward uses plain numbers. Running it backward re-executes
-the same instruction list under stan-math's own autodiff, on a scratch
-tape that is thrown away afterwards, and reads the derivatives out.
-That is the same arithmetic CmdStan's generated C++ performs for those
-statements, so the derivatives agree by construction rather than by
-testing.
+So the pass estimates both sides before committing (what the ops move,
+against what the register file costs to build, twice per evaluation and
+once as allocating autodiff values) and keeps the compiled form only
+when it is cheaper. The estimate separates the fourteen models exactly.
+`STANLI_ISLAND_ALWAYS=1` skips the estimate, which is how to ask why a
+region was left alone.
 
-Collapsing thousands of operations into one sounds like it must be
-faster, and mostly it is not. Measured against the same build with the
-pass switched off, on all fourteen corpus models that have a region big
-enough to compile, it was faster on one, a wash on four, and slower on
-nine -- as much as 20x slower. The reason is that the op count was
-never the cost. A region of scalar arithmetic is already about as cheap
-as the arithmetic itself, and re-running it under autodiff costs what
-CmdStan costs, which is more.
-
-What made the one model different is that its steps copy a
-1,500-element state vector each. Those copies are real memory traffic
-that the cells make free, and the model runs 2.6x faster compiled.
-
-So the pass estimates both sides before committing -- what the
-operations move, against what the cell array costs to build (twice per
-evaluation, and once as autodiff values, which allocate) -- and keeps
-the compiled form only when it is the cheaper one. The estimate
-separates the fourteen exactly: the one it keeps is 3.6x on the
-right side of the line, and every region it drops is 4-20x on the wrong
-side. Setting `STANLI_ISLAND_ALWAYS=1` skips the estimate, which is how
-to ask why a particular region was left alone.
-
-What the pass refuses outright, before any of that:
-
-- Short runs (under 32 ops), where per-op dispatch is cheaper anyway.
-- Regions with more than six distinct inputs.
-- Densities written in the dropped-constants form, whose value depends
-  on which arguments are parameters -- the island binds all of them the
-  same way, which only reproduces the keep-everything form.
-- Regions that produce an entry in the target total, which must stay
-  visible to the passes that read them.
+The pass also refuses outright: short runs (under 32 ops), regions with
+more than six distinct inputs, densities in the dropped-constants form
+(see the refusal above), and regions producing target entries.
 
 The remaining work for this class is to generate the backward pass
-directly rather than replaying the forward one under autodiff. That is
-what would make the compiled form cheaper than the ops on the models
-where it is currently a wash.
+directly instead of replaying the forward under autodiff.
 
 ## Compiled ODE right-hand sides (`ode_prog.cpp`, report fallbacks: `STANLI_DEBUG_ODE=1`)
 
-Models with differential equations pass a user-written function (the
-"right-hand side") to a numerical solver. The solver decides at run
-time which time points to evaluate it at, so this one function cannot
-be unrolled into the graph ahead of time. It used to be executed by
-walking the compiler's syntax tree every call, looking variables up by
-name in a map and allocating a fresh vector for every intermediate
-value. That cost about 6 microseconds per call, the solver makes
-hundreds of calls per gradient, and it was 97% of the total time on
-the ODE models.
+An ODE model passes a user function (the right-hand side) to a solver
+that decides at run time when to call it, so this one function cannot
+be unrolled into the graph. It used to be run by walking the compiler's
+syntax tree per call, with a map lookup per variable and an allocation
+per intermediate: about 6 us per call, hundreds of calls per gradient,
+97% of the total time on the ODE models.
 
-Now the function is translated once, when the model is loaded, into a
-simple instruction list: every variable becomes a numbered cell in one
-flat array, every operation becomes an entry like "cell 14 = cell 3
-times cell 9", and running the function is a single loop over the
-entries. Loops inside the function with known bounds are unrolled at
-translation time; conditions on run-time values become jump
-instructions. No lookups, no memory allocation.
-
-Anything the translator cannot handle falls back to the old
-tree-walking interpreter, so no model loses support; it is just slower.
-Setting `STANLI_DEBUG_ODE=1` prints when that happens. A test runs
+Now the function is translated once, at load, into a flat instruction
+list: variables become numbered cells, known-bound loops unroll,
+run-time conditions become jumps, and a call is one loop over the
+instructions with no lookups and no allocation. Anything the translator
+cannot handle falls back to the old interpreter (slower, never less
+supported); `STANLI_DEBUG_ODE=1` prints when that happens. A test runs
 every supported construct through both implementations and requires
-identical results, bit for bit.
+bit-identical results.
 
-Separately, the gradient used to solve the differential equation twice
-per evaluation, once for the values and once for the derivatives. The
-first solve already computes everything needed for the derivatives (it
-has to, for accuracy reasons), so we now save that information instead
-of throwing it away, and the second solve is gone.
+Separately, the gradient used to solve the ODE system twice, once for
+values and once for derivatives. The first solve already computes
+everything the derivatives need, so it is kept instead of thrown away
+and the second solve is gone.
 
 Together these made the ODE models 29-39x faster.
 
 ## Executor details (`executor.cpp`)
 
-Two smaller things live in the executor rather than in a pass:
+- Each op's context (the pointers telling the kernel where its inputs,
+  outputs, and scratch are) is built once at setup; nothing moves
+  afterwards, so there is nothing to rebuild per evaluation.
+- All values live in one arena, all adjoints in another, both allocated
+  once. A steady-state gradient evaluation performs no allocation.
+- Kernel function pointers are resolved once at setup into two flat
+  lists (forward order and reverse order, with backward-less ops left
+  out of the second), and both sweeps are unrolled four at a time.
 
-- Each op's "context" (the little bundle of pointers telling the kernel
-  where its inputs, outputs, and workspace are) is built once when the
-  model is set up, not rebuilt on every evaluation. All the pointers go
-  into buffers that never move after setup, so there is nothing to
-  rebuild. This mostly helps models with many small ops.
-- All values live in one big array, all gradient values in another, and
-  both are allocated once. A steady-state gradient evaluation performs
-  no memory allocation at all.
-- Which function to call for each op is decided once, at setup, into two
-  flat lists -- one in forward order, one in reverse, with the ops that
-  have nothing to do backward left out of the second. An evaluation
-  walks the list rather than looking anything up per op. Both sweeps are
-  written out four at a time, which lets the processor work on several
-  calls at once instead of waiting to see where each one goes.
-
-That last one is as far as this goes: a tail-call threaded version, the
-usual next step, measured slower than the plain unrolled loop
-(`tools/bench_dispatch.cpp` keeps the comparison), and after these
-changes the cost of an op is dominated by loading its context rather
-than by the call. Fewer ops is the remaining lever, which is what every
-pass above is for.
+A tail-call threaded dispatch, the usual next step, measured slower
+than the unrolled loop (`tools/bench_dispatch.cpp` keeps the
+comparison). After these changes per-op cost is dominated by loading
+the context, not the dispatch, so the remaining lever is fewer ops,
+which is what the passes above are.
 
 ## How we check all of this
 
-Every optimization here changes the graph, and a wrong graph produces
-wrong numbers silently. Three layers of checking:
+Every pass changes the graph, and a wrong graph produces wrong numbers
+silently. Three layers:
 
-- Unit tests per pass (`tests/test_reroll.cpp`, `tests/test_inplace.cpp`,
-  `tests/test_island.cpp`, `tests/test_ode_prog.cpp`,
-  `tests/test_pass_safety.cpp`). These
-  include tests that the passes refuse the cases they must refuse, and
-  a fuzz test that runs hundreds of random graphs through all passes
-  and compares gradients before and after.
-- A full-corpus A/B check (`harnesses/ab_corpus.py`). It evaluates every
-  model in the posteriordb test set twice, once with the passes turned
-  off and once with them on, and compares the log density and every
-  gradient component. The passes-off graph is separately verified
-  against CmdStan, so if A and B agree, the optimized graph inherits
-  that verification. This check has caught two real bugs that the unit
-  tests missed, on model shapes nobody thought to write a unit test
-  for. Run it after any change to a pass.
+- Unit tests per pass (`tests/test_reroll.cpp`, `test_inplace.cpp`,
+  `test_island.cpp`, `test_ode_prog.cpp`, `test_pass_safety.cpp`),
+  including tests that the passes refuse what they must refuse, and a
+  fuzz test that runs hundreds of random graphs through all passes and
+  compares gradients before and after.
+- A full-corpus A/B check (`harnesses/ab_corpus.py`): every posteriordb
+  model evaluated with the passes off and on, comparing the log density
+  and every gradient component. The passes-off graph is separately
+  verified against CmdStan, so if A and B agree, the optimized graph
+  inherits that verification. This has caught two real bugs the unit
+  tests missed. Run it after any change to a pass.
 - Direct verification against CmdStan (`tools/verify_sample.py`) for
-  models whose graphs a change affects.
+  models a change affects.
 
-The environment variables (`STANLI_NO_INPLACE`, `STANLI_NO_CONSTFOLD`,
-`STANLI_NO_REROLL`, `STANLI_NO_ISLAND`) exist so that a wrong result can
-be attributed to a single pass quickly: turn them off one at a time and
-see which one changes the answer. They are also how each pass is
-measured -- every speed number in this file is the same build with one
-variable set and unset.
+The env switches (`STANLI_NO_INPLACE`, `STANLI_NO_CONSTFOLD`,
+`STANLI_NO_REROLL`, `STANLI_NO_ISLAND`) exist so a wrong result can be
+attributed to one pass quickly, and they are how each pass is measured:
+every speed number is the same build with one variable set and unset.


### PR DESCRIPTION
Rewrites the prose docs to be about a third shorter (29% by words overall; more in prose, since tables and code blocks are fixed weight) and plainer, and fixes the places where they disagreed with the code or each other.

Cohesion fixes:
- STANLI_LITE_LP is off in every build, browser included. lite-lp.md, compact-densities.md, benchmarks.md and the README said otherwise in places.
- python/README's status section claimed no optimization, no parallel chains, no diagnostics, and declared-params-only output; all four shipped. Replaced with the actual limits (no VI/Pathfinder, unconstrained-scale inits, no jacobian=0).
- write_array covers all 119 compiling models via the graph plus the per-draw interpreter; the README still described the pre-interpreter prefix behavior.
- Number drift: 45 bitwise models (not 44), 7.8 MB wheel (not 'under seven' or 5 MB), current wasm sizes (5.79 MB raw / 1.52 MB gzipped).

Structural: benchmarks.md now carries measurements and points at OPTIMIZATIONS.md for mechanism instead of restating it. corpus-status.md (generated by tools/corpus.py) and CHANGELOG.md are untouched. The per-gradient table that tools/gen_docs.py parses is byte-identical and gen_docs.py --check passes.