### PR TITLE
release: 0.5.1, attach release assets before publishing

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -754,11 +754,17 @@ jobs:
           n=$(ls runtime/*.tar.gz | wc -l)
           echo "$n runtime assets"
           [ "$n" -eq 5 ]
+          # Immutable releases freeze their assets the moment they are
+          # published, so everything must attach while the release is a
+          # draft and publishing is the last step. Publishing first and
+          # uploading after is a 422; worse, deleting the failed release
+          # tombstones the tag name forever (v0.5.0 is such a casualty).
           gh release view "$GITHUB_REF_NAME" >/dev/null 2>&1 ||
-            gh release create "$GITHUB_REF_NAME" \
+            gh release create "$GITHUB_REF_NAME" --draft \
               --title "stanli ${GITHUB_REF_NAME#v}" --generate-notes
           gh release upload "$GITHUB_REF_NAME" \
             runtime/*.tar.gz stanli_*.tar.gz --clobber
+          gh release edit "$GITHUB_REF_NAME" --draft=false
 
   publish:
     # Tags only. PyPI versions can never be reused, so this must not fire

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.5.1
+
+A re-release of 0.5.0 for the R distribution channel; no code changes.
+The v0.5.0 GitHub release was published before its runtime assets
+attached, and under immutable releases that freezes it empty; deleting
+it tombstones the tag name forever, so the assets `stanli_install()`
+downloads need a release that can carry them. The release workflow now
+attaches assets to a draft and publishes last, which is the order
+immutable releases require.
+
 ## 0.5.0
 
 Three bindings and a workflow. 0.4.x could sample a model from Python or

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@seantalts/stanli",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Full Stan in the browser: stanc3 compiles the model in JS, a WASM runtime lowers it to an op graph and runs NUTS. No server, no C++ toolchain.",
   "type": "module",
   "main": "index.mjs",

--- a/python/stanli/__init__.py
+++ b/python/stanli/__init__.py
@@ -19,7 +19,7 @@ __all__ = ["Model", "Fit", "Summary", "OptimizeResult",
            "SAMPLER_COLUMNS", "__version__"]
 # The one place the version lives. setup.py and the release workflow both
 # read it from here.
-__version__ = "0.5.0"
+__version__ = "0.5.1"
 
 _BIN = pathlib.Path(__file__).parent / "_bin"
 

--- a/r/DESCRIPTION
+++ b/r/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: stanli
 Type: Package
 Title: The Stan Language Interpreter
-Version: 0.5.0
+Version: 0.5.1
 Authors@R: person("Sean", "Talts", email = "xitrium@gmail.com",
                   role = c("aut", "cre"))
 Description: Compile and sample Stan models without a C++ toolchain. Stan

--- a/r/R/install.R
+++ b/r/R/install.R
@@ -17,7 +17,7 @@
 # pinned binding with a runtime that has moved. The release workflow
 # asserts this equals the tag being cut, so bumping one without the
 # other fails there rather than at a user's install.
-stanli_runtime_release <- "v0.5.0"
+stanli_runtime_release <- "v0.5.1"
 
 runtime_filename <- function() {
   switch(Sys.info()[["sysname"]],


### PR DESCRIPTION
A re-release of 0.5.0 for the R distribution channel; no code changes.
The v0.5.0 release was published before its assets attached, which
immutable releases freeze; deleting it tombstoned the tag. The
runtime-release job now creates the release as a draft, uploads, and
publishes last. v0.4.0's release has the same empty-assets symptom,
which is how long the create-then-upload order has been broken.
