### PR TITLE
fix: refuse unsupported all-data densities

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ could not build one on their farm.
   <!--gen:lang_verified-->10/10<!--/gen--> models lifted from stanc3's own
   test suite, for the type and language constructs no real posterior
   happens to use, verified the same way.
-- Distribution coverage: [docs/coverage.md](docs/coverage.md). 71 of 72
+- Distribution coverage: [docs/coverage.md](docs/coverage.md). 69 of 72
   densities, 90 of 105 cdf/lcdf/lccdf, truncation, censoring, ordinal
   regression and the count GLMs, each bitwise against CmdStan.
 - Install size: one 22.2 MB shared library, a 7.8 MB wheel. Breakdown in

--- a/docs/coverage.md
+++ b/docs/coverage.md
@@ -7,7 +7,7 @@ against CmdStan with a generated single-function model.
 
 | family | supported |
 |---|---|
-| densities (`_lpdf`, `_lpmf`) | 71 / 72 |
+| densities (`_lpdf`, `_lpmf`) | 69 / 72 |
 | distribution functions (`_cdf`, `_lcdf`, `_lccdf`) | 90 / 105 |
 | scalar math (all-real signature) | 47 / 129 |
 
@@ -28,15 +28,13 @@ Adding a function is one line in an X-macro list in
 
 Not every density needs a kernel.
 
-**1. Rewrite, when the rewrite is exact.** `y ~ foo(...)` with every
-argument data contributes exactly zero: CmdStan calls
-`foo_lpdf<propto=true>` on all-double arguments and drops the term
-before any arithmetic. That rule needs no kernel and is the whole of
-`hypergeometric` and `discrete_range`, whose arguments are all
-integers. (One divergence: on data outside the density's support,
-CmdStan throws from its checks and stanli contributes 0. Such a model
-rejects every draw either way.) A rewrite that changes arithmetic does
-not belong here: `multi_normal_prec(y | mu, P)` equals
+**1. Rewrite, when the rewrite is exact.** A rewrite must preserve checks as
+well as the returned value. In particular, CmdStan checks an all-data
+`foo_lpdf<propto=true>` call before dropping its constant term. Stanli
+therefore refuses the propto forms of `hypergeometric` and
+`discrete_range` until it can execute their support checks; their normalized,
+all-data function calls can still constant-fold exactly. A rewrite that
+changes arithmetic does not belong here: `multi_normal_prec(y | mu, P)` equals
 `multi_normal(y | mu, inverse(P))` mathematically, but the inverse
 costs K^3 per evaluation and stops matching CmdStan bitwise. The kernel
 was fifteen lines.
@@ -63,10 +61,15 @@ contract.
 
 ## What is left
 
-**`gaussian_dlm_obs`**, the only unsupported density, for a structural
-reason: it takes seven arguments and `Op::in` holds six. Raising the
-limit would grow every `Op` and `KernelCtx` in every model for one
-density, so the lowering refuses and says why.
+**`hypergeometric` and `discrete_range` propto forms.** Their values are
+constant zero, but Stan Math performs support checks first. Until Stanli has
+an exact checked implementation, lowering refuses rather than silently
+accepting invalid data.
+
+**`gaussian_dlm_obs`.** It is unsupported for a structural reason: it takes
+seven arguments and `Op::in` holds six. Raising the limit would grow every
+`Op` and `KernelCtx` in every model for one density, so the lowering refuses
+and says why.
 
 **Vector `alpha` in the GLMs.** `bernoulli_logit_glm`,
 `poisson_log_glm` and `neg_binomial_2_log_glm` take the intercept as a

