### PR TITLE
fix: preserve shaped MIR scalar broadcasts

### DIFF
--- a/runtime/include/stanli/mir_interp.hpp
+++ b/runtime/include/stanli/mir_interp.hpp
@@ -118,10 +118,10 @@ class MirInterp {
         v.is_int = true;
         v.i = int_args[ii++];
         v.r.assign(v.i.begin(), v.i.end());
-        v.dims = {(int64_t)v.i.size()};
+        if (f.arg_types[k] != "UInt") v.dims = {(int64_t)v.i.size()};
       } else if (ai < args.size()) {
         v.r = args[ai++];
-        v.dims = {(int64_t)v.r.size()};
+        if (f.arg_types[k] != "UReal") v.dims = {(int64_t)v.r.size()};
       }
       sub.env_[f.arg_names[k]] = std::move(v);
     }
@@ -800,21 +800,37 @@ class MirInterp {
   Value eval_fun(const mir::Expr& e) {
     Value r;
     if (e.fn_lib == mir::Expr::Lib::UserDefined) return call_udf(e);
+    const auto is_scalar = [](const Value& v) {
+      return v.dims.empty() && v.r.size() == 1;
+    };
+    const auto broadcast_dims = [](const Value& a, const Value& b) {
+      if (a.dims.empty() != b.dims.empty())
+        return a.dims.empty() ? b.dims : a.dims;
+      if (a.r.size() > b.r.size()) return a.dims;
+      if (b.r.size() > a.r.size()) return b.dims;
+      return a.dims.empty() ? b.dims : a.dims;
+    };
+    const auto broadcast_size = [&](const Value& a, const Value& b) {
+      if (is_scalar(a)) return b.r.size();
+      if (is_scalar(b)) return a.r.size();
+      return a.r.size();
+    };
+    const auto shapes_match = [&](const Value& a, const Value& b) {
+      return is_scalar(a) || is_scalar(b) ||
+             (a.dims == b.dims && a.r.size() == b.r.size());
+    };
     // Elementwise with scalar broadcasting; results of real math are real
     // even on int inputs, and binary int results stay int only when both
     // sides are int scalars.
     auto bin = [&](auto f) {
       Value a = eval(e.args[0]), b = eval(e.args[1]);
       Value o;
-      if (a.r.size() != b.r.size() && a.r.size() != 1 && b.r.size() != 1)
-        fail(e.name + ": incompatible lengths " + std::to_string(a.r.size()) +
-                 " vs " + std::to_string(b.r.size()),
-             e.raw);
-      const size_t n = std::max(a.r.size(), b.r.size());
+      if (!shapes_match(a, b)) fail(e.name + ": incompatible shapes", e.raw);
+      const size_t n = broadcast_size(a, b);
       o.r.resize(n);
       for (size_t i = 0; i < n; ++i)
         o.r[i] = f(a.r[a.r.size() == 1 ? 0 : i], b.r[b.r.size() == 1 ? 0 : i]);
-      o.dims = a.r.size() >= b.r.size() ? a.dims : b.dims;
+      o.dims = broadcast_dims(a, b);
       if (a.is_int && b.is_int && a.i.size() == 1 && b.i.size() == 1) {
         o.is_int = true;
         o.i = {(int)val(f(T((double)a.i[0]), T((double)b.i[0])))};
@@ -845,7 +861,7 @@ class MirInterp {
       // a scalar operand (either side) scales elementwise.
       Value a = eval(e.args[0]), b = eval(e.args[1]);
       const bool a_mat = a.dims.size() == 2, b_mat = b.dims.size() == 2;
-      if (a.r.size() != 1 && b.r.size() != 1 && (a_mat || b_mat)) {
+      if (!is_scalar(a) && !is_scalar(b) && (a_mat || b_mat)) {
         const int64_t Ra = a_mat ? a.dims[0] : 1;
         const int64_t Ca = a_mat ? a.dims[1] : (int64_t)a.r.size();
         const int64_t Rb = b_mat ? b.dims[0] : (int64_t)b.r.size();
@@ -866,7 +882,7 @@ class MirInterp {
           r.dims = {(int64_t)r.r.size()};
         return r;
       }
-      if (a.r.size() != 1 && b.r.size() != 1 && !a_mat && !b_mat) {
+      if (!is_scalar(a) && !is_scalar(b) && !a_mat && !b_mat) {
         // vector * row_vector is an outer product when the result is a
         // matrix; row_vector * vector is a dot product when it is a scalar.
         if (e.type_ == "UMatrix") {
@@ -888,13 +904,13 @@ class MirInterp {
       }
       // Scalar scale, elementwise on the already-evaluated operands (an
       // argument may hold an RNG call; evaluating twice would draw twice).
-      if (a.r.size() != b.r.size() && a.r.size() != 1 && b.r.size() != 1)
+      if (a.r.size() != b.r.size() && !is_scalar(a) && !is_scalar(b))
         fail("Times__: incompatible lengths", e.raw);
-      const size_t n = std::max(a.r.size(), b.r.size());
+      const size_t n = broadcast_size(a, b);
       r.r.resize(n);
       for (size_t i = 0; i < n; ++i)
         r.r[i] = a.r[a.r.size() == 1 ? 0 : i] * b.r[b.r.size() == 1 ? 0 : i];
-      r.dims = a.r.size() >= b.r.size() ? a.dims : b.dims;
+      r.dims = broadcast_dims(a, b);
       if (a.is_int && b.is_int && a.i.size() == 1 && b.i.size() == 1) {
         r.is_int = true;
         r.i = {a.i[0] * b.i[0]};
@@ -923,20 +939,21 @@ class MirInterp {
     if (e.name == "fma" && e.args.size() == 3) {
       Value a = eval(e.args[0]), b = eval(e.args[1]), c = eval(e.args[2]);
       Value o;
-      const size_t n = std::max(a.r.size(), std::max(b.r.size(), c.r.size()));
-      for (const Value* x : {&a, &b, &c})
-        if (x->r.size() != n && x->r.size() != 1)
-          fail("fma: incompatible lengths", e.raw);
+      size_t n = 1;
+      bool have_container = false;
+      for (const Value* x : {&a, &b, &c}) {
+        if (is_scalar(*x)) continue;
+        if (have_container && (x->dims != o.dims || x->r.size() != n))
+          fail("fma: incompatible shapes", e.raw);
+        n = x->r.size();
+        o.dims = x->dims;
+        have_container = true;
+      }
       o.r.resize(n);
       for (size_t i = 0; i < n; ++i)
         o.r[i] = stan::math::fma(a.r[a.r.size() == 1 ? 0 : i],
                                  b.r[b.r.size() == 1 ? 0 : i],
                                  c.r[c.r.size() == 1 ? 0 : i]);
-      for (const Value* x : {&a, &b, &c})
-        if (x->r.size() == n && !x->dims.empty()) {
-          o.dims = x->dims;
-          break;
-        }
       return o;
     }
     if (e.name == "PMinus__") return un([](const T& x) { return -x; });

--- a/tests/test_mir.cpp
+++ b/tests/test_mir.cpp
@@ -1,5 +1,6 @@
 // MIR reader over the transformed-MIR sexp of eight schools.
 #include <stanli/mir.hpp>
+#include <stanli/mir_interp.hpp>
 #include <stanli/sexp.hpp>
 
 #include <cstdio>
@@ -94,6 +95,174 @@ int main(int argc, char** argv) {
   };
   for (const auto& s : p.log_prob) swalk(s);
   check(n_propto == 4, "4 propto lpdf calls");
+
+  // A scalar broadcasts over the container's logical geometry, including a
+  // zero-width vector. Flat width alone cannot identify the scalar when the
+  // vector has zero or one element.
+  {
+    std::map<std::string, const mir::FunDef*> functions;
+    MirInterp<double> interp(functions, "broadcast test");
+    auto real_value = [&](const std::string& name, std::vector<double> values,
+                          std::vector<int64_t> dims) {
+      DataMap::Entry value;
+      value.r = std::move(values);
+      value.dims = std::move(dims);
+      interp.env()[name] = std::move(value);
+    };
+    DataMap::Entry empty;
+    empty.dims = {0};
+    interp.env()["empty"] = empty;
+    real_value("one", {3.0}, {1});
+
+    mir::Expr scalar;
+    scalar.kind = mir::Expr::LitReal;
+    scalar.lit = 2.0;
+    scalar.type_ = "UReal";
+    scalar.unsized.leaf = mir::UnsizedLeaf::Real;
+    scalar.data_only = true;
+    for (const std::string& name : {"Plus__", "Times__"}) {
+      for (const std::string& variable : {"empty", "one"}) {
+        mir::Expr vector;
+        vector.kind = mir::Expr::Var;
+        vector.name = variable;
+        vector.type_ = "UVector";
+        vector.unsized.leaf = mir::UnsizedLeaf::Vector;
+        vector.data_only = true;
+        for (bool scalar_first : {false, true}) {
+          mir::Expr call;
+          call.kind = mir::Expr::FunApp;
+          call.name = name;
+          call.type_ = "UVector";
+          call.unsized.leaf = mir::UnsizedLeaf::Vector;
+          call.data_only = true;
+          call.args = scalar_first ? std::vector<mir::Expr>{scalar, vector}
+                                   : std::vector<mir::Expr>{vector, scalar};
+          const DataMap::Entry got = interp.eval(call);
+          const size_t want_size = variable == "empty" ? 0 : 1;
+          check(got.r.size() == want_size && got.dims.size() == 1 &&
+                    got.dims[0] == (int64_t)want_size,
+                name + " scalar/vector geometry");
+          if (want_size)
+            check(got.r[0] == (name == "Plus__" ? 5.0 : 6.0),
+                  name + " scalar/vector value");
+        }
+      }
+    }
+    for (const std::string& variable : {"empty", "one"}) {
+      mir::Expr vector;
+      vector.kind = mir::Expr::Var;
+      vector.name = variable;
+      vector.type_ = "UVector";
+      vector.unsized.leaf = mir::UnsizedLeaf::Vector;
+      vector.data_only = true;
+      for (int container_arg = 0; container_arg < 3; ++container_arg) {
+        mir::Expr call;
+        call.kind = mir::Expr::FunApp;
+        call.name = "fma";
+        call.type_ = "UVector";
+        call.unsized.leaf = mir::UnsizedLeaf::Vector;
+        call.data_only = true;
+        call.args = {scalar, scalar, scalar};
+        call.args[(size_t)container_arg] = vector;
+        const DataMap::Entry got = interp.eval(call);
+        const size_t want_size = variable == "empty" ? 0 : 1;
+        check(got.r.size() == want_size && got.dims.size() == 1 &&
+                  got.dims[0] == (int64_t)want_size,
+              "fma scalar/vector geometry");
+        if (want_size)
+          check(got.r[0] == (container_arg == 2 ? 7.0 : 8.0),
+                "fma scalar/vector value");
+      }
+    }
+
+    auto variable = [](const std::string& name, const std::string& type) {
+      mir::Expr e;
+      e.kind = mir::Expr::Var;
+      e.name = name;
+      e.type_ = type;
+      e.data_only = true;
+      return e;
+    };
+    auto times = [&](const std::string& lhs, const std::string& lhs_type,
+                     const std::string& rhs, const std::string& rhs_type,
+                     const std::string& result_type) {
+      mir::Expr e;
+      e.kind = mir::Expr::FunApp;
+      e.name = "Times__";
+      e.type_ = result_type;
+      e.data_only = true;
+      e.args = {variable(lhs, lhs_type), variable(rhs, rhs_type)};
+      return interp.eval(e);
+    };
+    real_value("m11", {2.0}, {1, 1});
+    real_value("m12", {3.0, 4.0}, {1, 2});
+    DataMap::Entry matrix =
+        times("m11", "UMatrix", "m12", "UMatrix", "UMatrix");
+    check(matrix.dims == std::vector<int64_t>({1, 2}) &&
+              matrix.r == std::vector<double>({6.0, 8.0}),
+          "Times__ width-one matrix product");
+    real_value("rv1", {2.0}, {1});
+    real_value("v1", {3.0}, {1});
+    DataMap::Entry dot = times("rv1", "URowVector", "v1", "UVector", "UReal");
+    check(dot.dims.empty() && dot.r == std::vector<double>({6.0}),
+          "Times__ width-one dot product");
+
+    real_value("v2", {4.0, 5.0}, {2});
+    auto refuses_elementwise =
+        [&](const std::string& name, const std::string& lhs,
+            const std::string& rhs, const std::string& type) {
+          mir::Expr call;
+          call.kind = mir::Expr::FunApp;
+          call.name = name;
+          call.type_ = type;
+          call.data_only = true;
+          call.args = {variable(lhs, type), variable(rhs, type)};
+          if (name == "fma") call.args.push_back(scalar);
+          bool refused = false;
+          try {
+            (void)interp.eval(call);
+          } catch (const std::exception&) {
+            refused = true;
+          }
+          return refused;
+        };
+    for (const std::string& name : {"Plus__", "fma"}) {
+      check(refuses_elementwise(name, "one", "v2", "UVector"),
+            name + " refuses vector[1]/vector[2] broadcast");
+    }
+
+    real_value("m23", {1, 2, 3, 4, 5, 6}, {2, 3});
+    real_value("m32", {1, 2, 3, 4, 5, 6}, {3, 2});
+    real_value("m03", {}, {0, 3});
+    real_value("m02", {}, {0, 2});
+    for (const std::string& name : {"Plus__", "fma"}) {
+      check(refuses_elementwise(name, "m23", "m32", "UMatrix"),
+            name + " refuses equal-width unequal matrix shapes");
+      check(refuses_elementwise(name, "m03", "m02", "UMatrix"),
+            name + " refuses unequal zero-width matrix shapes");
+    }
+
+    // The positional ODE fallback entry point reconstructs scalar/container
+    // geometry from each formal rather than flattening every argument.
+    mir::FunDef scale;
+    scale.name = "scale";
+    scale.arg_names = {"a", "x"};
+    scale.arg_views = {{0, mir::UnsizedLeaf::Real},
+                       {0, mir::UnsizedLeaf::Vector}};
+    scale.arg_types = {"UReal", "UVector"};
+    mir::Stmt returned;
+    returned.kind = mir::Stmt::Return;
+    returned.has_init = true;
+    returned.rhs.kind = mir::Expr::FunApp;
+    returned.rhs.name = "Times__";
+    returned.rhs.type_ = "UVector";
+    returned.rhs.args = {variable("a", "UReal"), variable("x", "UVector")};
+    scale.body = {returned};
+    const std::vector<double> scaled =
+        interp.call(scale, {{2.0}, {3.0, 4.0}}, {});
+    check(scaled == std::vector<double>({6.0, 8.0}),
+          "ODE call scalar formal broadcasts over vector");
+  }
 
   if (failures == 0) std::printf("test_mir OK\n");
   return failures == 0 ? 0 : 1;


### PR DESCRIPTION
## Summary

- distinguish true scalars from length-one containers in MirInterp
- preserve container geometry for scalar broadcasts, including empty shapes
- reject equal-width operands with incompatible logical shapes
- keep width-one matrix and vector products on the linear-algebra path
- reconstruct scalar ODE formals as scalars at the interpreter boundary

## Tests

- format check
- test_mir
- test_mir_unary_fallback
- test_ode_prog
- test_lower_view_contract
- test_mir_program_conformance
- test_mir_checks

Production scope: 39 additions, 22 deletions.