### PR TITLE
Compile with stanc3's optimizer: consume --O1 optimized MIR

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -163,11 +163,17 @@ jobs:
         id: deps-cache
         uses: actions/cache@v4
         with:
+          # stanc_embed.o is excluded: it belongs to the stanc-embed cache
+          # above, and a copy riding in here restores over a fresh object
+          # (and once satisfied dev_setup's presence check with a STALE
+          # one, shipping a wheel whose embedded compiler lagged the
+          # shim). The -embed1 suffix retires the poisoned entries.
           path: |
             deps/math
             deps/stan
             deps/stanc3
-          key: deps-${{ matrix.plat }}-${{ hashFiles('deps/fetch.sh') }}
+            !deps/stanc3/stanc_embed.o
+          key: deps-${{ matrix.plat }}-embed1-${{ hashFiles('deps/fetch.sh') }}
 
       - name: Vendored dependencies
         run: ./deps/fetch.sh
@@ -175,6 +181,9 @@ jobs:
       - name: Build the embedded stanc3 object
         if: steps.stanc-cache.outputs.cache-hit != 'true'
         run: |
+          # The stanc-embed cache missed, so any object on disk came from
+          # another cache and is stale by definition.
+          rm -f deps/stanc3/stanc_embed.o
           opam init --bare --disable-sandboxing --no-setup -y
           ./tools/dev_setup.sh --embed --no-build
           mkdir -p deps/ocaml-include

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ run by a small interpreter. There is no JIT and no C++ codegen;
 model.stan + data.json
   |  stanc3 (official OCaml compiler, linked into the library)
   v
-transformed MIR (s-expression)
+optimized MIR (--O1, s-expression)
   |  lowering: runtime/src/lower.cpp
   v
 op graph + preallocated value/adjoint arenas
@@ -83,7 +83,7 @@ NUTS (stan::mcmc::adapt_diag_e_nuts) -> draws
 1. **stanc3, in process.** The official Stan compiler (OCaml) is built
    as a self-contained object and linked into the shared library. It
    parses, typechecks, and optimizes the model; stanli consumes its
-   transformed MIR. Full language fidelity without a subprocess or a
+   optimized MIR (--O1). Full language fidelity without a subprocess or a
    reimplemented parser.
 
 2. **Lowering** (`runtime/src/lower.cpp`). Transformed data is evaluated

