### PR TITLE
feat: build a DataMap from a Stan var_context

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -237,6 +237,7 @@ add_library(stanli_shared SHARED
   runtime/src/inplace.cpp
   runtime/src/constfold.cpp
   runtime/src/data.cpp
+  runtime/src/data_var_context.cpp
   tests/tbb_stub.cpp)
 target_include_directories(stanli_shared PUBLIC runtime/include)
 target_compile_definitions(stanli_shared
@@ -333,7 +334,8 @@ add_library(stanli STATIC
   runtime/src/reroll.cpp
   runtime/src/inplace.cpp
   runtime/src/constfold.cpp
-  runtime/src/data.cpp)
+  runtime/src/data.cpp
+  runtime/src/data_var_context.cpp)
 target_include_directories(stanli PUBLIC runtime/include)
 target_compile_definitions(stanli PRIVATE STANLI_BUILD_ID="${STANLI_BUILD_ID}")
 # The BridgeStan facade is native-only: it finds its own sidecar manifest

--- a/runtime/include/stanli/data.hpp
+++ b/runtime/include/stanli/data.hpp
@@ -1,5 +1,5 @@
-// Runtime data container: built programmatically by tests, or parsed from
-// JSON with CmdStan's conventions.
+// Runtime data container: built programmatically by tests, parsed from JSON
+// with CmdStan's conventions, or copied out of a Stan var_context.
 #ifndef STANLI_DATA_HPP
 #define STANLI_DATA_HPP
 
@@ -8,6 +8,15 @@
 #include <stdexcept>
 #include <string>
 #include <vector>
