### PR TITLE
release: 0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## 0.7.0
+
+### A DataMap from a Stan var_context
+
+`DataMap::from_var_context` builds the runtime's data map straight from
+a `stan::io::var_context`, for bindings that already map their host
+arrays onto `stan::io` and would otherwise have to serialize to JSON
+and parse it back out. Reals and integers come from the context's two
+separate name lists, and since a var_context already stores
+multidimensional values flat and column-major -- the layout an entry
+wants -- nothing is reordered on the way in.
+
+Each construction path is its own translation unit, `data.cpp` for the
+JSON pair and `data_var_context.cpp` for this one, so a build can take
+either without the other; the header declares `stan::io::var_context`
+rather than including it, which keeps the stan headers off the include
+path of callers that never build a map this way. Requested by
+@andrjohns for `stanr` (#81), and built on the branch attached to that
+issue.
+
 ## 0.6.1
 
 ### stanli models behind the BridgeStan ABI

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@seantalts/stanli",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "description": "Full Stan in the browser: stanc3 compiles the model in JS, a WASM runtime lowers it to an op graph and runs NUTS. No server, no C++ toolchain.",
   "type": "module",
   "main": "index.mjs",

--- a/python/stanli/__init__.py
+++ b/python/stanli/__init__.py
@@ -21,7 +21,7 @@ __all__ = ["Model", "Fit", "Summary", "OptimizeResult",
            "SAMPLER_COLUMNS", "__version__"]
 # The one place the version lives. setup.py and the release workflow both
 # read it from here.
-__version__ = "0.6.1"
+__version__ = "0.7.0"
 
 _BIN = pathlib.Path(__file__).parent / "_bin"
 

--- a/r/DESCRIPTION
+++ b/r/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: stanli
 Type: Package
 Title: The Stan Language Interpreter
-Version: 0.6.1
+Version: 0.7.0
 Authors@R: person("Sean", "Talts", email = "xitrium@gmail.com",
                   role = c("aut", "cre"))
 Description: Compile and sample Stan models without a C++ toolchain. Stan

--- a/r/R/install.R
+++ b/r/R/install.R
@@ -17,7 +17,7 @@
 # pinned binding with a runtime that has moved. The release workflow
 # asserts this equals the tag being cut, so bumping one without the
 # other fails there rather than at a user's install.
-stanli_runtime_release <- "v0.6.1"
+stanli_runtime_release <- "v0.7.0"
 
 runtime_filename <- function() {
   switch(Sys.info()[["sysname"]],


### PR DESCRIPTION
`DataMap::from_var_context` (#83, closing #81) is the release. Version 0.7.0 in `python/stanli/__init__.py`, `js/package.json`, `r/DESCRIPTION`, and the `stanli_runtime_release` pin in `r/R/install.R` — the four the tag build cross-checks against the tag name.