### PR TITLE
WALNUTS NaN-density fix and a live comparison that stays honest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,15 @@ local error demands it, which is what makes funnel-like geometry
 tractable without cranking `delta`; its tunable is `max_error`, the
 largest drift in the joint log density allowed across one macro step.
 
+A NaN log density no longer kills WALNUTS warmup. stanli's kernels
+report out-of-support points as NaN rather than throwing (log of a
+negative is just a NaN), and walnutpie's acceptance statistic fed that
+NaN straight into its Adam step-size estimate, where one NaN is
+permanent; models whose trajectories cross out of support, dogs_log
+among them, died at the end of warmup with "macro_time must be in
+(0, inf)". The gradient wrapper now reports non-finite densities the
+way walnutpie's own exception path does: -inf, zero gradient.
+
 The browser page grew a sampler picker with a comparison mode: NUTS
 and WALNUTS run at once on the same model, data, and seed, NUTS's
 column on the left and WALNUTS's on the right, each with live traces,
@@ -22,7 +31,13 @@ a histogram, per-chain timing with min ESS and ESS per second, and the
 full summary table. Clicking a parameter row in either table selects
 it in both, redrawing the traces on a shared y range and the
 histograms on a shared x range, so the eye compares mixing and the
-posterior rather than axis choices.
+posterior rather than axis choices. The live traces share their y
+range the same way while the chains run, the two samplers' chains
+launch interleaved so a small worker pool cannot serialize them, and
+the up and down arrow keys step the selected parameter. Live repaints
+track the plotted range incrementally and draw at most two points per
+pixel column; both rescans used to pin the page on runs of a few
+hundred thousand draws.
 
 Groundwork for letting external samplers drive stanli models, plus two
 fixes that stand on their own.

--- a/runtime/src/walnuts.cpp
+++ b/runtime/src/walnuts.cpp
@@ -32,6 +32,22 @@ struct ExecLogpGrad {
     for (int64_t i = 0; i < n; ++i) ex->params_data()[i] = x(i);
     grad.resize(n);
     logp = ex->gradient(grad.data());
+    // walnutpie assumes the density throws or is finite: its acceptance
+    // statistic is exp(-|logp - logp_next|), and a NaN there -- which
+    // stanli's kernels produce freely, log of a negative is a NaN and
+    // not an exception -- poisons the Adam step-size estimate for good,
+    // surfacing as "macro_time must be in (0, inf)" at the end of
+    // warmup. Out-of-support points therefore report exactly what
+    // walnutpie's own exception path reports: -inf, zero gradient. A
+    // non-finite gradient at a finite logp gets the same treatment,
+    // because one more leapfrog step through it turns the position and
+    // then the momentum into NaN anyway.
+    bool ok = std::isfinite(logp);
+    for (int64_t i = 0; ok && i < n; ++i) ok = std::isfinite(grad(i));
+    if (!ok) {
+      logp = -std::numeric_limits<double>::infinity();
+      grad.setZero();
+    }
   }
 };
 

--- a/tests/test_walnuts.cpp
+++ b/tests/test_walnuts.cpp
@@ -110,6 +110,54 @@ int main() {
     expect_in("new seed differs", differ ? 1 : 0, 1, 1);
   }
 
