### PR TITLE
fix: preserve raw order for nested scalar arrays

### DIFF
--- a/runtime/src/lower.cpp
+++ b/runtime/src/lower.cpp
@@ -2651,23 +2651,6 @@ struct Lowering {
     if (tr.kind == mir::Transform::Identity) {
       Val value{raw, psi};
       CompiledModel::ParamView serial_view = parameter_view(s, raw, raw_len);
-      const bool nested_scalar = is_array(psi) &&
-                                 array_shape(psi).leaf == ViewKind::Flat &&
-                                 array_shape(psi).dims.size() > 1;
-      if (nested_scalar && !serial_view.storage_order.empty()) {
-        // FnReadParam exposes a nested scalar array first-index-fast. Arrays
-        // of Eigen containers already arrive outer-major with their leaf's
-        // native storage, as the constrained-layout/amatwa contract pins.
-        // Invert the established serialization map only at this scalar-array
-        // boundary; the raw slot remains the sampler input and still owns
-        // unconstrained accounting.
-        std::vector<int> gather((size_t)raw_len);
-        for (int64_t serial = 0; serial < raw_len; ++serial)
-          gather[(size_t)serial_view.storage_index(serial)] = (int)serial;
-        Val serial{raw, {}};  // physical boundary, not a logical graph value
-        value =
-            emit_value(OP_GATHER, {serial}, con_len, psi, std::move(gather));
-      }
       scope[s.decl_id] = value;
       // In write_array mode the column order is dictated by the FnWriteParam
       // statements, which come later and cover transformed parameters and

--- a/tests/fixtures/view_udf_shadow.stan
+++ b/tests/fixtures/view_udf_shadow.stan
@@ -9,5 +9,5 @@ parameters {
 }
 model {
   target += passthrough(z[1, 1]);
-  target += z[1, 2];
+  target += z[2, 1];
 }

--- a/tests/fixtures/view_udf_shadow.tmir.sexp
+++ b/tests/fixtures/view_udf_shadow.tmir.sexp
@@ -79,10 +79,10 @@
               (meta
                ((type_ (UArray (UArray UReal))) (loc <opaque>) (adlevel AutoDiffable))))
              ((Single
-               ((pattern (Lit Int 1))
+               ((pattern (Lit Int 2))
                 (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
               (Single
-               ((pattern (Lit Int 2))
+               ((pattern (Lit Int 1))
                 (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
            (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
         (meta <opaque>)))))
@@ -140,10 +140,10 @@
               (meta
                ((type_ (UArray (UArray UReal))) (loc <opaque>) (adlevel AutoDiffable))))
              ((Single
-               ((pattern (Lit Int 1))
+               ((pattern (Lit Int 2))
                 (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
               (Single
-               ((pattern (Lit Int 2))
+               ((pattern (Lit Int 1))
                 (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
            (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
         (meta <opaque>)))))

--- a/tests/test_bridgestan.cpp
+++ b/tests/test_bridgestan.cpp
@@ -249,6 +249,48 @@ void test_unc_names() {
   bs_model_destruct(s);
 }
 
+// Generated Stan deserializes array[2,3] real outer-first from q. Its CSV
+// surface is a separate contract: the first logical index is written fastest.
+// Literal expectations keep this test independent of stanli's Executor and
+// ParamView implementations.
+void test_nested_scalar_array_order() {
+  const std::string mir = slurp("tests/fixtures/viewa_scalar_column.tmir.sexp");
+  char* err = nullptr;
+  bs_model* m = bs_model_from_mir(mir.c_str(), "{}", 1, &err);
+  if (m == nullptr) {
+    fail(std::string("nested scalar array construct: ") +
+         (err ? err : "(no message)"));
+    bs_free_error_msg(err);
+    return;
+  }
+
+  expect_eq_int("nested scalar bs_param_unc_num", bs_param_unc_num(m), 6);
+  expect_eq_str("nested scalar bs_param_names", bs_param_names(m, false, false),
+                "a.1.1,a.2.1,a.1.2,a.2.2,a.1.3,a.2.3");
+
+  const double q[6] = {1, 2, 3, 4, 5, 6};
+  const double want_grad[6] = {0, 10, 0, 0, 1, 0};
+  double lp = 0;
+  double grad[6] = {};
+  expect_eq_int("nested scalar gradient rc",
+                bs_log_density_gradient(m, true, true, q, &lp, grad, &err), 0);
+  expect_bitwise("nested scalar lp", lp, 225);
+  for (int i = 0; i < 6; ++i)
+    expect_bitwise("nested scalar grad[" + std::to_string(i) + "]", grad[i],
+                   want_grad[i]);
+
+  double constrained[6] = {};
+  const double want_constrained[6] = {1, 4, 2, 5, 3, 6};
+  expect_eq_int(
+      "nested scalar constrain rc",
+      bs_param_constrain(m, false, false, q, constrained, nullptr, &err), 0);
+  for (int i = 0; i < 6; ++i)
+    expect_bitwise("nested scalar constrained[" + std::to_string(i) + "]",
+                   constrained[i], want_constrained[i]);
+
+  bs_model_destruct(m);
+}
+
 // The graph write_array path, checked against the same graph run directly.
 void test_constrain_graph() {
   using namespace stanli;
@@ -722,6 +764,7 @@ int main() {
   test_density_matches_executor();
   test_param_num_and_names();
   test_unc_names();
+  test_nested_scalar_array_order();
   test_constrain_graph();
   test_constrain_interp();
   test_unsupported();

--- a/tests/test_capi.cpp
+++ b/tests/test_capi.cpp
@@ -99,6 +99,13 @@ int main() {
       {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11},
       {0, 6, 1, 7, 2, 8, 3, 9, 4, 10, 5, 11});
 
+  // Generated Stan reads nested scalar arrays outer-first from q, while
+  // constrained output is first-index-fast. The two orders are deliberately
+  // different for this non-square declaration.
+  expect_names("tests/fixtures/viewa_scalar_column.tmir.sexp", "{}",
+               {"a.1.1", "a.2.1", "a.1.2", "a.2.2", "a.1.3", "a.2.3"},
+               {1, 2, 3, 4, 5, 6}, {1, 4, 2, 5, 3, 6});
+
   if (failures == 0) std::printf("test_capi OK\n");
   return failures == 0 ? 0 : 1;
 }

--- a/tests/test_lower_array_contract.cpp
+++ b/tests/test_lower_array_contract.cpp
@@ -92,7 +92,7 @@ void test_outer_gather() {
 
 void test_scalar_array_column() {
   check_gradient("tests/fixtures/viewa_scalar_column.tmir.sexp", {},
-                 {1, 2, 3, 4, 5, 6}, 234, {0, 0, 10, 1, 0, 0},
+                 {1, 2, 3, 4, 5, 6}, 225, {0, 10, 0, 0, 1, 0},
                  "array[2,3] column a[:,2]");
 }
 

--- a/tests/test_lower_views.cpp
+++ b/tests/test_lower_views.cpp
@@ -202,7 +202,7 @@ void test_udf_name_shadowing() {
     for (int i = 0; i < 4; ++i) ex.params_data()[i] = q[i];
     double grad[4] = {0, 0, 0, 0};
     const double lp = ex.gradient(grad);
-    // CmdStan reads array[2,2] with the first index fastest, so z[1,2] is
+    // Generated Stan reads nested scalar arrays outer-first, so z[2,1] is
     // q[2]. A leaked matrix view from the callee would instead select q[1].
     const double want_grad[4] = {1, 0, 1, 0};
     expect_eq("UDF shadow lp", lp, 1.0);


### PR DESCRIPTION
## Summary

- keep nested scalar-array sampler input in generated Stan outer-major order
- retain first-logical-index-fast constrained names and serialization at ParamView boundaries
- replace the old self-oracle with literal CmdStan and Reference BridgeStan expectations across Executor, C API, and BridgeStan
- preserve the lexical UDF view-shadow test under the corrected raw-order contract

## Scope

- production: 0 added, 17 removed
- handwritten tests and Stan fixture: 53 added, 3 removed
- generated MIR: one marked-generated fixture, 4 index substitutions

## Verification

- red phase: lower-array, C API, and BridgeStan tests failed on the old gather with lp 234 versus 225 and the corresponding gradient/value permutations
- Reference BridgeStan conformance: 15 comparisons, worst 0 relative, 0 ULP
- tools/format.sh --check
- RelWithDebInfo configure and full build
- CTest: 43/43
- CmdStan references: 129/129 within 1e-9; worst 3.63e-12
- write-array corpus: 119/119 complete
- pass A/B corpus: no flags; worst 3.46e-13

Independent pre-merge review found no critical, important, or minor findings.