### PR TITLE
Make the npm publish step able to authenticate

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -635,10 +635,19 @@ jobs:
       - id: deployment
         uses: actions/deploy-pages@v4
 
-  # npm, tag-gated like PyPI: npm-v* tags publish js/ through npm
-  # trusted publishing (OIDC, no token in secrets). The tag must agree
+  # npm, tag-gated like PyPI: npm-v* tags publish js/. The tag must agree
   # with js/package.json, and the artifacts are the same ones the wasm
   # job and the stancjs cache produced for this exact commit.
+  #
+  # Publishing needs ONE of these set up once, by hand, by someone signed
+  # in to the npm account -- neither can be done from this repository:
+  #   - a trusted publisher on npmjs.com for @seantalts/stanli (GitHub
+  #     Actions, repo seantalts/stanli, workflow wheels.yml, environment
+  #     npm), which is the tokenless path and attaches provenance; or
+  #   - a granular access token with publish rights on that package,
+  #     stored as the NPM_TOKEN repository secret.
+  # Until one exists every npm-v* tag fails here with a 404 on PUT, which
+  # is what the registry returns for "not allowed", not "not there".
   npm-publish:
     if: startsWith(github.ref, 'refs/tags/npm-v')
     needs: wasm
@@ -694,12 +703,35 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: '24'
-          registry-url: 'https://registry.npmjs.org'
 
+      # Trusted publishing exchanges the Actions OIDC token for a
+      # short-lived registry credential, and npm only learned how in
+      # 11.5.1. Whatever npm ships with the runner's Node is not a
+      # version this job should depend on.
+      - name: An npm that can do trusted publishing
+        run: |
+          npm install -g npm@latest
+          npm --version
+
+      # Two ways to authenticate, and the registry accepts exactly one of
+      # them per repository, so pick by what is configured rather than
+      # assuming. With NPM_TOKEN set this is an ordinary token publish.
+      # Without it, .npmrc must carry NO auth line at all: setup-node's
+      # registry-url writes a placeholder token, npm sends that instead of
+      # authenticating, and the registry answers 404 on a package that
+      # plainly exists -- which is what every npm-v* tag has done so far.
       - name: Publish
         run: |
           ls -la js/
-          cd js && npm publish
+          cd js
+          if [ -n "$NPM_TOKEN" ]; then
+            npm config set //registry.npmjs.org/:_authToken "$NPM_TOKEN"
+          else
+            echo "no NPM_TOKEN; publishing via trusted publishing (OIDC)"
+          fi
+          npm publish
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   # The R package's distribution channel. CRAN carries the R code and the
   # 40 KB bridge; the 16 MB runtime it dlopens comes from here, which is


### PR DESCRIPTION
npm-v0.5.0 and npm-v0.5.1 both failed the same way: `404 Not Found - PUT https://registry.npmjs.org/@seantalts%2fstanli`. The registry returns 404 for "not allowed", not "not there" - the package exists, seantalts owns it, and the tarball builds correctly (2.1 MB, 8 files, right name and version). It is an authorization failure.

Two causes were in this repository:

**setup-node's `registry-url` writes a placeholder token.** It pins .npmrc's auth to `NODE_AUTH_TOKEN`, and with no such secret it leaves its own placeholder (visible in the failed run as `NODE_AUTH_TOKEN: XXXXX-XXXXX-XXXXX-XXXXX`). npm sends that instead of authenticating, so the trusted-publishing exchange never runs. Dropped `registry-url` - npm defaults to the same registry - and the job now writes an auth line only when there is a real token.

**Trusted publishing needs npm >= 11.5.1** to do the OIDC exchange, and whatever npm ships with the runner's Node is not a version to depend on. Installs a current npm first.

**What this PR does not do.** The account still needs one of the following, and neither can be set up from a repository:

- a trusted publisher on npmjs.com for `@seantalts/stanli` (GitHub Actions, repo `seantalts/stanli`, workflow `wheels.yml`, environment `npm`) - tokenless, and attaches provenance; or
- a granular access token with publish rights on that package, stored as the `NPM_TOKEN` repository secret.

I checked: the repository has no secrets at all and the `npm` environment is empty, so today neither path is configured. This PR means the next tag after one of them exists will not then fail for a second, unrelated reason.

Note for whoever finishes this: rerunning the failed npm-v0.5.1 run will not pick up this fix, because a rerun uses the workflow as of the tagged commit. Since 0.5.1 never reached the registry the version number is still free, so the tag can be deleted and recreated on main after this merges.