--- a/docs/hacking.md
+++ b/docs/hacking.md
@@ -65,7 +65,7 @@ repeatedly below.
 ```
 model.stan + data.json
   |  stanc3, linked in-process (stanc_embed)
-  v  transformed MIR, as s-expressions
+  v  optimized MIR (--O1), as s-expressions
 mir_reader.cpp
   |  parsed into mir::Stmt / mir::Expr structs
   v

--- a/harnesses/ab_corpus.py
+++ b/harnesses/ab_corpus.py
@@ -103,7 +103,7 @@ def main():
 
         # op counts (reuse one stanc run for both dumps)
         sexp = tmp / f"{model}.sexp"
-        r = run([str(STANC), "--debug-transformed-mir", str(stan)])
+        r = run([str(STANC), "--O1", "--debug-optimized-mir", str(stan)])
         ops_a = ops_b = -1
         if r is not None and r.returncode == 0:
             sexp.write_text(r.stdout)

--- a/harnesses/corpus_bench.py
+++ b/harnesses/corpus_bench.py
@@ -108,7 +108,7 @@ def main():
 
         # ---- stanli ----
         sexp = tmp / f"{model}.sexp"
-        r = run([str(STANC), "--debug-transformed-mir", str(stan)], timeout)
+        r = run([str(STANC), "--O1", "--debug-optimized-mir", str(stan)], timeout)
         if r is None:
             notes.append("stanc_fail")
         else:

--- a/harnesses/fn_sweep.py
+++ b/harnesses/fn_sweep.py
@@ -278,7 +278,7 @@ def sweep_one(spec, cs, tmp, keep, density=True):
 
     ns = None
     sexp = d / "m.sexp"
-    mir = run([str(REPO / "deps/stanc3/stanc"), "--debug-transformed-mir", str(stan)])
+    mir = run([str(REPO / "deps/stanc3/stanc"), "--O1", "--debug-optimized-mir", str(stan)])
     if mir.returncode == 0:
         sexp.write_text(mir.stdout)
         bench = run([str(REPO / BUILD / "bench_grad"), str(sexp), str(data), "20000"])

--- a/harnesses/island_ab.py
+++ b/harnesses/island_ab.py
@@ -109,7 +109,7 @@ def main():
         if not stan.exists() or not dz.exists():
             continue
         sexp = tmp / f"{model}.sexp"
-        r = run([str(STANC), "--debug-transformed-mir", str(stan)], None, timeout)
+        r = run([str(STANC), "--O1", "--debug-optimized-mir", str(stan)], None, timeout)
         if r is None or not r.stdout:
             continue
         sexp.write_text(r.stdout)

--- a/harnesses/op_census.py
+++ b/harnesses/op_census.py
@@ -56,7 +56,7 @@ def main():
         dj = tmp / f"{model}.json"
         with zipfile.ZipFile(dz) as z:
             dj.write_bytes(z.read(z.namelist()[0]))
-        r = run([str(STANC), "--debug-transformed-mir", str(stan)])
+        r = run([str(STANC), "--O1", "--debug-optimized-mir", str(stan)])
         if r is None or r.returncode != 0:
             skipped.append(f"{model}: stanc")
             continue

--- a/js/README.md
+++ b/js/README.md
@@ -35,7 +35,7 @@ WASM runtime plus the stanc3 compiler. The compiler loads lazily, only
 when a call passes Stan source. `preload()` starts both loads in the
 background; call it at page idle so the first `sample()` skips the
 fetch and parse. An app that ships a fixed model can precompile it at
-build time (`stanc --debug-transformed-mir model.stan`) and pass `mir`
+build time (`stanc --O1 --debug-optimized-mir model.stan`) and pass `mir`
 instead of `code`; the runtime alone is ~1.5 MB gzipped.
 
 118 of 119 posteriordb corpus models verify against CmdStan's log

--- a/js/index.mjs
+++ b/js/index.mjs
@@ -12,7 +12,7 @@
 // one chain each -- run simultaneously. Compiling once and passing `mir`
 // keeps the 2.8 MB compiler in a single worker (or out of the page
 // entirely, if the model was precompiled at build time with
-// stanc --debug-transformed-mir).
+// stanc --O1 --debug-optimized-mir).
 
 const pool = [];
 const waiters = [];
@@ -99,8 +99,8 @@ export function compile(opts) {
  * @param {Object} opts
  * @param {string} [opts.code]     Stan source (compiled in the worker by
  *   stanc3, which loads lazily on first use).
- * @param {string} [opts.mir]      Precompiled transformed MIR (from
- *   `compile()` here, or `stanc --debug-transformed-mir` at build time).
+ * @param {string} [opts.mir]      Precompiled MIR (from `compile()`
+ *   here, or `stanc --O1 --debug-optimized-mir` at build time).
  *   When given, the 2.8 MB compiler never loads: the runtime alone is
  *   ~1.3 MB gzipped.
  * @param {Object|string} [opts.data]  Data as an object or JSON text.

--- a/js/worker.js
+++ b/js/worker.js
@@ -38,7 +38,7 @@ onmessage = async (e) => {
       // and never load the compiler.
       say("compiling Stan -> MIR (stanc3)");
       ensureStanc();
-      const sc = stanc("browser_model", req.code, ["debug-transformed-mir"]);
+      const sc = stanc("browser_model", req.code, ["O1", "debug-optimized-mir"]);
       if (sc.errors) throw new Error(Array.from(sc.errors).join("\n"));
       postMessage({ done: { mir: String(sc.result),
                             ms: { stanc: performance.now() - t0 } } });
@@ -49,7 +49,7 @@ onmessage = async (e) => {
     if (!mir) {
       say("compiling Stan -> MIR (stanc3)");
       ensureStanc();
-      const sc = stanc("browser_model", req.code, ["debug-transformed-mir"]);
+      const sc = stanc("browser_model", req.code, ["O1", "debug-optimized-mir"]);
       if (sc.errors) throw new Error(Array.from(sc.errors).join("\n"));
       mir = String(sc.result);
     }

--- a/python/stanli/__init__.py
+++ b/python/stanli/__init__.py
@@ -176,7 +176,7 @@ def _dptr(a):
 
 def _stanc_mir(model_path: pathlib.Path) -> str:
     stanc = _BIN / ("stanc.exe" if sys.platform == "win32" else "stanc")
-    r = subprocess.run([str(stanc), "--debug-transformed-mir",
+    r = subprocess.run([str(stanc), "--O1", "--debug-optimized-mir",
                         str(model_path)],
                        capture_output=True, text=True)
     if r.returncode != 0 or not r.stdout:
@@ -185,7 +185,7 @@ def _stanc_mir(model_path: pathlib.Path) -> str:
 
 
 def stan_to_mir(stan_code: str) -> str:
-    """Stan source to transformed-MIR text, without building a model.
+    """Stan source to optimized-MIR text, without building a model.
 
     The first half of compiling a model, on its own. Useful when the MIR
     is what you want to keep -- to cache it, ship it, or hand it to
@@ -539,8 +539,8 @@ class Model:
         err = ctypes.create_string_buffer(8192)
 
         if mir is not None:
-            # Already-compiled transformed MIR, from stan_to_mir or from
-            # `stanc --debug-transformed-mir`. Skips the compiler
+            # Already-compiled MIR, from stan_to_mir or from
+            # `stanc --O1 --debug-optimized-mir`. Skips the compiler
             # entirely, which is what a cached or shipped model wants.
             self._m = _lib.stanli_model_new(mir.encode(), data_json.encode(),
                                             err, len(err))

--- a/runtime/include/stanli/capi.h
+++ b/runtime/include/stanli/capi.h
@@ -30,9 +30,10 @@ typedef struct stanli_model stanli_model;
 #define STANLI_ABI_VERSION 1
 int stanli_abi_version(void);
 
-/* Compile transformed-MIR sexp text (from `stanc --debug-transformed-mir`)
- * against JSON data (CmdStan conventions). Returns null on failure with a
- * message in err. */
+/* Compile MIR sexp text (from `stanc --O1 --debug-optimized-mir`; the
+ * unoptimized --debug-transformed-mir form is the same format and also
+ * accepted) against JSON data (CmdStan conventions). Returns null on
+ * failure with a message in err. */
 stanli_model* stanli_model_new(const char* tmir_sexp, const char* data_json,
                                char* err, size_t err_len);
 

--- a/runtime/include/stanli/mir.hpp
+++ b/runtime/include/stanli/mir.hpp
@@ -198,6 +198,10 @@ struct Program {
   // emit_generated_quantities__, which the lowering pins to 1.
   std::vector<Stmt> generate_quantities;
   std::vector<FunDef> fun_defs;
+  // Output variable names (params, transformed params, generated
+  // quantities) in FnWriteParam emission order, from the MIR's
+  // output_vars section.
+  std::vector<std::string> output_vars;
 };
 
 Program read_program(const sexp::Node& root);

--- a/runtime/include/stanli/mir_interp.hpp
+++ b/runtime/include/stanli/mir_interp.hpp
@@ -911,6 +911,13 @@ class MirInterp {
       return bin([](const T& x, const T& y) { return stan::math::fmax(x, y); });
     if (e.name == "fmin")
       return bin([](const T& x, const T& y) { return stan::math::fmin(x, y); });
+    // --O1 partial evaluation rewrites `x * log(y)` to lmultiply(x, y);
+    // multiply_log computes exactly x * log(y), so the value is bitwise
+    // what the unoptimized form produced.
+    if (e.name == "lmultiply" || e.name == "multiply_log")
+      return bin([](const T& x, const T& y) {
+        return stan::math::multiply_log(x, y);
+      });
     if (e.name == "PMinus__") return un([](const T& x) { return -x; });
     if (e.name == "PPlus__") return un([](const T& x) { return x; });
     if (e.name == "exp")

--- a/runtime/include/stanli/mir_prog.hpp
+++ b/runtime/include/stanli/mir_prog.hpp
@@ -601,6 +601,19 @@ struct ProgramCompiler {
         const Range dst = it->second;
         const Range v = expr(s.rhs);
         if (s.lhs_idx.empty()) {
+          if (dst.len == 0 && v.len != 0) {
+            // The zero-length declaration is stanc3's --O1 inliner
+            // leaving a return variable unsized (`vector[0]`) for the
+            // assignment to size; adopt the assigned shape. The inliner
+            // assigns it exactly once, right where the call was, so no
+            // two branch arms can disagree about the size.
+            Range nd = v;
+            nd.reg = alloc(v.len);
+            for (int k = 0; k < v.len; ++k)
+              emit(Program::MOV, nd.reg + k, v.reg + k);
+            it->second = nd;
+            return;
+          }
           if (v.len != dst.len) bail("assignment width mismatch for " + s.lhs);
           if (!same_view(v, dst))
             bail("assignment logical view mismatch for " + s.lhs);

--- a/runtime/include/stanli/sexp.hpp
+++ b/runtime/include/stanli/sexp.hpp
@@ -1,4 +1,5 @@
-// Minimal s-expression parser for stanc3 --debug-transformed-mir output.
+// Minimal s-expression parser for stanc3 MIR dumps (--debug-optimized-mir
+// and --debug-transformed-mir share the format).
 // Atoms are bare tokens (including <opaque>) or double-quoted strings with
 // backslash escapes.
 #ifndef STANLI_SEXP_HPP

--- a/runtime/include/stanli/wa_interp.hpp
+++ b/runtime/include/stanli/wa_interp.hpp
@@ -90,6 +90,10 @@ class WaInterp {
   size_t n_gq_start_ = 0;
   bool saw_tp_ = false, saw_gq_ = false;
   bool have_cols_ = false;
+  // The variable the last FnWriteParam named, while columns are being
+  // discovered: the anchor for naming a write whose variable reference
+  // the optimizer substituted away (see write_param).
+  std::string last_written_;
 };
 
 }  // namespace stanli

--- a/runtime/kernels/matrix_fns.cpp
+++ b/runtime/kernels/matrix_fns.cpp
@@ -323,28 +323,40 @@ void lkjc_bwd(KernelCtx& ctx) { lkj_eval<true, false>(ctx); }
 double nid_glm_eval(KernelCtx& ctx) {
   const int64_t rows = ctx.idata[0], cols = ctx.idata[1];
   const bool propto = (ctx.variant & 0x80u) != 0;
+  // y is a parameter when stanc3's --O1 partial evaluator built the GLM
+  // out of `theta ~ normal(X * b, s)`: the outcome needs its gradient
+  // back. y-as-data (every hand-written GLM) keeps the double fast path.
+  const bool y_var = (ctx.variant & 0x1u) != 0;
   stan::math::nested_rev_autodiff nested;
   using stan::math::var;
   CMapV yd(ctx.in[0].data, rows);
   CMapM X(ctx.in[1].data, rows, cols);
+  VarV yv(y_var ? rows : 0);
+  for (int64_t i = 0; i < yv.size(); ++i) yv(i) = ctx.in[0].data[i];
   VarV alpha(ctx.in[2].len), beta(ctx.in[3].len), sigma(ctx.in[4].len);
   for (int64_t i = 0; i < ctx.in[2].len; ++i) alpha(i) = ctx.in[2].data[i];
   for (int64_t i = 0; i < ctx.in[3].len; ++i) beta(i) = ctx.in[3].data[i];
   for (int64_t i = 0; i < ctx.in[4].len; ++i) sigma(i) = ctx.in[4].data[i];
   var out;
   const bool one_a = ctx.in[2].len == 1, one_s = ctx.in[4].len == 1;
-  auto call = [&](auto&& a, auto&& s) {
-    return propto ? stan::math::normal_id_glm_lpdf<true>(yd, X, a, beta, s)
-                  : stan::math::normal_id_glm_lpdf<false>(yd, X, a, beta, s);
+  auto call = [&](auto&& y, auto&& a, auto&& s) {
+    return propto ? stan::math::normal_id_glm_lpdf<true>(y, X, a, beta, s)
+                  : stan::math::normal_id_glm_lpdf<false>(y, X, a, beta, s);
   };
-  if (one_a && one_s)
-    out = call(alpha(0), sigma(0));
-  else if (one_a)
-    out = call(alpha(0), sigma);
-  else if (one_s)
-    out = call(alpha, sigma(0));
+  auto dispatch = [&](auto&& y) {
+    if (one_a && one_s)
+      out = call(y, alpha(0), sigma(0));
+    else if (one_a)
+      out = call(y, alpha(0), sigma);
+    else if (one_s)
+      out = call(y, alpha, sigma(0));
+    else
+      out = call(y, alpha, sigma);
+  };
+  if (y_var)
+    dispatch(yv);
   else
-    out = call(alpha, sigma);
+    dispatch(yd);
   const double v = out.val();
   // One tape per gradient, not two. The forward differentiates it once
   // with a seed of 1 and keeps the partials; the backward is then the
@@ -354,6 +366,7 @@ double nid_glm_eval(KernelCtx& ctx) {
   // work than CmdStan does for the same statement.
   stan::math::grad(out.vi_);
   double* s = ctx.scratch;
+  for (int64_t i = 0; i < yv.size(); ++i) *s++ = yv(i).adj();
   for (int64_t i = 0; i < ctx.in[2].len; ++i) *s++ = alpha(i).adj();
   for (int64_t i = 0; i < ctx.in[3].len; ++i) *s++ = beta(i).adj();
   for (int64_t i = 0; i < ctx.in[4].len; ++i) *s++ = sigma(i).adj();
@@ -361,7 +374,10 @@ double nid_glm_eval(KernelCtx& ctx) {
 }
 
 int64_t nid_glm_scratch(const Op& op, const Slot* slots) {
-  return slots[op.in[2]].len + slots[op.in[3]].len + slots[op.in[4]].len;
+  // The y section exists only when y is active (variant bit 0), but the
+  // sizing hook cannot see the variant, so reserve it unconditionally.
+  return slots[op.in[0]].len + slots[op.in[2]].len + slots[op.in[3]].len +
+         slots[op.in[4]].len;
 }
 
 void nid_glm_fwd(KernelCtx& ctx) { ctx.out.data[0] = nid_glm_eval(ctx); }
@@ -370,6 +386,15 @@ void nid_glm_bwd(KernelCtx& ctx) {
   const unsigned mask = ctx.variant == 0 ? 0x1fu : (ctx.variant & 0x3fu);
   const double* s = ctx.scratch;
   const double w = ctx.out_adj;
+  // Mirror of the forward's scratch layout: y's partials are present
+  // exactly when variant bit 0 is set (never under the legacy variant==0
+  // encoding, whose forward bound y as data).
+  if (ctx.variant & 0x1u) {
+    if (ctx.in_adj[0].data)
+      for (int64_t i = 0; i < ctx.in[0].len; ++i)
+        ctx.in_adj[0].data[i] += w * s[i];
+    s += ctx.in[0].len;
+  }
   for (int k = 2; k <= 4; ++k) {
     const bool active = (mask & (0x4u << (k - 2))) && ctx.in_adj[k].data;
     for (int64_t i = 0; i < ctx.in[k].len; ++i, ++s)

--- a/runtime/src/lower.cpp
+++ b/runtime/src/lower.cpp
@@ -346,6 +346,28 @@ struct Lowering {
             return (long)std::max(en->r.size(), en->i.size());
           }
         }
+        // Shape query on a COMPUTED value: --O1 inlining substitutes call
+        // arguments into the callee's size expressions, so `rows(beta)`
+        // arrives as `rows(segment(beta, pos[i], m[i]))`. Lower the
+        // argument and answer from its slot metadata; any op this emits
+        // is one the body was about to emit anyway.
+        if ((e.name == "rows" || e.name == "cols" || e.name == "size" ||
+             e.name == "num_elements" || e.name == "FnLength") &&
+            e.args.size() == 1 && e.args[0].kind != mir::Expr::Var) {
+          const Val v = lower_expr(e.args[0]);
+          const int64_t len = g.slots[v.slot].len;
+          if (is_array(v.si)) {
+            const ArrayShape& sh = array_shape(v.si);
+            if (e.name == "size" || e.name == "FnLength")
+              return sh.dims.front();
+            if (e.name == "num_elements") return len;
+            fail(e.name + " is undefined for an array value", e.raw);
+          }
+          const LogicalDims dims = logical_dims(v.si, len, e.name);
+          if (e.name == "rows") return dims.rows;
+          if (e.name == "cols") return dims.cols;
+          return len;
+        }
         // Anything else data-only the td interpreter can evaluate (sum of an
         // int array in a size expression, etc.).
         if (e.data_only) {
@@ -934,6 +956,10 @@ struct Lowering {
   struct IslandRegion {
     std::vector<int> in_slots;
     std::vector<std::string> out_names;
+    // The register view of each live-out as the region compiler left it:
+    // the authority on shape when the outside declaration was the --O1
+    // inliner's zero-length sentinel and the region's assignment sized it.
+    std::vector<Range> out_views;
     bool has_target = false;  // the region contributed to the target
   };
 
@@ -1029,6 +1055,7 @@ struct Lowering {
           auto it = c.reals.find(name);
           if (it == c.reals.end()) continue;
           reg->out_names.push_back(name);
+          reg->out_views.push_back(it->second);
           for (int k = 0; k < it->second.len; ++k)
             prog->out_regs.push_back(it->second.reg + k);
         }
@@ -1086,20 +1113,11 @@ struct Lowering {
     std::shared_ptr<IslandProg> prog;
     Range ignored;
     lower_island(&s, nullptr, &reg, &ignored, &prog);
+    // Widths come from the region compiler's own registers: they are what
+    // out_regs packs, and they already reflect a zero-length sentinel
+    // declaration the region's assignment sized.
     std::vector<int> out_lens;
-    for (const std::string& name : reg.out_names) {
-      auto it = scope.find(name);
-      if (it != scope.end()) {
-        out_lens.push_back((int)g.slots[it->second.slot].len);
-        continue;
-      }
-      auto dl = decls.find(name);
-      if (dl == decls.end())
-        fail("parameter-dependent region assigns " + name +
-                 ", which has no declared shape",
-             s.raw);
-      out_lens.push_back((int)dl->second.len);
-    }
+    for (const Range& v : reg.out_views) out_lens.push_back(v.len);
     if (reg.has_target) out_lens.push_back(1);
     std::vector<int> out_slots;
     emit_island(prog, reg, out_lens, &out_slots);
@@ -1107,12 +1125,30 @@ struct Lowering {
     for (size_t k = 0; k < reg.out_names.size(); ++k) {
       const std::string& name = reg.out_names[k];
       SlotInfo si;
+      bool shaped_outside = false;
       auto old = scope.find(name);
       if (old != scope.end()) {
         si = old->second.si;
+        shaped_outside = g.slots[old->second.slot].len != 0;
       } else {
         auto dl = decls.find(name);
-        if (dl != decls.end()) si = dl->second.si;
+        if (dl != decls.end()) {
+          si = dl->second.si;
+          shaped_outside = dl->second.len != 0;
+        }
+      }
+      if (!shaped_outside) {
+        // The outside declaration was the inliner's zero-length sentinel;
+        // the region's registers carry the real shape.
+        si = SlotInfo{};
+        si.rows = reg.out_views[k].rows;
+        si.cols = reg.out_views[k].cols;
+        si.kind = reg.out_views[k].kind;
+        auto dl = decls.find(name);
+        if (dl != decls.end()) {
+          dl->second.len = reg.out_views[k].len;
+          dl->second.si = si;
+        }
       }
       // The island is parameter-dependent regardless of the old binding's
       // provenance; treating its live-out as data would select kernels that
@@ -2804,6 +2840,11 @@ struct Lowering {
           // inlined function), which only eval_int can answer.
           if (s.has_init) int_env[s.decl_id] = eval_int(s.init);
         } else {
+          // A redeclaration shadows whatever the name held: --O1 inlining
+          // reuses one symbol for a callee's local across loop iterations,
+          // and its size can differ per iteration. The stale binding must
+          // not constrain the fresh variable's width.
+          scope.erase(s.decl_id);
           DeclView sh;
           sh.len = sized_len(s.decl_type);
           sh.si = view_of(s.decl_type);
@@ -2967,11 +3008,21 @@ struct Lowering {
           } else {
             auto dl = decls.find(s.lhs);
             if (dl != decls.end()) {
-              SlotInfo expected = dl->second.si;
-              require_binding(rhs, dl->second.len, expected, s.lhs, s.raw);
-              const bool pf = rhs.si.param_free;
-              rhs.si = expected;
-              rhs.si.param_free = pf;
+              if (dl->second.len == 0 && g.slots[rhs.slot].len != 0) {
+                // stanc3's --O1 inliner declares a function's return
+                // variable zero-length (`array[real, 0]`, `vector[0]`)
+                // because the returned size is the callee's business, and
+                // C++ assignment resizes. Slots do not, so the first
+                // whole-variable assignment defines the shape instead.
+                dl->second.len = g.slots[rhs.slot].len;
+                dl->second.si = rhs.si;
+              } else {
+                SlotInfo expected = dl->second.si;
+                require_binding(rhs, dl->second.len, expected, s.lhs, s.raw);
+                const bool pf = rhs.si.param_free;
+                rhs.si = expected;
+                rhs.si.param_free = pf;
+              }
             }
           }
           scope[s.lhs] = rhs;

--- a/runtime/src/mir_reader.cpp
+++ b/runtime/src/mir_reader.cpp
@@ -192,6 +192,37 @@ Expr read_expr(const Node& n) {
         e.data_only = (*a)[1].is_atom() && (*a)[1].atom == "DataOnly";
     }
   }
+  // stanc3's partial evaluator (--O1) rewrites `c + a*b` into fma(a,b,c),
+  // whose fused rounding CmdStan's default (unoptimized) build never
+  // performs. The corpus references are that default build, so read it
+  // back as the mul+add it came from: bitwise what CmdStan computes, and
+  // no dedicated kernel needed. The optimizer's fma is elementwise over
+  // containers (prophet gets fma(vector, vector, vector)), hence
+  // EltTimes__, which is a plain product on scalars.
+  if (e.kind == Expr::FunApp && e.fn_lib == Expr::Lib::StanLib &&
+      e.name == "fma" && e.args.size() == 3) {
+    Expr mul;
+    mul.kind = Expr::FunApp;
+    mul.fn_lib = Expr::Lib::StanLib;
+    mul.name = "EltTimes__";
+    const bool a_scalar = e.args[0].unsized.depth == 0 &&
+                          (e.args[0].unsized.leaf == UnsizedLeaf::Real ||
+                           e.args[0].unsized.leaf == UnsizedLeaf::Int);
+    const Expr& shaped = a_scalar ? e.args[1] : e.args[0];
+    mul.type_ = shaped.type_.empty() ? "UReal" : shaped.type_;
+    mul.unsized = shaped.unsized;
+    mul.data_only = e.args[0].data_only && e.args[1].data_only;
+    mul.args = {e.args[0], e.args[1]};
+    Expr add;
+    add.kind = Expr::FunApp;
+    add.fn_lib = Expr::Lib::StanLib;
+    add.name = "Plus__";
+    add.type_ = e.type_;
+    add.unsized = e.unsized;
+    add.data_only = e.data_only;
+    add.args = {std::move(mul), std::move(e.args[2])};
+    return add;
+  }
   return e;
 }
 
@@ -477,13 +508,17 @@ void validate_checks(const Stmt& s, Bindings& bindings) {
       throw std::runtime_error("mir: unsupported or malformed FnCheck");
     }
     const Expr& value = s.fn_args[0];
-    const auto binding =
-        value.kind == Expr::Var ? bindings.find(value.name) : bindings.end();
-    if (binding == bindings.end() ||
-        binding->second.depth != value.unsized.depth ||
-        binding->second.leaf != value.unsized.leaf)
-      throw std::runtime_error(
-          "mir: FnCheck value type disagrees with its declaration");
+    // --O1 constant propagation may substitute the checked value itself
+    // (`(var 2)` where the source said `(var K)`); a non-Var value carries
+    // its own type and has no declaration to cross-check.
+    if (value.kind == Expr::Var) {
+      const auto binding = bindings.find(value.name);
+      if (binding == bindings.end() ||
+          binding->second.depth != value.unsized.depth ||
+          binding->second.leaf != value.unsized.leaf)
+        throw std::runtime_error(
+            "mir: FnCheck value type disagrees with its declaration");
+    }
   }
   if (s.kind == Stmt::IfElse) {
     for (const auto& child : s.body) {
@@ -553,6 +588,16 @@ Program read_program(const sexp::Node& root) {
     for (size_t i = 0; i < f.arg_names.size(); ++i)
       args[f.arg_names[i]] = f.arg_views[i];
     validate_checks(f.body, args);
+  }
+  if (const Node* ov = field(root, "output_vars")) {
+    // ((name <opaque> (...)) ...): parameters, transformed parameters and
+    // generated quantities in declaration order -- the order FnWriteParam
+    // statements emit them in. Only the names matter here; they are the
+    // naming fallback for a write whose variable reference the optimizer
+    // replaced with the value itself.
+    const Node& vars = (*ov)[1];
+    for (size_t i = 0; i < vars.size(); ++i)
+      prog.output_vars.push_back(vars[i][0].atom);
   }
   return prog;
 }

--- a/runtime/src/wa_interp.cpp
+++ b/runtime/src/wa_interp.cpp
@@ -116,6 +116,24 @@ bool WaInterp::write_param(MirInterp<double>& in, const mir::Stmt& s,
       base = &base->args[0];
     }
     std::string name = base->name;
+    if (name.empty()) {
+      // The optimizer (--O1 constant propagation) replaced the write's
+      // variable reference with the value itself, so the name is gone
+      // from the statement. Writes happen in output_vars order, and a
+      // substituted write is always a whole variable, so the name is the
+      // output var after the last one written.
+      const auto& ov = prog_->output_vars;
+      size_t idx = 0;
+      if (!last_written_.empty()) {
+        auto it = std::find(ov.begin(), ov.end(), last_written_);
+        if (it != ov.end()) idx = (size_t)(it - ov.begin()) + 1;
+      }
+      if (idx >= ov.size())
+        throw CompileError(
+            "stanli write_array: cannot name a substituted FnWriteParam");
+      name = ov[idx];
+    }
+    last_written_ = name;
     for (auto it = ixs.rbegin(); it != ixs.rend(); ++it)
       name += "." + std::to_string(*it);
     using Naming = CompiledModel::ParamView::Naming;

--- a/tests/fixtures/glmy.stan
+++ b/tests/fixtures/glmy.stan
@@ -1,0 +1,15 @@
+// y-side of a GLM as a parameter: at --O1 stanc3 rewrites
+// theta ~ normal(x * b, 1) into normal_id_glm_lupdf(theta | x, 0, b, 1),
+// so the kernel must propagate the gradient to theta, not just to b.
+data {
+  int N;
+  int K;
+  matrix[N, K] x;
+}
+parameters {
+  vector[N] theta;
+  vector[K] b;
+}
+model {
+  theta ~ normal(x * b, 1);
+}

--- a/tests/fixtures/glmy.tmir.sexp
+++ b/tests/fixtures/glmy.tmir.sexp
@@ -1,0 +1,585 @@
+((functions_block ())
+ (input_vars
+  ((N <opaque> SInt) (K <opaque> SInt)
+   (x <opaque>
+    (SMatrix AoS
+     ((pattern (Var N)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+     ((pattern (Var K)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+ (prepare_data
+  (((pattern
+     (Decl (decl_adtype DataOnly) (decl_id pos__) (decl_type (Sized SInt))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable pos__) ()) UInt
+      ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id N) (decl_type (Sized SInt))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable N) ()) UInt
+      ((pattern
+        (Indexed
+         ((pattern
+           (FunApp (CompilerInternal FnReadData)
+            (((pattern (Lit Str N))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+          (meta ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly))))
+         ((Single
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id K) (decl_type (Sized SInt))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable K) ()) UInt
+      ((pattern
+        (Indexed
+         ((pattern
+           (FunApp (CompilerInternal FnReadData)
+            (((pattern (Lit Str K))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+          (meta ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly))))
+         ((Single
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp (CompilerInternal FnValidateSize)
+      (((pattern (Lit Str x)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+       ((pattern (Lit Str N)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+       ((pattern (Var N)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp (CompilerInternal FnValidateSize)
+      (((pattern (Lit Str x)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+       ((pattern (Lit Str K)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+       ((pattern (Var K)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id x)
+      (decl_type
+       (Sized
+        (SMatrix AoS
+         ((pattern (Var N)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+         ((pattern (Var K)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id x_flat__)
+          (decl_type (Unsized (UArray UReal))) (initialize Uninit)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable x_flat__) ()) (UArray UReal)
+          ((pattern
+            (FunApp (CompilerInternal FnReadData)
+             (((pattern (Lit Str x))
+               (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable pos__) ()) UInt
+          ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar sym1__)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Var K)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (For (loopvar sym2__)
+                  (lower
+                   ((pattern (Lit Int 1))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (upper
+                   ((pattern (Var N))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (body
+                   ((pattern
+                     (Block
+                      (((pattern
+                         (Assignment
+                          ((LVariable x)
+                           ((Single
+                             ((pattern (Var sym2__))
+                              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                            (Single
+                             ((pattern (Var sym1__))
+                              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                          UMatrix
+                          ((pattern
+                            (Indexed
+                             ((pattern (Var x_flat__))
+                              (meta
+                               ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))
+                             ((Single
+                               ((pattern (Var pos__))
+                                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                           (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+                        (meta <opaque>))
+                       ((pattern
+                         (Assignment ((LVariable pos__) ()) UInt
+                          ((pattern
+                            (FunApp (StanLib Plus__ FnPlain AoS)
+                             (((pattern (Var pos__))
+                               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                              ((pattern (Lit Int 1))
+                               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                        (meta <opaque>)))))
+                    (meta <opaque>)))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp (CompilerInternal FnValidateSize)
+      (((pattern (Lit Str theta))
+        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+       ((pattern (Lit Str N)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+       ((pattern (Var N)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp (CompilerInternal FnValidateSize)
+      (((pattern (Lit Str b)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+       ((pattern (Lit Str K)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+       ((pattern (Var K)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+    (meta <opaque>))))
+ (log_prob
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id theta)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Var N)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity)
+             (dims
+              (((pattern (Var N))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id b)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Var K)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity)
+             (dims
+              (((pattern (Var K))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib normal_id_glm_lpdf (FnLpdf true) AoS)
+             (((pattern (Var theta))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))
+              ((pattern (Var x))
+               (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly))))
+              ((pattern (Lit Int 0))
+               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+              ((pattern (Var b))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))
+              ((pattern
+                (Promotion
+                 ((pattern (Lit Int 1))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                 UReal DataOnly))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>)))))
+    (meta <opaque>))))
+ (reverse_mode_log_prob
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id theta)
+      (decl_type
+       (Sized
+        (SVector SoA
+         ((pattern (Var N)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity)
+             (dims
+              (((pattern (Var N))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern SoA)))
+           ()))
+         (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id b)
+      (decl_type
+       (Sized
+        (SVector SoA
+         ((pattern (Var K)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity)
+             (dims
+              (((pattern (Var K))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern SoA)))
+           ()))
+         (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib normal_id_glm_lpdf (FnLpdf true) SoA)
+             (((pattern (Var theta))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))
+              ((pattern (Var x))
+               (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly))))
+              ((pattern (Lit Int 0))
+               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+              ((pattern (Var b))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))
+              ((pattern
+                (Promotion
+                 ((pattern (Lit Int 1))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                 UReal DataOnly))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>)))))
+    (meta <opaque>))))
+ (generate_quantities
+  (((pattern
+     (Decl (decl_adtype DataOnly) (decl_id theta)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Var N)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity)
+             (dims
+              (((pattern (Var N))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id b)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Var K)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity)
+             (dims
+              (((pattern (Var K))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt ())
+        (var
+         ((pattern (Var theta))
+          (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt ())
+        (var
+         ((pattern (Var b)) (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (IfElse
+      ((pattern
+        (FunApp (StanLib PNot__ FnPlain AoS)
+         (((pattern
+            (EOr
+             ((pattern (Var emit_transformed_parameters__))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+             ((pattern (Var emit_generated_quantities__))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+      ((pattern (Block (((pattern (Return ())) (meta <opaque>))))) (meta <opaque>)) ()))
+    (meta <opaque>))
+   ((pattern
+     (IfElse
+      ((pattern
+        (FunApp (StanLib PNot__ FnPlain AoS)
+         (((pattern (Var emit_generated_quantities__))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+      ((pattern (Block (((pattern (Return ())) (meta <opaque>))))) (meta <opaque>)) ()))
+    (meta <opaque>))))
+ (transform_inits
+  (((pattern
+     (Decl (decl_adtype DataOnly) (decl_id pos__) (decl_type (Sized SInt))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable pos__) ()) UInt
+      ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id theta)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Var N)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id theta_flat__)
+          (decl_type (Unsized (UArray UReal))) (initialize Uninit)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable theta_flat__) ()) (UArray UReal)
+          ((pattern
+            (FunApp (CompilerInternal FnReadData)
+             (((pattern (Lit Str theta))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable pos__) ()) UInt
+          ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar sym1__)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Var N)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (Assignment
+                  ((LVariable theta)
+                   ((Single
+                     ((pattern (Var sym1__))
+                      (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                  UVector
+                  ((pattern
+                    (Indexed
+                     ((pattern (Var theta_flat__))
+                      (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))
+                     ((Single
+                       ((pattern (Var pos__))
+                        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+                (meta <opaque>))
+               ((pattern
+                 (Assignment ((LVariable pos__) ()) UInt
+                  ((pattern
+                    (FunApp (StanLib Plus__ FnPlain AoS)
+                     (((pattern (Var pos__))
+                       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                      ((pattern (Lit Int 1))
+                       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var theta))
+          (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id b)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Var K)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id b_flat__)
+          (decl_type (Unsized (UArray UReal))) (initialize Uninit)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable b_flat__) ()) (UArray UReal)
+          ((pattern
+            (FunApp (CompilerInternal FnReadData)
+             (((pattern (Lit Str b))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable pos__) ()) UInt
+          ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar sym1__)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Var K)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (Assignment
+                  ((LVariable b)
+                   ((Single
+                     ((pattern (Var sym1__))
+                      (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                  UVector
+                  ((pattern
+                    (Indexed
+                     ((pattern (Var b_flat__))
+                      (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))
+                     ((Single
+                       ((pattern (Var pos__))
+                        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+                (meta <opaque>))
+               ((pattern
+                 (Assignment ((LVariable pos__) ()) UInt
+                  ((pattern
+                    (FunApp (StanLib Plus__ FnPlain AoS)
+                     (((pattern (Var pos__))
+                       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                      ((pattern (Lit Int 1))
+                       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var b)) (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))))
+ (unconstrain_array
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id theta)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Var N)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable theta) ()) UVector
+      ((pattern
+        (FunApp (CompilerInternal FnReadDeserializer)
+         (((pattern (Var N)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var theta))
+          (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id b)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Var K)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable b) ()) UVector
+      ((pattern
+        (FunApp (CompilerInternal FnReadDeserializer)
+         (((pattern (Var K)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var b)) (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))))
+ (output_vars
+  ((theta <opaque>
+    ((out_unconstrained_st
+      (SVector AoS
+       ((pattern (Var N)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+     (out_constrained_st
+      (SVector AoS
+       ((pattern (Var N)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+     (out_block Parameters) (out_trans Identity)))
+   (b <opaque>
+    ((out_unconstrained_st
+      (SVector AoS
+       ((pattern (Var K)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+     (out_constrained_st
+      (SVector AoS
+       ((pattern (Var K)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+     (out_block Parameters) (out_trans Identity)))))
+ (prog_name glmy_model) (prog_path tests/fixtures/glmy.stan))

--- a/tests/fixtures/gqconst.stan
+++ b/tests/fixtures/gqconst.stan
@@ -1,0 +1,13 @@
+// A generated quantity the optimizer folds to a constant: at --O1 the
+// FnWriteParam's argument becomes the literal itself, so the column name
+// must come from output_vars instead of the (gone) variable reference.
+parameters {
+  real x;
+}
+model {
+  x ~ normal(0, 1);
+}
+generated quantities {
+  real z;
+  z = 3;
+}

--- a/tests/fixtures/gqconst.tmir.sexp
+++ b/tests/fixtures/gqconst.tmir.sexp
@@ -1,0 +1,192 @@
+((functions_block ()) (input_vars ()) (prepare_data ())
+ (log_prob
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id x) (decl_type (Sized SReal))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity) (dims ()) (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib normal_lpdf (FnLpdf true) AoS)
+             (((pattern (Var x))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+              ((pattern
+                (Promotion
+                 ((pattern (Lit Int 0))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                 UReal DataOnly))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+              ((pattern
+                (Promotion
+                 ((pattern (Lit Int 1))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                 UReal DataOnly))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>)))))
+    (meta <opaque>))))
+ (reverse_mode_log_prob
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id x) (decl_type (Sized SReal))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity) (dims ()) (mem_pattern SoA)))
+           ()))
+         (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib normal_lpdf (FnLpdf true) SoA)
+             (((pattern (Var x))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+              ((pattern
+                (Promotion
+                 ((pattern (Lit Int 0))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                 UReal DataOnly))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+              ((pattern
+                (Promotion
+                 ((pattern (Lit Int 1))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                 UReal DataOnly))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>)))))
+    (meta <opaque>))))
+ (generate_quantities
+  (((pattern
+     (Decl (decl_adtype DataOnly) (decl_id x) (decl_type (Sized SReal))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity) (dims ()) (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt ())
+        (var
+         ((pattern (Var x)) (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (IfElse
+      ((pattern
+        (FunApp (StanLib PNot__ FnPlain AoS)
+         (((pattern
+            (EOr
+             ((pattern (Var emit_transformed_parameters__))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+             ((pattern (Var emit_generated_quantities__))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+      ((pattern (Block (((pattern (Return ())) (meta <opaque>))))) (meta <opaque>)) ()))
+    (meta <opaque>))
+   ((pattern
+     (IfElse
+      ((pattern
+        (FunApp (StanLib PNot__ FnPlain AoS)
+         (((pattern (Var emit_generated_quantities__))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+      ((pattern (Block (((pattern (Return ())) (meta <opaque>))))) (meta <opaque>)) ()))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id z) (decl_type (Sized SReal))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable z) ()) UReal
+      ((pattern
+        (Promotion
+         ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+         UReal DataOnly))
+       (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt ())
+        (var
+         ((pattern
+           (Promotion
+            ((pattern (Lit Int 3))
+             (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+            UReal DataOnly))
+          (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))))
+ (transform_inits
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id x) (decl_type (Sized SReal))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable x) ()) UReal
+      ((pattern
+        (Indexed
+         ((pattern
+           (FunApp (CompilerInternal FnReadData)
+            (((pattern (Lit Str x))
+              (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+          (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))
+         ((Single
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+       (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var x)) (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))))
+ (unconstrain_array
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id x) (decl_type (Sized SReal))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable x) ()) UReal
+      ((pattern (FunApp (CompilerInternal FnReadDeserializer) ()))
+       (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var x)) (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))))
+ (output_vars
+  ((x <opaque>
+    ((out_unconstrained_st SReal) (out_constrained_st SReal) (out_block Parameters)
+     (out_trans Identity)))
+   (z <opaque>
+    ((out_unconstrained_st SReal) (out_constrained_st SReal)
+     (out_block GeneratedQuantities) (out_trans Identity)))))
+ (prog_name gqconst_model) (prog_path tests/fixtures/gqconst.stan))

--- a/tests/fixtures/inlret.stan
+++ b/tests/fixtures/inlret.stan
@@ -1,0 +1,20 @@
+// A user function whose returned size only the callee knows: --O1 inlining
+// declares the return variable zero-length (vector[0]) and lets the
+// assignment size it, which slot-based lowering must adopt, not reject.
+functions {
+  vector centered(vector v) {
+    vector[rows(v)] out;
+    out = v - mean(v);
+    return out;
+  }
+}
+data {
+  int N;
+  vector[N] y;
+}
+parameters {
+  real mu;
+}
+model {
+  target += normal_lpdf(centered(y) | mu, 1);
+}

--- a/tests/fixtures/inlret.tmir.sexp
+++ b/tests/fixtures/inlret.tmir.sexp
@@ -1,0 +1,416 @@
+((functions_block
+  (((fdrt (ReturnType UVector)) (fdname centered) (fdsuffix FnPlain)
+    (fdargs ((AutoDiffable v UVector)))
+    (fdbody
+     (((pattern
+        (Block
+         (((pattern
+            (NRFunApp (CompilerInternal FnValidateSize)
+             (((pattern (Lit Str out))
+               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+              ((pattern (Lit Str "rows(v)"))
+               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+              ((pattern
+                (FunApp (StanLib rows FnPlain AoS)
+                 (((pattern (Var v))
+                   (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta <opaque>))
+          ((pattern
+            (Decl (decl_adtype AutoDiffable) (decl_id out)
+             (decl_type
+              (Sized
+               (SVector AoS
+                ((pattern
+                  (FunApp (StanLib rows FnPlain AoS)
+                   (((pattern (Var v))
+                     (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+                 (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+             (initialize Uninit)))
+           (meta <opaque>))
+          ((pattern
+            (Assignment ((LVariable out) ()) UVector
+             ((pattern
+               (FunApp (StanLib Minus__ FnPlain AoS)
+                (((pattern (Var v))
+                  (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))
+                 ((pattern
+                   (FunApp (StanLib mean FnPlain AoS)
+                    (((pattern (Var v))
+                      (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+                  (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
+              (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))
+           (meta <opaque>))
+          ((pattern
+            (Return
+             (((pattern (Var out))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+           (meta <opaque>)))))
+       (meta <opaque>))))
+    (fdloc <opaque>))))
+ (input_vars
+  ((N <opaque> SInt)
+   (y <opaque>
+    (SVector AoS
+     ((pattern (Var N)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+ (prepare_data
+  (((pattern
+     (Decl (decl_adtype DataOnly) (decl_id pos__) (decl_type (Sized SInt))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable pos__) ()) UInt
+      ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id N) (decl_type (Sized SInt))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable N) ()) UInt
+      ((pattern
+        (Indexed
+         ((pattern
+           (FunApp (CompilerInternal FnReadData)
+            (((pattern (Lit Str N))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+          (meta ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly))))
+         ((Single
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp (CompilerInternal FnValidateSize)
+      (((pattern (Lit Str y)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+       ((pattern (Lit Str N)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+       ((pattern (Var N)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id y)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Var N)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id y_flat__)
+          (decl_type (Unsized (UArray UReal))) (initialize Uninit)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable y_flat__) ()) (UArray UReal)
+          ((pattern
+            (FunApp (CompilerInternal FnReadData)
+             (((pattern (Lit Str y))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable pos__) ()) UInt
+          ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar sym1__)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Var N)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (Assignment
+                  ((LVariable y)
+                   ((Single
+                     ((pattern (Var sym1__))
+                      (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                  UVector
+                  ((pattern
+                    (Indexed
+                     ((pattern (Var y_flat__))
+                      (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))
+                     ((Single
+                       ((pattern (Var pos__))
+                        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+                (meta <opaque>))
+               ((pattern
+                 (Assignment ((LVariable pos__) ()) UInt
+                  ((pattern
+                    (FunApp (StanLib Plus__ FnPlain AoS)
+                     (((pattern (Var pos__))
+                       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                      ((pattern (Lit Int 1))
+                       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))))
+ (log_prob
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id mu) (decl_type (Sized SReal))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity) (dims ()) (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id inline_centered_return_sym4__)
+          (decl_type
+           (Sized
+            (SVector AoS
+             ((pattern (Lit Int 0))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+          (initialize Uninit)))
+        (meta <opaque>))
+       ((pattern
+         (Block
+          (((pattern
+             (NRFunApp (CompilerInternal FnValidateSize)
+              (((pattern (Lit Str out))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+               ((pattern (Lit Str "rows(v)"))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+               ((pattern
+                 (FunApp (StanLib rows FnPlain AoS)
+                  (((pattern (Var y))
+                    (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+            (meta <opaque>))
+           ((pattern
+             (Decl (decl_adtype AutoDiffable) (decl_id inline_centered_out_sym5__)
+              (decl_type
+               (Sized
+                (SVector AoS
+                 ((pattern
+                   (FunApp (StanLib rows FnPlain AoS)
+                    (((pattern (Var y))
+                      (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+              (initialize Uninit)))
+            (meta <opaque>))
+           ((pattern
+             (Assignment ((LVariable inline_centered_out_sym5__) ()) UVector
+              ((pattern
+                (FunApp (StanLib Minus__ FnPlain AoS)
+                 (((pattern (Var y))
+                   (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly))))
+                  ((pattern
+                    (FunApp (StanLib mean FnPlain AoS)
+                     (((pattern (Var y))
+                       (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))
+            (meta <opaque>))
+           ((pattern
+             (Assignment ((LVariable inline_centered_return_sym4__) ()) UVector
+              ((pattern (Var inline_centered_out_sym5__))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))
+            (meta <opaque>)))))
+        (meta <opaque>))
+       ((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib normal_lpdf (FnLpdf false) AoS)
+             (((pattern (Var inline_centered_return_sym4__))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))
+              ((pattern (Var mu))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+              ((pattern
+                (Promotion
+                 ((pattern (Lit Int 1))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                 UReal DataOnly))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>)))))
+    (meta <opaque>))))
+ (reverse_mode_log_prob
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id mu) (decl_type (Sized SReal))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity) (dims ()) (mem_pattern SoA)))
+           ()))
+         (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id inline_centered_return_sym1__)
+          (decl_type
+           (Sized
+            (SVector AoS
+             ((pattern (Lit Int 0))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+          (initialize Uninit)))
+        (meta <opaque>))
+       ((pattern
+         (Block
+          (((pattern
+             (NRFunApp (CompilerInternal FnValidateSize)
+              (((pattern (Lit Str out))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+               ((pattern (Lit Str "rows(v)"))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+               ((pattern
+                 (FunApp (StanLib rows FnPlain SoA)
+                  (((pattern (Var y))
+                    (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+            (meta <opaque>))
+           ((pattern
+             (Decl (decl_adtype AutoDiffable) (decl_id inline_centered_out_sym2__)
+              (decl_type
+               (Sized
+                (SVector AoS
+                 ((pattern
+                   (FunApp (StanLib rows FnPlain SoA)
+                    (((pattern (Var y))
+                      (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+              (initialize Uninit)))
+            (meta <opaque>))
+           ((pattern
+             (Assignment ((LVariable inline_centered_out_sym2__) ()) UVector
+              ((pattern
+                (FunApp (StanLib Minus__ FnPlain AoS)
+                 (((pattern (Var y))
+                   (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly))))
+                  ((pattern
+                    (FunApp (StanLib mean FnPlain AoS)
+                     (((pattern (Var y))
+                       (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))
+            (meta <opaque>))
+           ((pattern
+             (Assignment ((LVariable inline_centered_return_sym1__) ()) UVector
+              ((pattern (Var inline_centered_out_sym2__))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))
+            (meta <opaque>)))))
+        (meta <opaque>))
+       ((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib normal_lpdf (FnLpdf false) AoS)
+             (((pattern (Var inline_centered_return_sym1__))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))
+              ((pattern (Var mu))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+              ((pattern
+                (Promotion
+                 ((pattern (Lit Int 1))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                 UReal DataOnly))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>)))))
+    (meta <opaque>))))
+ (generate_quantities
+  (((pattern
+     (Decl (decl_adtype DataOnly) (decl_id mu) (decl_type (Sized SReal))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity) (dims ()) (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt ())
+        (var
+         ((pattern (Var mu)) (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (IfElse
+      ((pattern
+        (FunApp (StanLib PNot__ FnPlain AoS)
+         (((pattern
+            (EOr
+             ((pattern (Var emit_transformed_parameters__))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+             ((pattern (Var emit_generated_quantities__))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+      ((pattern (Block (((pattern (Return ())) (meta <opaque>))))) (meta <opaque>)) ()))
+    (meta <opaque>))
+   ((pattern
+     (IfElse
+      ((pattern
+        (FunApp (StanLib PNot__ FnPlain AoS)
+         (((pattern (Var emit_generated_quantities__))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+      ((pattern (Block (((pattern (Return ())) (meta <opaque>))))) (meta <opaque>)) ()))
+    (meta <opaque>))))
+ (transform_inits
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id mu) (decl_type (Sized SReal))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable mu) ()) UReal
+      ((pattern
+        (Indexed
+         ((pattern
+           (FunApp (CompilerInternal FnReadData)
+            (((pattern (Lit Str mu))
+              (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+          (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))
+         ((Single
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+       (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var mu)) (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))))
+ (unconstrain_array
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id mu) (decl_type (Sized SReal))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable mu) ()) UReal
+      ((pattern (FunApp (CompilerInternal FnReadDeserializer) ()))
+       (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var mu)) (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))))
+ (output_vars
+  ((mu <opaque>
+    ((out_unconstrained_st SReal) (out_constrained_st SReal) (out_block Parameters)
+     (out_trans Identity)))))
+ (prog_name inlret_model) (prog_path tests/fixtures/inlret.stan))

--- a/tests/fixtures/inlseg.stan
+++ b/tests/fixtures/inlseg.stan
@@ -1,0 +1,21 @@
+// An inlined callee whose declaration sizes query the shape of a computed
+// argument: --O1 turns `rows(beta)` into `rows(segment(beta, 1, 2))` at
+// the call site, so size evaluation must answer shape queries on
+// expressions, not just variables.
+functions {
+  real csum(vector beta) {
+    vector[rows(beta) + 1] u;
+    u = append_row(rep_vector(0.0, 1), beta);
+    return sum(cumulative_sum(u));
+  }
+}
+data {
+  int N;
+}
+parameters {
+  vector[N] beta;
+}
+model {
+  target += csum(segment(beta, 1, 2));
+  beta ~ normal(0, 1);
+}

--- a/tests/fixtures/inlseg.tmir.sexp
+++ b/tests/fixtures/inlseg.tmir.sexp
@@ -1,0 +1,536 @@
+((functions_block
+  (((fdrt (ReturnType UReal)) (fdname csum) (fdsuffix FnPlain)
+    (fdargs ((AutoDiffable beta UVector)))
+    (fdbody
+     (((pattern
+        (Block
+         (((pattern
+            (NRFunApp (CompilerInternal FnValidateSize)
+             (((pattern (Lit Str u))
+               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+              ((pattern (Lit Str "rows(beta) + 1"))
+               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+              ((pattern
+                (FunApp (StanLib Plus__ FnPlain AoS)
+                 (((pattern
+                    (FunApp (StanLib rows FnPlain AoS)
+                     (((pattern (Var beta))
+                       (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                  ((pattern (Lit Int 1))
+                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta <opaque>))
+          ((pattern
+            (Decl (decl_adtype AutoDiffable) (decl_id u)
+             (decl_type
+              (Sized
+               (SVector AoS
+                ((pattern
+                  (FunApp (StanLib Plus__ FnPlain AoS)
+                   (((pattern
+                      (FunApp (StanLib rows FnPlain AoS)
+                       (((pattern (Var beta))
+                         (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+                     (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                    ((pattern (Lit Int 1))
+                     (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                 (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+             (initialize Uninit)))
+           (meta <opaque>))
+          ((pattern
+            (Assignment ((LVariable u) ()) UVector
+             ((pattern
+               (FunApp (StanLib append_row FnPlain AoS)
+                (((pattern
+                   (FunApp (StanLib rep_vector FnPlain AoS)
+                    (((pattern (Lit Real 0.0))
+                      (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+                     ((pattern (Lit Int 1))
+                      (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                  (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly))))
+                 ((pattern (Var beta))
+                  (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+              (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))
+           (meta <opaque>))
+          ((pattern
+            (Return
+             (((pattern
+                (FunApp (StanLib sum FnPlain AoS)
+                 (((pattern
+                    (FunApp (StanLib cumulative_sum FnPlain AoS)
+                     (((pattern (Var u))
+                       (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+                   (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
+           (meta <opaque>)))))
+       (meta <opaque>))))
+    (fdloc <opaque>))))
+ (input_vars ((N <opaque> SInt)))
+ (prepare_data
+  (((pattern
+     (Decl (decl_adtype DataOnly) (decl_id N) (decl_type (Sized SInt))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable N) ()) UInt
+      ((pattern
+        (Indexed
+         ((pattern
+           (FunApp (CompilerInternal FnReadData)
+            (((pattern (Lit Str N))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+          (meta ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly))))
+         ((Single
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp (CompilerInternal FnValidateSize)
+      (((pattern (Lit Str beta)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+       ((pattern (Lit Str N)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+       ((pattern (Var N)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+    (meta <opaque>))))
+ (log_prob
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id beta)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Var N)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity)
+             (dims
+              (((pattern (Var N))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id inline_csum_return_sym4__)
+          (decl_type (Sized SReal)) (initialize Uninit)))
+        (meta <opaque>))
+       ((pattern
+         (Block
+          (((pattern
+             (NRFunApp (CompilerInternal FnValidateSize)
+              (((pattern (Lit Str u))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+               ((pattern (Lit Str "rows(beta) + 1"))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+               ((pattern
+                 (FunApp (StanLib Plus__ FnPlain AoS)
+                  (((pattern
+                     (FunApp (StanLib rows FnPlain AoS)
+                      (((pattern
+                         (FunApp (StanLib segment FnPlain AoS)
+                          (((pattern (Var beta))
+                            (meta
+                             ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))
+                           ((pattern (Lit Int 1))
+                            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                           ((pattern (Lit Int 2))
+                            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                        (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                   ((pattern (Lit Int 1))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+            (meta <opaque>))
+           ((pattern
+             (Decl (decl_adtype AutoDiffable) (decl_id inline_csum_u_sym5__)
+              (decl_type
+               (Sized
+                (SVector AoS
+                 ((pattern
+                   (FunApp (StanLib Plus__ FnPlain AoS)
+                    (((pattern
+                       (FunApp (StanLib rows FnPlain AoS)
+                        (((pattern
+                           (FunApp (StanLib segment FnPlain AoS)
+                            (((pattern (Var beta))
+                              (meta
+                               ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))
+                             ((pattern (Lit Int 1))
+                              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                             ((pattern (Lit Int 2))
+                              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                          (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+                      (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                     ((pattern (Lit Int 1))
+                      (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+              (initialize Uninit)))
+            (meta <opaque>))
+           ((pattern
+             (Assignment ((LVariable inline_csum_u_sym5__) ()) UVector
+              ((pattern
+                (FunApp (StanLib append_row FnPlain AoS)
+                 (((pattern
+                    (FunApp (StanLib rep_vector FnPlain AoS)
+                     (((pattern (Lit Real 0.0))
+                       (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+                      ((pattern (Lit Int 1))
+                       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                   (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly))))
+                  ((pattern
+                    (FunApp (StanLib segment FnPlain AoS)
+                     (((pattern (Var beta))
+                       (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))
+                      ((pattern (Lit Int 1))
+                       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                      ((pattern (Lit Int 2))
+                       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                   (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))
+            (meta <opaque>))
+           ((pattern
+             (Assignment ((LVariable inline_csum_return_sym4__) ()) UReal
+              ((pattern
+                (FunApp (StanLib sum FnPlain AoS)
+                 (((pattern
+                    (FunApp (StanLib cumulative_sum FnPlain AoS)
+                     (((pattern (Var inline_csum_u_sym5__))
+                       (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+                   (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+            (meta <opaque>)))))
+        (meta <opaque>))
+       ((pattern
+         (TargetPE
+          ((pattern (Var inline_csum_return_sym4__))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>))
+       ((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib normal_lpdf (FnLpdf true) AoS)
+             (((pattern (Var beta))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))
+              ((pattern
+                (Promotion
+                 ((pattern (Lit Int 0))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                 UReal DataOnly))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+              ((pattern
+                (Promotion
+                 ((pattern (Lit Int 1))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                 UReal DataOnly))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>)))))
+    (meta <opaque>))))
+ (reverse_mode_log_prob
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id beta)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Var N)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity)
+             (dims
+              (((pattern (Var N))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id inline_csum_return_sym1__)
+          (decl_type (Sized SReal)) (initialize Uninit)))
+        (meta <opaque>))
+       ((pattern
+         (Block
+          (((pattern
+             (NRFunApp (CompilerInternal FnValidateSize)
+              (((pattern (Lit Str u))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+               ((pattern (Lit Str "rows(beta) + 1"))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+               ((pattern
+                 (FunApp (StanLib Plus__ FnPlain SoA)
+                  (((pattern
+                     (FunApp (StanLib rows FnPlain AoS)
+                      (((pattern
+                         (FunApp (StanLib segment FnPlain AoS)
+                          (((pattern (Var beta))
+                            (meta
+                             ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))
+                           ((pattern (Lit Int 1))
+                            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                           ((pattern (Lit Int 2))
+                            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                        (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                   ((pattern (Lit Int 1))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+            (meta <opaque>))
+           ((pattern
+             (Decl (decl_adtype AutoDiffable) (decl_id inline_csum_u_sym2__)
+              (decl_type
+               (Sized
+                (SVector AoS
+                 ((pattern
+                   (FunApp (StanLib Plus__ FnPlain SoA)
+                    (((pattern
+                       (FunApp (StanLib rows FnPlain AoS)
+                        (((pattern
+                           (FunApp (StanLib segment FnPlain AoS)
+                            (((pattern (Var beta))
+                              (meta
+                               ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))
+                             ((pattern (Lit Int 1))
+                              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                             ((pattern (Lit Int 2))
+                              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                          (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+                      (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                     ((pattern (Lit Int 1))
+                      (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+              (initialize Uninit)))
+            (meta <opaque>))
+           ((pattern
+             (Assignment ((LVariable inline_csum_u_sym2__) ()) UVector
+              ((pattern
+                (FunApp (StanLib append_row FnPlain AoS)
+                 (((pattern
+                    (FunApp (StanLib rep_vector FnPlain AoS)
+                     (((pattern (Lit Real 0.0))
+                       (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+                      ((pattern (Lit Int 1))
+                       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                   (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly))))
+                  ((pattern
+                    (FunApp (StanLib segment FnPlain AoS)
+                     (((pattern (Var beta))
+                       (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))
+                      ((pattern (Lit Int 1))
+                       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                      ((pattern (Lit Int 2))
+                       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                   (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))
+            (meta <opaque>))
+           ((pattern
+             (Assignment ((LVariable inline_csum_return_sym1__) ()) UReal
+              ((pattern
+                (FunApp (StanLib sum FnPlain AoS)
+                 (((pattern
+                    (FunApp (StanLib cumulative_sum FnPlain AoS)
+                     (((pattern (Var inline_csum_u_sym2__))
+                       (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+                   (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+            (meta <opaque>)))))
+        (meta <opaque>))
+       ((pattern
+         (TargetPE
+          ((pattern (Var inline_csum_return_sym1__))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>))
+       ((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib normal_lpdf (FnLpdf true) AoS)
+             (((pattern (Var beta))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))
+              ((pattern
+                (Promotion
+                 ((pattern (Lit Int 0))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                 UReal DataOnly))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+              ((pattern
+                (Promotion
+                 ((pattern (Lit Int 1))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                 UReal DataOnly))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>)))))
+    (meta <opaque>))))
+ (generate_quantities
+  (((pattern
+     (Decl (decl_adtype DataOnly) (decl_id beta)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Var N)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity)
+             (dims
+              (((pattern (Var N))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt ())
+        (var
+         ((pattern (Var beta))
+          (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (IfElse
+      ((pattern
+        (FunApp (StanLib PNot__ FnPlain AoS)
+         (((pattern
+            (EOr
+             ((pattern (Var emit_transformed_parameters__))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+             ((pattern (Var emit_generated_quantities__))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+      ((pattern (Block (((pattern (Return ())) (meta <opaque>))))) (meta <opaque>)) ()))
+    (meta <opaque>))
+   ((pattern
+     (IfElse
+      ((pattern
+        (FunApp (StanLib PNot__ FnPlain AoS)
+         (((pattern (Var emit_generated_quantities__))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+      ((pattern (Block (((pattern (Return ())) (meta <opaque>))))) (meta <opaque>)) ()))
+    (meta <opaque>))))
+ (transform_inits
+  (((pattern
+     (Decl (decl_adtype DataOnly) (decl_id pos__) (decl_type (Sized SInt))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id beta)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Var N)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id beta_flat__)
+          (decl_type (Unsized (UArray UReal))) (initialize Uninit)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable beta_flat__) ()) (UArray UReal)
+          ((pattern
+            (FunApp (CompilerInternal FnReadData)
+             (((pattern (Lit Str beta))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable pos__) ()) UInt
+          ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar sym1__)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Var N)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (Assignment
+                  ((LVariable beta)
+                   ((Single
+                     ((pattern (Var sym1__))
+                      (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                  UVector
+                  ((pattern
+                    (Indexed
+                     ((pattern (Var beta_flat__))
+                      (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))
+                     ((Single
+                       ((pattern (Var pos__))
+                        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+                (meta <opaque>))
+               ((pattern
+                 (Assignment ((LVariable pos__) ()) UInt
+                  ((pattern
+                    (FunApp (StanLib Plus__ FnPlain AoS)
+                     (((pattern (Var pos__))
+                       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                      ((pattern (Lit Int 1))
+                       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var beta))
+          (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))))
+ (unconstrain_array
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id beta)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Var N)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable beta) ()) UVector
+      ((pattern
+        (FunApp (CompilerInternal FnReadDeserializer)
+         (((pattern (Var N)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var beta))
+          (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))))
+ (output_vars
+  ((beta <opaque>
+    ((out_unconstrained_st
+      (SVector AoS
+       ((pattern (Var N)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+     (out_constrained_st
+      (SVector AoS
+       ((pattern (Var N)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+     (out_block Parameters) (out_trans Identity)))))
+ (prog_name inlseg_model) (prog_path tests/fixtures/inlseg.stan))

--- a/tests/fixtures/vecfma.stan
+++ b/tests/fixtures/vecfma.stan
@@ -1,0 +1,14 @@
+// Vector fma from partial evaluation: --O1 rewrites `k .* t + c` into
+// fma(k, t, c) with all-vector arguments (prophet's linear_trend), which
+// the reader desugars elementwise.
+data {
+  int N;
+  vector[N] t;
+}
+parameters {
+  vector[N] k;
+  vector[N] c;
+}
+model {
+  target += normal_lpdf(k .* t + c | 0, 1);
+}

--- a/tests/fixtures/vecfma.tmir.sexp
+++ b/tests/fixtures/vecfma.tmir.sexp
@@ -1,0 +1,552 @@
+((functions_block ())
+ (input_vars
+  ((N <opaque> SInt)
+   (t <opaque>
+    (SVector AoS
+     ((pattern (Var N)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+ (prepare_data
+  (((pattern
+     (Decl (decl_adtype DataOnly) (decl_id pos__) (decl_type (Sized SInt))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable pos__) ()) UInt
+      ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id N) (decl_type (Sized SInt))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable N) ()) UInt
+      ((pattern
+        (Indexed
+         ((pattern
+           (FunApp (CompilerInternal FnReadData)
+            (((pattern (Lit Str N))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+          (meta ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly))))
+         ((Single
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp (CompilerInternal FnValidateSize)
+      (((pattern (Lit Str t)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+       ((pattern (Lit Str N)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+       ((pattern (Var N)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id t)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Var N)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id t_flat__)
+          (decl_type (Unsized (UArray UReal))) (initialize Uninit)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable t_flat__) ()) (UArray UReal)
+          ((pattern
+            (FunApp (CompilerInternal FnReadData)
+             (((pattern (Lit Str t))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable pos__) ()) UInt
+          ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar sym1__)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Var N)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (Assignment
+                  ((LVariable t)
+                   ((Single
+                     ((pattern (Var sym1__))
+                      (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                  UVector
+                  ((pattern
+                    (Indexed
+                     ((pattern (Var t_flat__))
+                      (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))
+                     ((Single
+                       ((pattern (Var pos__))
+                        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+                (meta <opaque>))
+               ((pattern
+                 (Assignment ((LVariable pos__) ()) UInt
+                  ((pattern
+                    (FunApp (StanLib Plus__ FnPlain AoS)
+                     (((pattern (Var pos__))
+                       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                      ((pattern (Lit Int 1))
+                       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp (CompilerInternal FnValidateSize)
+      (((pattern (Lit Str k)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+       ((pattern (Lit Str N)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+       ((pattern (Var N)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp (CompilerInternal FnValidateSize)
+      (((pattern (Lit Str c)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+       ((pattern (Lit Str N)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+       ((pattern (Var N)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+    (meta <opaque>))))
+ (log_prob
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id k)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Var N)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity)
+             (dims
+              (((pattern (Var N))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id c)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Var N)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity)
+             (dims
+              (((pattern (Var N))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib normal_lpdf (FnLpdf false) AoS)
+             (((pattern
+                (FunApp (StanLib fma FnPlain AoS)
+                 (((pattern (Var k))
+                   (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))
+                  ((pattern (Var t))
+                   (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly))))
+                  ((pattern (Var c))
+                   (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))
+              ((pattern
+                (Promotion
+                 ((pattern (Lit Int 0))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                 UReal DataOnly))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+              ((pattern
+                (Promotion
+                 ((pattern (Lit Int 1))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                 UReal DataOnly))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>)))))
+    (meta <opaque>))))
+ (reverse_mode_log_prob
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id k)
+      (decl_type
+       (Sized
+        (SVector SoA
+         ((pattern (Var N)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity)
+             (dims
+              (((pattern (Var N))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern SoA)))
+           ()))
+         (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id c)
+      (decl_type
+       (Sized
+        (SVector SoA
+         ((pattern (Var N)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity)
+             (dims
+              (((pattern (Var N))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern SoA)))
+           ()))
+         (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib normal_lpdf (FnLpdf false) SoA)
+             (((pattern
+                (FunApp (StanLib fma FnPlain SoA)
+                 (((pattern (Var k))
+                   (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))
+                  ((pattern (Var t))
+                   (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly))))
+                  ((pattern (Var c))
+                   (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))
+              ((pattern
+                (Promotion
+                 ((pattern (Lit Int 0))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                 UReal DataOnly))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+              ((pattern
+                (Promotion
+                 ((pattern (Lit Int 1))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                 UReal DataOnly))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>)))))
+    (meta <opaque>))))
+ (generate_quantities
+  (((pattern
+     (Decl (decl_adtype DataOnly) (decl_id k)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Var N)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity)
+             (dims
+              (((pattern (Var N))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id c)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Var N)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity)
+             (dims
+              (((pattern (Var N))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt ())
+        (var
+         ((pattern (Var k)) (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt ())
+        (var
+         ((pattern (Var c)) (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (IfElse
+      ((pattern
+        (FunApp (StanLib PNot__ FnPlain AoS)
+         (((pattern
+            (EOr
+             ((pattern (Var emit_transformed_parameters__))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+             ((pattern (Var emit_generated_quantities__))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+      ((pattern (Block (((pattern (Return ())) (meta <opaque>))))) (meta <opaque>)) ()))
+    (meta <opaque>))
+   ((pattern
+     (IfElse
+      ((pattern
+        (FunApp (StanLib PNot__ FnPlain AoS)
+         (((pattern (Var emit_generated_quantities__))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+      ((pattern (Block (((pattern (Return ())) (meta <opaque>))))) (meta <opaque>)) ()))
+    (meta <opaque>))))
+ (transform_inits
+  (((pattern
+     (Decl (decl_adtype DataOnly) (decl_id pos__) (decl_type (Sized SInt))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable pos__) ()) UInt
+      ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id k)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Var N)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id k_flat__)
+          (decl_type (Unsized (UArray UReal))) (initialize Uninit)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable k_flat__) ()) (UArray UReal)
+          ((pattern
+            (FunApp (CompilerInternal FnReadData)
+             (((pattern (Lit Str k))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable pos__) ()) UInt
+          ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar sym1__)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Var N)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (Assignment
+                  ((LVariable k)
+                   ((Single
+                     ((pattern (Var sym1__))
+                      (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                  UVector
+                  ((pattern
+                    (Indexed
+                     ((pattern (Var k_flat__))
+                      (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))
+                     ((Single
+                       ((pattern (Var pos__))
+                        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+                (meta <opaque>))
+               ((pattern
+                 (Assignment ((LVariable pos__) ()) UInt
+                  ((pattern
+                    (FunApp (StanLib Plus__ FnPlain AoS)
+                     (((pattern (Var pos__))
+                       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                      ((pattern (Lit Int 1))
+                       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var k)) (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id c)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Var N)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id c_flat__)
+          (decl_type (Unsized (UArray UReal))) (initialize Uninit)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable c_flat__) ()) (UArray UReal)
+          ((pattern
+            (FunApp (CompilerInternal FnReadData)
+             (((pattern (Lit Str c))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable pos__) ()) UInt
+          ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar sym1__)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Var N)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (Assignment
+                  ((LVariable c)
+                   ((Single
+                     ((pattern (Var sym1__))
+                      (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                  UVector
+                  ((pattern
+                    (Indexed
+                     ((pattern (Var c_flat__))
+                      (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))
+                     ((Single
+                       ((pattern (Var pos__))
+                        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+                (meta <opaque>))
+               ((pattern
+                 (Assignment ((LVariable pos__) ()) UInt
+                  ((pattern
+                    (FunApp (StanLib Plus__ FnPlain AoS)
+                     (((pattern (Var pos__))
+                       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                      ((pattern (Lit Int 1))
+                       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var c)) (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))))
+ (unconstrain_array
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id k)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Var N)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable k) ()) UVector
+      ((pattern
+        (FunApp (CompilerInternal FnReadDeserializer)
+         (((pattern (Var N)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var k)) (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id c)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Var N)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable c) ()) UVector
+      ((pattern
+        (FunApp (CompilerInternal FnReadDeserializer)
+         (((pattern (Var N)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var c)) (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))))
+ (output_vars
+  ((k <opaque>
+    ((out_unconstrained_st
+      (SVector AoS
+       ((pattern (Var N)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+     (out_constrained_st
+      (SVector AoS
+       ((pattern (Var N)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+     (out_block Parameters) (out_trans Identity)))
+   (c <opaque>
+    ((out_unconstrained_st
+      (SVector AoS
+       ((pattern (Var N)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+     (out_constrained_st
+      (SVector AoS
+       ((pattern (Var N)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+     (out_block Parameters) (out_trans Identity)))))
+ (prog_name vecfma_model) (prog_path tests/fixtures/vecfma.stan))

--- a/tests/test_lower.cpp
+++ b/tests/test_lower.cpp
@@ -1200,6 +1200,134 @@ int main() {
           "glm: lp matches the var path (propto reached the kernel)");
   }
 
+  // normal_id_glm with the OUTCOME as a parameter. stanc3's --O1 partial
+  // evaluator rewrites `theta ~ normal(x * b, 1)` into
+  // normal_id_glm_lupdf(theta | x, 0, b, 1), a shape the source language
+  // never hands the kernel directly: y is the thing being sampled, so its
+  // gradient must come back too, not only alpha/beta/sigma's.
+  {
+    DataMap d = DataMap::from_json(
+        R"({"N": 3, "K": 2,
+            "x": [[1.0, 2.0], [0.5, -1.0], [2.0, 0.25]]})");
+    CompiledModel gm = compile_model(slurp("tests/fixtures/glmy.tmir.sexp"), d);
+    Executor gex(std::move(gm.graph));
+    gm.bind(gex);
+    const double q[5] = {0.3, -0.2, 1.1, 0.7, -0.4};  // theta[3], b[2]
+    for (int i = 0; i < 5; ++i) gex.params_data()[i] = q[i];
+    double grad[5] = {0, 0, 0, 0, 0};
+    const double lp = gex.gradient(grad);
+
+    using stan::math::var;
+    Eigen::Matrix<var, -1, 1> theta(3), b(2);
+    for (int i = 0; i < 3; ++i) theta(i) = q[i];
+    for (int i = 0; i < 2; ++i) b(i) = q[3 + i];
+    Eigen::MatrixXd X(3, 2);
+    X << 1.0, 2.0, 0.5, -1.0, 2.0, 0.25;
+    var acc = stan::math::normal_id_glm_lpdf<true>(theta, X, 0, b, 1);
+    acc.grad();
+
+    bool g_ok = true;
+    for (int i = 0; i < 3; ++i)
+      if (grad[i] != theta(i).adj()) g_ok = false;
+    for (int i = 0; i < 2; ++i)
+      if (grad[3 + i] != b(i).adj()) g_ok = false;
+    check(g_ok, "glm param y: gradients bitwise against the var path");
+    check(lp == acc.val(), "glm param y: lp matches the var path");
+  }
+
+  // An inlined user function's return variable: --O1 declares it
+  // zero-length (`vector[0] inline_..._return_sym__`) and sizes it by
+  // assignment, so the lowering adopts the assigned shape instead of
+  // rejecting the width mismatch.
+  {
+    DataMap d = DataMap::from_json(R"({"N": 4, "y": [1.0, 2.0, 4.0, -0.5]})");
+    CompiledModel im =
+        compile_model(slurp("tests/fixtures/inlret.tmir.sexp"), d);
+    Executor iex(std::move(im.graph));
+    im.bind(iex);
+    iex.params_data()[0] = 0.4;  // mu
+    double grad[1] = {0};
+    const double lp = iex.gradient(grad);
+
+    using stan::math::var;
+    var mu = 0.4;
+    Eigen::VectorXd y(4);
+    y << 1.0, 2.0, 4.0, -0.5;
+    Eigen::VectorXd c = y.array() - y.mean();
+    var acc = stan::math::normal_lpdf<false>(c, mu, 1);
+    acc.grad();
+    const double tol = 64 * 2.220446049250313e-16;
+    check(std::abs(lp - acc.val()) <= tol * std::abs(acc.val()),
+          "inlined return: lp matches the var path");
+    check(
+        std::abs(grad[0] - mu.adj()) <= tol * std::max(1.0, std::abs(mu.adj())),
+        "inlined return: gradient matches the var path");
+  }
+
+  // A declaration sized by a shape query on a COMPUTED value:
+  // `vector[rows(segment(beta, 1, 2)) + 1]` after --O1 inlines a callee
+  // and substitutes the call argument into its size expressions.
+  {
+    DataMap d = DataMap::from_json(R"({"N": 3})");
+    CompiledModel sm =
+        compile_model(slurp("tests/fixtures/inlseg.tmir.sexp"), d);
+    Executor sex(std::move(sm.graph));
+    sm.bind(sex);
+    const double q[3] = {0.6, -0.3, 0.2};
+    for (int i = 0; i < 3; ++i) sex.params_data()[i] = q[i];
+    double grad[3] = {0, 0, 0};
+    const double lp = sex.gradient(grad);
+
+    using stan::math::var;
+    Eigen::Matrix<var, -1, 1> beta(3);
+    for (int i = 0; i < 3; ++i) beta(i) = q[i];
+    Eigen::Matrix<var, -1, 1> u(3);
+    u << 0.0, beta(0), beta(1);
+    var acc = stan::math::sum(stan::math::cumulative_sum(u));
+    acc += stan::math::normal_lpdf<true>(beta, 0, 1);
+    acc.grad();
+    const double tol = 64 * 2.220446049250313e-16;
+    check(std::abs(lp - acc.val()) <= tol * std::max(1.0, std::abs(acc.val())),
+          "shape query on expression: lp matches the var path");
+    bool g_ok = true;
+    for (int i = 0; i < 3; ++i)
+      if (std::abs(grad[i] - beta(i).adj()) >
+          tol * std::max(1.0, std::abs(beta(i).adj())))
+        g_ok = false;
+    check(g_ok, "shape query on expression: gradients match the var path");
+  }
+
+  // Vector fma from --O1 partial evaluation (`k .* t + c` becomes
+  // fma(k, t, c)): the reader's desugar has to be elementwise, and the
+  // result bitwise what the unfused form computes.
+  {
+    DataMap d = DataMap::from_json(R"({"N": 3, "t": [2.0, -1.0, 0.5]})");
+    CompiledModel fm =
+        compile_model(slurp("tests/fixtures/vecfma.tmir.sexp"), d);
+    Executor fex(std::move(fm.graph));
+    fm.bind(fex);
+    const double q[6] = {0.3, -0.2, 1.1, 0.7, -0.4, 0.9};  // k[3], c[3]
+    for (int i = 0; i < 6; ++i) fex.params_data()[i] = q[i];
+    double grad[6] = {0, 0, 0, 0, 0, 0};
+    const double lp = fex.gradient(grad);
+
+    using stan::math::var;
+    Eigen::Matrix<var, -1, 1> k(3), c(3);
+    for (int i = 0; i < 3; ++i) k(i) = q[i];
+    for (int i = 0; i < 3; ++i) c(i) = q[3 + i];
+    Eigen::VectorXd t(3);
+    t << 2.0, -1.0, 0.5;
+    Eigen::Matrix<var, -1, 1> mu(3);
+    for (int i = 0; i < 3; ++i) mu(i) = k(i) * t(i) + c(i);
+    var acc = stan::math::normal_lpdf<false>(mu, 0, 1);
+    acc.grad();
+    check(lp == acc.val(), "vector fma: lp bitwise against the var path");
+    bool g_ok = true;
+    for (int i = 0; i < 3; ++i)
+      if (grad[i] != k(i).adj() || grad[3 + i] != c(i).adj()) g_ok = false;
+    check(g_ok, "vector fma: gradients bitwise against the var path");
+  }
+
   // Where the CSV's three sections meet. stanc marks the boundaries with
   // early-return guards on emit_transformed_parameters__ /
   // emit_generated_quantities__; lowering pins both flags on, so the

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -290,6 +290,18 @@ def test_stan_to_mir_round_trips():
     assert (g_a == g_b).all(), f"gradient differs: {g_a} vs {g_b}"
 
 
+def test_stan_to_mir_is_optimized():
+    # The MIR handed to the runtime is stanc3's optimized MIR (--O1), not
+    # the raw transformed MIR. Partial evaluation is the observable: at O1
+    # stanc3 rewrites log(1 - theta) to log1m(theta), and the transformed
+    # MIR never contains log1m. Both compile paths -- the embedded stanc
+    # and the subprocess fallback -- must agree on this.
+    code = ("parameters { real<lower=0, upper=1> theta; } "
+            "model { target += log(1 - theta); }")
+    mir = stanli.stan_to_mir(code)
+    assert "log1m" in mir, "MIR is not optimized (expected log1m from --O1)"
+
+
 def test_stan_to_mir_reports_syntax_errors():
     try:
         stanli.stan_to_mir("parameters { real x } model { }")

--- a/tests/test_write_array.cpp
+++ b/tests/test_write_array.cpp
@@ -543,12 +543,40 @@ void test_transformed_parameter_checks() {
 
 }  // namespace
 
+// A generated quantity the optimizer folds to a constant: --O1 replaces
+// the FnWriteParam's variable reference with the literal value, so the
+// column's name has to come from the program's output_vars instead.
+void test_constant_folded_gq_column() {
+  using namespace stanli;
+  DataMap data;
+  CompiledModel cm =
+      compile_model(slurp("tests/fixtures/gqconst.tmir.sexp"), data);
+  if (!cm.write_array || !cm.write_array->interp) {
+    ++failures;
+    std::printf("FAIL gqconst: no interpreted write_array\n");
+    return;
+  }
+  WaInterp& wi = *cm.write_array->interp;
+  std::map<std::string, DataMap::Entry> params;
+  DataMap::Entry x;
+  x.r = {0.25};
+  params["x"] = x;
+  WaRng rng(1);
+  const std::vector<double> row = wi.eval(params, rng);
+  expect_eq("gqconst header", joined(wi.columns()), "x,z");
+  if (row.size() != 2 || row[0] != 0.25 || row[1] != 3.0) {
+    ++failures;
+    std::printf("FAIL gqconst row: got %zu values\n", row.size());
+  }
+}
+
 int main() {
   test_naming_rules();
   test_wanames_pipeline();
   test_wanames_interpreter_schema();
   test_array_of_matrix_columns();
   test_interpreted_gq();
+  test_constant_folded_gq_column();
   test_caller_owned_rng();
   test_transformed_parameter_checks();
   if (failures == 0) std::printf("test_write_array OK\n");

--- a/tools/bench_models.py
+++ b/tools/bench_models.py
@@ -65,7 +65,7 @@ def main():
         sexp = tmp / f"{model}.sexp"
         t0 = time.perf_counter()
         sexp.write_text(subprocess.run(
-            [str(stanc), "--debug-transformed-mir", str(stan)],
+            [str(stanc), "--O1", "--debug-optimized-mir", str(stan)],
             capture_output=True, text=True, check=True).stdout)
         t_stanc = time.perf_counter() - t0
 

--- a/tools/gen_fixtures.sh
+++ b/tools/gen_fixtures.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 cd "$(dirname "$0")/.."
 for f in tests/fixtures/*.stan; do
-  ./deps/stanc3/stanc --debug-transformed-mir "$f" > "${f%.stan}.tmir.sexp"
+  ./deps/stanc3/stanc --O1 --debug-optimized-mir "$f" > "${f%.stan}.tmir.sexp"
 done
 # stanc also emits C++ next to the model; fixtures only keep the MIR.
 rm -f tests/fixtures/*.hpp

--- a/tools/stanc_embed/dune
+++ b/tools/stanc_embed/dune
@@ -1,7 +1,7 @@
 (executable
  (name stanc_embed)
  (modes object)
- (libraries core fmt common frontend driver)
+ (libraries core fmt common frontend driver analysis_and_optimization)
  ; -runtime-variant _pic: link the PIC build of the OCaml runtime
  ; (libasmrun_pic.a). The default runtime carries R_X86_64_32 absolute
  ; relocations, which the linker rejects inside a shared object on Linux.

--- a/tools/stanc_embed/stanc_embed.ml
+++ b/tools/stanc_embed/stanc_embed.ml
@@ -1,6 +1,8 @@
-(* stanli embedding entry point: Stan code -> transformed-MIR sexp string.
-   Registered for C via Callback; built with -output-complete-obj so the
-   OCaml runtime rides inside one object file linked into libstanli.
+(* stanli embedding entry point: Stan code -> optimized-MIR sexp string
+   (stanc3 --O1: inlining, constant/copy propagation, dead code
+   elimination, partial evaluation). Registered for C via Callback; built
+   with -output-complete-obj so the OCaml runtime rides inside one object
+   file linked into libstanli.
    Return protocol: "OK<sexp>" or "ERR<message>". *)
 open Core
 
@@ -8,9 +10,10 @@ let compile_tmir (code : string) : string =
   let captured = ref [] in
   let flags =
     { Driver.Flags.default with
-      debug_settings =
+      optimization_level= Analysis_and_optimization.Optimize.O1
+    ; debug_settings =
         { Driver.Flags.default.debug_settings with
-          print_transformed_mir= Driver.Flags.Basic } } in
+          print_optimized_mir= Driver.Flags.Basic } } in
   let output : Driver.Entry.other_output -> unit = function
     | DebugOutput s -> captured := s :: !captured
     | _ -> () in
@@ -23,6 +26,6 @@ let compile_tmir (code : string) : string =
       "OK" ^ String.concat ~sep:"" (List.rev !captured)
   | Ok (Error e) ->
       "ERR" ^ Fmt.str "%a" (Frontend.Errors.pp ?printed_filename:None ?code:None) e
-  | Ok (Ok _) -> "ERRinternal: no transformed MIR captured"
+  | Ok (Ok _) -> "ERRinternal: no optimized MIR captured"
 
 let () = Stdlib.Callback.register "stanc_compile_tmir" compile_tmir

--- a/tools/stanli_check.cpp
+++ b/tools/stanli_check.cpp
@@ -39,7 +39,7 @@ static double eval_point(int64_t i, int variant) {
 static std::string run_stanc(const std::string& stanc,
                              const std::string& model) {
   const std::string cmd =
-      stanc + " --debug-transformed-mir '" + model + "' 2>/dev/null";
+      stanc + " --O1 --debug-optimized-mir '" + model + "' 2>/dev/null";
   std::unique_ptr<FILE, int (*)(FILE*)> pipe(popen(cmd.c_str(), "r"), pclose);
   if (!pipe) throw std::runtime_error("cannot run stanc");
   std::string out;

--- a/tools/stanli_run.cpp
+++ b/tools/stanli_run.cpp
@@ -65,7 +65,7 @@ static std::string embedded_stanc(const std::string& model) {
 static std::string run_stanc(const std::string& stanc,
                              const std::string& model) {
   const std::string cmd =
-      stanc + " --debug-transformed-mir '" + model + "' 2>/dev/null";
+      stanc + " --O1 --debug-optimized-mir '" + model + "' 2>/dev/null";
   std::unique_ptr<FILE, int (*)(FILE*)> pipe(popen(cmd.c_str(), "r"), pclose);
   if (!pipe) throw std::runtime_error("cannot run stanc: " + cmd);
   std::string out;

--- a/tools/wasm_check.cjs
+++ b/tools/wasm_check.cjs
@@ -37,7 +37,7 @@ function evalPoint(i, variant) {
 let mir;
 try {
   mir = execFileSync(path.join(repo, "deps", "stanc3", "stanc"),
-                     ["--debug-transformed-mir", model],
+                     ["--O1", "--debug-optimized-mir", model],
                      { maxBuffer: 1 << 28, encoding: "utf8" });
 } catch (e) {
   console.log("COMPILE_FAIL stanc: " + String(e.message).split("\n")[0]);


### PR DESCRIPTION
Every path that turns Stan source into MIR now asks stanc3 for the optimized MIR at `--O1` (inlining, constant/copy propagation, DCE, partial evaluation) instead of the raw transformed MIR: the embedded compiler, the Python fallback, the JS worker, the CLI tools, and the harnesses. The MIR format is unchanged, so previously compiled MIR still loads.

The optimizer emits shapes the runtime had never seen; each is handled and covered by a fixture test:

- `fma(a, b, c)` from partial evaluation, including all-vector arguments (prophet): the reader desugars it elementwise to `a*b + c`, bitwise what the unfused form computes and what the CmdStan references recorded.
- `lmultiply(x, y)` from `x * log(y)`: interpreted via `multiply_log`.
- `normal_id_glm_lpdf` with the outcome as a parameter (`theta ~ normal(X*b, s)` rewritten to the GLM form): the kernel now returns `dlp/dy` instead of silently dropping it, which was a 0.68 relative error on the IRT models.
- Inlined callees' zero-length return declarations (`vector[0]` sized by assignment): the lowering and the parameter-dependent region compiler adopt the assigned shape.
- Size expressions querying computed values (`rows(segment(beta, ...))`): answered by lowering the argument and reading its slot.
- Inliner symbol reuse across loop iterations with per-iteration sizes: a redeclaration now shadows the stale binding.
- `FnWriteParam` whose variable reference was constant-folded away: the column name falls back to the MIR's `output_vars` order.
- `FnCheck` whose checked value was constant-folded to a literal: the declaration cross-check applies to variables only.

Corpus: 129/129 within gate, worst deviation identical to the transformed-MIR baseline (hmm_gaussian at 3.63e-12), so the optimizer introduces no numeric drift on the reference oracle.