+  // ---- NaN density regions must not poison step-size adaptation ----------
+  // The target is normal_lpdf(x | 0, 1) + log(-x), and the log(-x) term
+  // reaches lp through raw vector kernels: for x > 0 it is a NaN, not an
+  // exception, exactly like posteriordb's dogs_log (where this was
+  // found). Trajectories cross x = 0 constantly, and a NaN log density
+  // fed walnutpie's exp(-|logp diff|) acceptance statistic straight into
+  // the Adam step-size estimate, where one NaN is permanent; these seeds
+  // died at the end of warmup with "macro_time must be in (0, inf)". The
+  // wrapper now reports non-finite points as -inf with a zero gradient,
+  // walnutpie's own convention for a throwing density.
+  {
+    for (uint32_t seed = 1; seed <= 5; ++seed) {
+      Graph g;
+      const int x = g.add_slot(1, true);
+      const int nx = g.add_slot(1, false);
+      g.add_op(OP_NEG, {x}, nx);
+      const int lx = g.add_slot(1, false);
+      g.add_op(OP_LOGV, {nx}, lx);
+      const int zero = g.add_slot(1, false);
+      const int one = g.add_slot(1, false);
+      const int nlp = g.add_slot(1, false);
+      g.add_op(OP_NORMAL_LPDF, {x, zero, one}, nlp);
+      const int lp = g.add_slot(1, false);
+      g.add_op(OP_ADD, {nlp, lx}, lp);
+      g.result_slot = lp;
+      Executor ex(std::move(g));
+      ex.value_ptr(zero)[0] = 0.0;
+      ex.value_ptr(one)[0] = 1.0;
+
+      WalnutsConfig cfg;
+      cfg.seed = seed;
+      cfg.warmup = 300;
+      cfg.samples = 200;
+      bool threw = false;
+      int bad = 0;
+      try {
+        auto draws = run_walnuts(ex, cfg);
+        for (const auto& q : draws)
+          if (!(q[0] < 0.0)) ++bad;  // outside support, or NaN
+      } catch (const std::exception&) {
+        threw = true;
+      }
+      const std::string tag = "nan-region seed " + std::to_string(seed);
+      expect_in(tag + " threw", threw ? 1 : 0, 0, 0);
+      expect_in(tag + " bad draws", bad, 0, 0);
+    }
+  }
+
   // ---- observer: sees every stored draw, phases in order -----------------
   {
     Graph g;

--- a/web/index.html
+++ b/web/index.html
@@ -498,13 +498,20 @@ async function runChains(sampler, opts, nChains, seed, onLive) {
 }
 
 function newLive(nChains) {
+  // lo/hi track the first parameter's range incrementally as chunks
+  // arrive. Rescanning every stored row on each repaint reads as
+  // simpler, but at a few hundred thousand draws it pins the main
+  // thread and the page stops responding mid-run.
   return { names: null,
            chains: Array.from({ length: nChains }, () => []),
            warm: new Array(nChains).fill(0),
-           drawn: new Array(nChains).fill(0) };
+           drawn: new Array(nChains).fill(0),
+           lo: Infinity, hi: -Infinity };
 }
