### PR TITLE
fix: spell STAN_THREADS=true in bs_model_info

### DIFF
--- a/runtime/src/bridgestan_abi.cpp
+++ b/runtime/src/bridgestan_abi.cpp
@@ -397,7 +397,10 @@ bs_model* bs_model_from_mir(const char* mir, const char* data,
               "; model \"" +
               m->name + "\"; " + std::to_string(m->cm.n_unconstrained) +
               " unconstrained parameters; -ffp-contract=off" +
-              (stanli::thread_safe_build() ? "; STAN_THREADS" : "") +
+              // BridgeStan's info reports the make invocation, so clients
+              // (walnutpie among them) grep for the make-args spelling
+              // "STAN_THREADS=true" and refuse to run multi-chain without it.
+              (stanli::thread_safe_build() ? "; STAN_THREADS=true" : "") +
               (stanli::exact_lp_build()
                    ? "; lp__ matches CmdStan exactly"
                    : "; lp__ offset from CmdStan by a per-model constant");

--- a/tests/test_bridgestan.cpp
+++ b/tests/test_bridgestan.cpp
@@ -17,6 +17,7 @@
 #include <stanli/bridgestan_internal.hpp>
 #include <stanli/compile.hpp>
 #include <stanli/executor_pool.hpp>
+#include <stanli/nuts.hpp>
 #include <stanli/wa_interp.hpp>
 
 #include <cmath>
@@ -159,6 +160,11 @@ void test_density_matches_executor() {
     fail("bs_model_info does not carry the build id: " + info);
   if (info.find("2.9.0") == std::string::npos)
     fail("bs_model_info does not name the BridgeStan ABI version: " + info);
+  // Clients grep for BridgeStan's make-args spelling, not a bare word:
+  // walnutpie refuses any model whose info lacks "STAN_THREADS=true".
+  if (stanli::thread_safe_build() &&
+      info.find("STAN_THREADS=true") == std::string::npos)
+    fail("bs_model_info does not carry STAN_THREADS=true: " + info);
 
   bs_model_destruct(m);
 }


### PR DESCRIPTION
walnutpie gates multi-chain sampling on the literal make-args spelling `STAN_THREADS=true` in `bs_model_info`. The facade emitted a bare `STAN_THREADS`, so every stanli pair was refused despite the build being thread safe.

Found by running the end-to-end walnutpie example (`walnuts_stan` over a `bridgestan.StanModel` loaded from a stanli lib pair). With this change the example samples 4 chains and the draws match the analytic posterior.

The conformance test now asserts the client's spelling whenever the build is thread safe, and fails against the old string.