### PR TITLE
Publish npm from the same v* release tag

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -663,12 +663,18 @@ jobs:
       - id: deployment
         uses: actions/deploy-pages@v4
 
-  # npm, tag-gated like PyPI: npm-v* tags publish js/ through npm
-  # trusted publishing (OIDC, no token in secrets). The tag must agree
-  # with js/package.json, and the artifacts are the same ones the wasm
-  # job and the stancjs cache produced for this exact commit.
+  # npm, tag-gated like PyPI. A release tag v* publishes every channel
+  # at once (PyPI, the runtime release, npm); versions move in lockstep,
+  # and both publish jobs assert their manifest agrees with the tag.
+  # npm-v* remains as an npm-only republish hatch for when npm alone
+  # fails on a release that already went out everywhere else. Publishing
+  # goes through npm trusted publishing (OIDC, no token in secrets), and
+  # the artifacts are the same ones the wasm job and the stancjs cache
+  # produced for this exact commit.
   npm-publish:
-    if: startsWith(github.ref, 'refs/tags/npm-v')
+    if: >-
+      startsWith(github.ref, 'refs/tags/v') ||
+      startsWith(github.ref, 'refs/tags/npm-v')
     needs: wasm
     runs-on: ubuntu-latest
     environment: npm
@@ -714,7 +720,8 @@ jobs:
 
       - name: Tag matches the packaged version
         run: |
-          tag="${GITHUB_REF_NAME#npm-v}"
+          tag="${GITHUB_REF_NAME#npm-}"
+          tag="${tag#v}"
           pkg=$(python3 -c "import json; print(json.load(open('js/package.json'))['version'])")
           echo "tag $tag, package.json $pkg"
           [ "$tag" = "$pkg" ]
@@ -834,7 +841,9 @@ jobs:
           ls -la dist/
 
       # stanli/__init__.py holds the version; the tag has to agree with it,
-      # or a mistyped tag silently publishes the wrong number.
+      # or a mistyped tag silently publishes the wrong number. The npm
+      # package rides the same tag now, so js/package.json has to agree
+      # too, or the release goes out with the channels disagreeing.
       - name: Tag matches the packaged version
         run: |
           tag="${GITHUB_REF_NAME#v}"
@@ -844,8 +853,10 @@ jobs:
           print(re.search(r'^__version__ = "([^"]+)"', src, re.M).group(1))
           PY
           )
-          echo "tag $tag, package $pkg"
+          npmpkg=$(python3 -c "import json; print(json.load(open('js/package.json'))['version'])")
+          echo "tag $tag, package $pkg, package.json $npmpkg"
           [ "$tag" = "$pkg" ]
+          [ "$tag" = "$npmpkg" ]
           ls dist/ | grep -q "stanli-$pkg-py3-none-" ||
             { echo "no wheel named for version $pkg"; exit 1; }
 

--- a/README.md
+++ b/README.md
@@ -276,12 +276,15 @@ publish job waits for them. Each build links the cached embedded stanc3
 object, runs the test suite, checks the platform tag, and samples eight
 schools from the installed wheel in a clean venv.
 
-To cut a release: bump `__version__` in `python/stanli/__init__.py` (the
-one place it lives), add a `CHANGELOG.md` entry, then tag. The publish
-job fires only on `refs/tags/v*`, asserts the tag matches the packaged
-version, and uploads through PyPI trusted publishing; no API token
-exists anywhere in the repo. The `pypi` deployment environment is
-restricted to `v*` tags as a second lock.
+To cut a release: bump the version in `python/stanli/__init__.py`,
+`js/package.json`, `r/DESCRIPTION`, and `r/R/install.R` (they move in
+lockstep), add a `CHANGELOG.md` entry, then tag. One `v*` tag publishes
+every channel: PyPI, npm, and the GitHub runtime release the R package
+installs from. The publish jobs assert the tag matches each manifest,
+so a forgotten bump fails the release rather than shipping channels
+that disagree. Uploads go through PyPI and npm trusted publishing; no
+API token exists anywhere in the repo. The `pypi` and `npm` deployment
+environments are restricted to release tags as a second lock.
 
 ```
 git tag -a v0.1.0 -m "stanli 0.1.0" && git push origin v0.1.0
@@ -291,11 +294,10 @@ No sdist is published: building from source needs a 30-minute OCaml
 toolchain step, so an sdist would only turn "no wheel for your platform"
 into a confusing build failure.
 
-The npm package `@seantalts/stanli` ships the same way on its own tag
-series: bump `version` in `js/package.json`, add the changelog entry,
-tag `npm-vX.Y.Z`. The `npm-publish` job asserts the tag matches
-`package.json` and publishes through npm trusted publishing. Three npm
-quirks worth knowing. A trusted publisher attaches only to a package
+The npm package `@seantalts/stanli` rides the same `v*` tag. An
+`npm-vX.Y.Z` tag still works as an npm-only republish hatch for when
+npm alone fails on a release that already went out everywhere else.
+Three npm quirks worth knowing. A trusted publisher attaches only to a package
 that already exists, so a package's first version goes out by hand with
 `npm publish`, and the publisher itself is configured on npmjs.com
 (Settings -> Trusted publisher: GitHub Actions, `seantalts` / `stanli` /

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@seantalts/stanli",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Full Stan in the browser: stanc3 compiles the model in JS, a WASM runtime lowers it to an op graph and runs NUTS. No server, no C++ toolchain.",
   "type": "module",
   "main": "index.mjs",


### PR DESCRIPTION
One `v*` tag now publishes every channel: PyPI, npm, and the runtime release the R package installs from. Versions move in lockstep across `python/stanli/__init__.py`, `js/package.json`, `r/DESCRIPTION`, and `r/R/install.R`; the PyPI publish job now also asserts `js/package.json` agrees with the tag, so a forgotten bump fails the release instead of shipping channels that disagree.

`npm-v*` tags remain as an npm-only republish hatch (the npm-v0.5.1 kind of failure). The `npm` deployment environment on GitHub now allows `v*` tags as well.

Bumps `js/package.json` to 0.6.1; after merge, an `npm-v0.6.1` tag ships npm the release that is already out on PyPI.