### PR TITLE
Name the default sampler "Stan-dard Dynamic HMC"; install R from GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,12 +21,12 @@ different binding, so a model samples to the same draws from any of them.
 | | | |
 | --- | --- | --- |
 | **Python** | `pip install stanli` | [python/README.md](python/README.md), [PyPI](https://pypi.org/project/stanli/) |
-| **R** | `install.packages("stanli")` then `stanli_install()` | [r/README.md](r/README.md) |
+| **R** | `remotes::install_github("seantalts/stanli", subdir = "r")` then `stanli_install()` | [r/README.md](r/README.md) |
 | **Browser / Node** | `npm install @seantalts/stanli` | [js/README.md](js/README.md), [npm](https://www.npmjs.com/package/@seantalts/stanli) |
 
-The R package is not on CRAN yet; until it is, install it from
-[r-universe](https://seantalts.r-universe.dev) or from a checkout (see
-[r/README.md](r/README.md)). It downloads its runtime on first use
+The R package is not on CRAN yet; until it is, install it from this
+repository with `remotes::install_github()` or from a checkout (see
+[R](#r) below). It downloads its runtime on first use
 rather than bundling it, because CRAN will not carry a 16 MB binary and
 could not build one on their farm.
 
@@ -210,6 +210,24 @@ subprocess.
 The same runtime behind an R binding, with `posterior`-shaped draws.
 Full documentation in [r/README.md](r/README.md).
 
+Not on CRAN yet, so install from this repository. The package lives in
+the `r/` subdirectory:
+
+```r
+# install.packages("remotes")
+remotes::install_github("seantalts/stanli", subdir = "r")
+
+# or, from a checkout of this repository
+# R CMD INSTALL r
+```
+
+That builds a 40 KB C bridge, so it wants the compiler R already
+expects for source packages (Xcode command line tools on macOS,
+`r-base-dev` on Debian and Ubuntu, Rtools on Windows). Nothing else is
+compiled: the sampler arrives prebuilt through `stanli_install()`
+below, which downloads the runtime for your platform from this
+repository's releases into `tools::R_user_dir("stanli", "cache")`.
+
 ```r
 library(stanli)
 stanli_install()   # one time: fetches the runtime for this platform
@@ -326,9 +344,13 @@ changes signature; adding a function does not need one.
 
 Two R distribution channels:
 
-- **r-universe** builds from this repository continuously; every push to
-  main becomes an installable binary with no tag. It needs a one-time
-  registry entry in `seantalts/seantalts.r-universe.dev`.
+- **GitHub**, which is what users install from today:
+  `remotes::install_github("seantalts/stanli", subdir = "r")` builds the
+  bridge from any commit, and `stanli_install()` then pulls the runtime
+  from the release the package pins. **r-universe** would serve prebuilt
+  binaries from main with no tag, but it is not wired up:
+  `seantalts.r-universe.dev` answers 404 until the one-time registry
+  entry exists in `seantalts/seantalts.r-universe.dev`.
 - **CRAN** cannot be automated by policy: a submission is a web-form
   upload confirmed by email. `r.yml` runs `R CMD check --as-cran` on
   every change under `r/`; a CRAN release is then bump `Version:` in

--- a/r/README.md
+++ b/r/README.md
@@ -4,15 +4,21 @@ Compile and sample Stan models without a C++ toolchain.
 
 ## Install
 
-Not on CRAN yet. Until it is:
+Not on CRAN yet. Until it is, install from GitHub; the package lives in
+the `r/` subdirectory of the repository:
 
 ```r
-# r-universe: binaries for Linux, macOS and Windows, rebuilt from main
-install.packages("stanli", repos = "https://seantalts.r-universe.dev")
+# install.packages("remotes")
+remotes::install_github("seantalts/stanli", subdir = "r")
 
 # or from a checkout
 # R CMD INSTALL r
 ```
+
+This builds the 40 KB C bridge from source, so it wants the toolchain R
+already expects for source packages: Xcode command line tools on macOS,
+`r-base-dev` on Debian and Ubuntu, Rtools on Windows. The sampler
+itself is not compiled here -- it arrives prebuilt below.
 
 Then, once per machine:
 

--- a/web/index.html
+++ b/web/index.html
@@ -112,8 +112,9 @@
 <h1>stanli: The Stan Language Interpreter</h1>
 <p class="sub">No server, no C++ toolchain;
 everything below happens in this tab, runs in the browser, samples on your machine.
-stanc3 (OCaml&rarr;JS) compiles the model, stanli.wasm lowers it to an op graph and runs NUTS
-or <a href="https://arxiv.org/abs/2506.18746">WALNUTS</a> &mdash; or both at once, side by side.
+stanc3 (OCaml&rarr;JS) compiles the model, stanli.wasm lowers it to an op graph and runs
+Stan-dard Dynamic HMC or <a href="https://arxiv.org/abs/2506.18746">WALNUTS</a>
+&mdash; or both at once, side by side.
 <p class="sub">And it's often FASTER?? </p>
 <a href="https://github.com/seantalts/stanli">github.com/seantalts/stanli</a>
 &middot; <a href="https://www.npmjs.com/package/@seantalts/stanli">npm</a>
@@ -127,11 +128,11 @@ or <a href="https://arxiv.org/abs/2506.18746">WALNUTS</a> &mdash; or both at onc
 </div>
 
 <div class="bar">
-  <button id="run">Run NUTS</button>
+  <button id="run">Run</button>
   <label>sampler <select id="sampler">
-    <option value="nuts">NUTS</option>
+    <option value="nuts">Stan-dard Dynamic HMC</option>
     <option value="walnuts">WALNUTS</option>
-    <option value="both">NUTS vs WALNUTS</option>
+    <option value="both">both, side by side</option>
   </select></label>
   <label class="combo" for="model">model
     <input id="model" type="text" role="combobox" aria-expanded="false"
@@ -459,12 +460,14 @@ catalogReady.then(() => {
 choose(CATALOG[0]);
 
 // ---- sampler selection -----------------------------------------------------
-const SAMPLER_LABEL = { nuts: "NUTS", walnuts: "WALNUTS" };
+// "Stan-dard Dynamic HMC" is what CmdStan runs by default: the NUTS
+// variant Stan has shipped for years. Spelled out rather than "NUTS"
+// because the choice sits beside WALNUTS, and an acronym next to an
+// acronym says nothing about which one is the familiar option.
+const SAMPLER_LABEL = { nuts: "Stan-dard Dynamic HMC", walnuts: "WALNUTS" };
 function samplerMode() { return $("sampler").value; }
 $("sampler").onchange = () => {
   const m = samplerMode();
-  $("run").textContent =
-      m === "both" ? "Run both" : `Run ${SAMPLER_LABEL[m]}`;
   // delta tunes NUTS's adaptation target; max err tunes how much the
   // joint log density may drift across one WALNUTS macro step. Each is
   // shown only when its sampler is in play.


### PR DESCRIPTION
Two small documentation and wording changes.

**Sampler naming on the web page.** The picker offered "NUTS" beside "WALNUTS", two acronyms that say nothing about which is the sampler Stan has always run. It now reads "Stan-dard Dynamic HMC" vs "WALNUTS" (third option: "both, side by side"), and the button is just "Run" since the sampler choice sits right next to it. The label flows through the status line, the comparison column headings, and the plot titles. Verified in a browser against the deployed wasm assets: single run and the side-by-side comparison both render the new names, no console errors.

**R install instructions.** The README told R users to install from `seantalts.r-universe.dev`, which answers 404 -- the one-time registry entry was never made, so that path never worked. CRAN is not an option yet either. The README now documents `remotes::install_github("seantalts/stanli", subdir = "r")`, says what it needs (a C compiler for the 40 KB bridge; the sampler itself arrives prebuilt through `stanli_install()`), and the releasing section notes r-universe is unwired rather than describing it as a live channel.

Tested end to end on macOS arm64 with R 4.6.1: `install_github` builds the bridge, `stanli_install()` pulls the v0.6.1 runtime from the release, and eight schools samples with 4 chains and sane R-hat/ESS.