+
+// Declared, not included: a caller who never builds a DataMap from a
+// var_context needs neither the stan headers on its include path nor
+// data_var_context.cpp in its build.
+namespace stan {
+namespace io {
+class var_context;
+}
+}  // namespace stan
 
 namespace stanli {
 
@@ -57,8 +66,11 @@ class DataMap {
     return it->second;
   }
 
+  // Each factory lives in its own translation unit -- data.cpp for the JSON
+  // pair, data_var_context.cpp for this one -- so a build can drop either.
   static DataMap from_json_file(const std::string& path);
   static DataMap from_json(const std::string& text);
+  static DataMap from_var_context(const stan::io::var_context& context);
 
  private:
   std::map<std::string, Entry> m_;

--- a/runtime/src/data_var_context.cpp
+++ b/runtime/src/data_var_context.cpp
@@ -1,0 +1,42 @@
+// Building a DataMap from a Stan var_context, for callers that already have
+// one -- language bindings that map their host arrays onto stan::io rather
+// than serializing to JSON first.
+#include <stanli/data.hpp>
+
+#include <stan/io/var_context.hpp>
+
+namespace stanli {
+
+DataMap DataMap::from_var_context(const stan::io::var_context& context) {
+  DataMap d;
+  // A var_context stores multidimensional values flat and column-major,
+  // which is what an Entry wants, so both loops copy without reordering.
+  // Scalars report no dims from either side.
+  std::vector<std::string> names;
+  context.names_r(names);
+  for (const std::string& name : names) {
+    // Contexts differ on whether an integer variable also shows up under
+    // names_r (as promoted doubles). Let the integer loop below own those:
+    // it is the one that fills Entry::i.
+    if (context.contains_i(name)) continue;
+    Entry e;
+    e.r = context.vals_r(name);
+    const std::vector<size_t> dims = context.dims_r(name);
+    e.dims.assign(dims.begin(), dims.end());
+    d.m_[name] = std::move(e);
+  }
+
+  context.names_i(names);
+  for (const std::string& name : names) {
+    Entry e;
+    e.is_int = true;
+    e.i = context.vals_i(name);
+    e.r.assign(e.i.begin(), e.i.end());  // ints are also usable as reals
+    const std::vector<size_t> dims = context.dims_i(name);
+    e.dims.assign(dims.begin(), dims.end());
+    d.m_[name] = std::move(e);
+  }
+  return d;
+}
+
+}  // namespace stanli

--- a/tests/test_data.cpp
+++ b/tests/test_data.cpp
@@ -1,8 +1,13 @@
-// JSON data loading (CmdStan conventions): scalars, arrays, nested arrays.
+// JSON data loading (CmdStan conventions): scalars, arrays, nested arrays,
+// and the same map built from a Stan var_context instead.
 #include <stanli/data.hpp>
 
+#include <stan/io/dump.hpp>
+
 #include <cstdio>
+#include <sstream>
 #include <string>
+#include <vector>
 
 static int failures = 0;
 static void check(bool ok, const std::string& what) {
@@ -37,6 +42,50 @@ int main() {
             m.at("M").r[1] == 3.0 && m.at("M").r[3] == 2.0,
         "matrix column-major with dims");
   check(m.at("yi").is_int && m.at("yi").i[2] == 1, "yi int array");
+
+  // A var_context keeps reals and ints under separate name lists, and its
+  // flat values are already column-major -- the same layout the JSON reader
+  // produces -- so the conversion copies rather than reorders.
+  std::istringstream dumped(
+      "n <- 4\n"
+      "x <- 1.5\n"
+      "rv <- c(0.5, -1.25, 3.75)\n"
+      "iv <- c(7, -2, 0)\n"
+      "R <- structure(c(1.5, 3.5, 5.5, 2.5, 4.5, 6.5), .Dim = c(3, 2))\n"
+      "I <- structure(c(1, 4, 2, 5, 3, 6), .Dim = c(2, 3))\n"
+      "RA <- structure(c(0.5, 1.5, 2.5, 3.5, 4.5, 5.5, 6.5, 7.5),"
+      " .Dim = c(2, 2, 2))\n"
+      "Z <- structure(c(), .Dim = c(2, 0, 3))\n");
+  stan::io::dump ctx(dumped);
+  DataMap c = DataMap::from_var_context(ctx);
+  check(c.at("n").is_int && c.at("n").i == std::vector<int>{4} &&
+            c.at("n").r == std::vector<double>{4.0} && c.at("n").dims.empty(),
+        "var_context int scalar");
+  check(!c.at("x").is_int && c.at("x").r == std::vector<double>{1.5} &&
+            c.at("x").dims.empty(),
+        "var_context real scalar");
+  check(!c.at("rv").is_int && c.at("rv").dims == std::vector<int64_t>{3} &&
+            c.at("rv").r == std::vector<double>({0.5, -1.25, 3.75}),
+        "var_context real array");
+  // Ints are usable as reals, the invariant set_int_array keeps.
+  check(c.at("iv").is_int && c.at("iv").dims == std::vector<int64_t>{3} &&
+            c.at("iv").i == std::vector<int>({7, -2, 0}) &&
+            c.at("iv").r == std::vector<double>({7, -2, 0}),
+        "var_context int array");
+  check(c.at("R").dims == std::vector<int64_t>({3, 2}) &&
+            c.at("R").r == std::vector<double>({1.5, 3.5, 5.5, 2.5, 4.5, 6.5}),
+        "var_context matrix stays column-major");
+  check(c.at("I").is_int && c.at("I").dims == std::vector<int64_t>({2, 3}) &&
+            c.at("I").i == std::vector<int>({1, 4, 2, 5, 3, 6}),
+        "var_context int matrix");
+  check(!c.at("RA").is_int &&
+            c.at("RA").dims == std::vector<int64_t>({2, 2, 2}) &&
+            c.at("RA").r.size() == 8 && c.at("RA").r[7] == 7.5,
+        "var_context 3-D real array");
+  check(
+      c.at("Z").dims == std::vector<int64_t>({2, 0, 3}) && c.at("Z").r.empty(),
+      "var_context zero-sized array");
+  check(!c.has("absent"), "var_context copies only what it holds");
 
   bool threw = false;
   try {


### PR DESCRIPTION
Closes #81.

Bindings that already map their host arrays onto `stan::io` had no way into a `DataMap` short of serializing to JSON and parsing it back. `DataMap::from_var_context` copies a context straight across: reals and ints come from the two separate name lists, and since a var_context already stores multidimensional values flat and column-major, nothing is reordered on the way in.

The factory lives in its own translation unit, so a build that wants one construction path and not the other just picks the source file: `data.cpp` for JSON, `data_var_context.cpp` for this. The header declares `stan::io::var_context` rather than including it, which keeps the stan headers off the include path of callers that never use it. Both directions are checked to compile and link on their own.

That is the one difference worth calling out against @andrjohns' [var-context branch](https://github.com/seantalts/stanli/compare/main...andrjohns:var-context), which this is otherwise built on and takes its test cases from. That branch reached the same selectivity with two CMake options and `#ifdef` blocks in four files. It turns out none of that is needed, because `data.cpp` contains only the JSON parser, so the two paths were already separable by file. Splitting the var_context path into its own TU gets the same result with no macros.

Two smaller choices: a static factory rather than a constructor, so it sits next to `from_json`/`from_json_file`; and the real loop skips names that `contains_i` reports, so the result does not depend on which loop runs last. `dump` and `json_data` keep the two lists disjoint, but a var_context is not required to.

Tests cover int and real scalars, int and real arrays, both matrix orientations, a 3-D array, and zero-sized dims, driven off `stan::io::dump`. 46/46 pass.
