### PR TITLE
feat: embed the BridgeStan manifest in the data argument

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -312,6 +312,9 @@ jobs:
           # a real load exercises the runtime finding its own sidecar, so
           # this cannot move into the linked C++ suite.
           /tmp/wheeltest/bin/python tests/test_bridgestan_pair.py
+          # The other transport: the manifest embedded in the data
+          # argument, two models through the one runtime library.
+          /tmp/wheeltest/bin/python tests/test_bridgestan_embed.py
 
       # The one check that a second implementation makes and stanli's own
       # tests cannot: the facade and its tests come from the same head, so

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 ## Unreleased
 
+### BridgeStan models without the copy
+
+The BridgeStan manifest can now ride inside the data argument under the
+reserved key `__stanli`; `bs_model_construct` validates it, strips it,
+and binds the rest as the model's data. One runtime library then serves
+every model, with nothing written to disk, where the lib pair costs a
+full ~29 MB copy of the runtime per model. The pair transport is
+unchanged and remains the answer for clients that take only a library
+path. `stanli.bridgestan_model(...)` is the Python sugar: it compiles
+the model, splices the manifest, and returns a `bridgestan.StanModel`
+bound to the runtime library itself. Because the embedded path needs no
+`dladdr`, it also lifts `bs_model_construct`'s Windows refusal for
+callers that use it. Design notes:
+`docs/superpowers/specs/2026-08-11-embedded-mir-data.md`.
+
 ### WALNUTS, next to NUTS
 
 The WALNUTS sampler (within-orbit adaptive step-length NUTS,

--- a/docs/superpowers/specs/2026-08-11-embedded-mir-data.md
+++ b/docs/superpowers/specs/2026-08-11-embedded-mir-data.md
@@ -1,0 +1,103 @@
+# Embedding the model in the data argument
+
+Status: implemented. Companion to
+[2026-08-10-bridgestan-facade-design.md](2026-08-10-bridgestan-facade-design.md),
+which built the lib-pair transport this spec adds an alternative to.
+
+## Problem
+
+A BridgeStan client identifies a model by the shared library it loads.
+The facade's answer is the lib pair: a full copy of the runtime
+(~29 MB), renamed per model, with a sidecar manifest holding the MIR.
+`bs_model_construct` finds the sidecar by asking `dladdr` where its own
+code was loaded from.
+
+The copy is the cost, and it is not just disk. It exists because dlopen
+identifies a library by inode, so the runtime must be a distinct file
+per model or every model resolves to the first one loaded. The `dladdr`
+trick also has no Windows equivalent in the facade today, so
+`bs_model_construct` refuses there outright.
+
+Both problems come from routing model identity through the filesystem.
+The construct call already has a channel that arrives at exactly the
+right moment and is opaque to every client: the `data` argument.
+
+## Design
+
+The manifest may ride inside the data JSON, under one reserved key:
+
+```json
+{
+  "__stanli": {"build_id": "...", "mir": "...", "name": "eight_schools"},
+  "J": 8,
+  "y": [28, 8, -3, 7, -1, 1, 18, 12]
+}
+```
+
+`bs_model_construct` checks the resolved data text (literal or `.json`
+file, same rule as before) for the key. If present, the sub-object is
+validated by `bs_read_manifest`, the same function that reads sidecars,
+so there is ONE manifest format with two transports. The key is then
+stripped and the remaining object is the model's data. If absent,
+construction falls back to the sidecar lookup unchanged.
+
+The key can never collide with a data variable: Stan identifiers begin
+with a letter.
+
+Malformed is loud, not a fallback. A payload that mentions `__stanli`
+but fails to parse, or carries a manifest with the wrong `build_id`,
+is an error naming the embedded manifest. Falling back to the sidecar
+would mask the typo behind a confusing "no sidecar found" message.
+
+On the Python side, `stanli.bridgestan_model(...)` is the sugar the
+facade design doc sketched: compile the model, splice the manifest into
+the data, and return a `bridgestan.StanModel` bound to the runtime
+library itself. No pair is written. `bridgestan` is imported lazily and
+stays out of stanli's dependencies.
+
+## What it provides
+
+- **Zero copies.** Every model shares the one runtime library already
+  inside the installed wheel. The per-model cost drops from ~29 MB to
+  the size of the MIR text (tens of KB), and it lives in memory, not
+  the pair cache.
+- **No dlopen aliasing.** Model identity moves from "which file did
+  dlopen open" to construct time, so the same library serving many
+  models is not merely safe but the point.
+- **`bs_model_construct` on Windows.** The embedded path needs no
+  `dladdr`, so the one platform refusal in the facade disappears for
+  clients that use it.
+- **In-process testability.** The sidecar path only works under a real
+  dlopen (a linked test resolves the anchor to the test binary), which
+  is why the pair test lives in Python. The embedded path is plain
+  argument passing and tests in the C++ suite.
+
+## What it requires
+
+- **A cooperating caller.** Someone must splice the manifest into the
+  data: `bridgestan_model` does it for Python, and other languages need
+  the same few lines. Clients that take only a library path (walnutpie's
+  `stan_cli`, the R and Julia packages driving a prebuilt `.so`) cannot
+  use it, which is why the pair transport remains.
+- **Inlined data.** Path-form data has to be read and re-serialized to
+  splice the key in, so the caller-side helper eats the file. The C
+  ABI itself still accepts a `.json` path whose contents embed the key.
+- **The same build discipline as the sidecar.** `build_id` must match
+  the runtime, for the same reason sidecars check it: the MIR dialect
+  and the lowering that reads it move together.
+
+## Pros and cons against the pair
+
+Pro: no 29 MB copy, no cache directory to manage, no inode trick,
+works on Windows, testable in-process. The manifest travels with the
+construct call, so there is no staleness window between writing a pair
+and loading it.
+
+Con: it is invisible to path-only clients, needs a per-language shim,
+and puts a multi-hundred-KB string through an argument every client
+logs or stores at will (a pair keeps the MIR in one file on disk). The
+data argument also stops being "just the data": tooling that round-trips
+it must preserve a key it does not understand.
+
+The two transports compose rather than compete: embedded first when the
+key is present, sidecar otherwise, one manifest format underneath.

--- a/python/stanli/__init__.py
+++ b/python/stanli/__init__.py
@@ -255,6 +255,54 @@ def _clone_file(src: pathlib.Path, dst: pathlib.Path) -> None:
     shutil.copyfile(src, dst)
 
 
+def _resolve_program(stan_file, stan_code, mir, name):
+    """(mir, name) from whichever form the caller has, compiling if needed."""
+    if mir is None:
+        if stan_code is None:
+            if stan_file is None:
+                raise ValueError("provide stan_file, stan_code, or mir")
+            stan_code = pathlib.Path(stan_file).read_text()
+        mir = stan_to_mir(stan_code)
+    if name is None:
+        name = pathlib.Path(stan_file).stem if stan_file else "stanli_model"
+    return mir, name
+
+
+def bridgestan_model(stan_file=None, stan_code=None, mir=None, data=None,
+                     name=None, **kw):
+    """A ``bridgestan.StanModel`` for this program, with nothing written.
+
+    Where ``bridgestan_lib`` writes a pair (a full copy of the runtime
+    plus a sidecar manifest), this writes no files at all: the manifest
+    rides inside the data argument under the reserved key ``"__stanli"``
+    (never a data variable; Stan identifiers begin with a letter), and
+    ``bs_model_construct`` reads it out before binding the rest as the
+    model's data. Every model then shares the one runtime library already
+    inside this package.
+
+    The trade is that someone must do this splice, so it only serves
+    callers that construct the model here; a sampler that takes only a
+    library path still wants the pair. Path-form ``data`` is read and
+    inlined for the same reason.
+
+    ``bridgestan`` is imported lazily and is not a stanli dependency.
+    Extra keyword arguments pass through to ``bridgestan.StanModel``.
+    """
+    import bridgestan
+
+    mir, name = _resolve_program(stan_file, stan_code, mir, name)
+    payload = json.loads(_data_to_json(data))
+    if not isinstance(payload, dict):
+        raise ValueError("data must be a JSON object")
+    payload["__stanli"] = {"build_id": build_id(), "mir": mir, "name": name}
+    # bridgestan warns that the library is "already loaded" -- it is, by
+    # stanli's own import, and sharing it is this function's design, so
+    # the warning is off unless the caller asks for it.
+    kw.setdefault("warn", False)
+    return bridgestan.StanModel(_runtime_lib_path(), json.dumps(payload),
+                                **kw)
+
+
 def bridgestan_lib(stan_file=None, stan_code=None, mir=None, name=None,
                    dir=None) -> pathlib.Path:
     """Write a Stan program as a BridgeStan model library, and return it.
@@ -270,19 +318,16 @@ def bridgestan_lib(stan_file=None, stan_code=None, mir=None, name=None,
     No data: a pair is a compiled PROGRAM, and ``bs_model_construct``
     takes the data, so one pair serves every dataset for that program.
 
+    A pair costs a full copy of the runtime. When the caller constructs
+    the model from Python anyway, ``bridgestan_model`` skips the copy by
+    embedding the manifest in the data argument instead.
+
     The pair is named by the hash of (runtime build, MIR), so the same
     program against the same runtime is one pair however often you ask, a
     different program is a different pair, and an upgraded runtime never
     serves a stale one. `dir` defaults to a per-user cache directory.
     """
-    if mir is None:
-        if stan_code is None:
-            if stan_file is None:
-                raise ValueError("provide stan_file, stan_code, or mir")
-            stan_code = pathlib.Path(stan_file).read_text()
-        mir = stan_to_mir(stan_code)
-    if name is None:
-        name = pathlib.Path(stan_file).stem if stan_file else "stanli_model"
+    mir, name = _resolve_program(stan_file, stan_code, mir, name)
 
     stem = "stanli_" + hashlib.sha256(
         (build_id() + "\0" + mir).encode()).hexdigest()[:16]

--- a/runtime/src/bridgestan_abi.cpp
+++ b/runtime/src/bridgestan_abi.cpp
@@ -484,8 +484,8 @@ bs_model* bs_model_construct(const char* data, unsigned int seed,
       }
     }
   } catch (const std::exception& e) {
-    set_error(error_msg, std::string("embedded __stanli manifest: ") +
-                             e.what());
+    set_error(error_msg,
+              std::string("embedded __stanli manifest: ") + e.what());
     return nullptr;
   } catch (...) {
     set_error(error_msg, "unknown error reading the embedded manifest");

--- a/runtime/src/bridgestan_abi.cpp
+++ b/runtime/src/bridgestan_abi.cpp
@@ -2,9 +2,11 @@
 //
 // BridgeStan's premise is "a Stan model as a differentiable shared
 // library". Reference BridgeStan gets there by compiling the model into
-// the library; stanli ships one universal library and puts the model in a
-// sidecar manifest next to a clone of it, so the same clients work with no
-// C++ toolchain on the user's machine.
+// the library; stanli ships one universal library and delivers the model
+// as a manifest, either embedded in the data argument under "__stanli" or
+// in a sidecar file next to a per-model clone of the library (see
+// bs_model_construct), so the same clients work with no C++ toolchain on
+// the user's machine.
 //
 // The compatibility stance is narrow on purpose: every call either behaves
 // exactly as the reference header documents, or returns -1 with a message
@@ -431,12 +433,71 @@ const int bs_patch_version = 0;
 
 bs_model* bs_model_construct(const char* data, unsigned int seed,
                              char** error_msg) {
+  // Two transports for the same manifest, tried in this order:
+  //
+  //   1. EMBEDDED: the data JSON carries the manifest itself under the
+  //      reserved key "__stanli" (never a data variable: Stan identifiers
+  //      begin with a letter). The key is validated, stripped, and the
+  //      rest is the model's data. No filesystem, no dladdr, so this one
+  //      also works on Windows and in a linked test.
+  //   2. SIDECAR: the manifest sits in a file next to this library, found
+  //      through dladdr. This is what lets clients that only take a
+  //      library path (stan_cli, the R and Julia packages) stay unaware
+  //      of stanli entirely.
+  //
+  // A payload that mentions the key and gets it wrong fails HERE, naming
+  // the embedded manifest -- sliding into the sidecar lookup would bury a
+  // typo under "no sidecar found".
+  try {
+    if (data != nullptr && data[0] != '\0') {
+      // Same resolution rule as load_data: a path ending in ".json" means
+      // the file's contents, anything else is the JSON itself.
+      std::string text(data);
+      if (text.size() >= 5 && text.compare(text.size() - 5, 5, ".json") == 0) {
+        std::ifstream f(text);
+        if (!f) {
+          set_error(error_msg, "could not read data file " + text);
+          return nullptr;
+        }
+        std::ostringstream ss;
+        ss << f.rdbuf();
+        text = ss.str();
+      }
+      // The substring scan keys the parse: data without the marker takes
+      // the sidecar path untouched, even when it is not valid JSON (that
+      // error belongs to load_data, which says so with more context).
+      if (text.find("\"__stanli\"") != std::string::npos) {
+        const nlohmann::json root = nlohmann::json::parse(text);
+        if (root.is_object() && root.contains("__stanli")) {
+          stanli::BsManifest man;
+          std::string err;
+          if (!stanli::bs_read_manifest(root["__stanli"].dump(), &man, &err)) {
+            set_error(error_msg, "embedded __stanli manifest: " + err);
+            return nullptr;
+          }
+          nlohmann::json rest = root;
+          rest.erase("__stanli");
+          const std::string rest_text = rest.dump();
+          return bs_model_from_mir(man.mir.c_str(), rest_text.c_str(), seed,
+                                   error_msg, man.name.c_str());
+        }
+      }
+    }
+  } catch (const std::exception& e) {
+    set_error(error_msg, std::string("embedded __stanli manifest: ") +
+                             e.what());
+    return nullptr;
+  } catch (...) {
+    set_error(error_msg, "unknown error reading the embedded manifest");
+    return nullptr;
+  }
+
 #ifdef _WIN32
-  (void)data;
   (void)seed;
   set_error(error_msg,
-            "bs_model_construct is not supported on this platform: finding "
-            "the sidecar manifest next to this library needs dladdr");
+            "bs_model_construct without an embedded \"__stanli\" manifest "
+            "is not supported on this platform: finding the sidecar "
+            "manifest next to this library needs dladdr");
   return nullptr;
 #else
   try {

--- a/tests/test_bridgestan.cpp
+++ b/tests/test_bridgestan.cpp
@@ -14,6 +14,8 @@
 // did not implement.
 #include "../runtime/third_party/bridgestan.h"
 
+#include "../runtime/third_party/nlohmann_json.hpp"
+
 #include <stanli/bridgestan_internal.hpp>
 #include <stanli/compile.hpp>
 #include <stanli/executor_pool.hpp>
@@ -604,6 +606,85 @@ void test_manifest() {
     fail("a manifest with no mir was rejected without a message");
 }
 
+// The embedded-manifest transport: the data JSON carries the model under
+// "__stanli". Unlike the sidecar this needs no dlopen, so the full
+// bs_model_construct path is exercised in-process here.
+void test_embedded_manifest() {
+  const std::string mir = slurp("tests/fixtures/conj.tmir.sexp");
+  nlohmann::json root = nlohmann::json::parse(slurp("tests/fixtures/conj.json"));
+  root["__stanli"] = {{"build_id", stanli::bs_build_id()},
+                     {"mir", mir},
+                     {"name", "conj_embedded"}};
+  const std::string data = root.dump();
+
+  char* err = nullptr;
+  bs_model* m = bs_model_construct(data.c_str(), 1234, &err);
+  if (m == nullptr) {
+    fail(std::string("bs_model_construct rejected an embedded manifest: ") +
+         (err != nullptr ? err : "(no message)"));
+    bs_free_error_msg(err);
+    return;
+  }
+  expect_eq_str("embedded name reaches bs_name", bs_name(m), "conj_embedded");
+
+  // The same model through the seam the pair path uses; the key must have
+  // been stripped, so the two see identical data and agree bitwise.
+  bs_model* w =
+      bs_model_from_mir(mir.c_str(), "tests/fixtures/conj.json", 1234, &err);
+  if (w == nullptr) {
+    fail("bs_model_from_mir failed on the reference construction");
+    bs_model_destruct(m);
+    return;
+  }
+  const int n = bs_param_unc_num(m);
+  expect_eq_int("embedded param count", n, bs_param_unc_num(w));
+  std::vector<double> q((size_t)n);
+  for (int i = 0; i < n; ++i) q[(size_t)i] = 0.1 * (double)(i + 1);
+  double lp = 0, want_lp = 0;
+  std::vector<double> g((size_t)n), want_g((size_t)n);
+  expect_eq_int("embedded gradient rc",
+                bs_log_density_gradient(m, true, true, q.data(), &lp, g.data(),
+                                        &err),
+                0);
+  expect_eq_int("reference gradient rc",
+                bs_log_density_gradient(w, true, true, q.data(), &want_lp,
+                                        want_g.data(), &err),
+                0);
+  expect_bitwise("embedded lp", lp, want_lp);
+  for (int i = 0; i < n; ++i)
+    expect_bitwise("embedded grad[" + std::to_string(i) + "]", g[(size_t)i],
+                   want_g[(size_t)i]);
+  bs_model_destruct(w);
+  bs_model_destruct(m);
+
+  // A wrong build id is the sidecar's staleness error, not a fallback:
+  // the MIR dialect moves with the runtime that lowers it.
+  root["__stanli"]["build_id"] = "abi1-deadbeef-Linux-x86_64";
+  err = nullptr;
+  m = bs_model_construct(root.dump().c_str(), 1234, &err);
+  if (m != nullptr) {
+    fail("an embedded manifest from another build was accepted");
+    bs_model_destruct(m);
+  } else if (err == nullptr ||
+             std::string(err).find("abi1-deadbeef") == std::string::npos) {
+    fail(std::string("the embedded staleness message names no build id: ") +
+         (err != nullptr ? err : "(no message)"));
+  }
+  bs_free_error_msg(err);
+
+  // Mentioning the key and getting it wrong is loud, never a silent slide
+  // into the sidecar lookup's "no manifest found".
+  err = nullptr;
+  m = bs_model_construct("{\"__stanli\": 7}", 1234, &err);
+  if (m != nullptr) {
+    fail("a non-object __stanli was accepted");
+    bs_model_destruct(m);
+  } else if (err == nullptr) {
+    fail("a non-object __stanli failed without a message");
+  }
+  bs_free_error_msg(err);
+}
+
 void test_construct_errors() {
   char* err = nullptr;
   // A model that cannot be compiled fails as a null return with a message,
@@ -647,6 +728,7 @@ int main() {
   test_initialize();
   test_print_callback();
   test_manifest();
+  test_embedded_manifest();
   test_construct_errors();
   if (failures == 0) std::printf("test_bridgestan OK\n");
   return failures == 0 ? 0 : 1;

--- a/tests/test_bridgestan.cpp
+++ b/tests/test_bridgestan.cpp
@@ -611,10 +611,11 @@ void test_manifest() {
 // bs_model_construct path is exercised in-process here.
 void test_embedded_manifest() {
   const std::string mir = slurp("tests/fixtures/conj.tmir.sexp");
-  nlohmann::json root = nlohmann::json::parse(slurp("tests/fixtures/conj.json"));
+  nlohmann::json root =
+      nlohmann::json::parse(slurp("tests/fixtures/conj.json"));
   root["__stanli"] = {{"build_id", stanli::bs_build_id()},
-                     {"mir", mir},
-                     {"name", "conj_embedded"}};
+                      {"mir", mir},
+                      {"name", "conj_embedded"}};
   const std::string data = root.dump();
 
   char* err = nullptr;
@@ -642,10 +643,9 @@ void test_embedded_manifest() {
   for (int i = 0; i < n; ++i) q[(size_t)i] = 0.1 * (double)(i + 1);
   double lp = 0, want_lp = 0;
   std::vector<double> g((size_t)n), want_g((size_t)n);
-  expect_eq_int("embedded gradient rc",
-                bs_log_density_gradient(m, true, true, q.data(), &lp, g.data(),
-                                        &err),
-                0);
+  expect_eq_int(
+      "embedded gradient rc",
+      bs_log_density_gradient(m, true, true, q.data(), &lp, g.data(), &err), 0);
   expect_eq_int("reference gradient rc",
                 bs_log_density_gradient(w, true, true, q.data(), &want_lp,
                                         want_g.data(), &err),

--- a/tests/test_bridgestan_embed.py
+++ b/tests/test_bridgestan_embed.py
@@ -1,0 +1,149 @@
+"""The embedded-manifest transport, exercised the way a sampler uses it.
+
+Where the pair test dlopens a per-model copy of the runtime and lets
+bs_model_construct find its sidecar, this test dlopens the ONE runtime
+library directly and hands the model in through the data argument under
+"__stanli". Two different models through the same library handle is the
+property that matters: with the pair transport that aliasing is exactly
+what breaks, and with this one it is the point.
+
+Run against an installed wheel (CI does) or a local build:
+
+    PYTHONPATH=python python3 tests/test_bridgestan_embed.py
+"""
+import ctypes
+import json
+import pathlib
+import sys
+
+import stanli
+
+NORMAL = "parameters { real x; } model { x ~ normal(0, 1); }"
+DATED = """
+data { int<lower=0> N; vector[N] y; }
+parameters { real theta; }
+model { theta ~ normal(0, 1); y ~ normal(theta, 1); }
+"""
+
+failures = []
+
+
+def check(what, ok):
+    if not ok:
+        failures.append(what)
+        print(f"FAIL {what}")
+
+
+def bind(lib):
+    lib.bs_model_construct.restype = ctypes.c_void_p
+    lib.bs_model_construct.argtypes = [ctypes.c_char_p, ctypes.c_uint,
+                                       ctypes.POINTER(ctypes.c_char_p)]
+    lib.bs_model_destruct.argtypes = [ctypes.c_void_p]
+    lib.bs_name.restype = ctypes.c_char_p
+    lib.bs_name.argtypes = [ctypes.c_void_p]
+    lib.bs_param_unc_num.restype = ctypes.c_int
+    lib.bs_param_unc_num.argtypes = [ctypes.c_void_p]
+    lib.bs_log_density.restype = ctypes.c_int
+    lib.bs_log_density.argtypes = [ctypes.c_void_p, ctypes.c_bool,
+                                   ctypes.c_bool,
+                                   ctypes.POINTER(ctypes.c_double),
+                                   ctypes.POINTER(ctypes.c_double),
+                                   ctypes.POINTER(ctypes.c_char_p)]
+    lib.bs_free_error_msg.argtypes = [ctypes.c_char_p]
+    return lib
+
+
+def embed(stan_code, name, data=None):
+    payload = dict(data or {})
+    payload["__stanli"] = {"build_id": stanli.build_id(),
+                          "mir": stanli.stan_to_mir(stan_code),
+                          "name": name}
+    return json.dumps(payload)
+
+
+def construct(lib, data):
+    err = ctypes.c_char_p()
+    m = lib.bs_model_construct(data.encode(), 1234, ctypes.byref(err))
+    return m, (err.value.decode() if err.value else None)
+
+
+def log_density(lib, m, q):
+    arr = (ctypes.c_double * len(q))(*q)
+    val = ctypes.c_double()
+    err = ctypes.c_char_p()
+    rc = lib.bs_log_density(m, True, True, arr, ctypes.byref(val),
+                            ctypes.byref(err))
+    if rc != 0:
+        raise RuntimeError(err.value.decode() if err.value else "(no message)")
+    return val.value
+
+
+def test_two_models_through_one_library():
+    lib = bind(ctypes.CDLL(str(stanli._runtime_lib_path())))
+    ma, err = construct(lib, embed(NORMAL, "n"))
+    check(f"the data-free model constructs ({err})", ma)
+    mb, err = construct(lib, embed(DATED, "d", {"N": 3, "y": [0.1, 0.2, 0.3]}))
+    check(f"the model with data constructs ({err})", mb)
+    if not (ma and mb):
+        return
+    check("each model keeps its own name",
+          lib.bs_name(ma) == b"n" and lib.bs_name(mb) == b"d")
+    check("each model keeps its own parameters",
+          lib.bs_param_unc_num(ma) == 1 and lib.bs_param_unc_num(mb) == 1)
+    # Two evaluations at the same point must give each model's OWN density.
+    la, lb = log_density(lib, ma, [0.5]), log_density(lib, mb, [0.5])
+    check("the two models disagree at a shared point", la != lb)
+    # And the values themselves, against stanli's front door.
+    want_a = stanli.Model(stan_code=NORMAL).log_prob_grad([0.5])[0]
+    want_b = stanli.Model(stan_code=DATED,
+                          data={"N": 3, "y": [0.1, 0.2, 0.3]
+                                }).log_prob_grad([0.5])[0]
+    check("data-free density matches stanli.Model", la == want_a)
+    check("with-data density matches stanli.Model", lb == want_b)
+    lib.bs_model_destruct(ma)
+    lib.bs_model_destruct(mb)
+
+
+def test_wrong_build_is_loud():
+    lib = bind(ctypes.CDLL(str(stanli._runtime_lib_path())))
+    payload = json.loads(embed(NORMAL, "n"))
+    payload["__stanli"]["build_id"] = "abi1-deadbeef-Linux-x86_64"
+    m, err = construct(lib, json.dumps(payload))
+    check("a stale embedded manifest is refused", not m)
+    check("the refusal names the build mismatch",
+          err is not None and "abi1-deadbeef" in err)
+    if m:
+        lib.bs_model_destruct(m)
+
+
+def test_bridgestan_model_sugar():
+    try:
+        import bridgestan  # noqa: F401
+    except ImportError:
+        print("skip: bridgestan not installed, sugar not exercised")
+        return
+    model = stanli.bridgestan_model(stan_code=DATED, name="d",
+                                    data={"N": 3, "y": [0.1, 0.2, 0.3]})
+    check("bridgestan_model names the model", model.name() == "d")
+    want = stanli.Model(stan_code=DATED,
+                        data={"N": 3, "y": [0.1, 0.2, 0.3]
+                              }).log_prob_grad([0.5])[0]
+    import numpy as np
+    check("bridgestan_model density matches stanli.Model",
+          model.log_density(np.array([0.5]), propto=True,
+                            jacobian=True) == want)
+
+
+def main():
+    test_two_models_through_one_library()
+    test_wrong_build_is_loud()
+    test_bridgestan_model_sugar()
+    if failures:
+        print(f"{len(failures)} failures")
+        return 1
+    print("test_bridgestan_embed OK")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
A second transport for the model manifest, alongside the lib pair. Design notes in docs/superpowers/specs/2026-08-11-embedded-mir-data.md; summary below.

## Usage (tested: samples and recovers the analytic posterior)

```python
import stanli
from walnutpie import walnuts_stan

model = stanli.bridgestan_model(
    stan_file="model.stan",
    data={"N": 10, "y": [0.1] * 10})
chains = walnuts_stan(model=model, num_chains=4, seed=42)
print(chains[0]["theta"].mean())
```

Where the model and data actually travel, line by line:

**Stored:**
- `bridgestan_model(...)` compiles `model.stan` to MIR in-process, then splices `{"build_id", "mir", "name"}` into your data dict under the reserved key (`python/stanli/__init__.py:297`) and serializes the whole thing to one JSON string (`:302`). Nothing is written to disk at any point; there is no pair, no cache directory.
- That string is handed to `bridgestan.StanModel` as its `data` argument, against the runtime library already inside the stanli package (`_bin/libstanli.*`). One caveat worth knowing: bridgestan keeps the argument alive as `model.data` for the life of the Python object (its `model.py`, `self.data = data or ""`), so the MIR text persists in process memory there. That is the concrete instance of the con listed below: the data argument stops being just the data, and clients may retain it.
- After construction the MIR string itself is not retained on the C++ side; `bs_model_from_mir` lowers it into the compiled graph and the text is gone.

**Read:**
- `bs_model_construct` resolves the data text (literal, or the contents of a `.json` path) and scans for the marker (`runtime/src/bridgestan_abi.cpp:469`).
- The sub-object is validated by `bs_read_manifest` (`:474`), the same function that reads sidecar files, including the `build_id` staleness check.
- The key is stripped (`:479`) and the remainder becomes the model's data for lowering (`:481`), so the model sees exactly the `{"N": ..., "y": ...}` you passed.

## How it works

The data JSON may carry the manifest under one reserved key:

```json
{
  "__stanli": {"build_id": "...", "mir": "...", "name": "eight_schools"},
  "J": 8,
  "y": [28, 8, -3, 7, -1, 1, 18, 12]
}
```

`bs_model_construct` resolves the data text (literal or `.json` path, same rule as `load_data`), and if it mentions the key, validates the sub-object with `bs_read_manifest`, the same function that reads sidecars, so there is one manifest format with two transports. The key is stripped and the remainder becomes the model's data. No key, and the sidecar lookup runs unchanged. The key can never collide with a data variable: Stan identifiers begin with a letter.

Mentioning the key and getting it wrong (bad JSON, wrong `build_id`, non-object) fails loudly, naming the embedded manifest. Falling back to the sidecar would bury a typo under "no sidecar found".

`stanli.bridgestan_model(...)` is the Python sugar the facade design doc sketched: compile, splice, return a `bridgestan.StanModel` bound to the runtime library itself. `bridgestan` stays a lazy import, not a dependency.

## What it provides

- Zero copies: every model shares the wheel's one runtime library. Per-model cost drops from a ~29 MB pair to the MIR text riding in the construct call.
- No dlopen aliasing: model identity moves from "which file did dlopen open" to construct time, so one library serving many models is the point rather than the hazard.
- `bs_model_construct` on Windows, for callers that embed: the sidecar's `dladdr` lookup was the reason for the platform refusal.
- In-process testability: the sidecar only works under a real dlopen, which is why the pair test lives in Python; the embedded path tests in the C++ suite.

## What it requires

- A cooperating caller to do the splice: `bridgestan_model` for Python, a few equivalent lines for other languages. Path-only clients (walnutpie's `stan_cli`, the R and Julia packages) cannot use it, which is why the pair transport remains.
- Inlined data: path-form data is read and re-serialized to splice the key in. The C ABI itself still accepts a `.json` path whose contents embed the key.
- The same `build_id` discipline as the sidecar: the MIR dialect and the lowering that reads it move together.

## Pros and cons vs the pair

Pro: no copy, no cache directory, no inode trick, works on Windows, testable in-process, and no staleness window between writing a pair and loading it. Con: invisible to path-only clients, needs a per-language shim, and the data argument stops being "just the data": a multi-hundred-KB string flows through an argument clients may log or store (bridgestan's `StanModel.data` retention above is the live example), and tooling that round-trips data must preserve a key it does not understand.

The transports compose rather than compete: embedded when the key is present, sidecar otherwise.

## Testing

- `test_bridgestan.cpp`: embedded construct agrees bitwise (lp and gradient) with `bs_model_from_mir` on the conj fixture; name propagation; wrong `build_id` refused naming both ids; non-object `__stanli` refused with a message.
- `tests/test_bridgestan_embed.py` (wired into the wheel CI next to the pair test): two different models through one dlopen'd runtime library, densities matching `stanli.Model`; stale-build refusal; the `bridgestan_model` sugar when `bridgestan` is installed.
- Full ctest suite green (43/43); the usage snippet above run verbatim, plus a 4-chain `walnuts_stan` run recovering the analytic posterior, with no pair written.