--- a/runtime/src/lower.cpp
+++ b/runtime/src/lower.cpp
@@ -1541,26 +1541,6 @@ struct Lowering {
     if (auto v = lower_eltwise_fn(e)) return *v;
     if (auto v = lower_matrix_fn(e)) return *v;
     if (auto v = lower_ode_fn(e)) return *v;
-    // `y ~ foo(...)` with every argument data is EXACTLY zero in CmdStan:
-    // the generated C++ calls foo_lpdf<propto=true> on all-double
-    // arguments, include_summand comes back false, and the whole term is
-    // dropped before any arithmetic happens. So the rewrite is not an
-    // approximation, and it covers densities no kernel exists for --
-    // hypergeometric and discrete_range are all-int, so ALL their uses
-    // land here or in the constant fold below. (categorical_logit already
-    // had this rule privately; this is the general form.) The one
-    // divergence is a model whose data is outside the density's support:
-    // CmdStan's checks throw before the early return, stanli contributes
-    // 0. That model rejects every draw anyway.
-    const bool is_density =
-        e.name.size() > 5 &&
-        (e.name.compare(e.name.size() - 5, 5, "_lpdf") == 0 ||
-         e.name.compare(e.name.size() - 5, 5, "_lpmf") == 0);
-    if (is_density && propto(e)) {
-      bool all_data = true;
-      for (const auto& a : e.args) all_data = all_data && a.data_only;
-      if (all_data) return constant(0.0);
-    }
     // A shape query in a REAL-valued expression. eval_int already answers
     // rows/cols/size from the slot or the data map, but only where an
     // integer was expected; brms's mo() helper writes

--- a/tests/test_lower.cpp
+++ b/tests/test_lower.cpp
@@ -1431,6 +1431,66 @@ int main() {
   }
 
   {
+    // Stan Math's hypergeometric implementation performs support checks
+    // before dropping an all-data propto term. Without a native density
+    // implementation, accepting the model as a constant zero would therefore
+    // be exact only for valid data and silently accept invalid data. The
+    // honest boundary is to refuse both.
+    const std::string hypergeometric_mir = R"(
+((functions_block ())
+ (input_vars
+  ((n <opaque> SInt) (N <opaque> SInt) (a <opaque> SInt)
+   (b <opaque> SInt)))
+ (prepare_data ())
+ (log_prob
+  (((pattern
+     (TargetPE
+      ((pattern
+        (FunApp (StanLib hypergeometric_lpmf (FnLpmf true) AoS)
+         (((pattern (Var n))
+           (meta ((type_ UInt) (adlevel DataOnly))))
+          ((pattern (Var N))
+           (meta ((type_ UInt) (adlevel DataOnly))))
+          ((pattern (Var a))
+           (meta ((type_ UInt) (adlevel DataOnly))))
+          ((pattern (Var b))
+           (meta ((type_ UInt) (adlevel DataOnly)))))))
+       (meta ((type_ UReal) (adlevel DataOnly))))))
+    (meta <opaque>)))))
+)";
+
+    check(stan::math::hypergeometric_lpmf<true>(1, 2, 3, 4) == 0.0,
+          "all-data propto oracle drops a valid density");
+    bool oracle_rejected = false;
+    try {
+      (void)stan::math::hypergeometric_lpmf<true>(4, 4, 3, 3);
+    } catch (const std::domain_error&) {
+      oracle_rejected = true;
+    }
+    check(oracle_rejected,
+          "all-data propto oracle still checks invalid support");
+
+    auto lowering_refuses = [&](int n, int N, int a, int b) {
+      DataMap d;
+      d.set_int("n", n);
+      d.set_int("N", N);
+      d.set_int("a", a);
+      d.set_int("b", b);
+      try {
+        (void)compile_model(hypergeometric_mir, d);
+      } catch (const CompileError& e) {
+        return std::string(e.what()).find("hypergeometric_lpmf") !=
+               std::string::npos;
+      }
+      return false;
+    };
+    check(lowering_refuses(1, 2, 3, 4),
+          "unsupported valid all-data propto density is refused");
+    check(lowering_refuses(4, 4, 3, 3),
+          "unsupported invalid all-data propto density is refused");
+  }
+
+  {
     // Error path: an unsupported function is reported by name, never
     // silently miscompiled. Mutate a known-good fixture's density name.
     std::string txt = slurp("tests/fixtures/es.tmir.sexp");


### PR DESCRIPTION
## Summary

- remove the generic constant-zero rewrite for unsupported all-data propto densities
- refuse hypergeometric/discrete_range sampling statements instead of erasing Stan Math support checks
- pin both the valid zero-valued case and invalid-support rejection against a direct Stan Math oracle
- correct full-semantics density coverage from 71/72 to 69/72

## Why

Stan Math performs domain/support validation before its propto early return. The old lowering silently returned zero for unsupported all-data densities, so invalid data accepted by Stanli was rejected by CmdStan. Until exact checked implementations exist, construction-time refusal is the honest boundary.

## Verification

- format check and diff check
- RelWithDebInfo configure and full build
- 46/46 CTests
- 129/129 reference models within 1e-9; worst 3.63e-12
- 119/119 write-array corpus models complete
- A/B corpus: no flags; worst 3.46e-13
- adversarial static review: READY

## Size

- production: +0/-20
- tests: +60/-0
- docs: +18/-15
- generated fixtures: unchanged