### PR TITLE
WALNUTS sampling, native and in the browser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 ## Unreleased
 
+### WALNUTS, next to NUTS
+
+The WALNUTS sampler (within-orbit adaptive step-length NUTS,
+arXiv:2506.18746) is now built in, via the vendored walnutpie headers
+(`runtime/third_party/walnutpie/`, MIT). `run_walnuts` mirrors
+`run_nuts` over the same executor gradient, `stanli_sample_walnuts_stream`
+mirrors `stanli_sample_stream` on the C ABI, and the npm package's
+`sample()` takes `sampler: "walnuts"`. Where NUTS picks one step size
+per chain, WALNUTS halves the step within a trajectory wherever the
+local error demands it, which is what makes funnel-like geometry
+tractable without cranking `delta`; its tunable is `max_error`, the
+largest drift in the joint log density allowed across one macro step.
+
+The browser page grew a sampler picker with a comparison mode: NUTS
+and WALNUTS run at once on the same model, data, and seed, NUTS's
+column on the left and WALNUTS's on the right, each with live traces,
+a histogram, per-chain timing with min ESS and ESS per second, and the
+full summary table. Clicking a parameter row in either table selects
+it in both, redrawing the traces on a shared y range and the
+histograms on a shared x range, so the eye compares mixing and the
+posterior rather than axis choices.
+
 Groundwork for letting external samplers drive stanli models, plus two
 fixes that stand on their own.
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,14 @@ project(stanli C CXX)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+# The one exception: walnuts.cpp wraps the vendored walnutpie headers,
+# which are written against C++20 concepts. It includes no stan-math --
+# just the executor interface and Eigen -- so the newer standard stays
+# contained to that translation unit.
+set_source_files_properties(runtime/src/walnuts.cpp PROPERTIES
+  COMPILE_OPTIONS "-std=c++20"
+  INCLUDE_DIRECTORIES ${CMAKE_CURRENT_SOURCE_DIR}/runtime/third_party)
 if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE RelWithDebInfo)
 endif()