-function liveHandler(live, canvas, label, nChains, progress) {
-  let lastDraw = 0;
+// Fold one chain's live messages into `live`, then let `redraw` decide
+// what to repaint -- the single view repaints its own canvas, the
+// comparison repaints both columns together so their axes stay shared.
+function liveHandler(live, progress, redraw) {
   return (c, m) => {
     if (m.liveMeta) { live.names = m.liveMeta.names; return; }
     const lv = m.live;
@@ -515,14 +522,25 @@ function liveHandler(live, canvas, label, nChains, progress) {
     }
     live.drawn[c] = lv.i;
     const chunk = new Float64Array(lv.rows);
-    for (let k = 0; k < chunk.length / lv.nCon; ++k)
-      live.chains[c].push(chunk.subarray(k * lv.nCon, (k + 1) * lv.nCon));
-    progress();
-    const now = performance.now();
-    if (now - lastDraw > 60) {
-      lastDraw = now;
-      liveTrace(canvas, live, nChains, false, label);
+    for (let k = 0; k < chunk.length / lv.nCon; ++k) {
+      const row = chunk.subarray(k * lv.nCon, (k + 1) * lv.nCon);
+      const v = row[0];
+      if (v < live.lo) live.lo = v;
+      if (v > live.hi) live.hi = v;
+      live.chains[c].push(row);
     }
+    progress();
+    redraw();
+  };
+}
+// At most one repaint per 60 ms, however fast the draws stream in.
+function throttled(fn) {
+  let last = 0;
+  return () => {
+    const now = performance.now();
+    if (now - last < 60) return;
+    last = now;
+    fn();
   };
 }
 
@@ -572,7 +590,7 @@ $("run").onclick = async () => {
 async function runSingle(mode, opts, nChains, seed, compiled, tWall) {
   const label = SAMPLER_LABEL[mode];
   const live = newLive(nChains);
-  const progress = () => {
+  const progress = throttled(() => {
     const w = live.warm.reduce((a, b) => a + b, 0);
     const d = live.drawn.reduce((a, b) => a + b, 0);
     $("status").textContent = d
@@ -580,10 +598,11 @@ async function runSingle(mode, opts, nChains, seed, compiled, tWall) {
           `${nChains} chains`
         : `${label} warmup: ${w}/${nChains * opts.warmup} across ` +
           `${nChains} chains`;
-  };
+  });
   const r = await runChains(
       mode, opts, nChains, seed,
-      liveHandler(live, $("trace"), label, nChains, progress));
+      liveHandler(live, progress, throttled(
+          () => liveTrace($("trace"), live, nChains, false, label))));
   liveTrace($("trace"), live, nChains, true, label);
   fit = r.fit;
   const ms = { stanc: compiled.ms.stanc, ...r.ms,
@@ -618,7 +637,7 @@ async function runCompare(opts, nChains, seed, compiled, tWall) {
   $("out").appendChild(wrap);
 
   const lives = { nuts: newLive(nChains), walnuts: newLive(nChains) };
-  const progress = () => {
+  const progress = throttled(() => {
     const part = (w) => {
       const l = lives[w];
       const d = l.drawn.reduce((a, b) => a + b, 0);
@@ -628,27 +647,66 @@ async function runCompare(opts, nChains, seed, compiled, tWall) {
                 : `warmup ${wu}/${nChains * opts.warmup}`);
     };
     $("status").textContent = part("nuts") + " · " + part("walnuts");
+  });
+  // Both live traces repaint together, on a y range computed across
+  // BOTH samplers' draws so far. Independent ranges here would let a
+  // sampler look calmer or wilder purely by axis choice, which is the
+  // exact illusion the finished view's shared axes exist to prevent.
+  const redrawLive = throttled(() => {
+    const lo = Math.min(lives.nuts.lo, lives.walnuts.lo);
+    const hi = Math.max(lives.nuts.hi, lives.walnuts.hi);
+    if (!(hi > lo)) return;
+    for (const w of ["nuts", "walnuts"])
+      liveTrace(cols[w].querySelector(".ctrace"), lives[w], nChains, false,
+                SAMPLER_LABEL[w], lo, hi);
+  });
+  const handlers = {
+    nuts: liveHandler(lives.nuts, progress, redrawLive),
+    walnuts: liveHandler(lives.walnuts, progress, redrawLive),
   };
-  // Both samplers launch together: 2 x nChains workers, the pool
-  // queueing whatever exceeds the hardware.
-  const [rn, rw] = await Promise.all(["nuts", "walnuts"].map((w) =>
-      runChains(w, opts, nChains, seed,
-                liveHandler(lives[w], cols[w].querySelector(".ctrace"),
-                            SAMPLER_LABEL[w], nChains, progress))));
+  // Launch interleaved -- n0, w0, n1, w1, ... -- so worker-pool slots
+  // alternate between the samplers. Launching one sampler's chains
+  // first would let it monopolize a small pool (the pool caps at the
+  // hardware's concurrency) and the "side by side" run would quietly
+  // become "one after the other" on a 4-core machine.
+  const jobs = [];
+  for (let c = 0; c < nChains; ++c)
+    for (const w of ["nuts", "walnuts"])
+      jobs.push(sample({
+        ...opts, code: undefined, seed: seed + c, sampler: w,
+        onLive: (m) => handlers[w](c, m),
+      }).then((r) => ({ w, r })));
+  const done = await Promise.all(jobs);
+  const collect = (w) => {
+    const rs = done.filter((d) => d.w === w).map((d) => d.r);
+    const ms = { lower: 0, sample: 0 };
+    for (const r of rs)
+      for (const k of ["lower", "sample"]) ms[k] += r.ms[k];
+    return { fit: { names: rs[0].names, samples: rs[0].samples,
+                    chains: rs.map((r) => r.columns) }, ms };
+  };
+  const rn = collect("nuts"), rw = collect("walnuts");
   cmpFits = { nuts: rn.fit, walnuts: rw.fit };
   const wall = performance.now() - tWall;
 
   for (const [w, r] of [["nuts", rn], ["walnuts", rw]]) {
     const perChain = r.ms.sample / nChains;
+    // Constant columns (a Viterbi state that never moves, a fixed
+    // generated quantity) have no ESS; they are excluded rather than
+    // reported as a NaN minimum.
     let minEss = Infinity;
-    for (const n of r.fit.names)
-      minEss = Math.min(minEss, rhatEss(r.fit, n).ess);
-    const essRate = minEss / (perChain / 1000);
+    for (const n of r.fit.names) {
+      const e = rhatEss(r.fit, n).ess;
+      if (Number.isFinite(e)) minEss = Math.min(minEss, e);
+    }
+    const essText = Number.isFinite(minEss)
+        ? `min ESS ${minEss.toFixed(0)} ` +
+          `(${(minEss / (perChain / 1000)).toFixed(0)}/s)`
+        : "min ESS n/a";
     cols[w].querySelector(".times").textContent =
         `${perChain < 1000 ? perChain.toFixed(0) + " ms"
                            : (perChain / 1000).toFixed(1) + " s"} ` +
-        `sampling per chain · min ESS ${minEss.toFixed(0)} ` +
-        `(${essRate.toFixed(0)}/s)`;
+        `sampling per chain · ${essText}`;
   }
   $("times").textContent =
       `${nChains} chains each, all in parallel: ` +
@@ -666,7 +724,29 @@ async function runCompare(opts, nChains, seed, compiled, tWall) {
   cmpSelect(cmpFits.nuts.names[0]);
 }
 
+// Arrow keys step the comparison's selected parameter, so flipping
+// through a model's parameters is one hand on the keyboard rather than
+// a click per row. Active only when a comparison is on screen and focus
+// is not in a form control (the model picker owns its own arrows).
+let cmpSelName = null;
+document.addEventListener("keydown", (e) => {
+  if (!cmpFits || (e.key !== "ArrowDown" && e.key !== "ArrowUp")) return;
+  const t = e.target;
+  if (t && /^(INPUT|TEXTAREA|SELECT)$/.test(t.tagName)) return;
+  const names = cmpFits.nuts.names;
+  const at = Math.max(0, names.indexOf(cmpSelName));
+  const next = e.key === "ArrowDown"
+      ? Math.min(names.length - 1, at + 1)
+      : Math.max(0, at - 1);
+  if (names[next] === cmpSelName) return;
+  e.preventDefault();
+  cmpSelect(names[next]);
+  document.querySelector(`#col-nuts tr[data-n="${CSS.escape(names[next])}"]`)
+      ?.scrollIntoView({ block: "nearest" });
+});
+
 function cmpSelect(name) {
+  cmpSelName = name;
   // The shared scales: y across both samplers' draws of this parameter,
   // x likewise for the histograms.
   let lo = Infinity, hi = -Infinity;
@@ -866,20 +946,17 @@ function axes(c, g, o) {
 }
 
 // The live view while a sampler runs: every chain's trace of the first
-// parameter, each growing as its worker streams draws in.
-function liveTrace(c, live, nChains, done, label) {
+// parameter, each growing as its worker streams draws in. ylo/yhi,
+// when given, pin the y range (the comparison passes the joint range
+// over both samplers); otherwise it fits this run's own draws.
+function liveTrace(c, live, nChains, done, label, ylo, yhi) {
   if (!live.names || !live.names.length) return;
   const g = c.getContext("2d");
   c.hidden = false;
   const seqs = live.chains.filter((s) => s.length > 1);
   if (!seqs.length) return;
-  let lo = Infinity, hi = -Infinity;
-  for (const s of seqs)
-    for (const row of s) {
-      const v = row[0];
-      if (v < lo) lo = v;
-      if (v > hi) hi = v;
-    }
+  let lo = ylo != null ? ylo : live.lo;
+  let hi = yhi != null ? yhi : live.hi;
   if (!(hi > lo)) { lo -= 1; hi += 1; }
   const total = Math.max(...seqs.map((s) => s.length));
   g.clearRect(0, 0, c.width, c.height);
@@ -889,12 +966,19 @@ function liveTrace(c, live, nChains, done, label) {
                   `${nChains} chains running`,
     xlabel: "draw", ylabel: live.names[0],
     xlo: 0, xhi: Math.max(total - 1, 1), ylo: lo, yhi: hi });
+  // Draw at most ~2 points per pixel column. A polyline of every draw
+  // is invisible past that density and, at hundreds of thousands of
+  // draws repainted every 60 ms, is what freezes the tab.
+  const stride = Math.max(1, Math.floor(total / (2 * c.width)));
   seqs.forEach((s, si) => {
     g.strokeStyle = CHAIN_COLORS[si % CHAIN_COLORS.length];
     g.globalAlpha = 0.8;
     g.beginPath();
-    for (let i = 0; i < s.length; ++i)
-      i ? g.lineTo(X(i), Y(s[i][0])) : g.moveTo(X(i), Y(s[i][0]));
+    let first = true;
+    for (let i = 0; i < s.length; i += stride) {
+      first ? g.moveTo(X(i), Y(s[i][0])) : g.lineTo(X(i), Y(s[i][0]));
+      first = false;
+    }
     g.stroke();
   });
   g.globalAlpha = 1;
@@ -916,13 +1000,18 @@ function drawTrace(c, f, name, title, ylo, yhi) {
   const { X, Y } = axes(c, g, {
     title, xlabel: "draw", ylabel: name,
     xlo: 0, xhi: f.samples - 1, ylo: lo, yhi: hi });
+  // Same ~2 points per pixel column cap as the live view.
+  const stride = Math.max(1, Math.floor(f.samples / (2 * c.width)));
   f.chains.forEach((ch, ci) => {
     g.strokeStyle = CHAIN_COLORS[ci % CHAIN_COLORS.length];
     g.globalAlpha = 0.8;
     g.beginPath();
     const xs = ch[name];
-    for (let i = 0; i < xs.length; ++i)
-      i ? g.lineTo(X(i), Y(xs[i])) : g.moveTo(X(i), Y(xs[i]));
+    let first = true;
+    for (let i = 0; i < xs.length; i += stride) {
+      first ? g.moveTo(X(i), Y(xs[i])) : g.lineTo(X(i), Y(xs[i]));
+      first = false;
+    }
     g.stroke();
   });
   g.globalAlpha = 1;


### PR DESCRIPTION
Follow-ups to #65, both found by using the comparison view in anger.

## fix: a NaN log density poisoned WALNUTS step-size adaptation

stanli's kernels report out-of-support points as NaN rather than throwing (log of a negative is a NaN, not an exception), while walnutpie assumes throw-or-finite: its acceptance statistic `exp(-|logp - logp_next|)` went NaN, fed the Adam step-size estimate where one NaN is permanent, and affected chains died at the end of warmup with "macro_time must be in (0, inf)". Reproduced on dogs_log (5/5 seeds), dogs_hierarchical, and dogs_nonhierarchical. The gradient wrapper now reports non-finite densities exactly as walnutpie's own exception path does (-inf, zero gradient); the regression test routes a NaN into lp through raw vector kernels so no density kernel can throw first, and failed on all five seeds before the fix.

## web: the live comparison runs together and shares axes while sampling

- Both live traces repaint together on a y range computed across both samplers' draws, so mid-run mixing is compared on the same scale the finished view already used.
- Chains launch interleaved (n0, w0, n1, w1, ...); launching one sampler's chains first let it take the whole worker pool on a 4-core machine, quietly serializing the "side by side" run.
- Live repaints track the range incrementally and draw at most two points per pixel column, with status updates throttled alongside; the previous full rescan-and-replot pinned the main thread on runs of a few hundred thousand draws.
- Up/down arrow keys step the selected parameter through both columns.
- Constant columns are excluded from the min-ESS line instead of reporting NaN.

Verified in Chrome: hmm_drive_0 comparison shows both samplers mid-run on one scale ("NUTS 1980/2000 · WALNUTS 2000/2000"), dogs_log completes with sane posteriors under both samplers, and arrow keys step both tables. All 38 native tests and the wasm test pass.