### PR TITLE
fix: preserve probability early returns

### DIFF
--- a/runtime/include/stanli/program_density.hpp
+++ b/runtime/include/stanli/program_density.hpp
@@ -63,7 +63,10 @@ extern template stan::math::var program_density<stan::math::var>(
 // in doubles through the recorder scalar (recorder.hpp), with no tape.
 // `partials` receives one double per argument. Nothing here differentiates
 // a density by hand.
-void program_density_partials(int id, const double* args, double* partials);
+// Returns whether Stan Math built a dependency edge. A constant early return
+// fills zero partials and returns false so reverse mode can skip, rather than
+// form an indeterminate infinite-adjoint-times-zero product.
+bool program_density_partials(int id, const double* args, double* partials);
 
 }  // namespace stanli
 

--- a/runtime/include/stanli/recorder.hpp
+++ b/runtime/include/stanli/recorder.hpp
@@ -24,9 +24,12 @@
 #include <stan/math/prim/functor/partials_propagator.hpp>
 #include <stan/math/prim/functor/broadcast_array.hpp>
 
+#include <algorithm>
 #include <cstddef>
+#include <cstdint>
 #include <ostream>
 #include <type_traits>
+#include <utility>
 
 namespace stanli {
 
@@ -69,18 +72,61 @@ inline Eigen::Map<const Eigen::Matrix<rvar, -1, 1>> as_rvar(const Desc& d) {
 }
 
 // Where build() deposits partials: one buffer per propagator edge, in
-// operand order. A null buf skips that edge's copy-out (its length is still
-// reported). The executor points these at per-op scratch.
+// operand order. A null buf skips that edge's copy-out. len is the configured
+// buffer width; it lets a probability function that returns before build()
+// explicitly record a zero pullback. The executor points these at per-op
+// scratch.
 struct sink {
   static constexpr int kMaxEdges = 8;
   double* buf[kMaxEdges]{};
-  int len[kMaxEdges]{};
+  int64_t len[kMaxEdges]{};
   double value{0};
+  bool deposited{false};
+  // Optional forward-to-reverse topology bit: 1 when build() created edges,
+  // 0 when the probability function returned a disconnected scalar.
+  double* connected{nullptr};
 };
 
 inline sink*& active_sink() {
   static thread_local sink* s = nullptr;
   return s;
+}
+
+// Recorder calls can throw on invalid domains. Restore the preceding
+// thread-local sink on every exit so nested or subsequent calls never see a
+// pointer to a dead stack object.
+class sink_scope {
+ public:
+  explicit sink_scope(sink& current) : previous_(active_sink()) {
+    active_sink() = &current;
+  }
+  ~sink_scope() { active_sink() = previous_; }
+  sink_scope(const sink_scope&) = delete;
+  sink_scope& operator=(const sink_scope&) = delete;
+
+ private:
+  sink* previous_;
+};
+
+inline double recorded_value(double value) { return value; }
+inline double recorded_value(const rvar& value) { return value.val(); }
+
+// Some Stan Math probability functions return a constant (typically
+// LOG_ZERO or zero for an empty input) before constructing their partials
+// propagator. Capture the function's return as well as build(): when build()
+// did not deposit, the return is the value and every partial is zero.
+template <typename F>
+inline void record_probability_call(F&& f) {
+  sink* s = active_sink();
+  if (s != nullptr) s->deposited = false;
+  const auto result = std::forward<F>(f)();
+  if (s == nullptr) return;
+  if (s->connected != nullptr) *s->connected = s->deposited ? 1.0 : 0.0;
+  if (s->deposited) return;
+  s->value = recorded_value(result);
+  for (int k = 0; k < sink::kMaxEdges; ++k)
+    if (s->buf[k] != nullptr)
+      std::fill_n(s->buf[k], static_cast<std::size_t>(s->len[k]), 0.0);
 }
 
 }  // namespace stanli
