### PR TITLE
Fix the facade's Windows link: BRIDGESTAN_EXPORT for consumers too

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -332,6 +332,12 @@ target_compile_definitions(stanli PRIVATE STANLI_BUILD_ID="${STANLI_BUILD_ID}")
 # saves compiling it.
 if(NOT EMSCRIPTEN)
   target_sources(stanli PRIVATE runtime/src/bridgestan_abi.cpp)
+  # PUBLIC, so anything linking the runtime sees the same decoration the
+  # definitions were compiled with. Without it the reference header's
+  # BS_PUBLIC is __declspec(dllimport) on Windows, and a test linking the
+  # static library asks for __imp_bs_* from a DLL that does not exist.
+  # Ignored everywhere else: BS_PUBLIC is a visibility attribute there.
+  target_compile_definitions(stanli PUBLIC BRIDGESTAN_EXPORT=1)
 endif()
 target_link_libraries(stanli PUBLIC stanmath sundials)
 if(NOT EMSCRIPTEN)

--- a/runtime/src/bridgestan_abi.cpp
+++ b/runtime/src/bridgestan_abi.cpp
@@ -26,7 +26,13 @@
 // executor from an ExecutorPool for the length of the call. The RNG is the
 // caller's, in a bs_rng handle, so two chains drawing generated quantities
 // through one model do not share a stream.
+// BS_PUBLIC is __declspec(dllimport) on Windows unless this is defined,
+// which would make these definitions, and any reference to them, look for
+// a DLL that does not exist. The build sets it for everything that links
+// the runtime; this keeps the file correct when compiled on its own.
+#ifndef BRIDGESTAN_EXPORT
 #define BRIDGESTAN_EXPORT 1
+#endif
 #include "../third_party/bridgestan.h"
 
 #include <stanli/bridgestan_internal.hpp>


### PR DESCRIPTION
The reference header's `BS_PUBLIC` expands to `__declspec(dllimport)` on
Windows unless `BRIDGESTAN_EXPORT` is defined. `bridgestan_abi.cpp`
defined it for itself, so the definitions were right, but nothing told
the test, whose references then looked for `__imp_bs_*` in a DLL that
does not exist. Every `bs_` symbol failed to link on win_amd64 and
nowhere else, which is how it reached main green: win_amd64 does not run
on pull requests.

The runtime target carries the definition PUBLIC, so anything linking it
sees the same decoration the definitions were compiled with. The in-file
define stays, guarded, so the file is still correct compiled on its own.
No effect off Windows, where `BS_PUBLIC` is a visibility attribute.

Verified by dispatching the full matrix on this branch rather than
trusting the PR gate:
[run 31485683703](https://github.com/seantalts/stanli/actions/runs/31485683703)
has win_amd64, wasm, both manylinux and macos arm64 green.

Also fixes the same failure on the other post-merge run (#59's merge hit
it too, since the cause is on main rather than in either change).