### PR TITLE
ci: fetch the reference BridgeStan sources before conforming against them

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -327,6 +327,23 @@ jobs:
         if: matrix.plat == 'manylinux_2_28_x86_64'
         run: |
           /tmp/wheeltest/bin/pip install bridgestan
+          # bridgestan downloads its own C++ sources from github the first
+          # time a model is compiled, inside the first conformance run. A
+          # 503 from that download surfaces as a conformance failure, which
+          # reads as "the facade disagrees with the reference" when nothing
+          # was ever compared -- main went red on exactly that. Fetch the
+          # sources up front, where a flaky mirror gets a few tries and a
+          # real outage says so in its own words. bridgestan retries the
+          # download itself, but only a URLError: it calls every HTTPError
+          # unrecoverable, and a 503 is an HTTPError.
+          for try in 1 2 3 4 5; do
+            /tmp/wheeltest/bin/python \
+              -c 'import bridgestan.download as d; d.get_bridgestan_src()' &&
+              break
+            echo "bridgestan source download failed (attempt $try of 5)"
+            [ "$try" = 5 ] && exit 1
+            sleep $((try * 20))
+          done
           for m in es simp newtrans conj; do
             case $m in
               es) data=tests/fixtures/eight_schools.json ;;


### PR DESCRIPTION
main is red, and not for a reason in the code. `bridgestan` downloads its own C++ sources from github the first time a model is compiled, which happens inside the first conformance run — so a 503 on that download surfaces as a conformance failure. The [run that merged #83](https://github.com/seantalts/stanli/actions/runs/31624972574/job/94208914283) reports the facade disagreeing with the reference when neither side had been built.

The download now happens up front, with five tries and a widening sleep, failing in its own words if the mirror is really gone. bridgestan's internal retry does not help here: it retries a `URLError` and calls every `HTTPError` unrecoverable, and a 503 is an `HTTPError`.

Retry semantics checked against a stub that fails a set number of times: succeeds mid-loop, exits 1 after five failures, and never falls through to the conformance runs on a failed fetch.