### PR TITLE
fix: refuse effectful necessity islands

### DIFF
--- a/runtime/include/stanli/mir_prog.hpp
+++ b/runtime/include/stanli/mir_prog.hpp
@@ -60,13 +60,6 @@ struct Bail {
   std::string why;
 };
 
-// Non-returning calls carry effects that a numeric register program cannot
-// erase. ODE compilation has a real MIR-interpreter fallback and therefore
-// refuses them. Parameter-dependent necessity islands do not yet have that
-// fallback; their legacy behavior stays named and isolated rather than being
-// mistaken for a generally safe policy.
-enum class NRFunAppPolicy { Refuse, LegacyIgnoreNecessityIsland };
-
 struct ProgramCompiler {
   Program& p;
   const std::map<std::string, const mir::FunDef*>& funs;
@@ -74,7 +67,6 @@ struct ProgramCompiler {
   std::map<std::string, std::vector<long>> ints;
   int branch_depth = 0;  // inside a branch on a runtime value
   int inline_depth = 0;
-  NRFunAppPolicy nrfunapp_policy = NRFunAppPolicy::Refuse;
   // A name that is neither a local nor a compile-time integer. The ODE
   // caller leaves this empty (its arguments are all bound up front);
   // lowering installs a hook that allocates registers for the graph slot
@@ -676,10 +668,8 @@ struct ProgramCompiler {
         return;
       }
       case mir::Stmt::NRFunApp:
-        if (nrfunapp_policy == NRFunAppPolicy::Refuse)
-          bail("statement function " + s.fn_name +
-               " requires the MIR interpreter");
-        return;
+        bail("statement function " + s.fn_name +
+             " requires the MIR interpreter");
       case mir::Stmt::Skip:
         return;
       default:

--- a/runtime/src/lower.cpp
+++ b/runtime/src/lower.cpp
@@ -957,12 +957,9 @@ struct Lowering {
                     Range* expr_out, std::shared_ptr<IslandProg>* prog_out) {
     auto prog = std::make_shared<IslandProg>();
     ProgramCompiler c{*prog, fun_defs};
-    // Necessity islands have no structured-MIR fallback yet. Keep their
-    // existing effect bug explicit at this sole call site; every other
-    // ProgramCompiler caller refuses NRFunApp by default instead of erasing
-    // it. The policy remains a correctness blocker until the island can
-    // execute effects exactly once outside its var replay.
-    c.nrfunapp_policy = NRFunAppPolicy::LegacyIgnoreNecessityIsland;
+    // Non-returning statement calls may print or reject. A register program
+    // would replay them during reverse mode, so ProgramCompiler refuses them
+    // until necessity islands have an execute-once effect path.
     for (const auto& [name, v] : int_env) c.ints[name] = {v};
     c.bind_extern = [&](const std::string& name, Range* r) {
       auto sc = scope.find(name);

--- a/tests/fixtures/necessity_effects.stan
+++ b/tests/fixtures/necessity_effects.stan
@@ -1,0 +1,26 @@
+// Parameter-dependent branches with a numeric live-out and an effect.
+// Without the target increment, lowering already refuses the region for
+// producing nothing; the live-out is what exposed the legacy silent erasure.
+data {
+  int<lower=1, upper=2> mode;
+}
+parameters {
+  real x;
+}
+model {
+  if (mode == 1) {
+    if (x > 0) {
+      print("positive x=", x);
+      target += x;
+    } else {
+      target += x;
+    }
+  } else {
+    if (x < 0) {
+      target += x;
+      reject("negative x=", x);
+    } else {
+      target += x;
+    }
+  }
+}

--- a/tests/fixtures/necessity_effects.tmir.sexp
+++ b/tests/fixtures/necessity_effects.tmir.sexp
@@ -1,0 +1,331 @@
+((functions_block ()) (input_vars ((mode <opaque> SInt)))
+ (prepare_data
+  (((pattern
+     (Decl (decl_adtype DataOnly) (decl_id mode) (decl_type (Sized SInt))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable mode) ()) UInt
+      ((pattern
+        (Indexed
+         ((pattern
+           (FunApp (CompilerInternal FnReadData)
+            (((pattern (Lit Str mode))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+          (meta ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly))))
+         ((Single
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnCheck
+        (trans
+         (Lower
+          ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (var_name mode)
+        (var
+         ((pattern (Var mode)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnCheck
+        (trans
+         (Upper
+          ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (var_name mode)
+        (var
+         ((pattern (Var mode)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+    (meta <opaque>))))
+ (log_prob
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id x) (decl_type (Sized SReal))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity) (dims ()) (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (IfElse
+          ((pattern
+            (FunApp (StanLib Equals__ FnPlain AoS)
+             (((pattern (Var mode))
+               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+              ((pattern (Lit Int 1))
+               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+          ((pattern
+            (Block
+             (((pattern
+                (IfElse
+                 ((pattern
+                   (FunApp (StanLib Greater__ FnPlain AoS)
+                    (((pattern (Var x))
+                      (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+                     ((pattern (Lit Int 0))
+                      (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel AutoDiffable))))
+                 ((pattern
+                   (Block
+                    (((pattern
+                       (NRFunApp (CompilerInternal FnPrint)
+                        (((pattern (Lit Str "positive x="))
+                          (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+                         ((pattern (Var x))
+                          (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
+                      (meta <opaque>))
+                     ((pattern
+                       (TargetPE
+                        ((pattern (Var x))
+                         (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+                      (meta <opaque>)))))
+                  (meta <opaque>))
+                 (((pattern
+                    (Block
+                     (((pattern
+                        (TargetPE
+                         ((pattern (Var x))
+                          (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+                       (meta <opaque>)))))
+                   (meta <opaque>)))))
+               (meta <opaque>)))))
+           (meta <opaque>))
+          (((pattern
+             (Block
+              (((pattern
+                 (IfElse
+                  ((pattern
+                    (FunApp (StanLib Less__ FnPlain AoS)
+                     (((pattern (Var x))
+                       (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+                      ((pattern (Lit Int 0))
+                       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                   (meta ((type_ UInt) (loc <opaque>) (adlevel AutoDiffable))))
+                  ((pattern
+                    (Block
+                     (((pattern
+                        (TargetPE
+                         ((pattern (Var x))
+                          (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+                       (meta <opaque>))
+                      ((pattern
+                        (NRFunApp (CompilerInternal FnReject)
+                         (((pattern (Lit Str "negative x="))
+                           (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+                          ((pattern (Var x))
+                           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
+                       (meta <opaque>)))))
+                   (meta <opaque>))
+                  (((pattern
+                     (Block
+                      (((pattern
+                         (TargetPE
+                          ((pattern (Var x))
+                           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+                        (meta <opaque>)))))
+                    (meta <opaque>)))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))))
+ (reverse_mode_log_prob
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id x) (decl_type (Sized SReal))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity) (dims ()) (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (IfElse
+          ((pattern
+            (FunApp (StanLib Equals__ FnPlain AoS)
+             (((pattern (Var mode))
+               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+              ((pattern (Lit Int 1))
+               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+          ((pattern
+            (Block
+             (((pattern
+                (IfElse
+                 ((pattern
+                   (FunApp (StanLib Greater__ FnPlain AoS)
+                    (((pattern (Var x))
+                      (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+                     ((pattern (Lit Int 0))
+                      (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel AutoDiffable))))
+                 ((pattern
+                   (Block
+                    (((pattern
+                       (NRFunApp (CompilerInternal FnPrint)
+                        (((pattern (Lit Str "positive x="))
+                          (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+                         ((pattern (Var x))
+                          (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
+                      (meta <opaque>))
+                     ((pattern
+                       (TargetPE
+                        ((pattern (Var x))
+                         (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+                      (meta <opaque>)))))
+                  (meta <opaque>))
+                 (((pattern
+                    (Block
+                     (((pattern
+                        (TargetPE
+                         ((pattern (Var x))
+                          (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+                       (meta <opaque>)))))
+                   (meta <opaque>)))))
+               (meta <opaque>)))))
+           (meta <opaque>))
+          (((pattern
+             (Block
+              (((pattern
+                 (IfElse
+                  ((pattern
+                    (FunApp (StanLib Less__ FnPlain AoS)
+                     (((pattern (Var x))
+                       (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+                      ((pattern (Lit Int 0))
+                       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                   (meta ((type_ UInt) (loc <opaque>) (adlevel AutoDiffable))))
+                  ((pattern
+                    (Block
+                     (((pattern
+                        (TargetPE
+                         ((pattern (Var x))
+                          (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+                       (meta <opaque>))
+                      ((pattern
+                        (NRFunApp (CompilerInternal FnReject)
+                         (((pattern (Lit Str "negative x="))
+                           (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+                          ((pattern (Var x))
+                           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
+                       (meta <opaque>)))))
+                   (meta <opaque>))
+                  (((pattern
+                     (Block
+                      (((pattern
+                         (TargetPE
+                          ((pattern (Var x))
+                           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+                        (meta <opaque>)))))
+                    (meta <opaque>)))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))))
+ (generate_quantities
+  (((pattern
+     (Decl (decl_adtype DataOnly) (decl_id x) (decl_type (Sized SReal))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity) (dims ()) (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt ())
+        (var
+         ((pattern (Var x)) (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (IfElse
+      ((pattern
+        (FunApp (StanLib PNot__ FnPlain AoS)
+         (((pattern
+            (EOr
+             ((pattern (Var emit_transformed_parameters__))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+             ((pattern (Var emit_generated_quantities__))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+      ((pattern (Block (((pattern (Return ())) (meta <opaque>))))) (meta <opaque>)) ()))
+    (meta <opaque>))
+   ((pattern
+     (IfElse
+      ((pattern
+        (FunApp (StanLib PNot__ FnPlain AoS)
+         (((pattern (Var emit_generated_quantities__))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+      ((pattern (Block (((pattern (Return ())) (meta <opaque>))))) (meta <opaque>)) ()))
+    (meta <opaque>))))
+ (transform_inits
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id x) (decl_type (Sized SReal))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable x) ()) UReal
+      ((pattern
+        (Indexed
+         ((pattern
+           (FunApp (CompilerInternal FnReadData)
+            (((pattern (Lit Str x))
+              (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+          (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))
+         ((Single
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+       (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var x)) (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))))
+ (unconstrain_array
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id x) (decl_type (Sized SReal))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable x) ()) UReal
+      ((pattern (FunApp (CompilerInternal FnReadDeserializer) ()))
+       (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var x)) (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))))
+ (output_vars
+  ((x <opaque>
+    ((out_unconstrained_st SReal) (out_constrained_st SReal) (out_block Parameters)
+     (out_trans Identity)))))
+ (prog_name necessity_effects_model) (prog_path tests/fixtures/necessity_effects.stan))

--- a/tests/test_rejectprint.cpp
+++ b/tests/test_rejectprint.cpp
@@ -169,6 +169,42 @@ int main() {
              lines[0] == "before scalar=0.1");
   }
 
+  // ---- parameter-dependent effects fail loud ---------------------------
+  // Generated Stan executes the taken print/reject once while evaluating
+  // the model. Necessity islands replay their register program for reverse
+  // mode, so they cannot preserve that contract yet. Refusal is the honest
+  // boundary: silently dropping either effect changes observable behavior,
+  // and dropping reject changes the posterior support.
+  {
+    const std::string effect_mir =
+        slurp("tests/fixtures/necessity_effects.tmir.sexp");
+    for (int mode = 1; mode <= 2; ++mode) {
+      std::vector<std::string> lines;
+      set_message_sink([&lines](const char* text, size_t len) {
+        lines.emplace_back(text, len);
+      });
+      bool threw = false;
+      std::string msg;
+      try {
+        DataMap d;
+        d.set_int("mode", mode);
+        (void)compile_model(effect_mir, d);
+      } catch (const CompileError& e) {
+        threw = true;
+        msg = e.what();
+      }
+      set_message_sink(nullptr);
+
+      const std::string effect = mode == 1 ? "FnPrint" : "FnReject";
+      const std::string tag = "necessity " + effect;
+      expect(tag + " refuses compilation", threw);
+      expect(tag + " names the unsupported effect: " + msg,
+             msg.find("parameter-dependent region") != std::string::npos &&
+                 msg.find(effect) != std::string::npos);
+      expect(tag + " is not executed while refusing", lines.empty());
+    }
+  }
+
   if (failures == 0) std::printf("test_rejectprint: all checks passed\n");
   return failures == 0 ? 0 : 1;
 }


### PR DESCRIPTION
## Summary

- stop parameter-dependent necessity islands from silently erasing non-returning statement calls such as print and reject
- remove the legacy ignore policy from the shared register-program compiler; ODE keeps its existing MIR-interpreter fallback
- fail model compilation with the exact unsupported effect until necessity islands have an execute-once effect path outside reverse replay

This closes a support-changing divergence: a reject beside a live target update previously compiled away and admitted points that generated Stan rejects.

## Characterization

A generated Stan fixture selects two parameter-dependent branches through data:

- mode 1: print plus target update
- mode 2: reject plus target update

Before the production edit both modes compiled successfully and produced no refusal message. The test now requires a named FnPrint/FnReject compile refusal and verifies that no effect runs while refusing.

## Verification

- tools/format.sh --check
- RelWithDebInfo configure and full build
- CTest: 44/44 passed
- posterior references: 129/129 within 1e-9; worst 3.63e-12
- write-array corpus: 119/119 compiling models complete
- A/B corpus: no flags; worst deviation 3.46e-13
- focused register-program conformance and ODE fallback tests passed
- generated transformed MIR regenerated byte-for-byte with the pinned stanc compiler

## Size and scope

- production: +5/-18, 23 changed lines, net -13
- handwritten characterization: 62 added lines
- generated fixture: 331 MIR lines, committed as generated output
- C++17 remains unchanged
