### PR TITLE
test: assert reroll's linearity by counting its work, not timing it

### DIFF
--- a/runtime/include/stanli/reroll.hpp
+++ b/runtime/include/stanli/reroll.hpp
@@ -17,6 +17,12 @@ struct RerollStats {
   int regions = 0;
   int64_t ops_before = 0;
   int64_t ops_after = 0;
+  // Entries of the per-slot use and writer lists the pass read. This is
+  // the term that was once quadratic in the op count, and it is what
+  // tests/test_reroll.cpp asserts near-linearity on: an exact integer,
+  // unlike a wall-clock reading, so the same graph gives the same answer
+  // on every machine.
+  int64_t list_steps = 0;
 };
 
 // In place. `fills` gains entries for materialized constant vectors.

--- a/runtime/src/reroll.cpp
+++ b/runtime/src/reroll.cpp
@@ -228,16 +228,31 @@ RerollStats reroll(Graph& g,
   // same answers; it just does not read the entries that cannot matter.
   // Entries actually inside a region are still visited, but regions are
   // disjoint, so that total is bounded by the list sizes: O(n log n).
-  const auto first_at_or_after = [](const std::vector<size_t>& v, size_t x) {
-    return std::lower_bound(v.begin(), v.end(), x);
+  //
+  // Every entry read is counted into st.list_steps, probes included, and
+  // that count is what the scaling test asserts on: it is an exact
+  // integer for a given graph, so it says the same thing on a laptop and
+  // on a shared CI runner, which a wall-clock reading does not.
+  const auto first_at_or_after = [&](const std::vector<size_t>& v, size_t x) {
+    size_t lo = 0, hi = v.size();
+    while (lo < hi) {
+      const size_t mid = lo + (hi - lo) / 2;
+      ++st.list_steps;
+      if (v[mid] < x) lo = mid + 1;
+      else hi = mid;
+    }
+    return v.begin() + (ptrdiff_t)lo;
   };
   // Is any entry of `v` in [lo, hi) not accepted by `ours`? `ours` names
   // the region's own ops, which are allowed to touch the slot.
   const auto any_in_range_but = [&](const std::vector<size_t>* v, size_t lo,
                                     size_t hi, auto&& ours) {
     if (v == nullptr) return false;
-    for (auto it = first_at_or_after(*v, lo); it != v->end() && *it < hi; ++it)
+    for (auto it = first_at_or_after(*v, lo); it != v->end() && *it < hi;
+         ++it) {
+      ++st.list_steps;
       if (!ours(*it)) return true;
+    }
     return false;
   };
   // Is any entry of `v` at or after `x`?

--- a/tests/test_reroll.cpp
+++ b/tests/test_reroll.cpp
@@ -794,10 +794,17 @@ static double peak_rss_mb() {
 #endif
 }
 
-// How long reroll takes on the lda shape at size n, with the region count
-// checked along the way so a pass that got fast by doing less is not
-// mistaken for a pass that got fast.
-static double time_lda_reroll(int n) {
+// What reroll costs on the lda shape at size n: the list entries it looks
+// at, which is the term that was quadratic, and the wall clock, which is
+// reported but not asserted on. The region count is checked along the way
+// so a pass that got cheap by doing less is not mistaken for a pass that
+// got cheap.
+struct LdaCost {
+  double sec;
+  int64_t steps;
+};
+
+static LdaCost lda_reroll_cost(int n) {
   ldashape::Built b = ldashape::build(n);
   std::vector<int> tt = b.terms;
   const auto t0 = std::chrono::steady_clock::now();
@@ -806,16 +813,20 @@ static double time_lda_reroll(int n) {
       std::chrono::duration<double>(std::chrono::steady_clock::now() - t0)
           .count();
   expect("lda big all regions found", st.regions == n);
-  return sec;
+  return {sec, st.list_steps};
 }
 
 static void test_lda_shape_cost() {
-  const double small = time_lda_reroll(8000);
-  const double big = time_lda_reroll(16000);
+  const LdaCost small = lda_reroll_cost(8000);
+  const LdaCost big = lda_reroll_cost(16000);
   const double rss = peak_rss_mb();
-  std::printf("  lda shape reroll: n=8000 %.2f s, n=16000 %.2f s (%.1fx),"
+  std::printf("  lda shape reroll: n=8000 %.2f s / %lld steps,"
+              " n=16000 %.2f s / %lld steps (%.1fx steps, %.1fx time),"
               " peak RSS %.0f MB\n",
-              small, big, small > 0.0 ? big / small : 0.0, rss);
+              small.sec, (long long)small.steps, big.sec,
+              (long long)big.steps,
+              small.steps > 0 ? (double)big.steps / (double)small.steps : 0.0,
+              small.sec > 0.0 ? big.sec / small.sec : 0.0, rss);
 
   // The memory ceiling is the guard that matters, because memory is what
   // broke, and unlike a wall-clock number an RSS figure means the same
@@ -826,11 +837,19 @@ static void test_lda_shape_cost() {
   // 12 GB at n=16000, so 1 GB separates them with room on both sides.
   if (rss > 0.0) expect("lda reroll space stays linear", rss < 1024.0);
 
-  // Time is linear with a log factor: a doubling measures about 2.1x
-  // here and 2.0x asymptotically, against 4x for the quadratic scan this
-  // replaced. 3x sits between them, and being a ratio it does not depend
-  // on how fast the machine is.
-  expect("lda reroll time stays near-linear", big < 3.0 * small);
+  // Count the work, do not time it. A doubling of n doubles the entries
+  // this pass reads (2.1x measured) against a quadrupling for the
+  // whole-list scan it replaced (4.0x measured), so 3x separates the two
+  // with room on both sides, and the count is the same integer on every
+  // machine.
+  //
+  // The wall clock is not. Two earlier versions of this check gated on
+  // it, first as an absolute budget and then as a ratio, and between
+  // them they failed three CI runs in one day on the shared macOS
+  // runners, on both arches, while the same binary measured 2.1x on a
+  // quiet laptop. The ratio formulation barely separated the two cases
+  // even there: the quadratic scan timed 3.1x against a 3.0x bound.
+  expect("lda reroll work stays near-linear", big.steps < 3 * small.steps);
 }
 
 static void test_write_fusion() {


### PR DESCRIPTION
`test_reroll` has failed three CI runs today, all on macOS, on both arches, under two different wall-clock formulations:

| run | job | assertion | measured |
|---|---|---|---|
| #33 | macos x86_64 | `lda reroll near-linear (<2 s)` | 2.55 s |
| #36 | macos x86_64 | `<3.0x` over a doubling | 4.6x |
| #37 | macos arm64 | `<3.0x` over a doubling | 4.0x |

Each of those runs had the other macOS arch pass, so it trips about half the time per job. The same binary measures 2.1x on a quiet laptop. The pass is fine; the gate is not, because it reads a shared runner's clock and calls the result an asymptotic property.

The ratio formulation barely had the resolution to do its job anyway. Restoring the quadratic whole-list scan under it times 3.1x here against a 3.0x bound, so a 3% margin separated "quadratic" from "linear" on the machine where the numbers are cleanest.

## Count the work instead

`RerollStats` gains `list_steps`: every entry of a per-slot use or writer list the pass reads, probes included. That is exactly the term #36 took from quadratic to O(n log n), and it is an exact integer for a given graph. The test asserts on its ratio at the same two sizes:

|  | n=8000 | n=16000 | ratio | |
|---|---:|---:|---:|---|
| binary search | 450,135 | 948,247 | 2.1x | passes |
| whole-list scan | 512,056,000 | 2,048,112,000 | 4.0x | fails |

Both rows measured, the second by restoring the old scan and confirming the new assertion rejects it. The count is bit-identical across runs, and it separates the two cases by 2x rather than by 3%.

## Verification

Counting the probes means a hand-rolled `lower_bound` rather than `std::lower_bound`, so the pass has to be shown to decide the same things:

- 119/119 models within 1e-9 of the CmdStan references, worst case `hmm_gaussian` 3.63e-12 (35180 ulp), the same figure #36 reported
- 33/33 tests pass

The wall clock is still measured and still printed, since it is what a human reading the log wants to see. It just no longer votes.