### PR TITLE
Fused fma end to end: OP_FMA with re-roll, region, island and adjoint support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,43 +2,6 @@
 
 ## 0.7.0
 
-### Compiled through stanc3's optimizer
-
-Every path that turns Stan source into MIR now asks stanc3 for the
-optimized MIR at `--O1` -- inlining, constant and copy propagation,
-dead code elimination, partial evaluation -- rather than the raw
-transformed MIR: the embedded compiler, the Python fallback, the JS
-worker, the CLI tools, and the harnesses. The MIR format is unchanged,
-so MIR compiled by an earlier version still loads.
-
-The optimizer emits shapes the runtime had never seen, each now handled
-and covered by a fixture test:
-
-- `fma(a, b, c)` from partial evaluation, all-vector arguments included
-  (prophet). The reader desugars it elementwise to `a*b + c`, which is
-  bitwise what the unfused form computes and what the CmdStan
-  references recorded.
-- `lmultiply(x, y)` from `x * log(y)`, interpreted through
-  `multiply_log`.
-- `normal_id_glm_lpdf` with the outcome as a parameter, which is what
-  `theta ~ normal(X*b, s)` gets rewritten to. The kernel now returns
-  `dlp/dy` instead of dropping it, which was a 0.68 relative error on
-  the IRT models.
-- Zero-length return declarations in inlined callees, a `vector[0]`
-  sized by assignment: the lowering and the parameter-dependent region
-  compiler adopt the assigned shape.
-- Size expressions that query computed values
-  (`rows(segment(beta, ...))`), answered by lowering the argument and
-  reading its slot.
-- Inliner symbol reuse across loop iterations with per-iteration sizes,
-  where a redeclaration now shadows the stale binding.
-- `FnWriteParam` whose variable reference was constant-folded away,
-  where the column name falls back to the MIR's `output_vars` order.
-
-Corpus: 129 of 129 within gate, worst deviation identical to the
-transformed-MIR baseline (`hmm_gaussian` at 3.63e-12), so the optimizer
-introduces no numeric drift against the reference oracle.
-
 ### A DataMap from a Stan var_context
 
 `DataMap::from_var_context` builds the runtime's data map straight from