@@ -202,6 +248,7 @@ class partials_propagator<stanli::rvar, void, Ops...> {
   stanli::rvar build(double value) {
     stanli::sink* s = stanli::active_sink();
     if (s != nullptr) {
+      s->deposited = true;
       s->value = value;
       emit_all(s, std::index_sequence_for<Ops...>{});
     }
@@ -213,10 +260,7 @@ class partials_propagator<stanli::rvar, void, Ops...> {
   void emit_one(stanli::sink* s) {
     using E = std::tuple_element_t<I, decltype(edges_)>;
     if constexpr (rt_has_emit<E>::value) {
-      s->len[I] = std::get<I>(edges_).size();
       if (s->buf[I] != nullptr) std::get<I>(edges_).emit(s->buf[I]);
-    } else {
-      s->len[I] = 0;  // data operand: no partials
     }
   }
 

--- a/runtime/kernels/densities.cpp
+++ b/runtime/kernels/densities.cpp
@@ -19,14 +19,8 @@ void register_density_kernels() {
       code, Kernel{fn##_fwd_gen, density_bwd<nreal>, density_scratch<nreal>});
   STANLI_INT_DENSITY_LIST(STANLI_REGISTER_INT_DENSITY)
 #undef STANLI_REGISTER_INT_DENSITY
-  // The list is the default. A density whose forward needs more than the
-  // shared one registers after it and wins: uniform_lpdf has to decide
-  // support itself, because stan-math returns LOG_ZERO out of support
-  // through an early return that never reaches the partials sink, and the
-  // recorder would leave the value at 0 (CmdStan -inf, stanli finite --
-  // caught by the dogs_log reference).
-  register_kernel(OP_UNIFORM_LPDF,
-                  Kernel{uniform_fwd, density_bwd<3>, density_scratch<3>});
+  // The list is the default. A density whose forward needs a genuinely
+  // different argument shape registers after it and wins.
   register_kernel(OP_POISSON_LOG_LPMF,
                   Kernel{poisson_log_fwd, density_bwd<1>, density_scratch<1>});
   register_kernel(
@@ -44,15 +38,15 @@ void register_density_kernels() {
   register_kernel(
       OP_BINOMIAL_LOGIT_LPMF,
       Kernel{binomial_logit_fwd, density_bwd<1>, density_scratch<1>});
-  register_kernel(
-      OP_BERNOULLI_LOGIT_GLM_LPMF,
-      Kernel{bernoulli_logit_glm_fwd, bernoulli_logit_glm_bwd, sum_in_lens});
+  register_kernel(OP_BERNOULLI_LOGIT_GLM_LPMF,
+                  Kernel{bernoulli_logit_glm_fwd, bernoulli_logit_glm_bwd,
+                         density_scratch<3>});
   register_kernel(
       OP_POISSON_LOG_GLM_LPMF,
-      Kernel{poisson_log_glm_fwd, poisson_log_glm_bwd, sum_in_lens});
+      Kernel{poisson_log_glm_fwd, poisson_log_glm_bwd, density_scratch<3>});
   register_kernel(OP_NEG_BINOMIAL_2_LOG_GLM_LPMF,
                   Kernel{neg_binomial_2_log_glm_fwd, neg_binomial_2_log_glm_bwd,
-                         sum_in_lens});
+                         density_scratch<4>});
   register_kernel(
       OP_BETA_BINOMIAL_LPMF,
       Kernel{beta_binomial_fwd, density_bwd<2>, density_scratch<2>});

--- a/runtime/kernels/densities_common.cpp
+++ b/runtime/kernels/densities_common.cpp
@@ -1,6 +1,5 @@
-// Half the densities models lean on, plus the hand-written kernels
-// (two int groups, a data matrix, a support test) that predate the
-// lists. The other half is densities_common_b.cpp.
+// Half the densities models lean on. The other half is
+// densities_common_b.cpp; hand-written shapes live in their own shards.
 //
 // One of the density shards: see densities_impl.hpp for why they
 // are split and what they share.
@@ -10,46 +9,6 @@ namespace stanli {
 namespace dens {
 
 STANLI_SCALAR_DENSITY_LIST_COMMON_A(STANLI_DEFINE_DENSITY_FWD)
-
-void uniform_fwd(KernelCtx& ctx) {
-  // stan-math reports out-of-support y with an early `return LOG_ZERO`
-  // that never reaches the partials sink, so the recorder would leave the
-  // value at 0 and the point would silently count as in support (caught
-  // by the dogs_log reference: CmdStan -inf, stanli finite). Handle
-  // support here; the density call then only ever runs on points where
-  // every stan-math path deposits through the sink.
-  const auto at = [&](int k, int64_t n) {
-    return ctx.in[k].data[ctx.in[k].len == 1 ? 0 : n];
-  };
-  const int64_t N =
-      std::max(ctx.in[0].len, std::max(ctx.in[1].len, ctx.in[2].len));
-  const bool elt = (ctx.variant & 0x40u) != 0;
-  bool any_out = false;
-  for (int64_t n = 0; n < N && !any_out; ++n)
-    any_out = at(0, n) < at(1, n) || at(0, n) > at(2, n);
-  if (any_out && !elt) {
-    ctx.out.data[0] = stan::math::LOG_ZERO;
-    const int64_t plen = ctx.in[0].len + ctx.in[1].len + ctx.in[2].len;
-    std::fill(ctx.scratch, ctx.scratch + plen, 0.0);
-    return;
-  }
-  // The list already generates exactly this call in densities_common_b.cpp.
-  // Writing it out again here would instantiate the whole three-argument
-  // family a second time (the lambdas are distinct closure types), so call
-  // the generated one; densities.cpp registers this wrapper over it.
-  uniform_lpdf_fwd_gen(ctx);
-  if (any_out && elt) {
-    // Elementwise variant: only the offending lanes are LOG_ZERO, and
-    // their partials contribute nothing.
-    const int64_t M = ctx.out.len;
-    for (int64_t n = 0; n < M; ++n)
-      if (at(0, n) < at(1, n) || at(0, n) > at(2, n)) {
-        ctx.out.data[n] = stan::math::LOG_ZERO;
-        for (int k = 0; k < 3; ++k)
-          ctx.scratch[static_cast<int64_t>(k) * M + n] = 0.0;
-      }
-  }
-}
 
 }  // namespace dens
 }  // namespace stanli

--- a/runtime/kernels/densities_glm.cpp
+++ b/runtime/kernels/densities_glm.cpp
@@ -20,19 +20,18 @@ void bernoulli_logit_glm_fwd(KernelCtx& ctx) {
   sink s = sink_for_args(ctx, 3);
   if (ctx.in[1].len != 1)
     throw std::runtime_error("glm: vector alpha unsupported");
-  active_sink() = &s;
+  sink_scope active(s);
   // beta is a vector regardless of its length; alpha scalar. Honour the
   // propto bit: bernoulli has no constant to drop, so the two forms agree
   // here, but hardcoding one is what made poisson_log_glm's lp land
   // sum(log(y!)) away from CmdStan's.
-  if (ctx.variant & 0x80u) {
-    stan::math::bernoulli_logit_glm_lpmf<true>(y, X, rvar(ctx.in[1].data[0]),
-                                               as_rvar(ctx.in[2]));
-  } else {
-    stan::math::bernoulli_logit_glm_lpmf<false>(y, X, rvar(ctx.in[1].data[0]),
-                                                as_rvar(ctx.in[2]));
-  }
-  active_sink() = nullptr;
+  record_probability_call([&] {
+    if (ctx.variant & 0x80u)
+      return stan::math::bernoulli_logit_glm_lpmf<true>(
+          y, X, rvar(ctx.in[1].data[0]), as_rvar(ctx.in[2]));
+    return stan::math::bernoulli_logit_glm_lpmf<false>(
+        y, X, rvar(ctx.in[1].data[0]), as_rvar(ctx.in[2]));
+  });
   ctx.out.data[0] = s.value;
 }
 // Edge order (x, alpha, beta): X data (edge 0 skipped by null adjoint),
@@ -52,17 +51,16 @@ void poisson_log_glm_fwd(KernelCtx& ctx) {
   sink s = sink_for_args(ctx, 3);
   if (ctx.in[1].len != 1)
     throw std::runtime_error("poisson_log_glm: vector alpha unsupported");
-  active_sink() = &s;
+  sink_scope active(s);
   // propto drops -lgamma(y+1), which is constant in the parameters but is
   // 10.45 on a six-observation test -- a constant offset, not noise.
-  if (ctx.variant & 0x80u) {
-    stan::math::poisson_log_glm_lpmf<true>(y, X, rvar(ctx.in[1].data[0]),
-                                           as_rvar(ctx.in[2]));
-  } else {
-    stan::math::poisson_log_glm_lpmf<false>(y, X, rvar(ctx.in[1].data[0]),
-                                            as_rvar(ctx.in[2]));
-  }
-  active_sink() = nullptr;
+  record_probability_call([&] {
+    if (ctx.variant & 0x80u)
+      return stan::math::poisson_log_glm_lpmf<true>(
+          y, X, rvar(ctx.in[1].data[0]), as_rvar(ctx.in[2]));
+    return stan::math::poisson_log_glm_lpmf<false>(
+        y, X, rvar(ctx.in[1].data[0]), as_rvar(ctx.in[2]));
+  });
   ctx.out.data[0] = s.value;
 }
 
@@ -78,25 +76,24 @@ void neg_binomial_2_log_glm_fwd(KernelCtx& ctx) {
   if (ctx.in[1].len != 1)
     throw std::runtime_error(
         "neg_binomial_2_log_glm: vector alpha unsupported");
-  active_sink() = &s;
+  sink_scope active(s);
   const bool propto = (ctx.variant & 0x80u) != 0;
-  if (ctx.in[3].len == 1) {
-    const rvar phi(ctx.in[3].data[0]);
-    if (propto) {
-      stan::math::neg_binomial_2_log_glm_lpmf<true>(
-          y, X, rvar(ctx.in[1].data[0]), as_rvar(ctx.in[2]), phi);
-    } else {
-      stan::math::neg_binomial_2_log_glm_lpmf<false>(
+  record_probability_call([&] {
+    if (ctx.in[3].len == 1) {
+      const rvar phi(ctx.in[3].data[0]);
+      if (propto)
+        return stan::math::neg_binomial_2_log_glm_lpmf<true>(
+            y, X, rvar(ctx.in[1].data[0]), as_rvar(ctx.in[2]), phi);
+      return stan::math::neg_binomial_2_log_glm_lpmf<false>(
           y, X, rvar(ctx.in[1].data[0]), as_rvar(ctx.in[2]), phi);
     }
-  } else if (propto) {
-    stan::math::neg_binomial_2_log_glm_lpmf<true>(
+    if (propto)
+      return stan::math::neg_binomial_2_log_glm_lpmf<true>(
+          y, X, rvar(ctx.in[1].data[0]), as_rvar(ctx.in[2]),
+          as_rvar(ctx.in[3]));
+    return stan::math::neg_binomial_2_log_glm_lpmf<false>(
         y, X, rvar(ctx.in[1].data[0]), as_rvar(ctx.in[2]), as_rvar(ctx.in[3]));
-  } else {
-    stan::math::neg_binomial_2_log_glm_lpmf<false>(
-        y, X, rvar(ctx.in[1].data[0]), as_rvar(ctx.in[2]), as_rvar(ctx.in[3]));
-  }
-  active_sink() = nullptr;
+  });
   ctx.out.data[0] = s.value;
 }
 

--- a/runtime/kernels/densities_impl.hpp
+++ b/runtime/kernels/densities_impl.hpp
@@ -38,8 +38,10 @@ inline sink sink_for_args(KernelCtx& ctx, int nargs) {
   int64_t off = 0;
   for (int k = 0; k < nargs; ++k) {
     s.buf[k] = ctx.scratch + off;
+    s.len[k] = ctx.in[k].len;
     off += ctx.in[k].len;
   }
+  s.connected = ctx.scratch + off;
   return s;
 }
 
@@ -58,7 +60,7 @@ template <int NArgs, unsigned Mask, unsigned VecMask, typename F,
           typename... Bound>
 void bind_args_m(KernelCtx& ctx, F&& f, const Bound&... bound) {
   if constexpr (sizeof...(Bound) == NArgs) {
-    f(bound...);
+    record_probability_call([&] { return f(bound...); });
   } else {
     constexpr int i = sizeof...(Bound);
     constexpr bool active = ((Mask >> i) & 1u) != 0;
@@ -108,7 +110,7 @@ void mask_dispatch(unsigned mask, KernelCtx& ctx, F&& f) {
 template <int NArgs, unsigned Mask, typename F, typename... Bound>
 void bind_args_elt_m(KernelCtx& ctx, int64_t n, F&& f, const Bound&... bound) {
   if constexpr (sizeof...(Bound) == NArgs) {
-    f(n, bound...);
+    record_probability_call([&] { return f(n, bound...); });
   } else {
     constexpr int i = sizeof...(Bound);
     constexpr bool active = ((Mask >> i) & 1u) != 0;
@@ -165,19 +167,23 @@ void density_fwd_elt(KernelCtx& ctx, FProp&& fp, FFull&& ff) {
   const int64_t N = ctx.out.len;
   const unsigned mask = ctx.variant & 0x3fu;
   for (int64_t n = 0; n < N; ++n) {
-    for (int k = 0; k < NArgs; ++k)
+    for (int k = 0; k < NArgs; ++k) {
       s.buf[k] = ctx.scratch + static_cast<int64_t>(k) * N + n;
-    active_sink() = &s;
-    if constexpr ((Tier & STANLI_DENSITY_PROPTO) != 0) {
-      if (ctx.variant & 0x80u) {
-        mask_dispatch_elt<NArgs>(mask, ctx, n, fp);
+      s.len[k] = 1;
+    }
+    s.connected = ctx.scratch + static_cast<int64_t>(NArgs) * N + n;
+    {
+      sink_scope active(s);
+      if constexpr ((Tier & STANLI_DENSITY_PROPTO) != 0) {
+        if (ctx.variant & 0x80u) {
+          mask_dispatch_elt<NArgs>(mask, ctx, n, fp);
+        } else {
+          full_form_elt<NArgs, Tier>(mask, ctx, n, ff);
+        }
       } else {
         full_form_elt<NArgs, Tier>(mask, ctx, n, ff);
       }
-    } else {
-      full_form_elt<NArgs, Tier>(mask, ctx, n, ff);
     }
-    active_sink() = nullptr;
     ctx.out.data[n] = s.value;
   }
 }
@@ -198,17 +204,18 @@ void density_fwd_sum(KernelCtx& ctx, FProp&& fp, FFull&& ff) {
   const unsigned mask = ctx.variant == 0
                             ? (1u << NArgs) - 1  // default: all active
                             : (ctx.variant & 0x3fu);
-  active_sink() = &s;
-  if constexpr ((Tier & STANLI_DENSITY_PROPTO) != 0) {
-    if (ctx.variant & 0x80u) {
-      mask_dispatch<NArgs, VecMask>(mask, ctx, fp);
+  {
+    sink_scope active(s);
+    if constexpr ((Tier & STANLI_DENSITY_PROPTO) != 0) {
+      if (ctx.variant & 0x80u) {
+        mask_dispatch<NArgs, VecMask>(mask, ctx, fp);
+      } else {
+        full_form<NArgs, Tier, VecMask>(mask, ctx, ff);
+      }
     } else {
       full_form<NArgs, Tier, VecMask>(mask, ctx, ff);
     }
-  } else {
-    full_form<NArgs, Tier, VecMask>(mask, ctx, ff);
   }
-  active_sink() = nullptr;
   ctx.out.data[0] = s.value;
 }
 
@@ -229,8 +236,8 @@ void density_fwd_v(KernelCtx& ctx, FProp&& fp, FFull&& ff) {
     // Real-argument densities reuse the same lambdas: scalar bindings
     // instantiate the same generic templates.
     density_fwd_elt<NArgs, Tier>(
-        ctx, [&](int64_t, const auto&... a) { fp(a...); },
-        [&](int64_t, const auto&... a) { ff(a...); });
+        ctx, [&](int64_t, const auto&... a) { return fp(a...); },
+        [&](int64_t, const auto&... a) { return ff(a...); });
     return;
   }
   density_fwd_sum<NArgs, Tier, VecMask>(ctx, fp, ff);
@@ -248,20 +255,26 @@ void density_bwd(KernelCtx& ctx) {
       ctx.variant == 0 ? (1u << NArgs) - 1 : (ctx.variant & 0x3fu);
   if (ctx.variant & 0x40u) {
     const int64_t N = ctx.out.len;
+    const double* connected = ctx.scratch + static_cast<int64_t>(NArgs) * N;
     for (int k = 0; k < NArgs; ++k) {
       if (((mask >> k) & 1u) == 0 || ctx.in_adj[k].data == nullptr) continue;
       const double* col = ctx.scratch + static_cast<int64_t>(k) * N;
       if (ctx.in_adj[k].len == 1 && N > 1) {
         double acc = 0;
-        for (int64_t n = N; n-- > 0;) acc += ctx.out_adj_vec.data[n] * col[n];
+        for (int64_t n = N; n-- > 0;)
+          if (connected[n] != 0.0) acc += ctx.out_adj_vec.data[n] * col[n];
         ctx.in_adj[k].data[0] += acc;
       } else {
         for (int64_t n = 0; n < N; ++n)
-          ctx.in_adj[k].data[n] += ctx.out_adj_vec.data[n] * col[n];
+          if (connected[n] != 0.0)
+            ctx.in_adj[k].data[n] += ctx.out_adj_vec.data[n] * col[n];
       }
     }
     return;
   }
+  int64_t n_partials = 0;
+  for (int k = 0; k < NArgs; ++k) n_partials += ctx.in[k].len;
+  if (ctx.scratch[n_partials] == 0.0) return;
   int64_t off = 0;
   for (int k = 0; k < NArgs; ++k) {
     if (((mask >> k) & 1u) != 0 && ctx.in_adj[k].data != nullptr) {
@@ -276,31 +289,32 @@ void density_bwd(KernelCtx& ctx) {
 // broadcast scalars (each element scales by its own adjoint).
 template <int NArgs>
 int64_t density_scratch(const Op& op, const Slot* slots) {
-  if (op.variant & 0x40u) return NArgs * slots[op.out].len;
-  return sum_in_lens(op, slots);
+  if (op.variant & 0x40u) return (NArgs + 1) * slots[op.out].len;
+  return sum_in_lens(op, slots) + 1;
 }
 
 // ---- lpmfs: integer outcome from idata, not a propagator edge --------------
 // The elementwise variant hands each recorder call outcome element n; the
 // summed path keeps the whole-vector call. STANLI_LPMF_FWD expands both.
-#define STANLI_LPMF_FWD_T(fname, dist, NARGS, TIER)                      \
-  void fname(KernelCtx& ctx) {                                           \
-    if (ctx.variant & 0x40u) {                                           \
-      density_fwd_elt<NARGS, density_tier(TIER)>(                        \
-          ctx,                                                           \
-          [&](int64_t n, const auto&... a) {                             \
-            stan::math::dist<true>(ctx.idata[n], a...);                  \
-          },                                                             \
-          [&](int64_t n, const auto&... a) {                             \
-            stan::math::dist<false>(ctx.idata[n], a...);                 \
-          });                                                            \
-      return;                                                            \
-    }                                                                    \
-    Eigen::Map<const Eigen::VectorXi> y(                                 \
-        ctx.idata, static_cast<Eigen::Index>(ctx.n_idata));              \
-    density_fwd_v<NARGS, TIER>(                                          \
-        ctx, [&](const auto&... a) { stan::math::dist<true>(y, a...); }, \
-        [&](const auto&... a) { stan::math::dist<false>(y, a...); });    \
+#define STANLI_LPMF_FWD_T(fname, dist, NARGS, TIER)                          \
+  void fname(KernelCtx& ctx) {                                               \
+    if (ctx.variant & 0x40u) {                                               \
+      density_fwd_elt<NARGS, density_tier(TIER)>(                            \
+          ctx,                                                               \
+          [&](int64_t n, const auto&... a) {                                 \
+            return stan::math::dist<true>(ctx.idata[n], a...);               \
+          },                                                                 \
+          [&](int64_t n, const auto&... a) {                                 \
+            return stan::math::dist<false>(ctx.idata[n], a...);              \
+          });                                                                \
+      return;                                                                \
+    }                                                                        \
+    Eigen::Map<const Eigen::VectorXi> y(                                     \
+        ctx.idata, static_cast<Eigen::Index>(ctx.n_idata));                  \
+    density_fwd_v<NARGS, TIER>(                                              \
+        ctx,                                                                 \
+        [&](const auto&... a) { return stan::math::dist<true>(y, a...); },   \
+        [&](const auto&... a) { return stan::math::dist<false>(y, a...); }); \
   }
 #define STANLI_LPMF_FWD(fname, dist, NARGS) \
   STANLI_LPMF_FWD_T(fname, dist, NARGS, 3)
@@ -310,11 +324,11 @@ int64_t density_scratch(const Op& op, const Slot* slots) {
 // share -- propto and per-argument activity from the variant byte,
 // elementwise output, the partials stashed for density_bwd to contract --
 // lives in density_fwd_v.
-#define STANLI_DEFINE_DENSITY_FWD(code, fn, n, tier)               \
-  void fn##_fwd_gen(KernelCtx& ctx) {                              \
-    density_fwd_v<n, tier>(                                        \
-        ctx, [](const auto&... a) { stan::math::fn<true>(a...); }, \
-        [](const auto&... a) { stan::math::fn<false>(a...); });    \
+#define STANLI_DEFINE_DENSITY_FWD(code, fn, n, tier)                      \
+  void fn##_fwd_gen(KernelCtx& ctx) {                                     \
+    density_fwd_v<n, tier>(                                               \
+        ctx, [](const auto&... a) { return stan::math::fn<true>(a...); }, \
+        [](const auto&... a) { return stan::math::fn<false>(a...); });    \
   }
 
 // Distribution functions: one form, no propto, and no elementwise
@@ -334,24 +348,25 @@ void cdf_fwd(KernelCtx& ctx, F&& f) {
     throw std::runtime_error("cdf: elementwise variant not implemented");
   // Tier here never carries the propto bit, so the first lambda is never
   // instantiated; it exists to satisfy the shared signature.
-  density_fwd_sum<NArgs, Tier, 0>(ctx, [](const auto&...) {}, f);
+  density_fwd_sum<NArgs, Tier, 0>(
+      ctx, [](const auto&...) { return 0.0; }, std::forward<F>(f));
 }
 
-#define STANLI_DEFINE_CDF_FWD(code, fn, n, tier)                \
-  void fn##_fwd_gen(KernelCtx& ctx) {                           \
-    cdf_fwd<n, density_tier(tier) & STANLI_DENSITY_FULL_MASKS>( \
-        ctx, [](const auto&... a) { stan::math::fn(a...); });   \
+#define STANLI_DEFINE_CDF_FWD(code, fn, n, tier)                     \
+  void fn##_fwd_gen(KernelCtx& ctx) {                                \
+    cdf_fwd<n, density_tier(tier) & STANLI_DENSITY_FULL_MASKS>(      \
+        ctx, [](const auto&... a) { return stan::math::fn(a...); }); \
   }
 
 // Integer-outcome cdfs. Same as above with the count read from idata,
 // the way the lpmfs read theirs -- a whole vector of outcomes in one
 // call, since the summed form is the only one these have.
-#define STANLI_DEFINE_INT_CDF_FWD(code, fn, nreal, tier)            \
-  void fn##_fwd_gen(KernelCtx& ctx) {                               \
-    Eigen::Map<const Eigen::VectorXi> y(                            \
-        ctx.idata, static_cast<Eigen::Index>(ctx.n_idata));         \
-    cdf_fwd<nreal, density_tier(tier) & STANLI_DENSITY_FULL_MASKS>( \
-        ctx, [&](const auto&... a) { stan::math::fn(y, a...); });   \
+#define STANLI_DEFINE_INT_CDF_FWD(code, fn, nreal, tier)                 \
+  void fn##_fwd_gen(KernelCtx& ctx) {                                    \
+    Eigen::Map<const Eigen::VectorXi> y(                                 \
+        ctx.idata, static_cast<Eigen::Index>(ctx.n_idata));              \
+    cdf_fwd<nreal, density_tier(tier) & STANLI_DENSITY_FULL_MASKS>(      \
+        ctx, [&](const auto&... a) { return stan::math::fn(y, a...); }); \
   }
 
 // Ordinal regression. The outcome goes over as a std::vector<int>, not
@@ -361,12 +376,12 @@ void cdf_fwd(KernelCtx& ctx, F&& f) {
 // std::vector is also exactly what CmdStan's generated code passes, so
 // this is the instantiation the references were produced from. The copy
 // is n ints per evaluation, against a density over the same n.
-#define STANLI_DEFINE_ORDERED_FWD(code, fn, nargs, vecmask)            \
-  void fn##_fwd_gen(KernelCtx& ctx) {                                  \
-    const std::vector<int> y(ctx.idata, ctx.idata + ctx.n_idata);      \
-    density_fwd_v<nargs, 2, vecmask>(                                  \
-        ctx, [&](const auto&... a) { stan::math::fn<true>(y, a...); }, \
-        [&](const auto&... a) { stan::math::fn<false>(y, a...); });    \
+#define STANLI_DEFINE_ORDERED_FWD(code, fn, nargs, vecmask)                   \
+  void fn##_fwd_gen(KernelCtx& ctx) {                                         \
+    const std::vector<int> y(ctx.idata, ctx.idata + ctx.n_idata);             \
+    density_fwd_v<nargs, 2, vecmask>(                                         \
+        ctx, [&](const auto&... a) { return stan::math::fn<true>(y, a...); }, \
+        [&](const auto&... a) { return stan::math::fn<false>(y, a...); });    \
   }
 
 // Declarations of everything the shards define, so registration in
@@ -380,7 +395,7 @@ STANLI_ORDERED_DENSITY_LIST(STANLI_DECLARE_FWD)
 #undef STANLI_DECLARE_FWD
 
 // The hand-written ones, which predate the lists and are not the same
-// shape (two int groups, a data matrix, a support test).
+// shape (two int groups or a data matrix).
 void poisson_log_fwd(KernelCtx&);
 void bernoulli_logit_fwd(KernelCtx&);
 void bernoulli_fwd(KernelCtx&);
@@ -395,8 +410,6 @@ void poisson_log_glm_bwd(KernelCtx&);
 void neg_binomial_2_log_glm_fwd(KernelCtx&);
 void neg_binomial_2_log_glm_bwd(KernelCtx&);
 void beta_binomial_fwd(KernelCtx&);
-void uniform_fwd(KernelCtx&);
-
 }  // namespace dens
 }  // namespace stanli
 

--- a/runtime/kernels/densities_lpmf.cpp
+++ b/runtime/kernels/densities_lpmf.cpp
@@ -41,31 +41,35 @@ int int_group_elem(const int* p, int64_t n) {
 const int* int_group_next(const int* p) {
   return p + (p[0] == -1 ? 2 : 1 + p[0]);
 }
-#define STANLI_BINOMIAL_FWD(fname, dist)                                       \
-  void fname(KernelCtx& ctx) {                                                 \
-    if (ctx.variant & 0x40u) {                                                 \
-      const int* g1 = ctx.idata;                                               \
-      const int* g2 = int_group_next(g1);                                      \
-      density_fwd_elt<1, 3>(                                                   \
-          ctx,                                                                 \
-          [&](int64_t n, const auto& theta) {                                  \
-            stan::math::dist<true>(int_group_elem(g1, n),                      \
-                                   int_group_elem(g2, n), theta);              \
-          },                                                                   \
-          [&](int64_t n, const auto& theta) {                                  \
-            stan::math::dist<false>(int_group_elem(g1, n),                     \
-                                    int_group_elem(g2, n), theta);             \
-          });                                                                  \
-      return;                                                                  \
-    }                                                                          \
-    with_int_group(ctx.idata, [&](const auto& n, const int* rest) {            \
-      with_int_group(rest, [&](const auto& N, const int*) {                    \
-        density_fwd_v<1, 3>(                                                   \
-            ctx,                                                               \
-            [&](const auto& theta) { stan::math::dist<true>(n, N, theta); },   \
-            [&](const auto& theta) { stan::math::dist<false>(n, N, theta); }); \
-      });                                                                      \
-    });                                                                        \
+#define STANLI_BINOMIAL_FWD(fname, dist)                                  \
+  void fname(KernelCtx& ctx) {                                            \
+    if (ctx.variant & 0x40u) {                                            \
+      const int* g1 = ctx.idata;                                          \
+      const int* g2 = int_group_next(g1);                                 \
+      density_fwd_elt<1, 3>(                                              \
+          ctx,                                                            \
+          [&](int64_t n, const auto& theta) {                             \
+            return stan::math::dist<true>(int_group_elem(g1, n),          \
+                                          int_group_elem(g2, n), theta);  \
+          },                                                              \
+          [&](int64_t n, const auto& theta) {                             \
+            return stan::math::dist<false>(int_group_elem(g1, n),         \
+                                           int_group_elem(g2, n), theta); \
+          });                                                             \
+      return;                                                             \
+    }                                                                     \
+    with_int_group(ctx.idata, [&](const auto& n, const int* rest) {       \
+      with_int_group(rest, [&](const auto& N, const int*) {               \
+        density_fwd_v<1, 3>(                                              \
+            ctx,                                                          \
+            [&](const auto& theta) {                                      \
+              return stan::math::dist<true>(n, N, theta);                 \
+            },                                                            \
+            [&](const auto& theta) {                                      \
+              return stan::math::dist<false>(n, N, theta);                \
+            });                                                           \
+      });                                                                 \
+    });                                                                   \
   }
 
 STANLI_BINOMIAL_FWD(binomial_fwd, binomial_lpmf)
@@ -81,10 +85,10 @@ void beta_binomial_fwd(KernelCtx& ctx) {
       density_fwd_sum<2, density_tier(2), 0>(
           ctx,
           [&](const auto&... a) {
-            stan::math::beta_binomial_lpmf<true>(n, N, a...);
+            return stan::math::beta_binomial_lpmf<true>(n, N, a...);
           },
           [&](const auto&... a) {
-            stan::math::beta_binomial_lpmf<false>(n, N, a...);
+            return stan::math::beta_binomial_lpmf<false>(n, N, a...);
           });
     });
   });

--- a/runtime/src/adjoint.cpp
+++ b/runtime/src/adjoint.cpp
@@ -719,12 +719,12 @@ void run_adjoint(const Program& fwd, const AdjProgram& ap, const double* val,
         const int ar = program_density_arity(I.len);
         double part[kMaxDensityArgs] = {0, 0, 0, 0};
         if (ar > 3) {
-          program_density_partials(I.len, val + I.va, part);
-          for (int k = ar; k-- > 0;) adj[I.a + k] += t * part[k];
+          if (program_density_partials(I.len, val + I.va, part))
+            for (int k = ar; k-- > 0;) adj[I.a + k] += t * part[k];
           break;
         }
         const double args[3] = {val[I.va], val[I.vb], val[I.vc]};
-        program_density_partials(I.len, args, part);
+        if (!program_density_partials(I.len, args, part)) break;
         if (ar > 2) adj[I.c] += t * part[2];
         if (ar > 1) adj[I.b] += t * part[1];
         adj[I.a] += t * part[0];

--- a/runtime/src/program_density.cpp
+++ b/runtime/src/program_density.cpp
@@ -58,16 +58,16 @@ auto call_with(F&& f, const T* a) {
 
 // The same, promoting doubles to the recording scalar on the way in.
 template <int Arity, typename F>
-void call_rvar(F&& f, const double* a) {
+auto call_rvar(F&& f, const double* a) {
   static_assert(Arity >= 1 && Arity <= 4, "density arity out of range");
   if constexpr (Arity == 1) {
-    f(rvar(a[0]));
+    return f(rvar(a[0]));
   } else if constexpr (Arity == 2) {
-    f(rvar(a[0]), rvar(a[1]));
+    return f(rvar(a[0]), rvar(a[1]));
   } else if constexpr (Arity == 3) {
-    f(rvar(a[0]), rvar(a[1]), rvar(a[2]));
+    return f(rvar(a[0]), rvar(a[1]), rvar(a[2]));
   } else {
-    f(rvar(a[0]), rvar(a[1]), rvar(a[2]), rvar(a[3]));
+    return f(rvar(a[0]), rvar(a[1]), rvar(a[2]), rvar(a[3]));
   }
 }
 
@@ -113,23 +113,28 @@ template double program_density<double>(int, const double*);
 template stan::math::var program_density<stan::math::var>(
     int, const stan::math::var*);
 
-void program_density_partials(int id, const double* args, double* partials) {
+bool program_density_partials(int id, const double* args, double* partials) {
   const int n = program_density_arity(id);
   sink s;
-  for (int k = 0; k < n; ++k) s.buf[k] = &partials[k];
-  active_sink() = &s;
+  for (int k = 0; k < n; ++k) {
+    s.buf[k] = &partials[k];
+    s.len[k] = 1;
+  }
+  sink_scope active(s);
   switch (id) {
-#define STANLI_PD_PARTIALS(opc, fn, arity, tier)                            \
-  case kId_##fn:                                                            \
-    call_rvar<arity>([](const auto&... x) { stan::math::fn<false>(x...); }, \
-                     args);                                                 \
+#define STANLI_PD_PARTIALS(opc, fn, arity, tier)                               \
+  case kId_##fn:                                                               \
+    record_probability_call([&] {                                              \
+      return call_rvar<arity>(                                                 \
+          [](const auto&... x) { return stan::math::fn<false>(x...); }, args); \
+    });                                                                        \
     break;
     STANLI_SCALAR_DENSITY_LIST(STANLI_PD_PARTIALS)
 #undef STANLI_PD_PARTIALS
     default:
       break;
   }
-  active_sink() = nullptr;
+  return s.deposited;
 }
 
 }  // namespace stanli

--- a/tests/test_adjoint.cpp
+++ b/tests/test_adjoint.cpp
@@ -13,6 +13,7 @@
 // contiguous register ranges the reductions depend on.
 #include <stanli/adjoint.hpp>
 #include <stanli/program_density.hpp>
+#include <stanli/recorder.hpp>
 #include <stanli/island.hpp>
 #include <stanli/program.hpp>
 
@@ -603,6 +604,51 @@ static void test_densities() {
   }
 }
 
+// Stan Math can return a constant support value before constructing its
+// partials propagator. The register-program API promises to fill every
+// partial, so it must write zeros rather than leave the caller's old values.
+static void test_density_early_return_partials() {
+  const int id = program_density_id_by_name("inv_gamma_lpdf");
+  expect("inv_gamma density id", id >= 0);
+  const double args[3] = {-1.0, 2.0, 3.0};
+  expect("inv_gamma early value", program_density<double>(id, args) ==
+                                      -std::numeric_limits<double>::infinity());
+  double partials[3] = {4.0, 5.0, 6.0};
+  expect("inv_gamma early disconnected",
+         !program_density_partials(id, args, partials));
+  for (double partial : partials)
+    expect("inv_gamma early partial", partial == 0.0);
+
+  // The var replay has no edge from an early-return literal to its inputs.
+  // An infinite upstream adjoint must therefore be skipped, not multiplied
+  // by a stored zero partial.
+  Build b({-1.0, 2.0, 3.0});
+  const int density = b.emit_density(id, {0, 1, 2});
+  const int squared = b.emit(Program::SQUARE, density);
+  check("inv_gamma disconnected", b.done({squared}, {1.0}));
+
+  // A built zero partial stays connected. Native reverse must retain the
+  // same indeterminate inf * 0 adjoint as the var replay.
+  Build connected({1.0, 2.0, 3.0});
+  const int connected_density = connected.emit_density(id, {0, 1, 2});
+  const int infinity = connected.konst(std::numeric_limits<double>::infinity());
+  const int scaled = connected.emit(Program::MUL, connected_density, infinity);
+  check("inv_gamma connected zero partial", connected.done({scaled}, {1.0}));
+
+  // Restoring the thread-local sink on exceptions is part of making the
+  // shared recorder compositional: one rejected evaluation must not leave a
+  // dangling pointer for the next density call.
+  const double bad_domain[3] = {1.0, -2.0, 3.0};
+  bool threw = false;
+  try {
+    program_density_partials(id, bad_domain, partials);
+  } catch (const std::domain_error&) {
+    threw = true;
+  }
+  expect("inv_gamma invalid alpha throws", threw);
+  expect("density exception restores sink", active_sink() == nullptr);
+}
+
 // ---- a composite region ------------------------------------------------
 
 // The shape the carver actually sees: an unrolled recurrence, each step
@@ -814,6 +860,7 @@ int main() {
   test_nan_operands();
   test_reductions();
   test_densities();
+  test_density_early_return_partials();
   test_recurrence();
   test_two_gradients();
   test_fuzz();

--- a/tests/test_densities.cpp
+++ b/tests/test_densities.cpp
@@ -21,6 +21,12 @@ static void expect_eq(const std::string& what, double got, double want) {
     std::printf("FAIL %-32s got %.17g want %.17g\n", what.c_str(), got, want);
   }
 }
+static void expect_nan(const std::string& what, double got, double want) {
+  if (!std::isnan(got) || !std::isnan(want)) {
+    ++failures;
+    std::printf("FAIL %-32s got %.17g want %.17g\n", what.c_str(), got, want);
+  }
+}
 // For comparisons across different instantiation activity. Kernels bind every
 // argument as rvar; a reference with data (double) arguments makes stan-math
 // take different to_ref_if caching paths, which reassociates shared
@@ -171,8 +177,8 @@ int main() {
 
   // ---- uniform_lpdf out of support: -inf, no partials --------------------
   // stan-math reports out-of-support y through an early return that never
-  // reaches the partials sink, so the kernel checks support itself. Found
-  // by the dogs_log reference: CmdStan said -inf, stanli said finite.
+  // reaches the partials sink. This was the first instance caught by the
+  // dogs_log reference: CmdStan said -inf while stanli said finite.
   {
     auto r = testutil::run_one_op(OP_UNIFORM_LPDF, {{0.1}, {-100.0}, {0.0}},
                                   {true, false, false});
@@ -187,6 +193,192 @@ int main() {
     expect_eq("uniform in value", r2.value, lp.val());
     expect_eq("uniform in dy", r2.grad[0], vy.adj());
     stan::math::recover_memory();
+  }
+
+  // ---- inv_gamma_lpdf early return: -inf, no partials ------------------
+  // Stan Math returns LOG_ZERO before building its partials propagator when
+  // any y is nonpositive. The returned value and zero pullback are both part
+  // of the contract: a recorder cannot infer them from a build() call that
+  // never happens.
+  {
+    Graph g;
+    const int y = g.add_slot(1, true);
+    const int alpha = g.add_slot(1, false);
+    const int beta = g.add_slot(1, false);
+    const int lp_slot = g.add_slot(1, false);
+    g.add_op(OP_INV_GAMMA_LPDF, {y, alpha, beta}, lp_slot);
+    g.result_slot = lp_slot;
+    Executor ex(std::move(g));
+    ex.value_ptr(alpha)[0] = 2.0;
+    ex.value_ptr(beta)[0] = 3.0;
+
+    // Seed the density scratch with a real derivative, then cross support.
+    // The second call must not reuse either the value or that derivative.
+    ex.params_data()[0] = 1.5;
+    double grad = 0;
+    const double valid = ex.gradient(&grad);
+    var vy = 1.5;
+    var valid_ref = stan::math::inv_gamma_lpdf<false>(vy, 2.0, 3.0);
+    valid_ref.grad();
+    expect_eq("inv_gamma valid value", valid, valid_ref.val());
+    expect_eq("inv_gamma valid dy", grad, vy.adj());
+    stan::math::recover_memory();
+
+    ex.params_data()[0] = -1.0;
+    grad = std::numeric_limits<double>::quiet_NaN();
+    const double invalid = ex.gradient(&grad);
+    var bad_y = -1.0;
+    var invalid_ref = stan::math::inv_gamma_lpdf<false>(bad_y, 2.0, 3.0);
+    invalid_ref.grad();
+    expect_eq("inv_gamma oos value", invalid, invalid_ref.val());
+    expect_eq("inv_gamma oos dy", grad, bad_y.adj());
+    stan::math::recover_memory();
+  }
+
+  // A vector call returns one LOG_ZERO for the whole density. This is the
+  // non-rerolled shape lowering emits for a vectorized sampling statement.
+  {
+    const std::vector<double> yv{1.5, -1.0, 2.25};
+    auto r = testutil::run_one_op(OP_INV_GAMMA_LPDF, {yv, {2.0}, {3.0}},
+                                  {true, false, false});
+    Eigen::Matrix<var, -1, 1> y_ref(3);
+    for (int i = 0; i < 3; ++i) y_ref(i) = yv[(size_t)i];
+    var lp_ref = stan::math::inv_gamma_lpdf<false>(y_ref, 2.0, 3.0);
+    lp_ref.grad();
+    expect_eq("inv_gamma vector value", r.value, lp_ref.val());
+    for (int i = 0; i < 3; ++i)
+      expect_eq("inv_gamma vector dy" + std::to_string(i), r.grad[(size_t)i],
+                y_ref(i).adj());
+    stan::math::recover_memory();
+  }
+
+  // A literal early return is disconnected, not merely an edge whose local
+  // derivative happens to be zero. Squaring -inf sends an infinite adjoint
+  // toward the density; Stan leaves y untouched rather than forming inf * 0.
+  {
+    Graph g;
+    const int y = g.add_slot(1, true);
+    const int alpha = g.add_slot(1, false);
+    const int beta = g.add_slot(1, false);
+    const int lp_slot = g.add_slot(1, false);
+    const int squared = g.add_slot(1, false);
+    g.add_op(OP_INV_GAMMA_LPDF, {y, alpha, beta}, lp_slot);
+    g.add_op(OP_SQUARE, {lp_slot}, squared);
+    g.result_slot = squared;
+    Executor ex(std::move(g));
+    ex.value_ptr(alpha)[0] = 2.0;
+    ex.value_ptr(beta)[0] = 3.0;
+    ex.params_data()[0] = -1.0;
+    double grad = std::numeric_limits<double>::quiet_NaN();
+    const double value = ex.gradient(&grad);
+
+    var y_ref = -1.0;
+    var lp_ref = stan::math::inv_gamma_lpdf<false>(y_ref, 2.0, 3.0);
+    var value_ref = stan::math::square(lp_ref);
+    value_ref.grad();
+    expect_eq("inv_gamma disconnected value", value, value_ref.val());
+    expect_eq("inv_gamma disconnected dy", grad, y_ref.adj());
+    stan::math::recover_memory();
+  }
+
+  // Conversely, a normal build remains connected even when its local
+  // derivative happens to be zero. At y=beta/(alpha+1), inv_gamma's d/dy is
+  // exactly zero; an infinite upstream adjoint therefore produces NaN on
+  // both Stan's edge and the Graph edge. The connectivity flag must not
+  // suppress that multiplication.
+  {
+    Graph g;
+    const int y = g.add_slot(1, true);
+    const int alpha = g.add_slot(1, false);
+    const int beta = g.add_slot(1, false);
+    const int infinity = g.add_slot(1, false);
+    const int lp_slot = g.add_slot(1, false);
+    const int scaled = g.add_slot(1, false);
+    g.add_op(OP_INV_GAMMA_LPDF, {y, alpha, beta}, lp_slot);
+    g.add_op(OP_MUL, {lp_slot, infinity}, scaled);
+    g.result_slot = scaled;
+    Executor ex(std::move(g));
+    ex.value_ptr(alpha)[0] = 2.0;
+    ex.value_ptr(beta)[0] = 3.0;
+    ex.value_ptr(infinity)[0] = std::numeric_limits<double>::infinity();
+    ex.params_data()[0] = 1.0;
+    double grad = 0;
+    const double value = ex.gradient(&grad);
+
+    var y_ref = 1.0;
+    var lp_ref = stan::math::inv_gamma_lpdf<false>(y_ref, 2.0, 3.0);
+    var value_ref = lp_ref * std::numeric_limits<double>::infinity();
+    value_ref.grad();
+    expect_eq("inv_gamma connected value", value, value_ref.val());
+    expect_nan("inv_gamma connected dy", grad, y_ref.adj());
+    stan::math::recover_memory();
+  }
+
+  // The fused elementwise kernel reuses one sink across lanes. An invalid
+  // lane between valid lanes must record LOG_ZERO and zero only its own
+  // partial, without inheriting the preceding lane's value.
+  {
+    const std::vector<double> yv{1.5, -1.0, 2.25};
+    const EltRun r =
+        run_elt_fused(OP_INV_GAMMA_LPDF, 0x01, 3, {yv, {2.0}, {3.0}},
+                      {true, false, false}, {});
+    double total = 0;
+    for (int i = 0; i < 3; ++i) {
+      var y_ref = yv[(size_t)i];
+      var lp_ref = stan::math::inv_gamma_lpdf<false>(y_ref, 2.0, 3.0);
+      lp_ref.grad();
+      total += lp_ref.val();
+      expect_eq("inv_gamma elt value" + std::to_string(i), r.out[(size_t)i],
+                lp_ref.val());
+      expect_eq("inv_gamma elt dy" + std::to_string(i), r.grad[(size_t)i],
+                y_ref.adj());
+      stan::math::recover_memory();
+    }
+    expect_eq("inv_gamma elt sum", r.value, total);
+  }
+
+  // Connectivity is per lane in the fused form: only the invalid lane is
+  // disconnected when downstream arithmetic sends it an infinite adjoint.
+  {
+    const std::vector<double> yv{1.5, -1.0, 2.25};
+    Graph g;
+    const int y = g.add_slot(3, true);
+    const int alpha = g.add_slot(1, false);
+    const int beta = g.add_slot(1, false);
+    const int lp = g.add_slot(3, false);
+    const int squared = g.add_slot(3, false);
+    const int total = g.add_slot(1, false);
+    Op density;
+    density.opcode = OP_INV_GAMMA_LPDF;
+    density.variant = 0x41;
+    density.out = lp;
+    density.in[0] = y;
+    density.in[1] = alpha;
+    density.in[2] = beta;
+    density.n_in = 3;
+    g.ops.push_back(density);
+    g.add_op(OP_SQUARE, {lp}, squared);
+    g.add_op(OP_SUM_VEC, {squared}, total);
+    g.result_slot = total;
+    Executor ex(std::move(g));
+    ex.value_ptr(alpha)[0] = 2.0;
+    ex.value_ptr(beta)[0] = 3.0;
+    for (int i = 0; i < 3; ++i) ex.params_data()[i] = yv[(size_t)i];
+    double grad[3] = {0, 0, 0};
+    const double value = ex.gradient(grad);
+
+    double value_ref = 0;
+    for (int i = 0; i < 3; ++i) {
+      var y_ref = yv[(size_t)i];
+      var lp_ref = stan::math::inv_gamma_lpdf<false>(y_ref, 2.0, 3.0);
+      var squared_ref = stan::math::square(lp_ref);
+      squared_ref.grad();
+      value_ref += squared_ref.val();
+      expect_eq("inv_gamma elt disconnected dy" + std::to_string(i), grad[i],
+                y_ref.adj());
+      stan::math::recover_memory();
+    }
+    expect_eq("inv_gamma elt disconnected value", value, value_ref);
   }
 
   // ---- normal_lpdf(y_pv, mu_ps, sigma_ps): all three parameters ----------

--- a/tests/test_glm.cpp
+++ b/tests/test_glm.cpp
@@ -3,16 +3,80 @@
 #include "models.hpp"
 
 #include <stan/math.hpp>
+#include <cmath>
 #include <cstdio>
+#include <limits>
 #include <string>
 #include <vector>
 
 static int failures = 0;
 static void expect_eq(const std::string& what, double got, double want) {
-  if (got != want) {
+  if (got != want && !(std::isnan(got) && std::isnan(want))) {
     ++failures;
     std::printf("FAIL %-16s got %.17g want %.17g\n", what.c_str(), got, want);
   }
+}
+
+// The three direct GLM kernels do not pass through the generated scalar
+// density wrappers. Empty outcomes return zero before Stan Math builds a
+// propagator, so each must still preserve the returned value and disconnected
+// topology through its own recorder call.
+static void check_empty_glm(uint16_t opcode, const std::string& name) {
+  using namespace stanli;
+  using stan::math::var;
+  constexpr int K = 2;
+
+  Graph g;
+  const int X_slot = g.add_slot(0, false);
+  const int alpha_slot = g.add_slot(1, true);
+  const int beta_slot = g.add_slot(K, true);
+  const bool has_phi = opcode == OP_NEG_BINOMIAL_2_LOG_GLM_LPMF;
+  const int phi_slot = has_phi ? g.add_slot(1, true) : -1;
+  const int infinity_slot = g.add_slot(1, false);
+  const int lp_slot = g.add_slot(1, false);
+  const int scaled_slot = g.add_slot(1, false);
+  if (has_phi) {
+    g.add_op(opcode, {X_slot, alpha_slot, beta_slot, phi_slot}, lp_slot,
+             {0, K});
+  } else {
+    g.add_op(opcode, {X_slot, alpha_slot, beta_slot}, lp_slot, {0, K});
+  }
+  g.add_op(OP_MUL, {lp_slot, infinity_slot}, scaled_slot);
+  g.result_slot = scaled_slot;
+
+  Executor ex(std::move(g));
+  ex.value_ptr(infinity_slot)[0] = std::numeric_limits<double>::infinity();
+  ex.params_data()[0] = 0.4;
+  ex.params_data()[1] = -0.3;
+  ex.params_data()[2] = 0.8;
+  if (has_phi) ex.params_data()[3] = 1.7;
+  std::vector<double> grad(has_phi ? 4 : 3, 0.0);
+  const double value = ex.gradient(grad.data());
+
+  const std::vector<int> y;
+  const Eigen::Matrix<double, -1, -1> X(0, K);
+  var alpha = 0.4;
+  Eigen::Matrix<var, -1, 1> beta(K);
+  beta << -0.3, 0.8;
+  var phi = 1.7;
+  var lp_ref;
+  if (opcode == OP_BERNOULLI_LOGIT_GLM_LPMF) {
+    lp_ref = stan::math::bernoulli_logit_glm_lpmf<false>(y, X, alpha, beta);
+  } else if (opcode == OP_POISSON_LOG_GLM_LPMF) {
+    lp_ref = stan::math::poisson_log_glm_lpmf<false>(y, X, alpha, beta);
+  } else {
+    lp_ref =
+        stan::math::neg_binomial_2_log_glm_lpmf<false>(y, X, alpha, beta, phi);
+  }
+  var value_ref = lp_ref * std::numeric_limits<double>::infinity();
+  value_ref.grad();
+  expect_eq(name + " empty value", value, value_ref.val());
+  expect_eq(name + " empty alpha", grad[0], alpha.adj());
+  for (int k = 0; k < K; ++k)
+    expect_eq(name + " empty beta" + std::to_string(k), grad[1 + k],
+              beta(k).adj());
+  if (has_phi) expect_eq(name + " empty phi", grad[3], phi.adj());
+  stan::math::recover_memory();
 }
 
 static void reference(const double* q, double* lp_out, double* grad_out) {
@@ -69,6 +133,10 @@ int main() {
     for (int i = 0; i < NP; ++i)
       expect_eq(tag + " g" + std::to_string(i), grad[i], grad_ref[i]);
   }
+
+  check_empty_glm(OP_BERNOULLI_LOGIT_GLM_LPMF, "bernoulli_logit_glm");
+  check_empty_glm(OP_POISSON_LOG_GLM_LPMF, "poisson_log_glm");
+  check_empty_glm(OP_NEG_BINOMIAL_2_LOG_GLM_LPMF, "neg_binomial_2_log_glm");
 
   if (failures == 0) std::printf("test_glm OK\n");
   return failures == 0 ? 0 : 1;


### PR DESCRIPTION
## Summary

- record Stan Math probability return values when a function exits before partials_propagator::build
- preserve disconnected early-return topology through Graph and native Program reverse passes, including fused lanes and zero-observation GLMs
- remove the uniform-only support workaround and restore the thread-local recorder sink on exceptions

## Characterization first

Before the production change, the new tests reproduced:

- scalar inv_gamma_lpdf: Graph returned 0 instead of -inf and reused a -2/3 derivative after a valid call
- vector inv_gamma_lpdf: Graph returned 0 instead of -inf
- fused inv_gamma_lpdf: an invalid lane inherited the preceding finite value
- Program partials: all caller sentinels were left untouched
- disconnected -inf with an infinite upstream adjoint: Graph and native Program produced NaN inputs while the Stan var oracle left them at zero
- exception path: active_sink retained a dangling stack pointer

The suite also pins the converse: a normal build with an exact-zero local partial remains connected and matches Stan inf*0 behavior.

## Scope

- production: 429 changed lines (224 additions, 205 deletions; net +19)
- tests: 313 changed lines
- generated fixtures: none

## Verification

- ./tools/format.sh --check
- RelWithDebInfo configure and full -j2 build
- 44/44 CTests
- 129/129 reference models within 1e-9; worst 3.63e-12
- 119/119 compiling write-array models complete
- A/B corpus: no flags; worst deviation 3.46e-13
- independent adversarial review: READY