### PR TITLE
chore: Google clang-format, gated in CI

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,5 @@
+# Google C++ style, with one deviation: include order is semantic in
+# this codebase (stan-math must precede Eigen so its plugin macros are
+# seen), so clang-format must not reorder it.
+BasedOnStyle: Google
+SortIncludes: Never

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,10 @@
+# Config ships ahead of its CI job: run-clang-tidy joins lint.yml in the
+# PR that addresses what it finds, so this file changes no gate here.
+Checks: >
+  bugprone-*,
+  -bugprone-easily-swappable-parameters,
+  performance-*,
+  misc-unused-using-decls,
+  modernize-use-nullptr,
+  modernize-use-override
+HeaderFilterRegex: '(runtime|tools|tests)/'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,14 @@
+name: lint
+on:
+  pull_request:
+  push:
+    branches: [main]
+jobs:
+  format:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      # The same binary that produced the tree's formatting: output
+      # drifts across clang-format major versions.
+      - run: pip install clang-format==22.1.8
+      - run: ./tools/format.sh --check

--- a/r/src/bridge.c
+++ b/r/src/bridge.c
@@ -25,22 +25,20 @@
  * filename was written for. */
 #ifdef _WIN32
 #include <windows.h>
-static void *dl_open(const char *path) {
-  return (void *)LoadLibraryA(path);
-}
-static void *dl_sym(void *h, const char *name) {
+static void* dl_open(const char* path) { return (void*)LoadLibraryA(path); }
+static void* dl_sym(void* h, const char* name) {
   /* Through uintptr_t: GetProcAddress returns a function pointer, and
    * converting one straight to void* is what -Wcast-function-type
    * exists to complain about. */
-  return (void *)(uintptr_t)GetProcAddress((HMODULE)h, name);
+  return (void*)(uintptr_t)GetProcAddress((HMODULE)h, name);
 }
-static void dl_close(void *h) { FreeLibrary((HMODULE)h); }
-static const char *dl_error(void) {
+static void dl_close(void* h) { FreeLibrary((HMODULE)h); }
+static const char* dl_error(void) {
   static char buf[512];
   const DWORD e = GetLastError();
-  const DWORD n = FormatMessageA(
-      FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS, NULL, e,
-      0, buf, (DWORD)sizeof buf - 1, NULL);
+  const DWORD n =
+      FormatMessageA(FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
+                     NULL, e, 0, buf, (DWORD)sizeof buf - 1, NULL);
   if (n == 0)
     snprintf(buf, sizeof buf, "could not load the library (error %lu)",
              (unsigned long)e);
@@ -48,13 +46,13 @@ static const char *dl_error(void) {
 }
 #else
 #include <dlfcn.h>
-static void *dl_open(const char *path) {
+static void* dl_open(const char* path) {
   return dlopen(path, RTLD_NOW | RTLD_LOCAL);
 }
-static void *dl_sym(void *h, const char *name) { return dlsym(h, name); }
-static void dl_close(void *h) { dlclose(h); }
-static const char *dl_error(void) {
-  const char *e = dlerror();
+static void* dl_sym(void* h, const char* name) { return dlsym(h, name); }
+static void dl_close(void* h) { dlclose(h); }
+static const char* dl_error(void) {
+  const char* e = dlerror();
   return e != NULL ? e : "unknown error";
 }
 #endif
@@ -79,7 +77,7 @@ typedef struct {
   int max_depth;
   int save_warmup;
   double init_radius;
-  const double *inits;
+  const double* inits;
   int num_threads;
 } stanli_sample_opts;
 
@@ -96,51 +94,50 @@ typedef struct {
   double tol_param;
   int history_size;
   double init_radius;
-  const double *init;
+  const double* init;
 } stanli_optimize_opts;
 
-static void *g_lib = NULL;
+static void* g_lib = NULL;
 
 /* Every entry point the R side uses. */
 static int (*p_abi_version)(void);
-static void *(*p_model_new_from_stan)(const char *, const char *, char *,
-                                      size_t);
-static void *(*p_model_new)(const char *, const char *, char *, size_t);
-static void (*p_model_free)(void *);
+static void* (*p_model_new_from_stan)(const char*, const char*, char*, size_t);
+static void* (*p_model_new)(const char*, const char*, char*, size_t);
+static void (*p_model_free)(void*);
 static int (*p_has_embedded_stanc)(void);
 static int (*p_exact_lp)(void);
 static int (*p_thread_safe)(void);
-static int64_t (*p_n_unconstrained)(const void *);
-static int (*p_grad)(void *, const double *, double *, double *);
-static int64_t (*p_n_constrained)(const void *);
-static const char *(*p_constrained_name)(const void *, int64_t);
-static int (*p_constrain)(void *, const double *, double *);
-static void (*p_sample_opts_init)(stanli_sample_opts *);
-static int64_t (*p_n_stored_draws)(const stanli_sample_opts *);
-static int (*p_sample_multi)(void *, const stanli_sample_opts *, double *,
-                             double *, char *, size_t);
-static const char *(*p_sampler_column_name)(int);
-static int (*p_summary_stats)(const double *, int64_t, int64_t, int64_t,
-                              double *);
-static int64_t (*p_diagnose_text)(const double *, int64_t, int64_t, int64_t,
-                                  const char *const *, const double *, int,
-                                  char *, size_t);
-static int64_t (*p_wa_n_columns)(const void *);
-static const char *(*p_wa_column_name)(const void *, int64_t);
-static void (*p_wa_seed)(void *, uint32_t);
-static int (*p_wa_row)(void *, const double *, double *);
-static void (*p_optimize_opts_init)(stanli_optimize_opts *);
-static int (*p_optimize)(void *, const stanli_optimize_opts *, double *,
-                         double *, double *, char *, size_t);
+static int64_t (*p_n_unconstrained)(const void*);
+static int (*p_grad)(void*, const double*, double*, double*);
+static int64_t (*p_n_constrained)(const void*);
+static const char* (*p_constrained_name)(const void*, int64_t);
+static int (*p_constrain)(void*, const double*, double*);
+static void (*p_sample_opts_init)(stanli_sample_opts*);
+static int64_t (*p_n_stored_draws)(const stanli_sample_opts*);
+static int (*p_sample_multi)(void*, const stanli_sample_opts*, double*, double*,
+                             char*, size_t);
+static const char* (*p_sampler_column_name)(int);
+static int (*p_summary_stats)(const double*, int64_t, int64_t, int64_t,
+                              double*);
+static int64_t (*p_diagnose_text)(const double*, int64_t, int64_t, int64_t,
+                                  const char* const*, const double*, int, char*,
+                                  size_t);
+static int64_t (*p_wa_n_columns)(const void*);
+static const char* (*p_wa_column_name)(const void*, int64_t);
+static void (*p_wa_seed)(void*, uint32_t);
+static int (*p_wa_row)(void*, const double*, double*);
+static void (*p_optimize_opts_init)(stanli_optimize_opts*);
+static int (*p_optimize)(void*, const stanli_optimize_opts*, double*, double*,
+                         double*, char*, size_t);
 
-#define BIND(fn, var)                                          \
-  do {                                                         \
-    *(void **)(&var) = dl_sym(g_lib, fn);                      \
-    if (var == NULL) {                                         \
-      dl_close(g_lib);                                         \
-      g_lib = NULL;                                            \
+#define BIND(fn, var)                                           \
+  do {                                                          \
+    *(void**)(&var) = dl_sym(g_lib, fn);                        \
+    if (var == NULL) {                                          \
+      dl_close(g_lib);                                          \
+      g_lib = NULL;                                             \
       return mkString("missing symbol in stanli library: " fn); \
-    }                                                          \
+    }                                                           \
   } while (0)
 
 SEXP stanli_bridge_load(SEXP path) {
@@ -154,13 +151,14 @@ SEXP stanli_bridge_load(SEXP path) {
    * field moved, every call would still succeed and read the wrong
    * offsets: a run at the wrong seed and the wrong step size, with no
    * error anywhere. Refuse instead. */
-  *(void **)(&p_abi_version) = dl_sym(g_lib, "stanli_abi_version");
+  *(void**)(&p_abi_version) = dl_sym(g_lib, "stanli_abi_version");
   if (p_abi_version == NULL) {
     dl_close(g_lib);
     g_lib = NULL;
-    return mkString("this stanli runtime predates the versioned ABI and is "
-                    "too old for this package. Run "
-                    "stanli_install(overwrite = TRUE).");
+    return mkString(
+        "this stanli runtime predates the versioned ABI and is "
+        "too old for this package. Run "
+        "stanli_install(overwrite = TRUE).");
   }
   if (p_abi_version() != STANLI_R_ABI_VERSION) {
     char msg[256];
@@ -204,23 +202,24 @@ SEXP stanli_bridge_loaded(void) { return ScalarLogical(g_lib != NULL); }
 
 static void require_loaded(void) {
   if (g_lib == NULL)
-    error("the stanli runtime is not loaded; call stanli_install() once, "
-          "then restart or call stanli:::load_runtime()");
+    error(
+        "the stanli runtime is not loaded; call stanli_install() once, "
+        "then restart or call stanli:::load_runtime()");
 }
 
 /* The model handle is an external pointer with a finalizer, so a model
  * that goes out of scope in R frees its arenas rather than leaking them
  * until the session ends. */
 static void model_finalizer(SEXP ext) {
-  void *m = R_ExternalPtrAddr(ext);
+  void* m = R_ExternalPtrAddr(ext);
   if (m != NULL && p_model_free != NULL) {
     p_model_free(m);
     R_ClearExternalPtr(ext);
   }
 }
 
-static void *model_ptr(SEXP ext) {
-  void *m = R_ExternalPtrAddr(ext);
+static void* model_ptr(SEXP ext) {
+  void* m = R_ExternalPtrAddr(ext);
   if (m == NULL) error("stanli model handle is no longer valid");
   return m;
 }
@@ -229,7 +228,7 @@ SEXP stanli_r_model_new(SEXP code, SEXP data_json, SEXP is_mir) {
   require_loaded();
   char err[8192];
   err[0] = '\0';
-  void *m;
+  void* m;
   if (asLogical(is_mir))
     m = p_model_new(CHAR(STRING_ELT(code, 0)), CHAR(STRING_ELT(data_json, 0)),
                     err, sizeof err);
@@ -263,7 +262,7 @@ SEXP stanli_r_n_unconstrained(SEXP m) {
 
 SEXP stanli_r_column_names(SEXP m) {
   require_loaded();
-  void *mm = model_ptr(m);
+  void* mm = model_ptr(m);
   /* write_array columns when the model has generated quantities, the
    * constrained parameters otherwise -- the same rule the Python
    * wrapper follows, so both report the same CSV. */
@@ -272,7 +271,7 @@ SEXP stanli_r_column_names(SEXP m) {
   if (!wa) n = p_n_constrained(mm);
   SEXP out = PROTECT(allocVector(STRSXP, (R_xlen_t)n));
   for (int64_t i = 0; i < n; ++i) {
-    const char *s = wa ? p_wa_column_name(mm, i) : p_constrained_name(mm, i);
+    const char* s = wa ? p_wa_column_name(mm, i) : p_constrained_name(mm, i);
     SET_STRING_ELT(out, (R_xlen_t)i, mkChar(s ? s : ""));
   }
   UNPROTECT(1);
@@ -281,7 +280,7 @@ SEXP stanli_r_column_names(SEXP m) {
 
 SEXP stanli_r_grad(SEXP m, SEXP q) {
   require_loaded();
-  void *mm = model_ptr(m);
+  void* mm = model_ptr(m);
   const int64_t n = p_n_unconstrained(mm);
   if (XLENGTH(q) != n)
     error("q has %lld elements, model has %lld unconstrained parameters",
@@ -291,8 +290,9 @@ SEXP stanli_r_grad(SEXP m, SEXP q) {
   const int rc = p_grad(mm, REAL(q), &lp, REAL(grad));
   if (rc != 0) {
     UNPROTECT(1);
-    error("log density evaluation failed at this point (domain error in a "
-          "distribution or function)");
+    error(
+        "log density evaluation failed at this point (domain error in a "
+        "distribution or function)");
   }
   SEXP out = PROTECT(allocVector(VECSXP, 2));
   SET_VECTOR_ELT(out, 0, ScalarReal(lp));
@@ -308,7 +308,7 @@ SEXP stanli_r_grad(SEXP m, SEXP q) {
 /* opts arrives from R as an unnamed positional list, so this order must
  * match sample_model() in R/stanli.R element for element. A swap of two
  * same-typed fields samples from the wrong configuration in silence. */
-static void fill_sample_opts(stanli_sample_opts *o, SEXP l) {
+static void fill_sample_opts(stanli_sample_opts* o, SEXP l) {
   p_sample_opts_init(o);
   o->seed = (uint32_t)asInteger(VECTOR_ELT(l, 0));
   o->chains = asInteger(VECTOR_ELT(l, 1));
@@ -324,7 +324,7 @@ static void fill_sample_opts(stanli_sample_opts *o, SEXP l) {
 
 SEXP stanli_r_sample(SEXP m, SEXP optlist, SEXP inits) {
   require_loaded();
-  void *mm = model_ptr(m);
+  void* mm = model_ptr(m);
   stanli_sample_opts o;
   fill_sample_opts(&o, optlist);
   if (XLENGTH(inits) > 0) o.inits = REAL(inits);
@@ -352,13 +352,13 @@ SEXP stanli_r_sample(SEXP m, SEXP optlist, SEXP inits) {
   const int wa = ncol > 0;
   if (!wa) ncol = p_n_constrained(mm);
   SEXP vals = PROTECT(allocVector(REALSXP, (R_xlen_t)(nchain * rows * ncol)));
-  double *vp = REAL(vals);
-  double *rp = REAL(raw);
-  double *row = (double *)R_alloc((size_t)ncol, sizeof(double));
+  double* vp = REAL(vals);
+  double* rp = REAL(raw);
+  double* row = (double*)R_alloc((size_t)ncol, sizeof(double));
   for (int64_t c = 0; c < nchain; ++c) {
     if (wa) p_wa_seed(mm, (uint32_t)(o.seed + c));
     for (int64_t i = 0; i < rows; ++i) {
-      const double *q = rp + (c * rows + i) * n;
+      const double* q = rp + (c * rows + i) * n;
       const int rc = wa ? p_wa_row(mm, q, row) : p_constrain(mm, q, row);
       if (rc != 0) {
         UNPROTECT(3);
@@ -415,13 +415,12 @@ SEXP stanli_r_diagnose(SEXP draws, SEXP dims, SEXP names, SEXP stats,
   const int64_t nchain = INTEGER(dims)[0];
   const int64_t ndraw = INTEGER(dims)[1];
   const int64_t ncol = INTEGER(dims)[2];
-  const char **nm =
-      (const char **)R_alloc((size_t)ncol, sizeof(const char *));
+  const char** nm = (const char**)R_alloc((size_t)ncol, sizeof(const char*));
   for (int64_t i = 0; i < ncol; ++i) nm[i] = CHAR(STRING_ELT(names, i));
-  const int64_t need = p_diagnose_text(REAL(draws), nchain, ndraw, ncol, nm,
-                                       REAL(stats), asInteger(max_depth), NULL,
-                                       0);
-  char *buf = (char *)R_alloc((size_t)(need > 0 ? need : 1), 1);
+  const int64_t need =
+      p_diagnose_text(REAL(draws), nchain, ndraw, ncol, nm, REAL(stats),
+                      asInteger(max_depth), NULL, 0);
+  char* buf = (char*)R_alloc((size_t)(need > 0 ? need : 1), 1);
   p_diagnose_text(REAL(draws), nchain, ndraw, ncol, nm, REAL(stats),
                   asInteger(max_depth), buf, (size_t)(need > 0 ? need : 1));
   return mkString(buf);
@@ -429,7 +428,7 @@ SEXP stanli_r_diagnose(SEXP draws, SEXP dims, SEXP names, SEXP stats,
 
 SEXP stanli_r_optimize(SEXP m, SEXP optlist, SEXP init) {
   require_loaded();
-  void *mm = model_ptr(m);
+  void* mm = model_ptr(m);
   stanli_optimize_opts o;
   p_optimize_opts_init(&o);
   o.seed = (uint32_t)asInteger(VECTOR_ELT(optlist, 0));

--- a/r/src/init.c
+++ b/r/src/init.c
@@ -36,7 +36,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"stanli_r_optimize", (DL_FUNC)&stanli_r_optimize, 3},
     {NULL, NULL, 0}};
 
-void R_init_stanli(DllInfo *dll) {
+void R_init_stanli(DllInfo* dll) {
   R_registerRoutines(dll, NULL, CallEntries, NULL, NULL);
   R_useDynamicSymbols(dll, FALSE);
 }

--- a/runtime/include/stanli/capi.h
+++ b/runtime/include/stanli/capi.h
@@ -79,26 +79,26 @@ int stanli_sample(stanli_model* m, uint32_t seed, int warmup, int samples,
 
 typedef struct {
   uint32_t seed;
-  int chains;      /* number of chains */
-  int chain_id;    /* id of the FIRST chain; chain c uses chain_id + c,
-                    * which is how CmdStan turns one seed into per-chain
-                    * streams. Matching it means a matched seed gives a
-                    * matched stream per chain. */
+  int chains;   /* number of chains */
+  int chain_id; /* id of the FIRST chain; chain c uses chain_id + c,
+                 * which is how CmdStan turns one seed into per-chain
+                 * streams. Matching it means a matched seed gives a
+                 * matched stream per chain. */
   int warmup;
-  int samples;     /* transitions, not stored rows: with thin > 1 a run
-                    * stores samples/thin of them, as CmdStan does */
+  int samples; /* transitions, not stored rows: with thin > 1 a run
+                * stores samples/thin of them, as CmdStan does */
   int thin;
-  double delta;    /* target acceptance statistic */
+  double delta; /* target acceptance statistic */
   int max_depth;
-  int save_warmup; /* store warmup draws ahead of the sampling draws */
-  double init_radius; /* uniform(-r, r) on the unconstrained scale; 0
-                       * starts at the origin (CmdStan's `init=0`) */
+  int save_warmup;     /* store warmup draws ahead of the sampling draws */
+  double init_radius;  /* uniform(-r, r) on the unconstrained scale; 0
+                        * starts at the origin (CmdStan's `init=0`) */
   const double* inits; /* chains * n_unconstrained on the UNCONSTRAINED
                         * scale, or null for random inits. Unconstrained
                         * because that is the scale stanli can read: a
                         * constrained init would need the inverse
                         * parameter transforms, which do not exist yet. */
-  int num_threads; /* honoured only when stanli_thread_safe(); see there */
+  int num_threads;     /* honoured only when stanli_thread_safe(); see there */
 } stanli_sample_opts;
 
 /* Fill with CmdStan's defaults: seed 1, 4 chains from id 1, 1000 warmup,
@@ -172,8 +172,8 @@ enum {
  * 2021 via stan's own estimators -- the numbers stansummary prints.
  * A constant column yields NaN for R-hat and ESS, which is the honest
  * answer rather than a pass. Returns 0 on success. */
-int stanli_summary_stats(const double* draws, int64_t n_chains,
-                         int64_t n_draws, int64_t n_cols, double* out);
+int stanli_summary_stats(const double* draws, int64_t n_chains, int64_t n_draws,
+                         int64_t n_cols, double* out);
 
 /* Convergence diagnostics as prose: divergences, treedepth saturation,
  * E-BFMI, R-hat, and bulk/tail ESS, each either confirmed or reported
@@ -199,9 +199,9 @@ typedef struct {
   uint32_t seed;
   int chain_id;
   int iter;
-  int jacobian;        /* include the change-of-variables Jacobian, making
-                        * this the posterior MODE rather than the penalized
-                        * maximum likelihood. CmdStan defaults it off. */
+  int jacobian; /* include the change-of-variables Jacobian, making
+                 * this the posterior MODE rather than the penalized
+                 * maximum likelihood. CmdStan defaults it off. */
   double init_alpha;
   double tol_obj;
   double tol_rel_obj;
@@ -210,7 +210,7 @@ typedef struct {
   double tol_param;
   int history_size;
   double init_radius;
-  const double* init;  /* unconstrained, or null for a random start */
+  const double* init; /* unconstrained, or null for a random start */
 } stanli_optimize_opts;
 
 /* CmdStan's defaults. Call before setting fields, for the same reason
@@ -242,8 +242,8 @@ int stanli_constrain(stanli_model* m, const double* q, double* out);
 typedef void (*stanli_draw_cb)(int32_t i, int32_t warmup, void* user);
 int stanli_sample_stream(stanli_model* m, uint32_t seed, int warmup,
                          int samples, double delta, double* draws,
-                         stanli_draw_cb cb, void* user,
-                         char* err, size_t err_len);
+                         stanli_draw_cb cb, void* user, char* err,
+                         size_t err_len);
 
 /* write_array: every CSV column CmdStan would emit for one draw --
  * constrained parameters, transformed parameters, generated quantities,

--- a/runtime/include/stanli/constfold.hpp
+++ b/runtime/include/stanli/constfold.hpp
@@ -31,10 +31,9 @@ struct ConstFoldStats {
 // there is one implementation of what an op means. If that evaluation throws
 // -- a density rejecting its own data, say -- the graph is left untouched.
 // STANLI_NO_CONSTFOLD=1 disables the pass.
-ConstFoldStats const_fold(Graph& g,
-                          std::vector<std::pair<int, std::vector<double>>>& fills,
-                          const std::vector<int>& roots,
-                          std::vector<int>* folded = nullptr);
+ConstFoldStats const_fold(
+    Graph& g, std::vector<std::pair<int, std::vector<double>>>& fills,
+    const std::vector<int>& roots, std::vector<int>* folded = nullptr);
 
 }  // namespace stanli
 

--- a/runtime/include/stanli/data.hpp
+++ b/runtime/include/stanli/data.hpp
@@ -43,9 +43,8 @@ class DataMap {
   void set_real_array(const std::string& name, std::vector<double> v,
                       std::vector<int64_t> dims = {}) {
     Entry e;
-    e.dims = dims.empty()
-                 ? std::vector<int64_t>{static_cast<int64_t>(v.size())}
-                 : std::move(dims);
+    e.dims = dims.empty() ? std::vector<int64_t>{static_cast<int64_t>(v.size())}
+                          : std::move(dims);
     e.r = std::move(v);
     m_[name] = std::move(e);
   }

--- a/runtime/include/stanli/diagnose.hpp
+++ b/runtime/include/stanli/diagnose.hpp
@@ -71,8 +71,8 @@ struct FitDiagnostics {
   std::vector<int64_t> divergent_by_chain;
   std::vector<int64_t> max_treedepth_by_chain;
   std::vector<double> ebfmi_by_chain;
-  std::vector<double> stepsize_by_chain;      // adapted, final
-  std::vector<double> accept_stat_by_chain;   // mean over post-warmup
+  std::vector<double> stepsize_by_chain;     // adapted, final
+  std::vector<double> accept_stat_by_chain;  // mean over post-warmup
 
   int64_t n_divergent = 0;
   int64_t n_max_treedepth = 0;

--- a/runtime/include/stanli/estimate.hpp
+++ b/runtime/include/stanli/estimate.hpp
@@ -54,7 +54,7 @@ struct OptimizeResult {
   std::vector<double> unconstrained;  // the mode, on the sampler's scale
   std::vector<double> values;         // every CSV column at that point
   std::vector<std::string> names;
-  int return_code = 0;                // 0 = converged
+  int return_code = 0;  // 0 = converged
   std::string message;
 };
 

--- a/runtime/include/stanli/graph.hpp
+++ b/runtime/include/stanli/graph.hpp
@@ -94,12 +94,12 @@ struct KernelCtx {
   const int* idata = nullptr;
   int64_t n_idata = 0;
   const void* udata = nullptr;
-  Desc out2{nullptr, 0};      // second output value (scalar), if any
+  Desc out2{nullptr, 0};  // second output value (scalar), if any
   // Backward only. Data inputs get {nullptr, len}: kernels skip them.
   Desc in_adj[6];
-  double out_adj = 0;         // scalar-output ops
+  double out_adj = 0;            // scalar-output ops
   Desc out_adj_vec{nullptr, 0};  // vector-output ops
-  double out2_adj = 0;        // adjoint of the second output
+  double out2_adj = 0;           // adjoint of the second output
 };
 
 // Payload for OP_REJECT and OP_PRINT: the literal chunks of the message,
@@ -134,8 +134,12 @@ class Executor {
   // The unconstrained parameter vector: the first n_params() arena entries,
   // in parameter-slot declaration order.
   double* params_data() { return values_.data(); }
-  double* param_ptr(int slot) { return values_.data() + graph_.slots[slot].offset; }
-  double* value_ptr(int slot) { return values_.data() + graph_.slots[slot].offset; }
+  double* param_ptr(int slot) {
+    return values_.data() + graph_.slots[slot].offset;
+  }
+  double* value_ptr(int slot) {
+    return values_.data() + graph_.slots[slot].offset;
+  }
 
   // Forward through all ops; returns value of result_slot (must be scalar).
   double forward();
@@ -171,10 +175,10 @@ class Executor {
   KernelCtx make_ctx_(const Op& op, const std::vector<char>& written);
 
   struct ProfEntry {
-    int64_t calls = 0;       // forward invocations
+    int64_t calls = 0;  // forward invocations
     int64_t fwd_ns = 0;
     int64_t bwd_ns = 0;
-    int64_t elems = 0;       // output elements per forward call, summed
+    int64_t elems = 0;  // output elements per forward call, summed
   };
 
   Graph graph_;

--- a/runtime/include/stanli/mir.hpp
+++ b/runtime/include/stanli/mir.hpp
@@ -14,8 +14,19 @@ namespace stanli {
 namespace mir {
 
 struct Expr {
-  enum Kind { Var, LitInt, LitReal, LitStr, FunApp, Promotion, Indexed,
-              TernaryIf, EOr, EAnd, Unsupported } kind = Unsupported;
+  enum Kind {
+    Var,
+    LitInt,
+    LitReal,
+    LitStr,
+    FunApp,
+    Promotion,
+    Indexed,
+    TernaryIf,
+    EOr,
+    EAnd,
+    Unsupported
+  } kind = Unsupported;
   std::string name;  // Var name or FunApp function name
   enum class Lib { StanLib, Internal, UserDefined } fn_lib = Lib::StanLib;
   bool fn_propto = false;  // (FnLpdf true) / (FnLpmf true)
@@ -31,10 +42,25 @@ struct Expr {
 struct Transform {
   // The names are stanc3's own MIR tags, so a new transform in the
   // compiler is greppable here.
-  enum Kind { Identity, Lower, Upper, LowerUpper, Offset, Multiplier,
-              OffsetMultiplier, Simplex, Ordered, PositiveOrdered,
-              CholeskyCorr, UnitVector, SumToZero, Correlation, Covariance,
-              CholeskyCov, Unsupported } kind = Identity;
+  enum Kind {
+    Identity,
+    Lower,
+    Upper,
+    LowerUpper,
+    Offset,
+    Multiplier,
+    OffsetMultiplier,
+    Simplex,
+    Ordered,
+    PositiveOrdered,
+    CholeskyCorr,
+    UnitVector,
+    SumToZero,
+    Correlation,
+    Covariance,
+    CholeskyCov,
+    Unsupported
+  } kind = Identity;
   std::vector<Expr> args;
   std::string raw;
 };
@@ -47,8 +73,20 @@ struct SizedType {
 };
 
 struct Stmt {
-  enum Kind { Decl, Assignment, TargetPE, Block, SList, For, IfElse, While,
-              NRFunApp, Return, Skip, Unsupported } kind = Unsupported;
+  enum Kind {
+    Decl,
+    Assignment,
+    TargetPE,
+    Block,
+    SList,
+    For,
+    IfElse,
+    While,
+    NRFunApp,
+    Return,
+    Skip,
+    Unsupported
+  } kind = Unsupported;
   // Decl
   std::string decl_id;
   SizedType decl_type;

--- a/runtime/include/stanli/mir_interp.hpp
+++ b/runtime/include/stanli/mir_interp.hpp
@@ -153,8 +153,7 @@ class MirInterp {
           r.r = {T((double)iv)};
           return r;
         }
-        fail("unknown variable " + e.name + " (type " + e.type_ + ")",
-             e.raw);
+        fail("unknown variable " + e.name + " (type " + e.type_ + ")", e.raw);
       }
       case mir::Expr::TernaryIf: {
         const bool c = val(eval(e.args[0]).r.at(0)) != 0.0;
@@ -225,9 +224,8 @@ class MirInterp {
           // means best_logp[1, k], and its Viterbi only matches CmdStan's
           // because the never-written element loses every comparison.
           if (e.is_int) e.i = {0};
-          e.r = {e.is_int
-                     ? T(0.0)
-                     : T(std::numeric_limits<double>::quiet_NaN())};
+          e.r = {e.is_int ? T(0.0)
+                          : T(std::numeric_limits<double>::quiet_NaN())};
         } else if (!st.decl_type.base.empty()) {
           // Bare sized decl: allocate so element writes work; real elements
           // are NaN until written (see the scalar case above).
@@ -238,9 +236,8 @@ class MirInterp {
             dims.push_back(v);
             n *= v;
           }
-          e.r.assign(n, e.is_int
-                            ? T(0.0)
-                            : T(std::numeric_limits<double>::quiet_NaN()));
+          e.r.assign(n, e.is_int ? T(0.0)
+                                 : T(std::numeric_limits<double>::quiet_NaN()));
           if (e.is_int) e.i.assign(n, 0);
           e.dims = std::move(dims);
         }
@@ -278,20 +275,18 @@ class MirInterp {
             // Row write into a matrix (A[i] = row_vector), col-major strided.
             const int64_t R = en->dims[0], C = en->dims[1];
             if ((int64_t)v.r.size() != C) fail("row write size mismatch");
-            for (int64_t j = 0; j < C; ++j)
-              en->r.at(j * R + (ix - 1)) = v.r[j];
+            for (int64_t j = 0; j < C; ++j) en->r.at(j * R + (ix - 1)) = v.r[j];
             return;
           }
           if ((size_t)ix > en->r.size())
-            en->r.resize(
-                ix, en->is_int
-                        ? T(0.0)
-                        : T(std::numeric_limits<double>::quiet_NaN()));
+            en->r.resize(ix, en->is_int
+                                 ? T(0.0)
+                                 : T(std::numeric_limits<double>::quiet_NaN()));
           en->r[ix - 1] = v.r.at(0);
           if (en->is_int) {
             if ((size_t)ix > en->i.size()) en->i.resize(ix, 0);
-            en->i[ix - 1] = v.is_int && !v.i.empty() ? v.i[0]
-                                                     : (int)val(v.r.at(0));
+            en->i[ix - 1] =
+                v.is_int && !v.i.empty() ? v.i[0] : (int)val(v.r.at(0));
           }
           return;
         }
@@ -318,8 +313,7 @@ class MirInterp {
             st.lhs_idx[1].name == "IndexSingle" && en->dims.size() == 2) {
           const long j = as_int(st.lhs_idx[1].args[0]);
           const int64_t R = en->dims[0];
-          for (int64_t i = 0; i < R; ++i)
-            en->r.at((j - 1) * R + i) = v.r.at(i);
+          for (int64_t i = 0; i < R; ++i) en->r.at((j - 1) * R + i) = v.r.at(i);
           return;
         }
         // Column-segment write X[a:b, j] = vector.
@@ -479,8 +473,7 @@ class MirInterp {
     auto it = funs_.find(e.name);
     if (it == funs_.end()) fail("unknown function " + e.name, e.raw);
     const mir::FunDef& f = *it->second;
-    if (e.args.size() != f.arg_names.size())
-      fail(e.name + " arity mismatch");
+    if (e.args.size() != f.arg_names.size()) fail(e.name + " arity mismatch");
     if (udf_depth_ > 64) fail("UDF recursion too deep");
     // Function bodies see their arguments and nothing else.
     MirInterp sub(funs_, where_, hooks_);
@@ -637,8 +630,8 @@ class MirInterp {
       return r;
     }
     {
-      std::string what = "unsupported index: dims=" +
-                         std::to_string(base.dims.size());
+      std::string what =
+          "unsupported index: dims=" + std::to_string(base.dims.size());
       for (size_t k = 1; k < e.args.size(); ++k)
         what += " [" + e.args[k].name + "]";
       fail(what, e.raw);
@@ -655,15 +648,13 @@ class MirInterp {
       Value a = eval(e.args[0]), b = eval(e.args[1]);
       Value o;
       if (a.r.size() != b.r.size() && a.r.size() != 1 && b.r.size() != 1)
-        fail(e.name + ": incompatible lengths " +
-                 std::to_string(a.r.size()) + " vs " +
-                 std::to_string(b.r.size()),
+        fail(e.name + ": incompatible lengths " + std::to_string(a.r.size()) +
+                 " vs " + std::to_string(b.r.size()),
              e.raw);
       const size_t n = std::max(a.r.size(), b.r.size());
       o.r.resize(n);
       for (size_t i = 0; i < n; ++i)
-        o.r[i] = f(a.r[a.r.size() == 1 ? 0 : i],
-                   b.r[b.r.size() == 1 ? 0 : i]);
+        o.r[i] = f(a.r[a.r.size() == 1 ? 0 : i], b.r[b.r.size() == 1 ? 0 : i]);
       o.dims = a.r.size() >= b.r.size() ? a.dims : b.dims;
       if (a.is_int && b.is_int && a.i.size() == 1 && b.i.size() == 1) {
         o.is_int = true;
@@ -686,8 +677,10 @@ class MirInterp {
         return T(f(val(x), val(y)) ? 1.0 : 0.0);
       });
     };
-    if (e.name == "Plus__") return bin([](const T& x, const T& y) { return x + y; });
-    if (e.name == "Minus__") return bin([](const T& x, const T& y) { return x - y; });
+    if (e.name == "Plus__")
+      return bin([](const T& x, const T& y) { return x + y; });
+    if (e.name == "Minus__")
+      return bin([](const T& x, const T& y) { return x - y; });
     if (e.name == "Times__") {
       // Times on shaped operands is linear algebra, not elementwise; only
       // a scalar operand (either side) scales elementwise.
@@ -698,8 +691,7 @@ class MirInterp {
         const int64_t Ca = a_mat ? a.dims[1] : (int64_t)a.r.size();
         const int64_t Rb = b_mat ? b.dims[0] : (int64_t)b.r.size();
         const int64_t Cb = b_mat ? b.dims[1] : 1;
-        if (Ca != Rb)
-          fail("Times__: inner dimension mismatch", e.raw);
+        if (Ca != Rb) fail("Times__: inner dimension mismatch", e.raw);
         // Col-major storage on both sides.
         r.r.assign((size_t)(Ra * Cb), T(0.0));
         for (int64_t j = 0; j < Cb; ++j)
@@ -762,15 +754,18 @@ class MirInterp {
       return bin([](const T& x, const T& y) { return stan::math::fmin(x, y); });
     if (e.name == "PMinus__") return un([](const T& x) { return -x; });
     if (e.name == "PPlus__") return un([](const T& x) { return x; });
-    if (e.name == "exp") return un([](const T& x) { return stan::math::exp(x); });
-    if (e.name == "log") return un([](const T& x) { return stan::math::log(x); });
+    if (e.name == "exp")
+      return un([](const T& x) { return stan::math::exp(x); });
+    if (e.name == "log")
+      return un([](const T& x) { return stan::math::log(x); });
     if (e.name == "log10")
       return un([](const T& x) { return stan::math::log10(x); });
     if (e.name == "sqrt")
       return un([](const T& x) { return stan::math::sqrt(x); });
     if (e.name == "square")
       return un([](const T& x) { return stan::math::square(x); });
-    if (e.name == "inv") return un([](const T& x) { return stan::math::inv(x); });
+    if (e.name == "inv")
+      return un([](const T& x) { return stan::math::inv(x); });
     if (e.name == "inv_logit")
       return un([](const T& x) { return stan::math::inv_logit(x); });
     if (e.name == "logit")
@@ -786,8 +781,8 @@ class MirInterp {
     if (e.name == "cumulative_sum") {
       Value a = eval(e.args[0]);
       Value o;
-      o.dims = a.dims.empty() ? std::vector<int64_t>{(int64_t)a.r.size()}
-                              : a.dims;
+      o.dims =
+          a.dims.empty() ? std::vector<int64_t>{(int64_t)a.r.size()} : a.dims;
       T s = T(0.0);
       for (const T& x : a.r) {
         s += x;
@@ -817,8 +812,7 @@ class MirInterp {
       Value x = eval(e.args[0]);
       const T alpha = eval(e.args[1]).r.at(0);
       const T rho = eval(e.args[2]).r.at(0);
-      const int64_t N = x.dims.size() == 2 ? x.dims[0]
-                                           : (int64_t)x.r.size();
+      const int64_t N = x.dims.size() == 2 ? x.dims[0] : (int64_t)x.r.size();
       const int64_t D = x.dims.size() == 2 ? x.dims[1] : 1;
       const T a2 = alpha * alpha;
       const T inv2r2 = T(1.0) / (T(2.0) * rho * rho);
@@ -829,8 +823,8 @@ class MirInterp {
         for (int64_t i = 0; i < N; ++i) {
           T sq = T(0.0);
           for (int64_t d = 0; d < D; ++d) {
-            const T diff = x.r.at((size_t)(i + N * d)) -
-                           x.r.at((size_t)(j + N * d));
+            const T diff =
+                x.r.at((size_t)(i + N * d)) - x.r.at((size_t)(j + N * d));
             sq += diff * diff;
           }
           o.r[(size_t)(j * N + i)] = a2 * stan::math::exp(-sq * inv2r2);
@@ -920,8 +914,7 @@ class MirInterp {
     if ((e.name == "dot_product" || e.name == "dot_self")) {
       Value a = eval(e.args[0]);
       Value b = e.name == "dot_self" ? a : eval(e.args[1]);
-      if (a.r.size() != b.r.size())
-        fail("dot_product: length mismatch", e.raw);
+      if (a.r.size() != b.r.size()) fail("dot_product: length mismatch", e.raw);
       T s = T(0.0);
       for (size_t i = 0; i < a.r.size(); ++i) s += a.r[i] * b.r[i];
       r.r = {s};
@@ -976,8 +969,8 @@ class MirInterp {
       Value a = eval(e.args[0]);
       const T m = lse(a.r);
       Value o;
-      o.dims = a.dims.empty() ? std::vector<int64_t>{(int64_t)a.r.size()}
-                              : a.dims;
+      o.dims =
+          a.dims.empty() ? std::vector<int64_t>{(int64_t)a.r.size()} : a.dims;
       for (const T& x : a.r)
         o.r.push_back(e.name == "softmax" ? stan::math::exp(x - m) : x - m);
       return o;
@@ -987,8 +980,7 @@ class MirInterp {
       const bool pre = e.name.find("_pre_") != std::string::npos;
       Value v = eval(e.args[pre ? 0 : 1]);
       Value m = eval(e.args[pre ? 1 : 0]);
-      if (m.dims.size() != 2)
-        fail(e.name + ": needs a matrix argument", e.raw);
+      if (m.dims.size() != 2) fail(e.name + ": needs a matrix argument", e.raw);
       const int64_t R = m.dims[0], C = m.dims[1];
       Value o;
       o.dims = {R, C};
@@ -1062,8 +1054,10 @@ class MirInterp {
           continue;
         }
         o.r.push_back(v2.r.at(0));
-        if (v2.is_int && !v2.i.empty()) o.i.push_back(v2.i[0]);
-        else o.is_int = false;
+        if (v2.is_int && !v2.i.empty())
+          o.i.push_back(v2.i[0]);
+        else
+          o.is_int = false;
       }
       if (!o.is_int) o.i.clear();
       if (rows_mode) {
@@ -1176,16 +1170,16 @@ class MirInterp {
     // handler earlier in this chain: that handler wins by position, and
     // deleting it as a "duplicate" of the entry here silently zeroes the
     // derivative.
-#define STANLI_INTERP_UNARY(code, ufn, VAL, DERIV)                        \
-  if (e.name == #ufn && e.args.size() == 1) {                             \
-    const Value a = eval(e.args[0]);                                       \
-    r.r.resize(a.r.size());                                                \
-    for (size_t i = 0; i < a.r.size(); ++i) {                              \
-      const double x = val(a.r[i]);                                        \
-      r.r[i] = T(VAL);                                                     \
-    }                                                                      \
-    r.dims = a.dims;                                                       \
-    return r;                                                              \
+#define STANLI_INTERP_UNARY(code, ufn, VAL, DERIV) \
+  if (e.name == #ufn && e.args.size() == 1) {      \
+    const Value a = eval(e.args[0]);               \
+    r.r.resize(a.r.size());                        \
+    for (size_t i = 0; i < a.r.size(); ++i) {      \
+      const double x = val(a.r[i]);                \
+      r.r[i] = T(VAL);                             \
+    }                                              \
+    r.dims = a.dims;                               \
+    return r;                                      \
   }
     STANLI_SCALAR_UNARY_LIST(STANLI_INTERP_UNARY)
 #undef STANLI_INTERP_UNARY
@@ -1204,10 +1198,8 @@ class MirInterp {
     if (shared_density || e.name == "bernoulli_lpmf" ||
         e.name == "binomial_lpmf" || e.name == "poisson_lpmf" ||
         e.name == "poisson_log_lpmf" || e.name == "student_t_lpdf" ||
-        e.name == "bernoulli_logit_lpmf" ||
-        e.name == "binomial_logit_lpmf" ||
-        e.name == "hypergeometric_lpmf" ||
-        e.name == "discrete_range_lpmf") {
+        e.name == "bernoulli_logit_lpmf" || e.name == "binomial_logit_lpmf" ||
+        e.name == "hypergeometric_lpmf" || e.name == "discrete_range_lpmf") {
       std::vector<Value> av;
       for (const auto& a : e.args) av.push_back(eval(a));
       size_t n = 1;
@@ -1223,15 +1215,15 @@ class MirInterp {
       };
       T acc = T(0.0);
       for (size_t i = 0; i < n; ++i) {
-#define STANLI_INTERP_DENSITY_EVAL(code, fn, n)                        \
-  if (e.name == #fn) {                                                   \
-    if constexpr (n == 1)                                                \
-      acc += stan::math::fn(sc(0, i));                                   \
-    else if constexpr (n == 2)                                           \
-      acc += stan::math::fn(sc(0, i), sc(1, i));                         \
-    else                                                                 \
-      acc += stan::math::fn(sc(0, i), sc(1, i), sc(2, i));               \
-    continue;                                                            \
+#define STANLI_INTERP_DENSITY_EVAL(code, fn, n)            \
+  if (e.name == #fn) {                                     \
+    if constexpr (n == 1)                                  \
+      acc += stan::math::fn(sc(0, i));                     \
+    else if constexpr (n == 2)                             \
+      acc += stan::math::fn(sc(0, i), sc(1, i));           \
+    else                                                   \
+      acc += stan::math::fn(sc(0, i), sc(1, i), sc(2, i)); \
+    continue;                                              \
   }
         STANLI_PROGRAM_DENSITY_LIST(STANLI_INTERP_DENSITY_EVAL)
 #undef STANLI_INTERP_DENSITY_EVAL
@@ -1242,18 +1234,16 @@ class MirInterp {
         else if (e.name == "binomial_lpmf")
           acc += stan::math::binomial_lpmf(ic(0, i), ic(1, i), sc(2, i));
         else if (e.name == "binomial_logit_lpmf")
-          acc += stan::math::binomial_logit_lpmf(ic(0, i), ic(1, i),
-                                                 sc(2, i));
+          acc += stan::math::binomial_logit_lpmf(ic(0, i), ic(1, i), sc(2, i));
         else if (e.name == "poisson_lpmf")
           acc += stan::math::poisson_lpmf(ic(0, i), sc(1, i));
         else if (e.name == "poisson_log_lpmf")
           acc += stan::math::poisson_log_lpmf(ic(0, i), sc(1, i));
         else if (e.name == "hypergeometric_lpmf")
-          acc += stan::math::hypergeometric_lpmf(ic(0, i), ic(1, i),
-                                                 ic(2, i), ic(3, i));
+          acc += stan::math::hypergeometric_lpmf(ic(0, i), ic(1, i), ic(2, i),
+                                                 ic(3, i));
         else if (e.name == "discrete_range_lpmf")
-          acc += stan::math::discrete_range_lpmf(ic(0, i), ic(1, i),
-                                                 ic(2, i));
+          acc += stan::math::discrete_range_lpmf(ic(0, i), ic(1, i), ic(2, i));
         else if (e.name == "student_t_lpdf")
           acc += stan::math::student_t_lpdf(sc(0, i), sc(1, i), sc(2, i),
                                             sc(3, i));
@@ -1306,8 +1296,7 @@ class MirInterp {
         r.r.insert(r.r.end(), b.r.begin(), b.r.end());
         return r;
       }
-      if (a.dims.size() == 2 && b.dims.size() == 2 &&
-          a.dims[1] == b.dims[1]) {
+      if (a.dims.size() == 2 && b.dims.size() == 2 && a.dims[1] == b.dims[1]) {
         // Matrices: stack rows, col-major storage interleaves columns.
         const int64_t Ra = a.dims[0], Rb = b.dims[0], C = a.dims[1];
         r.dims = {Ra + Rb, C};

--- a/runtime/include/stanli/mir_prog.hpp
+++ b/runtime/include/stanli/mir_prog.hpp
@@ -69,7 +69,8 @@ struct ProgramCompiler {
   [[noreturn]] void bail(const std::string& why) { throw Bail{why}; }
 
   int alloc(int n) {
-    if (p.n_regs + n > kMaxRegs) bail("right-hand side needs too many registers");
+    if (p.n_regs + n > kMaxRegs)
+      bail("right-hand side needs too many registers");
     const int r = p.n_regs;
     p.n_regs += n;
     return r;
@@ -122,7 +123,8 @@ struct ProgramCompiler {
         auto it = ints.find(e.args[0].name);
         if (it == ints.end()) bail("integer array " + e.args[0].name);
         const long ix = cint(e.args[1].args[0]);
-        if (ix < 1 || (size_t)ix > it->second.size()) bail("integer index range");
+        if (ix < 1 || (size_t)ix > it->second.size())
+          bail("integer index range");
         return it->second[(size_t)ix - 1];
       }
       case mir::Expr::FunApp:
@@ -133,8 +135,7 @@ struct ProgramCompiler {
           if (e.name == "IntDivide__" || e.name == "Divide__")
             return cint(e.args[0]) / cint(e.args[1]);
         }
-        if (e.args.size() == 1 && e.name == "PMinus__")
-          return -cint(e.args[0]);
+        if (e.args.size() == 1 && e.name == "PMinus__") return -cint(e.args[0]);
         bail("integer function " + e.name);
       default:
         bail("integer expression");
@@ -197,8 +198,8 @@ struct ProgramCompiler {
         const int z = konst(0.0), ta = alloc(1), tb = alloc(1), r = alloc(1);
         emit(Program::NE, ta, a.reg, z);
         emit(Program::NE, tb, b.reg, z);
-        emit(e.kind == mir::Expr::EOr ? Program::FMAX : Program::FMIN, r,
-             ta, tb);
+        emit(e.kind == mir::Expr::EOr ? Program::FMAX : Program::FMIN, r, ta,
+             tb);
         return {r, 1};
       }
       case mir::Expr::FunApp:
@@ -217,14 +218,12 @@ struct ProgramCompiler {
     const int jz = emit(Program::JZ, 0, cv.reg);
     const Range av = expr(a);
     const int dst = alloc(av.len);
-    for (int k = 0; k < av.len; ++k)
-      emit(Program::MOV, dst + k, av.reg + k);
+    for (int k = 0; k < av.len; ++k) emit(Program::MOV, dst + k, av.reg + k);
     const int jmp = emit(Program::JMP, 0);
     p.code[(size_t)jz].dst = (int)p.code.size();
     const Range bv = expr(b);
     if (bv.len != av.len) bail("conditional arms of different widths");
-    for (int k = 0; k < bv.len; ++k)
-      emit(Program::MOV, dst + k, bv.reg + k);
+    for (int k = 0; k < bv.len; ++k) emit(Program::MOV, dst + k, bv.reg + k);
     p.code[(size_t)jmp].dst = (int)p.code.size();
     return {dst, av.len};
   }
@@ -288,9 +287,12 @@ struct ProgramCompiler {
         // rather than approximate. (Measured, before this check: lp off
         // by exactly log(2*pi)/2 on a normal.)
         if (e.fn_propto)
-          bail("`~` inside a parameter-dependent region (write it as "
-               "`target += " + e.name + "(...)`, which keeps every "
-               "constant and is what the region can reproduce)");
+          bail(
+              "`~` inside a parameter-dependent region (write it as "
+              "`target += " +
+              e.name +
+              "(...)`, which keeps every "
+              "constant and is what the region can reproduce)");
         if ((int)e.args.size() != arity)
           bail(e.name + " takes " + std::to_string(arity) + " arguments here");
         Range av[3];
@@ -313,20 +315,34 @@ struct ProgramCompiler {
       if ((a.len != 1 && a.len != n) || (b.len != 1 && b.len != n))
         bail("binary " + e.name + " on mismatched widths");
       Program::Code c;
-      if (e.name == "Plus__") c = Program::ADD;
-      else if (e.name == "Minus__") c = Program::SUB;
-      else if (e.name == "Times__" || e.name == "EltTimes__") c = Program::MUL;
-      else if (e.name == "Divide__" || e.name == "EltDivide__") c = Program::DIV;
-      else if (e.name == "Pow__" || e.name == "pow") c = Program::POW;
-      else if (e.name == "fmax") c = Program::FMAX;
-      else if (e.name == "fmin") c = Program::FMIN;
-      else if (e.name == "Greater__") c = Program::GT;
-      else if (e.name == "Geq__") c = Program::GE;
-      else if (e.name == "Less__") c = Program::LT;
-      else if (e.name == "Leq__") c = Program::LE;
-      else if (e.name == "Equals__") c = Program::EQ;
-      else if (e.name == "NEquals__") c = Program::NE;
-      else bail("function " + e.name);
+      if (e.name == "Plus__")
+        c = Program::ADD;
+      else if (e.name == "Minus__")
+        c = Program::SUB;
+      else if (e.name == "Times__" || e.name == "EltTimes__")
+        c = Program::MUL;
+      else if (e.name == "Divide__" || e.name == "EltDivide__")
+        c = Program::DIV;
+      else if (e.name == "Pow__" || e.name == "pow")
+        c = Program::POW;
+      else if (e.name == "fmax")
+        c = Program::FMAX;
+      else if (e.name == "fmin")
+        c = Program::FMIN;
+      else if (e.name == "Greater__")
+        c = Program::GT;
+      else if (e.name == "Geq__")
+        c = Program::GE;
+      else if (e.name == "Less__")
+        c = Program::LT;
+      else if (e.name == "Leq__")
+        c = Program::LE;
+      else if (e.name == "Equals__")
+        c = Program::EQ;
+      else if (e.name == "NEquals__")
+        c = Program::NE;
+      else
+        bail("function " + e.name);
       const int r = alloc(n);
       for (int i = 0; i < n; ++i)
         emit(c, r + i, a.reg + (a.len == 1 ? 0 : i),
@@ -342,16 +358,26 @@ struct ProgramCompiler {
         return {r, 1};
       }
       Program::Code c;
-      if (e.name == "PMinus__") c = Program::NEG;
-      else if (e.name == "PPlus__") c = Program::MOV;
-      else if (e.name == "exp") c = Program::EXP;
-      else if (e.name == "log") c = Program::LOG;
-      else if (e.name == "sqrt") c = Program::SQRT;
-      else if (e.name == "square") c = Program::SQUARE;
-      else if (e.name == "inv") c = Program::INV;
-      else if (e.name == "fabs" || e.name == "abs") c = Program::FABS;
-      else if (e.name == "inv_logit") c = Program::INV_LOGIT;
-      else bail("function " + e.name);
+      if (e.name == "PMinus__")
+        c = Program::NEG;
+      else if (e.name == "PPlus__")
+        c = Program::MOV;
+      else if (e.name == "exp")
+        c = Program::EXP;
+      else if (e.name == "log")
+        c = Program::LOG;
+      else if (e.name == "sqrt")
+        c = Program::SQRT;
+      else if (e.name == "square")
+        c = Program::SQUARE;
+      else if (e.name == "inv")
+        c = Program::INV;
+      else if (e.name == "fabs" || e.name == "abs")
+        c = Program::FABS;
+      else if (e.name == "inv_logit")
+        c = Program::INV_LOGIT;
+      else
+        bail("function " + e.name);
       const int r = alloc(a.len);
       for (int i = 0; i < a.len; ++i) emit(c, r + i, a.reg + i);
       return {r, a.len};
@@ -483,8 +509,7 @@ struct ProgramCompiler {
         // The region's own running total. The caller decides what it is
         // (the ODE side never sees one; lowering makes it a target term),
         // so all this does is accumulate.
-        if (target_reg < 0)
-          bail("target += is not available in this region");
+        if (target_reg < 0) bail("target += is not available in this region");
         const Range v = expr(s.target);
         if (v.len != 1) bail("target += of a container");
         emit(Program::ADD, target_reg, target_reg, v.reg);
@@ -528,7 +553,6 @@ struct ProgramCompiler {
     return out;
   }
 };
-
 
 }  // namespace stanli
 

--- a/runtime/include/stanli/model_adapter.hpp
+++ b/runtime/include/stanli/model_adapter.hpp
@@ -78,9 +78,8 @@ class ExecutorModel {
   template <bool propto, bool jacobian, typename T>
   T log_prob(std::vector<T>& params_r, std::vector<int>& /*params_i*/,
              std::ostream* msgs) const {
-    Eigen::Matrix<T, -1, 1> q =
-        Eigen::Map<Eigen::Matrix<T, -1, 1>>(params_r.data(),
-                                            (Eigen::Index)params_r.size());
+    Eigen::Matrix<T, -1, 1> q = Eigen::Map<Eigen::Matrix<T, -1, 1>>(
+        params_r.data(), (Eigen::Index)params_r.size());
     return log_prob<propto, jacobian, T>(q, msgs);
   }
 
@@ -114,9 +113,8 @@ class ExecutorModel {
 
   template <typename RNG>
   void write_array(RNG& /*rng*/, std::vector<double>& params_r,
-                   std::vector<int>& /*params_i*/,
-                   std::vector<double>& values, bool /*include_tp*/ = true,
-                   bool /*include_gq*/ = true,
+                   std::vector<int>& /*params_i*/, std::vector<double>& values,
+                   bool /*include_tp*/ = true, bool /*include_gq*/ = true,
                    std::ostream* /*msgs*/ = nullptr) const {
     if (wa_ == nullptr) {
       values.assign(params_r.begin(), params_r.end());
@@ -143,8 +141,7 @@ class ExecutorModel {
   // Every unconstrained parameter is a scalar as far as a random init is
   // concerned, so each gets an empty dimension list.
   void get_dims(std::vector<std::vector<size_t>>& dims,
-                bool /*include_tp*/ = true,
-                bool /*include_gq*/ = true) const {
+                bool /*include_tp*/ = true, bool /*include_gq*/ = true) const {
     dims.assign((size_t)ex_->n_params(), std::vector<size_t>{});
   }
 

--- a/runtime/include/stanli/nuts.hpp
+++ b/runtime/include/stanli/nuts.hpp
@@ -97,9 +97,10 @@ bool thread_safe_build();
 // n_threads <= 1 runs sequentially. Larger values are honoured only on a
 // thread_safe_build(); elsewhere they are clamped to 1, because the
 // alternative is a wrong answer rather than a slow one.
-std::vector<ChainResult> run_nuts_chains(
-    const std::vector<Executor*>& execs, const NutsConfig& cfg,
-    int n_threads = 1, const DrawObserver& observe = {});
+std::vector<ChainResult> run_nuts_chains(const std::vector<Executor*>& execs,
+                                         const NutsConfig& cfg,
+                                         int n_threads = 1,
+                                         const DrawObserver& observe = {});
 
 // Build `n` executors over the same compiled graph, copying it out of an
 // already-bound one. The caller keeps ownership; `src` is not modified.

--- a/runtime/include/stanli/ode_prog.hpp
+++ b/runtime/include/stanli/ode_prog.hpp
@@ -51,17 +51,16 @@ struct RhsProgram : Program {
 // makes the two halves agree.
 struct RhsArg {
   bool is_int = false;
-  bool is_param = false;   // reals: theta region when true, x_r when false
-  int len = 0;             // reals
-  std::vector<int> ints;   // ints
+  bool is_param = false;  // reals: theta region when true, x_r when false
+  int len = 0;            // reals
+  std::vector<int> ints;  // ints
 };
 
 // Compile `f` against a variadic argument list. Never throws: failure
 // comes back as ok == false with a reason.
 RhsProgram compile_rhs_args(
-    const mir::FunDef& f,
-    const std::map<std::string, const mir::FunDef*>& funs, int n_y,
-    const std::vector<RhsArg>& args);
+    const mir::FunDef& f, const std::map<std::string, const mir::FunDef*>& funs,
+    int n_y, const std::vector<RhsArg>& args);
 
 // The deprecated interface's fixed (t, y, theta, x_r, x_i) convention,
 // expressed in the same terms.

--- a/runtime/include/stanli/optable.hpp
+++ b/runtime/include/stanli/optable.hpp
@@ -8,104 +8,104 @@ namespace stanli {
 
 // One list, two uses: the enum and the name table are generated from it,
 // so a new op cannot be added to one and forgotten in the other.
-#define STANLI_OPCODE_LIST(X)                                             \
-  X(OP_EXP)                                                               \
-  X(OP_ADD_N)                                                             \
-  X(OP_BCAST_FMA)                                                         \
-  X(OP_MATVEC)                                                            \
-  X(OP_POISSON_LOG_LPMF)                                                  \
-  X(OP_BERNOULLI_LOGIT_LPMF)                                              \
-  X(OP_BERNOULLI_LPMF)                                                    \
-  X(OP_POISSON_LPMF)                                                      \
-  X(OP_NEG_BINOMIAL_2_LPMF)                                               \
-  X(OP_BINOMIAL_LPMF)                                                     \
-  X(OP_BINOMIAL_LOGIT_LPMF)                                               \
-  X(OP_BERNOULLI_LOGIT_GLM_LPMF)                                          \
-  X(OP_POISSON_LOG_GLM_LPMF)                                              \
-  X(OP_NEG_BINOMIAL_2_LOG_GLM_LPMF)                                       \
-  X(OP_BETA_BINOMIAL_LPMF)                                                \
-  X(OP_LOGIT)                                                             \
-  X(OP_MEAN)                                                              \
-  X(OP_REP_VEC)                                                           \
-  X(OP_INDEX)                                                             \
-  X(OP_SET_INDEX)                                                         \
-  X(OP_SET_INDEX_INPLACE)                                                 \
-  X(OP_SLICE)                                                             \
-  X(OP_SET_SLICE)                                                         \
-  X(OP_SET_SLICE_STRIDED)                                                 \
-  X(OP_SLICE_STRIDED)                                                     \
-  X(OP_GATHER)                                                            \
-  X(OP_CONCAT2)                                                           \
-  X(OP_REP_MAT)                                                           \
-  X(OP_GP_EXP_QUAD_COV)                                                   \
-  X(OP_DIAG_MATRIX)                                                       \
-  X(OP_CHOLESKY)                                                          \
-  X(OP_MULTI_NORMAL_CHOL_LPDF)                                            \
-  X(OP_MULTI_NORMAL_LPDF)                                                 \
-  X(OP_MULTI_NORMAL_PREC_LPDF)                                            \
-  X(OP_GEMM)                                                              \
-  X(OP_LOG_SOFTMAX)                                                       \
-  X(OP_CONSTRAIN_CHOL_CORR)                                               \
-  X(OP_LKJ_CORR_CHOL_LPDF)                                                \
-  X(OP_LKJ_CORR_LPDF)                                                     \
-  X(OP_WISHART_LPDF)                                                      \
-  X(OP_INV_WISHART_LPDF)                                                  \
-  X(OP_WISHART_CHOL_LPDF)                                                 \
-  X(OP_INV_WISHART_CHOL_LPDF)                                             \
-  X(OP_MULTI_GP_LPDF)                                                   \
-  X(OP_MULTI_GP_CHOL_LPDF)                                              \
-  X(OP_MULTI_STUDENT_T_LPDF)                                            \
-  X(OP_MULTI_STUDENT_T_CHOL_LPDF)                                       \
-  X(OP_MULTINOMIAL_LPMF)                                                \
-  X(OP_MULTINOMIAL_LOGIT_LPMF)                                          \
-  X(OP_DIRICHLET_MULTINOMIAL_LPMF)                                      \
-  X(OP_ORDERED_PROBIT_LPMF)                                             \
-  X(OP_WIENER_LPDF)                                                     \
-  X(OP_LKJ_COV_LPDF)                                                    \
-  X(OP_BINOMIAL_LOGIT_GLM_LPMF)                                         \
-  X(OP_CATEGORICAL_LOGIT_GLM_LPMF)                                      \
-  X(OP_ORDERED_LOGISTIC_GLM_LPMF)                                       \
-  X(OP_NORMAL_ID_GLM_LPDF)                                                \
-  X(OP_TRANSPOSE)                                                         \
-  X(OP_ODE)                                                               \
-  X(OP_ISLAND)                                                            \
-  X(OP_EIGENVALUES_SYM)                                                   \
-  X(OP_EIGENVECTORS_SYM)                                                  \
-  X(OP_LOG_SUM_EXP)                                                       \
-  X(OP_LSE2)                                                              \
-  X(OP_LOG_DIFF_EXP)                                                      \
-  X(OP_LOG_MIX)                                                           \
-  X(OP_SOFTMAX)                                                           \
-  X(OP_SUM_VEC)                                                           \
-  X(OP_ADD)                                                               \
-  X(OP_SUB)                                                               \
-  X(OP_MUL)                                                               \
-  X(OP_DIV)                                                               \
-  X(OP_POW)                                                               \
-  X(OP_DOT)                                                               \
-  X(OP_NEG)                                                               \
-  X(OP_EXPV)                                                              \
-  X(OP_LOGV)                                                              \
-  X(OP_INV_LOGIT)                                                         \
-  X(OP_SQRT)                                                              \
-  X(OP_SQUARE)                                                            \
-  X(OP_LOG1M)                                                             \
-  X(OP_TANHV)                                                             \
-  X(OP_CUMSUM)                                                            \
-  X(OP_CONSTRAIN_LOWER)                                                   \
-  X(OP_CONSTRAIN_UPPER)                                                   \
-  X(OP_CONSTRAIN_LU)                                                      \
-  X(OP_CONSTRAIN_SIMPLEX)                                                 \
-  X(OP_CONSTRAIN_ORDERED)                                                 \
-  X(OP_CONSTRAIN_POS_ORDERED)                                             \
-  X(OP_CONSTRAIN_OFFSET_MULT)                                             \
-  X(OP_CONSTRAIN_UNIT_VECTOR)                                             \
-  X(OP_CONSTRAIN_SUM_TO_ZERO)                                             \
-  X(OP_CONSTRAIN_CORR_MATRIX)                                             \
-  X(OP_CONSTRAIN_COV_MATRIX)                                              \
-  X(OP_CONSTRAIN_CHOL_COV)                                                \
-  X(OP_REJECT)                                                            \
-  X(OP_PRINT)                                                             \
+#define STANLI_OPCODE_LIST(X)       \
+  X(OP_EXP)                         \
+  X(OP_ADD_N)                       \
+  X(OP_BCAST_FMA)                   \
+  X(OP_MATVEC)                      \
+  X(OP_POISSON_LOG_LPMF)            \
+  X(OP_BERNOULLI_LOGIT_LPMF)        \
+  X(OP_BERNOULLI_LPMF)              \
+  X(OP_POISSON_LPMF)                \
+  X(OP_NEG_BINOMIAL_2_LPMF)         \
+  X(OP_BINOMIAL_LPMF)               \
+  X(OP_BINOMIAL_LOGIT_LPMF)         \
+  X(OP_BERNOULLI_LOGIT_GLM_LPMF)    \
+  X(OP_POISSON_LOG_GLM_LPMF)        \
+  X(OP_NEG_BINOMIAL_2_LOG_GLM_LPMF) \
+  X(OP_BETA_BINOMIAL_LPMF)          \
+  X(OP_LOGIT)                       \
+  X(OP_MEAN)                        \
+  X(OP_REP_VEC)                     \
+  X(OP_INDEX)                       \
+  X(OP_SET_INDEX)                   \
+  X(OP_SET_INDEX_INPLACE)           \
+  X(OP_SLICE)                       \
+  X(OP_SET_SLICE)                   \
+  X(OP_SET_SLICE_STRIDED)           \
+  X(OP_SLICE_STRIDED)               \
+  X(OP_GATHER)                      \
+  X(OP_CONCAT2)                     \
+  X(OP_REP_MAT)                     \
+  X(OP_GP_EXP_QUAD_COV)             \
+  X(OP_DIAG_MATRIX)                 \
+  X(OP_CHOLESKY)                    \
+  X(OP_MULTI_NORMAL_CHOL_LPDF)      \
+  X(OP_MULTI_NORMAL_LPDF)           \
+  X(OP_MULTI_NORMAL_PREC_LPDF)      \
+  X(OP_GEMM)                        \
+  X(OP_LOG_SOFTMAX)                 \
+  X(OP_CONSTRAIN_CHOL_CORR)         \
+  X(OP_LKJ_CORR_CHOL_LPDF)          \
+  X(OP_LKJ_CORR_LPDF)               \
+  X(OP_WISHART_LPDF)                \
+  X(OP_INV_WISHART_LPDF)            \
+  X(OP_WISHART_CHOL_LPDF)           \
+  X(OP_INV_WISHART_CHOL_LPDF)       \
+  X(OP_MULTI_GP_LPDF)               \
+  X(OP_MULTI_GP_CHOL_LPDF)          \
+  X(OP_MULTI_STUDENT_T_LPDF)        \
+  X(OP_MULTI_STUDENT_T_CHOL_LPDF)   \
+  X(OP_MULTINOMIAL_LPMF)            \
+  X(OP_MULTINOMIAL_LOGIT_LPMF)      \
+  X(OP_DIRICHLET_MULTINOMIAL_LPMF)  \
+  X(OP_ORDERED_PROBIT_LPMF)         \
+  X(OP_WIENER_LPDF)                 \
+  X(OP_LKJ_COV_LPDF)                \
+  X(OP_BINOMIAL_LOGIT_GLM_LPMF)     \
+  X(OP_CATEGORICAL_LOGIT_GLM_LPMF)  \
+  X(OP_ORDERED_LOGISTIC_GLM_LPMF)   \
+  X(OP_NORMAL_ID_GLM_LPDF)          \
+  X(OP_TRANSPOSE)                   \
+  X(OP_ODE)                         \
+  X(OP_ISLAND)                      \
+  X(OP_EIGENVALUES_SYM)             \
+  X(OP_EIGENVECTORS_SYM)            \
+  X(OP_LOG_SUM_EXP)                 \
+  X(OP_LSE2)                        \
+  X(OP_LOG_DIFF_EXP)                \
+  X(OP_LOG_MIX)                     \
+  X(OP_SOFTMAX)                     \
+  X(OP_SUM_VEC)                     \
+  X(OP_ADD)                         \
+  X(OP_SUB)                         \
+  X(OP_MUL)                         \
+  X(OP_DIV)                         \
+  X(OP_POW)                         \
+  X(OP_DOT)                         \
+  X(OP_NEG)                         \
+  X(OP_EXPV)                        \
+  X(OP_LOGV)                        \
+  X(OP_INV_LOGIT)                   \
+  X(OP_SQRT)                        \
+  X(OP_SQUARE)                      \
+  X(OP_LOG1M)                       \
+  X(OP_TANHV)                       \
+  X(OP_CUMSUM)                      \
+  X(OP_CONSTRAIN_LOWER)             \
+  X(OP_CONSTRAIN_UPPER)             \
+  X(OP_CONSTRAIN_LU)                \
+  X(OP_CONSTRAIN_SIMPLEX)           \
+  X(OP_CONSTRAIN_ORDERED)           \
+  X(OP_CONSTRAIN_POS_ORDERED)       \
+  X(OP_CONSTRAIN_OFFSET_MULT)       \
+  X(OP_CONSTRAIN_UNIT_VECTOR)       \
+  X(OP_CONSTRAIN_SUM_TO_ZERO)       \
+  X(OP_CONSTRAIN_CORR_MATRIX)       \
+  X(OP_CONSTRAIN_COV_MATRIX)        \
+  X(OP_CONSTRAIN_CHOL_COV)          \
+  X(OP_REJECT)                      \
+  X(OP_PRINT)                       \
   X(OP_DIRICHLET_LPDF)
 
 // Scalar densities, one line each: this list generates the opcode, the
@@ -153,46 +153,45 @@ namespace stanli {
 // worth about eight tier-2 two-argument ones, which is why COMMON_A holds
 // six entries and REST_A holds seven.
 #define STANLI_SCALAR_DENSITY_LIST_COMMON_A(X) \
-  X(OP_NORMAL_LPDF, normal_lpdf, 3, 3) \
-  X(OP_CAUCHY_LPDF, cauchy_lpdf, 3, 3) \
-  X(OP_GAMMA_LPDF, gamma_lpdf, 3, 3) \
-  X(OP_BETA_LPDF, beta_lpdf, 3, 3) \
+  X(OP_NORMAL_LPDF, normal_lpdf, 3, 3)         \
+  X(OP_CAUCHY_LPDF, cauchy_lpdf, 3, 3)         \
+  X(OP_GAMMA_LPDF, gamma_lpdf, 3, 3)           \
+  X(OP_BETA_LPDF, beta_lpdf, 3, 3)             \
   X(OP_LOGNORMAL_LPDF, lognormal_lpdf, 3, 3)
 
-#define STANLI_SCALAR_DENSITY_LIST_COMMON_B(X) \
-  X(OP_STUDENT_T_LPDF, student_t_lpdf, 4, 3) \
-  X(OP_UNIFORM_LPDF, uniform_lpdf, 3, 3) \
+#define STANLI_SCALAR_DENSITY_LIST_COMMON_B(X)         \
+  X(OP_STUDENT_T_LPDF, student_t_lpdf, 4, 3)           \
+  X(OP_UNIFORM_LPDF, uniform_lpdf, 3, 3)               \
   X(OP_DOUBLE_EXP_LPDF, double_exponential_lpdf, 3, 3) \
-  X(OP_EXPONENTIAL_LPDF, exponential_lpdf, 2, 3) \
-  X(OP_INV_GAMMA_LPDF, inv_gamma_lpdf, 3, 3) \
-  X(OP_STD_NORMAL_LPDF, std_normal_lpdf, 1, 3) \
-  X(OP_WEIBULL_LPDF, weibull_lpdf, 3, 3) \
+  X(OP_EXPONENTIAL_LPDF, exponential_lpdf, 2, 3)       \
+  X(OP_INV_GAMMA_LPDF, inv_gamma_lpdf, 3, 3)           \
+  X(OP_STD_NORMAL_LPDF, std_normal_lpdf, 1, 3)         \
+  X(OP_WEIBULL_LPDF, weibull_lpdf, 3, 3)               \
   X(OP_LOGISTIC_LPDF, logistic_lpdf, 3, 3)
 
-#define STANLI_SCALAR_DENSITY_LIST_REST_A(X) \
-  X(OP_CHI_SQUARE_LPDF, chi_square_lpdf, 2, 2) \
-  X(OP_INV_CHI_SQUARE_LPDF, inv_chi_square_lpdf, 2, 2) \
+#define STANLI_SCALAR_DENSITY_LIST_REST_A(X)                         \
+  X(OP_CHI_SQUARE_LPDF, chi_square_lpdf, 2, 2)                       \
+  X(OP_INV_CHI_SQUARE_LPDF, inv_chi_square_lpdf, 2, 2)               \
   X(OP_SCALED_INV_CHI_SQUARE_LPDF, scaled_inv_chi_square_lpdf, 3, 2) \
-  X(OP_FRECHET_LPDF, frechet_lpdf, 3, 2) \
-  X(OP_GUMBEL_LPDF, gumbel_lpdf, 3, 2) \
-  X(OP_LOGLOGISTIC_LPDF, loglogistic_lpdf, 3, 2) \
-  X(OP_PARETO_LPDF, pareto_lpdf, 3, 2) \
-  X(OP_SKEW_NORMAL_LPDF, skew_normal_lpdf, 4, 2) \
+  X(OP_FRECHET_LPDF, frechet_lpdf, 3, 2)                             \
+  X(OP_GUMBEL_LPDF, gumbel_lpdf, 3, 2)                               \
+  X(OP_LOGLOGISTIC_LPDF, loglogistic_lpdf, 3, 2)                     \
+  X(OP_PARETO_LPDF, pareto_lpdf, 3, 2)                               \
+  X(OP_SKEW_NORMAL_LPDF, skew_normal_lpdf, 4, 2)                     \
   X(OP_EXP_MOD_NORMAL_LPDF, exp_mod_normal_lpdf, 4, 2)
 
-#define STANLI_SCALAR_DENSITY_LIST_REST_B(X) \
-  X(OP_PARETO_TYPE_2_LPDF, pareto_type_2_lpdf, 4, 2) \
-  X(OP_RAYLEIGH_LPDF, rayleigh_lpdf, 2, 2) \
-  X(OP_VON_MISES_LPDF, von_mises_lpdf, 3, 2) \
+#define STANLI_SCALAR_DENSITY_LIST_REST_B(X)             \
+  X(OP_PARETO_TYPE_2_LPDF, pareto_type_2_lpdf, 4, 2)     \
+  X(OP_RAYLEIGH_LPDF, rayleigh_lpdf, 2, 2)               \
+  X(OP_VON_MISES_LPDF, von_mises_lpdf, 3, 2)             \
   X(OP_BETA_PROPORTION_LPDF, beta_proportion_lpdf, 3, 2) \
   X(OP_SKEW_DOUBLE_EXPONENTIAL_LPDF, skew_double_exponential_lpdf, 4, 2)
 
-#define STANLI_SCALAR_DENSITY_LIST(X) \
+#define STANLI_SCALAR_DENSITY_LIST(X)    \
   STANLI_SCALAR_DENSITY_LIST_COMMON_A(X) \
   STANLI_SCALAR_DENSITY_LIST_COMMON_B(X) \
-  STANLI_SCALAR_DENSITY_LIST_REST_A(X) \
+  STANLI_SCALAR_DENSITY_LIST_REST_A(X)   \
   STANLI_SCALAR_DENSITY_LIST_REST_B(X)
-
 
 // Discrete densities: an integer outcome that rides in idata instead of
 // on a propagator edge, plus NReal real arguments that behave exactly like
@@ -204,10 +203,10 @@ namespace stanli {
 // list and stay hand-written: binomial carries two int groups and the GLM
 // carries a data matrix, so they are not the same shape. What is here is
 // everything whose outcome is a single int per lane.
-#define STANLI_INT_DENSITY_LIST(X)                                        \
-  X(OP_NEG_BINOMIAL_2_LOG_LPMF, neg_binomial_2_log_lpmf, 2, 3)            \
-  X(OP_NEG_BINOMIAL_LPMF, neg_binomial_lpmf, 2, 2)                        \
-  X(OP_BETA_NEG_BINOMIAL_LPMF, beta_neg_binomial_lpmf, 3, 2)              \
+#define STANLI_INT_DENSITY_LIST(X)                             \
+  X(OP_NEG_BINOMIAL_2_LOG_LPMF, neg_binomial_2_log_lpmf, 2, 3) \
+  X(OP_NEG_BINOMIAL_LPMF, neg_binomial_lpmf, 2, 2)             \
+  X(OP_BETA_NEG_BINOMIAL_LPMF, beta_neg_binomial_lpmf, 3, 2)   \
   X(OP_YULE_SIMON_LPMF, yule_simon_lpmf, 1, 2)
 
 // Distribution functions: cdf, lcdf, lccdf. Same shape as an lpdf --
@@ -242,89 +241,88 @@ namespace stanli {
 // like that would change the value and leave the partials describing the
 // old one. rvar has no arithmetic operators precisely so this fails to
 // compile instead.
-#define STANLI_SCALAR_CDF_LIST_A(X) \
-  X(OP_BETA_CDF, beta_cdf, 3, 0) \
-  X(OP_BETA_LCCDF, beta_lccdf, 3, 0) \
-  X(OP_BETA_LCDF, beta_lcdf, 3, 0) \
-  X(OP_BETA_PROPORTION_LCCDF, beta_proportion_lccdf, 3, 0) \
-  X(OP_BETA_PROPORTION_LCDF, beta_proportion_lcdf, 3, 0) \
-  X(OP_CAUCHY_CDF, cauchy_cdf, 3, 0) \
-  X(OP_CAUCHY_LCCDF, cauchy_lccdf, 3, 0) \
-  X(OP_CAUCHY_LCDF, cauchy_lcdf, 3, 0) \
-  X(OP_CHI_SQUARE_CDF, chi_square_cdf, 2, 0) \
-  X(OP_CHI_SQUARE_LCCDF, chi_square_lccdf, 2, 0) \
-  X(OP_CHI_SQUARE_LCDF, chi_square_lcdf, 2, 0) \
-  X(OP_DOUBLE_EXPONENTIAL_CDF, double_exponential_cdf, 3, 0) \
+#define STANLI_SCALAR_CDF_LIST_A(X)                              \
+  X(OP_BETA_CDF, beta_cdf, 3, 0)                                 \
+  X(OP_BETA_LCCDF, beta_lccdf, 3, 0)                             \
+  X(OP_BETA_LCDF, beta_lcdf, 3, 0)                               \
+  X(OP_BETA_PROPORTION_LCCDF, beta_proportion_lccdf, 3, 0)       \
+  X(OP_BETA_PROPORTION_LCDF, beta_proportion_lcdf, 3, 0)         \
+  X(OP_CAUCHY_CDF, cauchy_cdf, 3, 0)                             \
+  X(OP_CAUCHY_LCCDF, cauchy_lccdf, 3, 0)                         \
+  X(OP_CAUCHY_LCDF, cauchy_lcdf, 3, 0)                           \
+  X(OP_CHI_SQUARE_CDF, chi_square_cdf, 2, 0)                     \
+  X(OP_CHI_SQUARE_LCCDF, chi_square_lccdf, 2, 0)                 \
+  X(OP_CHI_SQUARE_LCDF, chi_square_lcdf, 2, 0)                   \
+  X(OP_DOUBLE_EXPONENTIAL_CDF, double_exponential_cdf, 3, 0)     \
   X(OP_DOUBLE_EXPONENTIAL_LCCDF, double_exponential_lccdf, 3, 0) \
-  X(OP_DOUBLE_EXPONENTIAL_LCDF, double_exponential_lcdf, 3, 0) \
-  X(OP_EXP_MOD_NORMAL_CDF, exp_mod_normal_cdf, 4, 0) \
-  X(OP_EXP_MOD_NORMAL_LCCDF, exp_mod_normal_lccdf, 4, 0) \
-  X(OP_EXP_MOD_NORMAL_LCDF, exp_mod_normal_lcdf, 4, 0) \
-  X(OP_EXPONENTIAL_CDF, exponential_cdf, 2, 0) \
-  X(OP_EXPONENTIAL_LCCDF, exponential_lccdf, 2, 0) \
-  X(OP_EXPONENTIAL_LCDF, exponential_lcdf, 2, 0) \
-  X(OP_FRECHET_CDF, frechet_cdf, 3, 0) \
-  X(OP_FRECHET_LCCDF, frechet_lccdf, 3, 0) \
-  X(OP_FRECHET_LCDF, frechet_lcdf, 3, 0) \
-  X(OP_GAMMA_CDF, gamma_cdf, 3, 0) \
-  X(OP_GAMMA_LCCDF, gamma_lccdf, 3, 0) \
-  X(OP_GAMMA_LCDF, gamma_lcdf, 3, 0) \
-  X(OP_GUMBEL_CDF, gumbel_cdf, 3, 0) \
-  X(OP_GUMBEL_LCCDF, gumbel_lccdf, 3, 0) \
-  X(OP_GUMBEL_LCDF, gumbel_lcdf, 3, 0) \
-  X(OP_INV_CHI_SQUARE_CDF, inv_chi_square_cdf, 2, 0) \
-  X(OP_INV_CHI_SQUARE_LCCDF, inv_chi_square_lccdf, 2, 0) \
-  X(OP_INV_CHI_SQUARE_LCDF, inv_chi_square_lcdf, 2, 0) \
-  X(OP_INV_GAMMA_CDF, inv_gamma_cdf, 3, 0) \
-  X(OP_INV_GAMMA_LCCDF, inv_gamma_lccdf, 3, 0) \
-  X(OP_INV_GAMMA_LCDF, inv_gamma_lcdf, 3, 0) \
-  X(OP_LOGISTIC_CDF, logistic_cdf, 3, 0) \
-  X(OP_LOGISTIC_LCCDF, logistic_lccdf, 3, 0) \
+  X(OP_DOUBLE_EXPONENTIAL_LCDF, double_exponential_lcdf, 3, 0)   \
+  X(OP_EXP_MOD_NORMAL_CDF, exp_mod_normal_cdf, 4, 0)             \
+  X(OP_EXP_MOD_NORMAL_LCCDF, exp_mod_normal_lccdf, 4, 0)         \
+  X(OP_EXP_MOD_NORMAL_LCDF, exp_mod_normal_lcdf, 4, 0)           \
+  X(OP_EXPONENTIAL_CDF, exponential_cdf, 2, 0)                   \
+  X(OP_EXPONENTIAL_LCCDF, exponential_lccdf, 2, 0)               \
+  X(OP_EXPONENTIAL_LCDF, exponential_lcdf, 2, 0)                 \
+  X(OP_FRECHET_CDF, frechet_cdf, 3, 0)                           \
+  X(OP_FRECHET_LCCDF, frechet_lccdf, 3, 0)                       \
+  X(OP_FRECHET_LCDF, frechet_lcdf, 3, 0)                         \
+  X(OP_GAMMA_CDF, gamma_cdf, 3, 0)                               \
+  X(OP_GAMMA_LCCDF, gamma_lccdf, 3, 0)                           \
+  X(OP_GAMMA_LCDF, gamma_lcdf, 3, 0)                             \
+  X(OP_GUMBEL_CDF, gumbel_cdf, 3, 0)                             \
+  X(OP_GUMBEL_LCCDF, gumbel_lccdf, 3, 0)                         \
+  X(OP_GUMBEL_LCDF, gumbel_lcdf, 3, 0)                           \
+  X(OP_INV_CHI_SQUARE_CDF, inv_chi_square_cdf, 2, 0)             \
+  X(OP_INV_CHI_SQUARE_LCCDF, inv_chi_square_lccdf, 2, 0)         \
+  X(OP_INV_CHI_SQUARE_LCDF, inv_chi_square_lcdf, 2, 0)           \
+  X(OP_INV_GAMMA_CDF, inv_gamma_cdf, 3, 0)                       \
+  X(OP_INV_GAMMA_LCCDF, inv_gamma_lccdf, 3, 0)                   \
+  X(OP_INV_GAMMA_LCDF, inv_gamma_lcdf, 3, 0)                     \
+  X(OP_LOGISTIC_CDF, logistic_cdf, 3, 0)                         \
+  X(OP_LOGISTIC_LCCDF, logistic_lccdf, 3, 0)                     \
   X(OP_LOGISTIC_LCDF, logistic_lcdf, 3, 0)
 
-#define STANLI_SCALAR_CDF_LIST_B(X) \
-  X(OP_LOGLOGISTIC_CDF, loglogistic_cdf, 3, 0) \
-  X(OP_LOGNORMAL_CDF, lognormal_cdf, 3, 0) \
-  X(OP_LOGNORMAL_LCCDF, lognormal_lccdf, 3, 0) \
-  X(OP_LOGNORMAL_LCDF, lognormal_lcdf, 3, 0) \
-  X(OP_NORMAL_CDF, normal_cdf, 3, 0) \
-  X(OP_NORMAL_LCCDF, normal_lccdf, 3, 0) \
-  X(OP_NORMAL_LCDF, normal_lcdf, 3, 0) \
-  X(OP_PARETO_CDF, pareto_cdf, 3, 0) \
-  X(OP_PARETO_LCCDF, pareto_lccdf, 3, 0) \
-  X(OP_PARETO_LCDF, pareto_lcdf, 3, 0) \
-  X(OP_PARETO_TYPE_2_CDF, pareto_type_2_cdf, 4, 0) \
-  X(OP_PARETO_TYPE_2_LCCDF, pareto_type_2_lccdf, 4, 0) \
-  X(OP_PARETO_TYPE_2_LCDF, pareto_type_2_lcdf, 4, 0) \
-  X(OP_RAYLEIGH_CDF, rayleigh_cdf, 2, 0) \
-  X(OP_RAYLEIGH_LCCDF, rayleigh_lccdf, 2, 0) \
-  X(OP_RAYLEIGH_LCDF, rayleigh_lcdf, 2, 0) \
-  X(OP_SCALED_INV_CHI_SQUARE_CDF, scaled_inv_chi_square_cdf, 3, 0) \
-  X(OP_SCALED_INV_CHI_SQUARE_LCCDF, scaled_inv_chi_square_lccdf, 3, 0) \
-  X(OP_SCALED_INV_CHI_SQUARE_LCDF, scaled_inv_chi_square_lcdf, 3, 0) \
-  X(OP_SKEW_NORMAL_CDF, skew_normal_cdf, 4, 0) \
-  X(OP_SKEW_NORMAL_LCCDF, skew_normal_lccdf, 4, 0) \
-  X(OP_SKEW_NORMAL_LCDF, skew_normal_lcdf, 4, 0) \
-  X(OP_STD_NORMAL_CDF, std_normal_cdf, 1, 0) \
-  X(OP_STD_NORMAL_LCCDF, std_normal_lccdf, 1, 0) \
-  X(OP_SKEW_DOUBLE_EXPONENTIAL_CDF, skew_double_exponential_cdf, 4, 0) \
-  X(OP_SKEW_DOUBLE_EXPONENTIAL_LCDF, skew_double_exponential_lcdf, 4, 0) \
+#define STANLI_SCALAR_CDF_LIST_B(X)                                        \
+  X(OP_LOGLOGISTIC_CDF, loglogistic_cdf, 3, 0)                             \
+  X(OP_LOGNORMAL_CDF, lognormal_cdf, 3, 0)                                 \
+  X(OP_LOGNORMAL_LCCDF, lognormal_lccdf, 3, 0)                             \
+  X(OP_LOGNORMAL_LCDF, lognormal_lcdf, 3, 0)                               \
+  X(OP_NORMAL_CDF, normal_cdf, 3, 0)                                       \
+  X(OP_NORMAL_LCCDF, normal_lccdf, 3, 0)                                   \
+  X(OP_NORMAL_LCDF, normal_lcdf, 3, 0)                                     \
+  X(OP_PARETO_CDF, pareto_cdf, 3, 0)                                       \
+  X(OP_PARETO_LCCDF, pareto_lccdf, 3, 0)                                   \
+  X(OP_PARETO_LCDF, pareto_lcdf, 3, 0)                                     \
+  X(OP_PARETO_TYPE_2_CDF, pareto_type_2_cdf, 4, 0)                         \
+  X(OP_PARETO_TYPE_2_LCCDF, pareto_type_2_lccdf, 4, 0)                     \
+  X(OP_PARETO_TYPE_2_LCDF, pareto_type_2_lcdf, 4, 0)                       \
+  X(OP_RAYLEIGH_CDF, rayleigh_cdf, 2, 0)                                   \
+  X(OP_RAYLEIGH_LCCDF, rayleigh_lccdf, 2, 0)                               \
+  X(OP_RAYLEIGH_LCDF, rayleigh_lcdf, 2, 0)                                 \
+  X(OP_SCALED_INV_CHI_SQUARE_CDF, scaled_inv_chi_square_cdf, 3, 0)         \
+  X(OP_SCALED_INV_CHI_SQUARE_LCCDF, scaled_inv_chi_square_lccdf, 3, 0)     \
+  X(OP_SCALED_INV_CHI_SQUARE_LCDF, scaled_inv_chi_square_lcdf, 3, 0)       \
+  X(OP_SKEW_NORMAL_CDF, skew_normal_cdf, 4, 0)                             \
+  X(OP_SKEW_NORMAL_LCCDF, skew_normal_lccdf, 4, 0)                         \
+  X(OP_SKEW_NORMAL_LCDF, skew_normal_lcdf, 4, 0)                           \
+  X(OP_STD_NORMAL_CDF, std_normal_cdf, 1, 0)                               \
+  X(OP_STD_NORMAL_LCCDF, std_normal_lccdf, 1, 0)                           \
+  X(OP_SKEW_DOUBLE_EXPONENTIAL_CDF, skew_double_exponential_cdf, 4, 0)     \
+  X(OP_SKEW_DOUBLE_EXPONENTIAL_LCDF, skew_double_exponential_lcdf, 4, 0)   \
   X(OP_SKEW_DOUBLE_EXPONENTIAL_LCCDF, skew_double_exponential_lccdf, 4, 0) \
-  X(OP_STD_NORMAL_LCDF, std_normal_lcdf, 1, 0) \
-  X(OP_STUDENT_T_CDF, student_t_cdf, 4, 0) \
-  X(OP_STUDENT_T_LCCDF, student_t_lccdf, 4, 0) \
-  X(OP_STUDENT_T_LCDF, student_t_lcdf, 4, 0) \
-  X(OP_UNIFORM_CDF, uniform_cdf, 3, 0) \
-  X(OP_UNIFORM_LCCDF, uniform_lccdf, 3, 0) \
-  X(OP_UNIFORM_LCDF, uniform_lcdf, 3, 0) \
-  X(OP_WEIBULL_CDF, weibull_cdf, 3, 0) \
-  X(OP_WEIBULL_LCCDF, weibull_lccdf, 3, 0) \
+  X(OP_STD_NORMAL_LCDF, std_normal_lcdf, 1, 0)                             \
+  X(OP_STUDENT_T_CDF, student_t_cdf, 4, 0)                                 \
+  X(OP_STUDENT_T_LCCDF, student_t_lccdf, 4, 0)                             \
+  X(OP_STUDENT_T_LCDF, student_t_lcdf, 4, 0)                               \
+  X(OP_UNIFORM_CDF, uniform_cdf, 3, 0)                                     \
+  X(OP_UNIFORM_LCCDF, uniform_lccdf, 3, 0)                                 \
+  X(OP_UNIFORM_LCDF, uniform_lcdf, 3, 0)                                   \
+  X(OP_WEIBULL_CDF, weibull_cdf, 3, 0)                                     \
+  X(OP_WEIBULL_LCCDF, weibull_lccdf, 3, 0)                                 \
   X(OP_WEIBULL_LCDF, weibull_lcdf, 3, 0)
 
 #define STANLI_SCALAR_CDF_LIST(X) \
-  STANLI_SCALAR_CDF_LIST_A(X) \
+  STANLI_SCALAR_CDF_LIST_A(X)     \
   STANLI_SCALAR_CDF_LIST_B(X)
-
 
 // The same, for distributions whose outcome is an integer: the count
 // rides in idata exactly as it does for the lpmfs, and the real
@@ -334,21 +332,21 @@ namespace stanli {
 // Not every discrete cdf fits: binomial and beta_binomial carry a second
 // int group (the trial count) and discrete_range is integers all the way
 // down, so those nine keep waiting for a layout rather than a list line.
-#define STANLI_INT_CDF_LIST(X)                                            \
-  X(OP_BERNOULLI_CDF, bernoulli_cdf, 1, 0)                                \
-  X(OP_BERNOULLI_LCCDF, bernoulli_lccdf, 1, 0)                            \
-  X(OP_BERNOULLI_LCDF, bernoulli_lcdf, 1, 0)                              \
-  X(OP_BETA_NEG_BINOMIAL_CDF, beta_neg_binomial_cdf, 3, 0)                \
-  X(OP_BETA_NEG_BINOMIAL_LCCDF, beta_neg_binomial_lccdf, 3, 0)            \
-  X(OP_BETA_NEG_BINOMIAL_LCDF, beta_neg_binomial_lcdf, 3, 0)              \
-  X(OP_NEG_BINOMIAL_CDF, neg_binomial_cdf, 2, 0)                          \
-  X(OP_NEG_BINOMIAL_LCCDF, neg_binomial_lccdf, 2, 0)                      \
-  X(OP_NEG_BINOMIAL_LCDF, neg_binomial_lcdf, 2, 0)                        \
-  X(OP_POISSON_CDF, poisson_cdf, 1, 0)                                    \
-  X(OP_POISSON_LCCDF, poisson_lccdf, 1, 0)                                \
-  X(OP_POISSON_LCDF, poisson_lcdf, 1, 0)                                  \
-  X(OP_YULE_SIMON_CDF, yule_simon_cdf, 1, 0)                              \
-  X(OP_YULE_SIMON_LCCDF, yule_simon_lccdf, 1, 0)                          \
+#define STANLI_INT_CDF_LIST(X)                                 \
+  X(OP_BERNOULLI_CDF, bernoulli_cdf, 1, 0)                     \
+  X(OP_BERNOULLI_LCCDF, bernoulli_lccdf, 1, 0)                 \
+  X(OP_BERNOULLI_LCDF, bernoulli_lcdf, 1, 0)                   \
+  X(OP_BETA_NEG_BINOMIAL_CDF, beta_neg_binomial_cdf, 3, 0)     \
+  X(OP_BETA_NEG_BINOMIAL_LCCDF, beta_neg_binomial_lccdf, 3, 0) \
+  X(OP_BETA_NEG_BINOMIAL_LCDF, beta_neg_binomial_lcdf, 3, 0)   \
+  X(OP_NEG_BINOMIAL_CDF, neg_binomial_cdf, 2, 0)               \
+  X(OP_NEG_BINOMIAL_LCCDF, neg_binomial_lccdf, 2, 0)           \
+  X(OP_NEG_BINOMIAL_LCDF, neg_binomial_lcdf, 2, 0)             \
+  X(OP_POISSON_CDF, poisson_cdf, 1, 0)                         \
+  X(OP_POISSON_LCCDF, poisson_lccdf, 1, 0)                     \
+  X(OP_POISSON_LCDF, poisson_lcdf, 1, 0)                       \
+  X(OP_YULE_SIMON_CDF, yule_simon_cdf, 1, 0)                   \
+  X(OP_YULE_SIMON_LCCDF, yule_simon_lccdf, 1, 0)               \
   X(OP_YULE_SIMON_LCDF, yule_simon_lcdf, 1, 0)
 
 // Ordinal regression. Two things make these different from the list
@@ -363,7 +361,7 @@ namespace stanli {
 // reroll.cpp must never fuse these: element n of a shared cutpoint
 // vector is not observation n's cutpoints. They are absent from both of
 // its opt-in lists, which is the whole guard.
-#define STANLI_ORDERED_DENSITY_LIST(X)                                    \
+#define STANLI_ORDERED_DENSITY_LIST(X) \
   X(OP_ORDERED_LOGISTIC_LPMF, ordered_logistic_lpmf, 2, 0x2)
 // Scalar unary math, one line each: opcode, kernel, registration,
 // lowering entry and interpreter branch all come from here. The value and
@@ -376,43 +374,52 @@ namespace stanli {
 // written out rather than obtained by instantiating an autodiff template.
 // fn_sweep.py checks every one against CmdStan, which is what makes
 // hand-written derivatives safe to write at this rate.
-#define STANLI_SCALAR_UNARY_LIST(X)                                       \
-  X(OP_LGAMMA, lgamma, stan::math::lgamma(x), stan::math::digamma(x))  \
-  X(OP_DIGAMMA, digamma, stan::math::digamma(x), stan::math::trigamma(x))  \
-  X(OP_LOG1P, log1p, stan::math::log1p(x), 1.0 / (1.0 + x))  \
-  X(OP_EXPM1, expm1, stan::math::expm1(x), std::exp(x))  \
-  X(OP_PHI, Phi, stan::math::Phi(x), stan::math::INV_SQRT_TWO_PI * std::exp(-0.5 * x * x))  \
-  X(OP_INV_PHI, inv_Phi, stan::math::inv_Phi(x), 1.0 / (stan::math::INV_SQRT_TWO_PI * std::exp(-0.5 * stan::math::inv_Phi(x) * stan::math::inv_Phi(x))))  \
-  X(OP_ERF, erf, std::erf(x), stan::math::TWO_OVER_SQRT_PI * std::exp(-x * x))  \
-  X(OP_ERFC, erfc, std::erfc(x), -stan::math::TWO_OVER_SQRT_PI * std::exp(-x * x))  \
-  X(OP_INV, inv, 1.0 / x, -1.0 / (x * x))  \
-  X(OP_INV_SQRT, inv_sqrt, stan::math::inv_sqrt(x), -0.5 / (x * std::sqrt(x)))  \
-  X(OP_INV_SQUARE, inv_square, 1.0 / (x * x), -2.0 / (x * x * x))  \
-  X(OP_LOG1M_EXP, log1m_exp, stan::math::log1m_exp(x), -std::exp(x) / (1.0 - std::exp(x)))  \
-  X(OP_LOG1P_EXP, log1p_exp, stan::math::log1p_exp(x), stan::math::inv_logit(x))  \
-  X(OP_LOG_INV_LOGIT, log_inv_logit, stan::math::log_inv_logit(x), stan::math::inv_logit(-x))  \
-  X(OP_LOG1M_INV_LOGIT, log1m_inv_logit, stan::math::log1m_inv_logit(x), -stan::math::inv_logit(x))  \
-  X(OP_INV_CLOGLOG, inv_cloglog, stan::math::inv_cloglog(x), std::exp(x - std::exp(x)))  \
-  X(OP_SIN, sin, std::sin(x), std::cos(x))  \
-  X(OP_COS, cos, std::cos(x), -std::sin(x))  \
-  X(OP_TAN, tan, std::tan(x), 1.0 / (std::cos(x) * std::cos(x)))  \
-  X(OP_ASIN, asin, std::asin(x), 1.0 / std::sqrt(1.0 - x * x))  \
-  X(OP_ACOS, acos, std::acos(x), -1.0 / std::sqrt(1.0 - x * x))  \
-  X(OP_ATAN, atan, std::atan(x), 1.0 / (1.0 + x * x))  \
-  X(OP_SINH, sinh, std::sinh(x), std::cosh(x))  \
-  X(OP_COSH, cosh, std::cosh(x), std::sinh(x))  \
-  X(OP_ASINH, asinh, std::asinh(x), 1.0 / std::sqrt(x * x + 1.0))  \
-  X(OP_ACOSH, acosh, std::acosh(x), 1.0 / std::sqrt(x * x - 1.0))  \
-  X(OP_ATANH, atanh, std::atanh(x), 1.0 / (1.0 - x * x))  \
-  X(OP_CBRT, cbrt, std::cbrt(x), 1.0 / (3.0 * std::cbrt(x) * std::cbrt(x)))  \
-  X(OP_EXP2, exp2, std::exp2(x), stan::math::LOG_TWO * std::exp2(x))  \
-  X(OP_LOG2, log2, stan::math::log2(x), 1.0 / (x * stan::math::LOG_TWO))  \
-  X(OP_LOG10, log10, std::log10(x), 1.0 / (x * stan::math::LOG_TEN))  \
-  X(OP_ABS, abs, std::fabs(x), x < 0 ? -1.0 : 1.0)  \
-  X(OP_FLOOR, floor, std::floor(x), 0.0)  \
-  X(OP_CEIL, ceil, std::ceil(x), 0.0)  \
-  X(OP_ROUND, round, std::round(x), 0.0)  \
-  X(OP_TRUNC, trunc, std::trunc(x), 0.0)  \
+#define STANLI_SCALAR_UNARY_LIST(X)                                            \
+  X(OP_LGAMMA, lgamma, stan::math::lgamma(x), stan::math::digamma(x))          \
+  X(OP_DIGAMMA, digamma, stan::math::digamma(x), stan::math::trigamma(x))      \
+  X(OP_LOG1P, log1p, stan::math::log1p(x), 1.0 / (1.0 + x))                    \
+  X(OP_EXPM1, expm1, stan::math::expm1(x), std::exp(x))                        \
+  X(OP_PHI, Phi, stan::math::Phi(x),                                           \
+    stan::math::INV_SQRT_TWO_PI* std::exp(-0.5 * x * x))                       \
+  X(OP_INV_PHI, inv_Phi, stan::math::inv_Phi(x),                               \
+    1.0 / (stan::math::INV_SQRT_TWO_PI *                                       \
+           std::exp(-0.5 * stan::math::inv_Phi(x) * stan::math::inv_Phi(x))))  \
+  X(OP_ERF, erf, std::erf(x), stan::math::TWO_OVER_SQRT_PI* std::exp(-x* x))   \
+  X(OP_ERFC, erfc, std::erfc(x),                                               \
+    -stan::math::TWO_OVER_SQRT_PI* std::exp(-x* x))                            \
+  X(OP_INV, inv, 1.0 / x, -1.0 / (x * x))                                      \
+  X(OP_INV_SQRT, inv_sqrt, stan::math::inv_sqrt(x), -0.5 / (x * std::sqrt(x))) \
+  X(OP_INV_SQUARE, inv_square, 1.0 / (x * x), -2.0 / (x * x * x))              \
+  X(OP_LOG1M_EXP, log1m_exp, stan::math::log1m_exp(x),                         \
+    -std::exp(x) / (1.0 - std::exp(x)))                                        \
+  X(OP_LOG1P_EXP, log1p_exp, stan::math::log1p_exp(x),                         \
+    stan::math::inv_logit(x))                                                  \
+  X(OP_LOG_INV_LOGIT, log_inv_logit, stan::math::log_inv_logit(x),             \
+    stan::math::inv_logit(-x))                                                 \
+  X(OP_LOG1M_INV_LOGIT, log1m_inv_logit, stan::math::log1m_inv_logit(x),       \
+    -stan::math::inv_logit(x))                                                 \
+  X(OP_INV_CLOGLOG, inv_cloglog, stan::math::inv_cloglog(x),                   \
+    std::exp(x - std::exp(x)))                                                 \
+  X(OP_SIN, sin, std::sin(x), std::cos(x))                                     \
+  X(OP_COS, cos, std::cos(x), -std::sin(x))                                    \
+  X(OP_TAN, tan, std::tan(x), 1.0 / (std::cos(x) * std::cos(x)))               \
+  X(OP_ASIN, asin, std::asin(x), 1.0 / std::sqrt(1.0 - x * x))                 \
+  X(OP_ACOS, acos, std::acos(x), -1.0 / std::sqrt(1.0 - x * x))                \
+  X(OP_ATAN, atan, std::atan(x), 1.0 / (1.0 + x * x))                          \
+  X(OP_SINH, sinh, std::sinh(x), std::cosh(x))                                 \
+  X(OP_COSH, cosh, std::cosh(x), std::sinh(x))                                 \
+  X(OP_ASINH, asinh, std::asinh(x), 1.0 / std::sqrt(x * x + 1.0))              \
+  X(OP_ACOSH, acosh, std::acosh(x), 1.0 / std::sqrt(x * x - 1.0))              \
+  X(OP_ATANH, atanh, std::atanh(x), 1.0 / (1.0 - x * x))                       \
+  X(OP_CBRT, cbrt, std::cbrt(x), 1.0 / (3.0 * std::cbrt(x) * std::cbrt(x)))    \
+  X(OP_EXP2, exp2, std::exp2(x), stan::math::LOG_TWO* std::exp2(x))            \
+  X(OP_LOG2, log2, stan::math::log2(x), 1.0 / (x * stan::math::LOG_TWO))       \
+  X(OP_LOG10, log10, std::log10(x), 1.0 / (x * stan::math::LOG_TEN))           \
+  X(OP_ABS, abs, std::fabs(x), x < 0 ? -1.0 : 1.0)                             \
+  X(OP_FLOOR, floor, std::floor(x), 0.0)                                       \
+  X(OP_CEIL, ceil, std::ceil(x), 0.0)                                          \
+  X(OP_ROUND, round, std::round(x), 0.0)                                       \
+  X(OP_TRUNC, trunc, std::trunc(x), 0.0)                                       \
   X(OP_STEP, step, x < 0 ? 0.0 : 1.0, 0.0)
 
 // The tier a density is actually built at. STANLI_LITE_LP drops the
@@ -459,12 +466,11 @@ enum Opcode : uint16_t {
 #define STANLI_OPCODE_ENUM(name) name,
 #define STANLI_DENSITY_ENUM(code, fn, n, m) code,
 #define STANLI_UNARY_ENUM(code, fn, v, d) code,
-  STANLI_ALL_OPCODES(STANLI_OPCODE_ENUM, STANLI_DENSITY_ENUM,
-                     STANLI_UNARY_ENUM)
+  STANLI_ALL_OPCODES(STANLI_OPCODE_ENUM, STANLI_DENSITY_ENUM, STANLI_UNARY_ENUM)
 #undef STANLI_OPCODE_ENUM
 #undef STANLI_DENSITY_ENUM
 #undef STANLI_UNARY_ENUM
-  OP_COUNT_
+      OP_COUNT_
 };
 
 // "OP_NORMAL_LPDF" for a known opcode, "OP_?" otherwise. Diagnostics and

--- a/runtime/include/stanli/program.hpp
+++ b/runtime/include/stanli/program.hpp
@@ -40,45 +40,64 @@ struct Program {
   // double and var passes. The discrete densities are deliberately not
   // here; they need an integer outcome the register file has nowhere to
   // put, and the interpreter carries them alone.
-#define STANLI_PROGRAM_DENSITY_LIST(X)                                     \
-  X(STD_NORMAL, std_normal_lpdf, 1)                                        \
-  X(EXPONENTIAL, exponential_lpdf, 2)                                      \
-  X(NORMAL, normal_lpdf, 3)                                                \
-  X(LOGNORMAL, lognormal_lpdf, 3)                                          \
-  X(CAUCHY, cauchy_lpdf, 3)                                                \
-  X(GAMMA, gamma_lpdf, 3)                                                  \
-  X(INV_GAMMA, inv_gamma_lpdf, 3)                                          \
-  X(BETA, beta_lpdf, 3)                                                    \
-  X(WEIBULL, weibull_lpdf, 3)                                              \
-  X(LOGISTIC, logistic_lpdf, 3)                                            \
-  X(DOUBLE_EXP, double_exponential_lpdf, 3)                                \
+#define STANLI_PROGRAM_DENSITY_LIST(X)      \
+  X(STD_NORMAL, std_normal_lpdf, 1)         \
+  X(EXPONENTIAL, exponential_lpdf, 2)       \
+  X(NORMAL, normal_lpdf, 3)                 \
+  X(LOGNORMAL, lognormal_lpdf, 3)           \
+  X(CAUCHY, cauchy_lpdf, 3)                 \
+  X(GAMMA, gamma_lpdf, 3)                   \
+  X(INV_GAMMA, inv_gamma_lpdf, 3)           \
+  X(BETA, beta_lpdf, 3)                     \
+  X(WEIBULL, weibull_lpdf, 3)               \
+  X(LOGISTIC, logistic_lpdf, 3)             \
+  X(DOUBLE_EXP, double_exponential_lpdf, 3) \
   X(UNIFORM, uniform_lpdf, 3)
 
   enum Code : uint8_t {
-    CONST,     // dst = pool[a]
-    CONSTR,    // dst[0..len) = pool[a + i]
-    MOV,       // dst = r[a]
-    MOVR,      // dst[0..len) = r[a + i]
-    ADD, SUB, MUL, DIV,              // dst = r[a] op r[b]
-    POW, FMAX, FMIN,
-    NEG, EXP, LOG, SQRT, SQUARE,     // dst = op(r[a])
-    INV, FABS, INV_LOGIT, LOG1M, TANH,
+    CONST,   // dst = pool[a]
+    CONSTR,  // dst[0..len) = pool[a + i]
+    MOV,     // dst = r[a]
+    MOVR,    // dst[0..len) = r[a + i]
+    ADD,
+    SUB,
+    MUL,
+    DIV,  // dst = r[a] op r[b]
+    POW,
+    FMAX,
+    FMIN,
+    NEG,
+    EXP,
+    LOG,
+    SQRT,
+    SQUARE,  // dst = op(r[a])
+    INV,
+    FABS,
+    INV_LOGIT,
+    LOG1M,
+    TANH,
     // Comparisons produce a plain 0/1 with no derivative, matching how
     // generated C++ evaluates them on values.
-    GT, GE, LT, LE, EQ, NE,
-    JZ,        // jump to `dst` when r[a] is zero
-    JMP,       // jump to `dst`
-    LOG_RANGE, EXP_RANGE,            // dst[i] = op(r[a+i]), i < len
-    DOT,       // dst = sum_i r[a+i] * r[b+i]      (Eigen redux, as OP_DOT)
-    LSE_RANGE, // dst = log_sum_exp(r[a..a+len))
-    SOFTMAX,   // dst[0..len) = softmax(r[a..a+len))
-    LSE2,      // dst = log_sum_exp(r[a], r[b])
-    LOG_MIX,   // dst = log_mix(r[a], r[b], r[c])
-    // Densities, propto-OFF only (the island carver refuses propto). With
-    // no term-dropping the value does not depend on which arguments are
-    // autodiff, so binding all of them as T reproduces the scalar op's
-    // value exactly; the extra partials computed for data arguments are
-    // discarded when the executor hands the island a null adjoint.
+    GT,
+    GE,
+    LT,
+    LE,
+    EQ,
+    NE,
+    JZ,   // jump to `dst` when r[a] is zero
+    JMP,  // jump to `dst`
+    LOG_RANGE,
+    EXP_RANGE,  // dst[i] = op(r[a+i]), i < len
+    DOT,        // dst = sum_i r[a+i] * r[b+i]      (Eigen redux, as OP_DOT)
+    LSE_RANGE,  // dst = log_sum_exp(r[a..a+len))
+    SOFTMAX,    // dst[0..len) = softmax(r[a..a+len))
+    LSE2,       // dst = log_sum_exp(r[a], r[b])
+    LOG_MIX,    // dst = log_mix(r[a], r[b], r[c])
+  // Densities, propto-OFF only (the island carver refuses propto). With
+  // no term-dropping the value does not depend on which arguments are
+  // autodiff, so binding all of them as T reproduces the scalar op's
+  // value exactly; the extra partials computed for data arguments are
+  // discarded when the executor hands the island a null adjoint.
 #define STANLI_PROGRAM_DENSITY_ENUM(code, name, arity) code,
     STANLI_PROGRAM_DENSITY_LIST(STANLI_PROGRAM_DENSITY_ENUM)
 #undef STANLI_PROGRAM_DENSITY_ENUM
@@ -114,33 +133,71 @@ void run_program(const Program& p, std::vector<T>& reg) {
       // Scalar constants get their own opcode: a right-hand side is mostly
       // scalars, and going through the ranged form cost the ODE models 3-4%
       // for the loop setup the compiler cannot see is one iteration.
-      case Program::CONST: d() = T(p.pool[(size_t)I.a]); break;
+      case Program::CONST:
+        d() = T(p.pool[(size_t)I.a]);
+        break;
       case Program::CONSTR:
         for (int32_t i = 0; i < I.len; ++i)
           reg[(size_t)(I.dst + i)] = T(p.pool[(size_t)(I.a + i)]);
         break;
-      case Program::MOV: d() = ra(); break;
+      case Program::MOV:
+        d() = ra();
+        break;
       case Program::MOVR:
         for (int32_t i = 0; i < I.len; ++i)
           reg[(size_t)(I.dst + i)] = reg[(size_t)(I.a + i)];
         break;
-      case Program::ADD: d() = ra() + rb(); break;
-      case Program::SUB: d() = ra() - rb(); break;
-      case Program::MUL: d() = ra() * rb(); break;
-      case Program::DIV: d() = ra() / rb(); break;
-      case Program::POW: d() = stan::math::pow(ra(), rb()); break;
-      case Program::FMAX: d() = stan::math::fmax(ra(), rb()); break;
-      case Program::FMIN: d() = stan::math::fmin(ra(), rb()); break;
-      case Program::NEG: d() = -ra(); break;
-      case Program::EXP: d() = stan::math::exp(ra()); break;
-      case Program::LOG: d() = stan::math::log(ra()); break;
-      case Program::SQRT: d() = stan::math::sqrt(ra()); break;
-      case Program::SQUARE: d() = stan::math::square(ra()); break;
-      case Program::INV: d() = stan::math::inv(ra()); break;
-      case Program::FABS: d() = stan::math::fabs(ra()); break;
-      case Program::INV_LOGIT: d() = stan::math::inv_logit(ra()); break;
-      case Program::LOG1M: d() = stan::math::log1m(ra()); break;
-      case Program::TANH: d() = stan::math::tanh(ra()); break;
+      case Program::ADD:
+        d() = ra() + rb();
+        break;
+      case Program::SUB:
+        d() = ra() - rb();
+        break;
+      case Program::MUL:
+        d() = ra() * rb();
+        break;
+      case Program::DIV:
+        d() = ra() / rb();
+        break;
+      case Program::POW:
+        d() = stan::math::pow(ra(), rb());
+        break;
+      case Program::FMAX:
+        d() = stan::math::fmax(ra(), rb());
+        break;
+      case Program::FMIN:
+        d() = stan::math::fmin(ra(), rb());
+        break;
+      case Program::NEG:
+        d() = -ra();
+        break;
+      case Program::EXP:
+        d() = stan::math::exp(ra());
+        break;
+      case Program::LOG:
+        d() = stan::math::log(ra());
+        break;
+      case Program::SQRT:
+        d() = stan::math::sqrt(ra());
+        break;
+      case Program::SQUARE:
+        d() = stan::math::square(ra());
+        break;
+      case Program::INV:
+        d() = stan::math::inv(ra());
+        break;
+      case Program::FABS:
+        d() = stan::math::fabs(ra());
+        break;
+      case Program::INV_LOGIT:
+        d() = stan::math::inv_logit(ra());
+        break;
+      case Program::LOG1M:
+        d() = stan::math::log1m(ra());
+        break;
+      case Program::TANH:
+        d() = stan::math::tanh(ra());
+        break;
       case Program::GT:
         d() = T(stan::math::value_of(ra()) > stan::math::value_of(rb()));
         break;
@@ -162,7 +219,9 @@ void run_program(const Program& p, std::vector<T>& reg) {
       case Program::JZ:
         if (stan::math::value_of(ra()) == 0.0) pc = I.dst - 1;
         break;
-      case Program::JMP: pc = I.dst - 1; break;
+      case Program::JMP:
+        pc = I.dst - 1;
+        break;
       case Program::LOG_RANGE:
         for (int32_t i = 0; i < I.len; ++i)
           reg[(size_t)(I.dst + i)] = stan::math::log(reg[(size_t)(I.a + i)]);
@@ -193,24 +252,26 @@ void run_program(const Program& p, std::vector<T>& reg) {
         for (int32_t i = 0; i < I.len; ++i) reg[(size_t)(I.dst + i)] = s(i);
         break;
       }
-      case Program::LSE2: d() = stan::math::log_sum_exp(ra(), rb()); break;
+      case Program::LSE2:
+        d() = stan::math::log_sum_exp(ra(), rb());
+        break;
       case Program::LOG_MIX:
         d() = stan::math::log_mix(ra(), rb(), reg[(size_t)I.c]);
         break;
-      // Generated from the same list as the enum and the two front ends,
-      // so a density cannot exist as an instruction with no case to run
-      // it. It used to be possible, and the failure was a silently
-      // unwritten register rather than an error.
-#define STANLI_PROGRAM_DENSITY_CASE(code, fn, n)                     \
-  case Program::code:                                                \
-    if constexpr (n == 1)                                            \
-      d() = stan::math::fn<false>(ra());                             \
-    else if constexpr (n == 2)                                       \
-      d() = stan::math::fn<false>(ra(), rb());                       \
-    else                                                             \
-      d() = stan::math::fn<false>(ra(), rb(), reg[(size_t)I.c]);     \
+        // Generated from the same list as the enum and the two front ends,
+        // so a density cannot exist as an instruction with no case to run
+        // it. It used to be possible, and the failure was a silently
+        // unwritten register rather than an error.
+#define STANLI_PROGRAM_DENSITY_CASE(code, fn, n)                 \
+  case Program::code:                                            \
+    if constexpr (n == 1)                                        \
+      d() = stan::math::fn<false>(ra());                         \
+    else if constexpr (n == 2)                                   \
+      d() = stan::math::fn<false>(ra(), rb());                   \
+    else                                                         \
+      d() = stan::math::fn<false>(ra(), rb(), reg[(size_t)I.c]); \
     break;
-      STANLI_PROGRAM_DENSITY_LIST(STANLI_PROGRAM_DENSITY_CASE)
+        STANLI_PROGRAM_DENSITY_LIST(STANLI_PROGRAM_DENSITY_CASE)
 #undef STANLI_PROGRAM_DENSITY_CASE
     }
   }

--- a/runtime/include/stanli/wa_interp.hpp
+++ b/runtime/include/stanli/wa_interp.hpp
@@ -40,23 +40,18 @@ class WaInterp {
 
   // One CSV row: constrained parameter values by name in, every column of
   // the generate_quantities section out.
-  std::vector<double> eval(
-      const std::map<std::string, DataMap::Entry>& params);
+  std::vector<double> eval(const std::map<std::string, DataMap::Entry>& params);
 
   // Valid after the first eval.
-  const std::vector<CompiledModel::ParamView>& columns() const {
-    return cols_;
-  }
+  const std::vector<CompiledModel::ParamView>& columns() const { return cols_; }
 
  private:
   bool read_param(MirInterp<double>& in, const mir::Stmt& s,
                   const std::map<std::string, DataMap::Entry>& params);
   bool write_param(MirInterp<double>& in, const mir::Stmt& s,
                    std::vector<double>& row);
-  bool rng_fun(MirInterp<double>& in, const mir::Expr& e,
-               DataMap::Entry* out);
-  bool ode_fun(MirInterp<double>& in, const mir::Expr& e,
-               DataMap::Entry* out);
+  bool rng_fun(MirInterp<double>& in, const mir::Expr& e, DataMap::Entry* out);
+  bool ode_fun(MirInterp<double>& in, const mir::Expr& e, DataMap::Entry* out);
 
   std::shared_ptr<const mir::Program> prog_;
   std::map<std::string, const mir::FunDef*> funs_;

--- a/runtime/kernels/constrain.cpp
+++ b/runtime/kernels/constrain.cpp
@@ -125,8 +125,8 @@ void clu_fwd(KernelCtx& ctx) {
     // .val() expression: e/(1+e) with an inf guard, no sign branch.
     if (packet_math()) {
       MapA(il, n) = CMapA(x, n).exp();
-      MapA(il, n) = (MapA(il, n).isInf()).select(1.0,
-                                                 MapA(il, n) / (1.0 + MapA(il, n)));
+      MapA(il, n) =
+          (MapA(il, n).isInf()).select(1.0, MapA(il, n) / (1.0 + MapA(il, n)));
     } else {
       for (int64_t i = 0; i < n; ++i) {
         const double e = std::exp(x[i]);
@@ -203,8 +203,8 @@ void structured_bwd(KernelCtx& ctx, RevF&& f) {
       y(i) = ctx.in[0].data[b * inner_raw + i];
     var lp = 0.0;
     auto x = f(y, lp);
-    Eigen::Map<const Eigen::VectorXd> seed(
-        ctx.out_adj_vec.data + b * inner_con, inner_con);
+    Eigen::Map<const Eigen::VectorXd> seed(ctx.out_adj_vec.data + b * inner_con,
+                                           inner_con);
     var j = stan::math::dot_product(seed, x) + ctx.out2_adj * lp;
     stan::math::grad(j.vi_);
     for (int64_t i = 0; i < inner_raw; ++i)
@@ -372,8 +372,7 @@ void matrix_constrain_fwd(KernelCtx& ctx, int64_t rows, int64_t cols, F&& f) {
   double lp = 0.0;
   Eigen::MatrixXd x = f(y, lp);
   for (int64_t j = 0; j < cols; ++j)
-    for (int64_t i = 0; i < rows; ++i)
-      ctx.out.data[j * rows + i] = x(i, j);
+    for (int64_t i = 0; i < rows; ++i) ctx.out.data[j * rows + i] = x(i, j);
   ctx.out2.data[0] = lp;
 }
 template <typename F>
@@ -451,8 +450,7 @@ void register_constrain_kernels() {
                   Kernel{clower_fwd, clower_bwd, constrain_scratch});
   register_kernel(OP_CONSTRAIN_UPPER,
                   Kernel{cupper_fwd, cupper_bwd, constrain_scratch});
-  register_kernel(OP_CONSTRAIN_LU,
-                  Kernel{clu_fwd, clu_bwd, constrain_scratch});
+  register_kernel(OP_CONSTRAIN_LU, Kernel{clu_fwd, clu_bwd, constrain_scratch});
   register_kernel(OP_CONSTRAIN_CHOL_CORR,
                   Kernel{chol_corr_fwd, chol_corr_bwd, nullptr});
   register_kernel(OP_CONSTRAIN_SIMPLEX,

--- a/runtime/kernels/densities.cpp
+++ b/runtime/kernels/densities.cpp
@@ -8,14 +8,15 @@ using namespace dens;
 
 void register_density_kernels() {
 #define STANLI_REGISTER_DENSITY(code, fn, n, tier) \
-  register_kernel(code, Kernel{fn##_fwd_gen, density_bwd<n>, density_scratch<n>});
+  register_kernel(code,                            \
+                  Kernel{fn##_fwd_gen, density_bwd<n>, density_scratch<n>});
   STANLI_SCALAR_DENSITY_LIST(STANLI_REGISTER_DENSITY)
 #undef STANLI_REGISTER_DENSITY
   // Discrete densities: the outcome sits in idata, so the real-argument
   // count is what the shared backward contracts.
 #define STANLI_REGISTER_INT_DENSITY(code, fn, nreal, tier) \
-  register_kernel(code,                                    \
-                  Kernel{fn##_fwd_gen, density_bwd<nreal>, density_scratch<nreal>});
+  register_kernel(                                         \
+      code, Kernel{fn##_fwd_gen, density_bwd<nreal>, density_scratch<nreal>});
   STANLI_INT_DENSITY_LIST(STANLI_REGISTER_INT_DENSITY)
 #undef STANLI_REGISTER_INT_DENSITY
   // The list is the default. A density whose forward needs more than the
@@ -28,38 +29,42 @@ void register_density_kernels() {
                   Kernel{uniform_fwd, density_bwd<3>, density_scratch<3>});
   register_kernel(OP_POISSON_LOG_LPMF,
                   Kernel{poisson_log_fwd, density_bwd<1>, density_scratch<1>});
-  register_kernel(OP_BERNOULLI_LOGIT_LPMF,
-                  Kernel{bernoulli_logit_fwd, density_bwd<1>, density_scratch<1>});
+  register_kernel(
+      OP_BERNOULLI_LOGIT_LPMF,
+      Kernel{bernoulli_logit_fwd, density_bwd<1>, density_scratch<1>});
   register_kernel(OP_BERNOULLI_LPMF,
                   Kernel{bernoulli_fwd, density_bwd<1>, density_scratch<1>});
   register_kernel(OP_POISSON_LPMF,
                   Kernel{poisson_fwd, density_bwd<1>, density_scratch<1>});
-  register_kernel(OP_NEG_BINOMIAL_2_LPMF,
-                  Kernel{neg_binomial_2_fwd, density_bwd<2>, density_scratch<2>});
+  register_kernel(
+      OP_NEG_BINOMIAL_2_LPMF,
+      Kernel{neg_binomial_2_fwd, density_bwd<2>, density_scratch<2>});
   register_kernel(OP_BINOMIAL_LPMF,
                   Kernel{binomial_fwd, density_bwd<1>, density_scratch<1>});
-  register_kernel(OP_BINOMIAL_LOGIT_LPMF,
-                  Kernel{binomial_logit_fwd, density_bwd<1>, density_scratch<1>});
-  register_kernel(OP_BERNOULLI_LOGIT_GLM_LPMF,
-                  Kernel{bernoulli_logit_glm_fwd, bernoulli_logit_glm_bwd,
-                         sum_in_lens});
-  register_kernel(OP_POISSON_LOG_GLM_LPMF,
-                  Kernel{poisson_log_glm_fwd, poisson_log_glm_bwd,
-                         sum_in_lens});
+  register_kernel(
+      OP_BINOMIAL_LOGIT_LPMF,
+      Kernel{binomial_logit_fwd, density_bwd<1>, density_scratch<1>});
+  register_kernel(
+      OP_BERNOULLI_LOGIT_GLM_LPMF,
+      Kernel{bernoulli_logit_glm_fwd, bernoulli_logit_glm_bwd, sum_in_lens});
+  register_kernel(
+      OP_POISSON_LOG_GLM_LPMF,
+      Kernel{poisson_log_glm_fwd, poisson_log_glm_bwd, sum_in_lens});
   register_kernel(OP_NEG_BINOMIAL_2_LOG_GLM_LPMF,
-                  Kernel{neg_binomial_2_log_glm_fwd,
-                         neg_binomial_2_log_glm_bwd, sum_in_lens});
-  register_kernel(OP_BETA_BINOMIAL_LPMF,
-                  Kernel{beta_binomial_fwd, density_bwd<2>,
-                         density_scratch<2>});
+                  Kernel{neg_binomial_2_log_glm_fwd, neg_binomial_2_log_glm_bwd,
+                         sum_in_lens});
+  register_kernel(
+      OP_BETA_BINOMIAL_LPMF,
+      Kernel{beta_binomial_fwd, density_bwd<2>, density_scratch<2>});
 #define STANLI_REGISTER_CDF(code, fn, n, tier) \
-  register_kernel(code, Kernel{fn##_fwd_gen, density_bwd<n>, density_scratch<n>});
+  register_kernel(code,                        \
+                  Kernel{fn##_fwd_gen, density_bwd<n>, density_scratch<n>});
   STANLI_SCALAR_CDF_LIST(STANLI_REGISTER_CDF)
   STANLI_INT_CDF_LIST(STANLI_REGISTER_CDF)
 #undef STANLI_REGISTER_CDF
 #define STANLI_REGISTER_ORDERED(code, fn, nargs, vm) \
-  register_kernel(code,                              \
-                  Kernel{fn##_fwd_gen, density_bwd<nargs>, density_scratch<nargs>});
+  register_kernel(                                   \
+      code, Kernel{fn##_fwd_gen, density_bwd<nargs>, density_scratch<nargs>});
   STANLI_ORDERED_DENSITY_LIST(STANLI_REGISTER_ORDERED)
 #undef STANLI_REGISTER_ORDERED
 }

--- a/runtime/kernels/densities_common.cpp
+++ b/runtime/kernels/densities_common.cpp
@@ -11,7 +11,6 @@ namespace dens {
 
 STANLI_SCALAR_DENSITY_LIST_COMMON_A(STANLI_DEFINE_DENSITY_FWD)
 
-
 void uniform_fwd(KernelCtx& ctx) {
   // stan-math reports out-of-support y with an early `return LOG_ZERO`
   // that never reaches the partials sink, so the recorder would leave the

--- a/runtime/kernels/densities_glm.cpp
+++ b/runtime/kernels/densities_glm.cpp
@@ -26,11 +26,11 @@ void bernoulli_logit_glm_fwd(KernelCtx& ctx) {
   // here, but hardcoding one is what made poisson_log_glm's lp land
   // sum(log(y!)) away from CmdStan's.
   if (ctx.variant & 0x80u) {
-    stan::math::bernoulli_logit_glm_lpmf<true>(
-        y, X, rvar(ctx.in[1].data[0]), as_rvar(ctx.in[2]));
+    stan::math::bernoulli_logit_glm_lpmf<true>(y, X, rvar(ctx.in[1].data[0]),
+                                               as_rvar(ctx.in[2]));
   } else {
-    stan::math::bernoulli_logit_glm_lpmf<false>(
-        y, X, rvar(ctx.in[1].data[0]), as_rvar(ctx.in[2]));
+    stan::math::bernoulli_logit_glm_lpmf<false>(y, X, rvar(ctx.in[1].data[0]),
+                                                as_rvar(ctx.in[2]));
   }
   active_sink() = nullptr;
   ctx.out.data[0] = s.value;
@@ -38,7 +38,6 @@ void bernoulli_logit_glm_fwd(KernelCtx& ctx) {
 // Edge order (x, alpha, beta): X data (edge 0 skipped by null adjoint),
 // alpha scalar, beta vector.
 void bernoulli_logit_glm_bwd(KernelCtx& ctx) { density_bwd<3>(ctx); }
-
 
 // The other GLMs brms and rstanarm emit directly. A model that writes one
 // of these does not merely run slower without it, it does not run. Alpha

--- a/runtime/kernels/densities_impl.hpp
+++ b/runtime/kernels/densities_impl.hpp
@@ -65,8 +65,7 @@ void bind_args_m(KernelCtx& ctx, F&& f, const Bound&... bound) {
     constexpr bool always_vec = ((VecMask >> i) & 1u) != 0;
     const auto bind_vector = [&] {
       if constexpr (active) {
-        bind_args_m<NArgs, Mask, VecMask>(ctx, f, bound...,
-                                          as_rvar(ctx.in[i]));
+        bind_args_m<NArgs, Mask, VecMask>(ctx, f, bound..., as_rvar(ctx.in[i]));
       } else {
         bind_args_m<NArgs, Mask, VecMask>(
             ctx, f, bound...,
@@ -80,8 +79,7 @@ void bind_args_m(KernelCtx& ctx, F&& f, const Bound&... bound) {
         bind_args_m<NArgs, Mask, VecMask>(ctx, f, bound...,
                                           rvar(ctx.in[i].data[0]));
       } else {
-        bind_args_m<NArgs, Mask, VecMask>(ctx, f, bound...,
-                                          ctx.in[i].data[0]);
+        bind_args_m<NArgs, Mask, VecMask>(ctx, f, bound..., ctx.in[i].data[0]);
       }
     } else {
       bind_vector();
@@ -194,8 +192,7 @@ void density_fwd_elt(KernelCtx& ctx, FProp&& fp, FFull&& ff) {
 // exist. Whatever the outcome looks like -- a propagator edge, one idata
 // group, two, an integer array -- it is bound by the caller's lambdas, so
 // this is shared by every density shape in these shards.
-template <int NArgs, int Tier, unsigned VecMask, typename FProp,
-          typename FFull>
+template <int NArgs, int Tier, unsigned VecMask, typename FProp, typename FFull>
 void density_fwd_sum(KernelCtx& ctx, FProp&& fp, FFull&& ff) {
   sink s = sink_for_args(ctx, NArgs);
   const unsigned mask = ctx.variant == 0
@@ -247,8 +244,8 @@ void density_fwd_v(KernelCtx& ctx, FProp&& fp, FFull&& ff) {
 // fused op replaces (bit-identical accumulation).
 template <int NArgs>
 void density_bwd(KernelCtx& ctx) {
-  const unsigned mask = ctx.variant == 0 ? (1u << NArgs) - 1
-                                         : (ctx.variant & 0x3fu);
+  const unsigned mask =
+      ctx.variant == 0 ? (1u << NArgs) - 1 : (ctx.variant & 0x3fu);
   if (ctx.variant & 0x40u) {
     const int64_t N = ctx.out.len;
     for (int k = 0; k < NArgs; ++k) {
@@ -256,8 +253,7 @@ void density_bwd(KernelCtx& ctx) {
       const double* col = ctx.scratch + static_cast<int64_t>(k) * N;
       if (ctx.in_adj[k].len == 1 && N > 1) {
         double acc = 0;
-        for (int64_t n = N; n-- > 0;)
-          acc += ctx.out_adj_vec.data[n] * col[n];
+        for (int64_t n = N; n-- > 0;) acc += ctx.out_adj_vec.data[n] * col[n];
         ctx.in_adj[k].data[0] += acc;
       } else {
         for (int64_t n = 0; n < N; ++n)
@@ -284,31 +280,29 @@ int64_t density_scratch(const Op& op, const Slot* slots) {
   return sum_in_lens(op, slots);
 }
 
-
-
 // ---- lpmfs: integer outcome from idata, not a propagator edge --------------
 // The elementwise variant hands each recorder call outcome element n; the
 // summed path keeps the whole-vector call. STANLI_LPMF_FWD expands both.
-#define STANLI_LPMF_FWD_T(fname, dist, NARGS, TIER)                            \
-  void fname(KernelCtx& ctx) {                                                 \
-    if (ctx.variant & 0x40u) {                                                 \
-      density_fwd_elt<NARGS, density_tier(TIER)>(                              \
-          ctx,                                                                 \
-          [&](int64_t n, const auto&... a) {                                   \
-            stan::math::dist<true>(ctx.idata[n], a...);                        \
-          },                                                                   \
-          [&](int64_t n, const auto&... a) {                                   \
-            stan::math::dist<false>(ctx.idata[n], a...);                       \
-          });                                                                  \
-      return;                                                                  \
-    }                                                                          \
-    Eigen::Map<const Eigen::VectorXi> y(                                       \
-        ctx.idata, static_cast<Eigen::Index>(ctx.n_idata));                    \
-    density_fwd_v<NARGS, TIER>(                                                \
-        ctx, [&](const auto&... a) { stan::math::dist<true>(y, a...); },       \
-        [&](const auto&... a) { stan::math::dist<false>(y, a...); });          \
+#define STANLI_LPMF_FWD_T(fname, dist, NARGS, TIER)                      \
+  void fname(KernelCtx& ctx) {                                           \
+    if (ctx.variant & 0x40u) {                                           \
+      density_fwd_elt<NARGS, density_tier(TIER)>(                        \
+          ctx,                                                           \
+          [&](int64_t n, const auto&... a) {                             \
+            stan::math::dist<true>(ctx.idata[n], a...);                  \
+          },                                                             \
+          [&](int64_t n, const auto&... a) {                             \
+            stan::math::dist<false>(ctx.idata[n], a...);                 \
+          });                                                            \
+      return;                                                            \
+    }                                                                    \
+    Eigen::Map<const Eigen::VectorXi> y(                                 \
+        ctx.idata, static_cast<Eigen::Index>(ctx.n_idata));              \
+    density_fwd_v<NARGS, TIER>(                                          \
+        ctx, [&](const auto&... a) { stan::math::dist<true>(y, a...); }, \
+        [&](const auto&... a) { stan::math::dist<false>(y, a...); });    \
   }
-#define STANLI_LPMF_FWD(fname, dist, NARGS)                                    \
+#define STANLI_LPMF_FWD(fname, dist, NARGS) \
   STANLI_LPMF_FWD_T(fname, dist, NARGS, 3)
 
 // One line per density in STANLI_SCALAR_DENSITY_LIST (optable.hpp) makes
@@ -316,11 +310,11 @@ int64_t density_scratch(const Op& op, const Slot* slots) {
 // share -- propto and per-argument activity from the variant byte,
 // elementwise output, the partials stashed for density_bwd to contract --
 // lives in density_fwd_v.
-#define STANLI_DEFINE_DENSITY_FWD(code, fn, n, tier)                             \
-  void fn##_fwd_gen(KernelCtx& ctx) {                                      \
-    density_fwd_v<n, tier>(                                                      \
-        ctx, [](const auto&... a) { stan::math::fn<true>(a...); },         \
-        [](const auto&... a) { stan::math::fn<false>(a...); });            \
+#define STANLI_DEFINE_DENSITY_FWD(code, fn, n, tier)               \
+  void fn##_fwd_gen(KernelCtx& ctx) {                              \
+    density_fwd_v<n, tier>(                                        \
+        ctx, [](const auto&... a) { stan::math::fn<true>(a...); }, \
+        [](const auto&... a) { stan::math::fn<false>(a...); });    \
   }
 
 // Distribution functions: one form, no propto, and no elementwise
@@ -343,24 +337,22 @@ void cdf_fwd(KernelCtx& ctx, F&& f) {
   density_fwd_sum<NArgs, Tier, 0>(ctx, [](const auto&...) {}, f);
 }
 
-#define STANLI_DEFINE_CDF_FWD(code, fn, n, tier)                         \
-  void fn##_fwd_gen(KernelCtx& ctx) {                                    \
-    cdf_fwd<n, density_tier(tier) & STANLI_DENSITY_FULL_MASKS>(          \
-        ctx, [](const auto&... a) { stan::math::fn(a...); });            \
+#define STANLI_DEFINE_CDF_FWD(code, fn, n, tier)                \
+  void fn##_fwd_gen(KernelCtx& ctx) {                           \
+    cdf_fwd<n, density_tier(tier) & STANLI_DENSITY_FULL_MASKS>( \
+        ctx, [](const auto&... a) { stan::math::fn(a...); });   \
   }
-
 
 // Integer-outcome cdfs. Same as above with the count read from idata,
 // the way the lpmfs read theirs -- a whole vector of outcomes in one
 // call, since the summed form is the only one these have.
-#define STANLI_DEFINE_INT_CDF_FWD(code, fn, nreal, tier)                 \
-  void fn##_fwd_gen(KernelCtx& ctx) {                                    \
-    Eigen::Map<const Eigen::VectorXi> y(                                 \
-        ctx.idata, static_cast<Eigen::Index>(ctx.n_idata));              \
-    cdf_fwd<nreal, density_tier(tier) & STANLI_DENSITY_FULL_MASKS>(      \
-        ctx, [&](const auto&... a) { stan::math::fn(y, a...); });        \
+#define STANLI_DEFINE_INT_CDF_FWD(code, fn, nreal, tier)            \
+  void fn##_fwd_gen(KernelCtx& ctx) {                               \
+    Eigen::Map<const Eigen::VectorXi> y(                            \
+        ctx.idata, static_cast<Eigen::Index>(ctx.n_idata));         \
+    cdf_fwd<nreal, density_tier(tier) & STANLI_DENSITY_FULL_MASKS>( \
+        ctx, [&](const auto&... a) { stan::math::fn(y, a...); });   \
   }
-
 
 // Ordinal regression. The outcome goes over as a std::vector<int>, not
 // the Eigen map the other lpmfs use: ordered_logistic hands its outcome
@@ -369,12 +361,12 @@ void cdf_fwd(KernelCtx& ctx, F&& f) {
 // std::vector is also exactly what CmdStan's generated code passes, so
 // this is the instantiation the references were produced from. The copy
 // is n ints per evaluation, against a density over the same n.
-#define STANLI_DEFINE_ORDERED_FWD(code, fn, nargs, vecmask)              \
-  void fn##_fwd_gen(KernelCtx& ctx) {                                    \
-    const std::vector<int> y(ctx.idata, ctx.idata + ctx.n_idata);        \
-    density_fwd_v<nargs, 2, vecmask>(                                    \
-        ctx, [&](const auto&... a) { stan::math::fn<true>(y, a...); },   \
-        [&](const auto&... a) { stan::math::fn<false>(y, a...); });      \
+#define STANLI_DEFINE_ORDERED_FWD(code, fn, nargs, vecmask)            \
+  void fn##_fwd_gen(KernelCtx& ctx) {                                  \
+    const std::vector<int> y(ctx.idata, ctx.idata + ctx.n_idata);      \
+    density_fwd_v<nargs, 2, vecmask>(                                  \
+        ctx, [&](const auto&... a) { stan::math::fn<true>(y, a...); }, \
+        [&](const auto&... a) { stan::math::fn<false>(y, a...); });    \
   }
 
 // Declarations of everything the shards define, so registration in

--- a/runtime/kernels/densities_lpmf.cpp
+++ b/runtime/kernels/densities_lpmf.cpp
@@ -17,7 +17,7 @@ STANLI_LPMF_FWD(neg_binomial_2_fwd, neg_binomial_2_lpmf, 2)
 #undef STANLI_LPMF_FWD
 
 // The same shape, one line per distribution (STANLI_INT_DENSITY_LIST).
-#define STANLI_DEFINE_INT_DENSITY(code, fn, nreal, tier)                       \
+#define STANLI_DEFINE_INT_DENSITY(code, fn, nreal, tier) \
   STANLI_LPMF_FWD_T(fn##_fwd_gen, fn, nreal, tier)
 STANLI_INT_DENSITY_LIST(STANLI_DEFINE_INT_DENSITY)
 #undef STANLI_DEFINE_INT_DENSITY
@@ -46,7 +46,7 @@ const int* int_group_next(const int* p) {
     if (ctx.variant & 0x40u) {                                                 \
       const int* g1 = ctx.idata;                                               \
       const int* g2 = int_group_next(g1);                                      \
-      density_fwd_elt<1, 3>(                                                      \
+      density_fwd_elt<1, 3>(                                                   \
           ctx,                                                                 \
           [&](int64_t n, const auto& theta) {                                  \
             stan::math::dist<true>(int_group_elem(g1, n),                      \
@@ -60,7 +60,7 @@ const int* int_group_next(const int* p) {
     }                                                                          \
     with_int_group(ctx.idata, [&](const auto& n, const int* rest) {            \
       with_int_group(rest, [&](const auto& N, const int*) {                    \
-        density_fwd_v<1, 3>(                                                      \
+        density_fwd_v<1, 3>(                                                   \
             ctx,                                                               \
             [&](const auto& theta) { stan::math::dist<true>(n, N, theta); },   \
             [&](const auto& theta) { stan::math::dist<false>(n, N, theta); }); \
@@ -71,7 +71,6 @@ const int* int_group_next(const int* p) {
 STANLI_BINOMIAL_FWD(binomial_fwd, binomial_lpmf)
 STANLI_BINOMIAL_FWD(binomial_logit_fwd, binomial_logit_lpmf)
 #undef STANLI_BINOMIAL_FWD
-
 
 // beta_binomial(n | N, alpha, beta): two integer groups, then two real
 // arguments that behave like any other density's. with_int_group unpacks

--- a/runtime/kernels/elementwise.cpp
+++ b/runtime/kernels/elementwise.cpp
@@ -11,7 +11,8 @@ namespace {
 // OP_EXP: scalar out = exp(in). Partial is the output itself; no scratch.
 void exp_fwd(KernelCtx& ctx) { ctx.out.data[0] = std::exp(ctx.in[0].data[0]); }
 void exp_bwd(KernelCtx& ctx) {
-  if (ctx.in_adj[0].data) ctx.in_adj[0].data[0] += ctx.out_adj * ctx.out.data[0];
+  if (ctx.in_adj[0].data)
+    ctx.in_adj[0].data[0] += ctx.out_adj * ctx.out.data[0];
 }
 
 // OP_ADD_N: scalar out = sum of scalar inputs.
@@ -321,14 +322,12 @@ void register_elementwise_kernels() {
   register_kernel(OP_SUM_VEC, Kernel{sum_vec_fwd, sum_vec_bwd, nullptr});
   register_kernel(OP_INDEX, Kernel{index_fwd, index_bwd, nullptr});
   register_kernel(OP_SET_INDEX, Kernel{set_index_fwd, set_index_bwd, nullptr});
-  register_kernel(OP_SET_INDEX_INPLACE,
-                  Kernel{set_index_inplace_fwd, set_index_inplace_bwd,
-                         nullptr});
+  register_kernel(OP_SET_INDEX_INPLACE, Kernel{set_index_inplace_fwd,
+                                               set_index_inplace_bwd, nullptr});
   register_kernel(OP_SLICE, Kernel{slice_fwd, slice_bwd, nullptr});
   register_kernel(OP_SET_SLICE, Kernel{set_slice_fwd, set_slice_bwd, nullptr});
-  register_kernel(OP_SET_SLICE_STRIDED,
-                  Kernel{set_slice_strided_fwd, set_slice_strided_bwd,
-                         nullptr});
+  register_kernel(OP_SET_SLICE_STRIDED, Kernel{set_slice_strided_fwd,
+                                               set_slice_strided_bwd, nullptr});
   register_kernel(OP_SLICE_STRIDED,
                   Kernel{slice_strided_fwd, slice_strided_bwd, nullptr});
   register_kernel(OP_GATHER, Kernel{gather_fwd, gather_bwd, nullptr});

--- a/runtime/kernels/eltwise_expr.cpp
+++ b/runtime/kernels/eltwise_expr.cpp
@@ -188,8 +188,7 @@ void pow_fwd(KernelCtx& ctx) {
 void pow_bwd(KernelCtx& ctx) {
   const double a = ctx.in[0].data[0], b = ctx.in[1].data[0];
   const double v = ctx.out.data[0];
-  if (ctx.in_adj[0].data)
-    ctx.in_adj[0].data[0] += ctx.out_adj * b * v / a;
+  if (ctx.in_adj[0].data) ctx.in_adj[0].data[0] += ctx.out_adj * b * v / a;
   if (ctx.in_adj[1].data)
     ctx.in_adj[1].data[0] += ctx.out_adj * std::log(a) * v;
 }
@@ -236,8 +235,7 @@ void tanhv_fwd(KernelCtx& ctx) {
 }
 void tanhv_bwd(KernelCtx& ctx) {
   if (!ctx.in_adj[0].data) return;
-  const double* dout = ctx.out.len == 1 ? &ctx.out_adj
-                                        : ctx.out_adj_vec.data;
+  const double* dout = ctx.out.len == 1 ? &ctx.out_adj : ctx.out_adj_vec.data;
   for (int64_t i = 0; i < ctx.out.len; ++i) {
     const double c = std::cosh(ctx.in[0].data[i]);
     ctx.in_adj[0].data[i] += dout[i] / (c * c);
@@ -344,9 +342,7 @@ void logitv_bwd(KernelCtx& ctx) {
   }
 }
 
-void mean_fwd(KernelCtx& ctx) {
-  ctx.out.data[0] = in_a(ctx, 0).mean();
-}
+void mean_fwd(KernelCtx& ctx) { ctx.out.data[0] = in_a(ctx, 0).mean(); }
 void mean_bwd(KernelCtx& ctx) {
   if (!ctx.in_adj[0].data) return;
   const double d = ctx.out_adj / static_cast<double>(ctx.in[0].len);
@@ -355,8 +351,7 @@ void mean_bwd(KernelCtx& ctx) {
 
 // rep_vector(x, n): out[i] = x; scalar adjoint accumulates ascending.
 void repv_fwd(KernelCtx& ctx) {
-  for (int64_t i = 0; i < ctx.out.len; ++i)
-    ctx.out.data[i] = ctx.in[0].data[0];
+  for (int64_t i = 0; i < ctx.out.len; ++i) ctx.out.data[i] = ctx.in[0].data[0];
 }
 void repv_bwd(KernelCtx& ctx) {
   if (!ctx.in_adj[0].data) return;
@@ -364,25 +359,24 @@ void repv_bwd(KernelCtx& ctx) {
     ctx.in_adj[0].data[0] += ctx.out_adj_vec.data[i];
 }
 
-
 // Generated from STANLI_SCALAR_UNARY_LIST (optable.hpp): the value in the
 // forward, the derivative contracted in the backward. Shape-preserving and
 // elementwise, so a re-rolled vector arrives here as one op.
-#define STANLI_DEFINE_UNARY(code, name, VAL, DERIV)                        \
-  void name##_ufwd(KernelCtx& ctx) {                                       \
-    for (int64_t i = 0; i < ctx.out.len; ++i) {                            \
-      const double x = ctx.in[0].data[i];                                  \
-      ctx.out.data[i] = (VAL);                                             \
-    }                                                                      \
-  }                                                                        \
-  void name##_ubwd(KernelCtx& ctx) {                                       \
-    if (!ctx.in_adj[0].data) return;                                       \
-    const double* dout =                                                   \
-        ctx.out.len == 1 ? &ctx.out_adj : ctx.out_adj_vec.data;            \
-    for (int64_t i = 0; i < ctx.out.len; ++i) {                            \
-      const double x = ctx.in[0].data[i];                                  \
-      ctx.in_adj[0].data[i] += dout[i] * (DERIV);                          \
-    }                                                                      \
+#define STANLI_DEFINE_UNARY(code, name, VAL, DERIV)             \
+  void name##_ufwd(KernelCtx& ctx) {                            \
+    for (int64_t i = 0; i < ctx.out.len; ++i) {                 \
+      const double x = ctx.in[0].data[i];                       \
+      ctx.out.data[i] = (VAL);                                  \
+    }                                                           \
+  }                                                             \
+  void name##_ubwd(KernelCtx& ctx) {                            \
+    if (!ctx.in_adj[0].data) return;                            \
+    const double* dout =                                        \
+        ctx.out.len == 1 ? &ctx.out_adj : ctx.out_adj_vec.data; \
+    for (int64_t i = 0; i < ctx.out.len; ++i) {                 \
+      const double x = ctx.in[0].data[i];                       \
+      ctx.in_adj[0].data[i] += dout[i] * (DERIV);               \
+    }                                                           \
   }
 STANLI_SCALAR_UNARY_LIST(STANLI_DEFINE_UNARY)
 #undef STANLI_DEFINE_UNARY

--- a/runtime/kernels/legacy_fns.cpp
+++ b/runtime/kernels/legacy_fns.cpp
@@ -13,9 +13,7 @@ void softmax_fwd(KernelCtx& ctx) {
   out = stan::math::softmax(x);
 }
 void softmax_bwd(KernelCtx& ctx) {
-  legacy_bwd_vec_in(ctx, [](const auto& x) {
-    return stan::math::softmax(x);
-  });
+  legacy_bwd_vec_in(ctx, [](const auto& x) { return stan::math::softmax(x); });
 }
 
 // Multivariate density via nested replay: dirichlet_lpdf(theta | alpha).
@@ -58,15 +56,23 @@ double dirichlet_eval(KernelCtx& ctx) {
       }
     var lpv;
     if (propto) {
-      if (a0 && a1) lpv = stan::math::dirichlet_lpdf<true>(th, alpha);
-      else if (a0) lpv = stan::math::dirichlet_lpdf<true>(th, alpha_d);
-      else if (a1) lpv = stan::math::dirichlet_lpdf<true>(thd, alpha);
-      else lpv = 0.0;
+      if (a0 && a1)
+        lpv = stan::math::dirichlet_lpdf<true>(th, alpha);
+      else if (a0)
+        lpv = stan::math::dirichlet_lpdf<true>(th, alpha_d);
+      else if (a1)
+        lpv = stan::math::dirichlet_lpdf<true>(thd, alpha);
+      else
+        lpv = 0.0;
     } else {
-      if (a0 && a1) lpv = stan::math::dirichlet_lpdf<false>(th, alpha);
-      else if (a0) lpv = stan::math::dirichlet_lpdf<false>(th, alpha_d);
-      else if (a1) lpv = stan::math::dirichlet_lpdf<false>(thd, alpha);
-      else lpv = stan::math::dirichlet_lpdf<false>(thd, alpha_d);
+      if (a0 && a1)
+        lpv = stan::math::dirichlet_lpdf<false>(th, alpha);
+      else if (a0)
+        lpv = stan::math::dirichlet_lpdf<false>(th, alpha_d);
+      else if (a1)
+        lpv = stan::math::dirichlet_lpdf<false>(thd, alpha);
+      else
+        lpv = stan::math::dirichlet_lpdf<false>(thd, alpha_d);
     }
     if constexpr (Grad) {
       var j = lpv * ctx.out_adj;
@@ -76,21 +82,28 @@ double dirichlet_eval(KernelCtx& ctx) {
           for (int64_t i = 0; i < K; ++i)
             ctx.in_adj[0].data[r * K + i] += th[r](i).adj();
       if (a1 && ctx.in_adj[1].data)
-        for (int64_t i = 0; i < K; ++i)
-          ctx.in_adj[1].data[i] += alpha(i).adj();
+        for (int64_t i = 0; i < K; ++i) ctx.in_adj[1].data[i] += alpha(i).adj();
     }
     return lpv.val();
   }
   if (propto) {
-    if (a0 && a1) lp = stan::math::dirichlet_lpdf<true>(theta, alpha);
-    else if (a0) lp = stan::math::dirichlet_lpdf<true>(theta, alpha_d);
-    else if (a1) lp = stan::math::dirichlet_lpdf<true>(theta_d, alpha);
-    else lp = 0.0;
+    if (a0 && a1)
+      lp = stan::math::dirichlet_lpdf<true>(theta, alpha);
+    else if (a0)
+      lp = stan::math::dirichlet_lpdf<true>(theta, alpha_d);
+    else if (a1)
+      lp = stan::math::dirichlet_lpdf<true>(theta_d, alpha);
+    else
+      lp = 0.0;
   } else {
-    if (a0 && a1) lp = stan::math::dirichlet_lpdf<false>(theta, alpha);
-    else if (a0) lp = stan::math::dirichlet_lpdf<false>(theta, alpha_d);
-    else if (a1) lp = stan::math::dirichlet_lpdf<false>(theta_d, alpha);
-    else lp = stan::math::dirichlet_lpdf<false>(theta_d, alpha_d);
+    if (a0 && a1)
+      lp = stan::math::dirichlet_lpdf<false>(theta, alpha);
+    else if (a0)
+      lp = stan::math::dirichlet_lpdf<false>(theta, alpha_d);
+    else if (a1)
+      lp = stan::math::dirichlet_lpdf<false>(theta_d, alpha);
+    else
+      lp = stan::math::dirichlet_lpdf<false>(theta_d, alpha_d);
   }
   if constexpr (Grad) {
     var j = lp * ctx.out_adj;
@@ -115,9 +128,8 @@ void log_softmax_fwd(KernelCtx& ctx) {
   out = stan::math::log_softmax(x);
 }
 void log_softmax_bwd(KernelCtx& ctx) {
-  legacy_bwd_vec_in(ctx, [](const auto& x) {
-    return stan::math::log_softmax(x);
-  });
+  legacy_bwd_vec_in(ctx,
+                    [](const auto& x) { return stan::math::log_softmax(x); });
 }
 
 }  // namespace

--- a/runtime/kernels/matrix_fns.cpp
+++ b/runtime/kernels/matrix_fns.cpp
@@ -73,8 +73,8 @@ std::vector<VecD> gp_points(const KernelCtx& ctx) {
 void gp_cov_fwd(KernelCtx& ctx) {
   const int64_t N = ctx.idata[0];
   auto pts = gp_points(ctx);
-  MatD c = stan::math::gp_exp_quad_cov(pts, ctx.in[1].data[0],
-                                       ctx.in[2].data[0]);
+  MatD c =
+      stan::math::gp_exp_quad_cov(pts, ctx.in[1].data[0], ctx.in[2].data[0]);
   MapM(ctx.out.data, N, N) = c;
 }
 void gp_cov_bwd(KernelCtx& ctx) {
@@ -123,9 +123,8 @@ void chol_fwd(KernelCtx& ctx) {
 }
 void chol_bwd(KernelCtx& ctx) {
   const int64_t n = ctx.idata[0];
-  matvar_bwd(ctx, n, [](const auto& a) {
-    return stan::math::cholesky_decompose(a);
-  });
+  matvar_bwd(ctx, n,
+             [](const auto& a) { return stan::math::cholesky_decompose(a); });
 }
 
 // Bind a slot as a var matrix or vector, and scatter the adjoints back
@@ -134,8 +133,7 @@ void chol_bwd(KernelCtx& ctx) {
 VarM tail_m(const KernelCtx& ctx, int k, int64_t rows, int64_t cols) {
   VarM M(rows, cols);
   for (int64_t j = 0; j < cols; ++j)
-    for (int64_t i = 0; i < rows; ++i)
-      M(i, j) = ctx.in[k].data[j * rows + i];
+    for (int64_t i = 0; i < rows; ++i) M(i, j) = ctx.in[k].data[j * rows + i];
   return M;
 }
 VarV tail_v(const KernelCtx& ctx, int k, int64_t n) {
@@ -152,8 +150,7 @@ void tail_scatter_m(KernelCtx& ctx, int k, const VarM& M) {
 }
 void tail_scatter_v(KernelCtx& ctx, int k, const VarV& v) {
   if (!ctx.in_adj[k].data) return;
-  for (int64_t i = 0; i < v.size(); ++i)
-    ctx.in_adj[k].data[i] += v(i).adj();
+  for (int64_t i = 0; i < v.size(); ++i) ctx.in_adj[k].data[i] += v(i).adj();
 }
 void tail_scatter_s(KernelCtx& ctx, int k, const stan::math::var& x) {
   if (ctx.in_adj[k].data) ctx.in_adj[k].data[0] += x.adj();
@@ -213,10 +210,10 @@ double mn_eval(KernelCtx& ctx) {
     var v_out;
     if (ay)
       v_out = aS ? (am ? call(ys, mu, S) : call(ys, mud, S))
-                  : (am ? call(ys, mu, Sd) : call(ys, mud, Sd));
+                 : (am ? call(ys, mu, Sd) : call(ys, mud, Sd));
     else
       v_out = aS ? (am ? call(ysd, mu, S) : call(ysd, mud, S))
-                  : (am ? call(ysd, mu, Sd) : call(ysd, mud, Sd));
+                 : (am ? call(ysd, mu, Sd) : call(ysd, mud, Sd));
     const double vv = v_out.val();
     if constexpr (Grad) {
       var jj = v_out * ctx.out_adj;
@@ -231,14 +228,22 @@ double mn_eval(KernelCtx& ctx) {
     }
     return vv;
   }
-  if (ay && am && aS) out = call(y, mu, S);
-  else if (ay && am) out = call(y, mu, Sd);
-  else if (ay && aS) out = call(y, mud, S);
-  else if (am && aS) out = call(yd, mu, S);
-  else if (ay) out = call(y, mud, Sd);
-  else if (am) out = call(yd, mu, Sd);
-  else if (aS) out = call(yd, mud, S);
-  else return call(yd, mud, Sd);
+  if (ay && am && aS)
+    out = call(y, mu, S);
+  else if (ay && am)
+    out = call(y, mu, Sd);
+  else if (ay && aS)
+    out = call(y, mud, S);
+  else if (am && aS)
+    out = call(yd, mu, S);
+  else if (ay)
+    out = call(y, mud, Sd);
+  else if (am)
+    out = call(yd, mu, Sd);
+  else if (aS)
+    out = call(yd, mud, S);
+  else
+    return call(yd, mud, Sd);
 
   const double v = out.val();
   if constexpr (Grad) {
@@ -310,9 +315,7 @@ void lkj_fwd(KernelCtx& ctx) { ctx.out.data[0] = lkj_eval<false>(ctx); }
 void lkj_bwd(KernelCtx& ctx) { lkj_eval<true>(ctx); }
 // lkj_corr takes the correlation matrix itself where the cholesky form
 // takes its factor: identical argument shapes, so identical kernel.
-void lkjc_fwd(KernelCtx& ctx) {
-  ctx.out.data[0] = lkj_eval<false, false>(ctx);
-}
+void lkjc_fwd(KernelCtx& ctx) { ctx.out.data[0] = lkj_eval<false, false>(ctx); }
 void lkjc_bwd(KernelCtx& ctx) { lkj_eval<true, false>(ctx); }
 
 // ---- normal_id_glm_lpdf(y | X, alpha, beta, sigma) ------------------------
@@ -334,10 +337,14 @@ double nid_glm_eval(KernelCtx& ctx) {
     return propto ? stan::math::normal_id_glm_lpdf<true>(yd, X, a, beta, s)
                   : stan::math::normal_id_glm_lpdf<false>(yd, X, a, beta, s);
   };
-  if (one_a && one_s) out = call(alpha(0), sigma(0));
-  else if (one_a) out = call(alpha(0), sigma);
-  else if (one_s) out = call(alpha, sigma(0));
-  else out = call(alpha, sigma);
+  if (one_a && one_s)
+    out = call(alpha(0), sigma(0));
+  else if (one_a)
+    out = call(alpha(0), sigma);
+  else if (one_s)
+    out = call(alpha, sigma(0));
+  else
+    out = call(alpha, sigma);
   const double v = out.val();
   // One tape per gradient, not two. The forward differentiates it once
   // with a seed of 1 and keeps the partials; the backward is then the
@@ -468,10 +475,10 @@ double wish_eval(KernelCtx& ctx) {
   }
   return v;
 }
-#define STANLI_WISH_KERNEL(name, kind)                                    \
-  void name##_fwd(KernelCtx& ctx) {                                       \
-    ctx.out.data[0] = wish_eval<false, kind>(ctx);                        \
-  }                                                                       \
+#define STANLI_WISH_KERNEL(name, kind)             \
+  void name##_fwd(KernelCtx& ctx) {                \
+    ctx.out.data[0] = wish_eval<false, kind>(ctx); \
+  }                                                \
   void name##_bwd(KernelCtx& ctx) { wish_eval<true, kind>(ctx); }
 STANLI_WISH_KERNEL(wish, kWishart)
 STANLI_WISH_KERNEL(iwish, kInvWishart)
@@ -523,8 +530,7 @@ double mst_eval(KernelCtx& ctx) {
   ys.reserve(reps);
   for (int64_t r = 0; r < reps; ++r) {
     VarV yy(K);
-    for (int64_t i = 0; i < K; ++i)
-      yy(i) = ctx.in[0].data[r * K + i];
+    for (int64_t i = 0; i < K; ++i) yy(i) = ctx.in[0].data[r * K + i];
     ys.push_back(std::move(yy));
   }
   var nu = ctx.in[1].data[0];
@@ -535,9 +541,10 @@ double mst_eval(KernelCtx& ctx) {
       return propto ? stan::math::multi_student_t_lpdf<true>(yarg, nu, mu, S)
                     : stan::math::multi_student_t_lpdf<false>(yarg, nu, mu, S);
     } else {
-      return propto
-                 ? stan::math::multi_student_t_cholesky_lpdf<true>(yarg, nu, mu, S)
-                 : stan::math::multi_student_t_cholesky_lpdf<false>(yarg, nu, mu, S);
+      return propto ? stan::math::multi_student_t_cholesky_lpdf<true>(yarg, nu,
+                                                                      mu, S)
+                    : stan::math::multi_student_t_cholesky_lpdf<false>(yarg, nu,
+                                                                       mu, S);
     }
   };
   var out = reps > 1 ? call(ys) : call(ys[0]);
@@ -629,9 +636,8 @@ double wiener_eval(KernelCtx& ctx) {
   VarV y = tail_v(ctx, 0, n);
   var alpha = ctx.in[1].data[0], tau = ctx.in[2].data[0];
   var beta = ctx.in[3].data[0], delta = ctx.in[4].data[0];
-  var out = propto
-                ? stan::math::wiener_lpdf<true>(y, alpha, tau, beta, delta)
-                : stan::math::wiener_lpdf<false>(y, alpha, tau, beta, delta);
+  var out = propto ? stan::math::wiener_lpdf<true>(y, alpha, tau, beta, delta)
+                   : stan::math::wiener_lpdf<false>(y, alpha, tau, beta, delta);
   const double v = out.val();
   if constexpr (Grad) {
     var j = out * ctx.out_adj;
@@ -645,10 +651,8 @@ double wiener_eval(KernelCtx& ctx) {
   return v;
 }
 
-#define STANLI_TAIL_KERNEL(name, fn, kind)                                \
-  void name##_fwd(KernelCtx& ctx) {                                       \
-    ctx.out.data[0] = fn<false, kind>(ctx);                               \
-  }                                                                       \
+#define STANLI_TAIL_KERNEL(name, fn, kind)                                    \
+  void name##_fwd(KernelCtx& ctx) { ctx.out.data[0] = fn<false, kind>(ctx); } \
   void name##_bwd(KernelCtx& ctx) { fn<true, kind>(ctx); }
 STANLI_TAIL_KERNEL(mgp, mgp_eval, kMultiGp)
 STANLI_TAIL_KERNEL(mgpc, mgp_eval, kMultiGpChol)
@@ -710,8 +714,10 @@ double tglm_eval(KernelCtx& ctx) {
     std::vector<int> NN(ctx.idata + rows, ctx.idata + 2 * rows);
     var alpha = ctx.in[1].data[0];
     VarV beta = tail_v(ctx, 2, cols);
-    out = propto ? stan::math::binomial_logit_glm_lpmf<true>(nn, NN, X, alpha, beta)
-                 : stan::math::binomial_logit_glm_lpmf<false>(nn, NN, X, alpha, beta);
+    out = propto ? stan::math::binomial_logit_glm_lpmf<true>(nn, NN, X, alpha,
+                                                             beta)
+                 : stan::math::binomial_logit_glm_lpmf<false>(nn, NN, X, alpha,
+                                                              beta);
     const double v0 = out.val();
     if constexpr (Grad) {
       var j = out * ctx.out_adj;
@@ -726,8 +732,10 @@ double tglm_eval(KernelCtx& ctx) {
     if constexpr (Kind == kCatLogitGlm) {
       VarV alpha = tail_v(ctx, 1, ctx.in[1].len);
       VarM beta = tail_m(ctx, 2, cols, ctx.in[2].len / cols);
-      out = propto ? stan::math::categorical_logit_glm_lpmf<true>(y, X, alpha, beta)
-                   : stan::math::categorical_logit_glm_lpmf<false>(y, X, alpha, beta);
+      out = propto ? stan::math::categorical_logit_glm_lpmf<true>(y, X, alpha,
+                                                                  beta)
+                   : stan::math::categorical_logit_glm_lpmf<false>(y, X, alpha,
+                                                                   beta);
       const double vv = out.val();
       if constexpr (Grad) {
         var j = out * ctx.out_adj;
@@ -741,8 +749,10 @@ double tglm_eval(KernelCtx& ctx) {
       // in = {X, beta, cutpoints}; alpha above is beta for this one.
       VarV beta = tail_v(ctx, 1, cols);
       VarV cuts = tail_v(ctx, 2, ctx.in[2].len);
-      out = propto ? stan::math::ordered_logistic_glm_lpmf<true>(y, X, beta, cuts)
-                   : stan::math::ordered_logistic_glm_lpmf<false>(y, X, beta, cuts);
+      out =
+          propto
+              ? stan::math::ordered_logistic_glm_lpmf<true>(y, X, beta, cuts)
+              : stan::math::ordered_logistic_glm_lpmf<false>(y, X, beta, cuts);
       const double vv = out.val();
       if constexpr (Grad) {
         var j = out * ctx.out_adj;
@@ -774,13 +784,10 @@ void olglm_bwd(KernelCtx& ctx) { tglm_eval<true, kOrdLogisticGlm>(ctx); }
 }  // namespace
 
 void register_matrix_kernels() {
-  register_kernel(OP_GP_EXP_QUAD_COV,
-                  Kernel{gp_cov_fwd, gp_cov_bwd, nullptr});
+  register_kernel(OP_GP_EXP_QUAD_COV, Kernel{gp_cov_fwd, gp_cov_bwd, nullptr});
   register_kernel(OP_WISHART_LPDF, Kernel{wish_fwd, wish_bwd, nullptr});
-  register_kernel(OP_INV_WISHART_LPDF,
-                  Kernel{iwish_fwd, iwish_bwd, nullptr});
-  register_kernel(OP_WISHART_CHOL_LPDF,
-                  Kernel{wishc_fwd, wishc_bwd, nullptr});
+  register_kernel(OP_INV_WISHART_LPDF, Kernel{iwish_fwd, iwish_bwd, nullptr});
+  register_kernel(OP_WISHART_CHOL_LPDF, Kernel{wishc_fwd, wishc_bwd, nullptr});
   register_kernel(OP_INV_WISHART_CHOL_LPDF,
                   Kernel{iwishc_fwd, iwishc_bwd, nullptr});
   register_kernel(OP_MULTI_GP_LPDF, Kernel{mgp_fwd, mgp_bwd, nullptr});
@@ -805,8 +812,7 @@ void register_matrix_kernels() {
                   Kernel{olglm_fwd, olglm_bwd, nullptr});
   register_kernel(OP_DIAG_MATRIX, Kernel{diag_fwd, diag_bwd, nullptr});
   register_kernel(OP_CHOLESKY, Kernel{chol_fwd, chol_bwd, nullptr});
-  register_kernel(OP_MULTI_NORMAL_CHOL_LPDF,
-                  Kernel{mnc_fwd, mnc_bwd, nullptr});
+  register_kernel(OP_MULTI_NORMAL_CHOL_LPDF, Kernel{mnc_fwd, mnc_bwd, nullptr});
   register_kernel(OP_MULTI_NORMAL_LPDF, Kernel{mn_fwd, mn_bwd, nullptr});
   register_kernel(OP_MULTI_NORMAL_PREC_LPDF,
                   Kernel{mnprec_fwd, mnprec_bwd, nullptr});
@@ -815,11 +821,9 @@ void register_matrix_kernels() {
                   Kernel{eigvals_fwd, eigvals_bwd, nullptr});
   register_kernel(OP_EIGENVECTORS_SYM,
                   Kernel{eigvecs_fwd, eigvecs_bwd, nullptr});
-  register_kernel(OP_TRANSPOSE,
-                  Kernel{transpose_fwd, transpose_bwd, nullptr});
+  register_kernel(OP_TRANSPOSE, Kernel{transpose_fwd, transpose_bwd, nullptr});
   register_kernel(OP_LKJ_CORR_CHOL_LPDF, Kernel{lkj_fwd, lkj_bwd, nullptr});
-  register_kernel(OP_LKJ_CORR_LPDF,
-                  Kernel{lkjc_fwd, lkjc_bwd, nullptr});
+  register_kernel(OP_LKJ_CORR_LPDF, Kernel{lkjc_fwd, lkjc_bwd, nullptr});
   register_kernel(OP_NORMAL_ID_GLM_LPDF,
                   Kernel{nid_glm_fwd, nid_glm_bwd, nid_glm_scratch});
 }

--- a/runtime/kernels/mixture.cpp
+++ b/runtime/kernels/mixture.cpp
@@ -92,30 +92,28 @@ void mix_bwd(KernelCtx& ctx) {
       ctx.in_adj[k].data[0] += acc;
     } else {
       for (int64_t i = 0; i < n; ++i)
-        ctx.in_adj[k].data[i] += ctx.out_adj_vec.data[i] * ctx.scratch[i * NArgs + k];
+        ctx.in_adj[k].data[i] +=
+            ctx.out_adj_vec.data[i] * ctx.scratch[i * NArgs + k];
     }
   }
 }
 
 void lse2_fwd(KernelCtx& ctx) {
-  mix_fwd<2>(ctx, [](const auto& a) {
-    return stan::math::log_sum_exp(a[0], a[1]);
-  });
+  mix_fwd<2>(ctx,
+             [](const auto& a) { return stan::math::log_sum_exp(a[0], a[1]); });
 }
 
 // log_diff_exp(a, b) = log(exp(a) - exp(b)). Truncation is what wants
 // it: stanc3 lowers `y ~ foo(...) T[l, u]` into the density minus
 // log_diff_exp(foo_lcdf(u|...), foo_lcdf(l|...)).
 void log_diff_exp_fwd(KernelCtx& ctx) {
-  mix_fwd<2>(ctx, [](const auto& a) {
-    return stan::math::log_diff_exp(a[0], a[1]);
-  });
+  mix_fwd<2>(
+      ctx, [](const auto& a) { return stan::math::log_diff_exp(a[0], a[1]); });
 }
 
 void log_mix_fwd(KernelCtx& ctx) {
-  mix_fwd<3>(ctx, [](const auto& a) {
-    return stan::math::log_mix(a[0], a[1], a[2]);
-  });
+  mix_fwd<3>(
+      ctx, [](const auto& a) { return stan::math::log_mix(a[0], a[1], a[2]); });
 }
 
 }  // namespace
@@ -125,8 +123,7 @@ void register_mixture_kernels() {
   register_kernel(OP_LSE2, Kernel{lse2_fwd, mix_bwd<2>, mix_scratch<2>});
   register_kernel(OP_LOG_DIFF_EXP,
                   Kernel{log_diff_exp_fwd, mix_bwd<2>, mix_scratch<2>});
-  register_kernel(OP_LOG_MIX,
-                  Kernel{log_mix_fwd, mix_bwd<3>, mix_scratch<3>});
+  register_kernel(OP_LOG_MIX, Kernel{log_mix_fwd, mix_bwd<3>, mix_scratch<3>});
 }
 
 }  // namespace stanli

--- a/runtime/kernels/ode.cpp
+++ b/runtime/kernels/ode.cpp
@@ -51,8 +51,8 @@ struct MirRhs {
       // y and theta arrive as T_y / T_param, which are T or double; the
       // register file is T, so promote through a small staging buffer only
       // when they differ.
-      std::vector<T> out, ys(y.begin(), y.end()), ths(theta.begin(),
-                                                      theta.end());
+      std::vector<T> out, ys(y.begin(), y.end()),
+          ths(theta.begin(), theta.end());
       run_rhs<T>(spec->prog, T(t), ys.data(), ths.data(), x_r.data(), out);
       return out;
     }
@@ -61,7 +61,8 @@ struct MirRhs {
     // arguments have to arrive already split out of the packed theta and
     // x_r -- in the same order compile_rhs_args assigned their register
     // ranges, which is the order spec->args records.
-    std::vector<std::vector<T>> reals{{T(t)}, std::vector<T>(y.begin(), y.end())};
+    std::vector<std::vector<T>> reals{{T(t)},
+                                      std::vector<T>(y.begin(), y.end())};
     std::vector<std::vector<int>> ints;
     size_t th_at = 0, xr_at = 0;
     for (const RhsArg& a : spec->args) {
@@ -93,9 +94,8 @@ struct VarRhs {
 
   template <typename T_y, typename T_param>
   Eigen::Matrix<stan::return_type_t<T_y, T_param>, Eigen::Dynamic, 1>
-  operator()(const double& t,
-             const Eigen::Matrix<T_y, Eigen::Dynamic, 1>& y, std::ostream*,
-             const std::vector<T_param>& theta,
+  operator()(const double& t, const Eigen::Matrix<T_y, Eigen::Dynamic, 1>& y,
+             std::ostream*, const std::vector<T_param>& theta,
              const std::vector<double>& x_r,
              const std::vector<int>& x_i) const {
     using T = stan::return_type_t<T_y, T_param>;
@@ -140,25 +140,22 @@ std::vector<std::vector<T>> solve(const OdeSpec& s, const std::vector<T>& z0,
                                     s.max_steps, nullptr, theta, s.x_r, s.x_i);
       break;
     case OdeSpec::ADAMS:
-      res = stan::math::ode_adams_tol(f, y0, s.t0, s.ts, s.rtol, s.atol,
-                                      s.max_steps, nullptr, theta, s.x_r,
-                                      s.x_i);
+      res =
+          stan::math::ode_adams_tol(f, y0, s.t0, s.ts, s.rtol, s.atol,
+                                    s.max_steps, nullptr, theta, s.x_r, s.x_i);
       break;
     case OdeSpec::CKRK:
       res = stan::math::ode_ckrk_tol(f, y0, s.t0, s.ts, s.rtol, s.atol,
-                                     s.max_steps, nullptr, theta, s.x_r,
-                                     s.x_i);
+                                     s.max_steps, nullptr, theta, s.x_r, s.x_i);
       break;
     default:
       res = stan::math::ode_rk45_tol(f, y0, s.t0, s.ts, s.rtol, s.atol,
-                                     s.max_steps, nullptr, theta, s.x_r,
-                                     s.x_i);
+                                     s.max_steps, nullptr, theta, s.x_r, s.x_i);
       break;
   }
   std::vector<std::vector<T>> out;
   out.reserve(res.size());
-  for (const auto& r : res)
-    out.emplace_back(r.data(), r.data() + r.size());
+  for (const auto& r : res) out.emplace_back(r.data(), r.data() + r.size());
   return out;
 }
 

--- a/runtime/src/capi.cpp
+++ b/runtime/src/capi.cpp
@@ -1,6 +1,5 @@
 #include <stanli/capi.h>
 
-
 #include <stanli/compile.hpp>
 #include <stanli/diagnose.hpp>
 #include <stanli/estimate.hpp>
@@ -27,7 +26,7 @@ void put_err(char* err, size_t err_len, const char* what) {
 }  // namespace
 
 struct stanli_model {
-  stanli::CompiledModel cm;   // graph moved out into ex
+  stanli::CompiledModel cm;  // graph moved out into ex
   std::unique_ptr<stanli::Executor> ex;
   std::vector<std::string> flat_names;  // constrained, flattened
   int64_t n_con = 0;
@@ -67,10 +66,13 @@ std::vector<double> interp_wa_row(stanli_model& m, const double* q) {
 // support at one point and fine at the next.
 double probe_point(int64_t i, int variant) {
   switch (variant) {
-    case 1: return 0.02 * static_cast<double>((i % 5) - 2);
-    case 2: return 0.0;
-    default: return 0.1 + 0.05 * static_cast<double>(i % 7) -
-                    0.15 * static_cast<double>(i % 3);
+    case 1:
+      return 0.02 * static_cast<double>((i % 5) - 2);
+    case 2:
+      return 0.0;
+    default:
+      return 0.1 + 0.05 * static_cast<double>(i % 7) -
+             0.15 * static_cast<double>(i % 3);
   }
 }
 
@@ -106,8 +108,8 @@ stanli_model* stanli_model_new(const char* tmir_sexp, const char* data_json,
           try {
             const auto row = interp_wa_row(*m, q.data());
             m->wa_n = (int64_t)row.size();
-            m->wa_names = stanli::CompiledModel::csv_names(
-                m->wa_interp->columns());
+            m->wa_names =
+                stanli::CompiledModel::csv_names(m->wa_interp->columns());
             found = true;
           } catch (const std::exception&) {
           }
@@ -166,8 +168,6 @@ int stanli_has_embedded_stanc(void) {
 
 int stanli_exact_lp(void) { return stanli::exact_lp_build() ? 1 : 0; }
 
-
-
 void stanli_model_free(stanli_model* m) { delete m; }
 
 int64_t stanli_n_unconstrained(const stanli_model* m) {
@@ -192,8 +192,8 @@ int stanli_grad(stanli_model* m, const double* q, double* lp, double* grad) {
 
 int stanli_sample(stanli_model* m, uint32_t seed, int warmup, int samples,
                   double delta, double* draws, char* err, size_t err_len) {
-  return stanli_sample_stream(m, seed, warmup, samples, delta, draws,
-                              nullptr, nullptr, err, err_len);
+  return stanli_sample_stream(m, seed, warmup, samples, delta, draws, nullptr,
+                              nullptr, err, err_len);
 }
 
 int stanli_sample_stream(stanli_model* m, uint32_t seed, int warmup,
@@ -258,8 +258,8 @@ int stanli_thread_safe(void) { return stanli::thread_safe_build() ? 1 : 0; }
 
 const char* stanli_sampler_column_name(int i) {
   static const char* kNames[STANLI_N_SAMPLER_COLS] = {
-      "lp__",       "accept_stat__", "stepsize__", "treedepth__",
-      "n_leapfrog__", "divergent__", "energy__"};
+      "lp__",         "accept_stat__", "stepsize__", "treedepth__",
+      "n_leapfrog__", "divergent__",   "energy__"};
   if (i < 0 || i >= STANLI_N_SAMPLER_COLS) return "";
   return kNames[i];
 }
@@ -323,8 +323,8 @@ int stanli_sample_multi(stanli_model* m, const stanli_sample_opts* opts,
       const auto& r = res[(size_t)c];
       if (!r.error.empty()) {
         if (failed++ == 0)
-          first_error = "chain " + std::to_string(cfg.chain_id + c) + ": " +
-                        r.error;
+          first_error =
+              "chain " + std::to_string(cfg.chain_id + c) + ": " + r.error;
         continue;
       }
       // A chain that stored fewer rows than asked would leave the tail of
@@ -335,10 +335,10 @@ int stanli_sample_multi(stanli_model* m, const stanli_sample_opts* opts,
         std::memcpy(draws + ((int64_t)c * n_stored + i) * n,
                     r.draws[(size_t)i].data(), sizeof(double) * (size_t)n);
         if (stats != nullptr && i < (int64_t)r.stats.rows.size())
-          std::memcpy(stats + ((int64_t)c * n_stored + i) *
-                                  STANLI_N_SAMPLER_COLS,
-                      r.stats.rows[(size_t)i].data(),
-                      sizeof(double) * STANLI_N_SAMPLER_COLS);
+          std::memcpy(
+              stats + ((int64_t)c * n_stored + i) * STANLI_N_SAMPLER_COLS,
+              r.stats.rows[(size_t)i].data(),
+              sizeof(double) * STANLI_N_SAMPLER_COLS);
       }
     }
     if (failed) put_err(err, err_len, first_error.c_str());
@@ -349,8 +349,8 @@ int stanli_sample_multi(stanli_model* m, const stanli_sample_opts* opts,
   }
 }
 
-int stanli_summary_stats(const double* draws, int64_t n_chains,
-                         int64_t n_draws, int64_t n_cols, double* out) {
+int stanli_summary_stats(const double* draws, int64_t n_chains, int64_t n_draws,
+                         int64_t n_cols, double* out) {
   try {
     stanli::DrawSet d{draws, n_chains, n_draws, n_cols};
     const auto s = stanli::summarize(d, {});
@@ -453,16 +453,16 @@ int stanli_optimize(stanli_model* m, const stanli_optimize_opts* opts,
       }
     };
 
-    const stanli::OptimizeResult r =
-        stanli::run_optimize(*m->ex, &wa, cfg);
+    const stanli::OptimizeResult r = stanli::run_optimize(*m->ex, &wa, cfg);
     for (size_t i = 0; i < r.unconstrained.size(); ++i)
       unconstrained[i] = r.unconstrained[i];
     if (values != nullptr)
       for (size_t i = 0; i < r.values.size(); ++i) values[i] = r.values[i];
     if (lp != nullptr) *lp = r.lp;
     if (r.return_code != 0)
-      put_err(err, err_len,
-              r.message.empty() ? "L-BFGS did not converge" : r.message.c_str());
+      put_err(
+          err, err_len,
+          r.message.empty() ? "L-BFGS did not converge" : r.message.c_str());
     return r.return_code;
   } catch (const std::exception& e) {
     put_err(err, err_len, e.what());

--- a/runtime/src/data.cpp
+++ b/runtime/src/data.cpp
@@ -52,8 +52,7 @@ static DataMap::Entry entry_from_json(const std::string& name, const json& v) {
           e.is_int = true;
           e.i.resize(R * C);
           for (int64_t i = 0; i < R; ++i)
-            for (int64_t j = 0; j < C; ++j)
-              e.i[j * R + i] = v[i][j].get<int>();
+            for (int64_t j = 0; j < C; ++j) e.i[j * R + i] = v[i][j].get<int>();
         }
         return e;
       }
@@ -70,11 +69,10 @@ static DataMap::Entry entry_from_json(const std::string& name, const json& v) {
         bool all_int = true;
         std::vector<int64_t> ix(D.size(), 0);
         std::function<void(const json&, size_t)> walk = [&](const json& node,
-                                                           size_t depth) {
+                                                            size_t depth) {
           if (depth == D.size()) {
             int64_t flatpos = 0;
-            for (size_t d = 0; d < D.size(); ++d)
-              flatpos += ix[d] * stride[d];
+            for (size_t d = 0; d < D.size(); ++d) flatpos += ix[d] * stride[d];
             e.r[flatpos] = node.get<double>();
             if (!node.is_number_integer()) all_int = false;
             return;

--- a/runtime/src/diagnose.cpp
+++ b/runtime/src/diagnose.cpp
@@ -75,10 +75,9 @@ std::vector<ParamSummary> summarize(const DrawSet& d,
 
     s.mean = flat.mean();
     // Sample sd (n-1), matching stansummary.
-    s.sd = n_total > 1
-               ? std::sqrt((flat.array() - s.mean).square().sum() /
-                           (double)(n_total - 1))
-               : 0.0;
+    s.sd = n_total > 1 ? std::sqrt((flat.array() - s.mean).square().sum() /
+                                   (double)(n_total - 1))
+                       : 0.0;
     s.q5 = stan::math::quantile(flat, 0.05);
     s.q50 = stan::math::quantile(flat, 0.50);
     s.q95 = stan::math::quantile(flat, 0.95);
@@ -270,7 +269,8 @@ std::string format_diagnostics(const FitDiagnostics& d) {
                     d.max_rhat, d.max_rhat_param.c_str(), kRhatThreshold);
       line(buf);
     } else {
-      std::snprintf(buf, sizeof buf, "R-hat is below %.2f for every "
+      std::snprintf(buf, sizeof buf,
+                    "R-hat is below %.2f for every "
                     "parameter (worst %.3f, %s).",
                     kRhatThreshold, d.max_rhat, d.max_rhat_param.c_str());
       line(buf);
@@ -321,9 +321,9 @@ std::string format_diagnostics(const FitDiagnostics& d) {
   if (problems == 0)
     line("No problems detected.");
   else
-    line(problems == 1 ? "1 diagnostic check failed."
-                       : std::to_string(problems) +
-                             " diagnostic checks failed.");
+    line(problems == 1
+             ? "1 diagnostic check failed."
+             : std::to_string(problems) + " diagnostic checks failed.");
   return out;
 }
 

--- a/runtime/src/executor.cpp
+++ b/runtime/src/executor.cpp
@@ -192,8 +192,7 @@ KernelCtx Executor::make_ctx_(const Op& op, const std::vector<char>& written) {
     const int si = op.in[i];
     const Slot& s = graph_.slots[si];
     const bool active = s.is_param || written[si];
-    ctx.in_adj[i] =
-        Desc{active ? adjoints_.data() + s.offset : nullptr, s.len};
+    ctx.in_adj[i] = Desc{active ? adjoints_.data() + s.offset : nullptr, s.len};
   }
   if (so.len == 1) ctx.out_adj = adjoints_[so.offset];
   ctx.out_adj_vec = Desc{adjoints_.data() + so.offset, so.len};
@@ -220,8 +219,8 @@ std::string Executor::profile_report() const {
   });
   char line[160];
   std::string out;
-  std::snprintf(line, sizeof line, "%-22s %10s %12s %12s %6s %12s\n",
-                "opcode", "calls", "fwd ns", "bwd ns", "%", "elems");
+  std::snprintf(line, sizeof line, "%-22s %10s %12s %12s %6s %12s\n", "opcode",
+                "calls", "fwd ns", "bwd ns", "%", "elems");
   out += line;
   for (uint16_t op : order) {
     const ProfEntry& e = prof_[op];
@@ -251,8 +250,8 @@ void Executor::run_forward_only() {
       const auto t1 = std::chrono::steady_clock::now();
       ProfEntry& e = prof_[op];
       ++e.calls;
-      e.fwd_ns += std::chrono::duration_cast<std::chrono::nanoseconds>(
-                      t1 - t0).count();
+      e.fwd_ns +=
+          std::chrono::duration_cast<std::chrono::nanoseconds>(t1 - t0).count();
       e.elems += ctx_[i].out.len;
     }
     return;
@@ -304,7 +303,8 @@ double Executor::gradient(double* grad_out) {
       k.backward(ctx);
       prof_[graph_.ops[pi].opcode].bwd_ns +=
           std::chrono::duration_cast<std::chrono::nanoseconds>(
-              std::chrono::steady_clock::now() - t0).count();
+              std::chrono::steady_clock::now() - t0)
+              .count();
     }
     std::memcpy(grad_out, adjoints_.data(), sizeof(double) * n_params_);
     return v;

--- a/runtime/src/inplace.cpp
+++ b/runtime/src/inplace.cpp
@@ -139,7 +139,11 @@ int forward_stores_to_loads(Graph& g, const std::vector<int>& roots) {
   if (g.result_slot >= 0) root_set.insert(g.result_slot);
 
   // Most recent write to each vector, as (op index, element, value slot).
-  struct Store { size_t op; int elem; int value; };
+  struct Store {
+    size_t op;
+    int elem;
+    int value;
+  };
   std::unordered_map<int, Store> last_store;
   std::unordered_map<int, int> rename;  // load output -> stored value slot
   const auto resolve = [&](int s) {

--- a/runtime/src/island.cpp
+++ b/runtime/src/island.cpp
@@ -51,23 +51,26 @@ bool scalar_ins(const Graph& g, const Op& op) {
 // instruction each compiles to. File-local on purpose: the MIR front
 // end's unary chain (mir_prog.hpp) is a different set -- it has INV and
 // FABS and lacks LOG1M and TANH -- so there is nothing to share.
-#define STANLI_ISLAND_UNARY_LIST(X)                                        \
-  X(OP_NEG, NEG)                                                           \
-  X(OP_EXPV, EXP)                                                          \
-  X(OP_LOGV, LOG)                                                          \
-  X(OP_SQRT, SQRT)                                                         \
-  X(OP_SQUARE, SQUARE)                                                     \
-  X(OP_INV_LOGIT, INV_LOGIT)                                               \
-  X(OP_LOG1M, LOG1M)                                                       \
+#define STANLI_ISLAND_UNARY_LIST(X) \
+  X(OP_NEG, NEG)                    \
+  X(OP_EXPV, EXP)                   \
+  X(OP_LOGV, LOG)                   \
+  X(OP_SQRT, SQRT)                  \
+  X(OP_SQUARE, SQUARE)              \
+  X(OP_INV_LOGIT, INV_LOGIT)        \
+  X(OP_LOG1M, LOG1M)                \
   X(OP_TANHV, TANH)
 
 // Unary opcode -> island instruction, or -1.
 int unary_code(uint16_t oc) {
   switch (oc) {
-#define X(opc, code) case opc: return Program::code;
+#define X(opc, code) \
+  case opc:          \
+    return Program::code;
     STANLI_ISLAND_UNARY_LIST(X)
 #undef X
-    default: return -1;
+    default:
+      return -1;
   }
 }
 
@@ -76,10 +79,13 @@ int unary_code(uint16_t oc) {
 // spells its opcode OP_<code>_LPDF.
 int density_code(uint16_t oc) {
   switch (oc) {
-#define X(code, name, arity) case OP_##code##_LPDF: return Program::code;
+#define X(code, name, arity) \
+  case OP_##code##_LPDF:     \
+    return Program::code;
     STANLI_PROGRAM_DENSITY_LIST(X)
 #undef X
-    default: return -1;
+    default:
+      return -1;
   }
 }
 
@@ -104,8 +110,7 @@ bool in_vocab(const Graph& g, const Op& op) {
     case OP_SET_SLICE:
       return op.n_idata == 1;
     case OP_DOT:
-      return op.n_in == 2 &&
-             g.slots[op.in[0]].len == g.slots[op.in[1]].len;
+      return op.n_in == 2 && g.slots[op.in[0]].len == g.slots[op.in[1]].len;
     case OP_LOG_SUM_EXP:
     case OP_SOFTMAX:
       return op.n_in == 1;
@@ -221,8 +226,7 @@ struct Compiler {
                           OP_DIV == OP_ADD + 3,
                       "binary code order");
         const int a = read_reg(op.in[0]), b = read_reg(op.in[1]);
-        const auto c = (Program::Code)(Program::ADD +
-                                          (op.opcode - OP_ADD));
+        const auto c = (Program::Code)(Program::ADD + (op.opcode - OP_ADD));
         emit(c, write_reg(op.out), a, b);
         return ok;
       }
@@ -239,23 +243,23 @@ struct Compiler {
         return ok;
       }
 #define X(opc, code) case opc:
-      STANLI_ISLAND_UNARY_LIST(X)
+        STANLI_ISLAND_UNARY_LIST(X)
 #undef X
-      {
-        const Program::Code c = (Program::Code)unary_code(op.opcode);
-        const int a = read_reg(op.in[0]);
-        const int d = write_reg(op.out);
-        if (out_len == 1) {
-          emit(c, d, a);
-        } else if (c == Program::LOG) {
-          emit(Program::LOG_RANGE, d, a, 0, 0, (int)out_len);
-        } else if (c == Program::EXP) {
-          emit(Program::EXP_RANGE, d, a, 0, 0, (int)out_len);
-        } else {
-          return false;  // vector unary outside the range vocabulary
+        {
+          const Program::Code c = (Program::Code)unary_code(op.opcode);
+          const int a = read_reg(op.in[0]);
+          const int d = write_reg(op.out);
+          if (out_len == 1) {
+            emit(c, d, a);
+          } else if (c == Program::LOG) {
+            emit(Program::LOG_RANGE, d, a, 0, 0, (int)out_len);
+          } else if (c == Program::EXP) {
+            emit(Program::EXP_RANGE, d, a, 0, 0, (int)out_len);
+          } else {
+            return false;  // vector unary outside the range vocabulary
+          }
+          return ok;
         }
-        return ok;
-      }
       case OP_INDEX: {
         const int idx = op.idata[0];
         if (idx < 0 || idx >= g.slots[op.in[0]].len) return false;
@@ -265,11 +269,9 @@ struct Compiler {
       }
       case OP_SLICE: {
         const int start = op.idata[0];
-        if (start < 0 || start + out_len > g.slots[op.in[0]].len)
-          return false;
+        if (start < 0 || start + out_len > g.slots[op.in[0]].len) return false;
         const int a = read_reg(op.in[0]);
-        emit(Program::MOVR, write_reg(op.out), a + start, 0, 0,
-             (int)out_len);
+        emit(Program::MOVR, write_reg(op.out), a + start, 0, 0, (int)out_len);
         return ok;
       }
       case OP_SET_INDEX:
@@ -288,8 +290,7 @@ struct Compiler {
       case OP_SET_SLICE: {
         const int start = op.idata[0];
         const int64_t vlen = g.slots[op.in[1]].len;
-        if (op.n_in != 2 || start < 0 || start + vlen > out_len)
-          return false;
+        if (op.n_in != 2 || start < 0 || start + vlen > out_len) return false;
         const int base = read_reg(op.in[0]);
         const int val = read_reg(op.in[1]);
         if (base_dead_here(op.in[0])) reg_of[op.out] = base;
@@ -411,8 +412,8 @@ int carve_islands(Graph& g,
         graph_elems += g.ops[u].opcode == OP_SET_INDEX_INPLACE
                            ? 1
                            : g.slots[g.ops[u].out].len;
-      const int64_t island_elems = kVarWeight * (int64_t)cc.prog.n_regs +
-                                   (int64_t)cc.prog.code.size();
+      const int64_t island_elems =
+          kVarWeight * (int64_t)cc.prog.n_regs + (int64_t)cc.prog.code.size();
       if (std::getenv("STANLI_DEBUG_ISLAND"))
         std::fprintf(stderr, "island? ops=%zu graph=%lld island=%lld\n", j - i,
                      (long long)graph_elems, (long long)island_elems);
@@ -492,10 +493,9 @@ int carve_islands(Graph& g,
         }
         if (std::getenv("STANLI_DEBUG_ISLAND")) {
           const IslandProg& p = *static_cast<const IslandProg*>(is.udata);
-          std::fprintf(stderr,
-                       "island: ops=%zu instr=%zu regs=%d ins=%zu outs=%zu\n",
-                       j - i, p.code.size(), p.n_regs, p.ins.size(),
-                       p.out_regs.size());
+          std::fprintf(
+              stderr, "island: ops=%zu instr=%zu regs=%d ins=%zu outs=%zu\n",
+              j - i, p.code.size(), p.n_regs, p.ins.size(), p.out_regs.size());
         }
         ++carved;
         i = j;

--- a/runtime/src/lower.cpp
+++ b/runtime/src/lower.cpp
@@ -11,7 +11,6 @@
 #include <stanli/sexp.hpp>
 #include <stanli/wa_interp.hpp>
 
-
 #include <cstdio>
 #include <cstdlib>
 #include <functional>
@@ -36,24 +35,24 @@ struct Lowering {
   // data-only conditions, size expressions. Its environment doubles as the
   // lowering's view of transformed data. Hooks route FnReadData to the
   // DataMap and unknown variables to the unrolled-loop int environment.
-  MirInterp<double> td{fun_defs, "prepare_data",
-      MirHooks{
-          [this](const std::string& n) -> const DataMap::Entry* {
-            return data.has(n) ? &data.at(n) : nullptr;
-          },
-          [this](const std::string& n, long* out) {
-            auto it = int_env.find(n);
-            if (it == int_env.end()) return false;
-            *out = it->second;
-            return true;
-          }}};
+  MirInterp<double> td{
+      fun_defs, "prepare_data",
+      MirHooks{[this](const std::string& n) -> const DataMap::Entry* {
+                 return data.has(n) ? &data.at(n) : nullptr;
+               },
+               [this](const std::string& n, long* out) {
+                 auto it = int_env.find(n);
+                 if (it == int_env.end()) return false;
+                 *out = it->second;
+                 return true;
+               }}};
   Graph g;
   CompiledModel out;
-  std::map<std::string, int> scope;            // var -> slot
-  std::map<std::string, long> int_env;         // data int scalars
+  std::map<std::string, int> scope;     // var -> slot
+  std::map<std::string, long> int_env;  // data int scalars
   std::map<double, int> const_cache;
   std::map<int, std::vector<double>> slot_values;  // constant/data fills
-  std::vector<SlotInfo> info;                  // parallel to g.slots
+  std::vector<SlotInfo> info;                      // parallel to g.slots
   std::vector<int> target_terms;
   std::vector<int> jac_slots;
   std::map<std::string, const mir::FunDef*> fun_defs;
@@ -127,9 +126,12 @@ struct Lowering {
         fail("unsupported int index expression", e.raw);
       }
       case mir::Expr::FunApp:
-        if (e.name == "Plus__") return eval_int(e.args[0]) + eval_int(e.args[1]);
-        if (e.name == "Minus__") return eval_int(e.args[0]) - eval_int(e.args[1]);
-        if (e.name == "Times__") return eval_int(e.args[0]) * eval_int(e.args[1]);
+        if (e.name == "Plus__")
+          return eval_int(e.args[0]) + eval_int(e.args[1]);
+        if (e.name == "Minus__")
+          return eval_int(e.args[0]) - eval_int(e.args[1]);
+        if (e.name == "Times__")
+          return eval_int(e.args[0]) * eval_int(e.args[1]);
         // Anything data-only the td interpreter can evaluate (sum of an
         // int array in a size expression, etc.).
         if (e.data_only) {
@@ -154,8 +156,7 @@ struct Lowering {
           DataMap::Entry* en = td.find(e.args[0].name);
           if (en) {
             if (e.name == "rows")
-              return en->dims.size() == 2 ? en->dims[0]
-                                          : (long)en->r.size();
+              return en->dims.size() == 2 ? en->dims[0] : (long)en->r.size();
             if (e.name == "cols") return en->dims.size() == 2 ? en->dims[1] : 1;
             return (long)std::max(en->r.size(), en->i.size());
           }
@@ -206,8 +207,7 @@ struct Lowering {
     }
     for (const auto& st : p.prepare_data) td.exec(st);
     for (auto& [name, e] : td.env()) {
-      if (e.is_int && e.i.size() == 1 && e.dims.empty())
-        int_env[name] = e.i[0];
+      if (e.is_int && e.i.size() == 1 && e.dims.empty()) int_env[name] = e.i[0];
     }
     int_env_data = int_env;
   }
@@ -231,8 +231,7 @@ struct Lowering {
     // kernels that take one read element n from n*K, which is where the
     // repack below puts it, and which is where a parameter of the same
     // type already sits.
-    const bool aoc = array_of_container.count(name) > 0 &&
-                     en->dims.size() == 2;
+    const bool aoc = array_of_container.count(name) > 0 && en->dims.size() == 2;
     if (en->dims.size() == 2 && !aoc) {
       si.rows = en->dims[0];
       si.cols = en->dims[1];
@@ -280,8 +279,7 @@ struct Lowering {
         const std::vector<int64_t>* bdims = nullptr;
         if (e.args[0].kind == mir::Expr::Var) {
           auto dd = decl_dims.find(e.args[0].name);
-          if (dd != decl_dims.end() && !dd->second.empty())
-            bdims = &dd->second;
+          if (dd != decl_dims.end() && !dd->second.empty()) bdims = &dd->second;
         }
         const size_t n_idx = e.args.size() - 1;
         // Between subrange read on a 1-D value: v[a:b] is contiguous.
@@ -298,8 +296,7 @@ struct Lowering {
           std::vector<int> idata;
           idata.reserve(iv.i.size());
           for (int x : iv.i) idata.push_back(x - 1);
-          return emit(OP_GATHER, {base.slot}, (int64_t)idata.size(), {},
-                      idata);
+          return emit(OP_GATHER, {base.slot}, (int64_t)idata.size(), {}, idata);
         }
         // Matrix row/column slices (col-major storage; rows>0 marks a
         // matrix slot).
@@ -348,8 +345,7 @@ struct Lowering {
             for (size_t d2 = d + 1; d2 < n_idx; ++d2) stride *= D[d2];
             off += (eval_int(e.args[1 + d].args[0]) - 1) * stride;
           }
-          if (inner == 1)
-            return emit(OP_INDEX, {base.slot}, 1, {}, {(int)off});
+          if (inner == 1) return emit(OP_INDEX, {base.slot}, 1, {}, {(int)off});
           return emit(OP_SLICE, {base.slot}, inner, {}, {(int)off});
         }
         // Row of a column-major data matrix / 2-D array: strided slice.
@@ -371,13 +367,13 @@ struct Lowering {
           flat = (eval_int(e.args[2].args[0]) - 1) * base.si.rows +
                  (eval_int(e.args[1].args[0]) - 1);
         } else {
-          std::string desc = "unsupported index expression: base=" +
-                             (e.args[0].kind == mir::Expr::Var
-                                  ? e.args[0].name
-                                  : std::string("<expr>"));
+          std::string desc =
+              "unsupported index expression: base=" +
+              (e.args[0].kind == mir::Expr::Var ? e.args[0].name
+                                                : std::string("<expr>"));
           for (size_t k = 1; k < e.args.size(); ++k)
-            desc += " [" +
-                    (e.args[k].name.empty() ? "?" : e.args[k].name) + "]";
+            desc +=
+                " [" + (e.args[k].name.empty() ? "?" : e.args[k].name) + "]";
           desc += " type=" + e.type_;
           fail(desc, e.raw);
         }
@@ -409,7 +405,6 @@ struct Lowering {
       }
     }
   }
-
 
   // ---- necessity islands ---------------------------------------------------
   // A region whose control flow depends on a parameter has no op-graph
@@ -466,8 +461,10 @@ struct Lowering {
       // An op takes at most six inputs (graph.hpp), and each outside
       // value the region reads is one of them.
       if ((int)reg->in_slots.size() >= 6)
-        c.bail("a parameter-dependent region may read at most 6 values "
-               "from outside it; " + name + " is one too many");
+        c.bail(
+            "a parameter-dependent region may read at most 6 values "
+            "from outside it; " +
+            name + " is one too many");
       r->reg = c.alloc((int)len);
       r->len = (int)len;
       prog->ins.push_back(IslandProg::LiveIn{r->reg, (int)len});
@@ -570,7 +567,8 @@ struct Lowering {
       auto dl = decl_lens.find(name);
       if (dl == decl_lens.end())
         fail("parameter-dependent region assigns " + name +
-             ", which has no declared shape", s.raw);
+                 ", which has no declared shape",
+             s.raw);
       out_lens.push_back((int)dl->second.len);
     }
     if (reg.has_target) out_lens.push_back(1);
@@ -644,8 +642,7 @@ struct Lowering {
     if (oc.kind == mir::Expr::Var) {
       DataMap::Entry* en = td.find(oc.name);
       if (en && en->is_int && !en->i.empty()) return en->i;
-      if (int_env.count(oc.name))
-        return {static_cast<int>(int_env[oc.name])};
+      if (int_env.count(oc.name)) return {static_cast<int>(int_env[oc.name])};
     }
     if (oc.kind == mir::Expr::LitInt) return {static_cast<int>(oc.lit_i)};
     if (oc.kind == mir::Expr::Indexed) {
@@ -658,8 +655,8 @@ struct Lowering {
       // Compile-time int expression (e.g. sum(y[n]) under an unrolled loop).
       return {static_cast<int>(eval_int(oc))};
     }
-    fail("int argument must be int data (kind=" +
-             std::to_string((int)oc.kind) + " type=" + oc.type_ + ")",
+    fail("int argument must be int data (kind=" + std::to_string((int)oc.kind) +
+             " type=" + oc.type_ + ")",
          oc.raw);
   }
 
@@ -725,8 +722,7 @@ struct Lowering {
     auto it = fun_defs.find(e.name);
     if (it == fun_defs.end()) fail("unknown function " + e.name, e.raw);
     const mir::FunDef& f = *it->second;
-    if (e.args.size() != f.arg_names.size())
-      fail(e.name + ": arity mismatch");
+    if (e.args.size() != f.arg_names.size()) fail(e.name + ": arity mismatch");
     if (++udf_depth > 64) fail("UDF recursion too deep in " + e.name);
     struct Binding {
       bool is_int = false;
@@ -805,8 +801,7 @@ struct Lowering {
     decl_lens = std::move(dl_saved);
     td.env() = std::move(env_saved);
     --udf_depth;
-    if (!returned)
-      fail(e.name + ": no return value on the executed path");
+    if (!returned) fail(e.name + ": no return value on the executed path");
     return ret;
   }
 
@@ -850,9 +845,10 @@ struct Lowering {
     // divergence is a model whose data is outside the density's support:
     // CmdStan's checks throw before the early return, stanli contributes
     // 0. That model rejects every draw anyway.
-    const bool is_density = e.name.size() > 5 &&
-                            (e.name.compare(e.name.size() - 5, 5, "_lpdf") == 0 ||
-                             e.name.compare(e.name.size() - 5, 5, "_lpmf") == 0);
+    const bool is_density =
+        e.name.size() > 5 &&
+        (e.name.compare(e.name.size() - 5, 5, "_lpdf") == 0 ||
+         e.name.compare(e.name.size() - 5, 5, "_lpmf") == 0);
     if (is_density && e.fn_propto) {
       bool all_data = true;
       for (const auto& a : e.args) all_data = all_data && a.data_only;
@@ -882,33 +878,39 @@ struct Lowering {
     // Densities. n_int leading args come from int data (idata); the rest are
     // real slots. Layouts: one int group = raw values; two groups =
     // [len, vals..., len, vals...]; glm = [y..., rows, cols].
-    struct Dens { uint16_t op; int nargs; int n_int; bool glm = false; };
+    struct Dens {
+      uint16_t op;
+      int nargs;
+      int n_int;
+      bool glm = false;
+    };
     static const std::map<std::string, Dens> kDens = {
         {"poisson_log_lpmf", {OP_POISSON_LOG_LPMF, 2, 1}},
         {"bernoulli_logit_lpmf", {OP_BERNOULLI_LOGIT_LPMF, 2, 1}},
-        // Generated from STANLI_SCALAR_DENSITY_LIST (optable.hpp): the same
-        // one line that made the opcode and the kernel makes this entry.
+    // Generated from STANLI_SCALAR_DENSITY_LIST (optable.hpp): the same
+    // one line that made the opcode and the kernel makes this entry.
 #define STANLI_DENSITY_TABLE(code, fn, n, m) {#fn, {code, n, 0}},
         STANLI_SCALAR_DENSITY_LIST(STANLI_DENSITY_TABLE)
 #undef STANLI_DENSITY_TABLE
-        // Discrete densities: outcome + n real arguments, one int group.
-        // Ordered ones have the same lowering shape -- their cutpoint
-        // vector is an ordinary real slot -- and differ only in that
-        // reroll never fuses them.
-#define STANLI_INT_DENSITY_TABLE(code, fn, nreal, t) {#fn, {code, nreal + 1, 1}},
-        STANLI_INT_DENSITY_LIST(STANLI_INT_DENSITY_TABLE)
+    // Discrete densities: outcome + n real arguments, one int group.
+    // Ordered ones have the same lowering shape -- their cutpoint
+    // vector is an ordinary real slot -- and differ only in that
+    // reroll never fuses them.
+#define STANLI_INT_DENSITY_TABLE(code, fn, nreal, t) \
+  {#fn, {code, nreal + 1, 1}},
+            STANLI_INT_DENSITY_LIST(STANLI_INT_DENSITY_TABLE)
 #undef STANLI_INT_DENSITY_TABLE
-        // cdf/lcdf/lccdf: all-real arguments, no int group, and
-        // fn_propto is never set on them.
+    // cdf/lcdf/lccdf: all-real arguments, no int group, and
+    // fn_propto is never set on them.
 #define STANLI_CDF_TABLE(code, fn, n, t) {#fn, {code, n, 0}},
-        STANLI_SCALAR_CDF_LIST(STANLI_CDF_TABLE)
+                STANLI_SCALAR_CDF_LIST(STANLI_CDF_TABLE)
 #undef STANLI_CDF_TABLE
-        // Integer-outcome cdfs: the count is the one int group.
+    // Integer-outcome cdfs: the count is the one int group.
 #define STANLI_INT_CDF_TABLE(code, fn, nreal, t) {#fn, {code, nreal + 1, 1}},
-        STANLI_INT_CDF_LIST(STANLI_INT_CDF_TABLE)
-        STANLI_ORDERED_DENSITY_LIST(STANLI_INT_CDF_TABLE)
+                    STANLI_INT_CDF_LIST(STANLI_INT_CDF_TABLE)
+                        STANLI_ORDERED_DENSITY_LIST(STANLI_INT_CDF_TABLE)
 #undef STANLI_INT_CDF_TABLE
-        {"bernoulli_lpmf", {OP_BERNOULLI_LPMF, 2, 1}},
+                            {"bernoulli_lpmf", {OP_BERNOULLI_LPMF, 2, 1}},
         {"poisson_lpmf", {OP_POISSON_LPMF, 2, 1}},
         {"neg_binomial_2_lpmf", {OP_NEG_BINOMIAL_2_LPMF, 3, 1}},
         {"binomial_lpmf", {OP_BINOMIAL_LPMF, 3, 2}},
@@ -917,8 +919,7 @@ struct Lowering {
         {"neg_binomial_2_log_glm_lpmf",
          {OP_NEG_BINOMIAL_2_LOG_GLM_LPMF, 5, 1, true}},
         {"beta_binomial_lpmf", {OP_BETA_BINOMIAL_LPMF, 4, 2}},
-        {"bernoulli_logit_glm_lpmf",
-         {OP_BERNOULLI_LOGIT_GLM_LPMF, 4, 1, true}},
+        {"bernoulli_logit_glm_lpmf", {OP_BERNOULLI_LOGIT_GLM_LPMF, 4, 1, true}},
         {"dirichlet_lpdf", {OP_DIRICHLET_LPDF, 2, 0}},
     };
     auto dit = kDens.find(e.name);
@@ -1007,8 +1008,8 @@ struct Lowering {
     }
 
     if ((e.name == "multi_normal_cholesky_lpdf" ||
-         e.name == "multi_normal_lpdf" ||
-         e.name == "multi_normal_prec_lpdf") && e.args.size() == 3) {
+         e.name == "multi_normal_lpdf" || e.name == "multi_normal_prec_lpdf") &&
+        e.args.size() == 3) {
       Val y = lower_expr(e.args[0]);
       Val mu = lower_expr(e.args[1]);
       Val m = lower_expr(e.args[2]);
@@ -1024,15 +1025,13 @@ struct Lowering {
              e.raw);
       const int64_t K = m.si.rows;
       const int64_t reps = g.slots[y.slot].len / K;
-      const uint16_t mn_op =
-          e.name.find("cholesky") != std::string::npos
-              ? OP_MULTI_NORMAL_CHOL_LPDF
-              : (e.name.find("prec") != std::string::npos
-                     ? OP_MULTI_NORMAL_PREC_LPDF
-                     : OP_MULTI_NORMAL_LPDF);
-      Val v = emit(mn_op,
-                   {y.slot, mu.slot, m.slot}, 1, {},
-                   {(int)K, (int)reps});
+      const uint16_t mn_op = e.name.find("cholesky") != std::string::npos
+                                 ? OP_MULTI_NORMAL_CHOL_LPDF
+                                 : (e.name.find("prec") != std::string::npos
+                                        ? OP_MULTI_NORMAL_PREC_LPDF
+                                        : OP_MULTI_NORMAL_LPDF);
+      Val v =
+          emit(mn_op, {y.slot, mu.slot, m.slot}, 1, {}, {(int)K, (int)reps});
       g.ops.back().variant = variant;
       return v;
     }
@@ -1041,9 +1040,9 @@ struct Lowering {
       Val L = lower_expr(e.args[0]);
       Val eta = lower_expr(e.args[1]);
       if (L.si.rows == 0) fail(e.name + " needs a matrix", e.raw);
-      Val v = emit(e.name == "lkj_corr_lpdf" ? OP_LKJ_CORR_LPDF
-                                             : OP_LKJ_CORR_CHOL_LPDF,
-                   {L.slot, eta.slot}, 1, {}, {(int)L.si.rows});
+      Val v = emit(
+          e.name == "lkj_corr_lpdf" ? OP_LKJ_CORR_LPDF : OP_LKJ_CORR_CHOL_LPDF,
+          {L.slot, eta.slot}, 1, {}, {(int)L.si.rows});
       g.ops.back().variant = (uint8_t)((e.fn_propto ? 0x80u : 0u) | 0x1u);
       return v;
     }
@@ -1084,8 +1083,8 @@ struct Lowering {
       idata.insert(idata.end(), NN.begin(), NN.end());
       idata.push_back((int)rows);
       idata.push_back((int)X.si.cols);
-      Val v = emit(OP_BINOMIAL_LOGIT_GLM_LPMF,
-                   {X.slot, alpha.slot, beta.slot}, 1, {}, idata);
+      Val v = emit(OP_BINOMIAL_LOGIT_GLM_LPMF, {X.slot, alpha.slot, beta.slot},
+                   1, {}, idata);
       g.ops.back().variant = (uint8_t)((e.fn_propto ? 0x80u : 0u) | 0x7u);
       return v;
     }
@@ -1119,10 +1118,9 @@ struct Lowering {
       Val w = lower_expr(e.args[2]);
       if (y.si.rows == 0 || S.si.rows == 0)
         fail(e.name + " needs matrix arguments", e.raw);
-      Val v = emit(e.name == "multi_gp_lpdf" ? OP_MULTI_GP_LPDF
-                                             : OP_MULTI_GP_CHOL_LPDF,
-                   {y.slot, S.slot, w.slot}, 1, {},
-                   {(int)y.si.rows, (int)y.si.cols});
+      Val v = emit(
+          e.name == "multi_gp_lpdf" ? OP_MULTI_GP_LPDF : OP_MULTI_GP_CHOL_LPDF,
+          {y.slot, S.slot, w.slot}, 1, {}, {(int)y.si.rows, (int)y.si.cols});
       g.ops.back().variant = (uint8_t)((e.fn_propto ? 0x80u : 0u) | 0x7u);
       return v;
     }
@@ -1139,11 +1137,10 @@ struct Lowering {
       if (S.si.rows == 0) fail(e.name + " needs a matrix argument", e.raw);
       const int64_t K = S.si.rows;
       const int64_t reps = g.slots[y.slot].len / K;
-      Val v = emit(e.name == "multi_student_t_lpdf"
-                       ? OP_MULTI_STUDENT_T_LPDF
-                       : OP_MULTI_STUDENT_T_CHOL_LPDF,
-                   {y.slot, nu.slot, mu.slot, S.slot}, 1, {},
-                   {(int)K, (int)reps});
+      Val v =
+          emit(e.name == "multi_student_t_lpdf" ? OP_MULTI_STUDENT_T_LPDF
+                                                : OP_MULTI_STUDENT_T_CHOL_LPDF,
+               {y.slot, nu.slot, mu.slot, S.slot}, 1, {}, {(int)K, (int)reps});
       g.ops.back().variant = (uint8_t)((e.fn_propto ? 0x80u : 0u) | 0xfu);
       return v;
     }
@@ -1234,9 +1231,9 @@ struct Lowering {
   std::optional<Val> lower_eltwise_fn(const mir::Expr& e) {
     // Elementwise binaries.
     static const std::map<std::string, uint16_t> kBin = {
-        {"Plus__", OP_ADD},      {"Minus__", OP_SUB},
-        {"Divide__", OP_DIV},    {"EltTimes__", OP_MUL},
-        {"EltDivide__", OP_DIV}, {"Pow__", OP_POW}, {"pow", OP_POW},
+        {"Plus__", OP_ADD},     {"Minus__", OP_SUB},     {"Divide__", OP_DIV},
+        {"EltTimes__", OP_MUL}, {"EltDivide__", OP_DIV}, {"Pow__", OP_POW},
+        {"pow", OP_POW},
     };
     if (e.name == "Times__") {
       Val a = lower_expr(e.args[0]);
@@ -1263,9 +1260,9 @@ struct Lowering {
         const int64_t rb = b.si.rows > 0 ? b.si.rows : g.slots[b.slot].len;
         if (rb != a.si.cols)
           fail("Times__: inner dimension mismatch (" +
-                   std::to_string(a.si.rows) + "x" +
-                   std::to_string(a.si.cols) + " times " +
-                   std::to_string(rb) + "x" + std::to_string(cb) + ")",
+                   std::to_string(a.si.rows) + "x" + std::to_string(a.si.cols) +
+                   " times " + std::to_string(rb) + "x" + std::to_string(cb) +
+                   ")",
                e.raw);
         SlotInfo si;
         si.rows = a.si.rows;
@@ -1311,10 +1308,16 @@ struct Lowering {
 #define STANLI_UNARY_TABLE(code, name, v, d) {#name, code},
         STANLI_SCALAR_UNARY_LIST(STANLI_UNARY_TABLE)
 #undef STANLI_UNARY_TABLE
-        {"PMinus__", OP_NEG}, {"exp", OP_EXPV},      {"log", OP_LOGV},
-        {"inv_logit", OP_INV_LOGIT}, {"sqrt", OP_SQRT},
-        {"square", OP_SQUARE}, {"log1m", OP_LOG1M},  {"softmax", OP_SOFTMAX},
-        {"tanh", OP_TANHV},    {"cumulative_sum", OP_CUMSUM},
+            {"PMinus__", OP_NEG},
+        {"exp", OP_EXPV},
+        {"log", OP_LOGV},
+        {"inv_logit", OP_INV_LOGIT},
+        {"sqrt", OP_SQRT},
+        {"square", OP_SQUARE},
+        {"log1m", OP_LOG1M},
+        {"softmax", OP_SOFTMAX},
+        {"tanh", OP_TANHV},
+        {"cumulative_sum", OP_CUMSUM},
         {"log_softmax", OP_LOG_SOFTMAX},
     };
     auto uit = kUn.find(e.name);
@@ -1444,8 +1447,7 @@ struct Lowering {
         auto dd = decl_dims.find(e.args[0].name);
         if (dd != decl_dims.end()) dims = dd->second;
       }
-      if (dims.size() != 2)
-        fail("to_matrix: unknown source shape", e.raw);
+      if (dims.size() != 2) fail("to_matrix: unknown source shape", e.raw);
       // array-major (row-major) source -> col-major matrix of the same
       // logical shape: transpose the storage.
       si.rows = dims[0];
@@ -1504,8 +1506,8 @@ struct Lowering {
       SlotInfo si;
       si.rows = N;
       si.cols = N;
-      return emit(OP_GP_EXP_QUAD_COV, {x.slot, alpha.slot, rho.slot}, N * N,
-                  si, {(int)N, (int)D});
+      return emit(OP_GP_EXP_QUAD_COV, {x.slot, alpha.slot, rho.slot}, N * N, si,
+                  {(int)N, (int)D});
     }
     if (e.name == "diag_matrix" && e.args.size() == 1) {
       Val v = lower_expr(e.args[0]);
@@ -1550,8 +1552,8 @@ struct Lowering {
       SlotInfo si;
       si.rows = n;
       si.cols = n;
-      Val left = emit(OP_GEMM, {d.slot, m.slot}, n * n, si,
-                      {(int)n, (int)n, (int)n});
+      Val left =
+          emit(OP_GEMM, {d.slot, m.slot}, n * n, si, {(int)n, (int)n, (int)n});
       return emit(OP_GEMM, {left.slot, d.slot}, n * n, si,
                   {(int)n, (int)n, (int)n});
     }
@@ -1568,8 +1570,8 @@ struct Lowering {
         const int64_t rb = b.si.rows > 0 ? b.si.rows : lb;
         if (ra != rb) fail("append_col row mismatch", e.raw);
         si.rows = ra;
-        si.cols = (a.si.rows > 0 ? a.si.cols : 1) +
-                  (b.si.rows > 0 ? b.si.cols : 1);
+        si.cols =
+            (a.si.rows > 0 ? a.si.cols : 1) + (b.si.rows > 0 ? b.si.cols : 1);
       } else if (a.si.rows > 0 || b.si.rows > 0) {
         // Stacking rows interleaves columns in col-major storage:
         // concatenate flat, then gather into destination order.
@@ -1606,15 +1608,15 @@ struct Lowering {
       const long i = eval_int(e.args[1]);
       const long j = eval_int(e.args[2]);
       const long n = eval_int(e.args[3]);
-      return emit(OP_SLICE, {a.slot}, n,
-                  {}, {(int)((j - 1) * a.si.rows + i - 1)});
+      return emit(OP_SLICE, {a.slot}, n, {},
+                  {(int)((j - 1) * a.si.rows + i - 1)});
     }
     if (e.name == "col" && e.args.size() == 2) {
       Val a = lower_expr(e.args[0]);
       if (a.si.rows == 0) fail("col on a slot without matrix shape");
       const long j = eval_int(e.args[1]);
-      return emit(OP_SLICE, {a.slot}, a.si.rows,
-                  {}, {(int)((j - 1) * a.si.rows)});
+      return emit(OP_SLICE, {a.slot}, a.si.rows, {},
+                  {(int)((j - 1) * a.si.rows)});
     }
     if (e.name == "row" && e.args.size() == 2) {
       Val a = lower_expr(e.args[0]);
@@ -1674,20 +1676,20 @@ struct Lowering {
   // constants -- so the kernel and the register machine are unchanged;
   // only the packing at this end is new.
   std::optional<Val> lower_ode_variadic(const mir::Expr& e) {
-    static const std::vector<std::pair<const char*, OdeSpec::Solver>>
-        kSolvers = {{"ode_bdf", OdeSpec::BDF},
-                    {"ode_adams", OdeSpec::ADAMS},
-                    {"ode_rk45", OdeSpec::RK45},
-                    {"ode_ckrk", OdeSpec::CKRK}};
+    static const std::vector<std::pair<const char*, OdeSpec::Solver>> kSolvers =
+        {{"ode_bdf", OdeSpec::BDF},
+         {"ode_adams", OdeSpec::ADAMS},
+         {"ode_rk45", OdeSpec::RK45},
+         {"ode_ckrk", OdeSpec::CKRK}};
     std::string base = e.name;
     bool with_tol = false;
     if (base.size() > 4 && base.compare(base.size() - 4, 4, "_tol") == 0) {
       with_tol = true;
       base = base.substr(0, base.size() - 4);
     }
-    const auto sit = std::find_if(
-        kSolvers.begin(), kSolvers.end(),
-        [&](const auto& s) { return base == s.first; });
+    const auto sit =
+        std::find_if(kSolvers.begin(), kSolvers.end(),
+                     [&](const auto& s) { return base == s.first; });
     if (sit == kSolvers.end()) return std::nullopt;
 
     const size_t fixed = with_tol ? 7 : 4;
@@ -1698,8 +1700,8 @@ struct Lowering {
     spec->adopt(fun_defs);
     spec->rhs_name = e.args[0].name;
     spec->solver = sit->second;
-    spec->stiff = spec->solver == OdeSpec::BDF ||
-                  spec->solver == OdeSpec::ADAMS;
+    spec->stiff =
+        spec->solver == OdeSpec::BDF || spec->solver == OdeSpec::ADAMS;
     stamp_ode_defaults(*spec);
     spec->t0 = const_values(e.args[2]).at(0);
     spec->ts = const_values(e.args[3]);
@@ -1817,7 +1819,6 @@ struct Lowering {
     return std::nullopt;
   }
 
-
   // ---- statements -----------------------------------------------------------
   void lower_read_param(const mir::Stmt& s) {
     // Declared (constrained) size from the read dims; the unconstrained raw
@@ -1833,8 +1834,7 @@ struct Lowering {
       n_batch = con_len / inner_con;
     }
     int64_t raw_len = con_len;
-    if (tr.kind == mir::Transform::Simplex)
-      raw_len = n_batch * (inner_con - 1);
+    if (tr.kind == mir::Transform::Simplex) raw_len = n_batch * (inner_con - 1);
     // sum_to_zero_vector[K]: K constrained from K-1 unconstrained, and
     // unlike the simplex it is volume-preserving, so there is no jacobian
     // term at all.
@@ -1858,15 +1858,15 @@ struct Lowering {
       const int64_t K = inner_con;
       n_batch = 1;
       raw_len = tr.kind == mir::Transform::Correlation
-                    ? K * (K - 1) / 2        // k_choose_2
-                    : K + K * (K - 1) / 2;   // K + k_choose_2
+                    ? K * (K - 1) / 2       // k_choose_2
+                    : K + K * (K - 1) / 2;  // K + k_choose_2
       con_len = K * K;
     }
     if (tr.kind == mir::Transform::CholeskyCov) {
       // cholesky_factor_cov[M, N] reads two dims; [K] is the square case.
-      chol_M = eval_int(s.read_dims[s.read_dims.size() >= 2
-                                        ? s.read_dims.size() - 2
-                                        : s.read_dims.size() - 1]);
+      chol_M = eval_int(
+          s.read_dims[s.read_dims.size() >= 2 ? s.read_dims.size() - 2
+                                              : s.read_dims.size() - 1]);
       chol_N = s.read_dims.size() >= 2 ? inner_con : chol_M;
       n_batch = 1;
       raw_len = (chol_N * (chol_N + 1)) / 2 + (chol_M - chol_N) * chol_N;
@@ -1981,11 +1981,9 @@ struct Lowering {
         opcode == OP_CONSTRAIN_SUM_TO_ZERO)
       tr_idata = {(int)n_batch, (int)inner_con};
     if (opcode == OP_CONSTRAIN_CHOL_CORR ||
-        opcode == OP_CONSTRAIN_CORR_MATRIX ||
-        opcode == OP_CONSTRAIN_COV_MATRIX)
+        opcode == OP_CONSTRAIN_CORR_MATRIX || opcode == OP_CONSTRAIN_COV_MATRIX)
       tr_idata = {(int)inner_con};
-    if (opcode == OP_CONSTRAIN_CHOL_COV)
-      tr_idata = {(int)chol_M, (int)chol_N};
+    if (opcode == OP_CONSTRAIN_CHOL_COV) tr_idata = {(int)chol_M, (int)chol_N};
     Val con = emit(opcode, ins, con_len, psi, tr_idata, jac);
     jac_slots.push_back(jac);
     scope[s.decl_id] = con.slot;
@@ -2056,8 +2054,8 @@ struct Lowering {
             si.rows = dl->second.rows;
             si.cols = dl->second.cols;
             prev = add_slot(dl->second.len, false, si);
-            out.fills.emplace_back(
-                prev, std::vector<double>(dl->second.len, 0.0));
+            out.fills.emplace_back(prev,
+                                   std::vector<double>(dl->second.len, 0.0));
           }
           bool all_single = true;
           for (const auto& ix : s.lhs_idx)
@@ -2065,8 +2063,7 @@ struct Lowering {
           auto dd = decl_dims.find(s.lhs);
           const int rhs = lower_expr(s.rhs).slot;
           // Between write w[a:b] = rhs (contiguous on 1-D values).
-          if (s.lhs_idx.size() == 1 &&
-              s.lhs_idx[0].name == "IndexBetween") {
+          if (s.lhs_idx.size() == 1 && s.lhs_idx[0].name == "IndexBetween") {
             const int64_t lo = eval_int(s.lhs_idx[0].args[0]);
             const int64_t hi = eval_int(s.lhs_idx[0].args[1]);
             if (g.slots[rhs].len != hi - lo + 1)
@@ -2087,8 +2084,7 @@ struct Lowering {
           }
           // Row-range column write M[a:b, j] = rhs (contiguous within the
           // column).
-          if (s.lhs_idx.size() == 2 &&
-              s.lhs_idx[0].name == "IndexBetween" &&
+          if (s.lhs_idx.size() == 2 && s.lhs_idx[0].name == "IndexBetween" &&
               s.lhs_idx[1].name == "IndexSingle" && info[prev].rows > 0) {
             const int64_t lo = eval_int(s.lhs_idx[0].args[0]);
             const int64_t hi = eval_int(s.lhs_idx[0].args[1]);
@@ -2096,14 +2092,12 @@ struct Lowering {
             if (g.slots[rhs].len != hi - lo + 1)
               fail("range assignment size mismatch for " + s.lhs);
             Val nv = emit(OP_SET_SLICE, {prev, rhs}, g.slots[prev].len,
-                          info[prev],
-                          {(int)(j * info[prev].rows + lo - 1)});
+                          info[prev], {(int)(j * info[prev].rows + lo - 1)});
             scope[s.lhs] = nv.slot;
             return;
           }
           if (all_single && dd != decl_dims.end() &&
-              s.lhs_idx.size() <= dd->second.size() &&
-              info[prev].rows == 0) {
+              s.lhs_idx.size() <= dd->second.size() && info[prev].rows == 0) {
             // Array-major offset; sub-array writes become SET_SLICE.
             const auto& D = dd->second;
             const size_t n_idx = s.lhs_idx.size();
@@ -2138,8 +2132,8 @@ struct Lowering {
               desc += " [" + (ix.name.empty() ? "?" : ix.name) + "]";
             fail(desc, s.raw);
           }
-          Val nv = emit(OP_SET_INDEX, {prev, rhs}, g.slots[prev].len, info[prev],
-                        {(int)flat});
+          Val nv = emit(OP_SET_INDEX, {prev, rhs}, g.slots[prev].len,
+                        info[prev], {(int)flat});
           scope[s.lhs] = nv.slot;
           return;
         }
@@ -2381,8 +2375,8 @@ CompiledModel compile_model(const std::string& tmir_text, const DataMap& data) {
   // Shared because the interpreted write_array fallback, when needed,
   // keeps the generate_quantities statements and UDF bodies alive for the
   // model's whole life.
-  auto prog = std::make_shared<mir::Program>(
-      mir::read_program(sexp::parse(tmir_text)));
+  auto prog =
+      std::make_shared<mir::Program>(mir::read_program(sexp::parse(tmir_text)));
   Lowering lo(data);
   CompiledModel cm = lo.run(*prog);
   if (!prog->generate_quantities.empty()) {
@@ -2408,8 +2402,8 @@ CompiledModel compile_model(const std::string& tmir_text, const DataMap& data) {
       // per-draw interpreter, seeded with data + transformed data and the
       // emission flags the guard blocks test.
       auto env = lo.td.env();
-      for (const char* flag : {"emit_transformed_parameters__",
-                               "emit_generated_quantities__"}) {
+      for (const char* flag :
+           {"emit_transformed_parameters__", "emit_generated_quantities__"}) {
         DataMap::Entry one;
         one.is_int = true;
         one.i = {1};

--- a/runtime/src/mir_reader.cpp
+++ b/runtime/src/mir_reader.cpp
@@ -180,27 +180,44 @@ SizedType read_sized(const Node& n) {
 Transform read_transform(const Node& n) {
   Transform t;
   if (n.is_atom()) {
-    if (n.atom == "Identity") t.kind = Transform::Identity;
-    else if (n.atom == "Simplex") t.kind = Transform::Simplex;
-    else if (n.atom == "Ordered") t.kind = Transform::Ordered;
-    else if (n.atom == "PositiveOrdered") t.kind = Transform::PositiveOrdered;
-    else if (n.atom == "CholeskyCorr") t.kind = Transform::CholeskyCorr;
-    else if (n.atom == "UnitVector") t.kind = Transform::UnitVector;
-    else if (n.atom == "SumToZero") t.kind = Transform::SumToZero;
-    else if (n.atom == "Correlation") t.kind = Transform::Correlation;
-    else if (n.atom == "Covariance") t.kind = Transform::Covariance;
-    else if (n.atom == "CholeskyCov") t.kind = Transform::CholeskyCov;
-    else t.kind = Transform::Unsupported;
+    if (n.atom == "Identity")
+      t.kind = Transform::Identity;
+    else if (n.atom == "Simplex")
+      t.kind = Transform::Simplex;
+    else if (n.atom == "Ordered")
+      t.kind = Transform::Ordered;
+    else if (n.atom == "PositiveOrdered")
+      t.kind = Transform::PositiveOrdered;
+    else if (n.atom == "CholeskyCorr")
+      t.kind = Transform::CholeskyCorr;
+    else if (n.atom == "UnitVector")
+      t.kind = Transform::UnitVector;
+    else if (n.atom == "SumToZero")
+      t.kind = Transform::SumToZero;
+    else if (n.atom == "Correlation")
+      t.kind = Transform::Correlation;
+    else if (n.atom == "Covariance")
+      t.kind = Transform::Covariance;
+    else if (n.atom == "CholeskyCov")
+      t.kind = Transform::CholeskyCov;
+    else
+      t.kind = Transform::Unsupported;
     t.raw = n.atom;
     return t;
   }
   const std::string& k = n[0].atom;
-  if (k == "Lower") t.kind = Transform::Lower;
-  else if (k == "Upper") t.kind = Transform::Upper;
-  else if (k == "LowerUpper") t.kind = Transform::LowerUpper;
-  else if (k == "Offset") t.kind = Transform::Offset;
-  else if (k == "Multiplier") t.kind = Transform::Multiplier;
-  else if (k == "OffsetMultiplier") t.kind = Transform::OffsetMultiplier;
+  if (k == "Lower")
+    t.kind = Transform::Lower;
+  else if (k == "Upper")
+    t.kind = Transform::Upper;
+  else if (k == "LowerUpper")
+    t.kind = Transform::LowerUpper;
+  else if (k == "Offset")
+    t.kind = Transform::Offset;
+  else if (k == "Multiplier")
+    t.kind = Transform::Multiplier;
+  else if (k == "OffsetMultiplier")
+    t.kind = Transform::OffsetMultiplier;
   else {
     t.kind = Transform::Unsupported;
     t.raw = dump(n);
@@ -224,8 +241,10 @@ Stmt read_stmt(const Node& n) {
   }
   const Node& p = (*pat)[1];
   if (p.is_atom()) {
-    if (p.atom == "Skip") s.kind = Stmt::Skip;
-    else s.raw = p.atom;
+    if (p.atom == "Skip")
+      s.kind = Stmt::Skip;
+    else
+      s.raw = p.atom;
     return s;
   }
   const std::string& head = p[0].atom;
@@ -244,8 +263,10 @@ Stmt read_stmt(const Node& n) {
         // still reach the failure in sized_len, which is where their
         // missing size belongs.
         if (t.size() > 1 && t[1].is_atom()) {
-          if (t[1].atom == "UReal") s.decl_type.base = "SReal";
-          else if (t[1].atom == "UInt") s.decl_type.base = "SInt";
+          if (t[1].atom == "UReal")
+            s.decl_type.base = "SReal";
+          else if (t[1].atom == "UInt")
+            s.decl_type.base = "SInt";
         }
       }
     }

--- a/runtime/src/nuts.cpp
+++ b/runtime/src/nuts.cpp
@@ -19,8 +19,7 @@
 
 namespace stanli {
 
-std::vector<std::vector<double>> run_nuts(Executor& ex,
-                                          const NutsConfig& cfg,
+std::vector<std::vector<double>> run_nuts(Executor& ex, const NutsConfig& cfg,
                                           SamplerStats* stats,
                                           const DrawObserver& observe) {
   // CmdStan's generator, seeded CmdStan's way: same engine (mixmax in this
@@ -40,7 +39,7 @@ std::vector<std::vector<double>> run_nuts(Executor& ex,
   const int64_t n = ex.n_params();
   Eigen::VectorXd q(n);
   boost::random::uniform_real_distribution<double> init_dist(-cfg.init_radius,
-                                                            cfg.init_radius);
+                                                             cfg.init_radius);
 
   // CmdStan draws uniform(-2, 2) on the unconstrained scale and REJECTS the
   // draw unless both the log density and its whole gradient are finite,
@@ -97,13 +96,13 @@ std::vector<std::vector<double>> run_nuts(Executor& ex,
               ? std::string("initialization failed: the supplied "
                             "unconstrained init has no finite log density "
                             "and gradient")
-              : cfg.init_radius == 0.0
-                    ? std::string("initialization failed: the origin has no "
-                                  "finite log density and gradient (init "
-                                  "radius is 0)")
-                    : "initialization failed: no draw in " +
-                          std::to_string(kMaxInitAttempts) +
-                          " attempts had finite log density and gradient");
+          : cfg.init_radius == 0.0
+              ? std::string("initialization failed: the origin has no "
+                            "finite log density and gradient (init "
+                            "radius is 0)")
+              : "initialization failed: no draw in " +
+                    std::to_string(kMaxInitAttempts) +
+                    " attempts had finite log density and gradient");
   }
   if (std::getenv("STANLI_DEBUG_INIT")) {
     std::fprintf(stderr, "init");
@@ -126,7 +125,8 @@ std::vector<std::vector<double>> run_nuts(Executor& ex,
   const int thin = cfg.thin > 0 ? cfg.thin : 1;
   std::vector<std::vector<double>> draws;
   draws.reserve((size_t)((cfg.save_warmup ? cfg.warmup : 0) + cfg.samples) /
-                (size_t)thin + 1);
+                    (size_t)thin +
+                1);
   if (stats) stats->rows.clear();
 
   Eigen::VectorXd qd(n);
@@ -144,12 +144,10 @@ std::vector<std::vector<double>> run_nuts(Executor& ex,
         // divergent__, energy__ in that order (stan::mcmc::base_nuts).
         sp.clear();
         sampler.get_sampler_params(sp);
-        stats->rows.push_back({s.log_prob(), s.accept_stat(),
-                               sp.size() > 0 ? sp[0] : 0.0,
-                               sp.size() > 1 ? sp[1] : 0.0,
-                               sp.size() > 2 ? sp[2] : 0.0,
-                               sp.size() > 3 ? sp[3] : 0.0,
-                               sp.size() > 4 ? sp[4] : 0.0});
+        stats->rows.push_back(
+            {s.log_prob(), s.accept_stat(), sp.size() > 0 ? sp[0] : 0.0,
+             sp.size() > 1 ? sp[1] : 0.0, sp.size() > 2 ? sp[2] : 0.0,
+             sp.size() > 3 ? sp[3] : 0.0, sp.size() > 4 ? sp[4] : 0.0});
       }
     }
     if (observe) observe(i, warmup, qd.data());

--- a/runtime/src/ode_prog.cpp
+++ b/runtime/src/ode_prog.cpp
@@ -14,9 +14,8 @@
 namespace stanli {
 
 RhsProgram compile_rhs_args(
-    const mir::FunDef& f,
-    const std::map<std::string, const mir::FunDef*>& funs, int n_y,
-    const std::vector<RhsArg>& args) {
+    const mir::FunDef& f, const std::map<std::string, const mir::FunDef*>& funs,
+    int n_y, const std::vector<RhsArg>& args) {
   RhsProgram p;
   if (f.arg_names.size() != args.size() + 2) {
     p.why = "right-hand side takes " + std::to_string(f.arg_names.size()) +

--- a/runtime/src/reroll.cpp
+++ b/runtime/src/reroll.cpp
@@ -84,11 +84,11 @@ bool is_idata_outcome_density(uint16_t oc) {
     case OP_POISSON_LOG_LPMF:
     case OP_NEG_BINOMIAL_2_LPMF:
       return true;
-    // Everything in STANLI_INT_DENSITY_LIST has exactly this shape by
-    // construction. The ordered densities deliberately do NOT appear:
-    // their cutpoint vector is shared by every lane, so element n of it
-    // is not lane n's, and the elementwise rewrite would be silently
-    // wrong rather than merely unfused.
+      // Everything in STANLI_INT_DENSITY_LIST has exactly this shape by
+      // construction. The ordered densities deliberately do NOT appear:
+      // their cutpoint vector is shared by every lane, so element n of it
+      // is not lane n's, and the elementwise rewrite would be silently
+      // wrong rather than merely unfused.
 #define STANLI_INT_DENSITY_CASE(code, fn, nreal, t) case code:
       STANLI_INT_DENSITY_LIST(STANLI_INT_DENSITY_CASE)
 #undef STANLI_INT_DENSITY_CASE
@@ -132,27 +132,27 @@ enum class InKind { kInvariant, kConstLanes, kLaneLocal, kBad };
 
 struct PosIn {
   InKind kind = InKind::kBad;
-  int producer_pos = -1;         // LANE_LOCAL: template position of producer
-  std::vector<double> values;    // CONST_LANES: one value per lane
+  int producer_pos = -1;       // LANE_LOCAL: template position of producer
+  std::vector<double> values;  // CONST_LANES: one value per lane
 };
 
 struct Pos {
   std::vector<PosIn> ins;
-  bool index_elision = false;  // OP_INDEX, idata==lane, base len==lanes
-  bool hoist = false;          // all inputs + idata invariant: emit once
-  bool term_density = false;   // density, every lane's out a target term
-  bool elt_density = false;    // density, every lane's out consumed only
-                               //   inside its own lane -> variant bit 6,
-                               //   out[n] = lane n's lp
-  bool term_widen = false;     // widenable, every lane's out a target term
-                               //   -> widen + OP_SUM_VEC, swap the terms
-  int slice_start = -1;        // OP_INDEX over a contiguous window
-  std::vector<int> gather_idx; // OP_INDEX with a data-driven index
-  int store_vec = -1;          // element write filling a window of this
-  int store_start = 0;         //   vector, starting here,
-  int store_stride = 1;        //   advancing by this much per lane
+  bool index_elision = false;   // OP_INDEX, idata==lane, base len==lanes
+  bool hoist = false;           // all inputs + idata invariant: emit once
+  bool term_density = false;    // density, every lane's out a target term
+  bool elt_density = false;     // density, every lane's out consumed only
+                                //   inside its own lane -> variant bit 6,
+                                //   out[n] = lane n's lp
+  bool term_widen = false;      // widenable, every lane's out a target term
+                                //   -> widen + OP_SUM_VEC, swap the terms
+  int slice_start = -1;         // OP_INDEX over a contiguous window
+  std::vector<int> gather_idx;  // OP_INDEX with a data-driven index
+  int store_vec = -1;           // element write filling a window of this
+  int store_start = 0;          //   vector, starting here,
+  int store_stride = 1;         //   advancing by this much per lane
   bool store_written_after = false;  // someone writes the vector later
-  std::vector<int> outcome_idata;  // lpmf: per-lane integer outcomes
+  std::vector<int> outcome_idata;    // lpmf: per-lane integer outcomes
 };
 
 bool is_element_store(const Op& op) {
@@ -239,8 +239,10 @@ RerollStats reroll(Graph& g,
     while (lo < hi) {
       const size_t mid = lo + (hi - lo) / 2;
       ++st.list_steps;
-      if (v[mid] < x) lo = mid + 1;
-      else hi = mid;
+      if (v[mid] < x)
+        lo = mid + 1;
+      else
+        hi = mid;
     }
     return v.begin() + (ptrdiff_t)lo;
   };
@@ -248,8 +250,7 @@ RerollStats reroll(Graph& g,
   // the region's own ops, which are allowed to touch the slot.
   const auto any_in_range_but = [&](const std::vector<size_t>& v, size_t lo,
                                     size_t hi, auto&& ours) {
-    for (auto it = first_at_or_after(v, lo); it != v.end() && *it < hi;
-         ++it) {
+    for (auto it = first_at_or_after(v, lo); it != v.end() && *it < hi; ++it) {
       ++st.list_steps;
       if (!ours(*it)) return true;
     }
@@ -299,8 +300,7 @@ RerollStats reroll(Graph& g,
   size_t i = 0;
   while (i < g.ops.size()) {
     bool rewrote = false;
-    for (int P = 1; P <= kMaxPeriod && i + 2 * (size_t)P <= g.ops.size();
-         ++P) {
+    for (int P = 1; P <= kMaxPeriod && i + 2 * (size_t)P <= g.ops.size(); ++P) {
       if (i < retry_at[(size_t)P]) continue;
       // Cheap pre-check before any lane counting: a profitable region must
       // contain an allowlisted density (term or elementwise), a per-lane
@@ -311,8 +311,7 @@ RerollStats reroll(Graph& g,
       for (int p = 0; p < P && !candidate; ++p) {
         const Op& t = g.ops[i + p];
         candidate = is_density(t.opcode) ||
-                    is_idata_outcome_density(t.opcode) ||
-                    is_element_store(t) ||
+                    is_idata_outcome_density(t.opcode) || is_element_store(t) ||
                     (is_widenable(t.opcode) && term_set.count(t.out) != 0);
       }
       if (!candidate) continue;
@@ -336,8 +335,8 @@ RerollStats reroll(Graph& g,
       std::vector<Pos> pos;
       int64_t Luse = L;
       bool classified = false;
-      for (int attempt = 0;
-           attempt < kMaxClassifyAttempts && Luse >= kMinLanes; ++attempt) {
+      for (int attempt = 0; attempt < kMaxClassifyAttempts && Luse >= kMinLanes;
+           ++attempt) {
         int64_t prefix = Luse;
         pos.assign((size_t)P, Pos{});
         std::unordered_map<int, int> lane0_producer;
@@ -398,16 +397,15 @@ RerollStats reroll(Graph& g,
               continue;
             }
             ok = false;
-            prefix =
-                std::min(prefix, std::max({br_inv, br_local, br_const}));
+            prefix = std::min(prefix, std::max({br_inv, br_local, br_const}));
           }
 
           // Output discipline prefixes. A lane's out may be consumed only
           // by later ops of its own lane instance; density outs may
           // instead be target terms (with no op consumers at all).
-          int64_t br_term = Luse;     // lanes whose out IS a term
-          int64_t br_nonterm = Luse;  // lanes whose out is NOT a term
-          int64_t br_internal = Luse; // lanes whose out does not escape
+          int64_t br_term = Luse;      // lanes whose out IS a term
+          int64_t br_nonterm = Luse;   // lanes whose out is NOT a term
+          int64_t br_internal = Luse;  // lanes whose out does not escape
           for (int64_t l = 0; l < Luse; ++l) {
             const int o = op_at(p, l).out;
             const bool is_term = term_set.count(o) != 0;
@@ -629,8 +627,8 @@ RerollStats reroll(Graph& g,
           classified = true;
           break;
         }
-        if (ok) prefix = 0;  // classifiable but useless
-        if (prefix >= Luse) prefix = Luse - 1;    // guarantee progress
+        if (ok) prefix = 0;                     // classifiable but useless
+        if (prefix >= Luse) prefix = Luse - 1;  // guarantee progress
         Luse = prefix;
       }
 

--- a/runtime/src/wa_interp.cpp
+++ b/runtime/src/wa_interp.cpp
@@ -38,13 +38,14 @@ std::vector<double> WaInterp::eval(
   return row;
 }
 
-bool WaInterp::read_param(
-    MirInterp<double>& in, const mir::Stmt& s,
-    const std::map<std::string, DataMap::Entry>& params) {
+bool WaInterp::read_param(MirInterp<double>& in, const mir::Stmt& s,
+                          const std::map<std::string, DataMap::Entry>& params) {
   auto it = params.find(s.decl_id);
   if (it == params.end())
-    throw CompileError("stanli write_array: no constrained value supplied "
-                       "for parameter " + s.decl_id);
+    throw CompileError(
+        "stanli write_array: no constrained value supplied "
+        "for parameter " +
+        s.decl_id);
   DataMap::Entry e = it->second;
   if (!s.read_dims.empty()) {
     std::vector<int64_t> dims;
@@ -211,8 +212,7 @@ bool WaInterp::rng_fun(MirInterp<double>& in, const mir::Expr& e,
     for (int64_t i = 0; i < K; ++i) m[i] = mu.r[(size_t)i];
     Eigen::MatrixXd sig(K, K);
     for (int64_t j = 0; j < K; ++j)
-      for (int64_t i = 0; i < K; ++i)
-        sig(i, j) = S.r.at((size_t)(j * K + i));
+      for (int64_t i = 0; i < K; ++i) sig(i, j) = S.r.at((size_t)(j * K + i));
     const Eigen::VectorXd draw =
         base == "multi_normal"
             ? stan::math::multi_normal_rng(m, sig, rng_)

--- a/tests/graph_helpers.hpp
+++ b/tests/graph_helpers.hpp
@@ -26,8 +26,7 @@ inline std::vector<double> run_grad(Graph g, const Fills& fills,
     double* p = ex.value_ptr(f.first);
     for (size_t j = 0; j < f.second.size(); ++j) p[j] = f.second[j];
   }
-  for (int64_t i = 0; i < ex.n_params(); ++i)
-    ex.params_data()[i] = fill_at(i);
+  for (int64_t i = 0; i < ex.n_params(); ++i) ex.params_data()[i] = fill_at(i);
   std::vector<double> out(1 + (size_t)ex.n_params());
   out[0] = ex.gradient(out.data() + 1);
   return out;

--- a/tests/models.hpp
+++ b/tests/models.hpp
@@ -20,9 +20,9 @@ namespace testmodels {
 //      + normal(mu | 0, 5) + cauchy(tau | 0, 5) + log_tau   (jacobian)
 struct EightSchools {
   Graph graph;
-  int mu, log_tau, theta_tilde;   // parameter slots
-  int y, sigma;                   // data slots
-  int zero, one, five;            // constant slots
+  int mu, log_tau, theta_tilde;  // parameter slots
+  int y, sigma;                  // data slots
+  int zero, one, five;           // constant slots
   static constexpr int J = 8;
   static constexpr double kY[J] = {28, 8, -3, 7, -1, 1, 18, 12};
   static constexpr double kSigma[J] = {15, 10, 16, 11, 9, 11, 10, 18};
@@ -77,7 +77,7 @@ struct LogisticGlm {
   Graph graph;
   int alpha, beta;
   int X;
-  int zero, p25, five, one;       // constant slots
+  int zero, p25, five, one;  // constant slots
   static constexpr int N = 20, K = 3;
   // Deterministic fixed data, column-major (Stan/Eigen convention).
   static const double kX[N * K];
@@ -85,12 +85,12 @@ struct LogisticGlm {
 };
 
 inline const double LogisticGlm::kX[LogisticGlm::N * LogisticGlm::K] = {
-    0.17, -1.30, 0.55,  1.02,  -0.21, -0.88, 0.34,  0.91,  -1.44, 0.62,
-    -0.53, 1.21, -0.09, 0.75,  -0.66, 1.35,  -1.02, 0.28,  0.44,  -0.37,
-    0.83, -1.19, 0.06,  0.97,  -0.74, 0.51,  1.28,  -0.42, -0.15, 0.68,
-    -0.95, 0.23, 1.07,  -0.58, 0.39,  -1.26, 0.71,  0.12,  -0.81, 1.14,
-    -0.33, 0.86, 0.49,  -1.08, 0.25,  0.93,  -0.61, 0.18,  1.31,  -0.47,
-    0.04, 0.78, -1.15,  0.36,  0.59,  -0.92, 1.24,  -0.28, 0.65,  -0.11};
+    0.17,  -1.30, 0.55,  1.02,  -0.21, -0.88, 0.34,  0.91,  -1.44, 0.62,
+    -0.53, 1.21,  -0.09, 0.75,  -0.66, 1.35,  -1.02, 0.28,  0.44,  -0.37,
+    0.83,  -1.19, 0.06,  0.97,  -0.74, 0.51,  1.28,  -0.42, -0.15, 0.68,
+    -0.95, 0.23,  1.07,  -0.58, 0.39,  -1.26, 0.71,  0.12,  -0.81, 1.14,
+    -0.33, 0.86,  0.49,  -1.08, 0.25,  0.93,  -0.61, 0.18,  1.31,  -0.47,
+    0.04,  0.78,  -1.15, 0.36,  0.59,  -0.92, 1.24,  -0.28, 0.65,  -0.11};
 inline const int LogisticGlm::kYint[LogisticGlm::N] = {
     1, 0, 1, 1, 0, 1, 0, 1, 0, 1, 0, 1, 1, 0, 0, 1, 0, 1, 1, 0};
 
@@ -111,8 +111,7 @@ inline LogisticGlm logistic_glm() {
   const int lp3 = g.add_slot(1, false);
   const int lp = g.add_slot(1, false);
 
-  g.add_op(OP_MATVEC, {m.X, m.beta}, eta0,
-           {LogisticGlm::N, LogisticGlm::K});
+  g.add_op(OP_MATVEC, {m.X, m.beta}, eta0, {LogisticGlm::N, LogisticGlm::K});
   g.add_op(OP_BCAST_FMA, {m.alpha, one, eta0}, eta);
   g.add_op(OP_BERNOULLI_LOGIT_LPMF, {eta}, lp1,
            std::vector<int>(LogisticGlm::kYint,

--- a/tests/tbb_stub.cpp
+++ b/tests/tbb_stub.cpp
@@ -4,7 +4,8 @@
 #if defined(__APPLE__)
 extern "C" void stanli_observe_stub(void*, bool) {}
 asm(".globl __ZN3tbb8internal26task_scheduler_observer_v37observeEb\n"
-    "__ZN3tbb8internal26task_scheduler_observer_v37observeEb = _stanli_observe_stub\n");
+    "__ZN3tbb8internal26task_scheduler_observer_v37observeEb = "
+    "_stanli_observe_stub\n");
 #else
 namespace tbb {
 namespace internal {

--- a/tests/test_brmsmono.cpp
+++ b/tests/test_brmsmono.cpp
@@ -87,8 +87,7 @@ int main() {
   // it evaluates one point per process.
   for (int64_t k = 0; k < n; ++k) ex.params_data()[k] = q[(size_t)k];
   const double again = ex.forward();
-  expect("evaluating the same point twice gives the same lp",
-         again == lp);
+  expect("evaluating the same point twice gives the same lp", again == lp);
   if (!(worst < 1e-5)) {
     ++failures;
     std::printf("FAIL finite differences: worst %.3g at parameter %d\n", worst,
@@ -97,8 +96,7 @@ int main() {
 
   // bsp_1 is the monotonic slope; if the mo() term were folded to zero
   // (the shape a wrong `rows` could take) its gradient would vanish.
-  expect("the monotonic term reaches the target",
-         std::fabs(grad[2]) > 1e-8);
+  expect("the monotonic term reaches the target", std::fabs(grad[2]) > 1e-8);
 
   if (failures == 0) std::printf("test_brmsmono: all checks passed\n");
   return failures == 0 ? 0 : 1;

--- a/tests/test_constfold.cpp
+++ b/tests/test_constfold.cpp
@@ -25,7 +25,10 @@
 
 static int failures = 0;
 static void expect(const char* what, bool ok) {
-  if (!ok) { ++failures; std::printf("FAIL %s\n", what); }
+  if (!ok) {
+    ++failures;
+    std::printf("FAIL %s\n", what);
+  }
 }
 static void expect_close(const char* what, double got, double want) {
   const double rel = std::abs(got - want) / std::max(std::abs(want), 1e-300);

--- a/tests/test_densities.cpp
+++ b/tests/test_densities.cpp
@@ -30,8 +30,8 @@ static void expect_close(const std::string& what, double got, double want) {
   const double tol = 1e-13 * (std::abs(want) > 1 ? std::abs(want) : 1.0);
   if (std::abs(got - want) > tol) {
     ++failures;
-    std::printf("FAIL %-32s got %.17g want %.17g (tol %g)\n", what.c_str(),
-                got, want, tol);
+    std::printf("FAIL %-32s got %.17g want %.17g (tol %g)\n", what.c_str(), got,
+                want, tol);
   }
 }
 
@@ -179,8 +179,7 @@ int main() {
     expect_eq("uniform oos value", r.value,
               -std::numeric_limits<double>::infinity());
     expect_eq("uniform oos dy", r.grad[0], 0.0);
-    auto r2 = testutil::run_one_op(OP_UNIFORM_LPDF,
-                                   {{-0.5}, {-100.0}, {0.0}},
+    auto r2 = testutil::run_one_op(OP_UNIFORM_LPDF, {{-0.5}, {-100.0}, {0.0}},
                                    {true, false, false});
     var vy = -0.5;
     var lp = stan::math::uniform_lpdf<false>(vy, -100.0, 0.0);
@@ -253,8 +252,7 @@ int main() {
 
   // ---- student_t_lpdf(y_data, nu_ps, mu_ps, sigma_ps) --------------------
   {
-    auto r = testutil::run_one_op(OP_STUDENT_T_LPDF,
-                                  {ys, {4.0}, {0.25}, {1.4}},
+    auto r = testutil::run_one_op(OP_STUDENT_T_LPDF, {ys, {4.0}, {0.25}, {1.4}},
                                   {false, true, true, true});
     Eigen::Map<Eigen::VectorXd> ymap(ys.data(), N);
     var vnu = 4.0, vmu = 0.25, vsig = 1.4;
@@ -373,10 +371,9 @@ int main() {
 
     // binomial: int groups; y vector, trials a language-level scalar (-1).
     std::vector<int> fused_b{N, 3, 0, 7, 1, 2, -1, 20};
-    check_elt("elt binomial", OP_BINOMIAL_LPMF, 0x01, N, {unit}, {true},
-              fused_b, [&](int64_t i) {
-                return std::vector<int>{-1, counts[i], -1, 20};
-              });
+    check_elt(
+        "elt binomial", OP_BINOMIAL_LPMF, 0x01, N, {unit}, {true}, fused_b,
+        [&](int64_t i) { return std::vector<int>{-1, counts[i], -1, 20}; });
   }
 
   if (failures == 0) std::printf("test_densities OK\n");

--- a/tests/test_diagnose.cpp
+++ b/tests/test_diagnose.cpp
@@ -26,8 +26,8 @@ static void expect_near(const std::string& what, double got, double want,
                         double tol) {
   if (!(std::fabs(got - want) <= tol)) {
     ++failures;
-    std::printf("FAIL %-30s got %.10g want %.10g (tol %g)\n", what.c_str(),
-                got, want, tol);
+    std::printf("FAIL %-30s got %.10g want %.10g (tol %g)\n", what.c_str(), got,
+                want, tol);
   }
 }
 
@@ -35,8 +35,8 @@ static void expect_in(const std::string& what, double got, double lo,
                       double hi) {
   if (!(got >= lo && got <= hi)) {
     ++failures;
-    std::printf("FAIL %-30s got %.6g want in [%g, %g]\n", what.c_str(), got,
-                lo, hi);
+    std::printf("FAIL %-30s got %.6g want in [%g, %g]\n", what.c_str(), got, lo,
+                hi);
   }
 }
 
@@ -174,8 +174,8 @@ int main() {
     DrawSet ds{d.data(), C, N, P};
     auto fd = diagnose(ds, summarize(ds, {"x"}), st.data(), 10);
     expect("divergences counted", fd.n_divergent == 3);
-    expect("divergences attributed", fd.divergent_by_chain[0] == 3 &&
-                                         fd.divergent_by_chain[1] == 0);
+    expect("divergences attributed",
+           fd.divergent_by_chain[0] == 3 && fd.divergent_by_chain[1] == 0);
     expect("treedepth counted", fd.n_max_treedepth == 2);
     expect_near("stepsize chain 0", fd.stepsize_by_chain[0], 0.25, 1e-12);
     expect_near("stepsize chain 1", fd.stepsize_by_chain[1], 0.35, 1e-12);

--- a/tests/test_e2e.cpp
+++ b/tests/test_e2e.cpp
@@ -15,8 +15,8 @@ static void expect_in(const std::string& what, double got, double lo,
                       double hi) {
   if (!(got >= lo && got <= hi)) {
     ++failures;
-    std::printf("FAIL %-14s got %.6g want in [%g, %g]\n", what.c_str(), got,
-                lo, hi);
+    std::printf("FAIL %-14s got %.6g want in [%g, %g]\n", what.c_str(), got, lo,
+                hi);
   }
 }
 static std::string slurp(const std::string& path) {

--- a/tests/test_eltwise.cpp
+++ b/tests/test_eltwise.cpp
@@ -64,9 +64,8 @@ int main() {
   check_case("add sv", OP_ADD, N, {{S}, B}, [](auto& v) {
     return stan::math::sum(stan::math::add(v[0](0), v[1]));
   });
-  check_case("add ss", OP_ADD, 1, {{S}, {T}}, [](auto& v) {
-    return v[0](0) + v[1](0);
-  });
+  check_case("add ss", OP_ADD, 1, {{S}, {T}},
+             [](auto& v) { return v[0](0) + v[1](0); });
   // SUB
   check_case("sub vv", OP_SUB, N, {A, B}, [](auto& v) {
     return stan::math::sum(stan::math::subtract(v[0], v[1]));
@@ -77,9 +76,8 @@ int main() {
   check_case("sub sv", OP_SUB, N, {{S}, B}, [](auto& v) {
     return stan::math::sum(stan::math::subtract(v[0](0), v[1]));
   });
-  check_case("sub ss", OP_SUB, 1, {{S}, {T}}, [](auto& v) {
-    return v[0](0) - v[1](0);
-  });
+  check_case("sub ss", OP_SUB, 1, {{S}, {T}},
+             [](auto& v) { return v[0](0) - v[1](0); });
   // MUL (vv = elt_multiply, matching EltTimes__)
   check_case("mul vv", OP_MUL, N, {A, B}, [](auto& v) {
     return stan::math::sum(stan::math::elt_multiply(v[0], v[1]));
@@ -90,9 +88,8 @@ int main() {
   check_case("mul sv", OP_MUL, N, {{S}, B}, [](auto& v) {
     return stan::math::sum(stan::math::multiply(v[0](0), v[1]));
   });
-  check_case("mul ss", OP_MUL, 1, {{S}, {T}}, [](auto& v) {
-    return v[0](0) * v[1](0);
-  });
+  check_case("mul ss", OP_MUL, 1, {{S}, {T}},
+             [](auto& v) { return v[0](0) * v[1](0); });
   // DIV (vv = elt_divide, vs = divide)
   check_case("div vv", OP_DIV, N, {A, B}, [](auto& v) {
     return stan::math::sum(stan::math::elt_divide(v[0], v[1]));
@@ -100,43 +97,33 @@ int main() {
   check_case("div vs", OP_DIV, N, {A, {T}}, [](auto& v) {
     return stan::math::sum(stan::math::divide(v[0], v[1](0)));
   });
-  check_case("div ss", OP_DIV, 1, {{S}, {T}}, [](auto& v) {
-    return v[0](0) / v[1](0);
-  });
+  check_case("div ss", OP_DIV, 1, {{S}, {T}},
+             [](auto& v) { return v[0](0) / v[1](0); });
   // POW (ss)
-  check_case("pow ss", OP_POW, 1, {{S}, {T}}, [](auto& v) {
-    return stan::math::pow(v[0](0), v[1](0));
-  });
+  check_case("pow ss", OP_POW, 1, {{S}, {T}},
+             [](auto& v) { return stan::math::pow(v[0](0), v[1](0)); });
 
   // Unaries, vector + scalar shapes.
-  check_case("neg v", OP_NEG, N, {A}, [](auto& v) {
-    return stan::math::sum(stan::math::minus(v[0]));
-  });
-  check_case("exp v", OP_EXPV, N, {A}, [](auto& v) {
-    return stan::math::sum(stan::math::exp(v[0]));
-  });
-  check_case("exp s", OP_EXPV, 1, {{S}}, [](auto& v) {
-    return stan::math::exp(v[0](0));
-  });
-  check_case("log v", OP_LOGV, N, {{1.5, 0.7, 0.4, 2.2}}, [](auto& v) {
-    return stan::math::sum(stan::math::log(v[0]));
-  });
+  check_case("neg v", OP_NEG, N, {A},
+             [](auto& v) { return stan::math::sum(stan::math::minus(v[0])); });
+  check_case("exp v", OP_EXPV, N, {A},
+             [](auto& v) { return stan::math::sum(stan::math::exp(v[0])); });
+  check_case("exp s", OP_EXPV, 1, {{S}},
+             [](auto& v) { return stan::math::exp(v[0](0)); });
+  check_case("log v", OP_LOGV, N, {{1.5, 0.7, 0.4, 2.2}},
+             [](auto& v) { return stan::math::sum(stan::math::log(v[0])); });
   check_case("inv_logit v", OP_INV_LOGIT, N, {A}, [](auto& v) {
     return stan::math::sum(stan::math::inv_logit(v[0]));
   });
-  check_case("sqrt v", OP_SQRT, N, {{0.5, 1.2, 2.0, 0.3}}, [](auto& v) {
-    return stan::math::sum(stan::math::sqrt(v[0]));
-  });
-  check_case("square v", OP_SQUARE, N, {A}, [](auto& v) {
-    return stan::math::sum(stan::math::square(v[0]));
-  });
-  check_case("log1m v", OP_LOG1M, N, {{0.2, -0.5, 0.7, 0.05}}, [](auto& v) {
-    return stan::math::sum(stan::math::log1m(v[0]));
-  });
+  check_case("sqrt v", OP_SQRT, N, {{0.5, 1.2, 2.0, 0.3}},
+             [](auto& v) { return stan::math::sum(stan::math::sqrt(v[0])); });
+  check_case("square v", OP_SQUARE, N, {A},
+             [](auto& v) { return stan::math::sum(stan::math::square(v[0])); });
+  check_case("log1m v", OP_LOG1M, N, {{0.2, -0.5, 0.7, 0.05}},
+             [](auto& v) { return stan::math::sum(stan::math::log1m(v[0])); });
   // DOT
-  check_case("dot", OP_DOT, 1, {A, B}, [](auto& v) {
-    return stan::math::dot_product(v[0], v[1]);
-  });
+  check_case("dot", OP_DOT, 1, {A, B},
+             [](auto& v) { return stan::math::dot_product(v[0], v[1]); });
 
   if (failures == 0) std::printf("test_eltwise OK\n");
   return failures == 0 ? 0 : 1;

--- a/tests/test_estimate.cpp
+++ b/tests/test_estimate.cpp
@@ -30,8 +30,8 @@ static void expect_near(const std::string& what, double got, double want,
                         double tol) {
   if (!(std::fabs(got - want) <= tol)) {
     ++failures;
-    std::printf("FAIL %-30s got %.10g want %.10g (tol %g)\n", what.c_str(),
-                got, want, tol);
+    std::printf("FAIL %-30s got %.10g want %.10g (tol %g)\n", what.c_str(), got,
+                want, tol);
   }
 }
 

--- a/tests/test_executor.cpp
+++ b/tests/test_executor.cpp
@@ -53,8 +53,7 @@ int main() {
   // ... and again with a value-only sweep in between.
   ex.forward_value_only();
   double grad2[2] = {0, 0};
-  expect_eq("grad after value-only", ex.gradient(grad2),
-            std::exp(0.3) + -1.1);
+  expect_eq("grad after value-only", ex.gradient(grad2), std::exp(0.3) + -1.1);
   expect_eq("d/da after value-only", grad2[0], grad[0]);
   expect_eq("d/db after value-only", grad2[1], grad[1]);
 
@@ -70,7 +69,9 @@ int main() {
   *ex2.param_ptr(s_a) = 0.5;
   *ex2.param_ptr(s_b) = 2.0;
   double* x = ex2.value_ptr(s_x);
-  x[0] = 1.0; x[1] = -2.0; x[2] = 0.25;
+  x[0] = 1.0;
+  x[1] = -2.0;
+  x[2] = 0.25;
   ex2.run_forward_only();
   const double* o = ex2.value_ptr(s_o);
   expect_eq("fma[0]", o[0], 0.5 + 2.0 * 1.0);

--- a/tests/test_glm.cpp
+++ b/tests/test_glm.cpp
@@ -53,9 +53,8 @@ int main() {
   testmodels::fill_logistic_glm_data(m, ex);
   const int NP = 4;
 
-  const double qs[3][NP] = {{0.2, 0.5, -0.8, 1.1},
-                            {-1.0, 0.0, 0.3, -0.2},
-                            {2.2, -1.5, 0.9, 0.4}};
+  const double qs[3][NP] = {
+      {0.2, 0.5, -0.8, 1.1}, {-1.0, 0.0, 0.3, -0.2}, {2.2, -1.5, 0.9, 0.4}};
 
   for (int c = 0; c < 3; ++c) {
     ex.param_ptr(m.alpha)[0] = qs[c][0];

--- a/tests/test_inplace.cpp
+++ b/tests/test_inplace.cpp
@@ -15,15 +15,17 @@
 
 static int failures = 0;
 static void expect(const char* what, bool ok) {
-  if (!ok) { ++failures; std::printf("FAIL %s\n", what); }
+  if (!ok) {
+    ++failures;
+    std::printf("FAIL %s\n", what);
+  }
 }
 static void expect_close(const char* what, double got, double want) {
-  const double rel =
-      std::abs(got - want) / std::max(std::abs(want), 1e-300);
+  const double rel = std::abs(got - want) / std::max(std::abs(want), 1e-300);
   if (!(rel < 1e-12)) {
     ++failures;
-    std::printf("FAIL %-26s got %.17g want %.17g rel %.2e\n", what, got,
-                want, rel);
+    std::printf("FAIL %-26s got %.17g want %.17g rel %.2e\n", what, got, want,
+                rel);
   }
 }
 
@@ -49,8 +51,7 @@ static std::vector<double> run_grad_twice(Graph g, const Fills& fills) {
   first[0] = ex.gradient(first.data() + 1);
   second[0] = ex.gradient(second.data() + 1);
   for (size_t i = 0; i < first.size(); ++i)
-    expect_close(("repeat v" + std::to_string(i)).c_str(), second[i],
-                 first[i]);
+    expect_close(("repeat v" + std::to_string(i)).c_str(), second[i], first[i]);
   return second;
 }
 
@@ -251,8 +252,8 @@ static void test_store_to_load_forwarding() {
   // L read-backs plus the L writes they made redundant.
   expect("forwarded and swept 2L ops", removed == 2 * L);
   for (const Op& op : g.ops) {
-    expect("no writes left", op.opcode != OP_SET_INDEX &&
-                                 op.opcode != OP_SET_INDEX_INPLACE);
+    expect("no writes left",
+           op.opcode != OP_SET_INDEX && op.opcode != OP_SET_INDEX_INPLACE);
     expect("no reads left", op.opcode != OP_INDEX);
   }
   reduce_into_result(g, terms);
@@ -382,8 +383,7 @@ static void test_env_disable() {
   expect("disabled: no stores forwarded", forward_stores_to_loads(g, {}) == 0);
   expect("disabled: graph untouched", g.ops.size() == before);
   for (const Op& op : g.ops)
-    expect("disabled: no destructive write",
-           op.opcode != OP_SET_INDEX_INPLACE);
+    expect("disabled: no destructive write", op.opcode != OP_SET_INDEX_INPLACE);
   test_unsetenv("STANLI_NO_INPLACE");
 
   // The same graph with the switch off: both passes do their work.
@@ -401,7 +401,10 @@ int main() {
   test_bail_later_reader();
   test_bail_root();
   test_dead_slots_freed();
-  if (failures) { std::printf("%d failures\n", failures); return 1; }
+  if (failures) {
+    std::printf("%d failures\n", failures);
+    return 1;
+  }
   std::printf("test_inplace OK\n");
   return 0;
 }

--- a/tests/test_island.cpp
+++ b/tests/test_island.cpp
@@ -25,8 +25,8 @@ static void expect_close(const std::string& what, double got, double want) {
   const double rel = std::abs(got - want) / std::max(std::abs(want), 1e-300);
   if (!(rel < 1e-12)) {
     ++failures;
-    std::printf("FAIL %-24s got %.17g want %.17g rel %.2e\n", what.c_str(),
-                got, want, rel);
+    std::printf("FAIL %-24s got %.17g want %.17g rel %.2e\n", what.c_str(), got,
+                want, rel);
   }
 }
 
@@ -57,10 +57,10 @@ struct HmmGraph {
 static HmmGraph build_hmm(int T, int W = 2) {
   HmmGraph h;
   Graph& g = h.g;
-  const int gp0 = g.add_slot(W, true);   // initial log-state
+  const int gp0 = g.add_slot(W, true);  // initial log-state
   const int mu = g.add_slot(2, true);
   const int sigma = g.add_slot(1, true);
-  const int z2 = g.add_slot(W, false);   // fill-backed template (absorbed)
+  const int z2 = g.add_slot(W, false);  // fill-backed template (absorbed)
   h.fills.emplace_back(z2, std::vector<double>((size_t)W, 0.0));
   auto cslot = [&](double v) {
     const int s = g.add_slot(1, false);
@@ -109,7 +109,7 @@ static HmmGraph build_hmm(int T, int W = 2) {
 }
 
 static void test_hmm_parity() {
-  HmmGraph ref = build_hmm(8);   // 8*11 = 88 body ops, above threshold
+  HmmGraph ref = build_hmm(8);  // 8*11 = 88 body ops, above threshold
   const std::vector<double> want = run_grad(std::move(ref.g), ref.fills);
 
   HmmGraph isl = build_hmm(8);
@@ -144,8 +144,7 @@ static void test_env_disable() {
   test_unsetenv("STANLI_NO_ISLAND");
 
   // The same graph with the switch off: the run carves.
-  expect("enabled: one island",
-         carve_islands(h.g, h.fills, h.terms, {}) == 1);
+  expect("enabled: one island", carve_islands(h.g, h.fills, h.terms, {}) == 1);
 }
 
 static void test_short_run_untouched() {
@@ -313,10 +312,10 @@ static void test_six_live_ins_ok() {
 static void test_live_in_and_out_slot() {
   Graph g;
   Fills fills;
-  const int seedp = g.add_slot(1, true);   // feeds the producer
+  const int seedp = g.add_slot(1, true);  // feeds the producer
   const int a = g.add_slot(1, true);
   const int vec = g.add_slot(10, false);
-  g.add_op(OP_REP_VEC, {seedp}, vec);      // the producer, before the region
+  g.add_op(OP_REP_VEC, {seedp}, vec);  // the producer, before the region
   auto cslot = [&](double v) {
     const int s = g.add_slot(1, false);
     fills.emplace_back(s, std::vector<double>{v});

--- a/tests/test_lower.cpp
+++ b/tests/test_lower.cpp
@@ -129,7 +129,8 @@ int main() {
     DataMap d;
     d.set_int("N", 3);
     d.set_real_array("y", {1.0, 2.0, 3.0});
-    CompiledModel lm = compile_model(slurp("tests/fixtures/loopy.tmir.sexp"), d);
+    CompiledModel lm =
+        compile_model(slurp("tests/fixtures/loopy.tmir.sexp"), d);
     Executor lex(std::move(lm.graph));
     lm.bind(lex);
     lex.params_data()[0] = 0.4;
@@ -154,7 +155,8 @@ int main() {
     DataMap d;
     d.set_int("M", 3);
     d.set_int_array("s", {2, 0, 1});
-    CompiledModel lm = compile_model(slurp("tests/fixtures/staticif.tmir.sexp"), d);
+    CompiledModel lm =
+        compile_model(slurp("tests/fixtures/staticif.tmir.sexp"), d);
     Executor lex(std::move(lm.graph));
     lm.bind(lex);
     lex.params_data()[0] = 0.3;
@@ -183,9 +185,10 @@ int main() {
   // Row of a 2-D int data array as a density outcome: y[i] reaches the
   // kernel as a T-length int array (Mb/Mt/irt_2pl pattern).
   {
-    DataMap d = DataMap::from_json(
-        R"({"M": 2, "T": 3, "y": [[1, 0, 1], [0, 0, 1]]})");
-    CompiledModel lm = compile_model(slurp("tests/fixtures/introw.tmir.sexp"), d);
+    DataMap d =
+        DataMap::from_json(R"({"M": 2, "T": 3, "y": [[1, 0, 1], [0, 0, 1]]})");
+    CompiledModel lm =
+        compile_model(slurp("tests/fixtures/introw.tmir.sexp"), d);
     check(lm.n_unconstrained == 3, "introw 3 unconstrained");
     Executor lex(std::move(lm.graph));
     lm.bind(lex);
@@ -197,8 +200,7 @@ int main() {
     Eigen::Matrix<var, -1, 1> pu(3);
     for (int i = 0; i < 3; ++i) pu(i) = 0.2 * (i + 1) - 0.3;
     var lj = 0.0;
-    Eigen::Matrix<var, -1, 1> pc =
-        stan::math::lub_constrain(pu, 0.0, 1.0, lj);
+    Eigen::Matrix<var, -1, 1> pc = stan::math::lub_constrain(pu, 0.0, 1.0, lj);
     const std::vector<std::vector<int>> yv = {{1, 0, 1}, {0, 0, 1}};
     var acc = 0.0;
     for (int i = 0; i < 2; ++i)
@@ -217,7 +219,8 @@ int main() {
     DataMap d;
     d.set_int("N", 2);
     d.set_real_array("y", {1.3, -0.7});
-    CompiledModel lm = compile_model(slurp("tests/fixtures/dfold.tmir.sexp"), d);
+    CompiledModel lm =
+        compile_model(slurp("tests/fixtures/dfold.tmir.sexp"), d);
     Executor lex(std::move(lm.graph));
     lm.bind(lex);
     lex.params_data()[0] = 0.25;
@@ -228,8 +231,8 @@ int main() {
     using stan::math::var;
     const double yv[2] = {1.3, -0.7};
     const double m = (yv[0] + yv[1]) / 2.0;
-    const double s = std::sqrt(((yv[0] - m) * (yv[0] - m) +
-                                (yv[1] - m) * (yv[1] - m)) / 1.0);
+    const double s = std::sqrt(
+        ((yv[0] - m) * (yv[0] - m) + (yv[1] - m) * (yv[1] - m)) / 1.0);
     Eigen::Matrix<var, -1, 1> muu(2);
     muu << 0.25, -0.6;
     var lj = 0.0;
@@ -293,7 +296,8 @@ int main() {
     DataMap d;
     d.set_int("N", 4);
     d.set_real_array("y", {2.0, 1.5, -1.0, 3.0});
-    CompiledModel lm = compile_model(slurp("tests/fixtures/tdext.tmir.sexp"), d);
+    CompiledModel lm =
+        compile_model(slurp("tests/fixtures/tdext.tmir.sexp"), d);
     Executor lex(std::move(lm.graph));
     lm.bind(lex);
     lex.params_data()[0] = 0.3;
@@ -324,7 +328,8 @@ int main() {
     DataMap d;
     d.set_real("a", 1.25);
     d.set_real("b", -0.5);
-    CompiledModel lm = compile_model(slurp("tests/fixtures/tdvocab.tmir.sexp"), d);
+    CompiledModel lm =
+        compile_model(slurp("tests/fixtures/tdvocab.tmir.sexp"), d);
     Executor lex(std::move(lm.graph));
     lm.bind(lex);
     lex.params_data()[0] = 0.3;
@@ -337,9 +342,9 @@ int main() {
     // not. The compiled path falls back to the interpreter, so the
     // interpreter's vocabulary has to cover the compiler's.
     const double dens = stan::math::inv_gamma_lpdf(1.5, 2, 3) +
-                     stan::math::weibull_lpdf(1.5, 2, 3) +
-                     stan::math::logistic_lpdf(0.25, 0, 1) +
-                     stan::math::double_exponential_lpdf(0.25, 0, 1);
+                        stan::math::weibull_lpdf(1.5, 2, 3) +
+                        stan::math::logistic_lpdf(0.25, 0, 1) +
+                        stan::math::double_exponential_lpdf(0.25, 0, 1);
     using stan::math::var;
     var mu = 0.3;
     var acc = stan::math::normal_lpdf<false>(mu, m + dens, 1.0);
@@ -355,7 +360,8 @@ int main() {
     DataMap d;
     d.set_int("N", 3);
     d.set_real_array("y", {1.1, -0.4, 2.2});
-    CompiledModel lm = compile_model(slurp("tests/fixtures/udflp.tmir.sexp"), d);
+    CompiledModel lm =
+        compile_model(slurp("tests/fixtures/udflp.tmir.sexp"), d);
     check(lm.n_unconstrained == 4, "udflp 4 unconstrained");
     Executor lex(std::move(lm.graph));
     lm.bind(lex);
@@ -394,7 +400,7 @@ int main() {
     check(lm.n_unconstrained == 9, "idx 9 unconstrained");
     Executor lex(std::move(lm.graph));
     lm.bind(lex);
-    const double q[9] = {0.5, -0.7, 1.2,           // v
+    const double q[9] = {0.5, -0.7, 1.2,                   // v
                          0.1, -0.3, 0.6, 0.9, -1.1, 0.2};  // M col-major
     for (int i = 0; i < 9; ++i) lex.params_data()[i] = q[i];
     double grad[9];
@@ -411,9 +417,9 @@ int main() {
     Eigen::Matrix<var, -1, 1> w(2);
     w << v(1), v(2);
     Eigen::Matrix<var, -1, 1> row1(3), col3(2), lcol2(2), v12(2);
-    row1 << M(0), M(2), M(4);      // row 1 of 2x3 col-major: stride 2
-    col3 << M(4), M(5);            // column 3: offset 4
-    lcol2 = w;                     // L[:,2] = w
+    row1 << M(0), M(2), M(4);  // row 1 of 2x3 col-major: stride 2
+    col3 << M(4), M(5);        // column 3: offset 4
+    lcol2 = w;                 // L[:,2] = w
     v12 << v(0), v(1);
     var t1 = stan::math::normal_lpdf<false>(g, 0.0, 1.0);
     var t2 = stan::math::normal_lpdf<false>(v12, 0.0, 2.0);
@@ -447,8 +453,7 @@ int main() {
     Eigen::Matrix<var, -1, 1> q(2);
     q << 0.3, -0.8;
     var lj = 0.0;
-    Eigen::Matrix<var, -1, 1> theta =
-        stan::math::simplex_constrain(q, lj);
+    Eigen::Matrix<var, -1, 1> theta = stan::math::simplex_constrain(q, lj);
     var t1 = stan::math::categorical_lpmf<false>(2, theta);
     const std::vector<int> ys = {3, 1, 3};
     var t2 = stan::math::categorical_lpmf<false>(ys, theta);
@@ -501,7 +506,8 @@ int main() {
   {
     DataMap d;
     d.set_int("C", 2);
-    CompiledModel lm = compile_model(slurp("tests/fixtures/aprow.tmir.sexp"), d);
+    CompiledModel lm =
+        compile_model(slurp("tests/fixtures/aprow.tmir.sexp"), d);
     check(lm.n_unconstrained == 8, "aprow 8 unconstrained");
     Executor lex(std::move(lm.graph));
     lm.bind(lex);
@@ -514,7 +520,7 @@ int main() {
     // A is 2xC col-major (q0..q3), B is 1xC (q4,q5), r is C (q6,q7).
     Eigen::Matrix<var, -1, 1> p(8);
     for (int i = 0; i < 8; ++i) p(i) = q[i];
-    auto A = [&](int i, int j) { return p(j * 2 + i); };     // 2 rows
+    auto A = [&](int i, int j) { return p(j * 2 + i); };  // 2 rows
     auto B = [&](int j) { return p(4 + j); };
     auto r = [&](int j) { return p(6 + j); };
     Eigen::Matrix<var, -1, 1> S(6), T(6);
@@ -568,11 +574,12 @@ int main() {
   // The unsupported-transform error path is covered by the
   // unsupported-function check below.
   {
-    CompiledModel cm = compile_model(slurp("tests/fixtures/chol.tmir.sexp"), [] {
-      DataMap d;
-      d.set_int("K", 3);
-      return d;
-    }());
+    CompiledModel cm =
+        compile_model(slurp("tests/fixtures/chol.tmir.sexp"), [] {
+          DataMap d;
+          d.set_int("K", 3);
+          return d;
+        }());
     check(cm.n_unconstrained == 3, "cholesky_corr unconstrained size is 3");
   }
   // Control flow on a parameter: an `if` and a ternary whose conditions
@@ -657,7 +664,8 @@ int main() {
   {
     DataMap d;
     d.set_real("y", 1.75);
-    CompiledModel tm = compile_model(slurp("tests/fixtures/trunc.tmir.sexp"), d);
+    CompiledModel tm =
+        compile_model(slurp("tests/fixtures/trunc.tmir.sexp"), d);
     Executor tex(std::move(tm.graph));
     tm.bind(tex);
     const double pts[2][2] = {{0.6, -0.3}, {-0.25, 0.4}};
@@ -689,8 +697,7 @@ int main() {
       check(grad[0] == u_mu.adj() && grad[1] == u_sig.adj(),
             "trunc: gradients bitwise against the var path");
       const double tol = 8 * 2.220446049250313e-16 * std::abs(acc.val());
-      check(std::abs(lp - acc.val()) <= tol,
-            "trunc: lp matches the var path");
+      check(std::abs(lp - acc.val()) <= tol, "trunc: lp matches the var path");
     }
   }
 
@@ -704,8 +711,8 @@ int main() {
     DataMap d;
     d.set_int("N", 3);
     d.set_real_array("y", yv);
-    CompiledModel tm = compile_model(slurp("tests/fixtures/truncvec.tmir.sexp"),
-                                     d);
+    CompiledModel tm =
+        compile_model(slurp("tests/fixtures/truncvec.tmir.sexp"), d);
     Executor tex(std::move(tm.graph));
     tm.bind(tex);
     // Declaration order: mu, theta[3], sigma.
@@ -726,9 +733,9 @@ int main() {
       var acc = u_sig;  // lower=0 jacobian
       // Scalar location: one log_diff_exp scaled by the element count.
       acc += stan::math::normal_lpdf<true>(y, mu, sigma);
-      acc -= 3.0 * stan::math::log_diff_exp(
-                       stan::math::normal_lcdf(10.0, mu, sigma),
-                       stan::math::normal_lcdf(0.0, mu, sigma));
+      acc -= 3.0 *
+             stan::math::log_diff_exp(stan::math::normal_lcdf(10.0, mu, sigma),
+                                      stan::math::normal_lcdf(0.0, mu, sigma));
       // Container location: one log_diff_exp per element, accumulated.
       acc += stan::math::normal_lpdf<true>(y, theta, 1.0);
       for (int i = 0; i < 3; ++i)
@@ -759,8 +766,8 @@ int main() {
     d.set_int("K", 2);
     d.set_real_array("y", {1, 3, 5, 2, 4, 6}, {3, 2});
     d.set_real_array("Sigma", {2.0, 0.5, 0.5, 1.0}, {2, 2});
-    CompiledModel am = compile_model(slurp("tests/fixtures/mnarr.tmir.sexp"),
-                                     d);
+    CompiledModel am =
+        compile_model(slurp("tests/fixtures/mnarr.tmir.sexp"), d);
     Executor aex(std::move(am.graph));
     am.bind(aex);
     const double pts[2][2] = {{0.4, -0.7}, {-0.3, 0.9}};
@@ -788,8 +795,7 @@ int main() {
       check(grad[0] == mu(0).adj() && grad[1] == mu(1).adj(),
             "mnarr: gradients bitwise against the var path");
       const double tol = 8 * 2.220446049250313e-16 * std::abs(acc.val());
-      check(std::abs(lp - acc.val()) <= tol,
-            "mnarr: lp matches the var path");
+      check(std::abs(lp - acc.val()) <= tol, "mnarr: lp matches the var path");
     }
   }
 
@@ -803,8 +809,8 @@ int main() {
     d.set_int("N", 3);
     d.set_int("K", 2);
     d.set_real_array("p", {0.3, 0.4, 0.2, 0.7, 0.6, 0.8}, {3, 2});
-    CompiledModel dm = compile_model(slurp("tests/fixtures/dirvec.tmir.sexp"),
-                                     d);
+    CompiledModel dm =
+        compile_model(slurp("tests/fixtures/dirvec.tmir.sexp"), d);
     Executor dex(std::move(dm.graph));
     dm.bind(dex);
     const double pts[2][2] = {{0.3, -0.4}, {-0.6, 0.8}};
@@ -831,8 +837,7 @@ int main() {
       check(grad[0] == u0.adj() && grad[1] == u1.adj(),
             "dirvec: gradients bitwise against the var path");
       const double tol = 8 * 2.220446049250313e-16 * std::abs(acc.val());
-      check(std::abs(lp - acc.val()) <= tol,
-            "dirvec: lp matches the var path");
+      check(std::abs(lp - acc.val()) <= tol, "dirvec: lp matches the var path");
     }
   }
 
@@ -853,8 +858,8 @@ int main() {
     d.set_real_array("y", {1, 3, 5, 2, 4, 6}, {3, 2});
     d.set_real_array("p", {0.3, 0.4, 0.2, 0.7, 0.6, 0.8}, {3, 2});
     d.set_real_array("Sigma", {2.0, 0.5, 0.5, 1.0}, {2, 2});
-    CompiledModel sm = compile_model(slurp("tests/fixtures/shapes.tmir.sexp"),
-                                     d);
+    CompiledModel sm =
+        compile_model(slurp("tests/fixtures/shapes.tmir.sexp"), d);
     Executor sex(std::move(sm.graph));
     sm.bind(sex);
     // Declaration order: mu, theta[3], sigma, m[2], a[2].
@@ -894,9 +899,9 @@ int main() {
       // order the model writes them.
       var acc = u_sig + au0 + au1;
       acc += stan::math::normal_lpdf<true>(t, mu, sigma);
-      acc -= 3.0 * stan::math::log_diff_exp(
-                       stan::math::normal_lcdf(10.0, mu, sigma),
-                       stan::math::normal_lcdf(0.0, mu, sigma));
+      acc -= 3.0 *
+             stan::math::log_diff_exp(stan::math::normal_lcdf(10.0, mu, sigma),
+                                      stan::math::normal_lcdf(0.0, mu, sigma));
       acc += stan::math::normal_lpdf<true>(t, theta, 1.0);
       for (int i = 0; i < 3; ++i)
         acc -= stan::math::log_diff_exp(
@@ -918,8 +923,7 @@ int main() {
       for (int i = 0; i < 9; ++i)
         expect_ulp("shapes g" + std::to_string(i), grad[i], want[i]);
       const double tol = 8 * 2.220446049250313e-16 * std::abs(acc.val());
-      check(std::abs(lp - acc.val()) <= tol,
-            "shapes: lp matches the var path");
+      check(std::abs(lp - acc.val()) <= tol, "shapes: lp matches the var path");
     }
   }
 
@@ -933,7 +937,8 @@ int main() {
     d.set_int("N", 4);
     d.set_int("K", 4);
     d.set_int_array("y", {1, 3, 2, 4});
-    CompiledModel om = compile_model(slurp("tests/fixtures/ordlog.tmir.sexp"), d);
+    CompiledModel om =
+        compile_model(slurp("tests/fixtures/ordlog.tmir.sexp"), d);
     Executor oex(std::move(om.graph));
     om.bind(oex);
     // 4 lambdas + 3 unconstrained cutpoints.
@@ -962,8 +967,8 @@ int main() {
     for (int i = 0; i < 4; ++i)
       if (grad[i] != lambda(i).adj()) grads_ok = false;
     check(grads_ok, "ordered_logistic: lambda gradients bitwise");
-    check(std::abs(lp - acc.val()) <= 8 * 2.220446049250313e-16 *
-                                          std::abs(acc.val()),
+    check(std::abs(lp - acc.val()) <=
+              8 * 2.220446049250313e-16 * std::abs(acc.val()),
           "ordered_logistic: lp matches the var path");
   }
 
@@ -1001,8 +1006,8 @@ int main() {
     acc += stan::math::normal_lpdf<true>(beta, 0, 2);
     acc += stan::math::exponential_lpdf<true>(phi, 1);
     acc += stan::math::poisson_log_glm_lpmf<true>(y, X, alpha, beta);
-    acc += stan::math::neg_binomial_2_log_glm_lpmf<true>(y, X, alpha, beta,
-                                                        phi);
+    acc +=
+        stan::math::neg_binomial_2_log_glm_lpmf<true>(y, X, alpha, beta, phi);
     acc.grad();
 
     const bool g_ok = grad[0] == alpha.adj() && grad[1] == beta(0).adj() &&

--- a/tests/test_matvec.cpp
+++ b/tests/test_matvec.cpp
@@ -20,8 +20,8 @@ int main() {
   using stan::math::var;
   const int R = 5, C = 3;
   // Column-major X (Stan/Eigen convention), same logical matrix as before.
-  double X[R * C] = {0.5,  2.0,  -0.4, 0.2,  1.3,  -1.2, -0.7, 0.9,
-                     0.8,  -0.1, 0.3,  1.1,  -1.5, -0.6, 0.7};
+  double X[R * C] = {0.5, 2.0,  -0.4, 0.2, 1.3,  -1.2, -0.7, 0.9,
+                     0.8, -0.1, 0.3,  1.1, -1.5, -0.6, 0.7};
   double yv[R] = {0.4, -1.0, 2.1, 0.3, -0.8};
   double betav[C] = {0.25, -0.5, 1.0};
 

--- a/tests/test_mixture.cpp
+++ b/tests/test_mixture.cpp
@@ -63,7 +63,7 @@ static void check_ref(const std::string& tag, uint16_t opcode, int64_t out_len,
 // a threaded vector; then SUM_VEC. Fused: one op with a len-N out, SUM_VEC.
 struct GraphRun {
   double value;
-  std::vector<double> out;   // the len-N intermediate
+  std::vector<double> out;  // the len-N intermediate
   std::vector<double> grad;
 };
 

--- a/tests/test_multichain.cpp
+++ b/tests/test_multichain.cpp
@@ -31,8 +31,8 @@ static void expect_in(const std::string& what, double got, double lo,
                       double hi) {
   if (!(got >= lo && got <= hi)) {
     ++failures;
-    std::printf("FAIL %-34s got %.6g want in [%g, %g]\n", what.c_str(), got,
-                lo, hi);
+    std::printf("FAIL %-34s got %.6g want in [%g, %g]\n", what.c_str(), got, lo,
+                hi);
   }
 }
 
@@ -77,7 +77,8 @@ int main() {
     // Bitwise: the clone runs the same ops over the same doubles in the
     // same order, so anything short of equality is a real difference.
     bool same = lp1 == lp2;
-    for (int64_t i = 0; i < n; ++i) same = same && g1[(size_t)i] == g2[(size_t)i];
+    for (int64_t i = 0; i < n; ++i)
+      same = same && g1[(size_t)i] == g2[(size_t)i];
     expect("clone gradient is bitwise identical", same);
 
     // And the two arenas are independent: evaluating one must not move
@@ -212,7 +213,7 @@ int main() {
     const double init[3] = {0.5, -0.25, 1.5};
     NutsConfig cfg;
     cfg.seed = 5;
-    cfg.warmup = 0;   // no adaptation, so the first draw stays near the init
+    cfg.warmup = 0;  // no adaptation, so the first draw stays near the init
     cfg.samples = 1;
     cfg.init = init;
     auto d = run_nuts(ex, cfg);
@@ -262,7 +263,8 @@ int main() {
     for (int c = 0; c < C; ++c)
       for (int i = 0; i < N; ++i) {
         for (int j = 0; j < D; ++j)
-          draws[(size_t)((c * N + i) * D + j)] = res[(size_t)c].draws[(size_t)i][(size_t)j];
+          draws[(size_t)((c * N + i) * D + j)] =
+              res[(size_t)c].draws[(size_t)i][(size_t)j];
         for (int k = 0; k < N_SAMPLER_COLS; ++k)
           stats[(size_t)((c * N + i) * N_SAMPLER_COLS + k)] =
               res[(size_t)c].stats.rows[(size_t)i][(size_t)k];

--- a/tests/test_newtrans.cpp
+++ b/tests/test_newtrans.cpp
@@ -37,8 +37,8 @@ static void expect_near(const std::string& what, double got, double want,
                         double tol) {
   if (!(std::fabs(got - want) <= tol)) {
     ++failures;
-    std::printf("FAIL %-28s got %.12g want %.12g (tol %g)\n", what.c_str(),
-                got, want, tol);
+    std::printf("FAIL %-28s got %.12g want %.12g (tol %g)\n", what.c_str(), got,
+                want, tol);
   }
 }
 static std::string slurp(const std::string& path) {
@@ -110,7 +110,8 @@ int main() {
   for (int64_t i = 0; i < n; ++i) ex.params_data()[i] = q[(size_t)i];
   ex.run_forward_only();
 
-  const auto view = [&](const std::string& name) -> const CompiledModel::ParamView* {
+  const auto view =
+      [&](const std::string& name) -> const CompiledModel::ParamView* {
     for (const auto& v : cm.views)
       if (v.name == name) return &v;
     return nullptr;
@@ -143,8 +144,8 @@ int main() {
   if (vals("R", R)) {
     expect("corr_matrix is 3x3", R.size() == 9);
     for (int k = 0; k < 3; ++k)
-      expect_near("corr diag " + std::to_string(k), R[(size_t)(k * 3 + k)],
-                  1.0, 1e-12);
+      expect_near("corr diag " + std::to_string(k), R[(size_t)(k * 3 + k)], 1.0,
+                  1e-12);
     // Symmetric, and every off-diagonal a valid correlation.
     for (int i = 0; i < 3; ++i)
       for (int j = 0; j < 3; ++j) {
@@ -188,8 +189,7 @@ int main() {
   // m = 0.3 and s = 1.7, the constrained value is exactly s*x + m.
   if (vals("a", a)) {
     const double x = q[0];  // `a` is the first declared parameter
-    expect_near("offset/multiplier scalar", a[0], std::fma(1.7, x, 0.3),
-                1e-13);
+    expect_near("offset/multiplier scalar", a[0], std::fma(1.7, x, 0.3), 1e-13);
   }
   if (vals("b", b)) {
     expect("offset/multiplier vector has 3 elements", b.size() == 3);
@@ -204,11 +204,10 @@ int main() {
     // e's raw slice starts after a(1) b(3) c(1) d(1) mu_p(3) sg_p(3).
     const int e0 = 1 + 3 + 1 + 1 + 3 + 3;
     for (int i = 0; i < 3; ++i)
-      expect_near("elementwise offset/multiplier " + std::to_string(i),
-                  e[(size_t)i],
-                  std::fma(sg_p[(size_t)i], q[(size_t)(e0 + i)],
-                           mu_p[(size_t)i]),
-                  1e-12);
+      expect_near(
+          "elementwise offset/multiplier " + std::to_string(i), e[(size_t)i],
+          std::fma(sg_p[(size_t)i], q[(size_t)(e0 + i)], mu_p[(size_t)i]),
+          1e-12);
   }
 
   if (failures == 0) std::printf("test_newtrans: all checks passed\n");

--- a/tests/test_nuts.cpp
+++ b/tests/test_nuts.cpp
@@ -13,8 +13,8 @@ static void expect_in(const std::string& what, double got, double lo,
                       double hi) {
   if (!(got >= lo && got <= hi)) {
     ++failures;
-    std::printf("FAIL %-18s got %.6g want in [%g, %g]\n", what.c_str(), got,
-                lo, hi);
+    std::printf("FAIL %-18s got %.6g want in [%g, %g]\n", what.c_str(), got, lo,
+                hi);
   }
 }
 
@@ -150,8 +150,8 @@ int main() {
     try {
       run_nuts(ex, cfg);
     } catch (const std::exception& e) {
-      threw_init = std::string(e.what()).find("initialization") !=
-                   std::string::npos;
+      threw_init =
+          std::string(e.what()).find("initialization") != std::string::npos;
     }
     if (!threw_init) {
       ++failures;
@@ -194,9 +194,10 @@ int main() {
                       std::isfinite(energy) && energy >= -lp_;
       if (!ok) {
         ++failures;
-        std::printf("FAIL stats row: lp %g accept %g step %g depth %g "
-                    "nleap %g div %g energy %g\n",
-                    lp_, accept, step, depth, nleap, div, energy);
+        std::printf(
+            "FAIL stats row: lp %g accept %g step %g depth %g "
+            "nleap %g div %g energy %g\n",
+            lp_, accept, step, depth, nleap, div, energy);
         break;
       }
       leapfrogs += (int64_t)nleap;

--- a/tests/test_ode_prog.cpp
+++ b/tests/test_ode_prog.cpp
@@ -42,8 +42,7 @@ void check(const std::string& name, const stanli::mir::FunDef& f,
            int n_y, int n_th, const std::vector<double>& x_r,
            const std::vector<int>& x_i, bool want_ok) {
   using namespace stanli;
-  RhsProgram p =
-      compile_rhs(f, funs, n_y, n_th, (int)x_r.size(), x_i);
+  RhsProgram p = compile_rhs(f, funs, n_y, n_th, (int)x_r.size(), x_i);
   if (p.ok != want_ok) {
     ++failures;
     std::printf("FAIL %s: compile ok=%d, wanted %d (%s)\n", name.c_str(),

--- a/tests/test_odevariadic.cpp
+++ b/tests/test_odevariadic.cpp
@@ -58,8 +58,7 @@ int main() {
   if (n != 6) return 1;
 
   std::vector<double> q((size_t)n);
-  for (int64_t i = 0; i < n; ++i)
-    q[(size_t)i] = -0.3 + 0.11 * (double)i;
+  for (int64_t i = 0; i < n; ++i) q[(size_t)i] = -0.3 + 0.11 * (double)i;
 
   std::vector<double> grad((size_t)n);
   for (int64_t i = 0; i < n; ++i) ex.params_data()[i] = q[(size_t)i];
@@ -78,17 +77,17 @@ int main() {
   {
     // Taken at a shifted point, so a solve that silently wrote nothing
     // cannot pass on the previous sweep's leftovers in the arena.
-    for (int64_t k = 0; k < n; ++k)
-      ex.params_data()[k] = q[(size_t)k] + 0.05;
+    for (int64_t k = 0; k < n; ++k) ex.params_data()[k] = q[(size_t)k] + 0.05;
     const double lp_vo = ex.forward_value_only();
     const double lp_full = ex.forward();
     const double dev =
         std::fabs(lp_vo - lp_full) / std::max(1.0, std::fabs(lp_full));
     if (!(dev < 1e-5)) {
       ++failures;
-      std::printf("FAIL value-only lp differs from the coupled solve by "
-                  "%.3g relative\n",
-                  dev);
+      std::printf(
+          "FAIL value-only lp differs from the coupled solve by "
+          "%.3g relative\n",
+          dev);
     }
 
     for (int64_t k = 0; k < n; ++k) ex.params_data()[k] = q[(size_t)k];
@@ -162,8 +161,8 @@ int main() {
     expect(std::string(other) + " has the same shape", o.size() == rk45.size());
     double w = 0;
     for (size_t k = 0; k < o.size() && k < rk45.size(); ++k)
-      w = std::max(w, std::fabs(o[k] - rk45[k]) /
-                          std::max(1e-8, std::fabs(rk45[k])));
+      w = std::max(
+          w, std::fabs(o[k] - rk45[k]) / std::max(1e-8, std::fabs(rk45[k])));
     // Four adaptive solvers on the same well-conditioned system agree to
     // their tolerances; a dead dispatch branch or an unapplied tolerance
     // does not.

--- a/tests/test_pass_safety.cpp
+++ b/tests/test_pass_safety.cpp
@@ -31,7 +31,10 @@
 
 static int failures = 0;
 static void expect(const char* what, bool ok) {
-  if (!ok) { ++failures; std::printf("FAIL %s\n", what); }
+  if (!ok) {
+    ++failures;
+    std::printf("FAIL %s\n", what);
+  }
 }
 
 using namespace stanli;
@@ -226,8 +229,8 @@ static Graph random_graph(std::mt19937& rng, Fills& fills,
         const int rd = g.add_slot(1, false);
         g.add_op(OP_INDEX, {vec}, rd, {k});
         const int lp = g.add_slot(1, false);
-        const int id = g.add_op(OP_NORMAL_LPDF, {cslot(0.1 * s), rd, sigma},
-                                lp);
+        const int id =
+            g.add_op(OP_NORMAL_LPDF, {cslot(0.1 * s), rd, sigma}, lp);
         g.ops[id].variant = 0x06;
         terms.push_back(lp);
         break;
@@ -242,8 +245,8 @@ static Graph random_graph(std::mt19937& rng, Fills& fills,
         const int rd = g.add_slot(1, false);
         g.add_op(OP_INDEX, {vecp}, rd, {k});
         const int lp = g.add_slot(1, false);
-        const int id = g.add_op(OP_NORMAL_LPDF, {cslot(0.3 - 0.05 * s), rd,
-                                                 sigma}, lp);
+        const int id =
+            g.add_op(OP_NORMAL_LPDF, {cslot(0.3 - 0.05 * s), rd, sigma}, lp);
         g.ops[id].variant = 0x06;
         terms.push_back(lp);
         break;
@@ -252,8 +255,7 @@ static Graph random_graph(std::mt19937& rng, Fills& fills,
         const int a = g.add_slot(1, false);
         g.add_op(OP_ADD, {mu, cslot(0.4 * ((s % 3) + 1))}, a);
         const int lp = g.add_slot(1, false);
-        const int id = g.add_op(OP_NORMAL_LPDF, {cslot(0.2 * s), a, sigma},
-                                lp);
+        const int id = g.add_op(OP_NORMAL_LPDF, {cslot(0.2 * s), a, sigma}, lp);
         g.ops[id].variant = 0x06;
         terms.push_back(lp);
         break;
@@ -304,7 +306,10 @@ static void test_random_graphs_preserve_gradients() {
       if (!std::isfinite(got[i]) || !std::isfinite(want[i])) continue;
       const double rel =
           std::abs(got[i] - want[i]) / std::max(std::abs(want[i]), 1e-300);
-      if (rel > worst) { worst = rel; worst_at = trial; }
+      if (rel > worst) {
+        worst = rel;
+        worst_at = trial;
+      }
     }
   }
   if (worst >= 1e-12) {
@@ -320,7 +325,10 @@ int main() {
   test_setenv("STANLI_ISLAND_ALWAYS", "1", 1);  // see the fuzz loop
   test_whitelist_backwards_ignore_values();
   test_random_graphs_preserve_gradients();
-  if (failures) { std::printf("%d failures\n", failures); return 1; }
+  if (failures) {
+    std::printf("%d failures\n", failures);
+    return 1;
+  }
   std::printf("test_pass_safety OK\n");
   return 0;
 }

--- a/tests/test_recorder.cpp
+++ b/tests/test_recorder.cpp
@@ -31,7 +31,9 @@ int main() {
   double gy_copy[8]{}, gmu_copy = 0, gsig_copy = 0;
   {
     stanli::sink s;
-    s.buf[0] = gy_copy; s.buf[1] = &gmu_copy; s.buf[2] = &gsig_copy;
+    s.buf[0] = gy_copy;
+    s.buf[1] = &gmu_copy;
+    s.buf[2] = &gsig_copy;
     stanli::active_sink() = &s;
     Eigen::Matrix<rvar, -1, 1> ry(N);
     for (int i = 0; i < N; ++i) ry(i) = rvar(ys[i]);
@@ -44,7 +46,9 @@ int main() {
   double gy_map[8]{}, gmu_map = 0, gsig_map = 0;
   {
     stanli::sink s;
-    s.buf[0] = gy_map; s.buf[1] = &gmu_map; s.buf[2] = &gsig_map;
+    s.buf[0] = gy_map;
+    s.buf[1] = &gmu_map;
+    s.buf[2] = &gsig_map;
     stanli::active_sink() = &s;
     auto ry = stanli::as_rvar(stanli::Desc{ys.data(), N});
     stan::math::normal_lpdf<false>(ry, rvar(0.25), rvar(1.4));
@@ -71,7 +75,9 @@ int main() {
   double ga = 0, gb = 0;
   {
     stanli::sink s;
-    s.buf[0] = nullptr; s.buf[1] = &ga; s.buf[2] = &gb;
+    s.buf[0] = nullptr;
+    s.buf[1] = &ga;
+    s.buf[2] = &gb;
     stanli::active_sink() = &s;
     stan::math::gamma_lpdf<false>(ymap, rvar(2.5), rvar(1.3));
     stanli::active_sink() = nullptr;

--- a/tests/test_reroll.cpp
+++ b/tests/test_reroll.cpp
@@ -23,15 +23,17 @@
 
 static int failures = 0;
 static void expect(const char* what, bool ok) {
-  if (!ok) { ++failures; std::printf("FAIL %s\n", what); }
+  if (!ok) {
+    ++failures;
+    std::printf("FAIL %s\n", what);
+  }
 }
 static void expect_close(const char* what, double got, double want) {
-  const double rel =
-      std::abs(got - want) / std::max(std::abs(want), 1e-300);
+  const double rel = std::abs(got - want) / std::max(std::abs(want), 1e-300);
   if (!(rel < 1e-12)) {
     ++failures;
-    std::printf("FAIL %-24s got %.17g want %.17g rel %.2e\n", what, got,
-                want, rel);
+    std::printf("FAIL %-24s got %.17g want %.17g rel %.2e\n", what, got, want,
+                rel);
   }
 }
 
@@ -57,7 +59,10 @@ static void test_radon_shape() {
   g.add_op(OP_REP_VEC, {alpha}, base);  // makes base a written slot
   std::vector<int> yconst(L);
   for (int n = 0; n < L; ++n) {
-    if (n == 5) { yconst[n] = yconst[1]; continue; }  // dedup'd pool
+    if (n == 5) {
+      yconst[n] = yconst[1];
+      continue;
+    }  // dedup'd pool
     yconst[n] = g.add_slot(1, false);
     fills.emplace_back(yconst[n], std::vector<double>{0.25 * n - 1.0});
   }
@@ -430,8 +435,8 @@ static void test_data_index_gathers() {
     const int a = g.add_slot(1, false);
     g.add_op(OP_INDEX, {alpha}, a, {idx[l]});
     const int lp = g.add_slot(1, false);
-    const int id = g.add_op(OP_NORMAL_LPDF, {cslot(0.3 * l - 1.0), a, sigma},
-                            lp);
+    const int id =
+        g.add_op(OP_NORMAL_LPDF, {cslot(0.3 * l - 1.0), a, sigma}, lp);
     g.ops[id].variant = 0x06;
     terms.push_back(lp);
   }
@@ -591,8 +596,8 @@ Built build(int L, int start, int stride = 1) {
   // stride 1: exactly the window, so the start==0 case covers the vector
   // and exercises the no-store elision. Otherwise: big enough for the comb.
   const int64_t last = start + (int64_t)(L - 1) * stride;
-  const int64_t vlen = stride == 1 ? start + (int64_t)L
-                                   : std::max((int64_t)start, last) + 1;
+  const int64_t vlen =
+      stride == 1 ? start + (int64_t)L : std::max((int64_t)start, last) + 1;
   b.y_hat = g.add_slot(vlen, false);
   b.fills.emplace_back(b.y_hat, std::vector<double>((size_t)vlen, 0.0));
   const int ydata = g.add_slot(vlen, false);
@@ -602,8 +607,7 @@ Built build(int L, int start, int stride = 1) {
   for (int l = 0; l < L; ++l) {
     const int v = g.add_slot(1, false);
     g.add_op(OP_INDEX, {b.a}, v, {l % J});
-    g.add_op(OP_SET_INDEX_INPLACE, {b.y_hat, v}, b.y_hat,
-             {start + l * stride});
+    g.add_op(OP_SET_INDEX_INPLACE, {b.y_hat, v}, b.y_hat, {start + l * stride});
   }
   const int lp = g.add_slot(1, false);
   const int id = g.add_op(OP_NORMAL_LPDF, {ydata, b.y_hat, b.sigma}, lp);
@@ -750,13 +754,13 @@ static void test_lda_shape_cost() {
   const LdaCost small = lda_reroll_cost(8000);
   const LdaCost big = lda_reroll_cost(16000);
   const double rss = peak_rss_mb();
-  std::printf("  lda shape reroll: n=8000 %.2f s / %lld steps,"
-              " n=16000 %.2f s / %lld steps (%.1fx steps, %.1fx time),"
-              " peak RSS %.0f MB\n",
-              small.sec, (long long)small.steps, big.sec,
-              (long long)big.steps,
-              small.steps > 0 ? (double)big.steps / (double)small.steps : 0.0,
-              small.sec > 0.0 ? big.sec / small.sec : 0.0, rss);
+  std::printf(
+      "  lda shape reroll: n=8000 %.2f s / %lld steps,"
+      " n=16000 %.2f s / %lld steps (%.1fx steps, %.1fx time),"
+      " peak RSS %.0f MB\n",
+      small.sec, (long long)small.steps, big.sec, (long long)big.steps,
+      small.steps > 0 ? (double)big.steps / (double)small.steps : 0.0,
+      small.sec > 0.0 ? big.sec / small.sec : 0.0, rss);
 
   // The memory ceiling is the guard that matters, because memory is what
   // broke, and unlike a wall-clock number an RSS figure means the same
@@ -825,14 +829,12 @@ static void test_write_fusion_bails() {
     Fills f2 = b.fills;
     std::vector<int> tt = b.terms;
     reroll(b.g, f2, tt, {});
-    expect("strided writes fused",
-           count(b.g, OP_SET_INDEX_INPLACE) == 0 &&
-               count(b.g, OP_SET_SLICE_STRIDED) == 1);
+    expect("strided writes fused", count(b.g, OP_SET_INDEX_INPLACE) == 0 &&
+                                       count(b.g, OP_SET_SLICE_STRIDED) == 1);
     reduce_into_result(b.g, tt);
     const std::vector<double> got = run_grad(std::move(b.g), f2);
     for (size_t i = 0; i < want.size() && i < got.size(); ++i)
-      expect_close(("strided v" + std::to_string(i)).c_str(), got[i],
-                   want[i]);
+      expect_close(("strided v" + std::to_string(i)).c_str(), got[i], want[i]);
   }
   {  // indices marching backwards: no positive stride, no fusion
     Built b = build(8, 14, -2);
@@ -1016,13 +1018,11 @@ static void test_e2e_fixtures() {
     const std::vector<double> want = e2e_grad(c.sexp, c.json, &ops_unrolled);
     test_unsetenv("STANLI_NO_REROLL");
     const std::vector<double> got = e2e_grad(c.sexp, c.json, &ops_rerolled);
-    expect((std::string(c.name) + " sizes").c_str(),
-           got.size() == want.size());
+    expect((std::string(c.name) + " sizes").c_str(), got.size() == want.size());
     for (size_t i = 0; i < want.size() && i < got.size(); ++i)
       expect_close((std::string(c.name) + " v" + std::to_string(i)).c_str(),
                    got[i], want[i]);
-    std::printf("%s: %zu ops -> %zu ops\n", c.name, ops_unrolled,
-                ops_rerolled);
+    std::printf("%s: %zu ops -> %zu ops\n", c.name, ops_unrolled, ops_rerolled);
     expect((std::string(c.name) + " shrinks 4x").c_str(),
            ops_rerolled < ops_unrolled / 4);
   }
@@ -1097,7 +1097,10 @@ int main() {
   test_write_fusion_bails();
   test_write_fusion_scalar_chain();
   test_e2e_fixtures();
-  if (failures) { std::printf("%d failures\n", failures); return 1; }
+  if (failures) {
+    std::printf("%d failures\n", failures);
+    return 1;
+  }
   std::printf("test_reroll OK\n");
   return 0;
 }

--- a/tests/test_sampling.cpp
+++ b/tests/test_sampling.cpp
@@ -29,8 +29,7 @@ namespace {
 
 int failures = 0;
 
-void expect_near(const std::string& what, double got, double want,
-                 double tol) {
+void expect_near(const std::string& what, double got, double want, double tol) {
   if (!(std::fabs(got - want) <= tol)) {
     ++failures;
     std::printf("FAIL %-26s got %.9g want %.9g +/- %.3g\n", what.c_str(), got,
@@ -111,7 +110,8 @@ void test_conjugate() {
   double ss = 0;
   for (double v : y) ss += (v - ybar) * (v - ybar);
 
-  CompiledModel cm = compile_model(slurp("tests/fixtures/conj.tmir.sexp"), data);
+  CompiledModel cm =
+      compile_model(slurp("tests/fixtures/conj.tmir.sexp"), data);
   if (!cm.write_array) {
     std::printf("FAIL conj: no write_array graph was compiled\n");
     ++failures;
@@ -177,8 +177,7 @@ void test_conjugate() {
       if (std::isnan(v)) ++nan_count;
     const double mu_c = r[c_mu_c], sigma = r[c_sigma];
     auto rel = [&](double got, double want) {
-      const double d = std::fabs(got - want) /
-                       std::max(1.0, std::fabs(want));
+      const double d = std::fabs(got - want) / std::max(1.0, std::fabs(want));
       if (d > worst_det) worst_det = d;
     };
     rel(r[c_prec], 1.0 / (sigma * sigma));  // transformed parameter

--- a/tests/test_write_array.cpp
+++ b/tests/test_write_array.cpp
@@ -112,8 +112,8 @@ void test_wanames_pipeline() {
       const double got = gq[(i - 1) * 2 + (j - 1)];
       if (got != want) {
         ++failures;
-        std::printf("FAIL wanames gq.%d.%d: got %.17g want %.17g\n", i, j,
-                    got, want);
+        std::printf("FAIL wanames gq.%d.%d: got %.17g want %.17g\n", i, j, got,
+                    want);
       }
     }
 }
@@ -139,8 +139,7 @@ void test_interpreted_gq() {
   params["sigma"] = sig;
   wi.seed(42);
   const std::vector<double> r1 = wi.eval(params);
-  expect_eq("gqrng header", joined(wi.columns()),
-            "sigma,yrep,crep,branchy,p");
+  expect_eq("gqrng header", joined(wi.columns()), "sigma,yrep,crep,branchy,p");
   if (r1.size() != 5) {
     ++failures;
     std::printf("FAIL gqrng: row size %zu\n", r1.size());

--- a/tools/bench_cmdstan_grad.cpp
+++ b/tools/bench_cmdstan_grad.cpp
@@ -14,8 +14,7 @@
 #include <vector>
 
 stan::model::model_base& new_model(stan::io::var_context& data_context,
-                                   unsigned int seed,
-                                   std::ostream* msg_stream);
+                                   unsigned int seed, std::ostream* msg_stream);
 
 int main(int argc, char** argv) {
   if (argc < 3) {

--- a/tools/bench_dispatch.cpp
+++ b/tools/bench_dispatch.cpp
@@ -91,14 +91,26 @@ int main() {
   std::vector<Step> steps((size_t)N + 1);
   std::vector<int> kind((size_t)N);
   for (int i = 0; i < N; ++i) {
-    ctx[(size_t)i] = Ctx{&vals[(size_t)i], &vals[(size_t)i + 1],
-                         &vals[(size_t)i + 2], 1};
+    ctx[(size_t)i] =
+        Ctx{&vals[(size_t)i], &vals[(size_t)i + 1], &vals[(size_t)i + 2], 1};
     kind[(size_t)i] = i % 4;
     switch (kind[(size_t)i]) {
-      case 0: fns[(size_t)i] = add_fwd; steps[(size_t)i].fn = t_add; break;
-      case 1: fns[(size_t)i] = mul_fwd; steps[(size_t)i].fn = t_mul; break;
-      case 2: fns[(size_t)i] = sub_fwd; steps[(size_t)i].fn = t_sub; break;
-      default: fns[(size_t)i] = neg_fwd; steps[(size_t)i].fn = t_neg; break;
+      case 0:
+        fns[(size_t)i] = add_fwd;
+        steps[(size_t)i].fn = t_add;
+        break;
+      case 1:
+        fns[(size_t)i] = mul_fwd;
+        steps[(size_t)i].fn = t_mul;
+        break;
+      case 2:
+        fns[(size_t)i] = sub_fwd;
+        steps[(size_t)i].fn = t_sub;
+        break;
+      default:
+        fns[(size_t)i] = neg_fwd;
+        steps[(size_t)i].fn = t_neg;
+        break;
     }
   }
   ctx[(size_t)N] = ctx[0];
@@ -107,9 +119,8 @@ int main() {
   const double loop_ns = time_ns(REPS, [&] {
     for (int i = 0; i < N; ++i) fns[(size_t)i](ctx[(size_t)i]);
   });
-  const double tail_ns = time_ns(REPS, [&] {
-    steps[0].fn(steps.data(), ctx.data());
-  });
+  const double tail_ns =
+      time_ns(REPS, [&] { steps[0].fn(steps.data(), ctx.data()); });
   // UNROLL4: today's loop, four separate call sites -- no kernel changes.
   const double unroll_ns = time_ns(REPS, [&] {
     int i = 0;
@@ -125,10 +136,18 @@ int main() {
     for (int i = 0; i < N; ++i) {
       Ctx& c = ctx[(size_t)i];
       switch (kind[(size_t)i]) {
-        case 0: c.out[0] = c.a[0] + c.b[0]; break;
-        case 1: c.out[0] = c.a[0] * c.b[0]; break;
-        case 2: c.out[0] = c.a[0] - c.b[0]; break;
-        default: c.out[0] = -c.a[0]; break;
+        case 0:
+          c.out[0] = c.a[0] + c.b[0];
+          break;
+        case 1:
+          c.out[0] = c.a[0] * c.b[0];
+          break;
+        case 2:
+          c.out[0] = c.a[0] - c.b[0];
+          break;
+        default:
+          c.out[0] = -c.a[0];
+          break;
       }
     }
   });

--- a/tools/bench_opcost.cpp
+++ b/tools/bench_opcost.cpp
@@ -70,8 +70,8 @@ static Graph make_graph(bool density, int* n_ops) {
 }
 
 static void fill_inputs(Executor& ex) {
-  ex.params_data()[0] = 0.3;   // mu
-  ex.params_data()[1] = 1.2;   // sigma
+  ex.params_data()[0] = 0.3;  // mu
+  ex.params_data()[1] = 1.2;  // sigma
   // data slots follow the params in the arena; y_i deterministic
   for (int i = 0; i < N; ++i)
     ex.params_data()[2 + 2 * i] = 0.1 * ((i % 17) - 8);
@@ -134,8 +134,8 @@ int main() {
     for (int i = 0; i < N; ++i) {
       const double y = 0.1 * ((i % 17) - 8);
       const double z = (y - muv) / sigv;
-      const double lp = -0.5 * z * z - std::log(sigv)
-                        - 0.918938533204672742;  // -0.5*log(2*pi)
+      const double lp = -0.5 * z * z - std::log(sigv) -
+                        0.918938533204672742;  // -0.5*log(2*pi)
       const double dmu = z / sigv;
       const double dsig = (z * z - 1.0) / sigv;
       sink += lp + dmu + dsig;
@@ -144,8 +144,10 @@ int main() {
 
   std::printf("graph ops: density=%d trivial=%d (N=%d density/add ops)\n",
               ops_d, ops_t, N);
-  std::printf("A exec grad density : %8.1f ns total, %6.2f ns/op, %6.2f ns/density-op\n",
-              a_ns, a_ns / ops_d, a_ns / N);
+  std::printf(
+      "A exec grad density : %8.1f ns total, %6.2f ns/op, %6.2f "
+      "ns/density-op\n",
+      a_ns, a_ns / ops_d, a_ns / N);
   std::printf("B exec fwd density  : %8.1f ns total, %6.2f ns/op\n", b_ns,
               b_ns / ops_d);
   std::printf("E exec grad trivial : %8.1f ns total, %6.2f ns/op\n", e_ns,

--- a/tools/dump_ops.cpp
+++ b/tools/dump_ops.cpp
@@ -40,9 +40,8 @@ static void summarize(const stanli::Graph& g) {
       per_op_scalar[op.opcode] += s;
     }
   }
-  std::printf("SUMMARY ops=%zu scalar_out=%lld vector_out=%lld\n",
-              g.ops.size(), (long long)scalar,
-              (long long)(g.ops.size() - scalar));
+  std::printf("SUMMARY ops=%zu scalar_out=%lld vector_out=%lld\n", g.ops.size(),
+              (long long)scalar, (long long)(g.ops.size() - scalar));
   // Opcodes by scalar-output count: the re-roll pass's remaining targets.
   std::vector<std::pair<int64_t, uint16_t>> rank;
   for (uint16_t oc = 0; oc < stanli::OP_COUNT_; ++oc)

--- a/tools/format.sh
+++ b/tools/format.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+# Format every tracked C/C++ file with the repo .clang-format (Google
+# style). Pass --check to fail on unformatted files instead of writing.
+set -e
+cd "$(dirname "$0")/.."
+mode=-i
+[ "$1" = "--check" ] && mode="--dry-run -Werror"
+git ls-files '*.cpp' '*.hpp' '*.h' '*.c' ':!deps/*' ':!runtime/third_party/*' |
+  xargs clang-format $mode

--- a/tools/ref_driver.cpp
+++ b/tools/ref_driver.cpp
@@ -19,8 +19,7 @@
 
 // Provided by the generated model translation unit.
 stan::model::model_base& new_model(stan::io::var_context& data_context,
-                                   unsigned int seed,
-                                   std::ostream* msg_stream);
+                                   unsigned int seed, std::ostream* msg_stream);
 
 // Same points as tools/stanli_check.cpp; see the note there on why more
 // than one exists.
@@ -75,8 +74,7 @@ int main(int argc, char** argv) {
     }
     std::printf("WANAMES %s\n", joined.c_str());
     std::printf("WAVALS");
-    for (int64_t i = 0; i < vars.size(); ++i)
-      std::printf(" %.17g", vars(i));
+    for (int64_t i = 0; i < vars.size(); ++i) std::printf(" %.17g", vars(i));
     std::printf("\n");
   } catch (const std::exception& e) {
     std::printf("WANAMES FAIL %s\n", e.what());

--- a/tools/stanli_check.cpp
+++ b/tools/stanli_check.cpp
@@ -38,8 +38,8 @@ static double eval_point(int64_t i, int variant) {
 
 static std::string run_stanc(const std::string& stanc,
                              const std::string& model) {
-  const std::string cmd = stanc + " --debug-transformed-mir '" + model +
-                          "' 2>/dev/null";
+  const std::string cmd =
+      stanc + " --debug-transformed-mir '" + model + "' 2>/dev/null";
   std::unique_ptr<FILE, int (*)(FILE*)> pipe(popen(cmd.c_str(), "r"), pclose);
   if (!pipe) throw std::runtime_error("cannot run stanc");
   std::string out;
@@ -63,10 +63,14 @@ int main(int argc, char** argv) {
   bool wa_values = false;
   for (int i = 3; i < argc; ++i) {
     const std::string a = argv[i];
-    if (a == "--columns") columns_only = true;
-    else if (a == "--wa-values") wa_values = true;
-    else if (a == "--stanc" && i + 1 < argc) stanc = argv[++i];
-    else if (a == "--point" && i + 1 < argc) variant = std::atoi(argv[++i]);
+    if (a == "--columns")
+      columns_only = true;
+    else if (a == "--wa-values")
+      wa_values = true;
+    else if (a == "--stanc" && i + 1 < argc)
+      stanc = argv[++i];
+    else if (a == "--point" && i + 1 < argc)
+      variant = std::atoi(argv[++i]);
   }
   if (const char* env = std::getenv("STANC")) stanc = env;
 
@@ -98,9 +102,9 @@ int main(int argc, char** argv) {
   // comparison against CmdStan's (harnesses/wa_header_check.py).
   if (columns_only) {
     if (!cm.write_array || cm.write_array->columns.empty()) {
-      std::printf("NO_COLUMNS %s\n",
-                  cm.write_array ? cm.write_array->truncated.c_str()
-                                 : "no generate_quantities section");
+      std::printf("NO_COLUMNS %s\n", cm.write_array
+                                         ? cm.write_array->truncated.c_str()
+                                         : "no generate_quantities section");
       return 1;
     }
     std::string h;
@@ -111,8 +115,7 @@ int main(int argc, char** argv) {
     }
     std::printf("%s\n", h.c_str());
     if (!cm.write_array->truncated.empty())
-      std::fprintf(stderr, "TRUNCATED %s\n",
-                   cm.write_array->truncated.c_str());
+      std::fprintf(stderr, "TRUNCATED %s\n", cm.write_array->truncated.c_str());
     return 0;
   }
 
@@ -183,8 +186,8 @@ int main(int argc, char** argv) {
         std::fprintf(stderr,
                      "WA %zu vars %lld values %lld nonfinite complete "
                      "(interpreted: %s)\n",
-                     wi.columns().size(), (long long)row.size(),
-                     (long long)bad, cm.write_array->truncated.c_str());
+                     wi.columns().size(), (long long)row.size(), (long long)bad,
+                     cm.write_array->truncated.c_str());
         if (wa_values) {
           std::string joined;
           for (const auto& nm :
@@ -198,8 +201,7 @@ int main(int argc, char** argv) {
         }
       } catch (const std::exception& we) {
         std::fprintf(stderr, "WA empty interp: %s\n", we.what());
-        if (wa_values)
-          std::printf("WANAMES FAIL %s\nWAVALS FAIL\n", we.what());
+        if (wa_values) std::printf("WANAMES FAIL %s\nWAVALS FAIL\n", we.what());
       }
     } else if (cm.write_array->columns.empty()) {
       std::fprintf(stderr, "WA empty %s\n", cm.write_array->truncated.c_str());
@@ -236,9 +238,8 @@ int main(int argc, char** argv) {
         std::printf("\n");
       }
     }
-    if (wa_values &&
-        (!cm.write_array ||
-         (!cm.write_array->interp && cm.write_array->columns.empty())))
+    if (wa_values && (!cm.write_array || (!cm.write_array->interp &&
+                                          cm.write_array->columns.empty())))
       std::printf("WANAMES FAIL no write_array\nWAVALS FAIL\n");
   } catch (const std::exception& e) {
     std::printf("EVAL_FAIL %s\n", e.what());

--- a/tools/stanli_run.cpp
+++ b/tools/stanli_run.cpp
@@ -64,8 +64,8 @@ static std::string embedded_stanc(const std::string& model) {
 
 static std::string run_stanc(const std::string& stanc,
                              const std::string& model) {
-  const std::string cmd = stanc + " --debug-transformed-mir '" + model +
-                          "' 2>/dev/null";
+  const std::string cmd =
+      stanc + " --debug-transformed-mir '" + model + "' 2>/dev/null";
   std::unique_ptr<FILE, int (*)(FILE*)> pipe(popen(cmd.c_str(), "r"), pclose);
   if (!pipe) throw std::runtime_error("cannot run stanc: " + cmd);
   std::string out;
@@ -105,21 +105,43 @@ int main(int argc, char** argv) {
   bool threads_asked = false;
   for (int i = 3; i < argc; ++i) {
     const std::string k = argv[i];
-    if (k == "--sampler-stats") { want_stats = true; continue; }
-    if (k == "--summary") { want_summary = true; continue; }
-    if (k == "--save-warmup") { cfg.save_warmup = true; continue; }
+    if (k == "--sampler-stats") {
+      want_stats = true;
+      continue;
+    }
+    if (k == "--summary") {
+      want_summary = true;
+      continue;
+    }
+    if (k == "--save-warmup") {
+      cfg.save_warmup = true;
+      continue;
+    }
     if (i + 1 >= argc) break;
     const std::string v = argv[++i];
-    if (k == "--seed") cfg.seed = (uint32_t)std::stoul(v);
-    else if (k == "--warmup") cfg.warmup = std::stoi(v);
-    else if (k == "--samples") cfg.samples = std::stoi(v);
-    else if (k == "--delta") cfg.delta = std::stod(v);
-    else if (k == "--max-depth") cfg.max_depth = std::stoi(v);
-    else if (k == "--chains") n_chains = std::stoi(v);
-    else if (k == "--num-threads") { n_threads = std::stoi(v); threads_asked = true; }
-    else if (k == "--thin") cfg.thin = std::stoi(v);
-    else if (k == "--init-radius") cfg.init_radius = std::stod(v);
-    else if (k == "--stanc") { stanc = v; stanc_explicit = true; }
+    if (k == "--seed")
+      cfg.seed = (uint32_t)std::stoul(v);
+    else if (k == "--warmup")
+      cfg.warmup = std::stoi(v);
+    else if (k == "--samples")
+      cfg.samples = std::stoi(v);
+    else if (k == "--delta")
+      cfg.delta = std::stod(v);
+    else if (k == "--max-depth")
+      cfg.max_depth = std::stoi(v);
+    else if (k == "--chains")
+      n_chains = std::stoi(v);
+    else if (k == "--num-threads") {
+      n_threads = std::stoi(v);
+      threads_asked = true;
+    } else if (k == "--thin")
+      cfg.thin = std::stoi(v);
+    else if (k == "--init-radius")
+      cfg.init_radius = std::stod(v);
+    else if (k == "--stanc") {
+      stanc = v;
+      stanc_explicit = true;
+    }
   }
   if (n_chains < 1) n_chains = 1;
   if (n_threads <= 0) n_threads = n_chains;
@@ -189,9 +211,9 @@ int main(int argc, char** argv) {
     // column instead (slower, but generated quantities run once per stored
     // draw). Without either we still report the constrained parameters the
     // log_prob graph already computes.
-    stanli::WaInterp* wi =
-        cm.write_array && cm.write_array->interp ? cm.write_array->interp.get()
-                                                 : nullptr;
+    stanli::WaInterp* wi = cm.write_array && cm.write_array->interp
+                               ? cm.write_array->interp.get()
+                               : nullptr;
     const bool have_wa =
         !wi && cm.write_array && !cm.write_array->columns.empty();
     if (cm.write_array && !cm.write_array->truncated.empty())
@@ -200,8 +222,8 @@ int main(int argc, char** argv) {
                    cm.write_array->truncated.c_str());
     std::unique_ptr<stanli::Executor> wex;
     if (have_wa) {
-      wex = std::make_unique<stanli::Executor>(
-          std::move(cm.write_array->graph));
+      wex =
+          std::make_unique<stanli::Executor>(std::move(cm.write_array->graph));
       cm.write_array->bind(*wex);
     }
 
@@ -262,8 +284,9 @@ int main(int argc, char** argv) {
 
     std::string hdr;
     if (want_stats)
-      hdr = "lp__,accept_stat__,stepsize__,treedepth__,n_leapfrog__,"
-            "divergent__,energy__";
+      hdr =
+          "lp__,accept_stat__,stepsize__,treedepth__,n_leapfrog__,"
+          "divergent__,energy__";
     for (const auto& n : stanli::CompiledModel::csv_names(cols)) {
       if (!hdr.empty()) hdr += ',';
       hdr += n;
@@ -275,8 +298,7 @@ int main(int argc, char** argv) {
     // full draw matrix is hundreds of megabytes, and streaming is why the
     // default path can print them at all.
     std::vector<double> summary_draws;
-    if (want_summary)
-      summary_draws.reserve(draws.size() * col_names.size());
+    if (want_summary) summary_draws.reserve(draws.size() * col_names.size());
 
     std::vector<double> row;
     for (size_t d = 0; d < draws.size(); ++d) {
@@ -319,8 +341,8 @@ int main(int argc, char** argv) {
       flat_stats.reserve(stats.rows.size() * stanli::N_SAMPLER_COLS);
       for (const auto& r : stats.rows)
         flat_stats.insert(flat_stats.end(), r.begin(), r.end());
-      const auto fd = stanli::diagnose(ds, sm, flat_stats.data(),
-                                       cfg.max_depth);
+      const auto fd =
+          stanli::diagnose(ds, sm, flat_stats.data(), cfg.max_depth);
       std::fprintf(stderr, "%s", stanli::format_diagnostics(fd).c_str());
     }
     // Gradient evaluations = leapfrog steps + init probes. Reported so a


### PR DESCRIPTION
Adopts Google C++ style via clang-format and gates it.

- .clang-format is BasedOnStyle: Google with one deviation, SortIncludes: Never: include order is semantic in this codebase (stan-math injects Eigen plugin macros and must precede any Eigen include; sorting broke the build), and this PR's rule is no semantic changes.
- One mechanical reformat commit: 75 files, +1652/-1488. Vendored runtime/third_party/ is excluded so upstream diffs stay usable.
- tools/format.sh formats or checks (--check) every tracked C/C++ file; lint.yml runs the check on every PR and main push with pip-pinned clang-format 22.1.8, the exact binary that produced the reformat (output drifts across major versions).
- .clang-tidy ships config only; run-clang-tidy joins the gate in a follow-up PR that addresses what it finds, keeping this PR mechanically pure.

Verified no semantic change: full rebuild, ctest 33/33, corpus replay byte-identical (119/119 models, worst hmm_gaussian 3.63e-12 unchanged).

After this merges, a one-line follow-up records the rebase-merged reformat commit in .git-blame-ignore-revs (the SHA does not exist until the rebase merge creates it).