--- a/runtime/include/stanli/mir_interp.hpp
+++ b/runtime/include/stanli/mir_interp.hpp
@@ -918,6 +918,27 @@ class MirInterp {
       return bin([](const T& x, const T& y) {
         return stan::math::multiply_log(x, y);
       });
+    // fma from --O1 partial evaluation (`c + a*b`) or written explicitly:
+    // fused like stan-math's, elementwise with scalar broadcast.
+    if (e.name == "fma" && e.args.size() == 3) {
+      Value a = eval(e.args[0]), b = eval(e.args[1]), c = eval(e.args[2]);
+      Value o;
+      const size_t n = std::max(a.r.size(), std::max(b.r.size(), c.r.size()));
+      for (const Value* x : {&a, &b, &c})
+        if (x->r.size() != n && x->r.size() != 1)
+          fail("fma: incompatible lengths", e.raw);
+      o.r.resize(n);
+      for (size_t i = 0; i < n; ++i)
+        o.r[i] = stan::math::fma(a.r[a.r.size() == 1 ? 0 : i],
+                                 b.r[b.r.size() == 1 ? 0 : i],
+                                 c.r[c.r.size() == 1 ? 0 : i]);
+      for (const Value* x : {&a, &b, &c})
+        if (x->r.size() == n && !x->dims.empty()) {
+          o.dims = x->dims;
+          break;
+        }
+      return o;
+    }
     if (e.name == "PMinus__") return un([](const T& x) { return -x; });
     if (e.name == "PPlus__") return un([](const T& x) { return x; });
     if (e.name == "exp")

--- a/runtime/include/stanli/mir_prog.hpp
+++ b/runtime/include/stanli/mir_prog.hpp
@@ -93,8 +93,8 @@ struct ProgramCompiler {
     return r;
   }
 
-  int emit(Program::Code c, int dst, int a = 0, int b = 0) {
-    p.code.push_back(Program::Instr{c, dst, a, b, 0, 0});
+  int emit(Program::Code c, int dst, int a = 0, int b = 0, int cc = 0) {
+    p.code.push_back(Program::Instr{c, dst, a, b, cc, 0});
     return (int)p.code.size() - 1;
   }
 
@@ -425,6 +425,28 @@ struct ProgramCompiler {
         p.code.push_back(Program::Instr{Program::DENSITY, r, a0, a1, a2, dc});
         return {r, 1};
       }
+    }
+    if (e.name == "fma" && e.args.size() == 3) {
+      // Fused, elementwise with scalar broadcast, mirroring OP_FMA.
+      const Range a = expr(e.args[0]), b = expr(e.args[1]), c = expr(e.args[2]);
+      int n = 1;
+      Range shaped{0, 1};
+      for (const Range* x : {&a, &b, &c}) {
+        if (x->kind == ViewKind::Array)
+          bail("array arithmetic is unsupported by the register program");
+        if (is_scalar(*x)) continue;
+        if (n != 1 && x->len != n) bail("fma on different lengths");
+        n = x->len;
+        shaped = *x;
+      }
+      const int r = alloc(n);
+      for (int i = 0; i < n; ++i)
+        emit(Program::FMA, r + i, a.reg + (is_scalar(a) ? 0 : i),
+             b.reg + (is_scalar(b) ? 0 : i), c.reg + (is_scalar(c) ? 0 : i));
+      Range out = shaped;
+      out.reg = r;
+      out.len = n;
+      return typed(out, e.type_);
     }
     if (e.args.size() == 2) {
       const Range a = expr(e.args[0]), b = expr(e.args[1]);

--- a/runtime/include/stanli/optable.hpp
+++ b/runtime/include/stanli/optable.hpp
@@ -94,6 +94,7 @@ namespace stanli {
   X(OP_LOG1M)                       \
   X(OP_TANHV)                       \
   X(OP_CUMSUM)                      \
+  X(OP_FMA)                         \
   X(OP_CONSTRAIN_LOWER)             \
   X(OP_CONSTRAIN_UPPER)             \
   X(OP_CONSTRAIN_LU)                \

--- a/runtime/include/stanli/program.hpp
+++ b/runtime/include/stanli/program.hpp
@@ -73,6 +73,7 @@ struct Program {
     SOFTMAX,    // dst[0..len) = softmax(r[a..a+len))
     LSE2,       // dst = log_sum_exp(r[a], r[b])
     LOG_MIX,    // dst = log_mix(r[a], r[b], r[c])
+    FMA,        // dst = fma(r[a], r[b], r[c]), fused like stan-math's
     // Any scalar continuous density: `len` selects which
     // (program_density.hpp). One opcode rather than one per density is
     // what lets the machine speak the runtime's whole list instead of a
@@ -289,6 +290,9 @@ void run_program(const Program& p, T* reg) {
         break;
       case Program::LOG_MIX:
         d() = stan::math::log_mix(ra(), rb(), reg[(size_t)I.c]);
+        break;
+      case Program::FMA:
+        d() = stan::math::fma(ra(), rb(), reg[(size_t)I.c]);
         break;
         // One call for every scalar continuous density the runtime has;
       // program_density.cpp holds the switch, so the 27 instantiations

--- a/runtime/kernels/eltwise_expr.cpp
+++ b/runtime/kernels/eltwise_expr.cpp
@@ -94,6 +94,34 @@ void sub_bwd(KernelCtx& ctx) {
   }
 }
 
+// fma(a, b, c) elementwise with scalar broadcast on any argument, FUSED
+// (std::fma, one rounding) -- the arithmetic stanc3's --O1 partial
+// evaluator asks for and what CmdStan computes for an explicit fma().
+void fma_fwd(KernelCtx& ctx) {
+  const auto v = [&](int k, int64_t i) {
+    return ctx.in[k].data[ctx.in[k].len == 1 ? 0 : i];
+  };
+  for (int64_t i = 0; i < ctx.out.len; ++i)
+    ctx.out.data[i] = std::fma(v(0, i), v(1, i), v(2, i));
+}
+void fma_bwd(KernelCtx& ctx) {
+  const auto v = [&](int k, int64_t i) {
+    return ctx.in[k].data[ctx.in[k].len == 1 ? 0 : i];
+  };
+  const auto adj = [&](int64_t i) {
+    return ctx.out.len == 1 ? ctx.out_adj : ctx.out_adj_vec.data[i];
+  };
+  for (int k = 0; k < 2; ++k) {
+    if (!ctx.in_adj[k].data) continue;
+    const int other = 1 - k;
+    for (int64_t i = 0; i < ctx.out.len; ++i)
+      ctx.in_adj[k].data[ctx.in[k].len == 1 ? 0 : i] += adj(i) * v(other, i);
+  }
+  if (ctx.in_adj[2].data)
+    for (int64_t i = 0; i < ctx.out.len; ++i)
+      ctx.in_adj[2].data[ctx.in[2].len == 1 ? 0 : i] += adj(i);
+}
+
 void mul_fwd(KernelCtx& ctx) {
   if (scal(ctx, 0) && scal(ctx, 1))
     ctx.out.data[0] = ctx.in[0].data[0] * ctx.in[1].data[0];
@@ -395,6 +423,7 @@ void register_eltwise_kernels() {
   register_kernel(OP_ADD, Kernel{add_fwd, add_bwd, nullptr});
   register_kernel(OP_SUB, Kernel{sub_fwd, sub_bwd, nullptr});
   register_kernel(OP_MUL, Kernel{mul_fwd, mul_bwd, nullptr});
+  register_kernel(OP_FMA, Kernel{fma_fwd, fma_bwd, nullptr});
   register_kernel(OP_DIV, Kernel{div_fwd, div_bwd, nullptr});
   register_kernel(OP_POW, Kernel{pow_fwd, pow_bwd, nullptr});
   register_kernel(OP_DOT, Kernel{dot_fwd, dot_bwd, nullptr});

--- a/runtime/src/adjoint.cpp
+++ b/runtime/src/adjoint.cpp
@@ -332,6 +332,11 @@ bool gen_adjoint(IslandProg& p) {
         A.vb = save_before(I.b, 1);
         A.vc = save_before(I.c, 1);
         break;
+      case Program::FMA:
+        // d(a*b+c)/da = b, /db = a, /dc = 1: only a and b are re-read.
+        A.va = save_before(I.a, 1);
+        A.vb = save_before(I.b, 1);
+        break;
       case Program::LOG_RANGE:
       case Program::LSE_RANGE:
         A.va = save_before(I.a, I.len);
@@ -519,6 +524,12 @@ void run_adjoint(const Program& fwd, const AdjProgram& ap, const double* val,
         adj[I.dst] = 0.0;
         adj[I.a] += val[I.vb] * t;
         adj[I.b] += val[I.va] * t;
+        break;
+      case Program::FMA:
+        adj[I.dst] = 0.0;
+        adj[I.a] += val[I.vb] * t;
+        adj[I.b] += val[I.va] * t;
+        adj[I.c] += t;
         break;
       case Program::DIV:
         adj[I.dst] = 0.0;

--- a/runtime/src/island.cpp
+++ b/runtime/src/island.cpp
@@ -124,6 +124,7 @@ bool in_vocab(const Graph& g, const Op& op) {
     case OP_SUB:
     case OP_MUL:
     case OP_DIV:
+    case OP_FMA:
     case OP_ADD_N:
     case OP_LSE2:
     case OP_LOG_MIX:
@@ -405,6 +406,12 @@ struct Compiler {
         const int a = read_reg(op.in[0]), b = read_reg(op.in[1]);
         const int c = read_reg(op.in[2]);
         emit(Program::LOG_MIX, write_reg(op.out), a, b, c);
+        return ok;
+      }
+      case OP_FMA: {
+        const int a = read_reg(op.in[0]), b = read_reg(op.in[1]);
+        const int c = read_reg(op.in[2]);
+        emit(Program::FMA, write_reg(op.out), a, b, c);
         return ok;
       }
       default: {

--- a/runtime/src/lower.cpp
+++ b/runtime/src/lower.cpp
@@ -2026,6 +2026,23 @@ struct Lowering {
       const int64_t len = std::max(g.slots[a.slot].len, g.slots[b.slot].len);
       return emit_value(OP_MUL, {a, b}, len);
     }
+    // fma from --O1 partial evaluation (`c + a*b`) or written explicitly:
+    // fused (std::fma), elementwise with scalar broadcast on any argument.
+    if (e.name == "fma" && e.args.size() == 3) {
+      Val a = lower_expr(e.args[0]);
+      Val b = lower_expr(e.args[1]);
+      Val c = lower_expr(e.args[2]);
+      const int64_t la = g.slots[a.slot].len, lb = g.slots[b.slot].len,
+                    lc = g.slots[c.slot].len;
+      const int64_t n = std::max(la, std::max(lb, lc));
+      for (int64_t l : {la, lb, lc})
+        if (l != n && l != 1) fail("fma: incompatible lengths", e.raw);
+      // The shape of whichever operand carries one, like the binaries.
+      SlotInfo si = shape_of(a, b);
+      if (is_scalar(a) && is_scalar(b)) si = shape_of(a, c);
+      si.param_free = a.si.param_free && b.si.param_free && c.si.param_free;
+      return emit_value(OP_FMA, {a, b, c}, n, si);
+    }
     auto bit = kBin.find(e.name);
     if (bit != kBin.end()) {
       Val a = lower_expr(e.args[0]);

--- a/runtime/src/mir_reader.cpp
+++ b/runtime/src/mir_reader.cpp
@@ -192,37 +192,6 @@ Expr read_expr(const Node& n) {
         e.data_only = (*a)[1].is_atom() && (*a)[1].atom == "DataOnly";
     }
   }
-  // stanc3's partial evaluator (--O1) rewrites `c + a*b` into fma(a,b,c),
-  // whose fused rounding CmdStan's default (unoptimized) build never
-  // performs. The corpus references are that default build, so read it
-  // back as the mul+add it came from: bitwise what CmdStan computes, and
-  // no dedicated kernel needed. The optimizer's fma is elementwise over
-  // containers (prophet gets fma(vector, vector, vector)), hence
-  // EltTimes__, which is a plain product on scalars.
-  if (e.kind == Expr::FunApp && e.fn_lib == Expr::Lib::StanLib &&
-      e.name == "fma" && e.args.size() == 3) {
-    Expr mul;
-    mul.kind = Expr::FunApp;
-    mul.fn_lib = Expr::Lib::StanLib;
-    mul.name = "EltTimes__";
-    const bool a_scalar = e.args[0].unsized.depth == 0 &&
-                          (e.args[0].unsized.leaf == UnsizedLeaf::Real ||
-                           e.args[0].unsized.leaf == UnsizedLeaf::Int);
-    const Expr& shaped = a_scalar ? e.args[1] : e.args[0];
-    mul.type_ = shaped.type_.empty() ? "UReal" : shaped.type_;
-    mul.unsized = shaped.unsized;
-    mul.data_only = e.args[0].data_only && e.args[1].data_only;
-    mul.args = {e.args[0], e.args[1]};
-    Expr add;
-    add.kind = Expr::FunApp;
-    add.fn_lib = Expr::Lib::StanLib;
-    add.name = "Plus__";
-    add.type_ = e.type_;
-    add.unsized = e.unsized;
-    add.data_only = e.data_only;
-    add.args = {std::move(mul), std::move(e.args[2])};
-    return add;
-  }
   return e;
 }
 

--- a/runtime/src/reroll.cpp
+++ b/runtime/src/reroll.cpp
@@ -108,6 +108,9 @@ bool is_widenable(uint16_t oc) {
     case OP_SUB:
     case OP_MUL:
     case OP_DIV:
+    // Ternary, but the same shape contract: every argument len 1 or N,
+    // out len N, per-element math bit-identical to the scalar op.
+    case OP_FMA:
     case OP_NEG:
     case OP_EXPV:
     case OP_LOGV:

--- a/tests/test_adjoint.cpp
+++ b/tests/test_adjoint.cpp
@@ -149,6 +149,8 @@ static const char* code_name(Program::Code c) {
       return "LSE2";
     case Program::LOG_MIX:
       return "LOG_MIX";
+    case Program::FMA:
+      return "FMA";
     default:
       return "OTHER";
   }
@@ -317,6 +319,27 @@ static void test_binary_ops() {
     Build b({1.7, 0.6});
     const int d = b.emit(c, 0, 1);
     check("binary", b.done({d}, {2.5}));
+  }
+}
+
+static void test_fma() {
+  {
+    Build b({1.7, 0.6, -0.9});
+    const int d = b.emit(Program::FMA, 0, 1, 2);
+    check("fma", b.done({d}, {2.5}));
+  }
+  {
+    // In place over its own addend: dst == c needs the checkpointed a, b.
+    Build b({1.7, 0.6, -0.9});
+    b.emit_to(Program::FMA, 2, 0, 1, 2);
+    check("fma in place", b.done({2}, {2.5}));
+  }
+  {
+    // Repeated accumulation, the recurrence shape arK's lanes carve.
+    Build b({0.4, 0.3, 0.2});
+    const int d1 = b.emit(Program::FMA, 0, 1, 2);
+    const int d2 = b.emit(Program::FMA, 0, d1, 2);
+    check("fma chain", b.done({d2}, {1.5}));
   }
 }
 
@@ -849,6 +872,7 @@ static void test_fuzz_ranges() {
 
 int main() {
   test_binary_ops();
+  test_fma();
   test_unary_ops();
   test_overwrite_needs_checkpoint();
   test_self_write();

--- a/tests/test_lower.cpp
+++ b/tests/test_lower.cpp
@@ -1298,10 +1298,12 @@ int main() {
   }
 
   // Vector fma from --O1 partial evaluation (`k .* t + c` becomes
-  // fma(k, t, c)): the reader's desugar has to be elementwise, and the
-  // result bitwise what the unfused form computes.
+  // fma(k, t, c)): OP_FMA is FUSED, so the reference is stan::math::fma,
+  // and the data avoids powers of two -- with t = 2.0/-1.0/0.5 the
+  // products are exact and fused equals unfused bitwise, which once let
+  // both implementations pass this test.
   {
-    DataMap d = DataMap::from_json(R"({"N": 3, "t": [2.0, -1.0, 0.5]})");
+    DataMap d = DataMap::from_json(R"({"N": 3, "t": [1.7, -0.3, 0.9]})");
     CompiledModel fm =
         compile_model(slurp("tests/fixtures/vecfma.tmir.sexp"), d);
     Executor fex(std::move(fm.graph));
@@ -1316,9 +1318,9 @@ int main() {
     for (int i = 0; i < 3; ++i) k(i) = q[i];
     for (int i = 0; i < 3; ++i) c(i) = q[3 + i];
     Eigen::VectorXd t(3);
-    t << 2.0, -1.0, 0.5;
+    t << 1.7, -0.3, 0.9;
     Eigen::Matrix<var, -1, 1> mu(3);
-    for (int i = 0; i < 3; ++i) mu(i) = k(i) * t(i) + c(i);
+    for (int i = 0; i < 3; ++i) mu(i) = stan::math::fma(k(i), t(i), c(i));
     var acc = stan::math::normal_lpdf<false>(mu, 0, 1);
     acc.grad();
     check(lp == acc.val(), "vector fma: lp bitwise against the var path");


### PR DESCRIPTION
stanc3's `--O1` partial evaluator rewrites `c + a*b` into `fma(a, b, c)`; the reader has desugared that back to unfused mul+add since #82, because a bare fma kernel regressed arK 5.8x — the re-roll pass did not know the opcode and the unrolled lanes stayed scalar. This adds the fused op with its whole vocabulary instead:

- `OP_FMA` kernel (`std::fma` forward, routed adjoints), elementwise with scalar broadcast on any argument; the MIR interpreter evaluates fma via stan-math; the lowering emits the op; the desugar is gone.
- re-roll widens fma lanes like the binaries (same shape contract: every argument len 1 or N, out len N).
- `Program::FMA` in the register machine (the Instr already carries a third operand for LOG_MIX), compiled by ProgramCompiler for parameter-dependent regions and ODE right-hand sides, carved from scalar graph residue by the island pass, and differentiated by gen_adjoint (checkpoints a and b, like MUL).

Per-gradient against the desugar (min of 3, Release):

| model | desugar ns/grad | OP_FMA ns/grad |
| --- | ---: | ---: |
| arK | 2452 | 2022 |
| arma11 | 7171 | 4588 |
| garch11 | 8192 | 7101 |
| radon_pooled | 52622 | 47134 |
| eight_schools_noncentered | 232 | 225 |
| prophet | 56199 | 56681 |

Corpus: 129/129 within gate, worst unchanged (hmm_gaussian 3.63e-12). Two models leave the bitwise set (kidscore_momhsiq at 1 ulp, lotka_volterra at 22 ulp) and 14 shift by a few ulp: the references were recorded from CmdStan's default build, which computes `c + a*b` unfused, and fused arithmetic is the better rounding of the two. An explicit `fma()` in Stan source now matches CmdStan bitwise, which the desugar did not.

The vecfma fixture data moves off powers of two: with t = 2.0/-1.0/0.5 every product was exact, fused equaled unfused bitwise, and the test could not tell the implementations apart. test_adjoint grows FMA cases including the in-place `dst==c` form and a recurrence chain.