@@ -217,6 +225,7 @@ add_library(stanli_shared SHARED
   runtime/src/adjoint.cpp
   runtime/src/program_density.cpp
   runtime/src/nuts.cpp
+  runtime/src/walnuts.cpp
   runtime/src/diagnose.cpp
   runtime/src/estimate.cpp
   runtime/src/mir_reader.cpp
@@ -313,6 +322,7 @@ add_library(stanli STATIC
   runtime/src/adjoint.cpp
   runtime/src/program_density.cpp
   runtime/src/nuts.cpp
+  runtime/src/walnuts.cpp
   runtime/src/diagnose.cpp
   runtime/src/estimate.cpp
   runtime/src/mir_reader.cpp
@@ -363,7 +373,7 @@ if(EMSCRIPTEN)
     "SHELL:-s MAXIMUM_MEMORY=4GB"
     "SHELL:-s STACK_SIZE=8MB"
     "SHELL:-s ENVIRONMENT=web,worker,node"
-    "SHELL:-s EXPORTED_FUNCTIONS=_stanli_model_new,_stanli_model_new_from_stan,_stanli_has_embedded_stanc,_stanli_exact_lp,_stanli_model_free,_stanli_n_unconstrained,_stanli_grad,_stanli_sample,_stanli_n_constrained,_stanli_constrained_name,_stanli_constrain,_stanli_wa_n_columns,_stanli_wa_column_name,_stanli_wa_seed,_stanli_wa_row,_stanli_sample_stream,_malloc,_free"
+    "SHELL:-s EXPORTED_FUNCTIONS=_stanli_model_new,_stanli_model_new_from_stan,_stanli_has_embedded_stanc,_stanli_exact_lp,_stanli_model_free,_stanli_n_unconstrained,_stanli_grad,_stanli_sample,_stanli_n_constrained,_stanli_constrained_name,_stanli_constrain,_stanli_wa_n_columns,_stanli_wa_column_name,_stanli_wa_seed,_stanli_wa_row,_stanli_sample_stream,_stanli_sample_walnuts_stream,_malloc,_free"
     "SHELL:-s EXPORTED_RUNTIME_METHODS=cwrap,UTF8ToString,stringToNewUTF8,HEAPF64,addFunction,removeFunction"
     "SHELL:-s ALLOW_TABLE_GROWTH=1")
 endif()
@@ -421,6 +431,7 @@ stanli_add_test(test_legacy)
 stanli_add_test(test_eight_schools)
 stanli_add_test(test_glm)
 stanli_add_test(test_nuts)
+stanli_add_test(test_walnuts)
 stanli_add_test(test_sexp)
 stanli_add_test(test_mir)
 stanli_add_test(test_transforms)

--- a/THIRD_PARTY_LICENSES.md
+++ b/THIRD_PARTY_LICENSES.md
@@ -15,10 +15,13 @@ distributes those components too.
 | [Boost](https://www.boost.org) | math special functions and utilities used by stan-math | Boost Software License 1.0 |
 | [SUNDIALS / CVODES](https://computing.llnl.gov/projects/sundials) | ODE integration for `integrate_ode_rk45` and `integrate_ode_bdf` | BSD 3-Clause |
 | [nlohmann/json](https://github.com/nlohmann/json) | reading CmdStan-format JSON data | MIT |
+| [walnutpie](https://github.com/flatironinstitute/walnuts) | WALNUTS sampler and its warmup adaptation | MIT |
 
 Full license texts ship with the vendored sources fetched by
 `deps/fetch.sh`; see `deps/math/LICENSE.md`, `deps/stan/LICENSE.md`, and
-the license files under `deps/math/lib/`.
+the license files under `deps/math/lib/`. walnutpie is vendored directly
+in this repository, headers and license together, at
+`runtime/third_party/walnutpie/`.
 
 Notes on the two that carry conditions beyond attribution:
 

--- a/js/index.mjs
+++ b/js/index.mjs
@@ -107,7 +107,12 @@ export function compile(opts) {
  * @param {number} [opts.seed=1]       Chain seed (sampler and GQ RNG).
  * @param {number} [opts.warmup=1000]
  * @param {number} [opts.samples=1000]
- * @param {number} [opts.delta=0.8]    Adaptation target acceptance.
+ * @param {number} [opts.delta=0.8]    Adaptation target acceptance (NUTS).
+ * @param {string} [opts.sampler="nuts"]  "nuts" or "walnuts" (within-orbit
+ *   adaptive step-length NUTS, arXiv:2506.18746).
+ * @param {number} [opts.maxError]     WALNUTS only: largest drift in the
+ *   joint log density allowed across one macro step before the step is
+ *   halved within the trajectory. Omit for the runtime default (0.5).
  * @param {function(string)} [opts.onProgress]  Stage announcements.
  * @param {function(Object)} [opts.onLive]  Streaming draws while NUTS
  *   runs: {liveMeta: {names, warmup, samples}} once per call, then
@@ -134,6 +139,8 @@ export function sample(opts) {
     warmup: opts.warmup == null ? 1000 : opts.warmup,
     samples: opts.samples == null ? 1000 : opts.samples,
     delta: opts.delta == null ? 0.8 : opts.delta,
+    sampler: opts.sampler === "walnuts" ? "walnuts" : "nuts",
+    maxError: opts.maxError == null ? 0 : opts.maxError,
   }, opts).then((done) => {
     const { names, samples, ms, exactLp } = done;
     const flat = new Float64Array(done.columns);

--- a/js/worker.js
+++ b/js/worker.js
@@ -1,8 +1,8 @@
 // The sampling worker: stanc3 (js_of_ocaml) compiles the model to MIR,
-// stanli.wasm lowers it and runs NUTS. Everything heavy lives here so the
-// page never blocks. Protocol: {cmd: "run", code, dataJson, seed, warmup,
-// samples, delta} in; {status} progress messages and one {done} or
-// {error} out.
+// stanli.wasm lowers it and runs NUTS or WALNUTS. Everything heavy lives
+// here so the page never blocks. Protocol: {cmd: "run", code, dataJson,
+// seed, warmup, samples, delta, sampler, maxError} in; {status} progress
+// messages and one {done} or {error} out.
 "use strict";
 importScripts("stanli.js");
 
@@ -69,7 +69,9 @@ onmessage = async (e) => {
     const n = Number(M._stanli_n_unconstrained(model));
     const samples = req.samples | 0;
     const warmup = req.warmup | 0;
-    say("NUTS: " + warmup + " warmup + " + samples + " draws");
+    const walnuts = req.sampler === "walnuts";
+    say((walnuts ? "WALNUTS: " : "NUTS: ") + warmup + " warmup + " +
+        samples + " draws");
     const drawsPtr = M._malloc(8 * samples * n);
 
     // Stream: every draw lands in the buffer before its callback, so the
@@ -106,9 +108,16 @@ onmessage = async (e) => {
       }
     }, "viii");
     }
-    const rc = M._stanli_sample_stream(model, req.seed >>> 0, warmup,
-                                       samples, +req.delta, drawsPtr,
-                                       cbPtr, 0, errPtr, errLen);
+    // Same streaming contract either way; WALNUTS's tunable is the max
+    // Hamiltonian error per macro step rather than NUTS's target
+    // acceptance rate, and 0 asks the runtime for its default.
+    const rc = walnuts
+        ? M._stanli_sample_walnuts_stream(model, req.seed >>> 0, warmup,
+                                          samples, +req.maxError || 0,
+                                          drawsPtr, cbPtr, 0, errPtr, errLen)
+        : M._stanli_sample_stream(model, req.seed >>> 0, warmup,
+                                  samples, +req.delta, drawsPtr,
+                                  cbPtr, 0, errPtr, errLen);
     if (cbPtr) M.removeFunction(cbPtr);
     if (liveRowPtr) M._free(liveRowPtr);
     if (rc !== 0) throw new Error(M.UTF8ToString(errPtr));

--- a/runtime/include/stanli/capi.h
+++ b/runtime/include/stanli/capi.h
@@ -261,6 +261,16 @@ int stanli_sample_stream(stanli_model* m, uint32_t seed, int warmup,
                          stanli_draw_cb cb, void* user, char* err,
                          size_t err_len);
 
+/* WALNUTS (within-orbit adaptive step-length NUTS, arXiv:2506.18746),
+ * same streaming contract as stanli_sample_stream. `max_error` is the
+ * sampler's tunable in place of NUTS's `delta`: the largest drift in
+ * the joint log density allowed across one macro step before the step
+ * is halved within the trajectory; pass 0 for the default (0.5). */
+int stanli_sample_walnuts_stream(stanli_model* m, uint32_t seed, int warmup,
+                                 int samples, double max_error, double* draws,
+                                 stanli_draw_cb cb, void* user, char* err,
+                                 size_t err_len);
+
 /* write_array: every CSV column CmdStan would emit for one draw --
  * constrained parameters, transformed parameters, generated quantities,
  * in CmdStan's column order. n_columns is 0 when the model has no

--- a/runtime/include/stanli/walnuts.hpp
+++ b/runtime/include/stanli/walnuts.hpp
@@ -1,0 +1,49 @@
+#ifndef STANLI_WALNUTS_HPP
+#define STANLI_WALNUTS_HPP
+
+#include <stanli/graph.hpp>
+#include <stanli/nuts.hpp>  // DrawObserver, shared with NUTS on purpose
+
+#include <cstdint>
+#include <vector>
+
+namespace stanli {
+
+// WALNUTS: within-orbit adaptive step-length NUTS (arXiv:2506.18746),
+// via the vendored walnutpie implementation. Where NUTS picks one step
+// size per chain and lives with it, WALNUTS halves the step within a
+// trajectory wherever the local error demands it, which is what makes
+// funnel-like geometry tractable without cranking delta.
+struct WalnutsConfig {
+  uint32_t seed = 0;
+  int chain_id = 1;
+  int warmup = 1000;
+  int samples = 1000;
+  // Trajectory doublings cap, the analogue of NUTS max_depth.
+  int max_depth = 10;
+  // Within-trajectory step control: a macro step may be cut in half up
+  // to this many times, and the joint density may drift at most
+  // max_error nats across a macro step before halving kicks in.
+  int max_step_halvings = 5;
+  double max_error = 0.5;
+  // Initial macro step size; warmup's Adam optimizer adapts it.
+  double init_step_size = 1.0;
+  // Initialization on the unconstrained scale, same contract as
+  // NutsConfig: uniform(-init_radius, init_radius) with finite lp and
+  // gradient required, or an explicit point.
+  double init_radius = 2.0;
+  const double* init = nullptr;
+};
+
+// Runs adaptive-walnuts warmup then fixed-parameter WALNUTS sampling.
+// Returns one unconstrained parameter vector per stored draw. `stats`,
+// when non-null, receives per-draw rows shaped like SamplerStats but
+// with WALNUTS's own diagnostics (see walnuts.cpp for the columns).
+std::vector<std::vector<double>> run_walnuts(Executor& ex,
+                                             const WalnutsConfig& cfg,
+                                             SamplerStats* stats = nullptr,
+                                             const DrawObserver& observe = {});
+
+}  // namespace stanli
+
+#endif

--- a/runtime/src/capi.cpp
+++ b/runtime/src/capi.cpp
@@ -5,6 +5,7 @@
 #include <stanli/estimate.hpp>
 #include <stanli/graph.hpp>
 #include <stanli/nuts.hpp>
+#include <stanli/walnuts.hpp>
 #include <stanli/wa_interp.hpp>
 
 #include <algorithm>
@@ -236,6 +237,34 @@ int stanli_sample_stream(stanli_model* m, uint32_t seed, int warmup,
       };
     }
     auto out = stanli::run_nuts(*m->ex, cfg, nullptr, observe);
+    for (size_t s = 0; s < out.size(); ++s)
+      std::memcpy(draws + s * n, out[s].data(), sizeof(double) * n);
+    return 0;
+  } catch (const std::exception& e) {
+    put_err(err, err_len, e.what());
+    return 1;
+  }
+}
+
+int stanli_sample_walnuts_stream(stanli_model* m, uint32_t seed, int warmup,
+                                 int samples, double max_error, double* draws,
+                                 stanli_draw_cb cb, void* user, char* err,
+                                 size_t err_len) {
+  try {
+    stanli::WalnutsConfig cfg;
+    cfg.seed = seed;
+    cfg.warmup = warmup;
+    cfg.samples = samples;
+    if (max_error > 0) cfg.max_error = max_error;
+    const int64_t n = m->ex->n_params();
+    stanli::DrawObserver observe;
+    if (cb) {
+      observe = [&](int64_t i, bool wu, const double* q) {
+        if (!wu) std::memcpy(draws + i * n, q, sizeof(double) * n);
+        cb((int32_t)i, wu ? 1 : 0, user);
+      };
+    }
+    auto out = stanli::run_walnuts(*m->ex, cfg, nullptr, observe);
     for (size_t s = 0; s < out.size(); ++s)
       std::memcpy(draws + s * n, out[s].data(), sizeof(double) * n);
     return 0;

--- a/runtime/src/walnuts.cpp
+++ b/runtime/src/walnuts.cpp
@@ -135,8 +135,8 @@ std::vector<std::vector<double>> run_walnuts(Executor& ex,
   CollectHandler handler{&draws, stats, &observe};
   ExecLogpGrad logp_grad{&ex};
 
-  const walnutpie::InitChainConfig init_cfg(
-      cfg.init_step_size, q, Eigen::VectorXd::Ones(n));
+  const walnutpie::InitChainConfig init_cfg(cfg.init_step_size, q,
+                                            Eigen::VectorXd::Ones(n));
   const walnutpie::WarmupConfig warmup_cfg =
       walnutpie::WarmupConfigBuilder{}
           .min_max_iter((size_t)cfg.warmup, (size_t)cfg.warmup)

--- a/runtime/src/walnuts.cpp
+++ b/runtime/src/walnuts.cpp
@@ -1,0 +1,165 @@
+// WALNUTS over the executor's gradient, via the vendored walnutpie
+// headers. This is the only C++20 translation unit in the runtime
+// (walnutpie is written against concepts); it deliberately includes no
+// stan-math, only the executor interface and Eigen, so the newer
+// standard never touches the rest of the build.
+#include <stanli/walnuts.hpp>
+
+#include <Eigen/Dense>
+
+#include <walnutpie/adaptive_walnuts.hpp>
+#include <walnutpie/config.hpp>
+#include <walnutpie/walnuts.hpp>
+
+#include <cmath>
+#include <limits>
+#include <random>
+#include <stdexcept>
+#include <vector>
+
+namespace stanli {
+
+namespace {
+
+// walnutpie's model interface: a const callable setting logp and grad.
+// Mutating the executor through a pointer keeps the callable const the
+// way the LogpGrad concept wants; the arenas are per-evaluation state.
+struct ExecLogpGrad {
+  Executor* ex;
+  void operator()(const Eigen::VectorXd& x, double& logp,
+                  Eigen::VectorXd& grad) const {
+    const int64_t n = ex->n_params();
+    for (int64_t i = 0; i < n; ++i) ex->params_data()[i] = x(i);
+    grad.resize(n);
+    logp = ex->gradient(grad.data());
+  }
+};
+
+// The chain handler walnutpie calls back on: collects stored draws,
+// per-draw stats, and forwards to the streaming observer. Stats rows
+// keep SamplerStats' 7-column CmdStan shape so consumers can share
+// code with NUTS; columns WALNUTS has no analogue for are NaN.
+//   lp__, accept_stat__(NaN), stepsize__, treedepth__(NaN),
+//   n_leapfrog__(NaN), divergent__(NaN), energy__(NaN)
+struct CollectHandler {
+  std::vector<std::vector<double>>* out;
+  SamplerStats* stats;
+  const DrawObserver* observe;
+  int64_t warm_i = 0;
+  int64_t samp_i = 0;
+  double cur_step = std::numeric_limits<double>::quiet_NaN();
+
+  void on_warmup(const Eigen::VectorXd& q, double /*lp*/, double step,
+                 const Eigen::VectorXd& /*inv_mass*/) {
+    cur_step = step;
+    if (*observe) (*observe)(warm_i, true, q.data());
+    ++warm_i;
+  }
+  void on_warmup_complete(double step, const Eigen::VectorXd& /*inv_mass*/) {
+    cur_step = step;
+  }
+  void on_sample(const Eigen::VectorXd& q, double lp) {
+    out->emplace_back(q.data(), q.data() + q.size());
+    if (stats) {
+      const double nan = std::numeric_limits<double>::quiet_NaN();
+      stats->rows.push_back({lp, nan, cur_step, nan, nan, nan, nan});
+    }
+    if (*observe) (*observe)(samp_i, false, q.data());
+    ++samp_i;
+  }
+  void on_logp_exception(const Eigen::VectorXd& /*q*/,
+                         const std::exception& /*e*/) noexcept {
+    // walnutpie already treats a throwing density as logp = -inf, which
+    // is the same "reject this point" semantics NUTS gets from stan's
+    // samplers; nothing further to do.
+  }
+};
+
+}  // namespace
+
+std::vector<std::vector<double>> run_walnuts(Executor& ex,
+                                             const WalnutsConfig& cfg,
+                                             SamplerStats* stats,
+                                             const DrawObserver& observe) {
+  const int64_t n = ex.n_params();
+
+  // One generator for init and sampling, a distinct stream per
+  // (seed, chain) pair. WALNUTS is a different sampler with a different
+  // consumption pattern, so there is no CmdStan stream to match the way
+  // nuts.cpp must; reproducibility per seed is the whole contract.
+  std::seed_seq seq{cfg.seed, static_cast<uint32_t>(cfg.chain_id)};
+  std::mt19937_64 rng(seq);
+
+  // Same initialization contract as run_nuts: uniform(-radius, radius)
+  // on the unconstrained scale, kept only when the log density and the
+  // whole gradient are finite, up to 100 attempts. A fixed point (an
+  // explicit init or radius 0) gets one attempt; retrying an identical
+  // point cannot help.
+  Eigen::VectorXd q(n);
+  {
+    std::uniform_real_distribution<double> init_dist(-cfg.init_radius,
+                                                     cfg.init_radius);
+    const bool fixed_point = cfg.init != nullptr || cfg.init_radius == 0.0;
+    const int kMaxInitAttempts = fixed_point ? 1 : 100;
+    std::vector<double> grad((size_t)n);
+    bool ok = false;
+    for (int attempt = 0; attempt < kMaxInitAttempts && !ok; ++attempt) {
+      if (cfg.init != nullptr)
+        for (int64_t i = 0; i < n; ++i) q(i) = cfg.init[i];
+      else if (cfg.init_radius == 0.0)
+        q.setZero();
+      else
+        for (int64_t i = 0; i < n; ++i) q(i) = init_dist(rng);
+      for (int64_t i = 0; i < n; ++i) ex.params_data()[i] = q(i);
+      try {
+        const double lp = ex.forward_value_only();
+        ok = std::isfinite(lp);
+        if (ok) {
+          const double glp = ex.gradient(grad.data());
+          ok = std::isfinite(glp);
+          for (int64_t i = 0; ok && i < n; ++i)
+            ok = std::isfinite(grad[(size_t)i]);
+        }
+      } catch (const std::exception&) {
+        ok = false;
+      }
+    }
+    if (!ok)
+      throw std::runtime_error(
+          "initialization failed: no draw in (-init_radius, init_radius) "
+          "had a finite log density and gradient after 100 attempts");
+  }
+
+  std::vector<std::vector<double>> draws;
+  draws.reserve((size_t)cfg.samples);
+  CollectHandler handler{&draws, stats, &observe};
+  ExecLogpGrad logp_grad{&ex};
+
+  const walnutpie::InitChainConfig init_cfg(
+      cfg.init_step_size, q, Eigen::VectorXd::Ones(n));
+  const walnutpie::WarmupConfig warmup_cfg =
+      walnutpie::WarmupConfigBuilder{}
+          .min_max_iter((size_t)cfg.warmup, (size_t)cfg.warmup)
+          .build();
+  const walnutpie::SamplingConfig sampling_cfg =
+      walnutpie::SamplingConfigBuilder{}
+          .min_max_iter((size_t)cfg.samples, (size_t)cfg.samples)
+          .max_trajectory_doublings((size_t)cfg.max_depth)
+          .max_step_halvings((size_t)cfg.max_step_halvings)
+          .max_hamiltonian_error(cfg.max_error)
+          .build();
+
+  walnutpie::AdaptiveWalnuts<ExecLogpGrad, std::mt19937_64, CollectHandler>
+      adaptive(rng, handler, logp_grad, init_cfg, warmup_cfg, sampling_cfg);
+  for (int i = 0; i < cfg.warmup; ++i) adaptive();
+
+  // sampler() freezes the adapted step size, mass matrix, and micro-step
+  // floor, and fires on_warmup_complete; the draws it produces are the
+  // Markov chain.
+  auto sampler = adaptive.sampler();
+  for (int i = 0; i < cfg.samples; ++i) sampler();
+
+  return draws;
+}
+
+}  // namespace stanli

--- a/runtime/third_party/walnutpie/LICENSE
+++ b/runtime/third_party/walnutpie/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025--2026 by the Walnutpie Developers.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/runtime/third_party/walnutpie/adam.hpp
+++ b/runtime/third_party/walnutpie/adam.hpp
@@ -1,0 +1,111 @@
+#pragma once
+
+#include <cmath>
+
+namespace walnutpie::detail {
+
+/**
+ * The Adam stochastic gradient optimizer specialized for step-size
+ * adaptation with a decreasing learning rate schedule.
+ *
+ * The specialization for step size builds in quadratic error (i.e.,
+ * log normal), following Nuts. That is, for observed accept rate
+ * `accept_observed` and target accept rate `accept_target`, the error
+ * is `-0.5 * (accept_observed - accept_target)^2` and its gradient is
+ * `accept_target - accept_observed`.
+ *
+ * This implementation includes a learning rate schedule that divides
+ * the specified learning rate by `pow(t, learn_rate_decay)` in
+ * iteration `t` (indexed from 1). The standard version of Adam uses
+ * `learn_decay_rate = 0`, so that the learning rate stays fixed and
+ * estimates continue to bounce around with new observations. With
+ * stepsize decay, Adam converges as long as `0 < learn_rate_decay <=
+ * 1`; Nuts used `learn_rate_decay = 0.75` for dual averaging and
+ * `learn_rate_decay=0.5` is a reasonable default for Adam.
+ *
+ * See: Kingma, Diederik P and Ba, Jimmy L. 2014. [Adam: A method for
+ * stochastic optimization]. Proceedings of the 3rd International
+ * Conference on Learning Representations (ICLR).
+ *
+ * For convergence with step-size decay, see: Zou, Fangyu and Shen, Li
+ * and Jie, Zequn and Zhang, Weizhong and Liu, Wei. 2019. A sufficient
+ * condition for convergences of Adam and RMSProp. Proceedings of the
+ * IEEE/CVF Conference on Computer Vision and Pattern Recognition.
+ */
+class Adam {
+ public:
+  /**
+   * Construct an Adam optimizer from tuning parameters and initialization.
+   *
+   * @param[in] step_size_init The initial step size.
+   * @param[in] accept_rate_target The target acceptance rate.
+   * @param[in] learning_rate The learning rate.
+   * @param[in] gradient_decay The gradient decay rate.
+   * @param[in] sq_gradient_decay The squared gradient decay rate.
+   * @param[in] stabilization The estimation stabilization parameter.
+   * @param[in] learn_rate_decay The decay exponent for iterations.
+   */
+  Adam(double step_size_init, double accept_rate_target, double learning_rate,
+       double gradient_decay, double sq_gradient_decay, double stabilization,
+       double learn_rate_decay)
+      : theta_(std::log(step_size_init)),
+        m_(0),
+        v_(0),
+        t_(0),
+        gradient_decay_pow_(1),
+        sq_gradient_decay_pow_(1),
+        target_accept_rate_(accept_rate_target),
+        learn_rate_(learning_rate),
+        gradient_decay_(gradient_decay),
+        sq_gradient_decay_(sq_gradient_decay),
+        stabilization_(stabilization),
+        learn_rate_decay_(learn_rate_decay) {}
+
+  /**
+   * Observe an acceptance probability in (0, 1).
+   *
+   * @param[in] alpha The acceptance probability.
+   * @pre alpha > 0 && alpha < 1
+   */
+  void operator()(double alpha) noexcept {
+    ++t_;
+    gradient_decay_pow_ *= gradient_decay_;
+    sq_gradient_decay_pow_ *= sq_gradient_decay_;
+
+    double grad = target_accept_rate_ - alpha;
+
+    m_ = gradient_decay_ * m_ + (1 - gradient_decay_) * grad;
+    v_ = sq_gradient_decay_ * v_ + (1 - sq_gradient_decay_) * grad * grad;
+
+    double m_hat = m_ / (1 - gradient_decay_pow_);
+    double v_hat = v_ / (1 - sq_gradient_decay_pow_);
+
+    double decayed_learn_rate = learn_rate_ / std::pow(t_, learn_rate_decay_);
+    double denom = std::sqrt(v_hat) + stabilization_;
+    theta_ -= decayed_learn_rate * m_hat / denom;
+  }
+
+  /**
+   * Return the step size estimate.
+   *
+   * @return The step size.
+   */
+  double step_size() const noexcept { return std::exp(theta_); }
+
+ private:
+  double theta_;
+  double m_;
+  double v_;
+  double t_;
+  double gradient_decay_pow_;
+  double sq_gradient_decay_pow_;
+
+  const double target_accept_rate_;
+  const double learn_rate_;         // Adam: alpha
+  const double gradient_decay_;     // Adam: beta2
+  const double sq_gradient_decay_;  // Adam: beta2
+  const double stabilization_;      // Adam: epsilon
+  const double learn_rate_decay_;
+};
+
+}  // namespace walnutpie::detail

--- a/runtime/third_party/walnutpie/adaptive_walnuts.hpp
+++ b/runtime/third_party/walnutpie/adaptive_walnuts.hpp
@@ -1,0 +1,365 @@
+#pragma once
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <functional>
+#include <random>
+#include <utility>
+
+#include <Eigen/Dense>
+
+#include "walnutpie/adam.hpp"
+#include "walnutpie/concepts.hpp"
+#include "walnutpie/config.hpp"
+#include "walnutpie/online_moments.hpp"
+#include "walnutpie/util.hpp"
+#include "walnutpie/walnuts.hpp"
+
+namespace walnutpie::detail {
+
+/**
+ * @brief A mass matrix estimator based on exponentially discounted draws
+ * and scores (gradients of log densities).
+ */
+class MassEstimator {
+ public:
+  /**
+   * @brief Construct a mass matrix estimator with the specified configuration,
+   * at the specified initial position and gradient of the log density at the
+   * position.
+   *
+   * The estimator observes positions and their gradients at given iterations
+   * with the function `observe()`. At each step, the discount factor for
+   * discounting past draws the online moment estimators is set to
+   * ```
+   * discount_factor = 1 - 1 / (iter_offset + iter)
+   * ```
+   * where `iter_offset` is the offset specified in the configuration and `iter`
+   * is the iteration number for the observation.
+   *
+   * The initial estimate is additively smoothed by multiplying by one
+   * minus the additive smoothing and adding the additive smoothing.
+   *
+   * The final estimate for the inverse mass matrix is given by the
+   * geometric mean of the variance of the scores (the inverse
+   * variance estimator) and the inverse variance of the draws (the
+   * variance estimator).
+   *
+   * @param[in] warmup_cfg The warmup configuration.
+   * @param[in] init_cfg The initialization configuration.
+   * @throw std::invalid_argument If the position and gradient are not the same
+   * size.
+   */
+  MassEstimator(const WarmupConfig& warmup_cfg, const InitChainConfig& init_cfg)
+      : warmup_cfg_(warmup_cfg) {
+    Eigen::VectorXd zero = Eigen::VectorXd::Zero(init_cfg.position().size());
+    score_var_estimator_ =
+        OnlineMoments(warmup_cfg.mass_init_count(), zero, init_cfg.mass());
+    draw_var_estimator_ =
+        OnlineMoments(warmup_cfg.mass_init_count(), zero,
+                      init_cfg.mass().array().inverse().matrix());
+  }
+
+  /**
+   * @brief Update the estimate for the specified iteration with the
+   * observation and gradient.
+   *
+   * @param[in] theta The position observed.
+   * @param[in] grad The gradient of the log density at the position.
+   * @param[in] iteration The iteration number.
+   * @pre theta.size() = grad.size()
+   * @pre iteration >= 0
+   */
+  void observe(const Eigen::VectorXd& theta, const Eigen::VectorXd& grad,
+               std::size_t iteration) {
+    double discount_factor = 1.0 - 1.0 / (warmup_cfg_.mass_init_count() +
+                                          static_cast<double>(iteration));
+    draw_var_estimator_.discount_observe(discount_factor, theta);
+    score_var_estimator_.discount_observe(discount_factor, grad);
+  }
+
+  /**
+   * @brief Return an estimate of the inverse mass matrix. The result
+   * is the geometric average of the variance of the draws and the
+   * inverse variance of the scores.
+   *
+   * @return The inverse mass matrix estimate.
+   */
+  Eigen::VectorXd inv_mass_estimate() const {
+    return (draw_var_estimator_.variance().array() /
+            score_var_estimator_.variance().array())
+        .sqrt()
+        .matrix();
+  }
+
+ private:
+  /** The warmup configuration for adaptive Walnutpie. */
+  WarmupConfig warmup_cfg_;
+
+  /** The online variance estimator for draws. */
+  OnlineMoments draw_var_estimator_;
+
+  /** The online inverse variance estimator for scores. */
+  OnlineMoments score_var_estimator_;
+};
+
+/**
+ * @brief The adaptation handler for the minimum number of micro steps
+ * per macro step.
+ *
+ * After being constructed with a target number of macro steps, this
+ * class is given observations of the number of micro steps taken and
+ * adjusts the minimum number of micro steps per macro step in order
+ * to achieve the target expected number of macro steps historically.
+ * There is slight regularization of a single observation at depth 2,
+ * but otherwise it just uses the floor of an average and thus rounds
+ * down.
+ */
+class MinMicroStepsAdaptHandler {
+ public:
+  /**
+   * Construct a minimum number of micro steps per macro step handler.
+   *
+   * @param[in] target_macro_steps Target number of expected macro steps.
+   * @param[in] min_micro_steps The minimum number of micro steps to return.
+   */
+  MinMicroStepsAdaptHandler(double target_macro_steps,
+                            std::size_t min_micro_steps)
+      : target_macro_steps_(target_macro_steps),
+        min_micro_steps_(min_micro_steps),
+        total_macro_steps_(2.0),
+        count_(1.0) {}
+
+  /**
+   * @brief Observe the specified number of macro steps in a Nuts trajectory.
+   *
+   * @param[in] macro_steps The number of macro steps used in a trajectory.
+   */
+  void observe(std::size_t macro_steps) {
+    total_macro_steps_ += static_cast<double>(macro_steps);
+    ++count_;
+  }
+
+  /**
+   * @brief Return the estimated minimum number of micro steps.
+   *
+   * This estimate is designed to achieve the expected number of macro steps
+   * per iteration.
+   *
+   * @return The minimum number of micro steps to use per macro step.
+   */
+  std::size_t min_micro_steps() const noexcept {
+    double mean_micro = total_macro_steps_ / count_;
+    double min_micro_steps = mean_micro / target_macro_steps_;
+    return std::max(min_micro_steps_,
+                    static_cast<std::size_t>(std::lround(min_micro_steps)));
+  }
+
+ private:
+  const double target_macro_steps_;
+  const std::size_t min_micro_steps_;
+  double total_macro_steps_;
+  double count_;
+};
+
+}  // namespace walnutpie::detail
+
+namespace walnutpie {
+
+/**
+ * @brief The adaptive Walnuts sampler.
+ *
+ * The adaptive Walnuts sampler is configured in the constructor, then
+ * provides a functor method `operator()()` for returning the next
+ * state in warmup. Warmup re-estimates step size and mass matrix
+ * each iteration, exponentially discounting the past.
+ *
+ * @tparam F Type of log density/gradient function.
+ * @tparam RNG Type of base random number generator.
+ * @tparam Handler Type of adaptation and sampling event handler.
+ */
+template <LogpGrad F, std::uniform_random_bit_generator RNG, ChainHandler H>
+class AdaptiveWalnuts {
+ public:
+  /**
+   * @brief Construct an adaptive Walnuts sampler.
+   *
+   * The configuration objects, the base random number generator, and
+   * the log density/gradient function are held by reference. The RNG
+   * changes state every time a random number is generated. The
+   * target depth specifies the expected Nuts tree depth, which is
+   * controlled through the minimum number of micro steps per macro
+   * step and adjusted with a mean estimator to achieve this average.
+   *
+   * @param[in] rng The base random number generator, stored by reference and
+   * modifed.
+   * @param[in,out] handler Event handler for adaptation and sampling, stored by
+   * reference and called back.
+   * @param[in] logp_grad The target log density and gradient function.
+   * @param[in] init_chain_cfg The initialization configuration for a single
+   * chain.
+   * @param[in] warmup_cfg The warmup configuration.
+   * @param[in] sampling_cfg The sampling configuration.
+   */
+  AdaptiveWalnuts(RNG& rng, H& handler, const F& logp_grad,
+                  const InitChainConfig& init_chain_cfg,
+                  const WarmupConfig& warmup_cfg,
+                  const SamplingConfig& sampling_cfg)
+      : warmup_cfg_(std::cref(warmup_cfg)),
+        sampling_cfg_(std::cref(sampling_cfg)),
+        rand_(rng),
+        handler_(handler),
+        logp_grad_(logp_grad, handler),
+        theta_(init_chain_cfg.position()),
+        iteration_(0),
+        adam_(init_chain_cfg.step_size(), warmup_cfg.step_accept_rate_target(),
+              warmup_cfg.step_learning_rate(), warmup_cfg.step_gradient_decay(),
+              warmup_cfg.step_sq_gradient_decay(),
+              warmup_cfg.step_stabilization(),
+              warmup_cfg.step_learn_rate_decay()),
+        mass_estimator_(warmup_cfg, init_chain_cfg),
+        min_micro_estimator_(warmup_cfg.max_macro_steps_target(),
+                             sampling_cfg.min_micro_steps()) {}
+
+  /**
+   * @brief Generate the next state for adaptation and the handler.
+   *
+   * This method should be called a number of time equal to the number
+   * of warmup iterations desired. These warmup draws are *not* drawn
+   * from a Markov chain and are not valid for inference. After
+   * warmup, call `sampler()` to return a sampler that fixes the
+   * tuning parameters and provides a proper Markov chain.
+   */
+  void operator()() {
+    Eigen::VectorXd inv_mass = mass_estimator_.inv_mass_estimate();
+    Eigen::VectorXd chol_mass = inv_mass.array().inverse().sqrt().matrix();
+    Eigen::VectorXd grad_select;
+    double logp_select;
+    std::size_t depth;
+    theta_ =
+        transition_w(rand_, logp_grad_, inv_mass, chol_mass, adam_.step_size(),
+                     sampling_cfg_.get().max_trajectory_doublings(),
+                     sampling_cfg_.get().max_step_halvings(),
+                     min_micro_estimator_.min_micro_steps(),
+                     sampling_cfg_.get().max_hamiltonian_error(),
+                     std::move(theta_), depth, grad_select, logp_select, adam_);
+    mass_estimator_.observe(theta_, grad_select, iteration_);
+    min_micro_estimator_.observe(1 << depth);
+    handler_.get().on_warmup(theta_, logp_select, step_size(), inv_mass);
+    ++iteration_;
+  }
+
+  /**
+   * @brief Return a Walnuts sampler with the current tuning parameter
+   * estimates.
+   *
+   * The returned sampler forms a proper Markov chain. The method passes
+   * along the compound random number generator and log density function and
+   * is hence not marked `const`.
+   *
+   * @return The Walnuts sampler with current tuning parameter estimates.
+   */
+  WalnutsSampler<F, RNG, H> sampler() {
+    handler_.get().on_warmup_complete(step_size(), inv_mass());
+    return WalnutsSampler<F, RNG, H>(
+        rand_.rng(), handler_, logp_grad_.logp_grad_, theta_, inv_mass(),
+        step_size(), sampling_cfg_.get().max_trajectory_doublings(),
+        sampling_cfg_.get().max_step_halvings(),
+        min_micro_estimator_.min_micro_steps(),
+        sampling_cfg_.get().max_hamiltonian_error());
+  }
+
+  /**
+   * @brief Return the diagonal of the diagonal inverse mass matrix.
+   *
+   * @return The diagonal of the inverse mass matrix.
+   */
+  Eigen::VectorXd inv_mass() const {
+    return mass_estimator_.inv_mass_estimate();
+  }
+
+  /**
+   * @brief Return the step size.
+   *
+   * @return The step size.
+   */
+  double step_size() const { return adam_.step_size(); }
+
+  /**
+   * @brief Return the minimum number of micro steps per macro step.
+   *
+   * @return The minimum number of micro steps per macro step.
+   */
+  std::size_t min_micro_steps() const {
+    return min_micro_estimator_.min_micro_steps();
+  }
+
+  /**
+   * @brief Return the number of dimensions of the position.
+   *
+   * @return The number of dimensions.
+   */
+  std::size_t dim() const noexcept {
+    return static_cast<std::size_t>(theta_.size());
+  }
+
+  /**
+   * @brief Return the natural logarithm of the step size.
+   *
+   * @return The log of the step size.
+   */
+  double log_step_size() const noexcept { return std::log(step_size()); }
+
+  /**
+   * @brief Return the natural logarithm of the diagonal of the
+   * diagonal mass matirx.
+   *
+   * @return The log of the diagonal of the mass matrix.
+   */
+  Eigen::VectorXd log_mass() const {
+    // equiv. inv_mass().array().inverse().log().matrix();
+    return -inv_mass().array().log().matrix();
+  }
+
+  /**
+   * @brief Return the current iteration.
+   *
+   * @return The iteration.
+   */
+  std::size_t iter() const noexcept { return iteration_; }
+
+ private:
+  /** The warmup configuration. */
+  std::reference_wrapper<const WarmupConfig> warmup_cfg_;
+
+  /** The Walnuts sampler configuration. */
+  std::reference_wrapper<const SamplingConfig> sampling_cfg_;
+
+  /** The random number generator required for Nuts. */
+  detail::Random<RNG> rand_;
+
+  /** The adaptation and sampling event handler. */
+  std::reference_wrapper<H> handler_;
+
+  /** The target log density/gradient function. */
+  const detail::NoExceptLogpGrad<F, H> logp_grad_;
+
+  /** The current state. */
+  Eigen::VectorXd theta_;
+
+  /** The current iteration. */
+  std::size_t iteration_;
+
+  /** The Adam optimizer for step size adaptation.
+   */
+  detail::Adam adam_;
+
+  /** The estimator for the mass matrix. */
+  detail::MassEstimator mass_estimator_;
+
+  /** The estimator for the minimum number of micro steps per macro step. */
+  detail::MinMicroStepsAdaptHandler min_micro_estimator_;
+};
+
+}  // namespace walnutpie

--- a/runtime/third_party/walnutpie/concepts.hpp
+++ b/runtime/third_party/walnutpie/concepts.hpp
@@ -1,0 +1,295 @@
+#pragma once
+
+#include <concepts>
+#include <cstddef>
+#include <ranges>
+
+#include <Eigen/Dense>
+
+namespace walnutpie::detail {
+
+/**
+ * @brief Concept for a type with a `.size()` member function.
+ *
+ * A type `T` satisfies `Sized` if `t.size()` is callable on a const
+ * instance and returns a value comparable for equality. This matches
+ * standard containers, `std::string`, `std::span`, and Eigen vectors
+ * and matrices.
+ */
+template <typename T>
+concept Sized = requires(const T& t) {
+  { t.size() } -> std::equality_comparable;
+};
+
+/**
+ * @brief Concept for an Eigen dense type with floating-point scalar.
+ *
+ * A type `T` satisfies `EigenDenseType` if it provides:
+ *  - a nested `Scalar` type that is a floating-point type,
+ *  - a `size()` member returning a value convertible to `Eigen::Index`,
+ *  - element access via `t(i)` returning a value convertible to `Scalar`.
+ *
+ * Models include `Eigen::VectorXd`, `Eigen::MatrixXd`, and other
+ * fixed- or dynamic-size Eigen dense types with floating-point scalars.
+ * For matrices, `t(i)` accesses elements in storage order (column-major
+ * by default).
+ */
+template <typename T>
+concept EigenDenseType = requires(const T& t) {
+  typename T::Scalar;
+  { t.size() } -> std::convertible_to<Eigen::Index>;
+  { t(0) } -> std::convertible_to<typename T::Scalar>;
+} && std::floating_point<typename T::Scalar>;
+
+/**
+ * @brief Concept for a leaf type in the floating-point validation tree.
+ *
+ * A type `T` satisfies `FloatingPointLeaf` if it is either a
+ * floating-point type or an Eigen dense type with floating-point
+ * scalar. These are the types whose elements can be checked directly,
+ * without further recursive descent through containers.
+ */
+template <typename T>
+concept FloatingPointLeaf = std::floating_point<T> || EigenDenseType<T>;
+
+/**
+ * @brief Concept for a floating-point leaf or a one-level container
+ * of such leaves.
+ *
+ * A type `T` satisfies `NestedFloatingPoint` if any of the following
+ * hold:
+ *  - `T` satisfies `FloatingPointLeaf` (a floating-point value or an
+ *    Eigen dense type with floating-point scalar),
+ *  - `T` is a `std::ranges::range` whose element type satisfies
+ *    `FloatingPointLeaf`.
+ *
+ * This covers `double`, `Eigen::VectorXd`, `std::vector<double>`, and
+ * `std::vector<Eigen::VectorXd>`, but does not recurse to deeper
+ * nesting such as `std::vector<std::vector<double>>`.
+ */
+template <typename T>
+concept NestedFloatingPoint =
+    FloatingPointLeaf<T> ||
+    (std::ranges::range<T> && FloatingPointLeaf<std::ranges::range_value_t<T>>);
+
+/**
+ * @brief Concept for a Markov chain sampler.
+ *
+ * A type `S` satisfies `Sampler` if it provides:
+ *  - `s()` callable on a non-const instance, returning a log density value
+ *    convertible to `double`. Each call advances the chain by one
+ *    iteration and returns the log density of the new draw. The
+ *    sampler is responsible for delivering the draw itself to any
+ *    chain-local handler it holds.
+ *  - `s.dim()` callable on a const instance, returning a value
+ *    convertible to `std::size_t`. This reports the dimensionality
+ *    of the parameter space being sampled.
+ *
+ * The single-argument operator must be invocable through a
+ * `std::reference_wrapper<S>`, which means `operator()` must not be
+ * `const`-only — it should be a non-const member function (or
+ * mutable-callable in some other way), since sampling advances
+ * internal state such as the position, RNG, and any adapted
+ * parameters.
+ */
+template <typename S>
+concept Sampler = requires(S& s, const S& cs) {
+  { s() } -> std::convertible_to<double>;
+  { cs.dim() } -> std::convertible_to<std::size_t>;
+};
+
+/**
+ * @brief Concept for a step size adaptation handler.
+ *
+ * A type `H` satisfies `StepSizeAdapter` if it provides:
+ *  - `h(accept_prob)` callable on a non-const instance with a
+ *    `double` argument, returning `void`. Each call observes one
+ *    acceptance probability and updates the internal estimate.
+ *  - `h.step_size()` callable on a const instance, returning a
+ *    value convertible to `double`. Reports the current adapted
+ *    step size.
+ */
+template <typename H>
+concept StepSizeAdapter = requires(H& h, const H& ch, double accept_prob) {
+  { h(accept_prob) } -> std::same_as<void>;
+  { ch.step_size() } -> std::convertible_to<double>;
+};
+
+/**
+ * @brief Concept for an adaptive sampler that tunes parameters during
+ * warmup and produces a fixed-parameter sampler for post-warmup
+ * draws.
+ *
+ * A type `A` satisfies `AdaptiveSampler` if it provides the following
+ * members:
+ *  - `a()` callable on a non-const instance, returning `void`. Each
+ *    call advances the adaptation by one iteration, updating tuning
+ *    parameters and calling back on any chain-local handler.
+ *  - `a.sampler()` callable on a non-const instance, returning a type
+ *    that satisfies the `Sampler` concept. This finalizes adaptation
+ *    and produces a sampler with fixed tuning parameters.
+ *  - `a.step_size()` callable on a const instance, returning a value
+ *    convertible to `double`. Reports the current adapted step size.
+ *  - `a.inv_mass()` callable on a const instance, returning a type
+ *    convertible to `Eigen::VectorXd`. Reports the current diagonal
+ *    inverse mass matrix estimate.
+ *  - `a.dim()` callable on a const instance, returning a value
+ *    convertible to `std::size_t`. Reports the dimensionality of the
+ *    parameter space.
+ *  - `a.iter()` callable on a const instance, returning a value
+ *    convertible to `std::size_t`. Reports the current iteration
+ *    count.
+ *  - `a.log_step_size()` callable on a const instance, returning a
+ *    value convertible to `double`. Reports the log of the current
+ *    adapted step size.
+ *  - `a.log_mass()` callable on a const instance, returning a type
+ *    convertible to `Eigen::VectorXd`. Reports the log of the
+ *    diagonal mass matrix.
+ */
+template <typename A>
+concept AdaptiveSampler = requires(A& a, const A& ca) {
+  { a() } -> std::same_as<void>;
+  { a.sampler() } -> detail::Sampler;
+  { ca.step_size() } -> std::convertible_to<double>;
+  { ca.inv_mass() } -> std::convertible_to<Eigen::VectorXd>;
+  { ca.dim() } -> std::convertible_to<std::size_t>;
+  { ca.iter() } -> std::convertible_to<std::size_t>;
+  { ca.log_step_size() } -> std::convertible_to<double>;
+  { ca.log_mass() } -> std::convertible_to<Eigen::VectorXd>;
+};
+
+}  // namespace walnutpie::detail
+
+namespace walnutpie {
+
+/**
+ * @brief Concept for a handler of cross-chain events.
+ *
+ * This only handles R-hat updates now.
+ *
+ * A type `H` satisfies `Handler` if it provides:
+ *  - `on_r_hat(double)` callable on a non-const instance, returning `void`,
+ */
+template <typename H>
+concept GlobalHandler = requires(H& h, const H& ch, double r_hat) {
+  { h.on_r_hat(r_hat) } -> std::same_as<void>;
+};
+
+/**
+ * @brief Concept for an interrupt callback.
+ *
+ * A type `H` satisfies `Handler` if it provides:
+ *  - `received_interrupt()` will return `true` if the process should
+ *    be interrupted.
+ */
+template <typename H>
+concept InterruptCallback = requires(H& h, const H& ch, double r_hat) {
+  { h.throw_if_interrupted() } -> std::same_as<void>;
+};
+
+/**
+ * @brief Concept for handler for errors
+ * The following member is required
+ * - `on_logp_exception(const Eigen::VectorXd&, std::exception&)` called
+ *    when the log density function throws an error
+ */
+template <typename H>
+concept ErrorCallback =
+    requires(H& h, const Eigen::VectorXd& position, const std::exception& exn) {
+      { h.on_logp_exception(position, exn) } -> std::same_as<void>;
+      { noexcept(h.on_logp_exception(position, exn)) };
+    };
+
+/**
+ * @brief Concept for a handler of sampling events.
+ *
+ * A type `H` satisfies `SampleHandler` if it satisfies `ErrorCallback` and
+ * additional provides the following member functions, each callable
+ * on a non-const instance and returning `void`:
+ *  - `on_sample(const Eigen::VectorXd&, double)` called once per
+ *    draw with the position and log density.
+ */
+template <typename H>
+concept SampleHandler =
+    ErrorCallback<H> &&
+    requires(H& h, const Eigen::VectorXd& position, double lp) {
+      { h.on_sample(position, lp) } -> std::same_as<void>;
+    };
+
+/**
+ * @brief An extension of the `SampleHandler` concept for additionally
+ * handling warmup events.
+ *
+ *
+ * A type `C` satisfies `ChainHandler` if it provides the following
+ * member functions, each callable on a non-const instance and returning
+ * `void`:
+ *  - `on_warmup(const Eigen::VectorXd&, double, double, const
+ * Eigen::VectorXd&)` called once per warmup draw with the position, log
+ * density, step size, and diagonal inverse mass matrix.
+ *  - `on_warmup_complete(double, const Eigen::VectorXd&)` called once
+ *    when warmup finishes, with the final step size and diagonal inverse
+ *    mass matrix.
+ *  - `on_sample(const Eigen::VectorXd&, double)` called once per
+ *    post-warmup draw with the position and log density.
+ */
+template <typename C>
+concept ChainHandler =
+    SampleHandler<C> && requires(C& c, const Eigen::VectorXd& position,
+                                 const Eigen::VectorXd& diag_inv_mass,
+                                 double lp, double step_size) {
+      {
+        c.on_warmup(position, lp, step_size, diag_inv_mass)
+      } -> std::same_as<void>;
+      { c.on_warmup_complete(step_size, diag_inv_mass) } -> std::same_as<void>;
+    };
+
+/**
+ * @brief Concept for a log density and gradient function.
+ *
+ * A type `F` satisfies `LogpGrad` if an object of type `const F&` can be
+ * called with arguments `(const Eigen::VectorXd&, double&, Eigen::VectorXd&)`
+ * and the call returns `void`. The first argument is the position at which
+ * to evaluate, and the second and third are output parameters set to the
+ * log density and its gradient, respectively.
+ *
+ * @tparam F The callable type to constrain.
+ */
+template <typename F>
+concept LogpGrad = requires(const F& f, const Eigen::VectorXd& x, double& logp,
+                            Eigen::VectorXd& grad) {
+  { f(x, logp, grad) } -> std::same_as<void>;
+};
+
+/**
+ * @brief Concept for a sequence of Markov chains over a shared set
+ * of variables.
+ *
+ * A type `M` satisfies `MarkovChainCollection` if it provides the
+ * following member functions, all callable on a const instance:
+ *  - `num_chains()` returning a value convertible to `std::size_t`,
+ *    the number of chains in the collection.
+ *  - `num_draws()` returning a value convertible to `std::size_t`,
+ *    the total number of draws across all chains.
+ *  - `dims()` returning a value convertible to `std::size_t`, the
+ *    dimensionality of each draw.
+ *  - `min_chain_size()` returning a value convertible to
+ *    `Eigen::Index`, the length of the shortest chain.
+ *  - `chain_view(std::size_t)` returning a type convertible to
+ *    `Eigen::MatrixXd`, a view of one chain (one draw per row).
+ *  - `draws(Eigen::Index)` returning a type convertible to
+ *    `Eigen::VectorXd`, the sequence of draws for one variable across
+ *    all chains.
+ */
+template <typename M>
+concept MarkovChainSequence =
+    requires(const M& m, std::size_t chain_index, Eigen::Index dim_index) {
+      { m.num_chains() } -> std::convertible_to<std::size_t>;
+      { m.num_draws() } -> std::convertible_to<std::size_t>;
+      { m.dims() } -> std::convertible_to<std::size_t>;
+      { m.min_chain_size() } -> std::convertible_to<Eigen::Index>;
+      { m.chain_view(chain_index) } -> std::convertible_to<Eigen::MatrixXd>;
+      { m.draws(dim_index) } -> std::convertible_to<Eigen::VectorXd>;
+    };
+
+}  // namespace walnutpie

--- a/runtime/third_party/walnutpie/config.hpp
+++ b/runtime/third_party/walnutpie/config.hpp
@@ -1,0 +1,1154 @@
+#pragma once
+
+#include <cstddef>
+#include <ostream>
+#include <random>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <Eigen/Dense>
+
+#include "walnutpie/concepts.hpp"
+#include "walnutpie/util.hpp"
+#include "walnutpie/validate.hpp"
+
+namespace walnutpie {
+
+/**
+ * @brief The initialization configuration for a single Markov chain.
+ *
+ * The initialization configuration specifies a step size, initial position,
+ * and initial mass matrix.
+ */
+class InitChainConfig {
+ public:
+  /**
+   * @brief Construct an initialization configuration.
+   *
+   * @param[in] step_size The initial step size.
+   * @param[in] position The initial position.
+   * @param[in] mass The initial mass matrix (diagonal).
+   */
+  InitChainConfig(double step_size, const Eigen::VectorXd& position,
+                  const Eigen::VectorXd& mass)
+      : step_size_(step_size), position_(position), mass_(mass) {}
+
+  /**
+   * @brief Return the initial step size.
+   *
+   * @return The step size.
+   */
+  double step_size() const noexcept { return step_size_; }
+
+  /**
+   * @brief Return the initial position.
+   *
+   * @return The position.
+   */
+  const Eigen::VectorXd& position() const noexcept { return position_; }
+
+  /**
+   * @brief Return the initial mass matrix.
+   *
+   * @return The mass matrix.
+   */
+  const Eigen::VectorXd& mass() const noexcept { return mass_; }
+
+ private:
+  double step_size_;
+  Eigen::VectorXd position_;
+  Eigen::VectorXd mass_;
+};
+
+/**
+ * @brief The initialization configuration for multiple Markov chains.
+ *
+ * Rather than a public constructor, it is built using an
+ * `InitConfigBuilder` instance.
+ *
+ * The initialization configuration specifies a step size, initial
+ * position, and initial mass matrix.
+ */
+class InitConfig {
+ public:
+  /**
+   * @brief Return the number of chains.
+   *
+   * @return The number of chains.
+   */
+  std::size_t num_chains() const noexcept { return step_sizes_.size(); }
+
+  /**
+   * @brief Return the dimensionality of the positions.
+   *
+   * If the initialization is empty, 0 is returned.
+   *
+   * @return The dimensionality.
+   */
+  std::size_t dims() const noexcept {
+    return positions_.empty()
+               ? 0u
+               : static_cast<std::size_t>(positions_.front().size());
+  }
+
+  /**
+   * @brief Return the initial step sizes.
+   *
+   * @return The step sizes.
+   */
+  const std::vector<double>& step_sizes() const noexcept { return step_sizes_; }
+
+  /**
+   * @brief Return the initial step size for the specified chain.
+   *
+   * @param[in] n The chain identifier.
+   * @return The step size.
+   */
+  double step_size(std::size_t n) const noexcept { return step_sizes_[n]; }
+
+  /**
+   * @brief Return the initial positions for all chains.
+   *
+   * @return The positions.
+   */
+  const std::vector<Eigen::VectorXd>& positions() const noexcept {
+    return positions_;
+  }
+
+  /**
+   * @brief Return the initial position for the specified chain.
+   *
+   * @param[in] n The chain index.
+   * @return The positions.
+   */
+  const Eigen::VectorXd& position(std::size_t n) const noexcept {
+    return positions_[n];
+  }
+
+  /**
+   * @brief Return the initial diagonal mass matrices for all chains.
+   *
+   * @return The mass matrix diagonals.
+   */
+  const std::vector<Eigen::VectorXd>& masses() const noexcept {
+    return masses_;
+  }
+
+  /**
+   * @brief Return the mass matrix for the specified chain.
+   *
+   * @param[in] n The chain index.
+   * @return The mass matrix.
+   */
+  const Eigen::VectorXd& mass(std::size_t n) const noexcept {
+    return masses_[n];
+  }
+
+  /**
+   * @brief Return the initialization configuration for the specified chain.
+   *
+   * @param[in] n The chain index.
+   * @return The indexed chain's initialization configuration.
+   */
+  InitChainConfig init_chain_config(std::size_t n) const {
+    return InitChainConfig(step_size(n), position(n), mass(n));
+  }
+
+ private:
+  friend class InitConfigBuilder;
+
+  /**
+   * @brief Construct an initialization configuration.
+   *
+   * This constructor does not validate arguments because it is only
+   * called internally. It only implements rvalue moves because that
+   * is the only way it is called.
+   *
+   * @param[in] step_sizes The step sizes.
+   * @param[in] positions The positions.
+   * @param[in] masses The diagonals of the diagonal mass matrixes.
+   */
+  InitConfig(std::vector<double>&& step_sizes,
+             std::vector<Eigen::VectorXd>&& positions,
+             std::vector<Eigen::VectorXd>&& masses)
+      : step_sizes_(std::move(step_sizes)),
+        positions_(std::move(positions)),
+        masses_(std::move(masses)) {}
+
+  InitConfig() = default;
+
+  std::vector<double> step_sizes_;
+  std::vector<Eigen::VectorXd> positions_;
+  std::vector<Eigen::VectorXd> masses_;
+};
+
+/**
+ * @brief The builder for initialization configurations.
+ *
+ * The usage to return an `InitConfig` is
+ * `InitConfigBuilder(4, 20).step_sizes(0.5).build();`
+ * with any number of config methods
+ * chained between the construction and call to build.
+ */
+class InitConfigBuilder {
+ public:
+  /**
+   * @brief Construct an initialization builder of the given sizes.
+   *
+   * @param[in] num_chains The number of Markov chains.
+   * @param[in] dims The dimensionality of each chain.
+   */
+  InitConfigBuilder(std::size_t num_chains, std::size_t dims)
+      : num_chains_(num_chains),
+        dims_(dims),
+        step_sizes_(std::vector<double>(num_chains, 0.1)),
+        positions_(std::vector<Eigen::VectorXd>(
+            num_chains,
+            Eigen::VectorXd::Zero(static_cast<Eigen::Index>(dims)))),
+        masses_(std::vector<Eigen::VectorXd>(
+            num_chains,
+            Eigen::VectorXd::Ones(static_cast<Eigen::Index>(dims)))) {}
+
+  /**
+   * @brief Set the step sizes to all be the specified value.
+   *
+   * @param[in] v The step size.
+   * @return A reference to this builder for chaining.
+   * @throw std::invalid_argument If the step size is not finite and positive.
+   */
+  InitConfigBuilder& step_sizes(double v) {
+    detail::validate_finite_positive(v, "step size");
+    step_sizes_ = std::vector<double>(num_chains_, v);
+    return *this;
+  }
+
+  /**
+   * @brief Set the step sizes to all be the specified values.
+   *
+   * @param[in] v The step sizes.
+   * @return A reference to this builder for chaining.
+   * @throw std::invalid_argument If any of the step sizes are not finite
+   * positive.
+   * @throw std::invalid_argument If the number of chains doesn't match the
+   * number specified in the constructor.
+   */
+  InitConfigBuilder& step_sizes(const std::vector<double>& v) {
+    detail::validate_size(v, num_chains_, "step_sizes", "num_chains");
+    detail::validate_finite_positive(v, "step_size");
+    step_sizes_ = v;
+    return *this;
+  }
+
+  /**
+   * @brief Randomly initialization the positions.
+   *
+   * Initialization is independent in each dimension with values drawn
+   * from a zero-centered normal distribution with the specified
+   * scale.
+   *
+   * @tparam RNG The type of the base random number generator.
+   * @param[in,out] rng The base random number generator.
+   * @param[in] init_scale The scale of the normal initial values.
+   * @return A reference to this builder for chaining.
+   * @throw std::invalid_argument If the initial scale is not finite and
+   * positive.
+   */
+  template <std::uniform_random_bit_generator RNG>
+  InitConfigBuilder& positions(RNG& rng, double init_scale) {
+    detail::validate_finite_positive(init_scale, "init_scale");
+    detail::Random<RNG> rand(rng);
+    positions_.resize(num_chains_);
+    for (std::size_t c = 0; c < num_chains_; ++c) {
+      rand.standard_normal(static_cast<Eigen::Index>(dims_), positions_[c]);
+      positions_[c] *= init_scale;
+    }
+    return *this;
+  }
+
+  /**
+   * @brief Initialize the positions all to the same value.
+   *
+   * @param[in] v The initial position.
+   * @return A reference to this builder for chaining.
+   * @throw std::invalid_argument If the dimensionality doesn't match
+   * that specified during construction.
+   * @throw std::invalid_argument If any of the initial positions contains
+   * non-finite values.
+   */
+  InitConfigBuilder& positions(const Eigen::VectorXd& v) {
+    detail::validate_size(v, dims_, "position", "dims");
+    detail::validate_finite(v, "position");
+    positions_ = std::vector<Eigen::VectorXd>(num_chains_, v);
+    return *this;
+  }
+
+  /**
+   * @brief Initialize the positions to the specified values.
+   *
+   * @param[in] vs The initial positions.
+   * @return A reference to this builder for chaining.
+   * @throw std::invalid_argument If the number of initial positions doesn't
+   * match the number of chains specified in the constructor.
+   * @throw std::invalid_argument If any of the initial positions contains
+   * non-finite values.
+   * @throw std::invalid_argumet If any of the initial positions has a
+   * dimensionality that does not match the dimensionality specified in the
+   * constructor.
+   */
+  InitConfigBuilder& positions(const std::vector<Eigen::VectorXd>& vs) {
+    detail::validate_size(vs, num_chains_, "positions", "num_chains");
+    detail::validate_finite(vs, "positions");
+    for (const auto& v : vs) {
+      detail::validate_size(v, dims_, "position", "dims");
+    }
+    positions_ = vs;
+    return *this;
+  }
+
+  /**
+   * @brief Initialize the positions to the specified values via move.
+   *
+   * @param[in] vs The initial positions.
+   * @return A reference to this builder for chaining.
+   * @throw std::invalid_argument If the number of initial positions doesn't
+   * match the number of chains specified in the constructor.
+   * @throw std::invalid_argument If any of the initial positions contains
+   * non-finite values.
+   * @throw std::invalid_argumet If any of the initial positions has a
+   * dimensionality that does not match the dimensionality specified in the
+   * constructor.
+   */
+  InitConfigBuilder& positions(std::vector<Eigen::VectorXd>&& vs) {
+    detail::validate_size(vs, num_chains_, "positions", "num_chains");
+    detail::validate_finite(vs, "positions");
+    for (const auto& v : vs) {
+      detail::validate_size(v, dims_, "position", "dims");
+    }
+    positions_ = std::move(vs);
+    return *this;
+  }
+
+  /**
+   * @brief Initialize the masses using the Nutpie outer product strategy.
+   *
+   * Following Nutpie, the initialization uses a smoothed negative
+   * outer product of gradient, which is the absolute value of the
+   * outer product of gradients linearly interpolated with a unit
+   * matrix with weight `mass_smoothing` on the unit matrix and `1 -
+   * mass_smoothing` on the regularized outer product.
+   *
+   * If the flag `average_masses` is `true`, then each chain's mass
+   * matrix is set to the geometric average of the per-chain mass
+   * matrixes.
+   *
+   * See: Seyboldt, Adrian and Carlson, Eliot and Carpenter,
+   * Bob. 2026. [Preconditioning Hamiltonian Monte Carlo by
+   * minimizing Fisher
+   * divergence](https://arxiv.org/abs/2603.18845v1). arXiv
+   * 2603.18845.
+   *
+   * @tparam LPG The type of the log density and gradient function.
+   * @param[in] logp_grad The log density and gradient function, called back.
+   * @param[in] mass_smoothing The additive smoothing for mass matrices.
+   * @param[in] average_masses Set to `true` to geometrically average mass
+   * matrices.
+   * @throw std::invalid_argumet If the mass smoothing is not in (0, 1).
+   * @return A reference to this builder for chaining.
+   */
+  template <LogpGrad F>
+  InitConfigBuilder& masses(const F& logp_grad, double mass_smoothing,
+                            bool average_masses = false) {
+    detail::validate_probability(mass_smoothing, "mass_smoothing");
+    Eigen::VectorXd grad;
+    masses_.resize(num_chains_);
+    for (std::size_t c = 0; c < num_chains_; ++c) {
+      double lp_to_discard;
+      logp_grad(positions_[c], lp_to_discard, grad);
+      masses_[c] = (1 - mass_smoothing) * grad.array().abs() + mass_smoothing;
+    }
+    if (average_masses) {
+      Eigen::Index D = masses_[0].size();
+      Eigen::VectorXd sum_log_mass = Eigen::VectorXd::Zero(D);
+      for (const auto& mass : masses_) {
+        sum_log_mass += mass.array().log().matrix();
+      }
+      auto avg_log_mass = sum_log_mass / num_chains_;
+      auto geom_mean_mass = avg_log_mass.array().exp().matrix();
+      masses_ = std::vector<Eigen::VectorXd>(num_chains_, geom_mean_mass);
+    }
+    return *this;
+  }
+
+  /**
+   * @brief Initialize the mass matrices all to the same value.
+   *
+   * @param[in] v The initial diagonal mass matrix.
+   * @return A reference to this builder for chaining.
+   * @throw std::invalid_argument If the dimensionality doesn't match
+   * that specified during construction.
+   * @throw std::invalid_argument If any of the initial mass matrix
+   * diagonals contains non-finite or non-positive values.
+   */
+  InitConfigBuilder& masses(const Eigen::VectorXd& v) {
+    detail::validate_size(v, dims_, "masses", "dims");
+    detail::validate_finite_positive(v, "masses");
+    masses_ = std::vector<Eigen::VectorXd>(num_chains_, v);
+    return *this;
+  }
+
+  /**
+   * @brief Initialize the mass matrices to the specified values.
+   *
+   * @param[in] vs The initial mass matrices.
+   * @return A reference to this builder for chaining.
+   * @throw std::invalid_argument If the number of initial mass
+   * matrices doesn't match the number of chains specified in the
+   * constructor.
+   * @throw std::invalid_argument If any of the initial mass matrices
+   * contains non-finite values.
+   * @throw std::invalid_argumet If any of the initial mass matrices
+   * has a dimensionality that does not match the dimensionality
+   * specified in the constructor.
+   */
+  InitConfigBuilder& masses(const std::vector<Eigen::VectorXd>& vs) {
+    detail::validate_size(vs, num_chains_, "masses", "num_chains");
+    detail::validate_finite_positive(vs, "masses");
+    for (const auto& v : vs) {
+      detail::validate_size(v, dims_, "all masses", "dims");
+    }
+    masses_ = vs;
+    return *this;
+  }
+
+  /**
+   * @brief Initialize the mass matrices to the specified values via
+   * move.
+   *
+   * @param[in] vs The initial mass matrices.
+   * @return A reference to this builder for chaining.
+   * @throw std::invalid_argument If the number of initial mass
+   * matrices doesn't match the number of chains specified in the
+   * constructor.
+   * @throw std::invalid_argument If any of the initial mass matrices
+   * contains non-finite values.
+   * @throw std::invalid_argumet If any of the initial mass matrices
+   * has a dimensionality that does not match the dimensionality
+   * specified in the constructor.
+   */
+  InitConfigBuilder& masses(std::vector<Eigen::VectorXd>&& vs) {
+    detail::validate_size(vs, num_chains_, "masses", "num_chains");
+    detail::validate_finite_positive(vs, "masses");
+    for (const auto& v : vs) {
+      detail::validate_size(v, dims_, "all masses", "dims");
+    }
+    masses_ = std::move(vs);
+    return *this;
+  }
+
+  /**
+   * @brief Return the initialization configuration.
+   *
+   * @return The initialization configuration.
+   */
+  InitConfig build() {
+    return InitConfig{std::move(step_sizes_), std::move(positions_),
+                      std::move(masses_)};
+  }
+
+  /**
+   * @brief Heuristically adapt the initial step sizes, then return
+   * the initialization configuration.
+   *
+   * @tparam RNG Type of the base random number generator.
+   * @tparam F Type of the log density and gradient function.
+   * @param[in] rng The base random number generator.
+   * @param[in] logp_grad The log density and gradient function.
+   */
+  template <std::uniform_random_bit_generator RNG, LogpGrad F>
+  InitConfig adapt_step_build(RNG& rng, const F& logp_grad) {
+    for (std::size_t c = 0; c < num_chains_; ++c) {
+      step_sizes_[c] = detail::adapt_step(rng, logp_grad, positions_[c],
+                                          masses_[c], step_sizes_[c], dims_);
+    }
+    return build();
+  }
+
+ private:
+  std::size_t num_chains_;
+  std::size_t dims_;
+  std::vector<double> step_sizes_;
+  std::vector<Eigen::VectorXd> positions_;
+  std::vector<Eigen::VectorXd> masses_;
+};
+
+/**
+ * @internal @brief Write a dump of the initial configurations to the
+ * specified stream.
+ *
+ * @param[in,out] out Stream to which configuration is written.
+ * @param[in] cfg The configuration to write.
+ * @return A reference to the output stream for chaining.
+ */
+inline std::ostream& operator<<(std::ostream& out, const InitConfig& cfg) {
+  out << "InitConfigs (by chain)\n";
+  for (std::size_t n = 0; n < cfg.step_sizes().size(); ++n) {
+    if (n > 0) {
+      out << "\n";
+    }
+    out << "  chain         = " << n << "\n"
+        << "    num_chains  = " << cfg.num_chains() << "\n"
+        << "    step_size   = " << cfg.step_sizes()[n] << "\n"
+        << "    position    = " << cfg.positions()[n].transpose() << "\n"
+        << "    mass        = " << cfg.masses()[n].transpose() << "\n";
+  }
+  return out;
+}
+
+/**
+ * @brief The warmup configuration object. The object supplies methods
+ * for all of the tuning parameters for warmup.
+ */
+class WarmupConfig {
+ public:
+  /**
+   * @brief Return the minimum number of warmup iterations.
+   *
+   * @return Minimum warmup iterations.
+   */
+  std::size_t min_iter() const { return min_iter_; }
+
+  /**
+   * @brief Return the maximum number of warmup iterations.
+   *
+   * @return Maximum warmup iterations.
+   */
+  std::size_t max_iter() const { return max_iter_; }
+
+  /**
+   * @brief Return the step-size convergence tolerance.
+   *
+   * @return The step-size convergence tolerance.
+   */
+  double step_size_converge_tol() const { return step_size_converge_tol_; }
+
+  /**
+   * @brief Return the mass matrix convergence tolerance. The
+   * tolerance is for the L2-norm of the diagonal.
+   *
+   * @return The mass matrix  convergence tolerance.
+   */
+  double mass_converge_tol() const { return mass_converge_tol_; }
+
+  /**
+   * @brief Return the initial count for the mass matrix estimator.
+   *
+   * @return The initial count for the mass matrix estimator.
+   */
+  double mass_init_count() const { return mass_init_count_; }
+
+  /**
+   * @brief Return the additive smoothing for the mass matrix estimator.
+   *
+   * @return The additive smoothing for the mass matrix estimator.
+   */
+  double mass_additive_smoothing() const { return mass_additive_smoothing_; }
+
+  /**
+   * @brief Return the target number of macro steps.
+   *
+   * @return The target number of macro steps.
+   */
+  double max_macro_steps_target() const { return max_macro_steps_target_; }
+
+  /**
+   * @brief Return the target acceptance rate.
+   *
+   * @return The target acceptance rate.
+   */
+  double step_accept_rate_target() const { return step_accept_rate_target_; }
+
+  /**
+   * @brief Return the step-size learning rate for the Adam optimizer.
+   *
+   * @return The step-size learning rate for the Adam optimizer.
+   */
+  double step_learning_rate() const { return step_learning_rate_; }
+
+  /**
+   * @brief Return the gradient decay rate for the Adam optimizer.
+   *
+   * @return The gradient decay rate for the Adam optimizer.
+   */
+  double step_gradient_decay() const { return step_gradient_decay_; }
+
+  /**
+   * @brief Return the squared gradient decay rate for the Adam optimizer.
+   *
+   * @return The squared gradient decay rate for the Adam optimizer.
+   */
+  double step_sq_gradient_decay() const { return step_sq_gradient_decay_; }
+
+  /**
+   * @brief Return the step-size stabilization.
+   *
+   * @return The step-size stabilization.
+   */
+  double step_stabilization() const { return step_stabilization_; }
+
+  /**
+   * @brief Return the step-size learning rate decay factor.
+   *
+   * @return The step-size learning rate decay factor.
+   */
+  double step_learn_rate_decay() const { return step_learn_rate_decay_; }
+
+  /**
+   * @brief Return the stride for publishing updates for convergence monitoring.
+   *
+   * @return The stride for publishing updates for convergence monitoring.
+   */
+  std::size_t publish_stride() const { return publish_stride_; }
+
+  /**
+   * @brief Return the period at which threads for chains yield.
+   *
+   * @return The the period at which threads for chains yield.
+   */
+  std::size_t yield_period() const { return yield_period_; }
+
+ private:
+  friend class WarmupConfigBuilder;
+
+  WarmupConfig() = default;
+
+  std::size_t min_iter_ = 50;
+  std::size_t max_iter_ = 1000;
+  double step_size_converge_tol_ = 0.1;
+  double mass_converge_tol_ = 1.0;
+  double mass_init_count_ = 4.0;
+  double mass_additive_smoothing_ = 1e-5;
+  double max_macro_steps_target_ = 15.0;
+  double step_accept_rate_target_ = 0.8;
+  double step_learning_rate_ = 0.05;
+  double step_gradient_decay_ = 0.8;
+  double step_sq_gradient_decay_ = 0.9;
+  double step_stabilization_ = 1e-4;
+  double step_learn_rate_decay_ = 0.5;
+  std::size_t publish_stride_ = 5;
+  std::size_t yield_period_ = 32;
+};
+
+/**
+ * @brief The builder for `WarmupConfig` objects.
+ */
+class WarmupConfigBuilder {
+ public:
+  /**
+   * @brief Set the minimum and maximum number of warmup iterations.
+   *
+   * @param[in] min_iter The minimum number of warmup iterations.
+   * @param[in] max_iter The maximum number of warmup iterations.
+   * @return This builder for chaining.
+   * @throw std::invalid_argument If `min_iter` > `max_iter`.
+   */
+  WarmupConfigBuilder& min_max_iter(std::size_t min_iter,
+                                    std::size_t max_iter) {
+    if (min_iter > max_iter) {
+      throw std::invalid_argument(
+          "min_iter cannot be greater than than max_iter");
+    }
+    cfg_.min_iter_ = min_iter;
+    cfg_.max_iter_ = max_iter;
+    return *this;
+  }
+
+  /**
+   * @brief Set the step size convergence tolerance.
+   *
+   * @param[in] v The step size convergence tolerance.
+   * @return This builder for chaining.
+   * @throw std::invalid_argument If the tolerance is not finite and positive.
+   */
+  WarmupConfigBuilder& step_size_converge_tol(double v) {
+    detail::validate_finite_positive(v, "step_size_converge_tol");
+    cfg_.step_size_converge_tol_ = v;
+    return *this;
+  }
+
+  /**
+   * @brief Set the mass matrix L2-norm convergence tolerance.
+   *
+   * @param[in] v The mass matrix L2-norm convergence tolerance.
+   * @return This builder for chaining.
+   * @throw std::invalid_argument If the tolerance is not finite and positive.
+   */
+  WarmupConfigBuilder& mass_converge_tol(double v) {
+    detail::validate_finite_positive(v, "mass_converge_tol");
+    cfg_.mass_converge_tol_ = v;
+    return *this;
+  }
+
+  /**
+   * @brief Set the mass matrix estimator initial count.
+   *
+   * @param[in] v The mass matrix estimator initial count.
+   * @return This builder for chaining.
+   * @throw std::invalid_argument If the initial count is not finite and
+   * positive.
+   */
+  WarmupConfigBuilder& mass_init_count(double v) {
+    detail::validate_finite_positive(v, "mass_init_count");
+    cfg_.mass_init_count_ = v;
+    return *this;
+  }
+
+  /**
+   * @brief Set the mass matrix estimator additive smoothing.
+   *
+   * @param[in] v The mass matrix estimator additive smoothing.
+   * @return This builder for chaining.
+   * @throw std::invalid_argument If the smoothing is not finite and positive.
+   */
+  WarmupConfigBuilder& mass_additive_smoothing(double v) {
+    detail::validate_finite_positive(v, "mass_additive_smoothing");
+    cfg_.mass_additive_smoothing_ = v;
+    return *this;
+  }
+
+  /**
+   * @brief Set the target number of macro steps.
+   *
+   * @param[in] v The target number of macro steps.
+   * @return This builder for chaining.
+   * @throw std::invalid_argument If the target is not finite and positive.
+   */
+  WarmupConfigBuilder& max_macro_steps_target(double v) {
+    detail::validate_finite_positive(v, "max_macro_steps_target");
+    cfg_.max_macro_steps_target_ = v;
+    return *this;
+  }
+
+  /**
+   * @brief Set the accept-rate target for step-size estimation.
+   *
+   * @param[in] v The accept-rate target.
+   * @return This builder for chaining.
+   * @throw std::invalid_argument If the accept rate is not in (0, 1).
+   */
+  WarmupConfigBuilder& step_accept_rate_target(double v) {
+    detail::validate_probability(v, "step_accept_rate_target");
+    cfg_.step_accept_rate_target_ = v;
+    return *this;
+  }
+
+  /**
+   * @brief Set the step size learning rate.
+   *
+   * @param[in] v The step size learning rate.
+   * @return This builder for chaining.
+   * @throw std::invalid_argument If the learning rate is not finite and
+   * positive.
+   */
+  WarmupConfigBuilder& step_learning_rate(double v) {
+    detail::validate_finite_positive(v, "step_learning_rate");
+    cfg_.step_learning_rate_ = v;
+    return *this;
+  }
+
+  /**
+   * @brief Set the gradient decay for the step-size estimator.
+   *
+   * @param[in] v The gradient decay for the step-size estimator.
+   * @return This builder for chaining.
+   * @throw std::invalid_argument If the decay is not in (0, 1).
+   */
+  WarmupConfigBuilder& step_gradient_decay(double v) {
+    detail::validate_probability(v, "step_gradient_decay");
+    cfg_.step_gradient_decay_ = v;
+    return *this;
+  }
+
+  /**
+   * @brief Set the squared gradient decay for the step-size estimator.
+   *
+   * @param[in] v The squared gradient decay for the step-size estimator.
+   * @return This builder for chaining.
+   * @throw std::invalid_argument If the decay is not in (0, 1).
+   */
+  WarmupConfigBuilder& step_sq_gradient_decay(double v) {
+    detail::validate_probability(v, "step_sq_gradient_decay");
+    cfg_.step_sq_gradient_decay_ = v;
+    return *this;
+  }
+
+  /**
+   * @brief Set the step-size estimator stabilization term.
+   *
+   * @param[in] v The step-size estimator stabilization term.
+   * @return This builder for chaining.
+   * @throw std::invalid_argument If the stabilization is not finite and
+   * positive.
+   */
+  WarmupConfigBuilder& step_stabilization(double v) {
+    detail::validate_finite_positive(v, "step_stabilization");
+    cfg_.step_stabilization_ = v;
+    return *this;
+  }
+
+  /**
+   * @brief Set the learning rate decay exponent for step size.
+   *
+   * @param[in] v The learning rate decay exponent.
+   * @return This builder for chaining.
+   * @throw std::invalid_argument If the decay exponent is not in (0, 1).
+   */
+  WarmupConfigBuilder& step_learn_rate_decay(double v) {
+    detail::validate_probability(v, "step_learn_rate_decay");
+    cfg_.step_learn_rate_decay_ = v;
+    return *this;
+  }
+
+  /**
+   * @brief Set the stride between publishing statistics for convergence
+   * monitoring.
+   *
+   * @param[in] v The stride for publishing statistics for convergence
+   * monitoring.
+   * @return This builder for chaining.
+   * @throw std::invalid_argument If the stride is not positive.
+   */
+  WarmupConfigBuilder& publish_stride(std::size_t v) {
+    detail::validate_positive(v, "publish_stride");
+    cfg_.publish_stride_ = v;
+    return *this;
+  }
+
+  /**
+   * @brief Set the iteration period between chain threads yielding.
+   *
+   * @param[in] v The iteration period between chain threads yielding.
+   * @return This builder for chaining.
+   * @throw std::invalid_argument If the yield period is not positive.
+   */
+  WarmupConfigBuilder& yield_period(std::size_t v) {
+    detail::validate_positive(v, "yield_period");
+    cfg_.yield_period_ = v;
+    return *this;
+  }
+
+  /**
+   * @brief Return the warmup configuration.
+   *
+   * @return The warmup configuration.
+   */
+  WarmupConfig build() { return cfg_; }
+
+ private:
+  WarmupConfig cfg_;
+};
+
+/**
+ * @internal @brief Print the tuning parameters specified by the
+ * warmup configuration to the output stream.
+ *
+ * @param[in,out] out Output stream to which configuration is printed.
+ * @param[in] cfg The sampling configuration.
+ * @return The output stream for chained calls.
+ */
+inline std::ostream& operator<<(std::ostream& out, const WarmupConfig& cfg) {
+  out << "WarmupConfig\n"
+      << "  min_iter                 = " << cfg.min_iter() << "\n"
+      << "  max_iter                 = " << cfg.max_iter() << "\n"
+      << "  step_size_converge_tol   = " << cfg.step_size_converge_tol() << "\n"
+      << "  mass_converge_tol        = " << cfg.mass_converge_tol() << "\n"
+      << "  mass_init_count          = " << cfg.mass_init_count() << "\n"
+      << "  mass_additive_smoothing  = " << cfg.mass_additive_smoothing()
+      << "\n"
+      << "  max_macro_steps_target   = " << cfg.max_macro_steps_target() << "\n"
+      << "  step_accept_rate_target  = " << cfg.step_accept_rate_target()
+      << "\n"
+      << "  step_learning_rate       = " << cfg.step_learning_rate() << "\n"
+      << "  step_gradient_decay      = " << cfg.step_gradient_decay() << "\n"
+      << "  step_sq_gradient_decay   = " << cfg.step_sq_gradient_decay() << "\n"
+      << "  step_stabilization       = " << cfg.step_stabilization() << "\n"
+      << "  step_learn_rate_decay    = " << cfg.step_learn_rate_decay() << "\n"
+      << "  publish_stride           = " << cfg.publish_stride() << "\n"
+      << "  yield_period             = " << cfg.yield_period() << "\n";
+  return out;
+}
+
+/**
+ * @brief A class to hold the configuration for the Walnuts sampler.
+ */
+class SamplingConfig {
+ public:
+  /**
+   * @brief Return the minimum number of sampling iterations.
+   *
+   * @return The minimum number of sampling iterations.
+   */
+  std::size_t min_iter() const noexcept { return min_iter_; }
+
+  /**
+   * @brief Return the maximum number of sampling iterations.
+   *
+   * @return The maximum number of sampling iterations.
+   */
+  std::size_t max_iter() const noexcept { return max_iter_; }
+
+  /**
+   * @brief Return the maximum number of trajectory doublings
+   * for Nuts.
+   *
+   * @return The maximum number of trajectory doublings.
+   */
+  std::size_t max_trajectory_doublings() const noexcept {
+    return max_trajectory_doublings_;
+  }
+
+  /**
+   * @brief Return the maximum number of stepsize halvings
+   * for Nuts.
+   *
+   * @return The maximum number of trajectory doublings.
+   */
+  std::size_t max_step_halvings() const noexcept { return max_step_halvings_; }
+
+  /**
+   * @brief Return the maximum error in the Hamiltonian allowed for Walnutpie.
+   *
+   * @return The maximum error in the Hamiltonian allowed for Walnutpie.
+   */
+  double max_hamiltonian_error() const noexcept {
+    return max_hamiltonian_error_;
+  }
+
+  /**
+   * @brief Return the minimum number of micro steps per macro step.
+   *
+   * @return The minimum number of micro steps per macro step.
+   */
+  std::size_t min_micro_steps() const noexcept { return min_micro_steps_; }
+
+  /**
+   * @brief Return the convergence tolerance for the R-hat statistic.
+   *
+   * @return The convergence tolerance for the R-hat statistic.
+   */
+  double rhat_converge_tol() const noexcept { return rhat_converge_tol_; }
+
+ private:
+  friend class SamplingConfigBuilder;
+
+  SamplingConfig() = default;
+
+  std::size_t min_iter_ = 50;
+  std::size_t max_iter_ = 1000;
+  std::size_t max_trajectory_doublings_ = 5;
+  std::size_t max_step_halvings_ = 5;
+  double max_hamiltonian_error_ = 0.5;
+  std::size_t min_micro_steps_ = 1;
+  double rhat_converge_tol_ = 1.01;
+};
+
+/**
+ * @brief The builder for sampling configurations.
+ *
+ * An example use would be:
+ * @code
+ * SampleConfigBuilder(50u, 100u)
+ *     .max_step_halvings(4u)
+ *     .min_micro_steps(2u)
+ *     .build();
+ * @endcode
+ */
+class SamplingConfigBuilder {
+ public:
+  /**
+   * @brief Set the minimum and maximum number of iterations.
+   *
+   * @param[in] min_iter The minimum number of iterations.
+   * @param[in] max_iter The maximum number of iterations.
+   * @return A reference to this builder for chaining.
+   * @throw std::invalid_argument If the minimum number of iterations
+   * is greater than the maximum number of iterations.
+   */
+  SamplingConfigBuilder& min_max_iter(std::size_t min_iter,
+                                      std::size_t max_iter) {
+    if (min_iter > max_iter) {
+      throw std::invalid_argument("min_iter must be <= max_iter");
+    }
+    cfg_.min_iter_ = min_iter;
+    cfg_.max_iter_ = max_iter;
+    return *this;
+  }
+
+  /**
+   * @brief Set the maximum number of trajectory doublings.
+   *
+   * @param[in] v The maximum number of trajectory doublings.
+   * @return A reference to this builder for chaining.
+   */
+  SamplingConfigBuilder& max_trajectory_doublings(std::size_t v) noexcept {
+    cfg_.max_trajectory_doublings_ = v;
+    return *this;
+  }
+
+  /**
+   * @brief Set the maximum number of step size halvings.
+   *
+   * @param[in] v The maximum number of step size halvings.
+   * @return A reference to this builder for chaining.
+   */
+  SamplingConfigBuilder& max_step_halvings(std::size_t v) noexcept {
+    cfg_.max_step_halvings_ = v;
+    return *this;
+  }
+
+  /**
+   * @brief Set the maximum error in the Hamiltonian for Walnutpie.
+   *
+   * @param[in] v The maximum error in the Hamiltonian for Walnutpie.
+   * @return A reference to this builder for chaining.
+   * @throw std::invalid_argument If the error is not finite and positive.
+   */
+  SamplingConfigBuilder& max_hamiltonian_error(double v) {
+    detail::validate_finite_positive(v, "max_hamiltonian_error");
+    cfg_.max_hamiltonian_error_ = v;
+    return *this;
+  }
+
+  /**
+   * @brief Set the minimum number of micro steps per macro step.
+   *
+   * @param[in] v The minimum number of micro steps per macro step.
+   * @return A reference to this builder for chaining.
+   * @throw std::invalid_argument If the minimum number of steps is not
+   * positive.
+   */
+  SamplingConfigBuilder& min_micro_steps(std::size_t v) {
+    detail::validate_positive(v, "min_micro_steps");
+    cfg_.min_micro_steps_ = v;
+    return *this;
+  }
+
+  /**
+   * @brief Set the R-hat convergence tolerance.
+   *
+   * @param[in] v The R-hat convergence tolerance.
+   * @return A reference to this builder for chaining.
+   * @throw std::invalid_argument If the tolerance is not finite and > 1.
+   */
+  SamplingConfigBuilder& rhat_converge_tol(double v) {
+    detail::validate_finite_gt1(v, "rhat_convergence_tol");
+    cfg_.rhat_converge_tol_ = v;
+    return *this;
+  }
+
+  /**
+   * @brief Return the sampling configuration.
+   *
+   * @return The sampling configuration.
+   */
+  SamplingConfig build() { return cfg_; }
+
+ private:
+  SamplingConfig cfg_;
+};
+
+/**
+ * @internal @brief Print the tuning parameters specified by the sampling
+ * configuration to the output stream.
+ *
+ * @param[in,out] out Output stream to which configuration is printed.
+ * @param[in] cfg The sampling configuration.
+ * @return The output stream for chained calls.
+ */
+inline std::ostream& operator<<(std::ostream& out, const SamplingConfig& cfg) {
+  out << "SamplingConfig\n"
+      << "  min_iter                   = " << cfg.min_iter() << "\n"
+      << "  max_iter                   = " << cfg.max_iter() << "\n"
+      << "  max_trajectory_doublings   = " << cfg.max_trajectory_doublings()
+      << "\n"
+      << "  max_step_halvings          = " << cfg.max_step_halvings() << "\n"
+      << "  max_hamiltonian_error      = " << cfg.max_hamiltonian_error()
+      << "\n"
+      << "  min_micro_steps            = " << cfg.min_micro_steps() << "\n"
+      << "  rhat_converge_tol          = " << cfg.rhat_converge_tol() << "\n";
+  return out;
+}
+
+/**
+ * @brief Encapsulated configuration for Walnutpie.
+ *
+ * Walnuts configurations include initialization, warmup, and sampling
+ * configurations.
+ */
+class WalnutsConfig {
+ public:
+  /**
+   * @brief Construct a Walnuts configuration given the component
+   * configurations.
+   *
+   * The arguments will be moved if they are rvalues and copied if lvalues.
+   *
+   * @param[in] init The initialization configuration.
+   * @param[in] warmup The warmup configuration.
+   * @param[in] sampling The sampling configuration.
+   */
+  WalnutsConfig(InitConfig init, WarmupConfig warmup, SamplingConfig sampling)
+      : init_(std::move(init)),
+        warmup_(std::move(warmup)),
+        sampling_(std::move(sampling)) {};
+
+  /**
+   * @brief Return the initialization configuration.
+   *
+   * @return The initialization configuration.
+   */
+  const InitConfig& init() const noexcept { return init_; }
+
+  /**
+   * @brief Return the warmup configuration.
+   *
+   * @return The warmup configuration.
+   */
+  const WarmupConfig& warmup() const noexcept { return warmup_; }
+
+  /**
+   * @brief Return the sampling configuration.
+   *
+   * @return The sampling configuration.
+   */
+  const SamplingConfig& sampling() const noexcept { return sampling_; }
+
+ private:
+  /** The initialization configuration for all chains. */
+  InitConfig init_;
+
+  /** The warmup configuration shared by all chains. */
+  WarmupConfig warmup_;
+
+  /** The sampling configuration shared by all chains for warmup and sampling.
+   */
+  SamplingConfig sampling_;
+};
+
+/**
+ * @brief Print the Walnuts configuration.
+ *
+ * This just delegates to printing the initialization, warmup, and
+ * sampling configurations separated by newlines.
+ *
+ * @param[in,out] out Output stream to which configuration is printed.
+ * @param[in] cfg The Walnuts configuration.
+ * @return The output stream for chained calls.
+ */
+inline std::ostream& operator<<(std::ostream& out, const WalnutsConfig& cfg) {
+  out << cfg.init() << "\n" << cfg.warmup() << "\n" << cfg.sampling() << "\n";
+  return out;
+}
+
+}  // namespace walnutpie

--- a/runtime/third_party/walnutpie/online_moments.hpp
+++ b/runtime/third_party/walnutpie/online_moments.hpp
@@ -1,0 +1,249 @@
+#pragma once
+
+#include <cstddef>
+#include <limits>
+#include <string>
+
+#include <Eigen/Dense>
+
+#include "walnutpie/validate.hpp"
+
+namespace walnutpie::detail {
+
+/**
+ * @brief Accumulator for online mean and smaple variance calculations.
+ *
+ * Welford's algorithm stores sufficient statistics with which to
+ * compute a running mean and sample variance. The accumulator stores
+ * only three sufficient statistics: a `std::size_t` and two `double`
+ * values. The algorithm is more numerically stable for variance
+ * calculations than the naive algorithm.
+ */
+class WelfordAccumulator {
+ public:
+  /**
+   * @brief Construct an accumulator with no observed values.
+   */
+  WelfordAccumulator() : n_(0), mean_(0.0), M2_(0.0) {}
+
+  /**
+   * @brief Observe a value.
+   *
+   * @param[in] x The observed value.
+   */
+  void observe(double x) {
+    ++n_;
+    const double delta = x - mean_;
+    mean_ += delta / static_cast<double>(n_);
+    const double delta2 = x - mean_;
+    M2_ += delta * delta2;
+  }
+
+  /**
+   * @brief Return the number of values observed.
+   *
+   * @return The number of values observed.
+   */
+  std::size_t count() const { return n_; }
+
+  /**
+   * @brief Return the mean of all of the values observed, or 0
+   * if no values have been observed.
+   *
+   * @return The mean of the observed values.
+   */
+  double mean() const { return mean_; }
+
+  /**
+   * @brief Return the sample variance of the observed values.
+   *
+   * The sample variance is the unbiased estimator of variance.
+   * It divides by number of observations minus one. Thus if
+   * there have been fewer than two observations, the sample
+   * variance is undefined and `NaN` will be returned.
+   *
+   * @return The sample variance of the observed values.
+   */
+  double sample_variance() const {
+    return n_ > 1 ? (M2_ / static_cast<double>(n_ - 1))
+                  : std::numeric_limits<double>::quiet_NaN();
+  }
+
+  /**
+   * @brief Reset the accumulator to its initial state of having seen
+   * zero observations.
+   */
+  void reset() {
+    n_ = 0;
+    mean_ = 0.0;
+    M2_ = 0.0;
+  }
+
+ private:
+  std::size_t n_;
+  double mean_;
+  double M2_;
+};
+
+/**
+ * @brief An accumulator estimating discounted means and variances online.
+ *
+ * The `observe()` method receives vector value updates and maintains a
+ * running estimate of discounted means and variances. Historical counts
+ * are discounted by the multiplying by the discount factor before each
+ * new observation is added (with a count of one). 1 does no discounting
+ * and 0 completely forgets the past.
+ *
+ * The implementation uses a weighted variant of Welford's algorithm that
+ * discounts past observations. It requires a constant memory of size
+ * proportional to the dimensionality of the observed vectors (i.e.,
+ * O(`dim`)). Each of its methods runs in time proportional to the size
+ * of the update vectors (i.e., O(`dim`)). Arithmetic is stable
+ * following the original Welford accumulator, to which it reduces
+ * when `discount_factor = 1`.
+ *
+ * After initialization and updating with `N` vectors
+ * `y[0], ..., y[N - 1]`, the weight for vector `y[n]` is
+ * ```
+ * weight[n] = discount_factor^(N - n - 1).
+ * ```
+ *
+ * The discounted mean is calculated in the usual way for weighted
+ * averages,
+ * ```
+ * mean = sum(y .* weight) / sum(weight),
+ * ```
+ * where `.*` is elementwise product.
+ *
+ *
+ * The discounted mean is then used to estimate the discounted variance,
+ *
+ * ```
+ * var = sum(weight .* (y - mean)^2) / sum(weight).
+ * ```
+ */
+class OnlineMoments {
+ public:
+  /**
+   * @brief Construct a default online estimator of size zero.
+   */
+  OnlineMoments() : weight_(0) {}
+
+  /**
+   * @brief Construct an online estimator of moments with the
+   * specified discount factor and initialization.
+   *
+   * The initialization specifies the initial mean and the initial
+   * variance, assigning them a weight that is interpreted as if the
+   * initial mean and variance were the result of a count of
+   * `init_weight` observations.
+   *
+   * @param[in] init_weight Weight (in number of draws) of initial mean
+   * and variance (positive).
+   * @param[in] init_mean Initial mean.
+   * @param[in] init_variance Initial variance.
+   * @throw std::invalid_argument If `discount_factor` is not in (0, 1).
+   * @throw std::invalid_argument If the initial weight is not finite and
+   * positive.
+   * @throw std::invalid_argument If the initial mean and variance are not
+   * the same size.
+   */
+  OnlineMoments(double init_weight, const Eigen::VectorXd& init_mean,
+                const Eigen::VectorXd& init_variance)
+      : weight_(init_weight),
+        mean_(init_mean),
+        sum_sq_dev_(init_weight * init_variance) {
+    detail::validate_positive(init_weight, "init_weight");
+    detail::validate_same_size(init_mean, init_variance, "init_mean",
+                               "init_variance");
+  }
+
+  /**
+   * @brief Set the discount factor for previous observations to the specified
+   * value.
+   *
+   * @param[in] discount_factor The discount factor.
+   * @throw std::invalid_argument If the discount factor is not in (0, 1).
+   */
+  void set_discount_factor(double discount_factor) {
+    detail::validate_probability_inclusive(discount_factor, "discount_factor");
+    discount_factor_ = discount_factor;
+  }
+
+  /**
+   * @brief Update this accumulator with the specified observation.
+   *
+   * The observed value `y` is assigned a weight (or count) of 1, and
+   * the weights of the past observations are discounted by the discount
+   * factor.
+   *
+   * @tparam Derived The type of matrix underlying the observation.
+   * @param[in] y The observed vector.
+   * @pre y.size() == mean().size()
+   */
+  template <typename Derived>
+  void observe(const Eigen::MatrixBase<Derived>& y) {
+    auto delta = y - mean_;
+    weight_ = discount_factor_ * weight_ + 1;
+    mean_ += delta / weight_;
+    sum_sq_dev_.noalias() =
+        discount_factor_ * sum_sq_dev_ + delta.cwiseProduct(y - mean_);
+  }
+
+  /**
+   * @brief Set the discount factor, then update with the specified observation.
+   *
+   * This is a convenience method to call `set_discount_factor(discount_factor)`
+   * and `observe(y)`.
+   *
+   * @tparam Derived The type of matrix underlying the observation.
+   * @param[in] discount_factor The discount factor.
+   * @param[in] y The observed vector.
+   * @throw discount_factor > 0 && discount_factor <= 1
+   * @pre y.size() == mean().size()
+   */
+  template <typename Derived>
+  void discount_observe(double discount_factor,
+                        const Eigen::MatrixBase<Derived>& y) {
+    set_discount_factor(discount_factor);
+    observe(y);
+  }
+
+  /**
+   * @brief Return the estimate of the mean.
+   *
+   * @return The mean estimate.
+   */
+  const Eigen::VectorXd& mean() const noexcept { return mean_; }
+
+  /**
+   * @brief Return the maximum likelihood estimate of the variance, or
+   * a vector of 1 values if there have been no observations.
+   *
+   * @return The variance estimate.
+   */
+  Eigen::VectorXd variance() const {
+    if (!(weight_ > 0)) {
+      return Eigen::VectorXd::Ones(mean_.size());
+    }
+    return sum_sq_dev_ / weight_;
+  }
+
+ private:
+  /** The discount factor applied to the weights of previous observations.
+   *
+   * Gets reset before it is used in discounted Welford algorithm.
+   */
+  double discount_factor_ = std::numeric_limits<double>::quiet_NaN();
+
+  /** The combined weight of all previous observations. */
+  double weight_;
+
+  /** The current mean estimate */
+  Eigen::VectorXd mean_;
+
+  /** The sum of weighted squared deviations from the mean. */
+  Eigen::VectorXd sum_sq_dev_;
+};
+
+}  // namespace walnutpie::detail

--- a/runtime/third_party/walnutpie/util.hpp
+++ b/runtime/third_party/walnutpie/util.hpp
@@ -1,0 +1,406 @@
+#pragma once
+
+#include <cmath>
+#include <cstddef>
+#include <functional>
+#include <limits>
+#include <numeric>
+#include <random>
+#include <type_traits>
+#include <vector>
+
+#include <Eigen/Dense>
+
+#include "walnutpie/concepts.hpp"
+
+namespace walnutpie::detail {
+
+#if defined(__has_attribute) && __has_attribute(always_inline)
+#define WALNUTPIE_STRONG_INLINE [[gnu::always_inline]] inline
+#else
+#define WALNUTPIE_STRONG_INLINE inline
+#endif
+
+#ifdef __APPLE__
+#include <pthread/qos.h>
+WALNUTPIE_STRONG_INLINE void interactive_qos() {
+  pthread_set_qos_class_self_np(QOS_CLASS_USER_INTERACTIVE, 0);  // best
+}
+WALNUTPIE_STRONG_INLINE void initiated_qos() {
+  pthread_set_qos_class_self_np(QOS_CLASS_USER_INITIATED, 0);  // next best
+}
+#else
+WALNUTPIE_STRONG_INLINE void interactive_qos() {}
+WALNUTPIE_STRONG_INLINE void initiated_qos() {}
+#endif
+
+/**
+ * @brief A conservative constant destructive interference size.
+ *
+ * The std::hardware_destructive_interference_size is not universally supported
+ * and can underreport when it is supported. 128 is safe for ARM and Intel
+ * hardware.
+ */
+inline constexpr std::size_t FALSE_SHARING_GUARD_SIZE = 128;
+
+/**
+ * @brief Proposal update schemes for MCMC transitions.
+ */
+enum class Update {
+  Barker,    /**< Use Barker's acceptance rule (proportional to density). */
+  Metropolis /**< Use standard Metropolis acceptance rule */
+};
+
+/**
+ * @brief Time direction of Hamiltonian simulation.
+ */
+enum class Direction {
+  Backward, /**< Step backward in time. */
+  Forward   /**< Step forward in time. */
+};
+
+/**
+ * @brief A type definition for constructing `Direction::Backward` constants.
+ */
+using Backward_t = std::integral_constant<Direction, Direction::Backward>;
+
+/**
+ * @brief A type definition for constructing `Direction::Forward` constants.
+ */
+using Forward_t = std::integral_constant<Direction, Direction::Forward>;
+
+/**
+ * @brief A class encapsulating the randomizers needed for Hamiltonian Monte
+ * Carlo.
+ *
+ * @tparam RNG The type of the base random number generator.
+ */
+template <std::uniform_random_bit_generator RNG>
+class Random {
+ public:
+  /**
+   * @brief Construct a randomizer with the specified base random number
+   * generator.
+   *
+   * The base generator is held as a reference and used for all of the
+   * generation. Thus it must be kept in scope as the instance constructed with
+   * it is used. The base generator may be shared with other applications.
+   *
+   * @param[in,out] rng The base random number generator.
+   */
+  explicit Random(RNG& rng) noexcept
+      : rng_(rng), unif_(0.0, 1.0), binary_(0.5), normal_(0.0, 1.0) {}
+
+  /**
+   * @brief Return a number between 0 and 1 generated uniformly at random.
+   *
+   * The base random number generator is used to generate from a
+   * `uniform([0, 1])` distribution.
+   *
+   * @return A number between 0 and 1 generated uniformly at random.
+   */
+  double uniform_real_01() { return unif_(rng_); }
+
+  /**
+   * @brief Return `true` or `false` uniformly at random.
+   *
+   * The base random number generator is used to generate from
+   * a `uniform({0, 1})` distribution.
+   *
+   * @return A boolean value generated uniformly at random.
+   */
+  bool uniform_binary() { return binary_(rng_); }
+
+  /**
+   * @brief Return a vector of values generated according to a
+   * standard normal distribution.
+   *
+   * The base random number generator is used to generate each
+   * component independently from a `normal(0, 1)` distribution.
+   *
+   * @param[in] n The size of the vector generated.
+   * @return An expression template for a standard normal vector.
+   */
+  auto standard_normal(Eigen::Index n) {
+    return Eigen::VectorXd::NullaryExpr(
+        n, [this](Eigen::Index /*i*/) { return this->normal_(rng_); });
+  }
+
+  /**
+   * @brief Write a vector of random standard normal variables into the out
+   * vector.
+   *
+   * The base random number generator is used to generate each
+   * component independently from a `normal(0, 1)` distribution.
+   *
+   * @param[in] n The size of the vector generated.
+   * @param[out] out The output vector.
+   */
+  void standard_normal(Eigen::Index n, Eigen::VectorXd& out) {
+    out = standard_normal(n);
+  }
+
+  /**
+   * @brief Return a reference to the base random number generator.
+   *
+   * @return The base random number generator.
+   */
+  RNG& rng() noexcept { return rng_; }
+
+ private:
+  /** The base random number generator reference. */
+  RNG& rng_;  // not std::reference_wrapper to prevent copying
+
+  /** The `uniform([0, 1])` random number generator. */
+  std::uniform_real_distribution<double> unif_;
+
+  /** The `uniform({0, 1})` random number generator. */
+  std::bernoulli_distribution binary_;
+
+  /** The `normal(0, 1)` random number generator. */
+  std::normal_distribution<double> normal_;
+};
+
+/**
+ * @brief Return the log of the sum of the exponentiated arguments.
+ *
+ * The mathematical definition is `log_sum_exp(x1, x2) = log(exp(x1) +
+ * exp(x2))`. The implementation is high precision and numerically stable.
+ *
+ * @param[in] x1 The first argument.
+ * @param[in] x2 The second argument.
+ * @return The log of the sum of the exponentiations of the arguments.
+ */
+inline double log_sum_exp(const double& x1, const double& x2) {
+  auto m = std::fmax(x1, x2);
+  if (std::isnan(x1) || std::isnan(x2)) {
+    return std::numeric_limits<double>::quiet_NaN();
+  }
+  if (std::isinf(m) || std::isnan(x1 + x2)) {
+    return std::fmax(x1, x2);
+  }
+  return m + std::log(std::exp(x1 - m) + std::exp(x2 - m));
+}
+
+/**
+ * @brief Return the log of the sum of the components of the argument
+ * exponentiated.
+ *
+ * The mathematical definition is `log_sum_exp(v) = log(sum(exp(x))`.
+ * The implementation is high precision and numerically stable.
+ *
+ * @param[in] x The vector argument.
+ * @return The log of the sum of the exponentiation of the vector's components.
+ */
+inline double log_sum_exp(const Eigen::VectorXd& x) {
+  using std::log;
+  if (x.size() == 0) {  // Eigen triggers assert on empty .maxCoeff()
+    return -std::numeric_limits<double>::infinity();
+  }
+  double m = x.maxCoeff();
+  if (std::isinf(m)) {
+    return m;  // x[i] all -inf or all +inf; ow NaN
+  }
+  return m + log((x.array() - m).exp().sum());
+}
+
+/**
+ * @brief Return the unnormalized log density of the specified momentum given
+ * the specified inverse mass matrix diagonal.
+ *
+ * The unnormalized log density is the negative kinetic energy.
+ *
+ * The formula is `-0.5 * rho' .* inv_mass * rho`, which for diagonals works
+ * out to `-0.5 * rho**2 * inv_mass` elementwise.
+ *
+ * @param[in] rho Vector of momenta.
+ * @param[in] inv_mass_diag The diagonal of the diagonal inverse mass matrix.
+ * @return The log density of the momentum.
+ */
+inline double logp_momentum(const Eigen::VectorXd& rho,
+                            const Eigen::VectorXd& inv_mass_diag) {
+  return -0.5 * (inv_mass_diag.array() * rho.array().square()).sum();
+}
+
+/**
+ * @brief Return the difference in log density (negative Hamiltonian)
+ * between the intial position and momentum and the result of taking
+ * one leapfrog step with the specified inverse mass matrix and step size.
+ *
+ * As an internal function called by an algorithm that controls the
+ * inverse mass matrix and step size, there is no error checking to
+ * enusre `theta`, `rho`, and `inv_M` are all the same size, that
+ * `inv_M` has all finite positive entries, and that the step size is
+ * finite and positive.
+ *
+ * @tparam F The type of the log density and gradient function.
+ * @param[in] theta The starting position.
+ * @param[in] rho The starting momentum.
+ * @param[in] M The diagonal of the diagonal inverse mass matrix.
+ * @param[in] step The step size.
+ */
+template <LogpGrad F>
+double leapfrog_error(const F& logp_grad, const Eigen::VectorXd& theta,
+                      const Eigen::VectorXd& rho, const Eigen::VectorXd& inv_M,
+                      double step) {
+  Eigen::VectorXd grad;
+  double logp;
+  logp_grad(theta, logp, grad);
+  logp += detail::logp_momentum(rho, inv_M);
+  Eigen::VectorXd rho_star = rho + 0.5 * step * grad;
+  Eigen::VectorXd theta_star =
+      theta + step * (inv_M.array() * rho_star.array()).matrix();
+  double logp_star;
+  logp_grad(theta_star, logp_star, grad);
+  rho_star = rho_star + 0.5 * step * grad;
+  logp_star += detail::logp_momentum(rho_star, inv_M);
+  double diff = logp_star - logp;
+  return diff;
+}
+
+/**
+ * @brief Return the adapted step size for the specified initial
+ * step size, given an initial position and inverse mass matrix.
+ *
+ * The algorithm randomly generates a momentum. Then until
+ * the Metropolis acceptance rate is below 0.9, it continues
+ * to double the step size. Then until the Metropolis accept
+ * rate is above 0.6, it continues to divide it by sqrt(2).
+ * This is a slightly more fine-grained version of the heuristic
+ * step size initialization used by Nuts.
+ *
+ * There is no error testing here for consistency because this
+ * function is called from a controlled setting.
+ *
+ * @tparam RNG Type of the base random number generator.
+ * @tparam F Type of the log density and gradient function.
+ * @param[in] rng The base random number generator.
+ * @param[in] logp_grad The log density and gradient function.
+ * @param theta The initial position.
+ * @param M The diagonal of the diagonal mass matrix.
+ * @param step The initial step size guess.
+ * @param D The dimensioanlity
+ * @return The adapted step size.
+ */
+template <std::uniform_random_bit_generator RNG, LogpGrad F>
+double adapt_step(RNG& rng, const F& logp_grad, const Eigen::VectorXd& theta,
+                  const Eigen::VectorXd& M, double step, std::size_t D) {
+  detail::Random<RNG> rand(rng);
+  Eigen::VectorXd inv_M = M.array().inverse().matrix();
+  Eigen::VectorXd rho =
+      (rand.standard_normal(static_cast<Eigen::Index>(D)).array() *
+       M.array().sqrt())
+          .matrix();
+  while (detail::leapfrog_error(logp_grad, theta, rho, inv_M, step) >
+         std::log(0.9)) {
+    step *= 2;
+  }
+  while (detail::leapfrog_error(logp_grad, theta, rho, inv_M, step) <
+         std::log(0.6)) {
+    step *= std::sqrt(0.5);
+  }
+  return step;
+}
+
+/**
+ * @brief A wrapper for a log density and gradient function that traps
+ * exceptions.
+ *
+ * @tparam F Type of underlying log density and gradient function.
+ */
+template <LogpGrad F, ErrorCallback H>
+class NoExceptLogpGrad {
+ public:
+  /**
+   * @brief Construct a log density and gradient function from a base
+   * log density and gradient function.
+   *
+   * The log density and gradient function will be stored as a
+   * constant reference.
+   *
+   * @param[in] logp_grad The base log density and gradient function, called
+   * back.
+   * @param[in] handler The sample handler, used when exceptions are thrown.
+   */
+  NoExceptLogpGrad(const F& logp_grad, H& handler)
+      : logp_grad_(std::cref(logp_grad)), handler_(handler) {}
+
+  /**
+   * @brief Given the specified position, set the log density and
+   * gradient.
+   *
+   * @param[in] x The position vector.
+   * @param[out] logp The log density to set.
+   * @param[out] grad The gradient to set.
+   */
+  void operator()(const Eigen::VectorXd& x, double& logp,
+                  Eigen::VectorXd& grad) const noexcept {
+    try {
+      logp_grad_.get()(x, logp, grad);
+    } catch (const std::exception& e) {
+      handler_.get().on_logp_exception(x, e);
+      // logp_grad failure equivalent to -inf log density
+      logp = -std::numeric_limits<double>::infinity();
+      grad.setZero(x.size());
+    }
+  }
+
+  /** The log density and gradient function. */
+  const std::reference_wrapper<const F> logp_grad_;
+  const std::reference_wrapper<H> handler_;
+};
+
+/**
+ * @brief Return the gradient of the log density at the specified position.
+ *
+ * @tparam F The type of the target log density/gradient function.
+ * @param[in] logp_grad The target log density/gradient function.
+ * @param[in] theta The position at which to evaluate the gradient.
+ * @return The gradient of the log density at `theta`.
+ */
+inline Eigen::VectorXd grad(const LogpGrad auto& logp_grad,
+                            const Eigen::VectorXd& theta) {
+  Eigen::VectorXd g;
+  double logp;
+  logp_grad(theta, logp, g);
+  return g;
+}
+
+/**
+ * @brief Returns the L2 relative distance between the two vectors
+ * scaled by the second vector.
+
+ * The computation is `norm((a - b) / b)`.
+ *
+ * @param[in] a The test vector.
+ * @param[in] b The baseline vector.
+ * @return The relative difference
+ */
+inline double l2_rel_diff(const Eigen::VectorXd& a,
+                          const Eigen::VectorXd& b) noexcept {
+  return ((a - b).array() / b.array()).matrix().norm();
+}
+
+/**
+ * @brief Return the sum of the sizes in the vector.
+ *
+ * @param[in] xs The vector to sum.
+ * @return The sum.
+ */
+inline std::size_t sum(const std::vector<std::size_t>& xs) noexcept {
+  return std::transform_reduce(xs.begin(), xs.end(), std::size_t(0),
+                               std::plus<>{}, std::identity());
+}
+
+/**
+ * @brief Return the bias-adjusted sample variance estimate.
+ *
+ * @param[in] xs The vector whose variance is required.
+ * @return The variance.
+ */
+inline double variance(const Eigen::VectorXd& xs) noexcept {
+  return (xs.array() - xs.mean()).square().sum() /
+         static_cast<double>((xs.size() - 1));
+}
+
+}  // namespace walnutpie::detail

--- a/runtime/third_party/walnutpie/validate.hpp
+++ b/runtime/third_party/walnutpie/validate.hpp
@@ -1,0 +1,289 @@
+#pragma once
+
+#include <cmath>
+#include <concepts>
+#include <cstddef>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include <Eigen/Dense>
+
+#include "walnutpie/concepts.hpp"
+
+namespace walnutpie::detail {
+
+/**
+ * @brief Validate the standard vector is the specified size.
+ *
+ * @tparam T The type of vector elements.
+ * @param[in] x The vector.
+ * @param[in] size The size to test.
+ * @param[in] var The name of the vector.
+ * @param[in] target The name of size.
+ * @throw invalid_argument If the container size is not the specified size.
+ */
+template <typename T>
+inline void validate_size(const std::vector<T>& x, std::size_t size,
+                          const std::string& var, const std::string& target) {
+  if (x.size() == size) {
+    return;
+  }
+  throw std::invalid_argument(var + " size must match " + target);
+}
+
+/**
+ * @brief Validate the Eigen container is the specified size.
+ *
+ * @tparam T The type of vector elements.
+ * @tparam R The size or dynamic specification of rows.
+ * @tparam C The size or dynamic specification of columns.
+ * @param[in] x The container.
+ * @param[in] size The size to test.
+ * @param[in] var The name of the container.
+ * @param[in] target The name of size.
+ * @throw invalid_argument If the container size is not the specified size.
+ */
+template <std::floating_point T, int R, int C>
+inline void validate_size(const Eigen::Matrix<T, R, C>& x, std::size_t size,
+                          const std::string& var, const std::string& target) {
+  if (x.size() == static_cast<Eigen::Index>(size)) {
+    return;
+  }
+  throw std::invalid_argument(var + " size must match " + target);
+}
+
+/**
+ * @brief Throw an exception if the containers do not have the same size.
+ *
+ * @tparam T1 Type of first container.
+ * @tparam T2 Type of second container.
+ * @param[in] x1 The first container.
+ * @param[in] x2 The second container.
+ * @param[in] name1 The first container's name.
+ * @param[in] name2 The second container's name.
+ * @throw std::invalid_argument If the containers are not the same size.
+ */
+template <Sized T1, Sized T2>
+inline void validate_same_size(const T1& x1, const T2& x2,
+                               const std::string& name1,
+                               const std::string& name2) {
+  if (x1.size() == x2.size()) {
+    return;
+  }
+  std::string msg = name1 + " and " + name2 + " must be the same size.";
+  throw std::invalid_argument(msg);
+}
+
+/**
+ * @brief Throw an exception if the value is not finite and > 1.
+ *
+ * @tparam T The type of value.
+ * @param[in] x The value.
+ * @param[in] var The name of the value.
+ * @throw std::invalid_argument If the value is not finite and > 1.
+ */
+template <std::floating_point T>
+inline void validate_finite_gt1(T x, const std::string& var) {
+  if (std::isfinite(x) && x > 1) {
+    return;
+  }
+  throw std::invalid_argument(var + " must be finite and > 1");
+}
+
+/**
+ * @brief Throw an exception if the value is not finite and > 0.
+ *
+ * @tparam T The type of value.
+ * @param[in] x The value.
+ * @param[in] var The name of the value.
+ * @throw std::invalid_argument If the value is not finite and > 0.
+ */
+template <std::floating_point T>
+inline void validate_finite_positive(T x, const std::string& var) {
+  if (std::isfinite(x) && x > 0) {
+    return;
+  }
+  throw std::invalid_argument(var + " must be finite and > 0");
+}
+
+/**
+ * @brief Throw an exception if the container's elements are not
+ * finite and > 0.
+ *
+ * @tparam T The type of values.
+ * @tparam R The row size (or -1 for dynamic).
+ * @tparam C The column size (or -1 for dynamic).
+ * @param[in] xs The container.
+ * @param[in] var The name of the container.
+ * @throw std::invalid_argument If the container has an element that
+ * is not finite and > 0.
+ */
+template <std::floating_point T, int R, int C>
+inline void validate_finite_positive(const Eigen::Matrix<T, R, C>& xs,
+                                     const std::string& var) {
+  for (Eigen::Index i = 0; i < xs.size(); ++i) {
+    validate_finite_positive(xs(i), var);
+  }
+}
+
+/**
+ * @brief Throw an exception if the container's elements are not
+ * finite and > 0.
+ *
+ * @tparam T The type of values (container or floating point).
+ * @param[in] xs The container.
+ * @param[in] var The name of the container.
+ * @throw std::invalid_argument If the container has an element that
+ * is not finite and > 0.
+ */
+template <NestedFloatingPoint T>
+inline void validate_finite_positive(const std::vector<T>& xs,
+                                     const std::string& var) {
+  for (const auto& x : xs) {
+    validate_finite_positive(x, var);
+  }
+}
+
+/**
+ * @brief Throw an exception if the value is not finite.
+ *
+ * @tparam T The type of value.
+ * @param[in] x The value.
+ * @param[in] var The name of the value.
+ * @throw std::invalid_argument If the value is not finite.
+ */
+template <std::floating_point T>
+inline void validate_finite(T x, const std::string& var) {
+  if (std::isfinite(x)) {
+    return;
+  }
+  throw std::invalid_argument(var + " must be finite");
+}
+
+/**
+ * @brief Throw an exception if the container's elements are not
+ * finite.
+ *
+ * @tparam T The type of values.
+ * @tparam R The row size (or -1 for dynamic).
+ * @tparam C The column size (or -1 for dynamic).
+ * @param[in] xs The container.
+ * @param[in] var The name of the container.
+ * @throw std::invalid_argument If the container has an element that
+ * is not finite.
+ */
+template <std::floating_point T, int R, int C>
+inline void validate_finite(const Eigen::Matrix<T, R, C>& xs,
+                            const std::string& var) {
+  for (Eigen::Index i = 0; i < xs.size(); ++i) {
+    validate_finite(xs(i), var);
+  }
+}
+
+/**
+ * @brief Throw an exception if the container's elements are not
+ * finite.
+ *
+ * @tparam T The type of values (container or floating point).
+ * @param[in] xs The container.
+ * @param[in] var The name of the container.
+ * @throw std::invalid_argument If the container has an element that
+ * is not finite.
+ */
+template <NestedFloatingPoint T>
+inline void validate_finite(const std::vector<T>& xs, const std::string& var) {
+  for (const auto& x : xs) {
+    validate_finite(x, var);
+  }
+}
+
+/**
+ * @brief Throw an exception if the value is not positive and finite.
+ *
+ * @tparam T Type of value.
+ * @param[in] x The variable's value.
+ * @param[in] name The variable's name.
+ * @throw std::invalid_argument If the value is not positive and finite.
+ */
+template <std::floating_point T>
+inline void validate_positive(T x, const std::string& name) {
+  if (x > 0 && !std::isinf(x)) {
+    return;
+  }
+  std::string msg = name + " must be in (0, inf).";
+  throw std::invalid_argument(msg);
+}
+
+/**
+ * @brief Throw an exception if the value is not positive.
+ *
+ * @tparam T Type of integral value.
+ * @param[in] x The integral value.
+ * @param[in] name The name of the variable.
+ * @throw std::invalid_argument If the value is not positive.
+ */
+template <std::integral T>
+inline void validate_positive(T x, const std::string& name) {
+  if (x > 0) {
+    return;
+  }
+  std::string msg = name + " must be in {1, 2, ... }";
+  throw std::invalid_argument(msg);
+}
+
+/**
+ * @brief Throw an exception if the Eigen container's components are
+ * not positive and finite.
+ *
+ * @tparam T The type of elements.
+ * @param[in] x The Eigen container.
+ * @param[in] name The container's name.
+ * @throw std::invalid_argument If the elements of the container are
+ * not all positive and finite.
+ */
+template <std::floating_point T, int R, int C>
+inline void validate_positive(const Eigen::Matrix<T, R, C>& x,
+                              const std::string& name) {
+  if ((x.array() > 0.0).all() && x.allFinite()) {
+    return;
+  }
+  std::string msg = name + " must be in (0, inf).";
+  throw std::invalid_argument(msg);
+}
+
+/**
+ * @brief Throw an exception if the value is not in (0, 1).
+ *
+ * @tparam T Type of value.
+ * @param[in] x The variable's value.
+ * @param[in] name The variable's name.
+ * @throw std::invalid_argument If the value is not in (0, 1).
+ */
+template <std::floating_point T>
+inline void validate_probability(T x, const std::string& name) {
+  if (x > 0 && x < 1) {
+    return;
+  }
+  std::string msg = name + " must be in (0, 1)";
+  throw std::invalid_argument(msg);
+}
+
+/**
+ * @brief Throw an exception if the value is not in [0, 1].
+ *
+ * @tparam T Type of value.
+ * @param[in] x The variable's value.
+ * @param[in] name The variable's name.
+ * @throw std::invalid_argument If the value is not in [0, 1].
+ */
+template <std::floating_point T>
+inline void validate_probability_inclusive(T x, const std::string& name) {
+  if (x >= 0 && x <= 1) {
+    return;
+  }
+  std::string msg = name + " must be in [0, 1]";
+  throw std::invalid_argument(msg);
+}
+
+}  // namespace walnutpie::detail

--- a/runtime/third_party/walnutpie/walnuts.hpp
+++ b/runtime/third_party/walnutpie/walnuts.hpp
@@ -1,0 +1,768 @@
+#pragma once
+
+#include <cmath>
+#include <cstdlib>
+#include <functional>
+#include <limits>
+#include <optional>
+#include <random>
+#include <stdexcept>
+#include <string>
+#include <tuple>
+#include <utility>
+
+#include <Eigen/Dense>
+
+#include "walnutpie/concepts.hpp"
+#include "walnutpie/util.hpp"
+#include "walnutpie/validate.hpp"
+
+namespace walnutpie::detail {
+
+/**
+ * @brief A class for holding the minimal information in a Hamiltonian
+ * trajectory required for Walnuts.
+ *
+ * A span has member variables for the initial and final states' (a)
+ * position, (b) momentum, (c) log density of the state, and (d)
+ * gradient of target log density. It also holds a selected state,
+ * the gradient of the selected state, and the log of the sum of all
+ * joint densities on the trajectory. The gradients could be recomputed,
+ * but storing them serves as a local cache.
+ *
+ */
+class SpanW {
+ public:
+  /**
+   * @brief Construct a span of one state given the specified
+   * position, momentum, gradient, and log density.
+   *
+   * @param[in] theta The position.
+   * @param[in] rho The momentum.
+   * @param[in] grad_theta The gradient of the log density at `theta`.
+   * @param[in] logp_pos The log density of the position.
+   * @param[in] logp_joint The joint log density of the position and momentum.
+   * @return The span constructed from the initial point.
+   */
+  static SpanW from_initial_point(Eigen::VectorXd&& theta,
+                                  Eigen::VectorXd&& rho,
+                                  Eigen::VectorXd&& grad_theta, double logp_pos,
+                                  double logp_joint) {
+    return {theta,
+            rho,
+            grad_theta,
+            logp_joint,
+            theta,
+            std::move(rho),
+            grad_theta,
+            logp_joint,
+            std::move(theta),
+            std::move(grad_theta),
+            logp_pos,
+            logp_joint};
+  }
+
+  /**
+   * @brief Construct a span by concatenating the two specified spans
+   * with the given state selected and total log density.
+   *
+   * @param[in] span1 The earlier span by temporal ordering.
+   * @param[in] span2 The later span by temporal ordering.
+   * @param[in] theta_select The selected position.
+   * @param[in] grad_select The gradient of the target log density at the
+   * selected position.
+   * @param[in] logp_pos_select The log density of the selected position.
+   * @param[in] logp_joint_total The log of the sum of the joint densities of
+   * positions and momentums on the trajectory.
+   */
+  static SpanW from_subspans(SpanW&& span1, SpanW&& span2,
+                             Eigen::VectorXd&& theta_select,
+                             Eigen::VectorXd&& grad_select,
+                             double logp_pos_select, double logp_joint_total) {
+    return {std::move(span1.theta_bk_),
+            std::move(span1.rho_bk_),
+            std::move(span1.grad_theta_bk_),
+            span1.logp_bk_,
+            std::move(span2.theta_fw_),
+            std::move(span2.rho_fw_),
+            std::move(span2.grad_theta_fw_),
+            span2.logp_fw_,
+            std::move(theta_select),
+            std::move(grad_select),
+            logp_pos_select,
+            logp_joint_total};
+  }
+
+  /** The earliest state. */
+  Eigen::VectorXd theta_bk_;
+
+  /** The earliest momentum. */
+  Eigen::VectorXd rho_bk_;
+
+  /** The gradient of the target log density at the earliest state . */
+  Eigen::VectorXd grad_theta_bk_;
+
+  /** The joint log density of the earliest position and momentum. */
+  double logp_bk_;
+
+  /** The latest state in the trajectory. */
+  Eigen::VectorXd theta_fw_;
+
+  /** The latest momentum in the trajectory. */
+  Eigen::VectorXd rho_fw_;
+
+  /** The gradient of the target log density at the latest position. */
+  Eigen::VectorXd grad_theta_fw_;
+
+  /** The joint log density of the latest position and momentum. */
+  double logp_fw_;
+
+  /** The selected state. */
+  Eigen::VectorXd theta_select_;
+
+  /** The gradient of the log density at the selected state. */
+  Eigen::VectorXd grad_select_;
+
+  /** The log density of the selected state. */
+  double logp_pos_select_;
+
+  /** The log of the sum of the joint densities in the trajectory. */
+  double logp_;
+};
+
+/**
+ * @brief Return a tuple of the arguments ordered by direction.
+
+ * The arguments are forwarded as is the returned tuple and returned
+ * by reference, so function arguments must stay in scope. If the
+ * template argument `D` is `Direction::Forward`, then the tuple is
+ * `(x1, x2)`; if `D` is `Direction::Backward`, the returned tuple is
+ * `(x2, x1)`.
+ *
+ * The template parameter `T` is generic in order to allow reference
+ * collapsing in callers. Working through all of the types and forwarding
+ * here, the type of the return
+ *
+ * @tparam D The `Direction` in which to combine the arguments
+ * (`Forward` or `Backward`).
+ * @tparam T The type of the arguments.
+ * @param[in] x1 The first argument.
+ * @param[in] x2 The second argument.
+ * @return The arguments ordered according to `D`.
+ */
+template <Direction D, typename T>
+static std::tuple<T&, T&> order_forward_backward(T&& x1, T&& x2) {
+  if constexpr (D == Direction::Forward) {
+    return std::forward_as_tuple(std::forward<T>(x1), std::forward<T>(x2));
+  } else {  // Direction::Backward
+    return std::forward_as_tuple(std::forward<T>(x2), std::forward<T>(x1));
+  }
+}
+
+/**
+ * @brief Return `true` if the two spans ordered as specified form a
+ * U-turn in the metric determined by the inverse mass matrix.
+ *
+ * For computing U-turns, the squared distance between two vectors `x` and `y`
+ * is defined by the Mahalanobis distance,
+ * ```
+ * d(x, y)**2 = (x - y)' * inv_mass * (x - y).
+ * ```
+ * Equivalently, distance is measured in the Euclidean metric with metric
+ * tensor given by the mass matrix.
+ *
+ * If the spans ordered according to `D` are `(span_bk, span_fw)`, let
+ * `theta_start` be the first position in `span_bk` and let `theta_end` be
+ * the last position of `span_fw`. The U-turn condition will be satisfied if
+ * ```
+ * theta_start * delta < 0  OR   theta_end * delta < 0,
+ * ```
+ * where
+ * ```
+ * delta = inv_mass .* (theta_end - theta_start).
+ * ```
+ *
+ * @tparam D The direction in which to order the spans.
+ * @tparam U The type of spans, which must define begin and end positions.
+ * @param[in] span1 The first argument span.
+ * @param[in] span2 The second argument span.
+ * @param[in] inv_mass The inverse mass matrix to determine distances.
+ * @return `true` if there is a U-turn between the ends of the ordered spans.
+ */
+template <Direction D>
+static bool uturn(const SpanW& span1, const SpanW& span2,
+                  const Eigen::VectorXd& inv_mass) {
+  auto [span_bk, span_fw] = order_forward_backward<D>(span1, span2);
+  auto scaled_diff =
+      (inv_mass.array() * (span_fw.theta_fw_ - span_bk.theta_bk_).array())
+          .matrix();
+  return span_fw.rho_fw_.dot(scaled_diff) < 0 ||
+         span_bk.rho_bk_.dot(scaled_diff) < 0;
+}
+
+/**
+ * @brief Return `true` if running the specified number of leapfrog steps
+ * is within the maximum error tolerance.
+ *
+ * @tparam F The type of the log density/gradient function.
+ * @param[in] logp_grad The log density/gradient function.
+ * @param[in] inv_mass The diagonal of the diagonal inverse mass matrix.
+ * @param[in] step The micro step size.
+ * @param[in] num_steps The number of micro steps to take.
+ * @param[in] max_error The maximum error in Hamiltonian at macro steps.
+ * @param[in] logp_next Initial log density.
+ * @param[in,out] theta_next Input initial position, set to final position.
+ * @param[in,out] rho_next Input initial momentum, set to final position.
+ * @param[in,out] grad_next Input initial gradient, set to final gradient.
+ */
+template <LogpGrad F>
+static bool within_tolerance(const F& logp_grad,
+                             const Eigen::VectorXd& inv_mass, double step,
+                             std::size_t num_steps, double max_error,
+                             double logp_next, Eigen::VectorXd& theta_next,
+                             Eigen::VectorXd& rho_next,
+                             Eigen::VectorXd& grad_next) {
+  double half_step = 0.5 * step;
+  double logp = logp_next;
+  for (std::size_t n = 0; n < num_steps; ++n) {
+    rho_next += half_step * grad_next;
+    theta_next.array() += step * inv_mass.array() * rho_next.array();
+    logp_grad(theta_next, logp_next, grad_next);
+    rho_next += half_step * grad_next;
+  }
+  logp_next += logp_momentum(rho_next, inv_mass);
+  return std::abs(logp_next - logp) <= max_error;  // only tests one way
+}
+
+/**
+ * @brief Return `true` if the number of micro steps provided is the one chosen
+ * from the input position, moment, and gradient.
+ *
+ * @tparam F Type of log density/gradient function.
+ * @param[in] logp_grad The log density/gradient function.
+ * @param[in] inv_mass The diagonal of the diagonal inverse mass matrix.
+ * @param[in] step The micro step size.
+ * @param[in] num_steps The number of micro steps proposed forward.
+ * @param[in] min_micro_steps The minimum number of micro steps to take.
+ * @param[in] max_error The maximum error tolerance in Hessians.
+ * @param[in] logp_next The log density of the starting position.
+ * @param[in] theta The final position from which to reverse.
+ * @param[in] rho The final momentum from which to reverse.
+ * @param[in] grad The final gradient from which to reverse.
+ * @return `true` if the path ending in the specified state is reversible.
+ */
+template <LogpGrad F>
+static bool reversible(const F& logp_grad, const Eigen::VectorXd& inv_mass,
+                       double step, std::size_t num_steps,
+                       std::size_t min_micro_steps, double max_error,
+                       double logp_next, const Eigen::VectorXd& theta,
+                       const Eigen::VectorXd& rho,
+                       const Eigen::VectorXd& grad) {
+  if (num_steps == 1) {
+    return true;
+  }
+  Eigen::VectorXd theta_next(theta.size());  // declare here to allocate once
+  Eigen::VectorXd rho_next(theta.size());
+  Eigen::VectorXd grad_next(theta.size());
+  while (num_steps >= 2 * min_micro_steps) {
+    theta_next = theta;
+    rho_next = -rho;
+    grad_next = grad;
+    num_steps /= 2;
+    step *= 2;
+    if (within_tolerance(logp_grad, inv_mass, step, num_steps, max_error,
+                         logp_next, theta_next, rho_next, grad_next)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+/**
+ * @brief Take a macro step from the specified state given the log
+ * density/gradient, tuning parameters and adaptation handler and
+ * return whether it conserves the Hamiltonian and is reversible.
+ *
+ * @tparam D The time direction of Hamiltonian simulation.
+ * @tparam F The type of the log density/gradient function.
+ * @tparam A The type of the adaptation handler.
+ * @param[in] logp_grad The target log density/gradient function.
+ * @param[in] inv_mass The diagonal of the diagonal inverse mass matrix.
+ * @param[in] step The initial micro step size.
+ * @param[in] max_step_halvings The maximum number of halvings of the step size.
+ * @param[in] min_micro_steps The minimum number of micro steps per macro step.
+ * @param[in] max_error The maximum difference in Hamiltonians allowed in macro
+ * steps.
+ * @param[in] span The span to extend.
+ * @param[out] theta_next The position after the macro step.
+ * @param[out] rho_next The momentum after the macro step.
+ * @param[out] grad_next The gradient of the position after the macro step.
+ * @param[out] logp_pos_next The log density of the position and momentum after
+ * the macro step.
+ * @param[out] logp_next The log density of the position and momentum after the
+ * macro step.
+ * @param[in,out] adapt_handler The step-size adaptation handler.
+ * @return `true` if the Hamiltonian is conserved reversibly.
+ */
+template <Direction D, LogpGrad F, StepSizeAdapter A>
+static bool macro_step(const F& logp_grad, const Eigen::VectorXd& inv_mass,
+                       double step, std::size_t max_step_halvings,
+                       std::size_t min_micro_steps, double max_error,
+                       const SpanW& span, Eigen::VectorXd& theta_next,
+                       Eigen::VectorXd& rho_next, Eigen::VectorXd& grad_next,
+                       double& logp_pos_next, double& logp_next,
+                       A& adapt_handler) {
+  constexpr bool is_forward = (D == Direction::Forward);
+  const Eigen::VectorXd& theta = is_forward ? span.theta_fw_ : span.theta_bk_;
+  const Eigen::VectorXd& rho = is_forward ? span.rho_fw_ : span.rho_bk_;
+  const Eigen::VectorXd& grad =
+      is_forward ? span.grad_theta_fw_ : span.grad_theta_bk_;
+  double logp = is_forward ? span.logp_fw_ : span.logp_bk_;
+  step = is_forward ? step : -step;
+  for (std::size_t num_steps = min_micro_steps, halvings = 0;
+       halvings < max_step_halvings; ++halvings, num_steps *= 2, step *= 0.5) {
+    theta_next = theta;
+    rho_next = rho;
+    grad_next = grad;
+    double half_step = 0.5 * step;
+    for (std::size_t n = 0; n < num_steps; ++n) {
+      rho_next += half_step * grad_next;
+      theta_next.array() += step * inv_mass.array() * rho_next.array();
+      logp_grad(theta_next, logp_pos_next, grad_next);
+      rho_next += half_step * grad_next;
+    }
+    logp_next = logp_pos_next + logp_momentum(rho_next, inv_mass);
+    if (num_steps == min_micro_steps) {
+      double min_accept = std::exp(-std::fabs(logp - logp_next));
+      adapt_handler(min_accept);
+    }
+    if (std::fabs(logp - logp_next) <= max_error) {
+      return reversible(logp_grad, inv_mass, step, num_steps, min_micro_steps,
+                        max_error, logp_next, theta_next, rho_next, grad_next);
+    }
+  }
+  return false;
+}
+
+/**
+ * @brief Return the specified spans combined into a new span and update
+ * the selected position.
+ *
+ * If the direction `D` is `Forward`, then `span_new` is ordered after
+ * `span_old` in time; if it is `Backward`, then `span_new` is before
+ * `span_old`.
+ *
+ * The new selected state is determined with either a
+ * Metropolis update rule or a Barker update rule based on the
+ * template parameter, using the specified random number generator.
+ *
+ * @tparam U The type of update (`Metropolis` or `Barker`).
+ * @tparam D The direction of combination in time (`Forward` or `Backward`).
+ * @tparam Rand The type for the source of randomness.
+ * @param[in,out] rng The random number generator used to select a new position.
+ * @param[in] span_old The old span.
+ * @param[in] span_new The span continuing the old span forward or backward in
+ * time.
+ * @return The combined span.
+ */
+template <Update U, Direction D, std::uniform_random_bit_generator RNG>
+inline SpanW combine(Random<RNG>& rng, SpanW&& span_old, SpanW&& span_new) {
+  double logp_total = log_sum_exp(span_old.logp_, span_new.logp_);
+  double log_denominator;
+  if constexpr (U == Update::Metropolis) {
+    log_denominator = span_old.logp_;
+  } else {  // Update::Barker
+    log_denominator = logp_total;
+  }
+  double update_logprob = span_new.logp_ - log_denominator;
+  bool update = std::log(rng.uniform_real_01()) < update_logprob;
+  auto& selected = update ? span_new.theta_select_ : span_old.theta_select_;
+  auto& grad_selected = update ? span_new.grad_select_ : span_old.grad_select_;
+  double logp_pos_select =
+      update ? span_new.logp_pos_select_ : span_old.logp_pos_select_;
+  auto&& [span_bk, span_fw] = order_forward_backward<D>(span_old, span_new);
+  return SpanW::from_subspans(std::move(span_bk), std::move(span_fw),
+                              std::move(selected), std::move(grad_selected),
+                              logp_pos_select, logp_total);
+}
+
+/**
+ * @brief Extend the specified span with a span of a single state.
+ *
+ * Given the specified span and direction `D`, build a new leaf span consisting
+ * of a single state. If `D` is `Forward`, the leaf extends the specified span
+ * forward in time; if `Backward`, it extends the span backward in time.
+ *
+ * The step-size adaptation handler is called with the acceptance of each
+ * macro step attempt.
+ *
+ * The step size is reduced so that the Hamiltonian is conserved
+ * within the specified error. The mass matrix and macro step size
+ * are passed on to the leapfrog algorithm.
+ *
+ * The result is `std::optional` and will be `std::nullopt` only if the
+ * specified span could not be extended reversibly within the error threshold.
+ *
+ * @tparam D The direction in time to extend.
+ * @tparam F The type of the log density/gradient function.
+ * @tparam A The type of the adaptation handler.
+ * @param[in] logp_grad The log density/gradient function.
+ * @param[in] span The span to extend.
+ * @param[in] inv_mass The diagonal of the diagonal inverse mass matrix.
+ * @param[in] step The macro step size.
+ * @param[in] max_step_halvings The maximum number of halvings of the step size.
+ * @param[in] min_micro_steps The minimum number of micro steps per macro step.
+ * @param[in] max_error The maximum error allowed in the Hamiltonian.
+ * @param[in,out] adapt_handler The step-size adaptation handler.
+ * @return The span resulting from extending the specified span or
+ * `std::nullopt` if that could not be done reversibly within threshold.
+ */
+template <Direction D, LogpGrad F, StepSizeAdapter A>
+static std::optional<SpanW> build_leaf(const F& logp_grad, const SpanW& span,
+                                       const Eigen::VectorXd& inv_mass,
+                                       double step,
+                                       std::size_t max_step_halvings,
+                                       std::size_t min_micro_steps,
+                                       double max_error, A& adapt_handler) {
+  Eigen::VectorXd theta_next;
+  Eigen::VectorXd rho_next;
+  Eigen::VectorXd grad_theta_next;
+  // values are dummies; will be reset by macro step
+  double logp_pos_next = -std::numeric_limits<double>::infinity();
+  double logp_next = -std::numeric_limits<double>::infinity();
+  if (!macro_step<D>(logp_grad, inv_mass, step, max_step_halvings,
+                     min_micro_steps, max_error, span, theta_next, rho_next,
+                     grad_theta_next, logp_pos_next, logp_next,
+                     adapt_handler)) {
+    return std::nullopt;
+  }
+  return SpanW::from_initial_point(std::move(theta_next), std::move(rho_next),
+                                   std::move(grad_theta_next), logp_pos_next,
+                                   logp_next);
+}
+
+/**
+ * @brief Return a span of two to the power of the depth states extending from
+ * the specified span, returning `nullopt` if there is a U-turn at any point.
+ *
+ * @tparam D The direction in time to extend.
+ * @tparam F The type of the log density/gradient function.
+ * @tparam Rand The type for the source of randomness.
+ * @tparam A The type of the step-size adaptation callback function.
+ * @param[in,out] rng The random number generator.
+ * @param[in] logp_grad The log density/gradient function.
+ * @param[in] inv_mass The diagonal of the diagonal inverse mass matrix.
+ * @param[in] step The macro step size.
+ * @param[in] depth The maximum Nuts depth.
+ * @param[in] max_step_halvings The maximum number of halvings of the step size.
+ * @param[in] min_micro_steps The minimum number of micro steps per macro step.
+ * @param[in] max_error The maximum error allowed at macro steps.
+ * @param[in] last_span The span to extend.
+ * @param[in,out] adapt_handler The step-size adaptation handler.
+ * @return The new span or `std::nullopt` if it could not be constructed.
+ */
+template <Direction D, LogpGrad F, std::uniform_random_bit_generator RNG,
+          StepSizeAdapter A>
+static std::optional<SpanW> build_span(Random<RNG>& rng, const F& logp_grad,
+                                       const Eigen::VectorXd& inv_mass,
+                                       double step, std::size_t depth,
+                                       std::size_t max_step_halvings,
+                                       std::size_t min_micro_steps,
+                                       double max_error, const SpanW& last_span,
+                                       A& adapt_handler) {
+  if (depth == 0) {
+    return build_leaf<D>(logp_grad, last_span, inv_mass, step,
+                         max_step_halvings, min_micro_steps, max_error,
+                         adapt_handler);
+  }
+  auto maybe_subspan1 = build_span<D>(rng, logp_grad, inv_mass, step, depth - 1,
+                                      max_step_halvings, min_micro_steps,
+                                      max_error, last_span, adapt_handler);
+  if (!maybe_subspan1) {
+    return std::nullopt;
+  }
+  auto maybe_subspan2 = build_span<D>(
+      rng, logp_grad, inv_mass, step, depth - 1, max_step_halvings,
+      min_micro_steps, max_error, *maybe_subspan1, adapt_handler);
+  if (!maybe_subspan2) {
+    return std::nullopt;
+  }
+  if (uturn<D>(*maybe_subspan1, *maybe_subspan2, inv_mass)) {
+    return std::nullopt;
+  }
+  return std::make_optional(combine<Update::Barker, D>(
+      rng, std::move(*maybe_subspan1), std::move(*maybe_subspan2)));
+}
+
+/**
+ * @brief Return the next state in the Markov chain given the previous state.
+ *
+ * @tparam F The type of the log density/gradient function.
+ * @tparam Rand The type for the source of randomness.
+ * @tparam A The type of the step-size adaptation callback function.
+ * @param[in,out] rand The random number generator.
+ * @param[in] logp_grad The log density/gradient function.
+ * @param[in] inv_mass The diagonal of the diagonal inverse mass matrix.
+ * @param[in] chol_mass The diagonal of the diagonal Cholesky factor of the mass
+ * matrix.
+ * @param[in] step The macro step size.
+ * @param[in] max_depth The maximum number of trajectory doublings in Nuts.
+ * @param[in] max_step_halvings The maximum number of halvings of the step size.
+ * @param[in] min_micro_steps The minimum number of micro steps per macro step.
+ * @param[in] max_error The maximum difference in Hamiltonians.
+ * @param[in] theta The current state.
+ * @param[out] depth The tree depth used by the transition.
+ * @param[out] theta_grad The gradient of the log density at the previous state.
+ * @param[out] logp_pos_select The log density of the selected position.
+ * @param[in,out] step_size_adapter The step-size adaptation handler.
+ * @return The next position in the Markov chain.
+ */
+template <LogpGrad F, class Rand, StepSizeAdapter A>
+inline Eigen::VectorXd transition_w(
+    Rand& rand, const F& logp_grad, const Eigen::VectorXd& inv_mass,
+    const Eigen::VectorXd& chol_mass, double step, std::size_t max_depth,
+    std::size_t max_step_halvings, std::size_t min_micro_steps,
+    double max_error, Eigen::VectorXd&& theta, std::size_t& depth,
+    Eigen::VectorXd& theta_grad, double& logp_pos_select,
+    A& step_size_adapter) {
+  auto z = rand.standard_normal(chol_mass.size());
+  Eigen::VectorXd rho = (chol_mass.array() * z.array()).matrix();
+  Eigen::VectorXd grad(theta.size());
+  double logp_pos;
+  logp_grad(theta, logp_pos, grad);
+  double logp_joint = logp_pos + logp_momentum(rho, inv_mass);
+  auto span_accum = SpanW::from_initial_point(
+      std::move(theta), std::move(rho), std::move(grad), logp_pos, logp_joint);
+  for (depth = 1; depth <= max_depth; ++depth) {
+    // helper to turn runtime direction into compile-time template enum
+    auto expand_in_direction = [&](auto direction) -> bool {
+      constexpr Direction D = direction;
+      auto maybe_next_span = build_span<D>(
+          rand, logp_grad, inv_mass, step, depth - 1, max_step_halvings,
+          min_micro_steps, max_error, span_accum, step_size_adapter);
+      if (!maybe_next_span) {
+        return true;
+      }
+      bool combined_uturn = uturn<D>(span_accum, *maybe_next_span, inv_mass);
+      span_accum = combine<Update::Metropolis, D>(rand, std::move(span_accum),
+                                                  std::move(*maybe_next_span));
+      return combined_uturn;
+    };
+
+    bool go_forward = rand.uniform_binary();
+    bool made_uturn = go_forward ? expand_in_direction(Forward_t{})
+                                 : expand_in_direction(Backward_t{});
+
+    if (made_uturn) {
+      break;
+    }
+  }
+  theta_grad = span_accum.grad_select_;
+  logp_pos_select = span_accum.logp_pos_select_;
+  return std::move(span_accum.theta_select_);
+}
+
+/**
+ * @brief A functor of one argument that does nothing.
+ *
+ * The use is as an adaptation handler when there is no adaptation. Because
+ * it has no body, it will be inlined away at optimization level `-O2` or
+ * above.
+ */
+class NoOpStepSizeAdapter {
+ public:
+  /**
+   * Do nothing, ignoring the step size acceptance argument.
+   *
+   */
+  constexpr void operator()(double) const noexcept {}
+
+  /**
+   * Return an invalid step size.
+   */
+  [[noreturn]] double step_size() const {
+    throw std::logic_error(
+        "should not call step_size() in NoOpStepSizeAdapter");
+  }
+};
+
+}  // namespace walnutpie::detail
+
+namespace walnutpie {
+
+/**
+ * @brief The Walnuts Markov chain Monte Carlo (MCMC) sampler.
+ *
+ * The sampler is constructed with a base random number generator, a log density
+ * and gradient function, an initialization, and several tuning parameters.
+ * It provides a no-argument functor for generating the next element of the
+ * Markov chain.
+ *
+ * @tparam F The type of the log density and gradient function.
+ * @tparam RNG The type of the base random number generator.
+ * @tparam Handler The type of the sampling event handler.
+ */
+template <LogpGrad F, std::uniform_random_bit_generator RNG, SampleHandler H>
+class WalnutsSampler {
+ public:
+  /**
+   * @brief Construct a Walnuts sampler from the specified RNG, target log
+   * density/gradient initialization, and tuning parameters.
+   *
+   * @param[in,out] rng The base random number generator.
+   * @param[in,out] sample_handler The sampling and on-stop event handler.
+   * @param[in] logp_grad The target log density and gradient function (see the
+   * class documentation.
+   * @param[in] theta The initial position.
+   * @param[in] inv_mass The diagonal of the diagonal inverse mass matrix.
+   * @param[in] macro_time The macro time discretization interval.
+   * @param[in] max_nuts_depth The maximum number of trajectory doublings for
+   * Nuts.
+   * @param[in] max_step_halvings The maximum number of times the step size is
+   * halved.
+   * @param[in] min_micro_steps The minimum number of micro steps per macro
+   * step.
+   * @param[in] max_error The log of the maximum error in joint densities
+   * allowed in Hamiltonian trajectories.
+   * @throw std::invalid_argument If `inv_mass_matrix` has non-positive or
+   * infinite entries.
+   * @throw std::invalid_argument If `macro_time` is not positive or not
+   * finite.
+   * @throw std::invalid_argument If `max_nuts_depth` is not positive.
+   * @throw std::invalid_argument If `max_step_halvings` is not positive.
+   * @throw std::invalid_argument If `min_micro_steps` is not positive.
+   * @throw std::invalid_argument If `max_error` is not positive or not finite.
+
+   */
+  WalnutsSampler(RNG& rng, H& sample_handler, const F& logp_grad,
+                 const Eigen::VectorXd& theta, const Eigen::VectorXd& inv_mass,
+                 double macro_time, std::size_t max_nuts_depth,
+                 std::size_t max_step_halvings, std::size_t min_micro_steps,
+                 double max_error)
+      : rand_(rng),
+        sample_handler_(sample_handler),
+        logp_grad_(logp_grad, sample_handler),
+        theta_(theta),
+        inv_mass_(inv_mass),
+        cholesky_mass_(inv_mass.array().sqrt().inverse().matrix()),
+        macro_time_(macro_time),
+        max_nuts_depth_(max_nuts_depth),
+        max_step_halvings_(max_step_halvings),
+        min_micro_steps_(min_micro_steps),
+        max_error_(max_error),
+        no_op_step_size_adapter_() {
+    detail::validate_positive(inv_mass, "inv_mass");
+    detail::validate_positive(macro_time, "macro_time");
+    detail::validate_positive(max_nuts_depth, "max_nuts_depth");
+    detail::validate_positive(max_step_halvings, "max_step_halvings");
+    detail::validate_positive(min_micro_steps, "min_micro_steps");
+    detail::validate_positive(max_error, "max_error");
+  }
+
+  /**
+   * @brief Construct a sampler by copying the specified sampler.
+   *
+   * @param[in] sampler Sampler to copy.
+   */
+  WalnutsSampler(const WalnutsSampler& sampler) = default;
+
+  /**
+   * @brief Construct a sampler by moving the specified sampler.
+   *
+   * @param[in] sampler Sampler to move.
+   */
+  WalnutsSampler(WalnutsSampler&& sampler) = default;
+
+  /**
+   * @brief Generate the next draw and send it to the handler and return
+   * its log density.
+   *
+   * @return The unnormalized log density of the next draw.
+   */
+  double operator()() {
+    std::size_t depth;
+    Eigen::VectorXd grad_next;
+    double logp_pos;
+    theta_ = transition_w(rand_, logp_grad_, inv_mass_, cholesky_mass_,
+                          macro_time_, max_nuts_depth_, max_step_halvings_,
+                          min_micro_steps_, max_error_, std::move(theta_),
+                          depth, grad_next, logp_pos, no_op_step_size_adapter_);
+    sample_handler_.get().on_sample(theta_, logp_pos);
+    return logp_pos;
+  }
+
+  /**
+   * @brief  Return a constant reference the diagonal of the diagonal inverse
+   * mass matrix.
+   *
+   * The value of the inverse mass matrix will change on subsequent calls to
+   * `operator()(S&)`.
+   *
+   * @return The diagonal of the inverse mass matrix.
+   */
+  const Eigen::VectorXd& inverse_mass_matrix_diagonal() const noexcept {
+    return inv_mass_;
+  }
+
+  /**
+   * @brief Return the macro time discretization interval for Nuts.
+   *
+   * @return The time discretization interval for Nuts.
+   */
+  double macro_time() const noexcept { return macro_time_; }
+
+  /**
+   * @brief Return the maximum error allowed among Hamiltonians.
+   *
+   * @return The maximum error allowed among Hamiltonians.
+   */
+  double max_error() const noexcept { return max_error_; }
+
+  /**
+   * @brief Return the number of dimensions.
+   *
+   * @return The number of dimensions.
+   */
+  std::size_t dim() const noexcept {
+    return static_cast<std::size_t>(theta_.size());
+  }
+
+ private:
+  /** The underlying randomizer. */
+  detail::Random<RNG> rand_;
+
+  /** Reference to the sampling event handler. */
+  std::reference_wrapper<H> sample_handler_;
+
+  /** The target log density/gradient function. */
+  const detail::NoExceptLogpGrad<F, H> logp_grad_;
+
+  /** The current position. */
+  Eigen::VectorXd theta_;
+
+  /** The diagonal of the diagonal inverse mass matrix. */
+  Eigen::VectorXd inv_mass_;
+
+  /** The diagonal of the diagonal Cholesky factor of the mass matrix. */
+  Eigen::VectorXd cholesky_mass_;
+
+  /** The macro time discretization interval for Nuts. */
+  const double macro_time_;
+
+  /** The maximum number of doublings in Nuts trajectories. */
+  const std::size_t max_nuts_depth_;
+
+  /** The maximum number of halvings of the step size. */
+  const std::size_t max_step_halvings_;
+
+  /** The minimum number of micro steps per macro step. */
+  const std::size_t min_micro_steps_;
+
+  /** The max difference of Hamiltonians along a macro step. */
+  const double max_error_;
+
+  /** A handler for adaptation which does nothing. */
+  const detail::NoOpStepSizeAdapter no_op_step_size_adapter_;
+};
+
+}  // namespace walnutpie

--- a/tests/test_walnuts.cpp
+++ b/tests/test_walnuts.cpp
@@ -1,0 +1,146 @@
+// WALNUTS end to end through the vendored walnutpie sampler driving the
+// executor's gradient. Statistical checks with fixed seeds, same shape as
+// test_nuts.cpp so the two samplers stay comparable.
+#include "models.hpp"
+
+#include <stanli/walnuts.hpp>
+#include <cmath>
+#include <cstdio>
+#include <string>
+#include <vector>
+
+static int failures = 0;
+static void expect_in(const std::string& what, double got, double lo,
+                      double hi) {
+  if (!(got >= lo && got <= hi)) {
+    ++failures;
+    std::printf("FAIL %-18s got %.6g want in [%g, %g]\n", what.c_str(), got, lo,
+                hi);
+  }
+}
+
+int main() {
+  using namespace stanli;
+
+  // ---- 10-dim standard normal: mean 0, sd 1 ------------------------------
+  {
+    const int D = 10;
+    Graph g;
+    const int x = g.add_slot(D, true);
+    const int zero = g.add_slot(1, false);
+    const int one = g.add_slot(1, false);
+    const int lp = g.add_slot(1, false);
+    g.add_op(OP_NORMAL_LPDF, {x, zero, one}, lp);
+    g.result_slot = lp;
+    Executor ex(std::move(g));
+    ex.value_ptr(zero)[0] = 0.0;
+    ex.value_ptr(one)[0] = 1.0;
+
+    WalnutsConfig cfg;
+    cfg.seed = 20260811;
+    cfg.warmup = 1000;
+    cfg.samples = 2000;
+    auto draws = run_walnuts(ex, cfg);
+    if ((int)draws.size() != cfg.samples) {
+      std::printf("FAIL draw count %zu\n", draws.size());
+      return 1;
+    }
+    for (int d = 0; d < D; ++d) {
+      double m = 0, m2 = 0;
+      for (const auto& q : draws) m += q[d];
+      m /= draws.size();
+      for (const auto& q : draws) m2 += (q[d] - m) * (q[d] - m);
+      const double sd = std::sqrt(m2 / (draws.size() - 1));
+      expect_in("norm mean[" + std::to_string(d) + "]", m, -0.15, 0.15);
+      expect_in("norm sd[" + std::to_string(d) + "]", sd, 0.85, 1.15);
+    }
+  }
+
+  // ---- eight schools: posterior locations, no NaNs -----------------------
+  {
+    auto m = testmodels::eight_schools();
+    Executor ex(std::move(m.graph));
+    testmodels::fill_eight_schools_data(m, ex);
+
+    WalnutsConfig cfg;
+    cfg.seed = 8675309;
+    cfg.warmup = 1000;
+    cfg.samples = 2000;
+    auto draws = run_walnuts(ex, cfg);
+
+    double mu_mean = 0, tau_mean = 0;
+    int nan_count = 0;
+    for (const auto& q : draws) {
+      for (double v : q)
+        if (std::isnan(v)) ++nan_count;
+      mu_mean += q[0];
+      tau_mean += std::exp(q[1]);
+    }
+    mu_mean /= draws.size();
+    tau_mean /= draws.size();
+    expect_in("es nan_count", nan_count, 0, 0);
+    expect_in("es mu mean", mu_mean, 2.5, 6.5);
+    expect_in("es tau mean", tau_mean, 2.0, 6.0);
+  }
+
+  // ---- determinism: same seed, same chain; new seed, new chain -----------
+  {
+    Graph g;
+    const int x = g.add_slot(3, true);
+    const int zero = g.add_slot(1, false);
+    const int one = g.add_slot(1, false);
+    const int lp = g.add_slot(1, false);
+    g.add_op(OP_NORMAL_LPDF, {x, zero, one}, lp);
+    g.result_slot = lp;
+    Executor ex(std::move(g));
+    ex.value_ptr(zero)[0] = 0.0;
+    ex.value_ptr(one)[0] = 1.0;
+
+    WalnutsConfig cfg;
+    cfg.seed = 42;
+    cfg.warmup = 200;
+    cfg.samples = 100;
+    auto a = run_walnuts(ex, cfg);
+    auto b = run_walnuts(ex, cfg);
+    cfg.seed = 43;
+    auto c = run_walnuts(ex, cfg);
+    bool same = a == b;
+    expect_in("same seed identical", same ? 1 : 0, 1, 1);
+    bool differ = a != c;
+    expect_in("new seed differs", differ ? 1 : 0, 1, 1);
+  }
+
+  // ---- observer: sees every stored draw, phases in order -----------------
+  {
+    Graph g;
+    const int x = g.add_slot(2, true);
+    const int zero = g.add_slot(1, false);
+    const int one = g.add_slot(1, false);
+    const int lp = g.add_slot(1, false);
+    g.add_op(OP_NORMAL_LPDF, {x, zero, one}, lp);
+    g.result_slot = lp;
+    Executor ex(std::move(g));
+    ex.value_ptr(zero)[0] = 0.0;
+    ex.value_ptr(one)[0] = 1.0;
+
+    WalnutsConfig cfg;
+    cfg.seed = 7;
+    cfg.warmup = 50;
+    cfg.samples = 60;
+    int n_warm = 0, n_samp = 0;
+    auto draws = run_walnuts(ex, cfg, nullptr,
+                             [&](int64_t, bool warm, const double*) {
+                               (warm ? n_warm : n_samp)++;
+                             });
+    expect_in("observer warmup", n_warm, 50, 50);
+    expect_in("observer samples", n_samp, 60, 60);
+    expect_in("draws", (double)draws.size(), 60, 60);
+  }
+
+  if (failures) {
+    std::printf("%d failures\n", failures);
+    return 1;
+  }
+  std::printf("OK\n");
+  return 0;
+}

--- a/tests/test_walnuts.cpp
+++ b/tests/test_walnuts.cpp
@@ -128,10 +128,9 @@ int main() {
     cfg.warmup = 50;
     cfg.samples = 60;
     int n_warm = 0, n_samp = 0;
-    auto draws = run_walnuts(ex, cfg, nullptr,
-                             [&](int64_t, bool warm, const double*) {
-                               (warm ? n_warm : n_samp)++;
-                             });
+    auto draws = run_walnuts(
+        ex, cfg, nullptr,
+        [&](int64_t, bool warm, const double*) { (warm ? n_warm : n_samp)++; });
     expect_in("observer warmup", n_warm, 50, 50);
     expect_in("observer samples", n_samp, 60, 60);
     expect_in("draws", (double)draws.size(), 60, 60);

--- a/tests/test_wasm.cjs
+++ b/tests/test_wasm.cjs
@@ -72,7 +72,20 @@ createStanli().then((M) => {
   const mu = muSum / samples;
   if (!(mu > 3.0 && mu < 6.0)) fail("mu " + mu + " outside (3, 6)");
 
+  // WALNUTS through the same streaming C entry the worker uses: same
+  // posterior, so the same window on mean(mu).
+  const rcW = M._stanli_sample_walnuts_stream(model, 1, warmup, samples, 0,
+                                              drawsPtr, 0, 0, errPtr, errLen);
+  if (rcW !== 0) fail("walnuts: " + M.UTF8ToString(errPtr));
+  let muSumW = 0;
+  for (let s = 0; s < samples; ++s) {
+    M._stanli_constrain(model, drawsPtr + 8 * s * n, rowPtr);
+    muSumW += M.HEAPF64[rowPtr / 8 + muIdx];
+  }
+  const muW = muSumW / samples;
+  if (!(muW > 3.0 && muW < 6.0)) fail("walnuts mu " + muW + " outside (3, 6)");
+
   M._stanli_model_free(model);
   console.log("test_wasm OK  lp(0) = " + lp.toFixed(6) + "  mean(mu) = " +
-              mu.toFixed(3));
+              mu.toFixed(3) + "  walnuts mean(mu) = " + muW.toFixed(3));
 }).catch((e) => fail(String(e && e.stack || e)));

--- a/tools/exported_symbols.def
+++ b/tools/exported_symbols.def
@@ -21,6 +21,7 @@ EXPORTS
   stanli_grad
   stanli_sample
   stanli_sample_stream
+  stanli_sample_walnuts_stream
   stanli_n_constrained
   stanli_constrained_name
   stanli_constrain

--- a/web/index.html
+++ b/web/index.html
@@ -61,6 +61,19 @@
           max-width: 62rem; }
   #note b { font-weight: 600; }
   #note .stats { opacity: .8; white-space: nowrap; }
+  /* The side-by-side sampler comparison: NUTS's column left, WALNUTS's
+     right, each with its own trace, histogram, timing line, and summary
+     table. Clicking a parameter row in either table selects it in both. */
+  .cmp { display: flex; gap: 1.2rem; flex-wrap: wrap; margin-top: .6rem; }
+  .cmp .col { flex: 1 1 440px; min-width: 0; }
+  .cmp h3 { font-size: .95rem; margin: 0 0 .3rem;
+            font-family: ui-monospace, monospace; }
+  .cmp canvas { border: 1px solid #8883; border-radius: 6px;
+                max-width: 100%; display: block; margin-bottom: .5rem; }
+  .cmp table { width: 100%; }
+  /* A wide summary table scrolls inside its own column instead of
+     overlapping its neighbor. */
+  .cmp .ctable { overflow-x: auto; }
   /* The model picker: a text input that filters a listbox under it, so
      120 models stay reachable by typing instead of by scrolling. */
   .combo { position: relative; }
@@ -98,8 +111,9 @@
 <body>
 <h1>stanli: The Stan Language Interpreter</h1>
 <p class="sub">No server, no C++ toolchain;
-everything below happens in this tab, runs in the browser, samples on your machine. 
-stanc3 (OCaml&rarr;JS) compiles the model, stanli.wasm lowers it to an op graph and runs NUTS. 
+everything below happens in this tab, runs in the browser, samples on your machine.
+stanc3 (OCaml&rarr;JS) compiles the model, stanli.wasm lowers it to an op graph and runs NUTS
+or <a href="https://arxiv.org/abs/2506.18746">WALNUTS</a> &mdash; or both at once, side by side.
 <p class="sub">And it's often FASTER?? </p>
 <a href="https://github.com/seantalts/stanli">github.com/seantalts/stanli</a>
 &middot; <a href="https://www.npmjs.com/package/@seantalts/stanli">npm</a>
@@ -114,6 +128,11 @@ stanc3 (OCaml&rarr;JS) compiles the model, stanli.wasm lowers it to an op graph 
 
 <div class="bar">
   <button id="run">Run NUTS</button>
+  <label>sampler <select id="sampler">
+    <option value="nuts">NUTS</option>
+    <option value="walnuts">WALNUTS</option>
+    <option value="both">NUTS vs WALNUTS</option>
+  </select></label>
   <label class="combo" for="model">model
     <input id="model" type="text" role="combobox" aria-expanded="false"
            aria-controls="modellist" aria-autocomplete="list"
@@ -124,7 +143,8 @@ stanc3 (OCaml&rarr;JS) compiles the model, stanli.wasm lowers it to an op graph 
   <label>warmup <input id="warmup" value="1000"></label>
   <label>samples <input id="samples" value="1000"></label>
   <label>seed <input id="seed" value="1"></label>
-  <label>delta <input id="delta" value="0.8"></label>
+  <label id="deltalab">delta <input id="delta" value="0.8"></label>
+  <label id="maxerrlab" hidden>max err <input id="maxerr" value="0.5"></label>
   <button id="csv" class="plain" hidden>Download CSV</button>
   <span id="status"></span>
 </div>
@@ -438,9 +458,73 @@ catalogReady.then(() => {
 });
 choose(CATALOG[0]);
 
+// ---- sampler selection -----------------------------------------------------
+const SAMPLER_LABEL = { nuts: "NUTS", walnuts: "WALNUTS" };
+function samplerMode() { return $("sampler").value; }
+$("sampler").onchange = () => {
+  const m = samplerMode();
+  $("run").textContent =
+      m === "both" ? "Run both" : `Run ${SAMPLER_LABEL[m]}`;
+  // delta tunes NUTS's adaptation target; max err tunes how much the
+  // joint log density may drift across one WALNUTS macro step. Each is
+  // shown only when its sampler is in play.
+  $("deltalab").hidden = m === "walnuts";
+  $("maxerrlab").hidden = m === "nuts";
+};
+
 // ---- run -------------------------------------------------------------------
 // fit = {names, samples, chains: [{name: Float64Array} per chain]}
+// Single-sampler runs keep one fit; a comparison run keeps one per
+// sampler so both stay inspectable (and downloadable) side by side.
 let fit = null;
+let cmpFits = null;  // { nuts: fit, walnuts: fit } after a "both" run
+
+// Run nChains chains of one sampler from already-compiled MIR, streaming
+// live draws into `onLive(chain, msg)`. Returns {fit, ms}.
+async function runChains(sampler, opts, nChains, seed, onLive) {
+  const results = await Promise.all(
+      Array.from({ length: nChains }, (_, c) => sample({
+        ...opts, code: undefined, seed: seed + c, sampler,
+        onLive: onLive ? (m) => onLive(c, m) : undefined,
+      })));
+  const ms = { lower: 0, sample: 0 };
+  for (const r of results)
+    for (const k of ["lower", "sample"]) ms[k] += r.ms[k];
+  return {
+    fit: { names: results[0].names, samples: results[0].samples,
+           chains: results.map((r) => r.columns) },
+    ms,
+  };
+}
+
+function newLive(nChains) {
+  return { names: null,
+           chains: Array.from({ length: nChains }, () => []),
+           warm: new Array(nChains).fill(0),
+           drawn: new Array(nChains).fill(0) };
+}
+function liveHandler(live, canvas, label, nChains, progress) {
+  let lastDraw = 0;
+  return (c, m) => {
+    if (m.liveMeta) { live.names = m.liveMeta.names; return; }
+    const lv = m.live;
+    if (lv.phase === "warmup") {
+      live.warm[c] = lv.i;
+      progress();
+      return;
+    }
+    live.drawn[c] = lv.i;
+    const chunk = new Float64Array(lv.rows);
+    for (let k = 0; k < chunk.length / lv.nCon; ++k)
+      live.chains[c].push(chunk.subarray(k * lv.nCon, (k + 1) * lv.nCon));
+    progress();
+    const now = performance.now();
+    if (now - lastDraw > 60) {
+      lastDraw = now;
+      liveTrace(canvas, live, nChains, false, label);
+    }
+  };
+}
 
 $("run").onclick = async () => {
   $("run").disabled = true;
@@ -452,6 +536,9 @@ $("run").onclick = async () => {
   $("csv").hidden = true;
   $("trace").hidden = true;
   $("hist").hidden = true;
+  fit = null;
+  cmpFits = null;
+  const mode = samplerMode();
   const nChains = Math.max(1, parseInt($("chains").value, 10) || 4);
   const seed = parseInt($("seed").value, 10) || 1;
   const opts = {
@@ -460,59 +547,20 @@ $("run").onclick = async () => {
     warmup: parseInt($("warmup").value, 10) || 1000,
     samples: parseInt($("samples").value, 10) || 1000,
     delta: parseFloat($("delta").value) || 0.8,
+    maxError: parseFloat($("maxerr").value) || 0,
   };
   try {
-    // Compile once; every chain then runs from the same MIR, in its own
-    // worker, all simultaneously.
+    // Compile once; every chain of every sampler then runs from the same
+    // MIR, in its own worker, all simultaneously.
     $("status").textContent = "compiling (stanc3)";
     const tWall = performance.now();
     const compiled = await compile({ code: opts.code });
-    const live = { names: null,
-                   chains: Array.from({ length: nChains }, () => []),
-                   warm: new Array(nChains).fill(0),
-                   drawn: new Array(nChains).fill(0) };
-    let lastDraw = 0;
-    const progress = () => {
-      const w = live.warm.reduce((a, b) => a + b, 0);
-      const d = live.drawn.reduce((a, b) => a + b, 0);
-      $("status").textContent = d
-          ? `sampling: ${d}/${nChains * opts.samples} draws across ` +
-            `${nChains} chains`
-          : `warmup: ${w}/${nChains * opts.warmup} across ${nChains} chains`;
-    };
-    const results = await Promise.all(
-        Array.from({ length: nChains }, (_, c) => sample({
-          ...opts, code: undefined, mir: compiled.mir, seed: seed + c,
-          onLive: (m) => {
-            if (m.liveMeta) { live.names = m.liveMeta.names; return; }
-            const lv = m.live;
-            if (lv.phase === "warmup") {
-              live.warm[c] = lv.i;
-              progress();
-              return;
-            }
-            live.drawn[c] = lv.i;
-            const chunk = new Float64Array(lv.rows);
-            for (let k = 0; k < chunk.length / lv.nCon; ++k)
-              live.chains[c].push(
-                  chunk.subarray(k * lv.nCon, (k + 1) * lv.nCon));
-            progress();
-            const now = performance.now();
-            if (now - lastDraw > 60) {
-              lastDraw = now;
-              liveTrace(live, nChains);
-            }
-          },
-        })));
-    liveTrace(live, nChains, true);
-    const chains = results;
-    const ms = { stanc: compiled.ms.stanc, lower: 0, sample: 0,
-                 wall: performance.now() - tWall };
-    for (const r of results)
-      for (const k of ["lower", "sample"]) ms[k] += r.ms[k];
-    fit = { names: chains[0].names, samples: chains[0].samples,
-            chains: chains.map((r) => r.columns) };
-    render(ms, nChains);
+    const runOpts = { ...opts, mir: compiled.mir };
+    if (mode === "both") {
+      await runCompare(runOpts, nChains, seed, compiled, tWall);
+    } else {
+      await runSingle(mode, runOpts, nChains, seed, compiled, tWall);
+    }
     $("csv").hidden = false;
   } catch (e) {
     $("err").textContent = String(e.message || e);
@@ -521,11 +569,134 @@ $("run").onclick = async () => {
   $("status").textContent = "";
 };
 
+async function runSingle(mode, opts, nChains, seed, compiled, tWall) {
+  const label = SAMPLER_LABEL[mode];
+  const live = newLive(nChains);
+  const progress = () => {
+    const w = live.warm.reduce((a, b) => a + b, 0);
+    const d = live.drawn.reduce((a, b) => a + b, 0);
+    $("status").textContent = d
+        ? `${label} sampling: ${d}/${nChains * opts.samples} draws across ` +
+          `${nChains} chains`
+        : `${label} warmup: ${w}/${nChains * opts.warmup} across ` +
+          `${nChains} chains`;
+  };
+  const r = await runChains(
+      mode, opts, nChains, seed,
+      liveHandler(live, $("trace"), label, nChains, progress));
+  liveTrace($("trace"), live, nChains, true, label);
+  fit = r.fit;
+  const ms = { stanc: compiled.ms.stanc, ...r.ms,
+               wall: performance.now() - tWall };
+  render(ms, nChains, label);
+}
+
+// ---- the comparison --------------------------------------------------------
+// One column per sampler, NUTS on the left, WALNUTS on the right: live
+// trace while the chains run, then a histogram, the timing line, and the
+// full summary table. The same parameter is selected in both columns --
+// clicking a row in either table redraws both traces on a SHARED y range
+// and both histograms on a shared x range, so the eye compares mixing
+// and the posterior rather than axis choices.
+function cmpCol(which) {
+  const col = document.createElement("div");
+  col.className = "col";
+  col.id = `col-${which}`;
+  col.innerHTML =
+      `<h3>${SAMPLER_LABEL[which]}</h3>` +
+      `<canvas class="ctrace" width="540" height="170"></canvas>` +
+      `<canvas class="chist" width="540" height="140" hidden></canvas>` +
+      `<div class="times"></div><div class="ctable"></div>`;
+  return col;
+}
+
+async function runCompare(opts, nChains, seed, compiled, tWall) {
+  const wrap = document.createElement("div");
+  wrap.className = "cmp";
+  const cols = { nuts: cmpCol("nuts"), walnuts: cmpCol("walnuts") };
+  wrap.append(cols.nuts, cols.walnuts);
+  $("out").appendChild(wrap);
+
+  const lives = { nuts: newLive(nChains), walnuts: newLive(nChains) };
+  const progress = () => {
+    const part = (w) => {
+      const l = lives[w];
+      const d = l.drawn.reduce((a, b) => a + b, 0);
+      const wu = l.warm.reduce((a, b) => a + b, 0);
+      return `${SAMPLER_LABEL[w]} ` +
+             (d ? `${d}/${nChains * opts.samples} draws`
+                : `warmup ${wu}/${nChains * opts.warmup}`);
+    };
+    $("status").textContent = part("nuts") + " · " + part("walnuts");
+  };
+  // Both samplers launch together: 2 x nChains workers, the pool
+  // queueing whatever exceeds the hardware.
+  const [rn, rw] = await Promise.all(["nuts", "walnuts"].map((w) =>
+      runChains(w, opts, nChains, seed,
+                liveHandler(lives[w], cols[w].querySelector(".ctrace"),
+                            SAMPLER_LABEL[w], nChains, progress))));
+  cmpFits = { nuts: rn.fit, walnuts: rw.fit };
+  const wall = performance.now() - tWall;
+
+  for (const [w, r] of [["nuts", rn], ["walnuts", rw]]) {
+    const perChain = r.ms.sample / nChains;
+    let minEss = Infinity;
+    for (const n of r.fit.names)
+      minEss = Math.min(minEss, rhatEss(r.fit, n).ess);
+    const essRate = minEss / (perChain / 1000);
+    cols[w].querySelector(".times").textContent =
+        `${perChain < 1000 ? perChain.toFixed(0) + " ms"
+                           : (perChain / 1000).toFixed(1) + " s"} ` +
+        `sampling per chain · min ESS ${minEss.toFixed(0)} ` +
+        `(${essRate.toFixed(0)}/s)`;
+  }
+  $("times").textContent =
+      `${nChains} chains each, all in parallel: ` +
+      `${(wall / 1000).toFixed(1)} s wall ` +
+      `(stanc ${compiled.ms.stanc.toFixed(0)} ms, once); ` +
+      `click a row to compare that parameter`;
+
+  for (const w of ["nuts", "walnuts"]) {
+    const f = cmpFits[w];
+    const div = cols[w].querySelector(".ctable");
+    div.innerHTML = summaryTable(f);
+    for (const tr of div.querySelectorAll("tr[data-n]"))
+      tr.onclick = () => cmpSelect(tr.dataset.n);
+  }
+  cmpSelect(cmpFits.nuts.names[0]);
+}
+
+function cmpSelect(name) {
+  // The shared scales: y across both samplers' draws of this parameter,
+  // x likewise for the histograms.
+  let lo = Infinity, hi = -Infinity;
+  for (const w of ["nuts", "walnuts"])
+    for (const ch of cmpFits[w].chains)
+      for (const x of ch[name] || []) {
+        if (x < lo) lo = x;
+        if (x > hi) hi = x;
+      }
+  if (!(hi > lo)) { lo -= 1; hi += 1; }
+  for (const w of ["nuts", "walnuts"]) {
+    const col = $(`col-${w}`);
+    const f = cmpFits[w];
+    if (!(name in f.chains[0])) continue;
+    drawTrace(col.querySelector(".ctrace"), f, name,
+              `${name}  ${SAMPLER_LABEL[w]}, ${f.chains.length} chains`,
+              lo, hi);
+    const h = col.querySelector(".chist");
+    h.hidden = false;
+    drawHist(h, f, name, lo, hi);
+    for (const tr of col.querySelectorAll("tr[data-n]"))
+      tr.classList.toggle("selected", tr.dataset.n === name);
+  }
+}
+
 // ---- summaries -------------------------------------------------------------
-function allDraws(name) {
-  const parts = fit.chains.map((c) => c[name]);
-  const out = new Float64Array(parts.length * fit.samples);
-  parts.forEach((p, i) => out.set(p, i * fit.samples));
+function allDraws(f, name) {
+  const parts = f.chains.map((c) => c[name]);
+  const out = new Float64Array(parts.length * f.samples);
+  parts.forEach((p, i) => out.set(p, i * f.samples));
   return out;
 }
 function meanOf(xs) { let s = 0; for (const x of xs) s += x; return s / xs.length; }
@@ -536,17 +707,17 @@ function varOf(xs, m) {
 
 // Split-chain R-hat and a Geyer-style bulk ESS over the split chains:
 // the standard diagnostics, on plain (not rank-normalized) draws.
-function splitChains(name) {
-  const half = Math.floor(fit.samples / 2);
+function splitChains(f, name) {
+  const half = Math.floor(f.samples / 2);
   const seqs = [];
-  for (const c of fit.chains) {
+  for (const c of f.chains) {
     const xs = c[name];
-    seqs.push(xs.subarray(0, half), xs.subarray(fit.samples - half));
+    seqs.push(xs.subarray(0, half), xs.subarray(f.samples - half));
   }
   return seqs;
 }
-function rhatEss(name) {
-  const seqs = splitChains(name);
+function rhatEss(f, name) {
+  const seqs = splitChains(f, name);
   const m = seqs.length, n = seqs[0].length;
   const means = seqs.map(meanOf);
   const vars = seqs.map((s, i) => varOf(s, means[i]));
@@ -577,47 +748,51 @@ function rhatEss(name) {
   const ess = (m * n) / (1 + 2 * sumRho);
   return { rhat, ess: Math.min(ess, m * n) };
 }
-function colStats(name) {
-  const xs = allDraws(name);
+function colStats(f, name) {
+  const xs = allDraws(f, name);
   const sorted = Float64Array.from(xs).sort();
   const mean = meanOf(xs);
   const q = (p) => sorted[Math.min(xs.length - 1, Math.floor(p * xs.length))];
   return { mean, sd: Math.sqrt(varOf(xs, mean)),
-           q5: q(0.05), q50: q(0.5), q95: q(0.95), ...rhatEss(name) };
+           q5: q(0.05), q50: q(0.5), q95: q(0.95), ...rhatEss(f, name) };
 }
 
-function render(ms, nChains) {
-  const f = (x) => (Math.abs(x) >= 1000 ? x.toFixed(0) : x.toPrecision(4));
+function summaryTable(f) {
+  const fmt = (x) => (Math.abs(x) >= 1000 ? x.toFixed(0) : x.toPrecision(4));
   let html = "<table><tr><th>parameter</th><th>mean</th><th>sd</th>" +
              "<th>5%</th><th>50%</th><th>95%</th><th>R&#770;</th>" +
              "<th>ESS</th></tr>";
-  fit.names.forEach((n) => {
-    const st = colStats(n);
+  f.names.forEach((n) => {
+    const st = colStats(f, n);
     const badR = st.rhat > 1.01 ? ' class="bad"' : "";
-    html += `<tr data-n="${n}"><td>${n}</td><td>${f(st.mean)}</td>` +
-            `<td>${f(st.sd)}</td><td>${f(st.q5)}</td>` +
-            `<td>${f(st.q50)}</td><td>${f(st.q95)}</td>` +
+    html += `<tr data-n="${n}"><td>${n}</td><td>${fmt(st.mean)}</td>` +
+            `<td>${fmt(st.sd)}</td><td>${fmt(st.q5)}</td>` +
+            `<td>${fmt(st.q50)}</td><td>${fmt(st.q95)}</td>` +
             `<td${badR}>${st.rhat.toFixed(3)}</td>` +
             `<td>${st.ess.toFixed(0)}</td></tr>`;
   });
-  $("out").innerHTML = html + "</table>";
+  return html + "</table>";
+}
+
+function render(ms, nChains, label) {
+  $("out").innerHTML = summaryTable(fit);
   const perChain = ms.sample / nChains;
   $("times").textContent =
-      `${nChains} chain${nChains > 1 ? "s" : ""} in parallel: ` +
+      `${nChains} ${label} chain${nChains > 1 ? "s" : ""} in parallel: ` +
       `${(ms.wall / 1000).toFixed(1)} s wall, ` +
       `${perChain < 1000 ? perChain.toFixed(0) + " ms"
                          : (perChain / 1000).toFixed(1) + " s"} ` +
       `sampling per chain (stanc ${ms.stanc.toFixed(0)} ms, once); ` +
       `click a row for trace + histogram`;
   for (const tr of $("out").querySelectorAll("tr[data-n]"))
-    tr.onclick = () => showPlots(tr);
+    tr.onclick = () => showPlots(tr, label);
 }
 
 // The plots follow the selection: one pair, parked above the table while
-// NUTS streams, then moved into a row of its own directly under whichever
-// parameter was clicked. Moving the node keeps the canvases and their
-// contexts alive, so nothing has to be redrawn to relocate them.
-function showPlots(tr) {
+// the sampler streams, then moved into a row of its own directly under
+// whichever parameter was clicked. Moving the node keeps the canvases and
+// their contexts alive, so nothing has to be redrawn to relocate them.
+function showPlots(tr, label) {
   const plots = $("plots");
   const prev = $("out").querySelector("tr.plotrow");
   if (prev && prev.previousElementSibling === tr) {
@@ -639,48 +814,14 @@ function showPlots(tr) {
   row.appendChild(cell);
   tr.after(row);
   tr.classList.add("selected");
-  tracePlot(tr.dataset.n);
-  histPlot(tr.dataset.n);
+  const name = tr.dataset.n;
+  drawTrace($("trace"), fit, name,
+            `${name}  trace, ${fit.chains.length} chains`);
+  drawHist($("hist"), fit, name);
 }
 
 // ---- plots -----------------------------------------------------------------
 const CHAIN_COLORS = ["#4a7", "#47a", "#a47", "#a74", "#7a4", "#74a"];
-
-// The live view while NUTS runs: every chain's trace of the first
-// parameter, each growing as its worker streams draws in.
-function liveTrace(live, nChains, done) {
-  if (!live.names || !live.names.length) return;
-  const c = $("trace"), g = c.getContext("2d");
-  c.hidden = false;
-  const seqs = live.chains.filter((s) => s.length > 1);
-  if (!seqs.length) return;
-  let lo = Infinity, hi = -Infinity;
-  for (const s of seqs)
-    for (const row of s) {
-      const v = row[0];
-      if (v < lo) lo = v;
-      if (v > hi) hi = v;
-    }
-  if (!(hi > lo)) { lo -= 1; hi += 1; }
-  const total = Math.max(...seqs.map((s) => s.length));
-  g.clearRect(0, 0, c.width, c.height);
-  const { X, Y } = axes(c, g, {
-    title: done ? `${live.names[0]}  ${nChains} chains`
-                : `${live.names[0]}  live, ${seqs.length} of ${nChains} ` +
-                  `chains running`,
-    xlabel: "draw", ylabel: live.names[0],
-    xlo: 0, xhi: Math.max(total - 1, 1), ylo: lo, yhi: hi });
-  seqs.forEach((s, si) => {
-    g.strokeStyle = CHAIN_COLORS[si % CHAIN_COLORS.length];
-    g.globalAlpha = 0.8;
-    g.beginPath();
-    for (let i = 0; i < s.length; ++i)
-      i ? g.lineTo(X(i), Y(s[i][0])) : g.moveTo(X(i), Y(s[i][0]));
-    g.stroke();
-  });
-  g.globalAlpha = 1;
-}
-// ---- plots -----------------------------------------------------------------
 const PAD = { l: 52, r: 10, t: 20, b: 28 };
 
 // Frame, tick labels and axis names. Returns the mappers into the plot
@@ -724,19 +865,58 @@ function axes(c, g, o) {
   };
 }
 
-function tracePlot(name) {
-  const c = $("trace"), g = c.getContext("2d");
+// The live view while a sampler runs: every chain's trace of the first
+// parameter, each growing as its worker streams draws in.
+function liveTrace(c, live, nChains, done, label) {
+  if (!live.names || !live.names.length) return;
+  const g = c.getContext("2d");
+  c.hidden = false;
+  const seqs = live.chains.filter((s) => s.length > 1);
+  if (!seqs.length) return;
+  let lo = Infinity, hi = -Infinity;
+  for (const s of seqs)
+    for (const row of s) {
+      const v = row[0];
+      if (v < lo) lo = v;
+      if (v > hi) hi = v;
+    }
+  if (!(hi > lo)) { lo -= 1; hi += 1; }
+  const total = Math.max(...seqs.map((s) => s.length));
+  g.clearRect(0, 0, c.width, c.height);
+  const { X, Y } = axes(c, g, {
+    title: done ? `${live.names[0]}  ${label}, ${nChains} chains`
+                : `${live.names[0]}  ${label} live, ${seqs.length} of ` +
+                  `${nChains} chains running`,
+    xlabel: "draw", ylabel: live.names[0],
+    xlo: 0, xhi: Math.max(total - 1, 1), ylo: lo, yhi: hi });
+  seqs.forEach((s, si) => {
+    g.strokeStyle = CHAIN_COLORS[si % CHAIN_COLORS.length];
+    g.globalAlpha = 0.8;
+    g.beginPath();
+    for (let i = 0; i < s.length; ++i)
+      i ? g.lineTo(X(i), Y(s[i][0])) : g.moveTo(X(i), Y(s[i][0]));
+    g.stroke();
+  });
+  g.globalAlpha = 1;
+}
+
+// Finished-run trace. ylo/yhi, when given, pin the y range so paired
+// plots share a scale; otherwise the range fits this fit's own draws.
+function drawTrace(c, f, name, title, ylo, yhi) {
+  const g = c.getContext("2d");
   c.hidden = false;
   g.clearRect(0, 0, c.width, c.height);
-  let lo = Infinity, hi = -Infinity;
-  for (const ch of fit.chains)
-    for (const x of ch[name]) { if (x < lo) lo = x; if (x > hi) hi = x; }
-  if (!(hi > lo)) { lo -= 1; hi += 1; }
+  let lo = ylo, hi = yhi;
+  if (lo == null || hi == null) {
+    lo = Infinity; hi = -Infinity;
+    for (const ch of f.chains)
+      for (const x of ch[name]) { if (x < lo) lo = x; if (x > hi) hi = x; }
+    if (!(hi > lo)) { lo -= 1; hi += 1; }
+  }
   const { X, Y } = axes(c, g, {
-    title: name + "  trace, " + fit.chains.length + " chains",
-    xlabel: "draw", ylabel: name,
-    xlo: 0, xhi: fit.samples - 1, ylo: lo, yhi: hi });
-  fit.chains.forEach((ch, ci) => {
+    title, xlabel: "draw", ylabel: name,
+    xlo: 0, xhi: f.samples - 1, ylo: lo, yhi: hi });
+  f.chains.forEach((ch, ci) => {
     g.strokeStyle = CHAIN_COLORS[ci % CHAIN_COLORS.length];
     g.globalAlpha = 0.8;
     g.beginPath();
@@ -747,16 +927,19 @@ function tracePlot(name) {
   });
   g.globalAlpha = 1;
 }
-function histPlot(name) {
-  const xs = allDraws(name);
-  let lo = Infinity, hi = -Infinity;
-  for (const x of xs) { if (x < lo) lo = x; if (x > hi) hi = x; }
-  if (!(hi > lo)) { lo -= 1; hi += 1; }
+function drawHist(c, f, name, xlo, xhi) {
+  const xs = allDraws(f, name);
+  let lo = xlo, hi = xhi;
+  if (lo == null || hi == null) {
+    lo = Infinity; hi = -Infinity;
+    for (const x of xs) { if (x < lo) lo = x; if (x > hi) hi = x; }
+    if (!(hi > lo)) { lo -= 1; hi += 1; }
+  }
   const nb = 40, counts = new Array(nb).fill(0);
   for (const x of xs)
-    ++counts[Math.min(nb - 1, ((x - lo) / (hi - lo) * nb) | 0)];
+    ++counts[Math.min(nb - 1, Math.max(0, ((x - lo) / (hi - lo) * nb) | 0))];
   const peak = Math.max(...counts);
-  const c = $("hist"), g = c.getContext("2d");
+  const g = c.getContext("2d");
   c.hidden = false;
   g.clearRect(0, 0, c.width, c.height);
   const { X, Y } = axes(c, g, {
@@ -772,12 +955,21 @@ function histPlot(name) {
 
 // ---- CSV -------------------------------------------------------------------
 $("csv").onclick = () => {
-  const lines = ["chain," + fit.names.join(",")];
-  fit.chains.forEach((ch, ci) => {
-    for (let s = 0; s < fit.samples; ++s)
-      lines.push((ci + 1) + "," +
-                 fit.names.map((n) => ch[n][s]).join(","));
-  });
+  const lines = [];
+  const emit = (label, f) => {
+    for (let ci = 0; ci < f.chains.length; ++ci)
+      for (let s = 0; s < f.samples; ++s)
+        lines.push((label ? label + "," : "") + (ci + 1) + "," +
+                   f.names.map((n) => f.chains[ci][n][s]).join(","));
+  };
+  if (cmpFits) {
+    lines.push("sampler,chain," + cmpFits.nuts.names.join(","));
+    emit("nuts", cmpFits.nuts);
+    emit("walnuts", cmpFits.walnuts);
+  } else {
+    lines.push("chain," + fit.names.join(","));
+    emit("", fit);
+  }
   const blob = new Blob([lines.join("\n") + "\n"], { type: "text/csv" });
   const a = document.createElement("a");
   a.href = URL.createObjectURL(blob);
@@ -797,7 +989,7 @@ it works</a></p>
 <!--gen:corpus_median-->2.07x<!--/gen--> CmdStan across
 <!--gen:corpus_n_grad-->119<!--/gen--> posteriordb models, with
 <!--gen:corpus_at_par-->100<!--/gen--> of them at or above it. We benchmark every posteriordb model and explain why some are slower:
-<a href="https://github.com/seantalts/stanli/blob/main/docs/benchmarks.md">benchmarks</a>. 
+<a href="https://github.com/seantalts/stanli/blob/main/docs/benchmarks.md">benchmarks</a>.
 The biggest architectural win is that Stanli analyzes the model graph and pre-allocates a linear array for gradient storage for everything except for ODE UDFs and conditionals on parameters.
 The other graph optimizations are explained <a href="https://github.com/seantalts/stanli/blob/main/runtime/src/OPTIMIZATIONS.md">here</a>.
 </p>
@@ -806,7 +998,7 @@ compiled to WebAssembly instead of native costs about 1.5x to 2x per
 gradient. The figures in the paragraph
 above are native ones, so the margin over CmdStan in here is nearer par
 than 2x. For heavy work, <code>pip install stanli</code> to run the native build.</p>
-<p><b>Numerically accurate and consistent with CmdStan</b> 
+<p><b>Numerically accurate and consistent with CmdStan</b>
 <!--gen:corpus_verified-->118/120<!--/gen--> posteriordb models are
 replayed against the log density, the full gradient and the generated
 quantities CmdStan actually printed, and


### PR DESCRIPTION
Vendors the walnutpie headers (flatironinstitute/walnuts @052bbe6c, MIT) and runs WALNUTS (within-orbit adaptive step-length NUTS, arXiv:2506.18746) over the executor's gradient, next to the existing NUTS path.

## Runtime

- `run_walnuts` mirrors `run_nuts`: same init-retry contract, same `DrawObserver` streaming, `SamplerStats` rows in the same 7-column shape with NaN where WALNUTS has no analogue.
- `runtime/src/walnuts.cpp` is the one C++20 translation unit in an otherwise C++17 build (walnutpie is written against concepts). It includes no stan-math, only the executor interface and Eigen, and the public header is C++17-clean, so nothing else in the build or its consumers sees the newer standard.
- Only the sampler headers are vendored; walnutpie's parallel driver (jthread chain workers plus an R-hat controller for early stopping) is excluded. Chains in walnutpie adapt independently, so nothing statistical is lost; R-hat early stopping can come later as a `run_walnuts_chains`.
- Seeding is `seed_seq{seed, chain_id}` into `mt19937_64`: per-seed reproducibility, with no CmdStan stream to match since this sampler does not exist there.

## C ABI and packages

- `stanli_sample_walnuts_stream` mirrors `stanli_sample_stream`. The tunable is `max_error`, the largest drift in the joint log density allowed across one macro step before the step halves within the trajectory (0 asks for the default 0.5), in place of NUTS's `delta`.
- Exported native (.def; the macOS/Linux lists already wildcard `stanli_*`) and wasm; the npm wrapper takes `sampler: "walnuts"` plus `maxError`.

## Web

The page grows a sampler picker whose third option runs NUTS and WALNUTS at once on the same model, data, and seed: NUTS's column on the left, WALNUTS's on the right, each with live traces, a histogram, per-chain timing with min ESS and ESS per second, and the full summary table. Clicking a parameter row in either table selects it in both and redraws traces on a shared y range and histograms on a shared x range, so the eye compares mixing and posteriors rather than axis choices. Single-sampler runs keep the existing plots-under-the-row behavior; CSV downloads gain a sampler column on comparison runs.

## Tests

- `test_walnuts`: 10-dim standard normal moments, eight schools posterior locations, same-seed determinism, observer counts.
- `test_wasm.cjs` now samples eight schools through both engines' streaming C entries.
- All 38 native tests pass; verified the comparison page live in Chrome (eight schools: 44 ms/chain min ESS 2218 for NUTS vs 34 ms/chain min ESS 1821 for WALNUTS, posteriors matching).