### PR TITLE
npm publish never reached trusted publishing

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -691,10 +691,21 @@ jobs:
           echo "tag $tag, package.json $pkg"
           [ "$tag" = "$pkg" ]
 
+      # Deliberately no registry-url: setup-node writes an .npmrc with a
+      # placeholder _authToken when it is given one, npm sees credentials
+      # and never attempts the OIDC exchange, and the registry answers a
+      # write it cannot authorize with 404 rather than 401. That is what
+      # npm-v0.5.1 died of. Trusted publishing wants no token at all.
       - uses: actions/setup-node@v4
         with:
           node-version: '24'
-          registry-url: 'https://registry.npmjs.org'
+
+      # Trusted publishing landed in npm 11.5.1; whatever Node ships is
+      # not a promise about that.
+      - name: npm new enough to exchange the OIDC token
+        run: |
+          npm install -g npm@latest
+          npm --version
 
       - name: Publish
         run: |

--- a/README.md
+++ b/README.md
@@ -294,12 +294,18 @@ into a confusing build failure.
 The npm package `@seantalts/stanli` ships the same way on its own tag
 series: bump `version` in `js/package.json`, add the changelog entry,
 tag `npm-vX.Y.Z`. The `npm-publish` job asserts the tag matches
-`package.json` and publishes through npm trusted publishing. Two npm
-quirks worth knowing: a trusted publisher attaches only to a package
+`package.json` and publishes through npm trusted publishing. Three npm
+quirks worth knowing. A trusted publisher attaches only to a package
 that already exists, so a package's first version goes out by hand with
-`npm publish`; and the package is scoped because npm's name-similarity
-filter rejects unscoped `stanli`, which is why `publishConfig.access` is
-set to public.
+`npm publish`, and the publisher itself is configured on npmjs.com
+(Settings -> Trusted publisher: GitHub Actions, `seantalts` / `stanli` /
+`wheels.yml` / environment `npm`). The package is scoped because npm's
+name-similarity filter rejects unscoped `stanli`, which is why
+`publishConfig.access` is set to public. And the job passes
+`actions/setup-node` no `registry-url`: given one it writes an `.npmrc`
+carrying a placeholder auth token, npm sees credentials and never
+attempts the OIDC exchange, and the registry answers a write it cannot
+authorize with 404 rather than 401.
 
 ### R
 


### PR DESCRIPTION
`npm-v0.5.1`'s publish job failed with `E404 Not Found - PUT https://registry.npmjs.org/@seantalts%2fstanli`, and the registry still carries only the 0.1.0 that went out by hand.

404 there is npm's answer to a write it cannot authorize, not a missing package. The cause is in the log two lines up: `NODE_AUTH_TOKEN: XXXXX-XXXXX-XXXXX-XXXXX`. `actions/setup-node` writes an `.npmrc` with that placeholder whenever it is given a `registry-url`, npm finds credentials there, and never attempts the OIDC exchange that `id-token: write` and `environment: npm` exist for.

- No `registry-url`, no token: trusted publishing wants neither.
- `npm install -g npm@latest` first, since the exchange landed in npm 11.5.1 and what Node 24 ships is not a promise about that.
- README documents both, plus the half that is not in the repository.

**Needs a one-time setting on npmjs.com**: the package's trusted publisher (Settings -> Trusted publisher) must point at GitHub Actions, `seantalts` / `stanli`, workflow `wheels.yml`, environment `npm`. Without it the exchange has nothing to trade with and the next tag fails the same way.