### PR TITLE
fix: preserve categorical validation and propto semantics

### DIFF
--- a/runtime/include/stanli/graph.hpp
+++ b/runtime/include/stanli/graph.hpp
@@ -116,6 +116,18 @@ struct BoundCheckSpec {
   bool shapes_match = false;
 };
 
+// The two categorical families share one exact value/check/pullback op.
+// `scalar_outcome` is a language type distinction: array[1] int must select
+// Stan Math's vector overload even though its flat slot also has length one.
+struct CategoricalSpec {
+  bool logit = false;
+  bool scalar_outcome = false;
+  // These are independent: write_array values depend on q but instantiate on
+  // double, while a graph-constant AutoDiffable local instantiates on var.
+  bool arg_autodiff = false;
+  bool propto = true;  // template flag; Stan Math decides what it can drop
+};
+
 class Executor {
  public:
   explicit Executor(Graph g);
@@ -150,13 +162,12 @@ class Executor {
 
   // Forward through all ops; returns value of result_slot (must be scalar).
   double forward();
-  // The same value, computed the way CmdStan's log_prob<double> computes
-  // it: kernels that would build partials for a later reverse sweep may
-  // skip them. Only OP_ODE currently differs, and it differs a lot -- it
-  // solves the states alone instead of the coupled state-plus-sensitivity
-  // system, which is both cheaper and, at a solution grazing zero, a
-  // different answer. Use it where CmdStan uses the double path, chiefly
-  // deciding whether an initial point is valid.
+  // The value from CmdStan's log_prob<double> instantiation. Kernels may
+  // skip partials or select a double-only overload. OP_CATEGORICAL thereby
+  // observes propto's compile-time scalar type, while OP_ODE solves states
+  // alone instead of the coupled state-plus-sensitivity system. Use this
+  // where CmdStan uses the double path, chiefly when deciding whether an
+  // initial point is valid.
   //
   // Safe to interleave with gradient(): that always runs a full forward
   // first, so nothing stale survives into a reverse sweep.

--- a/runtime/include/stanli/mir.hpp
+++ b/runtime/include/stanli/mir.hpp
@@ -53,6 +53,7 @@ struct Expr {
   std::string type_;       // UInt UReal UVector URowVector UMatrix ...
   UnsizedView unsized;     // structural (UArray ...), without text parsing
   bool data_only = false;  // adlevel DataOnly
+  bool promoted = false;   // explicit MIR Promotion to this adlevel/type
   std::string raw;         // Unsupported diagnostics
 };
 
@@ -124,6 +125,7 @@ struct Stmt {
   // Decl
   std::string decl_id;
   SizedType decl_type;
+  bool decl_data_only = false;
   bool has_init = false;
   Expr init;
   std::optional<Transform> read_transform;  // set iff init is FnReadParam
@@ -184,6 +186,7 @@ struct FunDef {
   std::vector<std::string> arg_names;
   std::vector<std::string> arg_types;  // unsized: UReal UVector UMatrix ...
   std::vector<UnsizedView> arg_views;
+  std::vector<bool> arg_data_only;
   std::vector<Stmt> body;
 };
 

--- a/runtime/include/stanli/mir_interp.hpp
+++ b/runtime/include/stanli/mir_interp.hpp
@@ -30,6 +30,7 @@
 
 #include <stan/math.hpp>
 
+#include <cmath>
 #include <cstdint>
 #include <functional>
 #include <limits>
@@ -110,6 +111,7 @@ class MirInterp {
                       const std::vector<std::vector<T>>& args,
                       const std::vector<std::vector<int>>& int_args) {
     MirInterp sub(funs_, where_, hooks_);
+    sub.propto_ctx_ = propto_ctx_;
     size_t ai = 0, ii = 0;
     for (size_t k = 0; k < f.arg_names.size(); ++k) {
       const bool is_int = f.arg_types[k].find("UInt") != std::string::npos;
@@ -449,6 +451,7 @@ class MirInterp {
   std::map<std::string, Value> env_;
   std::map<std::string, std::vector<int64_t>> decl_dims_;
   int udf_depth_ = 0;
+  bool propto_ctx_ = true;
 
   [[noreturn]] void fail(const std::string& msg,
                          const std::string& raw = "") const {
@@ -637,6 +640,7 @@ class MirInterp {
     // Function bodies see their arguments and nothing else.
     MirInterp sub(funs_, where_, hooks_);
     sub.udf_depth_ = udf_depth_ + 1;
+    sub.propto_ctx_ = propto_ctx_ && e.fn_propto;
     for (size_t i = 0; i < e.args.size(); ++i)
       sub.env_[f.arg_names[i]] = eval(e.args[i]);
     try {
@@ -1384,6 +1388,45 @@ class MirInterp {
   }
     STANLI_SCALAR_UNARY_LIST(STANLI_INTERP_UNARY)
 #undef STANLI_INTERP_UNARY
+
+    // Categorical arguments are containers as a whole, not elementwise
+    // broadcasts. Preserve scalar-vs-array outcome overloads and the
+    // caller's propto instantiation exactly as the graph kernel does.
+    if ((e.name == "categorical_lpmf" || e.name == "categorical_logit_lpmf") &&
+        e.args.size() == 2) {
+      Value outcome = eval(e.args[0]);
+      Value value = eval(e.args[1]);
+      std::vector<int> outcomes = outcome.i;
+      if (outcomes.empty() && !outcome.r.empty()) {
+        outcomes.reserve(outcome.r.size());
+        for (const T& x : outcome.r) {
+          const double v = val(x);
+          if (!std::isfinite(v) || std::trunc(v) != v ||
+              v < std::numeric_limits<int>::min() ||
+              v > std::numeric_limits<int>::max())
+            fail("malformed integer categorical outcome", e.raw);
+          outcomes.push_back(static_cast<int>(v));
+        }
+      }
+      const bool scalar = e.args[0].unsized.depth == 0;
+      if (scalar && outcomes.size() != 1)
+        fail("categorical scalar outcome has wrong width", e.raw);
+      if (value.dims.size() != 1)
+        fail("categorical probability argument is not a vector", e.raw);
+      Eigen::Matrix<T, Eigen::Dynamic, 1> arg(value.r.size());
+      for (size_t k = 0; k < value.r.size(); ++k)
+        arg((Eigen::Index)k) = value.r[k];
+      const bool propto = e.fn_propto && propto_ctx_;
+      const auto density = [&](const auto& n) -> T {
+        if (e.name == "categorical_logit_lpmf")
+          return propto ? stan::math::categorical_logit_lpmf<true>(n, arg)
+                        : stan::math::categorical_logit_lpmf<false>(n, arg);
+        return propto ? stan::math::categorical_lpmf<true>(n, arg)
+                      : stan::math::categorical_lpmf<false>(n, arg);
+      };
+      r.r = {scalar ? density(outcomes[0]) : density(outcomes)};
+      return r;
+    }
 
     // The continuous scalar ones come from the shared list, so this can
     // never be narrower than what the register-machine compiler accepts

--- a/runtime/include/stanli/mir_interp.hpp
+++ b/runtime/include/stanli/mir_interp.hpp
@@ -266,7 +266,11 @@ class MirInterp {
           // The flat read buffer is consumed with sequential 1-D indexing
           // regardless of the source variable's shape.
           Value flat = read_data(read_name, st.raw);
-          flat.dims = {(int64_t)std::max(flat.r.size(), flat.i.size())};
+          const auto declared = decl_dims_.find(st.lhs);
+          if (declared != decl_dims_.end() && declared->second.empty())
+            flat.dims.clear();
+          else
+            flat.dims = {(int64_t)std::max(flat.r.size(), flat.i.size())};
           env_[st.lhs] = std::move(flat);
           return;
         }

--- a/runtime/include/stanli/mir_interp.hpp
+++ b/runtime/include/stanli/mir_interp.hpp
@@ -118,10 +118,10 @@ class MirInterp {
         v.is_int = true;
         v.i = int_args[ii++];
         v.r.assign(v.i.begin(), v.i.end());
-        v.dims = {(int64_t)v.i.size()};
+        if (f.arg_types[k] != "UInt") v.dims = {(int64_t)v.i.size()};
       } else if (ai < args.size()) {
         v.r = args[ai++];
-        v.dims = {(int64_t)v.r.size()};
+        if (f.arg_types[k] != "UReal") v.dims = {(int64_t)v.r.size()};
       }
       sub.env_[f.arg_names[k]] = std::move(v);
     }
@@ -800,21 +800,37 @@ class MirInterp {
   Value eval_fun(const mir::Expr& e) {
     Value r;
     if (e.fn_lib == mir::Expr::Lib::UserDefined) return call_udf(e);
+    const auto is_scalar = [](const Value& v) {
+      return v.dims.empty() && v.r.size() == 1;
+    };
+    const auto broadcast_dims = [](const Value& a, const Value& b) {
+      if (a.dims.empty() != b.dims.empty())
+        return a.dims.empty() ? b.dims : a.dims;
+      if (a.r.size() > b.r.size()) return a.dims;
+      if (b.r.size() > a.r.size()) return b.dims;
+      return a.dims.empty() ? b.dims : a.dims;
+    };
+    const auto broadcast_size = [&](const Value& a, const Value& b) {
+      if (is_scalar(a)) return b.r.size();
+      if (is_scalar(b)) return a.r.size();
+      return a.r.size();
+    };
+    const auto shapes_match = [&](const Value& a, const Value& b) {
+      return is_scalar(a) || is_scalar(b) ||
+             (a.dims == b.dims && a.r.size() == b.r.size());
+    };
     // Elementwise with scalar broadcasting; results of real math are real
     // even on int inputs, and binary int results stay int only when both
     // sides are int scalars.
     auto bin = [&](auto f) {
       Value a = eval(e.args[0]), b = eval(e.args[1]);
       Value o;
-      if (a.r.size() != b.r.size() && a.r.size() != 1 && b.r.size() != 1)
-        fail(e.name + ": incompatible lengths " + std::to_string(a.r.size()) +
-                 " vs " + std::to_string(b.r.size()),
-             e.raw);
-      const size_t n = std::max(a.r.size(), b.r.size());
+      if (!shapes_match(a, b)) fail(e.name + ": incompatible shapes", e.raw);
+      const size_t n = broadcast_size(a, b);
       o.r.resize(n);
       for (size_t i = 0; i < n; ++i)
         o.r[i] = f(a.r[a.r.size() == 1 ? 0 : i], b.r[b.r.size() == 1 ? 0 : i]);
-      o.dims = a.r.size() >= b.r.size() ? a.dims : b.dims;
+      o.dims = broadcast_dims(a, b);
       if (a.is_int && b.is_int && a.i.size() == 1 && b.i.size() == 1) {
         o.is_int = true;
         o.i = {(int)val(f(T((double)a.i[0]), T((double)b.i[0])))};
@@ -845,7 +861,7 @@ class MirInterp {
       // a scalar operand (either side) scales elementwise.
       Value a = eval(e.args[0]), b = eval(e.args[1]);
       const bool a_mat = a.dims.size() == 2, b_mat = b.dims.size() == 2;
-      if (a.r.size() != 1 && b.r.size() != 1 && (a_mat || b_mat)) {
+      if (!is_scalar(a) && !is_scalar(b) && (a_mat || b_mat)) {
         const int64_t Ra = a_mat ? a.dims[0] : 1;
         const int64_t Ca = a_mat ? a.dims[1] : (int64_t)a.r.size();
         const int64_t Rb = b_mat ? b.dims[0] : (int64_t)b.r.size();
@@ -866,7 +882,7 @@ class MirInterp {
           r.dims = {(int64_t)r.r.size()};
         return r;
       }
-      if (a.r.size() != 1 && b.r.size() != 1 && !a_mat && !b_mat) {
+      if (!is_scalar(a) && !is_scalar(b) && !a_mat && !b_mat) {
         // vector * row_vector is an outer product when the result is a
         // matrix; row_vector * vector is a dot product when it is a scalar.
         if (e.type_ == "UMatrix") {
@@ -888,13 +904,13 @@ class MirInterp {
       }
       // Scalar scale, elementwise on the already-evaluated operands (an
       // argument may hold an RNG call; evaluating twice would draw twice).
-      if (a.r.size() != b.r.size() && a.r.size() != 1 && b.r.size() != 1)
+      if (a.r.size() != b.r.size() && !is_scalar(a) && !is_scalar(b))
         fail("Times__: incompatible lengths", e.raw);
-      const size_t n = std::max(a.r.size(), b.r.size());
+      const size_t n = broadcast_size(a, b);
       r.r.resize(n);
       for (size_t i = 0; i < n; ++i)
         r.r[i] = a.r[a.r.size() == 1 ? 0 : i] * b.r[b.r.size() == 1 ? 0 : i];
-      r.dims = a.r.size() >= b.r.size() ? a.dims : b.dims;
+      r.dims = broadcast_dims(a, b);
       if (a.is_int && b.is_int && a.i.size() == 1 && b.i.size() == 1) {
         r.is_int = true;
         r.i = {a.i[0] * b.i[0]};
@@ -923,20 +939,21 @@ class MirInterp {
     if (e.name == "fma" && e.args.size() == 3) {
       Value a = eval(e.args[0]), b = eval(e.args[1]), c = eval(e.args[2]);
       Value o;
-      const size_t n = std::max(a.r.size(), std::max(b.r.size(), c.r.size()));
-      for (const Value* x : {&a, &b, &c})
-        if (x->r.size() != n && x->r.size() != 1)
-          fail("fma: incompatible lengths", e.raw);
+      size_t n = 1;
+      bool have_container = false;
+      for (const Value* x : {&a, &b, &c}) {
+        if (is_scalar(*x)) continue;
+        if (have_container && (x->dims != o.dims || x->r.size() != n))
+          fail("fma: incompatible shapes", e.raw);
+        n = x->r.size();
+        o.dims = x->dims;
+        have_container = true;
+      }
       o.r.resize(n);
       for (size_t i = 0; i < n; ++i)
         o.r[i] = stan::math::fma(a.r[a.r.size() == 1 ? 0 : i],
                                  b.r[b.r.size() == 1 ? 0 : i],
                                  c.r[c.r.size() == 1 ? 0 : i]);
-      for (const Value* x : {&a, &b, &c})
-        if (x->r.size() == n && !x->dims.empty()) {
-          o.dims = x->dims;
-          break;
-        }
       return o;
     }
     if (e.name == "PMinus__") return un([](const T& x) { return -x; });

--- a/runtime/include/stanli/optable.hpp
+++ b/runtime/include/stanli/optable.hpp
@@ -112,6 +112,7 @@ namespace stanli {
   X(OP_CHECK_MATCHING_DIMS)         \
   X(OP_CHECK_LOWER)                 \
   X(OP_CHECK_UPPER)                 \
+  X(OP_CATEGORICAL)                 \
   X(OP_REJECT)                      \
   X(OP_PRINT)                       \
   X(OP_DIRICHLET_LPDF)

--- a/runtime/kernels/message.cpp
+++ b/runtime/kernels/message.cpp
@@ -18,6 +18,7 @@
 #include <stanli/graph.hpp>
 #include <stanli/message_sink.hpp>
 #include <stanli/optable.hpp>
+#include <stanli/packet.hpp>
 #include <stanli/structured_check.hpp>
 
 #include <stan/math/prim/err/check_cholesky_factor.hpp>
@@ -31,7 +32,11 @@
 #include <stan/math/prim/err/check_simplex.hpp>
 #include <stan/math/prim/err/check_sum_to_zero.hpp>
 #include <stan/math/prim/err/check_unit_vector.hpp>
+#include <stan/math/prim/prob/categorical_logit_lpmf.hpp>
+#include <stan/math/prim/prob/categorical_lpmf.hpp>
+#include <stan/math/rev.hpp>
 
+#include <cmath>
 #include <limits>
 #include <sstream>
 #include <stdexcept>
@@ -248,6 +253,81 @@ void check_fwd(KernelCtx& ctx) {
   ctx.out.data[0] = 0.0;
 }
 
+int categorical_outcome(double value) {
+  if (!std::isfinite(value) || std::trunc(value) != value ||
+      value < std::numeric_limits<int>::min() ||
+      value > std::numeric_limits<int>::max())
+    throw std::logic_error("malformed integer categorical outcome");
+  return static_cast<int>(value);
+}
+
+std::vector<int> categorical_outcomes(const KernelCtx& ctx,
+                                      const CategoricalSpec& spec) {
+  if (spec.scalar_outcome && ctx.in[0].len != 1)
+    throw std::logic_error("categorical scalar outcome has wrong width");
+  std::vector<int> outcomes;
+  outcomes.reserve((size_t)ctx.in[0].len);
+  for (int64_t i = 0; i < ctx.in[0].len; ++i)
+    outcomes.push_back(categorical_outcome(ctx.in[0].data[i]));
+  return outcomes;
+}
+
+template <typename Arg>
+auto categorical_eval(const CategoricalSpec& spec,
+                      const std::vector<int>& outcomes, const Arg& arg) {
+  if (spec.scalar_outcome) {
+    if (spec.logit)
+      return spec.propto
+                 ? stan::math::categorical_logit_lpmf<true>(outcomes[0], arg)
+                 : stan::math::categorical_logit_lpmf<false>(outcomes[0], arg);
+    return spec.propto ? stan::math::categorical_lpmf<true>(outcomes[0], arg)
+                       : stan::math::categorical_lpmf<false>(outcomes[0], arg);
+  }
+  if (spec.logit)
+    return spec.propto
+               ? stan::math::categorical_logit_lpmf<true>(outcomes, arg)
+               : stan::math::categorical_logit_lpmf<false>(outcomes, arg);
+  return spec.propto ? stan::math::categorical_lpmf<true>(outcomes, arg)
+                     : stan::math::categorical_lpmf<false>(outcomes, arg);
+}
+
+Eigen::Matrix<stan::math::var, -1, 1> categorical_vars(const Desc& input) {
+  Eigen::Matrix<stan::math::var, -1, 1> arg(input.len);
+  for (int64_t k = 0; k < input.len; ++k) arg(k) = input.data[k];
+  return arg;
+}
+
+void categorical_fwd(KernelCtx& ctx) {
+  if (ctx.n_in != 2 || ctx.out.len != 1 || ctx.udata == nullptr)
+    throw std::logic_error("malformed categorical op");
+  const auto& spec = *static_cast<const CategoricalSpec*>(ctx.udata);
+  const std::vector<int> outcomes = categorical_outcomes(ctx, spec);
+  if (spec.arg_autodiff && !values_only()) {
+    stan::math::nested_rev_autodiff nested;
+    const auto arg = categorical_vars(ctx.in[1]);
+    ctx.out.data[0] = categorical_eval(spec, outcomes, arg).val();
+  } else {
+    Eigen::Map<const Eigen::VectorXd> arg(ctx.in[1].data, ctx.in[1].len);
+    ctx.out.data[0] = categorical_eval(spec, outcomes, arg);
+  }
+}
+
+void categorical_bwd(KernelCtx& ctx) {
+  const auto& spec = *static_cast<const CategoricalSpec*>(ctx.udata);
+  if (!spec.arg_autodiff || ctx.in_adj[1].data == nullptr ||
+      (!spec.scalar_outcome && ctx.in[0].len == 0))
+    return;
+  stan::math::nested_rev_autodiff nested;
+  auto arg = categorical_vars(ctx.in[1]);
+  for (int64_t k = 0; k < ctx.in[1].len; ++k)
+    arg(k).adj() = ctx.in_adj[1].data[k];
+  const auto outcomes = categorical_outcomes(ctx, spec);
+  const stan::math::var lp = categorical_eval(spec, outcomes, arg);
+  stan::math::grad((lp * ctx.out_adj).vi_);
+  for (int64_t k = 0; k < ctx.in[1].len; ++k)
+    ctx.in_adj[1].data[k] = arg(k).adj();
+}
+
 }  // namespace
 
 void register_message_kernels() {
@@ -257,6 +337,8 @@ void register_message_kernels() {
                   Kernel{check_matching_dims_fwd, nullptr, nullptr});
   register_kernel(OP_CHECK_LOWER, Kernel{check_fwd<true>, nullptr, nullptr});
   register_kernel(OP_CHECK_UPPER, Kernel{check_fwd<false>, nullptr, nullptr});
+  register_kernel(OP_CATEGORICAL,
+                  Kernel{categorical_fwd, categorical_bwd, nullptr});
   register_kernel(OP_REJECT, Kernel{reject_fwd, nullptr, nullptr});
   register_kernel(OP_PRINT, Kernel{print_fwd, nullptr, nullptr});
 }

--- a/runtime/src/constfold.cpp
+++ b/runtime/src/constfold.cpp
@@ -56,7 +56,8 @@ std::vector<char> mark_constant_ops(const Graph& g) {
       bool c = op.n_in > 0 && op.opcode != OP_CHECK_STRUCTURED &&
                op.opcode != OP_CHECK_MATCHING_DIMS &&
                op.opcode != OP_CHECK_LOWER && op.opcode != OP_CHECK_UPPER &&
-               op.opcode != OP_PRINT && op.opcode != OP_REJECT;
+               op.opcode != OP_CATEGORICAL && op.opcode != OP_PRINT &&
+               op.opcode != OP_REJECT;
       for (int k = 0; k < op.n_in; ++k)
         if (op.in[k] >= 0 && live[(size_t)op.in[k]]) c = false;
       if (c && op.out >= 0 && no_fold[(size_t)op.out]) c = false;

--- a/runtime/src/lower.cpp
+++ b/runtime/src/lower.cpp
@@ -147,6 +147,7 @@ std::vector<double> graph_order(const DataMap::Entry& en,
 struct Lowering {
   struct Val {
     int slot;
+    bool autodiff = false;  // instantiated C++ scalar type carries var
     SlotInfo si;
   };
   static_assert(sizeof(Val) == 32);
@@ -187,6 +188,9 @@ struct Lowering {
   std::vector<int> target_terms;
   std::vector<int> jac_slots;
   std::map<std::string, const mir::FunDef*> fun_defs;
+  // A generic UDF keeps one scalar template type per formal. Locals and its
+  // return use the promoted type, but a direct formal reference keeps its own.
+  std::map<std::string, bool> udf_formal_autodiff;
   std::map<std::string, bool> effectful_cache;
   std::set<std::string> effectful_visiting;
   std::set<std::string> int_locals;  // SInt locals in log_prob (data-only)
@@ -205,7 +209,33 @@ struct Lowering {
   // density inside an inlined user function is unnormalized only if the
   // call that reached it was.
   bool propto_ctx = true;
+  // OR of the actual real/container scalar types for the current inlined
+  // UDF. Generic AutoDiffable locals and returns instantiate to this type.
+  bool udf_autodiff_ctx = false;
+  bool scalar_autodiff() const {
+    return udf_depth == 0 ? !in_write_array : udf_autodiff_ctx;
+  }
   bool propto(const mir::Expr& e) const { return e.fn_propto && propto_ctx; }
+
+  // Static C++ scalar type without lowering/evaluating the expression. This
+  // is intentionally small: ordinary ops propagate Val::autodiff from their
+  // lowered operands; only a data-condition ternary needs the unchosen arm.
+  bool expression_autodiff(const mir::Expr& e) const {
+    if (e.unsized.leaf == mir::UnsizedLeaf::Int || e.data_only) return false;
+    if (e.promoted) return scalar_autodiff();
+    if (e.kind == mir::Expr::Var) {
+      const auto formal = udf_formal_autodiff.find(e.name);
+      if (formal != udf_formal_autodiff.end()) return formal->second;
+      const auto value = scope.find(e.name);
+      return value != scope.end() ? value->second.autodiff : scalar_autodiff();
+    }
+    if (e.kind == mir::Expr::TernaryIf && e.args.size() == 3)
+      return expression_autodiff(e.args[1]) || expression_autodiff(e.args[2]);
+    bool autodiff = false;
+    for (const mir::Expr& arg : e.args)
+      autodiff = autodiff || expression_autodiff(arg);
+    return autodiff;
+  }
 
   explicit Lowering(const DataMap& d, std::shared_ptr<ShapeInterner> pool =
                                           std::make_shared<ShapeInterner>())
@@ -250,7 +280,7 @@ struct Lowering {
   }
 
   Val constant(double v) {
-    Val out{const_slot(v), SlotInfo{0, 0, true}};
+    Val out{const_slot(v), false, SlotInfo{0, 0, true}};
     DataMap::Entry en;
     en.r = {v};
     observe(out, std::move(en));
@@ -585,7 +615,8 @@ struct Lowering {
     std::vector<double> vals(dims.begin(), dims.end());
     const int slot = add_slot((int64_t)vals.size(), false);
     out.fills.emplace_back(slot, vals);
-    Val v{slot, array_view({(int64_t)dims.size()}, ViewKind::Flat, true)};
+    Val v{slot, false,
+          array_view({(int64_t)dims.size()}, ViewKind::Flat, true)};
     DataMap::Entry en;
     en.is_int = true;
     en.r = std::move(vals);
@@ -696,7 +727,7 @@ struct Lowering {
     validate_view(si, (int64_t)vals.size(), "data value " + name);
     const int s = add_slot((int64_t)vals.size(), false);
     out.fills.emplace_back(s, vals);
-    Val v{s, si};
+    Val v{s, false, si};
     scope[name] = v;
     observe(v, *en);
     return s;
@@ -704,6 +735,22 @@ struct Lowering {
 
   // ---- expressions ----------------------------------------------------------
   Val lower_expr(const mir::Expr& e) {
+    Val value = lower_expr_impl(e);
+    if (e.promoted) {
+      value.autodiff = expression_autodiff(e);
+    } else if (e.kind == mir::Expr::Var) {
+      const auto formal = udf_formal_autodiff.find(e.name);
+      if (formal != udf_formal_autodiff.end()) value.autodiff = formal->second;
+    } else if (e.kind == mir::Expr::TernaryIf && e.args.size() == 3) {
+      // A known data condition chooses one implementation value, but C++ has
+      // already promoted the expression. MIR records that promoted type, so
+      // no arm may be evaluated merely to rediscover it.
+      value.autodiff = expression_autodiff(e);
+    }
+    return value;
+  }
+
+  Val lower_expr_impl(const mir::Expr& e) {
     switch (e.kind) {
       case mir::Expr::Var: {
         auto it = scope.find(e.name);
@@ -1154,7 +1201,7 @@ struct Lowering {
       // provenance; treating its live-out as data would select kernels that
       // deliberately omit adjoints for that input.
       si.param_free = false;
-      scope[name] = Val{out_slots[k], si};
+      scope[name] = Val{out_slots[k], scalar_autodiff(), si};
     }
     if (reg.has_target) target_terms.push_back(out_slots.back());
   }
@@ -1171,11 +1218,11 @@ struct Lowering {
     si.rows = value.rows;
     si.cols = value.cols;
     si.kind = value.kind;
-    return {out_slots[0], si};
+    return {out_slots[0], scalar_autodiff(), si};
   }
 
   Val finish_emit(Op op, int64_t out_len, SlotInfo out_si,
-                  std::vector<int> idata) {
+                  std::vector<int> idata, bool autodiff) {
     const int o = add_slot(out_len, false);
     op.out = o;
     if (!idata.empty()) {
@@ -1184,19 +1231,20 @@ struct Lowering {
       op.n_idata = (int64_t)g.idata_pool.back().size();
     }
     g.ops.push_back(op);
-    return {o, out_si};
+    return {o, autodiff, out_si};
   }
 
   // Low-level emission for dynamic slot lists and graph scaffolding whose
   // output dependency is explicit at the call site.
   Val emit_raw(uint16_t opcode, std::vector<int> ins, int64_t out_len,
-               SlotInfo out_si, std::vector<int> idata = {}, int out2 = -1) {
+               SlotInfo out_si, std::vector<int> idata = {}, int out2 = -1,
+               bool autodiff = false) {
     Op op;
     op.opcode = opcode;
     op.out2 = out2;
     op.n_in = 0;
     for (int s : ins) op.in[op.n_in++] = s;
-    return finish_emit(op, out_len, out_si, std::move(idata));
+    return finish_emit(op, out_len, out_si, std::move(idata), autodiff);
   }
 
   // The expression seam: a pure result is parameter-free exactly when all of
@@ -1210,18 +1258,20 @@ struct Lowering {
     op.out2 = out2;
     op.n_in = 0;
     out_si.param_free = true;
+    bool autodiff = false;
     for (const Val& in : ins) {
       op.in[op.n_in++] = in.slot;
       out_si.param_free = out_si.param_free && in.si.param_free;
+      autodiff = autodiff || in.autodiff;
     }
-    return finish_emit(op, out_len, out_si, std::move(idata));
+    return finish_emit(op, out_len, out_si, std::move(idata), autodiff);
   }
 
   // Fallback for expressions with no native lowering: a data-only subtree
-  // is evaluated at compile time and materialized as a constant. Declines
-  // (returns nullopt) when the interpreter can't evaluate it either;
-  // propto densities never fold (their value is
-  // instantiation-dependent).
+  // is evaluated at compile time and materialized as a constant. Unsupported
+  // expressions and Stan validation failures decline; the latter must stay
+  // at model evaluation rather than move to construction. Propto densities
+  // never fold because their value is instantiation-dependent.
   bool expr_effectful(const mir::Expr& e) {
     if (e.kind == mir::Expr::FunApp &&
         e.fn_lib == mir::Expr::Lib::UserDefined && fun_effectful(e.name))
@@ -1272,6 +1322,10 @@ struct Lowering {
       return td.eval(e);
     } catch (const CompileError&) {
       return std::nullopt;
+    } catch (const std::domain_error&) {
+      return std::nullopt;
+    } catch (const std::invalid_argument&) {
+      return std::nullopt;
     }
   }
 
@@ -1298,7 +1352,7 @@ struct Lowering {
     std::vector<double> vals = graph_order(en, e.type_ == "UMatrix", false);
     const int s = add_slot((int64_t)vals.size(), false);
     out.fills.emplace_back(s, vals);
-    Val v{s, si};
+    Val v{s, false, si};
     observe(v, std::move(en));
     return v;
   }
@@ -1393,7 +1447,7 @@ struct Lowering {
     struct Binding {
       bool is_int = false;
       long iv = 0;
-      Val v{-1, {}};
+      Val v{-1, false, {}};
       std::optional<DataMap::Entry> data;
     };
     std::vector<Binding> binds(e.args.size());
@@ -1416,28 +1470,41 @@ struct Lowering {
             observe(binds[i].v, *binds[i].data);
         }
       }
+      const bool formal_data = i < f.arg_data_only.size() && f.arg_data_only[i];
+      if (!in_write_array && formal_data && !binds[i].is_int &&
+          (binds[i].v.autodiff || !binds[i].v.si.param_free))
+        fail(e.name + ": data-only argument depends on a parameter", e.raw);
     }
     if (++udf_depth > 64) {
       --udf_depth;
       fail("UDF recursion too deep in " + e.name);
     }
     auto sc_saved = scope;
+    auto formal_autodiff_saved = udf_formal_autodiff;
     auto ie_saved = int_env;
     auto decls_saved = decls;
     auto il_saved = int_locals;
     auto env_saved = td.env();
     scope.clear();
+    udf_formal_autodiff.clear();
     int_env.clear();
     decls.clear();
     int_locals.clear();
     td.env().clear();
-    Val ret{-1, {}};
+    Val ret{-1, false, {}};
     bool returned = false;
     const bool propto_saved = propto_ctx;
+    const bool autodiff_saved = udf_autodiff_ctx;
     propto_ctx = propto_ctx && e.fn_propto;
+    udf_autodiff_ctx = false;
+    for (size_t i = 0; i < binds.size(); ++i)
+      if (!binds[i].is_int && f.arg_views[i].leaf != mir::UnsizedLeaf::Int)
+        udf_autodiff_ctx = udf_autodiff_ctx || binds[i].v.autodiff;
     auto restore = [&] {
       propto_ctx = propto_saved;
+      udf_autodiff_ctx = autodiff_saved;
       scope = std::move(sc_saved);
+      udf_formal_autodiff = std::move(formal_autodiff_saved);
       int_env = std::move(ie_saved);
       decls = std::move(decls_saved);
       int_locals = std::move(il_saved);
@@ -1459,7 +1526,9 @@ struct Lowering {
           int_env[name] = binds[i].iv;
         } else {
           scope[name] = binds[i].v;
-          decls[name] = DeclView{g.slots[binds[i].v.slot].len, binds[i].v.si};
+          udf_formal_autodiff[name] = binds[i].v.autodiff;
+          decls[name] = DeclView{g.slots[binds[i].v.slot].len,
+                                 binds[i].v.autodiff, binds[i].v.si};
         }
       }
       // CmdStan passes the CALLER's propto__ value into a user density.
@@ -1471,6 +1540,7 @@ struct Lowering {
       restore();
       throw;
     }
+    ret.autodiff = e.unsized.leaf != mir::UnsizedLeaf::Int && udf_autodiff_ctx;
     restore();
     if (!returned) fail(e.name + ": no return value on the executed path");
     return ret;
@@ -1494,7 +1564,7 @@ struct Lowering {
       if (parts.empty()) {
         SlotInfo empty;
         empty.param_free = true;
-        acc = Val{add_slot(0, false), empty};
+        acc = Val{add_slot(0, false), false, empty};
         out.fills.emplace_back(acc.slot, std::vector<double>{});
       } else {
         acc = parts[0];
@@ -1594,9 +1664,39 @@ struct Lowering {
     fail("unsupported function " + e.name);
   }
 
-  // Density calls: the table-driven kernels plus the ones that decompose
-  // onto existing ops (categorical) or carry matrix arguments
-  // (multi_normal, lkj, glm).
+  // Density calls: the table-driven kernels plus exact categorical and
+  // matrix-argument implementations (multi_normal, lkj, glm).
+  Val emit_categorical(const mir::Expr& e, const Val& outcome, const Val& arg,
+                       bool logit) {
+    const bool scalar_outcome = e.args[0].unsized.depth == 0;
+    if (e.args[0].unsized.leaf != mir::UnsizedLeaf::Int ||
+        e.args[0].unsized.depth > 1 ||
+        e.args[1].unsized.leaf != mir::UnsizedLeaf::Vector ||
+        e.args[1].unsized.depth != 0)
+      fail(e.name + ": expected int or array[] int and vector", e.raw);
+    const bool array_outcome = is_array(outcome.si) &&
+                               array_shape(outcome.si).leaf == ViewKind::Flat &&
+                               array_shape(outcome.si).dims.size() == 1;
+    if ((scalar_outcome && !is_scalar(outcome)) ||
+        (!scalar_outcome && !array_outcome) || !is_vector(arg.si))
+      fail(e.name + ": MIR type does not match lowered values", e.raw);
+    if (!e.args[0].data_only || !outcome.si.param_free ||
+        (udf_depth == 0 && e.args[1].data_only == arg.autodiff))
+      fail(e.name + ": MIR adlevel contradicts lowered dependencies", e.raw);
+    auto spec = std::make_shared<CategoricalSpec>();
+    spec->logit = logit;
+    spec->scalar_outcome = scalar_outcome;
+    // The graph dependency and instantiated C++ scalar type are independent:
+    // write_array varies with q but uses double, while an autodiff local can
+    // be graph-constant and still make Stan retain a propto summand.
+    spec->arg_autodiff = arg.autodiff;
+    spec->propto = propto(e);
+    Val checked = emit_value(OP_CATEGORICAL, {outcome, arg}, 1, {});
+    g.ops.back().udata = spec.get();
+    g.udata_pool.push_back(std::move(spec));
+    return checked;
+  }
+
   std::optional<Val> lower_density_fn(const mir::Expr& e) {
     // Densities. n_int leading args come from int data (idata); the rest are
     // real slots. Layouts: one int group = raw values; two groups =
@@ -1669,12 +1769,14 @@ struct Lowering {
       std::vector<int> ins;
       SlotInfo first_real_si;
       SlotInfo result_si{0, 0, true};
+      bool result_autodiff = false;
       uint8_t variant = 0;
       for (size_t i = d.n_int; i < e.args.size(); ++i) {
         const Val arg = lower_expr(e.args[i]);
         if (i == d.n_int) first_real_si = arg.si;
         ins.push_back(arg.slot);
         result_si.param_free = result_si.param_free && arg.si.param_free;
+        result_autodiff = result_autodiff || arg.autodiff;
         if (!e.args[i].data_only) variant |= (uint8_t)(1u << (i - d.n_int));
       }
       if (propto(e)) variant |= 0x80u;
@@ -1686,7 +1788,7 @@ struct Lowering {
         idata.push_back((int)xsi.rows);
         idata.push_back((int)xsi.cols);
       }
-      Val dv = emit_raw(d.op, ins, 1, result_si, idata);
+      Val dv = emit_raw(d.op, ins, 1, result_si, idata, -1, result_autodiff);
       // GLM ops used to be the one density shape that got no variant at
       // all, so their kernels hardcoded propto=false and poisson_log_glm's
       // lp landed sum(log(y!)) -- 10.45 on a six-row test -- away from
@@ -1703,36 +1805,14 @@ struct Lowering {
     }
 
     if (e.name == "categorical_logit_lpmf" && e.args.size() == 2) {
-      // stan-math evaluates log_softmax(beta) then picks the outcomes,
-      // which is exactly this composition.
-      if (propto(e) && e.args[1].data_only) return constant(0.0);
+      const Val outcome = lower_expr(e.args[0]);
       Val b = lower_expr(e.args[1]);
-      Val ls = emit_value(OP_LOG_SOFTMAX, {b}, g.slots[b.slot].len);
-      auto ns = int_arg_values(e.args[0]);
-      if (e.args[0].type_ == "UInt" && ns.size() == 1)
-        return emit_value(OP_INDEX, {ls}, 1, {}, {ns[0] - 1});
-      std::vector<int> idata;
-      for (int n : ns) idata.push_back(n - 1);
-      Val ga = emit_value(OP_GATHER, {ls}, (int64_t)idata.size(), {}, idata);
-      return emit_value(OP_SUM_VEC, {ga}, 1);
+      return emit_categorical(e, outcome, b, true);
     }
     if (e.name == "categorical_lpmf" && e.args.size() == 2) {
-      // stan-math computes log(theta[n-1]) on the scalar type directly (no
-      // ops_partials), so this decomposes exactly onto existing ops. For an
-      // array outcome the reference logs the whole simplex once and gathers,
-      // which also fixes the adjoint association for repeated categories.
-      if (propto(e) && e.args[1].data_only) return constant(0.0);
+      const Val outcome = lower_expr(e.args[0]);
       Val th = lower_expr(e.args[1]);
-      auto ns = int_arg_values(e.args[0]);
-      if (e.args[0].type_ == "UInt" && ns.size() == 1) {
-        Val el = emit_value(OP_INDEX, {th}, 1, {}, {ns[0] - 1});
-        return emit_value(OP_LOGV, {el}, 1);
-      }
-      Val lg = emit_value(OP_LOGV, {th}, g.slots[th.slot].len);
-      std::vector<int> idata;
-      for (int n : ns) idata.push_back(n - 1);
-      Val ga = emit_value(OP_GATHER, {lg}, (int64_t)idata.size(), {}, idata);
-      return emit_value(OP_SUM_VEC, {ga}, 1);
+      return emit_categorical(e, outcome, th, false);
     }
 
     if ((e.name == "multi_normal_cholesky_lpdf" ||
@@ -1905,12 +1985,15 @@ struct Lowering {
     if (e.name == "wiener_lpdf" && e.args.size() == 5) {
       std::vector<int> ins;
       SlotInfo result_si{0, 0, true};
+      bool result_autodiff = false;
       for (int i = 0; i < 5; ++i) {
         const Val arg = lower_expr(e.args[i]);
         ins.push_back(arg.slot);
         result_si.param_free = result_si.param_free && arg.si.param_free;
+        result_autodiff = result_autodiff || arg.autodiff;
       }
-      Val v = emit_raw(OP_WIENER_LPDF, ins, 1, result_si, {});
+      Val v =
+          emit_raw(OP_WIENER_LPDF, ins, 1, result_si, {}, -1, result_autodiff);
       g.ops.back().variant = (uint8_t)((propto(e) ? 0x80u : 0u) | 0x1fu);
       return v;
     }
@@ -2194,9 +2277,9 @@ struct Lowering {
           fail("to_matrix: requested shape does not match source length",
                e.raw);
         si = matrix_view(rows, cols, a.si.param_free);
-        return Val{a.slot, si};
+        return Val{a.slot, a.autodiff, si};
       }
-      if (is_matrix(a.si)) return Val{a.slot, a.si};
+      if (is_matrix(a.si)) return Val{a.slot, a.autodiff, a.si};
       std::vector<int64_t> dims;
       if (is_array(a.si)) dims = array_shape(a.si).dims;
       if (dims.size() != 2) fail("to_matrix: unknown source shape", e.raw);
@@ -2214,7 +2297,7 @@ struct Lowering {
       si.rows = 0;
       si.cols = 0;
       stamp_kind(&si, e.type_);
-      return Val{a.slot, si};
+      return Val{a.slot, a.autodiff, si};
     }
     if (e.name == "rep_matrix") {
       SlotInfo si;
@@ -2708,7 +2791,7 @@ struct Lowering {
     if (declared_len != con_len)
       fail("parameter view length does not match constrained storage", s.raw);
     validate_view(psi, con_len, "parameter " + s.decl_id);
-    decls[s.decl_id] = DeclView{con_len, psi};
+    decls[s.decl_id] = DeclView{con_len, scalar_autodiff(), psi};
     const int raw = add_slot(raw_len, /*is_param=*/true);
     out.param_names.push_back(s.decl_id);
     {
@@ -2725,7 +2808,7 @@ struct Lowering {
     out.n_unconstrained += raw_len;
 
     if (tr.kind == mir::Transform::Identity) {
-      Val value{raw, psi};
+      Val value{raw, scalar_autodiff(), psi};
       CompiledModel::ParamView serial_view = parameter_view(s, raw, raw_len);
       scope[s.decl_id] = value;
       // In write_array mode the column order is dictated by the FnWriteParam
@@ -2828,7 +2911,8 @@ struct Lowering {
                   checked_immediate(matrix_rows, "structured matrix rows"),
                   checked_immediate(matrix_cols, "structured matrix columns")};
     }
-    Val con = emit_raw(opcode, ins, con_len, psi, tr_idata, jac);
+    Val con =
+        emit_raw(opcode, ins, con_len, psi, tr_idata, jac, scalar_autodiff());
     jac_slots.push_back(jac);
     scope[s.decl_id] = con;
     if (!in_write_array)
@@ -2837,10 +2921,12 @@ struct Lowering {
 
   struct DeclView {
     int64_t len = 0;
+    bool autodiff = false;
     SlotInfo si;
   };
   // The only name-keyed declaration protocol. Runtime values carry the same
-  // SlotInfo in `scope`; this registry is needed only before first binding.
+  // static scalar type and SlotInfo in `scope`; this registry is needed only
+  // before first binding.
   std::map<std::string, DeclView> decls;
 
   void lower_stmt(const mir::Stmt& s) {
@@ -2864,11 +2950,13 @@ struct Lowering {
           scope.erase(s.decl_id);
           DeclView sh;
           sh.len = sized_len(s.decl_type);
+          sh.autodiff = !s.decl_data_only && scalar_autodiff();
           sh.si = view_of(s.decl_type);
           if (s.has_init) {
             Val v = lower_expr(s.init);
             SlotInfo expected = view_of(s.decl_type, v.si.param_free);
             require_binding(v, sh.len, expected, s.decl_id, s.raw);
+            v.autodiff = sh.autodiff;
             v.si = expected;
             scope[s.decl_id] = v;
           }
@@ -2886,7 +2974,7 @@ struct Lowering {
         }
         if (!s.lhs_idx.empty()) {
           // Element write under unrolled control flow: functional update.
-          Val prev_v{-1, {}};
+          Val prev_v{-1, false, {}};
           auto it = scope.find(s.lhs);
           if (it != scope.end()) {
             prev_v = it->second;
@@ -2896,7 +2984,8 @@ struct Lowering {
               fail("indexed assignment to undeclared " + s.lhs);
             SlotInfo si = dl->second.si;
             si.param_free = true;
-            prev_v = Val{add_slot(dl->second.len, false), si};
+            prev_v =
+                Val{add_slot(dl->second.len, false), dl->second.autodiff, si};
             out.fills.emplace_back(prev_v.slot,
                                    std::vector<double>(dl->second.len, 0.0));
           }
@@ -3020,6 +3109,7 @@ struct Lowering {
             require_binding(rhs, g.slots[old->second.slot].len, old->second.si,
                             s.lhs, s.raw);
             const bool param_free = rhs.si.param_free;
+            rhs.autodiff = old->second.autodiff;
             rhs.si = old->second.si;
             rhs.si.param_free = param_free;
           } else {
@@ -3040,6 +3130,7 @@ struct Lowering {
                 rhs.si = expected;
                 rhs.si.param_free = pf;
               }
+              rhs.autodiff = dl->second.autodiff;
             }
           }
           scope[s.lhs] = rhs;

--- a/runtime/src/mir_reader.cpp
+++ b/runtime/src/mir_reader.cpp
@@ -143,6 +143,7 @@ Expr read_expr_pattern(const Node& p) {
     }
   } else if (p.head_is("Promotion")) {
     e = read_expr(p[1]);  // transparent: keep inner, adopt promoted type later
+    e.promoted = true;
     return e;
   } else if (p.head_is("TernaryIf")) {
     e.kind = Expr::TernaryIf;
@@ -294,6 +295,8 @@ Stmt read_stmt(const Node& n) {
   if (head == "Decl") {
     s.kind = Stmt::Decl;
     if (const Node* id = field(p, "decl_id")) s.decl_id = (*id)[1].atom;
+    if (const Node* ad = field(p, "decl_adtype"))
+      s.decl_data_only = (*ad)[1].is_atom() && (*ad)[1].atom == "DataOnly";
     if (const Node* dt = field(p, "decl_type")) {
       const Node& t = (*dt)[1];  // (Sized ST) or (Unsized T)
       s.decl_type = t.head_is("Sized") ? read_sized(t[1]) : SizedType{};
@@ -415,7 +418,13 @@ Stmt read_stmt(const Node& n) {
   return s;
 }
 
-using Bindings = std::map<std::string, UnsizedView>;
+struct Binding {
+  UnsizedView view;
+  bool declared_data_only = false;
+};
+
+using Bindings = std::map<std::string, Binding>;
+using Functions = std::map<std::string, const FunDef*>;
 
 UnsizedView declared_view(const SizedType& type) {
   const std::string& base = type.base == "SArray" ? type.elem_base : type.base;
@@ -447,10 +456,80 @@ UnsizedView declared_view(const SizedType& type) {
   return view;
 }
 
-void validate_checks(const std::vector<Stmt>& body, Bindings& bindings);
+void validate_bindings(const std::vector<Stmt>& body, Bindings& bindings,
+                       const Functions& functions);
 
-void validate_checks(const Stmt& s, Bindings& bindings) {
-  if (s.kind == Stmt::Decl) bindings[s.decl_id] = declared_view(s.decl_type);
+void validate_expression(const Expr& e, const Bindings& bindings,
+                         const Functions& functions) {
+  if (e.kind == Expr::FunApp && e.fn_lib == Expr::Lib::StanLib &&
+      (e.name == "categorical_lpmf" || e.name == "categorical_logit_lpmf")) {
+    if (e.args.size() != 2 || e.args[0].unsized.leaf != UnsizedLeaf::Int ||
+        e.args[0].unsized.depth > 1 ||
+        e.args[1].unsized.leaf != UnsizedLeaf::Vector ||
+        e.args[1].unsized.depth != 0)
+      throw std::runtime_error("mir: malformed categorical signature");
+    for (const Expr& arg : e.args) {
+      if (arg.kind != Expr::Var) continue;
+      const auto binding = bindings.find(arg.name);
+      if (binding == bindings.end())
+        throw std::runtime_error("mir: categorical argument has no binding");
+      if (binding->second.view.depth != arg.unsized.depth ||
+          binding->second.view.leaf != arg.unsized.leaf)
+        throw std::runtime_error(
+            "mir: categorical argument type disagrees with its binding");
+      // GQ is statically double even for a constrained-parameter read. In
+      // log_prob, though, DataOnly metadata on an AutoDiffable declaration is
+      // contradictory and must not be allowed to change propto semantics.
+      if (arg.data_only && !binding->second.declared_data_only)
+        throw std::runtime_error(
+            "mir: categorical argument adlevel disagrees with its binding");
+    }
+  }
+  if (e.kind == Expr::FunApp && e.fn_lib == Expr::Lib::UserDefined) {
+    const auto found = functions.find(e.name);
+    if (found == functions.end())
+      throw std::runtime_error("mir: call to unknown user function " + e.name);
+    const FunDef& function = *found->second;
+    if (e.args.size() != function.arg_names.size())
+      throw std::runtime_error("mir: user function arity mismatch for " +
+                               e.name);
+    for (size_t i = 0; i < e.args.size(); ++i) {
+      if (e.args[i].unsized.depth != function.arg_views[i].depth ||
+          e.args[i].unsized.leaf != function.arg_views[i].leaf)
+        throw std::runtime_error(
+            "mir: user function argument type mismatch for " + e.name);
+      if (e.args[i].kind == Expr::Var && !e.args[i].promoted) {
+        const auto binding = bindings.find(e.args[i].name);
+        if (binding == bindings.end() ||
+            binding->second.view.depth != e.args[i].unsized.depth ||
+            binding->second.view.leaf != e.args[i].unsized.leaf)
+          throw std::runtime_error(
+              "mir: user function argument type disagrees with its binding "
+              "for " +
+              e.name);
+      }
+      if (function.arg_data_only[i] && !e.args[i].data_only)
+        throw std::runtime_error(
+            "mir: data-only function argument depends on a parameter");
+    }
+  }
+  for (const Expr& arg : e.args) validate_expression(arg, bindings, functions);
+}
+
+void validate_bindings(const Stmt& s, Bindings& bindings,
+                       const Functions& functions) {
+  for (const Expr* e :
+       {&s.init, &s.rhs, &s.target, &s.lower, &s.upper, &s.cond})
+    validate_expression(*e, bindings, functions);
+  for (const auto* expressions : {&s.read_dims, &s.lhs_idx, &s.fn_args})
+    for (const Expr& e : *expressions)
+      validate_expression(e, bindings, functions);
+  for (const Transform* transform :
+       {s.read_transform ? &*s.read_transform : nullptr,
+        s.check_transform ? &*s.check_transform : nullptr})
+    if (transform)
+      for (const Expr& e : transform->args)
+        validate_expression(e, bindings, functions);
   if (s.kind == Stmt::NRFunApp && s.fn_name == "FnCheck") {
     if (!s.check_transform)
       throw std::runtime_error("mir: FnCheck has no transform");
@@ -483,25 +562,33 @@ void validate_checks(const Stmt& s, Bindings& bindings) {
     if (value.kind == Expr::Var) {
       const auto binding = bindings.find(value.name);
       if (binding == bindings.end() ||
-          binding->second.depth != value.unsized.depth ||
-          binding->second.leaf != value.unsized.leaf)
+          binding->second.view.depth != value.unsized.depth ||
+          binding->second.view.leaf != value.unsized.leaf)
         throw std::runtime_error(
             "mir: FnCheck value type disagrees with its declaration");
     }
   }
-  if (s.kind == Stmt::IfElse) {
+  if (s.kind == Stmt::Decl) {
+    bindings[s.decl_id] = Binding{declared_view(s.decl_type), s.decl_data_only};
+  }
+  if (s.kind == Stmt::SList) {
+    validate_bindings(s.body, bindings, functions);
+  } else if (s.kind == Stmt::IfElse) {
     for (const auto& child : s.body) {
       Bindings branch = bindings;
-      validate_checks(child, branch);
+      validate_bindings(child, branch, functions);
     }
   } else if (!s.body.empty()) {
     Bindings nested = bindings;
-    validate_checks(s.body, nested);
+    if (s.kind == Stmt::For)
+      nested[s.loopvar] = Binding{UnsizedView{0, UnsizedLeaf::Int}, true};
+    validate_bindings(s.body, nested, functions);
   }
 }
 
-void validate_checks(const std::vector<Stmt>& body, Bindings& bindings) {
-  for (const auto& s : body) validate_checks(s, bindings);
+void validate_bindings(const std::vector<Stmt>& body, Bindings& bindings,
+                       const Functions& functions) {
+  for (const auto& s : body) validate_bindings(s, bindings, functions);
 }
 
 }  // namespace
@@ -529,6 +616,8 @@ Program read_program(const sexp::Node& root) {
           // (AutoDiffable name type) or (DataOnly name type)
           f.arg_names.push_back(args[a][1].atom);
           f.arg_views.push_back(read_unsized(args[a][2]));
+          f.arg_data_only.push_back(args[a][0].is_atom() &&
+                                    args[a][0].atom == "DataOnly");
           f.arg_types.push_back(args[a][2].is_atom() ? args[a][2].atom
                                                      : dump(args[a][2], 40));
         }
@@ -543,20 +632,22 @@ Program read_program(const sexp::Node& root) {
   read_stmt_list((*lp)[1], prog.log_prob);
   if (const Node* gq = field(root, "generate_quantities"))
     read_stmt_list((*gq)[1], prog.generate_quantities);
+  Functions functions;
+  for (const auto& f : prog.fun_defs) functions[f.name] = &f;
   Bindings inputs;
   for (const auto& [name, type] : prog.input_vars)
-    inputs[name] = declared_view(type);
+    inputs[name] = Binding{declared_view(type), true};
   Bindings prepare_bindings = inputs;
-  validate_checks(prog.prepare_data, prepare_bindings);
-  Bindings log_prob_bindings = inputs;
-  validate_checks(prog.log_prob, log_prob_bindings);
-  Bindings gq_bindings = inputs;
-  validate_checks(prog.generate_quantities, gq_bindings);
+  validate_bindings(prog.prepare_data, prepare_bindings, functions);
+  Bindings log_prob_bindings = prepare_bindings;
+  validate_bindings(prog.log_prob, log_prob_bindings, functions);
+  Bindings gq_bindings = prepare_bindings;
+  validate_bindings(prog.generate_quantities, gq_bindings, functions);
   for (const auto& f : prog.fun_defs) {
     Bindings args;
     for (size_t i = 0; i < f.arg_names.size(); ++i)
-      args[f.arg_names[i]] = f.arg_views[i];
-    validate_checks(f.body, args);
+      args[f.arg_names[i]] = Binding{f.arg_views[i], f.arg_data_only[i]};
+    validate_bindings(f.body, args, functions);
   }
   if (const Node* ov = field(root, "output_vars")) {
     // ((name <opaque> (...)) ...): parameters, transformed parameters and

--- a/runtime/src/reroll.cpp
+++ b/runtime/src/reroll.cpp
@@ -169,7 +169,7 @@ bool ops_match(const Graph& g, const Op& a, const Op& b) {
   if (a.opcode != b.opcode || a.variant != b.variant || a.n_in != b.n_in ||
       a.out2 >= 0 || b.out2 >= 0 || a.opcode == OP_CHECK_STRUCTURED ||
       a.opcode == OP_CHECK_MATCHING_DIMS || a.opcode == OP_CHECK_LOWER ||
-      a.opcode == OP_CHECK_UPPER)
+      a.opcode == OP_CHECK_UPPER || a.opcode == OP_CATEGORICAL)
     return false;
   for (int j = 0; j < a.n_in; ++j)
     if (g.slots[a.in[j]].len != g.slots[b.in[j]].len) return false;

--- a/tests/categorical_check_mir.hpp
+++ b/tests/categorical_check_mir.hpp
@@ -1,0 +1,554 @@
+#ifndef STANLI_TEST_CATEGORICAL_CHECK_MIR_HPP
+#define STANLI_TEST_CATEGORICAL_CHECK_MIR_HPP
+
+#include <cstring>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+
+// A minimal hand-written transformed-MIR program for one categorical call.
+// Keeping this as text makes the behavior tests independent of stanc's
+// generated fixture output while still entering through the public MIR reader
+// and lowering path.
+inline std::string categorical_check_mir(const std::string& function,
+                                         bool scalar_outcome, int outcome_size,
+                                         int arg_size, bool propto = true,
+                                         bool autodiff_local_arg = false,
+                                         bool nested_outcome_binding = false,
+                                         bool wrap_density_udf = false) {
+  std::ostringstream out;
+  out << "((functions_block ())\n"
+      << " (input_vars\n  ((outcome <opaque> ";
+  if (scalar_outcome) {
+    out << "SInt";
+  } else if (nested_outcome_binding) {
+    out << "(SArray\n"
+        << "     (SArray SInt ((pattern (Lit Int " << outcome_size
+        << ")) (meta ((type_ UInt) (adlevel DataOnly)))))\n"
+        << "     ((pattern (Lit Int 1)) (meta ((type_ UInt) (adlevel "
+           "DataOnly)))))";
+  } else {
+    out << "(SArray SInt ((pattern (Lit Int " << outcome_size
+        << ")) (meta ((type_ UInt) (adlevel DataOnly)))))";
+  }
+  out << ")\n   (arg <opaque>\n    (SVector AoS\n     ((pattern (Lit Int "
+      << arg_size << ")) (meta ((type_ UInt) (adlevel DataOnly))))))))\n"
+      << " (prepare_data ())\n"
+      << " (log_prob\n"
+      << "  (((pattern\n"
+      << "     (Decl (decl_adtype AutoDiffable) (decl_id anchor)\n"
+      << "      (decl_type (Sized SReal))\n"
+      << "      (initialize\n"
+      << "       (Assign\n"
+      << "        ((pattern\n"
+      << "          (FunApp\n"
+      << "           (CompilerInternal\n"
+      << "            (FnReadParam (constrain Identity) (dims ())\n"
+      << "             (mem_pattern AoS)))\n"
+      << "           ()))\n"
+      << "         (meta ((type_ UReal) (adlevel AutoDiffable))))))))\n"
+      << "    (meta <opaque>))\n"
+      << "   ((pattern\n"
+      << "     (TargetPE\n"
+      << "      ((pattern (Var anchor))\n"
+      << "       (meta ((type_ UReal) (adlevel AutoDiffable))))))\n"
+      << "    (meta <opaque>))\n";
+  if (autodiff_local_arg) {
+    out << "   ((pattern\n"
+        << "     (Decl (decl_adtype AutoDiffable) (decl_id local_arg)\n"
+        << "      (decl_type\n"
+        << "       (Sized\n"
+        << "        (SVector AoS\n"
+        << "         ((pattern (Lit Int " << arg_size
+        << ")) (meta ((type_ UInt) (adlevel DataOnly)))))))\n"
+        << "      (initialize Default)))\n"
+        << "    (meta <opaque>))\n"
+        << "   ((pattern\n"
+        << "     (Assignment ((LVariable local_arg) ()) UVector\n"
+        << "      ((pattern (Var arg))\n"
+        << "       (meta ((type_ UVector) (adlevel AutoDiffable))))))\n"
+        << "    (meta <opaque>))\n";
+  }
+  out << "   ((pattern\n     (TargetPE\n      ((pattern\n";
+  if (wrap_density_udf)
+    out << "        (FunApp (UserDefined identity_real FnPlain)\n"
+        << "         (((pattern\n";
+  out << (wrap_density_udf ? "            " : "        ") << "(FunApp (StanLib "
+      << function << " (FnLpmf " << (propto ? "true" : "false") << ") AoS)\n"
+      << (wrap_density_udf ? "             " : "         ")
+      << "(((pattern (Var outcome))\n"
+      << (wrap_density_udf ? "               " : "           ")
+      << "(meta ((type_ " << (scalar_outcome ? "UInt" : "(UArray UInt)")
+      << ") (adlevel DataOnly))))\n"
+      << (wrap_density_udf ? "              " : "          ")
+      << "((pattern (Var " << (autodiff_local_arg ? "local_arg" : "arg")
+      << "))\n"
+      << (wrap_density_udf ? "               " : "           ")
+      << "(meta ((type_ UVector) (adlevel "
+      << (autodiff_local_arg ? "AutoDiffable" : "DataOnly") << ")))))))\n";
+  if (wrap_density_udf)
+    out << "           (meta ((type_ UReal) (adlevel DataOnly)))))))\n";
+  out << "       (meta ((type_ UReal) (adlevel "
+      << (autodiff_local_arg ? "AutoDiffable" : "DataOnly") << "))))))\n"
+      << "    (meta <opaque>)))))\n";
+  return out.str();
+}
+
+inline std::string categorical_effect_check_mir() {
+  std::string mir = categorical_check_mir("categorical_lpmf", true, 1, 3);
+  const std::string empty_functions = "(functions_block ())";
+  const std::string functions = R"((functions_block
+  (((fdrt (ReturnType UInt)) (fdname noisy) (fdsuffix FnPlain)
+    (fdargs ((DataOnly x UInt)))
+    (fdbody
+     (((pattern
+        (Block
+         (((pattern
+            (NRFunApp (CompilerInternal FnPrint)
+             (((pattern (Lit Str "categorical effect"))
+               (meta ((type_ UReal) (adlevel DataOnly)))))))
+           (meta <opaque>))
+          ((pattern
+            (Return
+             (((pattern (Var x))
+               (meta ((type_ UInt) (adlevel DataOnly)))))))
+           (meta <opaque>)))))
+       (meta <opaque>))))
+    (fdloc <opaque>)))))";
+  mir.replace(mir.find(empty_functions), empty_functions.size(), functions);
+
+  const std::string outcome =
+      "((pattern (Var outcome))\n           (meta ((type_ UInt) (adlevel "
+      "DataOnly))))";
+  const std::string call =
+      "((pattern\n            (FunApp (UserDefined noisy FnPlain)\n"
+      "             (((pattern (Var outcome))\n"
+      "               (meta ((type_ UInt) (adlevel DataOnly)))))))\n"
+      "           (meta ((type_ UInt) (adlevel DataOnly))))";
+  mir.replace(mir.find(outcome), outcome.size(), call);
+  return mir;
+}
+
+inline std::string categorical_udf_actual_mir(const std::string& function) {
+  std::string mir =
+      categorical_check_mir(function, true, 1, 3, false, false, false, true);
+  const std::string empty_functions = "(functions_block ())";
+  const std::string functions = R"((functions_block
+  (((fdrt (ReturnType UReal)) (fdname identity_real) (fdsuffix FnPlain)
+    (fdargs ((DataOnly x UReal)))
+    (fdbody
+     (((pattern
+        (Block
+         (((pattern
+            (Return
+             (((pattern (Var x))
+               (meta ((type_ UReal) (adlevel DataOnly)))))))
+           (meta <opaque>)))))
+       (meta <opaque>))))
+    (fdloc <opaque>)))))";
+  mir.replace(mir.find(empty_functions), empty_functions.size(), functions);
+
+  return mir;
+}
+
+inline std::string categorical_udf_mir(const std::string& function, bool propto,
+                                       bool autodiff_local_arg,
+                                       bool udf_body_local = false,
+                                       bool data_formal = false) {
+  std::string mir =
+      categorical_check_mir(function, true, 1, 3, propto, autodiff_local_arg);
+  const std::string udf_name =
+      function == "categorical_lpmf" ? "cat_lpmf" : "cat_logit_lpmf";
+  std::ostringstream functions;
+  functions << "(functions_block\n"
+            << "  (((fdrt (ReturnType UReal)) (fdname " << udf_name
+            << ") (fdsuffix (FnLpmf ()))\n"
+            << "    (fdargs ((DataOnly y UInt) ("
+            << (data_formal ? "DataOnly" : "AutoDiffable") << " p UVector)))\n"
+            << "    (fdbody\n"
+            << "     (((pattern\n"
+            << "        (Block\n"
+            << "         (((pattern\n"
+            << "            (Return\n"
+            << "             (((pattern\n"
+            << "                (FunApp (StanLib " << function
+            << " (FnLpmf true) AoS)\n"
+            << "                 (((pattern (Var y))\n"
+            << "                   (meta ((type_ UInt) (adlevel DataOnly))))\n"
+            << "                  ((pattern (Var p))\n"
+            << "                   (meta ((type_ UVector) (adlevel "
+               "AutoDiffable)))))))\n"
+            << "               (meta ((type_ UReal) (adlevel "
+               "AutoDiffable)))))))\n"
+            << "           (meta <opaque>)))))\n"
+            << "       (meta <opaque>))))\n"
+            << "    (fdloc <opaque>))))";
+  const std::string empty_functions = "(functions_block ())";
+  mir.replace(mir.find(empty_functions), empty_functions.size(),
+              functions.str());
+
+  if (udf_body_local) {
+    const std::string return_marker =
+        "         (((pattern\n"
+        "            (Return";
+    const size_t ret = mir.find(return_marker);
+    if (ret == std::string::npos)
+      throw std::logic_error("categorical UDF fixture has no return");
+    const std::string local =
+        "         (((pattern\n"
+        "            (Decl (decl_adtype AutoDiffable) (decl_id q)\n"
+        "             (decl_type\n"
+        "              (Sized\n"
+        "               (SVector AoS\n"
+        "                ((pattern (Lit Int 3))\n"
+        "                 (meta ((type_ UInt) (adlevel DataOnly)))))))\n"
+        "             (initialize\n"
+        "              (Assign\n"
+        "               ((pattern (Var p))\n"
+        "                (meta ((type_ UVector) (adlevel "
+        "AutoDiffable))))))))\n"
+        "           (meta <opaque>))\n"
+        "          ((pattern\n"
+        "            (Return";
+    mir.replace(ret, return_marker.size(), local);
+    const size_t local_return = mir.find("(Return", ret);
+    const size_t p = mir.find("(Var p)", local_return);
+    if (p == std::string::npos)
+      throw std::logic_error("categorical UDF fixture has no return argument");
+    mir.replace(p, std::strlen("(Var p)"), "(Var q)");
+  }
+
+  const size_t log_prob = mir.find("(log_prob");
+  const std::string old_call = "(FunApp (StanLib " + function + " (FnLpmf " +
+                               (propto ? "true" : "false") + ") AoS)";
+  const size_t call = mir.find(old_call, log_prob);
+  if (log_prob == std::string::npos || call == std::string::npos)
+    throw std::logic_error("categorical UDF fixture has no density call");
+  const std::string new_call = "(FunApp (UserDefined " + udf_name +
+                               " (FnLpmf " + (propto ? "true" : "false") + "))";
+  mir.replace(call, old_call.size(), new_call);
+  return mir;
+}
+
+inline std::string categorical_udf_return_mir(const std::string& function) {
+  std::string mir = categorical_check_mir(function, true, 1, 3, true, true);
+  const std::string empty_functions = "(functions_block ())";
+  const std::string functions = R"((functions_block
+  (((fdrt (ReturnType UVector)) (fdname choose_vector) (fdsuffix FnPlain)
+    (fdargs ((AutoDiffable ignored UVector) (DataOnly value UVector)))
+    (fdbody
+     (((pattern
+        (Block
+         (((pattern
+            (Return
+             (((pattern (Var value))
+               (meta ((type_ UVector) (adlevel DataOnly)))))))
+           (meta <opaque>)))))
+       (meta <opaque>))))
+    (fdloc <opaque>)))))";
+  mir.replace(mir.find(empty_functions), empty_functions.size(), functions);
+
+  const size_t density = mir.find("(FunApp (StanLib " + function);
+  const std::string old_arg =
+      "((pattern (Var local_arg))\n"
+      "           (meta ((type_ UVector) (adlevel AutoDiffable))))";
+  const size_t arg = mir.find(old_arg, density);
+  if (density == std::string::npos || arg == std::string::npos)
+    throw std::logic_error("categorical return fixture has no vector argument");
+  const std::string new_arg = R"(((pattern
+           (FunApp (UserDefined choose_vector FnPlain)
+            (((pattern (Var local_arg))
+              (meta ((type_ UVector) (adlevel AutoDiffable))))
+             ((pattern (Var arg))
+              (meta ((type_ UVector) (adlevel DataOnly)))))))
+          (meta ((type_ UVector) (adlevel AutoDiffable)))))";
+  mir.replace(arg, old_arg.size(), new_arg);
+  return mir;
+}
+
+inline std::string categorical_udf_ternary_type_mir(
+    const std::string& function) {
+  std::string mir = categorical_udf_mir(function, true, false);
+  const std::string formal = "(AutoDiffable p UVector)))";
+  const size_t formal_at = mir.find(formal);
+  if (formal_at == std::string::npos)
+    throw std::logic_error("categorical UDF fixture has no vector formal");
+  mir.replace(formal_at, formal.size(),
+              "(AutoDiffable p UVector) (AutoDiffable ignored UReal)))");
+
+  const size_t body_density = mir.find("(FunApp (StanLib " + function);
+  const std::string body_arg =
+      "((pattern (Var p))\n"
+      "                   (meta ((type_ UVector) (adlevel AutoDiffable))))";
+  const size_t body_arg_at = mir.find(body_arg, body_density);
+  if (body_density == std::string::npos || body_arg_at == std::string::npos)
+    throw std::logic_error("categorical UDF fixture has no body argument");
+  const std::string ternary = R"(((pattern
+                   (TernaryIf
+                    ((pattern (Lit Int 1))
+                     (meta ((type_ UInt) (adlevel DataOnly))))
+                    ((pattern (Var p))
+                     (meta ((type_ UVector) (adlevel AutoDiffable))))
+                    ((pattern (Var p))
+                     (meta ((type_ UVector) (adlevel AutoDiffable))))))
+                  (meta ((type_ UVector) (adlevel AutoDiffable)))))";
+  mir.replace(body_arg_at, body_arg.size(), ternary);
+
+  const size_t log_prob = mir.find("(log_prob");
+  const std::string caller_arg =
+      "((pattern (Var arg))\n"
+      "           (meta ((type_ UVector) (adlevel DataOnly))))";
+  const size_t caller_arg_at = mir.find(caller_arg, log_prob);
+  if (log_prob == std::string::npos || caller_arg_at == std::string::npos)
+    throw std::logic_error("categorical UDF fixture has no caller argument");
+  const std::string with_ignored =
+      caller_arg +
+      "\n          ((pattern (Var anchor))\n"
+      "           (meta ((type_ UReal) (adlevel AutoDiffable))))";
+  mir.replace(caller_arg_at, caller_arg.size(), with_ignored);
+  return mir;
+}
+
+inline std::string categorical_udf_promoted_actual_mir(
+    const std::string& function) {
+  std::string mir = categorical_udf_ternary_type_mir(function);
+  const std::string actual =
+      "((pattern (Var anchor))\n"
+      "           (meta ((type_ UReal) (adlevel AutoDiffable))))";
+  const size_t log_prob = mir.find("(log_prob");
+  const size_t actual_at = mir.find(actual, log_prob);
+  if (log_prob == std::string::npos || actual_at == std::string::npos)
+    throw std::logic_error("categorical UDF fixture has no real actual");
+  const std::string promoted = R"(((pattern
+           (Promotion
+            ((pattern (Var outcome))
+             (meta ((type_ UInt) (adlevel DataOnly))))
+            UReal DataOnly))
+          (meta ((type_ UReal) (adlevel DataOnly)))))";
+  mir.replace(actual_at, actual.size(), promoted);
+  return mir;
+}
+
+inline std::string categorical_promoted_ternary_mir(const std::string& function,
+                                                    bool through_udf) {
+  std::string mir =
+      through_udf ? categorical_udf_mir(function, true, true)
+                  : categorical_check_mir(function, true, 1, 3, true, true);
+  const std::string inputs = "(input_vars\n  ((outcome";
+  const size_t input = mir.find(inputs);
+  if (input == std::string::npos)
+    throw std::logic_error("categorical ternary fixture has no inputs");
+  mir.replace(input, inputs.size(),
+              "(input_vars\n  ((flag <opaque> SInt)\n   (outcome");
+
+  const size_t log_prob = mir.find("(log_prob");
+  const std::string old_arg =
+      "((pattern (Var local_arg))\n"
+      "           (meta ((type_ UVector) (adlevel AutoDiffable))))";
+  const size_t arg = mir.find(old_arg, log_prob);
+  if (log_prob == std::string::npos || arg == std::string::npos)
+    throw std::logic_error(
+        "categorical ternary fixture has no vector argument");
+  const std::string ternary = R"(((pattern
+           (TernaryIf
+            ((pattern (Var flag))
+             (meta ((type_ UInt) (adlevel DataOnly))))
+            ((pattern (Var arg))
+             (meta ((type_ UVector) (adlevel DataOnly))))
+            ((pattern (Var local_arg))
+             (meta ((type_ UVector) (adlevel AutoDiffable))))))
+          (meta ((type_ UVector) (adlevel AutoDiffable)))))";
+  mir.replace(arg, old_arg.size(), ternary);
+  return mir;
+}
+
+inline std::string categorical_parameter_effect_mir(
+    std::string mir, const std::string& function) {
+  const std::string empty_functions = "(functions_block ())";
+  const std::string functions = R"((functions_block
+  (((fdrt (ReturnType UInt)) (fdname noisy) (fdsuffix FnPlain)
+    (fdargs ((DataOnly x UInt)))
+    (fdbody
+     (((pattern
+        (Block
+         (((pattern
+            (NRFunApp (CompilerInternal FnPrint)
+             (((pattern (Lit Str "categorical effect"))
+               (meta ((type_ UReal) (adlevel DataOnly)))))))
+           (meta <opaque>))
+          ((pattern
+            (Return
+             (((pattern (Var x))
+               (meta ((type_ UInt) (adlevel DataOnly)))))))
+           (meta <opaque>)))))
+       (meta <opaque>))))
+    (fdloc <opaque>)))))";
+  mir.replace(mir.find(empty_functions), empty_functions.size(), functions);
+
+  const size_t density =
+      mir.find("(FunApp (StanLib " + function, mir.find("(log_prob"));
+  const std::string old_outcome =
+      "((pattern (Var y)) (meta ((type_ UInt) (loc <opaque>) (adlevel "
+      "DataOnly))))";
+  const size_t outcome = mir.find(old_outcome, density);
+  if (density == std::string::npos || outcome == std::string::npos)
+    throw std::logic_error("categorical effect fixture has no scalar outcome");
+  const std::string new_outcome = R"(((pattern
+                (FunApp (UserDefined noisy FnPlain)
+                 (((pattern (Var y))
+                   (meta ((type_ UInt) (adlevel DataOnly)))))))
+               (meta ((type_ UInt) (adlevel DataOnly)))))";
+  mir.replace(outcome, old_outcome.size(), new_outcome);
+  return mir;
+}
+
+inline std::string categorical_write_array_mir(
+    std::string mir, const std::string& function, bool propto,
+    bool island_arg = false, bool data_udf = false, bool force_interp = false,
+    int forced_outcome_count = 1) {
+  if (data_udf) {
+    const std::string empty_functions = "(functions_block ())";
+    const std::string functions = R"((functions_block
+  (((fdrt (ReturnType UReal)) (fdname data_categorical) (fdsuffix FnPlain)
+    (fdargs ((DataOnly y UInt) (DataOnly p UVector)))
+    (fdbody
+     (((pattern
+        (Block
+         (((pattern
+            (Return
+             (((pattern (Lit Real 0.0))
+               (meta ((type_ UReal) (adlevel DataOnly)))))))
+           (meta <opaque>)))))
+       (meta <opaque>))))
+    (fdloc <opaque>)))))";
+    mir.replace(mir.find(empty_functions), empty_functions.size(), functions);
+  }
+  const std::string boundary = "    (meta <opaque>))))\n (transform_inits";
+  const size_t pos = mir.find(boundary, mir.find("(generate_quantities"));
+  if (pos == std::string::npos)
+    throw std::logic_error("categorical write-array fixture has no boundary");
+  const std::string vector_arg = island_arg ? R"(((pattern
+              (TernaryIf
+               ((pattern
+                 (FunApp (StanLib Greater__ FnPlain AoS)
+                  (((pattern
+                     (Indexed
+                      ((pattern (Var theta))
+                       (meta ((type_ UVector) (adlevel AutoDiffable))))
+                      ((Single
+                        ((pattern (Lit Int 1))
+                         (meta ((type_ UInt) (adlevel DataOnly))))))))
+                    (meta ((type_ UReal) (adlevel AutoDiffable))))
+                   ((pattern (Lit Int 0))
+                    (meta ((type_ UInt) (adlevel DataOnly)))))))
+                (meta ((type_ UInt) (adlevel AutoDiffable))))
+               ((pattern (Var theta))
+                (meta ((type_ UVector) (adlevel AutoDiffable))))
+               ((pattern (Var theta))
+                (meta ((type_ UVector) (adlevel AutoDiffable))))))
+             (meta ((type_ UVector) (adlevel DataOnly)))))"
+                                            : R"(((pattern (Var theta))
+             (meta ((type_ UVector) (adlevel DataOnly)))))";
+  std::ostringstream replacement;
+  replacement
+      << "    (meta <opaque>))\n"
+      << "   ((pattern\n"
+      << "     (Decl (decl_adtype DataOnly) (decl_id categorical_value)\n"
+      << "      (decl_type (Sized SReal))\n"
+      << "      (initialize\n"
+      << "       (Assign\n"
+      << "        ((pattern\n"
+      << "          (FunApp "
+      << (data_udf ? "(UserDefined data_categorical FnPlain)"
+                   : "(StanLib " + function + " (FnLpmf " +
+                         (propto ? std::string("true") : std::string("false")) +
+                         ") AoS)")
+      << "\n"
+      << "           (";
+  if (force_interp) {
+    const std::string draw = R"(((pattern
+             (FunApp (StanLib binomial_rng FnRng AoS)
+              (((pattern (Lit Int 1))
+                (meta ((type_ UInt) (adlevel DataOnly))))
+               ((pattern (Lit Real 1.0))
+                (meta ((type_ UReal) (adlevel DataOnly)))))))
+            (meta ((type_ UInt) (adlevel DataOnly)))))";
+    if (forced_outcome_count == 1) {
+      replacement << draw;
+    } else {
+      replacement << "((pattern\n"
+                  << "             (FunApp (CompilerInternal FnMakeArray)\n"
+                  << "              (";
+      for (int i = 0; i < forced_outcome_count; ++i) replacement << draw;
+      replacement << ")))\n"
+                  << "            (meta ((type_ (UArray UInt)) (adlevel "
+                     "DataOnly))))";
+    }
+  } else {
+    replacement << "((pattern (Var y))\n"
+                << "             (meta ((type_ UInt) (adlevel DataOnly))))";
+  }
+  replacement << "\n            " << vector_arg << ")))\n"
+              << "         (meta ((type_ UReal) (adlevel DataOnly))))))))\n"
+              << "    (meta <opaque>))\n"
+              << "   ((pattern\n"
+              << "     (NRFunApp\n"
+              << "      (CompilerInternal\n"
+              << "       (FnWriteParam (unconstrain_opt ())\n"
+              << "        (var\n"
+              << "         ((pattern (Var categorical_value))\n"
+              << "          (meta ((type_ UReal) (adlevel DataOnly)))))))\n"
+              << "      ()))\n"
+              << "    (meta <opaque>))))\n"
+              << " (transform_inits";
+  mir.replace(pos, boundary.size(), replacement.str());
+  return mir;
+}
+
+inline std::string categorical_transformed_data_mismatch_mir(bool in_gq) {
+  std::string mir = categorical_check_mir("categorical_lpmf", true, 1, 3);
+  const std::string inputs = "(input_vars\n  ((outcome";
+  mir.replace(mir.find(inputs), inputs.size(),
+              "(input_vars\n  ((source <opaque> SReal)\n   (outcome");
+  const std::string empty_prepare = "(prepare_data ())";
+  const std::string prepare = R"((prepare_data
+  (((pattern
+     (Decl (decl_adtype DataOnly) (decl_id td_outcome)
+      (decl_type (Sized SReal))
+      (initialize
+       (Assign
+        ((pattern (Var source))
+         (meta ((type_ UReal) (adlevel DataOnly))))))))
+    (meta <opaque>)))))";
+  mir.replace(mir.find(empty_prepare), empty_prepare.size(), prepare);
+
+  if (!in_gq) {
+    const size_t call = mir.find("(FunApp (StanLib categorical_lpmf");
+    const std::string needle = "(Var outcome)";
+    const size_t outcome = mir.find(needle, call);
+    if (call == std::string::npos || outcome == std::string::npos)
+      throw std::logic_error("categorical test fixture has no outcome call");
+    mir.replace(outcome, needle.size(), "(Var td_outcome)");
+    return mir;
+  }
+
+  while (!mir.empty() && (mir.back() == '\n' || mir.back() == '\r'))
+    mir.pop_back();
+  mir.pop_back();  // root list
+  mir += R"(
+ (generate_quantities
+  (((pattern
+     (TargetPE
+      ((pattern
+        (FunApp (StanLib categorical_lpmf (FnLpmf true) AoS)
+         (((pattern (Var td_outcome))
+           (meta ((type_ UInt) (adlevel DataOnly))))
+          ((pattern (Var arg))
+           (meta ((type_ UVector) (adlevel DataOnly)))))))
+       (meta ((type_ UReal) (adlevel DataOnly))))))
+    (meta <opaque>)))))
+)";
+  return mir;
+}
+
+#endif

--- a/tests/test_bridgestan.cpp
+++ b/tests/test_bridgestan.cpp
@@ -13,6 +13,7 @@
 // return exactly -1 with a message, never a plausible number for flags it
 // did not implement.
 #include "../runtime/third_party/bridgestan.h"
+#include "categorical_check_mir.hpp"
 
 #include "../runtime/third_party/nlohmann_json.hpp"
 
@@ -438,6 +439,39 @@ void test_constrain_interp() {
   bs_rng_destruct(a);
   bs_rng_destruct(b);
   bs_model_destruct(m);
+
+  // The RNG-bearing outcome forces the whole section through WaInterp; the
+  // categorical call before it must remain available through BridgeStan.
+  const std::string categorical = categorical_write_array_mir(
+      slurp("tests/fixtures/cat.tmir.sexp"), "categorical_logit_lpmf", false,
+      false, false, true);
+  err = nullptr;
+  m = bs_model_from_mir(categorical.c_str(), R"({"K":3,"y":2,"ys":[3,1,3]})",
+                        1234, &err);
+  if (m == nullptr) {
+    fail(std::string("interpreted categorical construct: ") +
+         (err ? err : "(no message)"));
+    bs_free_error_msg(err);
+    return;
+  }
+  expect_eq_str("interpreted categorical names", bs_param_names(m, true, true),
+                "theta.1,theta.2,theta.3,categorical_value");
+  const double categorical_q[2] = {0.0, 0.0};
+  std::vector<double> categorical_row(4);
+  bs_rng* categorical_rng = bs_rng_construct(1234, &err);
+  if (categorical_rng == nullptr) {
+    fail("interpreted categorical rng construction");
+  } else {
+    expect_eq_int(
+        "interpreted categorical constrain rc",
+        bs_param_constrain(m, true, true, categorical_q, categorical_row.data(),
+                           categorical_rng, &err),
+        0);
+    expect_bitwise("interpreted categorical value", categorical_row[3],
+                   -std::log(3.0));
+    bs_rng_destruct(categorical_rng);
+  }
+  bs_model_destruct(m);
 }
 
 void test_unsupported() {
@@ -852,6 +886,26 @@ void test_construct_errors() {
                      "gq_sum_to_zero");
       bs_rng_destruct(rng);
     }
+    bs_model_destruct(m);
+  }
+
+  // All-data propto categorical calls remain runtime checks. The facade must
+  // propagate the same Stan Math error instead of reporting a finite density.
+  err = nullptr;
+  const std::string categorical_mir =
+      categorical_check_mir("categorical_logit_lpmf", false, 1, 3);
+  m = bs_model_from_mir(categorical_mir.c_str(),
+                        R"({"outcome":[4],"arg":[-1,0,1]})", 1, &err);
+  if (m == nullptr) {
+    fail(std::string("categorical-check model construction: ") +
+         (err != nullptr ? err : "(no message)"));
+    bs_free_error_msg(err);
+  } else {
+    const double q = 0.0;
+    double lp = 0.0;
+    const int rc = bs_log_density(m, true, true, &q, &lp, &err);
+    expect_refused("categorical-check density", rc, &err,
+                   "categorical outcome out of support");
     bs_model_destruct(m);
   }
 

--- a/tests/test_capi.cpp
+++ b/tests/test_capi.cpp
@@ -4,6 +4,7 @@
 // scalars are bare, containers are indexed even at length one, and matrices
 // carry row/column indices in column-major order. This test is intentionally
 // at the ABI boundary so a second flattening policy in capi.cpp cannot drift.
+#include "categorical_check_mir.hpp"
 #include "structured_array_oracles.hpp"
 
 #include <stanli/capi.h>
@@ -267,6 +268,64 @@ void expect_structured_checks() {
   stanli_model_free(model);
 }
 
+void expect_categorical_check() {
+  const std::string mir = categorical_check_mir("categorical_lpmf", true, 1, 3);
+  char err[8192]{};
+  stanli_model* model = stanli_model_new(
+      mir.c_str(), R"({"outcome":4,"arg":[0.2,0.3,0.5]})", err, sizeof err);
+  if (model == nullptr) {
+    ++failures;
+    std::printf("FAIL C API categorical-check construction: %s\n", err);
+    return;
+  }
+  double q = 0.0;
+  double lp = 0.0;
+  double grad = 0.0;
+  if (stanli_grad(model, &q, &lp, &grad) != 1 ||
+      lp != -std::numeric_limits<double>::infinity()) {
+    ++failures;
+    std::printf("FAIL C API accepted invalid categorical outcome\n");
+  }
+  stanli_model_free(model);
+}
+
+void expect_categorical_interpreted_write_array() {
+  const std::string mir = categorical_write_array_mir(
+      slurp("tests/fixtures/cat.tmir.sexp"), "categorical_lpmf", false, false,
+      false, true);
+  char err[8192]{};
+  stanli_model* model = stanli_model_new(
+      mir.c_str(), R"({"K":3,"y":2,"ys":[3,1,3]})", err, sizeof err);
+  if (model == nullptr) {
+    ++failures;
+    std::printf("FAIL C API interpreted categorical construction: %s\n", err);
+    return;
+  }
+  const int64_t n = stanli_wa_n_columns(model);
+  std::vector<double> row((size_t)n);
+  const double q[2] = {0.0, 0.0};
+  stanli_wa_seed(model, 1234);
+  if (stanli_wa_row(model, q, row.data()) != 0) {
+    ++failures;
+    std::printf("FAIL C API interpreted categorical row\n");
+  } else {
+    bool found = false;
+    for (int64_t i = 0; i < n; ++i) {
+      const char* name = stanli_wa_column_name(model, i);
+      if (name != nullptr && std::string(name) == "categorical_value") {
+        found = true;
+        expect_near("C API interpreted categorical value", row[(size_t)i],
+                    -std::log(3.0));
+      }
+    }
+    if (!found) {
+      ++failures;
+      std::printf("FAIL C API interpreted categorical column\n");
+    }
+  }
+  stanli_model_free(model);
+}
+
 }  // namespace
 
 int main() {
@@ -302,6 +361,8 @@ int main() {
   expect_invalid_data_rejected();
   expect_runtime_bound_rejected();
   expect_structured_checks();
+  expect_categorical_check();
+  expect_categorical_interpreted_write_array();
 
   if (failures == 0) std::printf("test_capi OK\n");
   return failures == 0 ? 0 : 1;

--- a/tests/test_constfold.cpp
+++ b/tests/test_constfold.cpp
@@ -132,6 +132,27 @@ static void test_env_disable() {
   test_unsetenv("STANLI_NO_CONSTFOLD");
 }
 
+static void test_keeps_categorical_op() {
+  Graph g;
+  Fills fills;
+  const int outcome = g.add_slot(1, false);
+  const int theta = g.add_slot(3, false);
+  fills.emplace_back(outcome, std::vector<double>{2.0});
+  fills.emplace_back(theta, std::vector<double>{0.2, 0.3, 0.5});
+  const int checked = g.add_slot(1, false);
+  const int op = g.add_op(OP_CATEGORICAL, {outcome, theta}, checked);
+  auto spec = std::make_shared<CategoricalSpec>();
+  spec->scalar_outcome = true;
+  g.ops[(size_t)op].udata = spec.get();
+  g.udata_pool.push_back(std::move(spec));
+  g.result_slot = checked;
+
+  ConstFoldStats st = const_fold(g, fills, {checked});
+  expect("categorical op is not folded", st.ops_removed == 0);
+  expect("categorical op survives", g.ops.size() == 1);
+  expect("categorical op still runs", run_grad(std::move(g), fills)[0] == 0);
+}
+
 int main() {
   {  // kernels register through the first Executor
     Graph g;
@@ -143,6 +164,7 @@ int main() {
   }
   test_folds_data_arithmetic();
   test_refuses_midchain_reader();
+  test_keeps_categorical_op();
   test_env_disable();
   if (failures == 0) std::printf("test_constfold OK\n");
   return failures == 0 ? 0 : 1;

--- a/tests/test_executor.cpp
+++ b/tests/test_executor.cpp
@@ -36,11 +36,11 @@ int main() {
 
   expect_eq("forward", ex.forward(), std::exp(0.3) + -1.1);
 
-  // The value-only forward is the same value for every kernel that has no
-  // partials to skip -- which is all of them but OP_ODE -- and it must not
-  // disturb a gradient taken afterwards. That second half is the whole
-  // safety argument for the mode: gradient() runs its own full forward, so
-  // nothing a value-only sweep skipped can survive into a reverse sweep.
+  // This graph has no kernel whose double instantiation changes its value,
+  // and a value-only pass must not disturb a gradient taken afterwards.
+  // That second half is the safety argument for the mode: gradient() runs
+  // its own full forward, so nothing a value-only sweep skipped can survive
+  // into a reverse sweep.
   expect_eq("forward_value_only", ex.forward_value_only(),
             std::exp(0.3) + -1.1);
 

--- a/tests/test_lower.cpp
+++ b/tests/test_lower.cpp
@@ -2,12 +2,16 @@
 // log_prob gradient matches a var reference that mirrors the lowering's
 // evaluation order. Plus the unsupported-construct error path.
 #include "env_helpers.hpp"
+#include "categorical_check_mir.hpp"
+#include "stdout_capture.hpp"
 #include <stanli/compile.hpp>
 #include <stanli/graph.hpp>
 #include <stanli/optable.hpp>
 #include <stanli/packet.hpp>
+#include <stanli/wa_interp.hpp>
 
 #include <stan/math.hpp>
+#include <algorithm>
 #include <cmath>
 #include <cstdio>
 #include <cstdlib>
@@ -566,6 +570,702 @@ int main() {
     for (int i = 0; i < 2; ++i)
       expect_eq("cat g" + std::to_string(i), grad[i], q(i).adj());
     stan::math::recover_memory();
+  }
+
+  // An empty array outcome validates a parameter vector but contributes a
+  // disconnected zero. In particular, an unselected zero probability must
+  // not be reached by a zero-adjoint log backward and turn into 0 / 0.
+  {
+    std::string mir = slurp("tests/fixtures/cat.tmir.sexp");
+    auto replace_all = [&](const std::string& from, const std::string& to) {
+      for (size_t pos = mir.find(from); pos != std::string::npos;
+           pos = mir.find(from, pos + to.size()))
+        mir.replace(pos, from.size(), to);
+    };
+    replace_all("(pattern (Lit Int 3))", "(pattern (Lit Int 0))");
+    replace_all("(constrain Simplex)", "(constrain Identity)");
+
+    DataMap d;
+    d.set_int("K", 2);
+    d.set_int("y", 1);
+    d.set_int_array("ys", {});
+    CompiledModel lm = compile_model(mir, d);
+    check(lm.n_unconstrained == 2, "empty categorical identity width");
+    Executor lex(std::move(lm.graph));
+    lm.bind(lex);
+    lex.params_data()[0] = 1.0;
+    lex.params_data()[1] = 0.0;
+    double grad[2];
+    const double lp = lex.gradient(grad);
+
+    using stan::math::var;
+    Eigen::Matrix<var, -1, 1> theta(2);
+    theta << 1.0, 0.0;
+    const std::vector<int> empty;
+    var acc = stan::math::categorical_lpmf<false>(1, theta) +
+              stan::math::categorical_lpmf<false>(empty, theta);
+    acc.grad();
+    expect_eq("empty categorical lp", lp, acc.val());
+    for (int i = 0; i < 2; ++i)
+      expect_eq("empty categorical g" + std::to_string(i), grad[i],
+                theta(i).adj());
+    stan::math::recover_memory();
+  }
+
+  // Parameter-dependent categorical-logit calls keep their exact value and
+  // pullback. Exercise both scalar
+  // and array outcomes under normalized and propto MIR flags.
+  for (bool propto : {false, true}) {
+    std::string mir = slurp("tests/fixtures/cat.tmir.sexp");
+    auto replace_all = [&](const std::string& from, const std::string& to) {
+      for (size_t pos = mir.find(from); pos != std::string::npos;
+           pos = mir.find(from, pos + to.size()))
+        mir.replace(pos, from.size(), to);
+    };
+    replace_all("categorical_lpmf", "categorical_logit_lpmf");
+    replace_all("(constrain Simplex)", "(constrain Identity)");
+    if (propto) replace_all("(FnLpmf false)", "(FnLpmf true)");
+
+    DataMap d = DataMap::from_json(R"({"K":3,"y":2,"ys":[3,1,3]})");
+    CompiledModel lm = compile_model(mir, d);
+    check(lm.n_unconstrained == 3,
+          "categorical logit identity parameter width");
+    Executor lex(std::move(lm.graph));
+    lm.bind(lex);
+    const double point[3] = {-0.4, 0.2, 0.9};
+    std::copy(std::begin(point), std::end(point), lex.params_data());
+    double grad[3];
+    const double lp = lex.gradient(grad);
+
+    using stan::math::var;
+    Eigen::Matrix<var, -1, 1> beta(3);
+    for (int i = 0; i < 3; ++i) beta(i) = point[i];
+    const std::vector<int> ys = {3, 1, 3};
+    var acc = propto ? stan::math::categorical_logit_lpmf<true>(2, beta) +
+                           stan::math::categorical_logit_lpmf<true>(ys, beta)
+                     : stan::math::categorical_logit_lpmf<false>(2, beta) +
+                           stan::math::categorical_logit_lpmf<false>(ys, beta);
+    acc.grad();
+    const std::string mode = propto ? "propto" : "normalized";
+    expect_eq("categorical logit parameter " + mode + " lp", lp, acc.val());
+    for (int i = 0; i < 3; ++i)
+      expect_eq(
+          "categorical logit parameter " + mode + " g" + std::to_string(i),
+          grad[i], beta(i).adj());
+    stan::math::recover_memory();
+  }
+
+  // Reverse replay must accumulate into an adjoint already written by a
+  // later consumer in the same order as Stan's tape. Grouping the density's
+  // two logit contributions before adding that existing 0.1 changes one bit.
+  {
+    Graph g;
+    const int beta = g.add_slot(3, true);
+    const int outcome = g.add_slot(1, false);
+    const int cat = g.add_slot(1, false);
+    const int cat_op = g.add_op(OP_CATEGORICAL, {outcome, beta}, cat);
+    auto spec = std::make_shared<CategoricalSpec>();
+    spec->logit = true;
+    spec->scalar_outcome = true;
+    spec->arg_autodiff = true;
+    spec->propto = false;
+    g.ops[(size_t)cat_op].udata = spec.get();
+    g.udata_pool.push_back(std::move(spec));
+    const int beta0 = g.add_slot(1, false);
+    g.add_op(OP_INDEX, {beta}, beta0, {0});
+    const int scale = g.add_slot(1, false);
+    const int linear = g.add_slot(1, false);
+    g.add_op(OP_MUL, {beta0, scale}, linear);
+    const int total = g.add_slot(1, false);
+    g.add_op(OP_ADD, {cat, linear}, total);
+    g.result_slot = total;
+
+    Executor ex(std::move(g));
+    std::fill(ex.params_data(), ex.params_data() + 3, -2.0);
+    ex.value_ptr(outcome)[0] = 1.0;
+    ex.value_ptr(scale)[0] = 0.1;
+    double got_grad[3];
+    const double got = ex.gradient(got_grad);
+
+    Eigen::Matrix<stan::math::var, -1, 1> ref_beta(3);
+    ref_beta << -2.0, -2.0, -2.0;
+    stan::math::var ref_cat =
+        stan::math::categorical_logit_lpmf<false>(1, ref_beta);
+    stan::math::var ref_linear = ref_beta(0) * 0.1;
+    stan::math::var ref = ref_cat + ref_linear;
+    ref.grad();
+    expect_eq("categorical existing-adjoint value", got, ref.val());
+    for (int i = 0; i < 3; ++i)
+      expect_eq("categorical existing-adjoint g" + std::to_string(i),
+                got_grad[i], ref_beta(i).adj());
+    stan::math::recover_memory();
+  }
+
+  // Array outcomes add one callback contribution per observation. Preserve
+  // that exact accumulation order under a non-unit upstream adjoint; replacing
+  // it with count * adjoint changes the selected gradient's low bit. The zero
+  // unselected probability also pins Stan Math's disconnected-log topology.
+  {
+    Graph g;
+    const int theta = g.add_slot(2, true);
+    const int outcomes = g.add_slot(6, false);
+    const int cat = g.add_slot(1, false);
+    const int cat_op = g.add_op(OP_CATEGORICAL, {outcomes, theta}, cat);
+    auto spec = std::make_shared<CategoricalSpec>();
+    spec->logit = false;
+    spec->scalar_outcome = false;
+    spec->arg_autodiff = true;
+    spec->propto = false;
+    g.ops[(size_t)cat_op].udata = spec.get();
+    g.udata_pool.push_back(std::move(spec));
+    const int scale = g.add_slot(1, false);
+    const int total = g.add_slot(1, false);
+    g.add_op(OP_MUL, {cat, scale}, total);
+    g.result_slot = total;
+
+    Executor ex(std::move(g));
+    ex.params_data()[0] = 1.0;
+    ex.params_data()[1] = 0.0;
+    std::fill(ex.value_ptr(outcomes), ex.value_ptr(outcomes) + 6, 1.0);
+    ex.value_ptr(scale)[0] = 0.1;
+    double got_grad[2];
+    const double got = ex.gradient(got_grad);
+
+    Eigen::Matrix<stan::math::var, -1, 1> ref_theta(2);
+    ref_theta << 1.0, 0.0;
+    const std::vector<int> ref_outcomes(6, 1);
+    stan::math::var ref =
+        stan::math::categorical_lpmf<false>(ref_outcomes, ref_theta) * 0.1;
+    ref.grad();
+    expect_eq("categorical array scaled value", got, ref.val());
+    expect_eq("categorical array scaled selected", got_grad[0],
+              ref_theta(0).adj());
+    check(std::isnan(got_grad[1]) && std::isnan(ref_theta(1).adj()),
+          "categorical array scaled unselected topology");
+    stan::math::recover_memory();
+  }
+
+  // A user density is templated on each actual scalar type. The same
+  // unqualified vector formal is double when called with data and var when
+  // called with an autodiff local, even when both graph values are constant.
+  for (const std::string& fn : {"categorical_lpmf", "categorical_logit_lpmf"}) {
+    for (bool propto : {false, true}) {
+      for (bool local : {false, true}) {
+        for (bool body_local : {false, true}) {
+          DataMap d;
+          d.set_int("outcome", 2);
+          const std::vector<double> arg =
+              fn == "categorical_lpmf" ? std::vector<double>{0.2, 0.3, 0.5}
+                                       : std::vector<double>{-1.0, 0.0, 1.0};
+          d.set_real_array("arg", arg);
+          CompiledModel lm = compile_model(
+              categorical_udf_mir(fn, propto, local, body_local), d);
+          Executor ex(std::move(lm.graph));
+          lm.bind(ex);
+          ex.params_data()[0] = 0.75;
+          double grad = 0.0;
+          const double got = ex.gradient(&grad);
+          Eigen::VectorXd v(3);
+          for (int i = 0; i < 3; ++i) v(i) = arg[(size_t)i];
+          const double full =
+              fn == "categorical_lpmf"
+                  ? stan::math::categorical_lpmf<false>(2, v)
+                  : stan::math::categorical_logit_lpmf<false>(2, v);
+          const double want = 0.75 + (propto && !local ? 0.0 : full);
+          const std::string tag =
+              fn + std::string(propto ? " propto " : " normalized ") +
+              (local ? "autodiff actual" : "data actual") +
+              (body_local ? " through UDF local" : " direct formal");
+          expect_ulp(tag + " value", got, want);
+          expect_eq(tag + " anchor gradient", grad, 1.0);
+        }
+      }
+    }
+  }
+
+  // Speculative constant folding must not move a data-only UDF's Stan Math
+  // validation to model construction. On an invalid call it declines the
+  // fold, leaving the exact runtime op and its original exception intact.
+  for (const std::string& fn : {"categorical_lpmf", "categorical_logit_lpmf"}) {
+    DataMap d;
+    d.set_int("outcome", 4);
+    const std::vector<double> arg = fn == "categorical_lpmf"
+                                        ? std::vector<double>{0.2, 0.3, 0.5}
+                                        : std::vector<double>{-1.0, 0.0, 1.0};
+    d.set_real_array("arg", arg);
+    try {
+      CompiledModel lm =
+          compile_model(categorical_udf_mir(fn, false, false), d);
+      check(
+          std::any_of(lm.graph.ops.begin(), lm.graph.ops.end(),
+                      [](const Op& op) { return op.opcode == OP_CATEGORICAL; }),
+          fn + " invalid data UDF retains runtime check");
+      Executor ex(std::move(lm.graph));
+      lm.bind(ex);
+      ex.params_data()[0] = 0.75;
+      double grad = 0.0;
+      std::string got_message;
+      try {
+        (void)ex.gradient(&grad);
+      } catch (const std::domain_error& e) {
+        got_message = e.what();
+      }
+      Eigen::Map<const Eigen::VectorXd> v(arg.data(), (Eigen::Index)arg.size());
+      std::string want_message;
+      try {
+        if (fn == "categorical_lpmf")
+          (void)stan::math::categorical_lpmf<false>(4, v);
+        else
+          (void)stan::math::categorical_logit_lpmf<false>(4, v);
+      } catch (const std::domain_error& e) {
+        want_message = e.what();
+      }
+      check(!got_message.empty(), fn + " invalid data UDF rejects at runtime");
+      check(got_message == want_message,
+            fn + " invalid data UDF exception message");
+    } catch (const std::exception& e) {
+      ++failures;
+      std::printf("FAIL %s invalid data UDF constructed late check: %s\n",
+                  fn.c_str(), e.what());
+    }
+
+    try {
+      CompiledModel lm = compile_model(categorical_udf_actual_mir(fn), d);
+      check(
+          std::any_of(lm.graph.ops.begin(), lm.graph.ops.end(),
+                      [](const Op& op) { return op.opcode == OP_CATEGORICAL; }),
+          fn + " invalid nested UDF actual retains runtime check");
+      Executor ex(std::move(lm.graph));
+      lm.bind(ex);
+      ex.params_data()[0] = 0.75;
+      double grad = 0.0;
+      std::string got_message;
+      try {
+        (void)ex.gradient(&grad);
+      } catch (const std::domain_error& e) {
+        got_message = e.what();
+      }
+      check(!got_message.empty(),
+            fn + " invalid nested UDF actual rejects at runtime");
+    } catch (const std::exception& e) {
+      ++failures;
+      std::printf(
+          "FAIL %s invalid nested UDF actual constructed late check: "
+          "%s\n",
+          fn.c_str(), e.what());
+    }
+  }
+
+  // A generic UDF's return scalar type is selected from every actual, not
+  // just from the expression on its return statement. Here the returned data
+  // vector becomes a vector<var> because an otherwise-unused actual is var,
+  // so an outer propto categorical call retains its summand.
+  for (const std::string& fn : {"categorical_lpmf", "categorical_logit_lpmf"}) {
+    DataMap d;
+    d.set_int("outcome", 2);
+    const std::vector<double> arg = fn == "categorical_lpmf"
+                                        ? std::vector<double>{0.2, 0.3, 0.5}
+                                        : std::vector<double>{-1.0, 0.0, 1.0};
+    d.set_real_array("arg", arg);
+    CompiledModel lm = compile_model(categorical_udf_return_mir(fn), d);
+    Executor ex(std::move(lm.graph));
+    lm.bind(ex);
+    ex.params_data()[0] = 0.75;
+    double grad = 0.0;
+    const double got = ex.gradient(&grad);
+    Eigen::Map<const Eigen::VectorXd> v(arg.data(), (Eigen::Index)arg.size());
+    const double density =
+        fn == "categorical_lpmf"
+            ? stan::math::categorical_lpmf<false>(2, v)
+            : stan::math::categorical_logit_lpmf<false>(2, v);
+    expect_ulp(fn + " UDF instantiated return value", got, 0.75 + density);
+    expect_eq(fn + " UDF instantiated return gradient", grad, 1.0);
+  }
+
+  // Each generic UDF formal keeps its own scalar type. An unrelated var
+  // actual promotes locals and the return, but it must not turn a ternary
+  // whose two arms derive from a data-instantiated vector formal into var.
+  for (const std::string& fn : {"categorical_lpmf", "categorical_logit_lpmf"}) {
+    DataMap d;
+    d.set_int("outcome", 2);
+    d.set_real_array("arg", fn == "categorical_lpmf"
+                                ? std::vector<double>{0.2, 0.3, 0.5}
+                                : std::vector<double>{-1.0, 0.0, 1.0});
+    CompiledModel lm = compile_model(categorical_udf_ternary_type_mir(fn), d);
+    Executor ex(std::move(lm.graph));
+    lm.bind(ex);
+    ex.params_data()[0] = 0.75;
+    double grad = 0.0;
+    expect_eq(fn + " per-formal ternary value", ex.gradient(&grad), 0.75);
+    expect_eq(fn + " per-formal ternary gradient", grad, 1.0);
+
+    CompiledModel promoted_lm =
+        compile_model(categorical_udf_promoted_actual_mir(fn), d);
+    Executor promoted_ex(std::move(promoted_lm.graph));
+    promoted_lm.bind(promoted_ex);
+    promoted_ex.params_data()[0] = 0.75;
+    grad = 0.0;
+    expect_eq(fn + " promoted int UDF actual value",
+              promoted_ex.gradient(&grad), 0.75);
+    expect_eq(fn + " promoted int UDF actual gradient", grad, 1.0);
+  }
+
+  // A data condition selects one arm at model construction, but the C++ type
+  // of a mixed data/autodiff ternary is promoted before that selection. Its
+  // propto term is therefore retained even when the data arm wins, directly
+  // and when the ternary supplies an unqualified UDF formal.
+  for (const std::string& fn : {"categorical_lpmf", "categorical_logit_lpmf"}) {
+    for (bool through_udf : {false, true}) {
+      for (int flag : {0, 1}) {
+        DataMap d;
+        d.set_int("flag", flag);
+        d.set_int("outcome", 2);
+        const std::vector<double> arg =
+            fn == "categorical_lpmf" ? std::vector<double>{0.2, 0.3, 0.5}
+                                     : std::vector<double>{-1.0, 0.0, 1.0};
+        d.set_real_array("arg", arg);
+        CompiledModel lm =
+            compile_model(categorical_promoted_ternary_mir(fn, through_udf), d);
+        Executor ex(std::move(lm.graph));
+        lm.bind(ex);
+        ex.params_data()[0] = 0.75;
+        double grad = 0.0;
+        const double got = ex.gradient(&grad);
+        Eigen::Map<const Eigen::VectorXd> v(arg.data(),
+                                            (Eigen::Index)arg.size());
+        const double density =
+            fn == "categorical_lpmf"
+                ? stan::math::categorical_lpmf<false>(2, v)
+                : stan::math::categorical_logit_lpmf<false>(2, v);
+        const std::string tag =
+            fn + std::string(through_udf ? " nested" : " direct") +
+            (flag ? " data arm" : " autodiff arm");
+        expect_ulp(tag + " promoted ternary value", got, 0.75 + density);
+        expect_eq(tag + " promoted ternary gradient", grad, 1.0);
+      }
+    }
+  }
+
+  // An effectful data-only outcome is a runtime value, not a compile-time
+  // immediate. It executes once, then the exact categorical op consumes that
+  // value and supplies the same pullback as Stan Math.
+  for (const std::string& fn : {"categorical_lpmf", "categorical_logit_lpmf"}) {
+    std::string mir = slurp("tests/fixtures/cat.tmir.sexp");
+    if (fn == "categorical_logit_lpmf") {
+      for (size_t pos = mir.find("categorical_lpmf"); pos != std::string::npos;
+           pos = mir.find("categorical_lpmf", pos + fn.size()))
+        mir.replace(pos, std::strlen("categorical_lpmf"), fn);
+      for (size_t pos = mir.find("(constrain Simplex)");
+           pos != std::string::npos;
+           pos = mir.find("(constrain Simplex)", pos + 20))
+        mir.replace(pos, std::strlen("(constrain Simplex)"),
+                    "(constrain Identity)");
+    }
+    mir = categorical_parameter_effect_mir(std::move(mir), fn);
+    DataMap d = DataMap::from_json(R"({"K":3,"y":2,"ys":[3,1,3]})");
+    std::optional<CompiledModel> lm;
+    {
+      stanli_test::StdoutCapture captured;
+      lm = compile_model(mir, d);
+      check(captured.finish().empty(), fn + " effect absent while compiling");
+    }
+    Executor ex(std::move(lm->graph));
+    lm->bind(ex);
+
+    std::vector<double> point;
+    std::vector<double> want_grad;
+    double want = 0.0;
+    using stan::math::var;
+    if (fn == "categorical_lpmf") {
+      point = {0.3, -0.8};
+      Eigen::Matrix<var, -1, 1> q(2);
+      q << point[0], point[1];
+      var jac = 0.0;
+      const auto theta = stan::math::simplex_constrain(q, jac);
+      const std::vector<int> ys = {3, 1, 3};
+      var lp = jac + stan::math::categorical_lpmf<false>(2, theta) +
+               stan::math::categorical_lpmf<false>(ys, theta);
+      lp.grad();
+      want = lp.val();
+      want_grad = {q(0).adj(), q(1).adj()};
+    } else {
+      point = {-0.4, 0.2, 0.9};
+      Eigen::Matrix<var, -1, 1> beta(3);
+      for (int i = 0; i < 3; ++i) beta(i) = point[(size_t)i];
+      const std::vector<int> ys = {3, 1, 3};
+      var lp = stan::math::categorical_logit_lpmf<false>(2, beta) +
+               stan::math::categorical_logit_lpmf<false>(ys, beta);
+      lp.grad();
+      want = lp.val();
+      want_grad = {beta(0).adj(), beta(1).adj(), beta(2).adj()};
+    }
+    stan::math::recover_memory();
+    std::copy(point.begin(), point.end(), ex.params_data());
+    for (int run = 0; run < 2; ++run) {
+      std::vector<double> grad(point.size());
+      stanli_test::StdoutCapture captured;
+      expect_eq(fn + " effect value " + std::to_string(run),
+                ex.gradient(grad.data()), want);
+      check(captured.finish() == "categorical effect\n",
+            fn + " outcome effect executes once " + std::to_string(run));
+      for (size_t i = 0; i < grad.size(); ++i)
+        expect_eq(fn + " effect gradient " + std::to_string(i), grad[i],
+                  want_grad[i]);
+    }
+  }
+
+  // write_array is instantiated on doubles even though its parameter slots
+  // vary with q. Normalized calls retain their value; propto calls validate
+  // and return zero. The same rule holds when parameter control flow produces
+  // the vector, because graph dependency and instantiated scalar type differ.
+  for (const std::string& fn : {"categorical_lpmf", "categorical_logit_lpmf"}) {
+    for (bool propto : {false, true}) {
+      for (bool island : {false, true}) {
+        DataMap d = DataMap::from_json(R"({"K":3,"y":2,"ys":[3,1,3]})");
+        CompiledModel lm = compile_model(
+            categorical_write_array_mir(slurp("tests/fixtures/cat.tmir.sexp"),
+                                        fn, propto, island),
+            d);
+        const std::string tag =
+            fn + std::string(propto ? " propto" : " normalized") +
+            (island ? " island" : " direct");
+        check(lm.write_array && lm.write_array->truncated.empty(),
+              tag + " write_array compiles");
+        if (!lm.write_array || !lm.write_array->truncated.empty()) continue;
+        Executor ex(std::move(lm.write_array->graph));
+        lm.write_array->bind(ex);
+        ex.params_data()[0] = 0.0;
+        ex.params_data()[1] = 0.0;
+        ex.run_forward_only();
+        bool found = false;
+        for (const auto& col : lm.write_array->columns) {
+          if (col.name != "categorical_value") continue;
+          found = true;
+          expect_ulp(tag + " write_array value", ex.value_ptr(col.slot)[0],
+                     propto ? 0.0 : -std::log(3.0));
+        }
+        check(found, tag + " write_array column");
+      }
+    }
+  }
+
+  // An RNG anywhere in generated quantities selects the interpreted
+  // write_array for the whole section. Categorical calls before that fallback
+  // retain their scalar/array and normalized/propto semantics there too.
+  for (const std::string& fn : {"categorical_lpmf", "categorical_logit_lpmf"}) {
+    for (bool propto : {false, true}) {
+      for (int outcome_count : {1, 3}) {
+        DataMap d = DataMap::from_json(R"({"K":3,"y":2,"ys":[3,1,3]})");
+        const std::string interpreted_mir = categorical_write_array_mir(
+            slurp("tests/fixtures/cat.tmir.sexp"), fn, propto, false, false,
+            true, outcome_count);
+        CompiledModel lm = compile_model(interpreted_mir, d);
+        const std::string tag =
+            fn + std::string(propto ? " propto" : " normalized") +
+            (outcome_count == 1 ? " scalar" : " array");
+        check(lm.write_array && lm.write_array->interp,
+              tag + " interpreted write_array selected");
+        if (!lm.write_array || !lm.write_array->interp) continue;
+        Executor ex(std::move(lm.graph));
+        lm.bind(ex);
+        std::fill(ex.params_data(), ex.params_data() + ex.n_params(), 0.0);
+        ex.run_forward_only();
+        WaRng rng(1234);
+        const std::vector<double> row =
+            lm.write_array->interp->eval(lm.constrained_env(ex), rng);
+        bool found = false;
+        for (const auto& col : lm.write_array->interp->columns()) {
+          if (col.name != "categorical_value") continue;
+          found = true;
+          Eigen::VectorXd arg(3);
+          if (fn == "categorical_lpmf")
+            arg.setConstant(1.0 / 3.0);
+          else
+            arg.setZero();
+          const std::vector<int> outcomes((size_t)outcome_count, 1);
+          double want = 0.0;
+          if (fn == "categorical_lpmf") {
+            if (outcome_count == 1)
+              want = propto ? stan::math::categorical_lpmf<true>(1, arg)
+                            : stan::math::categorical_lpmf<false>(1, arg);
+            else
+              want = propto
+                         ? stan::math::categorical_lpmf<true>(outcomes, arg)
+                         : stan::math::categorical_lpmf<false>(outcomes, arg);
+          } else if (outcome_count == 1) {
+            want = propto ? stan::math::categorical_logit_lpmf<true>(1, arg)
+                          : stan::math::categorical_logit_lpmf<false>(1, arg);
+          } else {
+            want =
+                propto
+                    ? stan::math::categorical_logit_lpmf<true>(outcomes, arg)
+                    : stan::math::categorical_logit_lpmf<false>(outcomes, arg);
+          }
+          expect_eq(tag + " interpreted value", row.at((size_t)col.slot), want);
+        }
+        check(found, tag + " interpreted column");
+
+        // The outcome expression is evaluated exactly once. Compare the next
+        // draw with a stream on which the same callbacks were invoked once.
+        WaRng reference_rng(1234);
+        for (int i = 0; i < outcome_count; ++i)
+          (void)stan::math::binomial_rng(1, 1.0, reference_rng.gen());
+        expect_eq(tag + " interpreted RNG position",
+                  stan::math::uniform_rng(0.0, 1.0, rng.gen()),
+                  stan::math::uniform_rng(0.0, 1.0, reference_rng.gen()));
+      }
+    }
+  }
+
+  // Propto still validates on the interpreted route. A deterministic RNG
+  // keeps the section in WaInterp while producing an out-of-range category.
+  for (const std::string& fn : {"categorical_lpmf", "categorical_logit_lpmf"}) {
+    std::string mir = categorical_write_array_mir(
+        slurp("tests/fixtures/cat.tmir.sexp"), fn, true, false, false, true);
+    const size_t gq = mir.find("(generate_quantities");
+    const size_t density = mir.find("(FunApp (StanLib " + fn, gq);
+    const size_t rng = mir.find("(FunApp (StanLib binomial_rng", density);
+    const std::string one = "(pattern (Lit Int 1))";
+    const size_t trials = mir.find(one, rng);
+    check(gq != std::string::npos && density != std::string::npos &&
+              rng != std::string::npos && trials != std::string::npos,
+          fn + " invalid interpreted mutation found target");
+    if (trials != std::string::npos)
+      mir.replace(trials, one.size(), "(pattern (Lit Int 4))");
+    DataMap d = DataMap::from_json(R"({"K":3,"y":2,"ys":[3,1,3]})");
+    CompiledModel lm = compile_model(mir, d);
+    check(lm.write_array && lm.write_array->interp,
+          fn + " invalid interpreted write_array selected");
+    if (!lm.write_array || !lm.write_array->interp) continue;
+    Executor ex(std::move(lm.graph));
+    lm.bind(ex);
+    std::fill(ex.params_data(), ex.params_data() + ex.n_params(), 0.0);
+    ex.run_forward_only();
+    WaRng rng_state(1234);
+    std::string got_message;
+    try {
+      (void)lm.write_array->interp->eval(lm.constrained_env(ex), rng_state);
+    } catch (const std::domain_error& e) {
+      got_message = e.what();
+    }
+    Eigen::VectorXd arg = Eigen::VectorXd::Constant(3, 1.0 / 3.0);
+    std::string want_message;
+    try {
+      if (fn == "categorical_lpmf")
+        (void)stan::math::categorical_lpmf<true>(4, arg);
+      else
+        (void)stan::math::categorical_logit_lpmf<true>(4, arg);
+    } catch (const std::domain_error& e) {
+      want_message = e.what();
+    }
+    check(!got_message.empty(), fn + " interpreted propto validates");
+    check(got_message == want_message,
+          fn + " interpreted propto exception message");
+  }
+
+  // Equal flattened widths do not make a scalar the shape owner. With K=1,
+  // scalar-left multiplication must retain the vector's logical geometry in
+  // the interpreter before the categorical runtime check.
+  for (const std::string& fn : {"categorical_lpmf", "categorical_logit_lpmf"}) {
+    std::string mir = categorical_write_array_mir(
+        slurp("tests/fixtures/cat.tmir.sexp"), fn, false, false, false, true);
+    const size_t gq = mir.find("(generate_quantities");
+    const size_t density = mir.find("(FunApp (StanLib " + fn, gq);
+    const std::string vector_arg =
+        "((pattern (Var theta))\n"
+        "             (meta ((type_ UVector) (adlevel DataOnly)))))";
+    const size_t arg = mir.find(vector_arg, density);
+    check(gq != std::string::npos && density != std::string::npos &&
+              arg != std::string::npos,
+          fn + " scalar-left vector mutation found target");
+    if (arg != std::string::npos) {
+      const std::string scaled_arg = R"(((pattern
+             (FunApp (StanLib Times__ FnPlain AoS)
+              (((pattern (Lit Real 1.0))
+                (meta ((type_ UReal) (adlevel DataOnly))))
+               ((pattern (Var theta))
+                (meta ((type_ UVector) (adlevel DataOnly)))))))
+            (meta ((type_ UVector) (adlevel DataOnly))))))";
+      mir.replace(arg, vector_arg.size(), scaled_arg);
+    }
+    DataMap d = DataMap::from_json(R"({"K":1,"y":1,"ys":[1,1,1]})");
+    CompiledModel lm = compile_model(mir, d);
+    check(lm.write_array && lm.write_array->interp,
+          fn + " scalar-left interpreted write_array selected");
+    if (!lm.write_array || !lm.write_array->interp) continue;
+    Executor ex(std::move(lm.graph));
+    lm.bind(ex);
+    ex.run_forward_only();
+    WaRng rng(1234);
+    const std::vector<double> row =
+        lm.write_array->interp->eval(lm.constrained_env(ex), rng);
+    bool found = false;
+    for (const auto& col : lm.write_array->interp->columns()) {
+      if (col.name != "categorical_value") continue;
+      found = true;
+      expect_eq(fn + " scalar-left vector value", row.at((size_t)col.slot),
+                0.0);
+    }
+    check(found, fn + " scalar-left vector column");
+  }
+
+  // A shaped zero-width operand also owns the broadcast geometry. The RNG
+  // forces WaInterp; Stan's empty-outcome logit overload returns zero without
+  // indexing either the outcomes or the empty vector.
+  {
+    const std::string fn = "categorical_logit_lpmf";
+    std::string mir =
+        categorical_write_array_mir(slurp("tests/fixtures/cat.tmir.sexp"), fn,
+                                    false, false, false, true, 0);
+    const size_t gq = mir.find("(generate_quantities");
+    const size_t density = mir.find("(FunApp (StanLib " + fn, gq);
+    const std::string vector_arg =
+        "((pattern (Var theta))\n"
+        "             (meta ((type_ UVector) (adlevel DataOnly)))))";
+    const size_t arg = mir.find(vector_arg, density);
+    check(gq != std::string::npos && density != std::string::npos &&
+              arg != std::string::npos,
+          "empty scalar-left vector mutation found target");
+    if (arg != std::string::npos) {
+      const std::string scaled_empty = R"(((pattern
+             (FunApp (StanLib Times__ FnPlain AoS)
+              (((pattern
+                 (FunApp (StanLib normal_rng FnRng AoS)
+                  (((pattern (Lit Real 0.0))
+                    (meta ((type_ UReal) (adlevel DataOnly))))
+                   ((pattern (Lit Real 1.0))
+                    (meta ((type_ UReal) (adlevel DataOnly)))))))
+                (meta ((type_ UReal) (adlevel DataOnly))))
+               ((pattern
+                 (FunApp (StanLib head FnPlain AoS)
+                  (((pattern (Var theta))
+                    (meta ((type_ UVector) (adlevel DataOnly))))
+                   ((pattern (Lit Int 0))
+                    (meta ((type_ UInt) (adlevel DataOnly)))))))
+                (meta ((type_ UVector) (adlevel DataOnly)))))))
+            (meta ((type_ UVector) (adlevel DataOnly))))))";
+      mir.replace(arg, vector_arg.size(), scaled_empty);
+    }
+    DataMap d = DataMap::from_json(R"({"K":3,"y":2,"ys":[3,1,3]})");
+    CompiledModel lm = compile_model(mir, d);
+    check(lm.write_array && lm.write_array->interp,
+          "empty scalar-left interpreted write_array selected");
+    if (lm.write_array && lm.write_array->interp) {
+      Executor ex(std::move(lm.graph));
+      lm.bind(ex);
+      ex.run_forward_only();
+      WaRng rng(1234);
+      const std::vector<double> row =
+          lm.write_array->interp->eval(lm.constrained_env(ex), rng);
+      bool found = false;
+      for (const auto& col : lm.write_array->interp->columns()) {
+        if (col.name != "categorical_value") continue;
+        found = true;
+        expect_eq("empty scalar-left vector value", row.at((size_t)col.slot),
+                  0.0);
+      }
+      check(found, "empty scalar-left vector column");
+    }
   }
 
   // rep_matrix on parameters (row-vector across rows, scalar fill) with
@@ -1618,6 +2318,503 @@ int main() {
           "unsupported valid all-data propto density is refused");
     check(lowering_refuses(4, 4, 3, 3),
           "unsupported invalid all-data propto density is refused");
+  }
+
+  {
+    // An all-data propto categorical term returns zero, but only after Stan
+    // Math validates the outcome and probability/logit vector. Compare the
+    // whole observable contract, including which competing error wins and
+    // the scalar-vs-array overload selected for a length-one outcome.
+    struct Outcome {
+      std::string kind;
+      std::string message;
+      double value = 0.0;
+    };
+    auto observe = [](auto&& call) {
+      Outcome out;
+      try {
+        out.value = call();
+        out.kind = "value";
+      } catch (const std::domain_error& e) {
+        out.kind = "domain_error";
+        out.message = e.what();
+      } catch (const std::invalid_argument& e) {
+        out.kind = "invalid_argument";
+        out.message = e.what();
+      } catch (const std::exception& e) {
+        out.kind = "other";
+        out.message = e.what();
+      }
+      return out;
+    };
+    auto oracle = [&](const std::string& fn, bool scalar,
+                      const std::vector<int>& outcome,
+                      const std::vector<double>& arg, bool propto) {
+      return observe([&] {
+        Eigen::Map<const Eigen::VectorXd> v(arg.data(),
+                                            (Eigen::Index)arg.size());
+        if (fn == "categorical_lpmf") {
+          if (propto)
+            return scalar ? stan::math::categorical_lpmf<true>(outcome.at(0), v)
+                          : stan::math::categorical_lpmf<true>(outcome, v);
+          return scalar ? stan::math::categorical_lpmf<false>(outcome.at(0), v)
+                        : stan::math::categorical_lpmf<false>(outcome, v);
+        }
+        if (propto)
+          return scalar ? stan::math::categorical_logit_lpmf<true>(
+                              outcome.at(0), v)
+                        : stan::math::categorical_logit_lpmf<true>(outcome, v);
+        return scalar
+                   ? stan::math::categorical_logit_lpmf<false>(outcome.at(0), v)
+                   : stan::math::categorical_logit_lpmf<false>(outcome, v);
+      });
+    };
+    auto lowered = [&](const std::string& fn, bool scalar,
+                       const std::vector<int>& outcome,
+                       const std::vector<double>& arg, bool propto) {
+      return observe([&] {
+        DataMap d;
+        if (scalar)
+          d.set_int("outcome", outcome.at(0));
+        else
+          d.set_int_array("outcome", outcome);
+        d.set_real_array("arg", arg);
+        CompiledModel model =
+            compile_model(categorical_check_mir(fn, scalar, (int)outcome.size(),
+                                                (int)arg.size(), propto),
+                          d);
+        Executor ex(std::move(model.graph));
+        model.bind(ex);
+        return ex.forward();
+      });
+    };
+    auto same_as_stan = [&](const std::string& label, const std::string& fn,
+                            bool scalar, std::vector<int> outcome,
+                            std::vector<double> arg, bool propto = true) {
+      const Outcome want = oracle(fn, scalar, outcome, arg, propto);
+      const Outcome got = lowered(fn, scalar, outcome, arg, propto);
+      check(got.kind == want.kind, label + " exception class");
+      check(got.message == want.message, label + " exception message");
+      if (want.kind == "value")
+        expect_eq(label + " value", got.value, want.value);
+    };
+    auto local_autodiff_oracle = [&](const std::string& fn, bool scalar,
+                                     const std::vector<int>& outcome,
+                                     const std::vector<double>& arg) {
+      return observe([&] {
+        Eigen::Matrix<stan::math::var, -1, 1> v((Eigen::Index)arg.size());
+        for (size_t i = 0; i < arg.size(); ++i) v((Eigen::Index)i) = arg[i];
+        try {
+          stan::math::var lp =
+              fn == "categorical_lpmf"
+                  ? (scalar
+                         ? stan::math::categorical_lpmf<true>(outcome.at(0), v)
+                         : stan::math::categorical_lpmf<true>(outcome, v))
+                  : (scalar ? stan::math::categorical_logit_lpmf<true>(
+                                  outcome.at(0), v)
+                            : stan::math::categorical_logit_lpmf<true>(outcome,
+                                                                       v));
+          const double value = lp.val();
+          stan::math::recover_memory();
+          return value;
+        } catch (...) {
+          stan::math::recover_memory();
+          throw;
+        }
+      });
+    };
+    auto local_autodiff_lowered = [&](const std::string& fn, bool scalar,
+                                      const std::vector<int>& outcome,
+                                      const std::vector<double>& arg) {
+      return observe([&] {
+        DataMap d;
+        if (scalar)
+          d.set_int("outcome", outcome.at(0));
+        else
+          d.set_int_array("outcome", outcome);
+        d.set_real_array("arg", arg);
+        CompiledModel model =
+            compile_model(categorical_check_mir(fn, scalar, (int)outcome.size(),
+                                                (int)arg.size(), true, true),
+                          d);
+        Executor ex(std::move(model.graph));
+        model.bind(ex);
+        ex.params_data()[0] = 0.0;
+        return ex.forward();
+      });
+    };
+    auto same_local_autodiff_as_stan =
+        [&](const std::string& label, const std::string& fn, bool scalar,
+            std::vector<int> outcome, std::vector<double> arg) {
+          const Outcome want = local_autodiff_oracle(fn, scalar, outcome, arg);
+          const Outcome got = local_autodiff_lowered(fn, scalar, outcome, arg);
+          check(got.kind == want.kind, label + " exception class");
+          check(got.message == want.message, label + " exception message");
+          if (want.kind == "value")
+            expect_eq(label + " value", got.value, want.value);
+        };
+
+    const double nan = std::numeric_limits<double>::quiet_NaN();
+    const double inf = std::numeric_limits<double>::infinity();
+    same_as_stan("categorical scalar valid", "categorical_lpmf", true, {2},
+                 {0.2, 0.3, 0.5});
+    same_as_stan("categorical zero probability", "categorical_lpmf", true, {2},
+                 {1.0, 0.0, 0.0});
+    same_as_stan("categorical scalar outcome", "categorical_lpmf", true, {4},
+                 {0.2, 0.3, 0.5});
+    same_as_stan("categorical outcome before simplex", "categorical_lpmf", true,
+                 {4}, {0.2, 0.2, 0.2});
+    same_as_stan("categorical later array outcome", "categorical_lpmf", false,
+                 {1, 4, 2}, {0.2, 0.3, 0.5});
+    same_as_stan("categorical length-one array", "categorical_lpmf", false, {4},
+                 {0.2, 0.3, 0.5});
+    same_as_stan("categorical empty outcome", "categorical_lpmf", false, {},
+                 {0.2, 0.3, 0.5});
+    same_as_stan("categorical empty still checks simplex", "categorical_lpmf",
+                 false, {}, {0.2, 0.2, 0.2});
+    same_as_stan("categorical scalar empty probabilities", "categorical_lpmf",
+                 true, {1}, {});
+    same_as_stan("categorical empty probabilities", "categorical_lpmf", false,
+                 {}, {});
+    same_as_stan("categorical normalized valid", "categorical_lpmf", false,
+                 {1, 3}, {0.2, 0.3, 0.5}, false);
+    same_as_stan("categorical normalized bad simplex", "categorical_lpmf", true,
+                 {1}, {0.2, 0.2, 0.2}, false);
+    same_as_stan("categorical normalized invalid outcome", "categorical_lpmf",
+                 false, {1, 4}, {0.2, 0.3, 0.5}, false);
+    same_as_stan("categorical normalized empty outcome", "categorical_lpmf",
+                 false, {}, {0.2, 0.3, 0.5}, false);
+
+    same_as_stan("categorical logit scalar valid", "categorical_logit_lpmf",
+                 true, {2}, {-1.0, 0.0, 1.0});
+    same_as_stan("categorical logit scalar outcome", "categorical_logit_lpmf",
+                 true, {4}, {-1.0, 0.0, 1.0});
+    same_as_stan("categorical logit outcome before finite",
+                 "categorical_logit_lpmf", true, {4}, {0.0, nan, 1.0});
+    same_as_stan("categorical logit later array outcome",
+                 "categorical_logit_lpmf", false, {1, 4, 2}, {-1.0, 0.0, 1.0});
+    same_as_stan("categorical logit length-one array", "categorical_logit_lpmf",
+                 false, {4}, {-1.0, 0.0, 1.0});
+    same_as_stan("categorical logit empty checks NaN", "categorical_logit_lpmf",
+                 false, {}, {0.0, nan, 1.0});
+    same_as_stan("categorical logit checks infinity", "categorical_logit_lpmf",
+                 true, {1}, {0.0, inf, 1.0});
+    same_as_stan("categorical logit empty vectors", "categorical_logit_lpmf",
+                 false, {}, {});
+    same_as_stan("categorical logit scalar empty vector",
+                 "categorical_logit_lpmf", true, {1}, {});
+    same_as_stan("categorical logit normalized valid", "categorical_logit_lpmf",
+                 false, {1, 3}, {-1.0, 0.0, 1.0}, false);
+    same_as_stan("categorical logit normalized infinite",
+                 "categorical_logit_lpmf", true, {1}, {0.0, inf, 1.0}, false);
+    same_as_stan("categorical logit normalized invalid outcome",
+                 "categorical_logit_lpmf", false, {1, 4}, {-1.0, 0.0, 1.0},
+                 false);
+    same_as_stan("categorical logit normalized empty outcome",
+                 "categorical_logit_lpmf", false, {}, {-1.0, 0.0, 1.0}, false);
+    same_as_stan("categorical logit normalized empty vectors",
+                 "categorical_logit_lpmf", false, {}, {}, false);
+
+    // A local declared AutoDiffable remains a var in generated C++ even when
+    // assigned entirely from data. Its graph slot is parameter-free, so the
+    // exact op can own the value, but propto must still retain the summand.
+    same_local_autodiff_as_stan("categorical local autodiff valid",
+                                "categorical_lpmf", true, {2}, {0.2, 0.3, 0.5});
+    same_local_autodiff_as_stan("categorical local autodiff length-one array",
+                                "categorical_lpmf", false, {2},
+                                {0.2, 0.3, 0.5});
+    {
+      DataMap local_data;
+      local_data.set_int_array("outcome", {2});
+      local_data.set_real_array("arg", {0.2, 0.3, 0.5});
+      CompiledModel local_model = compile_model(
+          categorical_check_mir("categorical_lpmf", false, 1, 3, true, true),
+          local_data);
+      Executor local_ex(std::move(local_model.graph));
+      local_model.bind(local_ex);
+      local_ex.params_data()[0] = 0.0;
+      expect_eq("categorical propto value-only double instantiation",
+                local_ex.forward_value_only(), 0.0);
+    }
+    same_local_autodiff_as_stan("categorical local autodiff invalid",
+                                "categorical_lpmf", true, {4}, {0.2, 0.3, 0.5});
+    same_local_autodiff_as_stan("categorical logit local autodiff valid",
+                                "categorical_logit_lpmf", false, {1, 3},
+                                {-1.0, 0.0, 1.0});
+    same_local_autodiff_as_stan("categorical logit local autodiff invalid",
+                                "categorical_logit_lpmf", false, {1, 4},
+                                {-1.0, 0.0, 1.0});
+    auto check_local_exact_graph = [&](const std::string& label,
+                                       const std::string& fn, bool scalar,
+                                       const std::vector<int>& outcome,
+                                       const std::vector<double>& arg) {
+      DataMap local_data;
+      if (scalar)
+        local_data.set_int("outcome", outcome.at(0));
+      else
+        local_data.set_int_array("outcome", outcome);
+      local_data.set_real_array("arg", arg);
+      CompiledModel local_model =
+          compile_model(categorical_check_mir(fn, scalar, (int)outcome.size(),
+                                              (int)arg.size(), true, true),
+                        local_data);
+      bool found_exact = false;
+      int exact_slot = -1;
+      bool found_decomposition = false;
+      for (const Op& op : local_model.graph.ops) {
+        if (op.opcode == OP_CATEGORICAL) {
+          found_exact = true;
+          exact_slot = op.out;
+        }
+        found_decomposition = found_decomposition || op.opcode == OP_INDEX ||
+                              op.opcode == OP_GATHER || op.opcode == OP_LOGV ||
+                              op.opcode == OP_LOG_SOFTMAX ||
+                              op.opcode == OP_SUM_VEC;
+      }
+      bool exact_value_used = exact_slot == local_model.graph.result_slot;
+      for (const Op& op : local_model.graph.ops)
+        for (int i = 0; i < op.n_in; ++i)
+          exact_value_used = exact_value_used || op.in[i] == exact_slot;
+      check(found_exact, label + " exact op");
+      check(exact_value_used, label + " exact op owns target value");
+      check(!found_decomposition, label + " no unchecked decomposition");
+    };
+    check_local_exact_graph("categorical local autodiff", "categorical_lpmf",
+                            true, {4}, {0.2, 0.3, 0.5});
+    check_local_exact_graph("categorical logit local autodiff",
+                            "categorical_logit_lpmf", false, {1, 4},
+                            {-1.0, 0.0, 1.0});
+
+    auto malformed_refused = [](const std::string& mir, const DataMap& data) {
+      try {
+        (void)compile_model(mir, data);
+      } catch (const std::exception& e) {
+        return std::string(e.what()).find("categorical") != std::string::npos;
+      }
+      return false;
+    };
+    {
+      std::string mir = categorical_check_mir("categorical_lpmf", true, 1, 3);
+      const std::string from = "(Var outcome)";
+      mir.replace(mir.find(from), from.size(), "(Var anchor)");
+      DataMap malformed_data;
+      malformed_data.set_int("outcome", 2);
+      malformed_data.set_real_array("arg", {0.2, 0.3, 0.5});
+      check(malformed_refused(mir, malformed_data),
+            "categorical rejects data-only parameter outcome metadata");
+    }
+    {
+      std::string mir = categorical_check_mir("categorical_lpmf", true, 1, 3);
+      const std::string from = "outcome <opaque> SInt";
+      mir.replace(mir.find(from), from.size(), "outcome <opaque> SReal");
+      DataMap malformed_data;
+      malformed_data.set_real("outcome", 2.0);
+      malformed_data.set_real_array("arg", {0.2, 0.3, 0.5});
+      check(malformed_refused(mir, malformed_data),
+            "categorical rejects real binding with integer metadata");
+    }
+    {
+      std::string mir = slurp("tests/fixtures/cat.tmir.sexp");
+      const std::string from =
+          "((pattern (Var theta))\n"
+          "               (meta ((type_ UVector) (loc <opaque>) (adlevel "
+          "AutoDiffable))))";
+      const size_t pos = mir.find(from);
+      check(pos != std::string::npos,
+            "categorical malformed arg mutation found target");
+      if (pos != std::string::npos) {
+        std::string to = from;
+        to.replace(to.find("AutoDiffable"), std::strlen("AutoDiffable"),
+                   "DataOnly");
+        mir.replace(pos, from.size(), to);
+      }
+      DataMap malformed_data =
+          DataMap::from_json(R"({"K":3,"y":2,"ys":[3,1,3]})");
+      check(malformed_refused(mir, malformed_data),
+            "categorical rejects data-only parameter vector metadata");
+    }
+    {
+      const std::string mir = categorical_check_mir("categorical_lpmf", false,
+                                                    2, 3, true, false, true);
+      DataMap malformed_data =
+          DataMap::from_json(R"({"outcome":[[1,2]],"arg":[0.2,0.3,0.5]})");
+      check(malformed_refused(mir, malformed_data),
+            "categorical rejects flattened rank-two outcome metadata");
+    }
+    for (bool in_gq : {false, true}) {
+      const std::string malformed =
+          categorical_transformed_data_mismatch_mir(in_gq);
+      check(malformed.find("(Var td_outcome)") != std::string::npos,
+            "categorical transformed-data fixture rewrites outcome");
+      DataMap malformed_data;
+      malformed_data.set_real("source", 2.0);
+      malformed_data.set_int("outcome", 2);
+      malformed_data.set_real_array("arg", {0.2, 0.3, 0.5});
+      check(malformed_refused(malformed, malformed_data),
+            std::string("categorical rejects transformed-data binding in ") +
+                (in_gq ? "generated quantities" : "log probability"));
+    }
+    {
+      std::string malformed = categorical_write_array_mir(
+          slurp("tests/fixtures/cat.tmir.sexp"), "categorical_lpmf", false);
+      const size_t gq = malformed.find("(generate_quantities");
+      const size_t call =
+          malformed.find("(FunApp (StanLib categorical_lpmf", gq);
+      const size_t outcome = malformed.find("(Var y)", call);
+      check(gq != std::string::npos && call != std::string::npos &&
+                outcome != std::string::npos,
+            "categorical missing-binding mutation found target");
+      if (outcome != std::string::npos)
+        malformed.replace(outcome, std::strlen("(Var y)"), "(Var missing)");
+      DataMap malformed_data =
+          DataMap::from_json(R"({"K":3,"y":2,"ys":[3,1,3]})");
+      check(malformed_refused(malformed, malformed_data),
+            "categorical rejects missing GQ binding before fallback");
+    }
+    {
+      std::string malformed = categorical_write_array_mir(
+          slurp("tests/fixtures/cat.tmir.sexp"), "categorical_lpmf", false,
+          false, false, true);
+      const size_t gq = malformed.find("(generate_quantities");
+      const size_t call =
+          malformed.find("(FunApp (StanLib categorical_lpmf", gq);
+      const std::string vector_arg =
+          "((pattern (Var theta))\n"
+          "             (meta ((type_ UVector) (adlevel DataOnly)))))";
+      const size_t arg = malformed.find(vector_arg, call);
+      check(gq != std::string::npos && call != std::string::npos &&
+                arg != std::string::npos,
+            "categorical malformed fallback mutation found target");
+      if (arg != std::string::npos) {
+        const std::string scalar_arg =
+            "((pattern (Lit Real 1.0))\n"
+            "             (meta ((type_ UReal) (adlevel DataOnly)))))";
+        malformed.replace(arg, vector_arg.size(), scalar_arg);
+      }
+      DataMap malformed_data =
+          DataMap::from_json(R"({"K":3,"y":2,"ys":[3,1,3]})");
+      check(malformed_refused(malformed, malformed_data),
+            "categorical rejects malformed GQ signature before fallback");
+    }
+    {
+      std::string malformed = categorical_write_array_mir(
+          slurp("tests/fixtures/cat.tmir.sexp"), "categorical_lpmf", false,
+          false, true, true);
+      const size_t gq = malformed.find("(generate_quantities");
+      const size_t call =
+          malformed.find("(FunApp (UserDefined data_categorical", gq);
+      const std::string vector_arg =
+          "((pattern (Var theta))\n"
+          "             (meta ((type_ UVector) (adlevel DataOnly)))))";
+      const size_t arg = malformed.find(vector_arg, call);
+      check(gq != std::string::npos && call != std::string::npos &&
+                arg != std::string::npos,
+            "categorical malformed UDF fallback mutation found target");
+      if (arg != std::string::npos) {
+        const std::string scalar_arg =
+            "((pattern (Lit Real 1.0))\n"
+            "             (meta ((type_ UReal) (adlevel DataOnly)))))";
+        malformed.replace(arg, vector_arg.size(), scalar_arg);
+      }
+      DataMap malformed_data =
+          DataMap::from_json(R"({"K":3,"y":2,"ys":[3,1,3]})");
+      check(malformed_refused(malformed, malformed_data),
+            "categorical rejects malformed UDF actual before fallback");
+    }
+    {
+      std::string malformed = categorical_write_array_mir(
+          slurp("tests/fixtures/cat.tmir.sexp"), "categorical_lpmf", false,
+          false, true, true);
+      const std::string formal = "(DataOnly p UVector)";
+      const size_t formal_at = malformed.find(formal);
+      const size_t gq = malformed.find("(generate_quantities");
+      const size_t call =
+          malformed.find("(FunApp (UserDefined data_categorical", gq);
+      const std::string actual =
+          "((pattern (Var theta))\n"
+          "             (meta ((type_ UVector) (adlevel DataOnly)))))";
+      const size_t actual_at = malformed.find(actual, call);
+      check(formal_at != std::string::npos && gq != std::string::npos &&
+                call != std::string::npos && actual_at != std::string::npos,
+            "categorical malformed UDF binding mutation found target");
+      if (actual_at != std::string::npos) {
+        std::string scalar_actual = actual;
+        scalar_actual.replace(scalar_actual.find("UVector"),
+                              std::strlen("UVector"), "UReal");
+        malformed.replace(actual_at, actual.size(), scalar_actual);
+      }
+      if (formal_at != std::string::npos)
+        malformed.replace(formal_at, formal.size(), "(DataOnly p UReal)");
+      DataMap malformed_data =
+          DataMap::from_json(R"({"K":3,"y":2,"ys":[3,1,3]})");
+      check(malformed_refused(malformed, malformed_data),
+            "categorical rejects UDF metadata that contradicts its binding");
+    }
+    for (const std::string& fn :
+         {"categorical_lpmf", "categorical_logit_lpmf"}) {
+      DataMap malformed_data;
+      malformed_data.set_int("outcome", 2);
+      malformed_data.set_real_array("arg",
+                                    fn == "categorical_lpmf"
+                                        ? std::vector<double>{0.2, 0.3, 0.5}
+                                        : std::vector<double>{-1.0, 0.0, 1.0});
+      bool direct_refused = false;
+      try {
+        (void)compile_model(categorical_udf_mir(fn, true, true, false, true),
+                            malformed_data);
+      } catch (const std::exception& e) {
+        const std::string msg = e.what();
+        direct_refused = msg.find("data-only") != std::string::npos &&
+                         msg.find("parameter") != std::string::npos;
+      }
+      check(direct_refused, fn + " rejects parameter at data UDF formal");
+
+      DataMap gq_data = DataMap::from_json(R"({"K":3,"y":2,"ys":[3,1,3]})");
+      bool gq_accepted = true;
+      try {
+        CompiledModel gq_model = compile_model(
+            categorical_write_array_mir(slurp("tests/fixtures/cat.tmir.sexp"),
+                                        fn, false, false, true),
+            gq_data);
+      } catch (const std::exception& e) {
+        (void)e;
+        gq_accepted = false;
+      }
+      check(gq_accepted, fn + " accepts GQ parameter at data UDF formal");
+    }
+
+    DataMap d;
+    d.set_int("outcome", 2);
+    d.set_real_array("arg", {0.2, 0.3, 0.5});
+    CompiledModel model =
+        compile_model(categorical_check_mir("categorical_lpmf", true, 1, 3), d);
+    Executor ex(std::move(model.graph));
+    model.bind(ex);
+    ex.params_data()[0] = 0.75;
+    double grad = 0.0;
+    expect_eq("categorical check zero target", ex.gradient(&grad), 0.75);
+    expect_eq("categorical check disconnected gradient", grad, 1.0);
+
+    DataMap effect_data;
+    effect_data.set_int("outcome", 2);
+    effect_data.set_real_array("arg", {0.2, 0.3, 0.5});
+    std::optional<CompiledModel> effect_model;
+    {
+      stanli_test::StdoutCapture captured;
+      effect_model = compile_model(categorical_effect_check_mir(), effect_data);
+      check(captured.finish().empty(),
+            "categorical outcome effect absent while compiling");
+    }
+    Executor effect_ex(std::move(effect_model->graph));
+    effect_model->bind(effect_ex);
+    effect_ex.params_data()[0] = 0.25;
+    for (int i = 0; i < 2; ++i) {
+      stanli_test::StdoutCapture captured;
+      expect_eq("categorical effect target " + std::to_string(i),
+                effect_ex.gradient(&grad), 0.25);
+      check(captured.finish() == "categorical effect\n",
+            "categorical outcome effect executes once " + std::to_string(i));
+    }
   }
 
   {

--- a/tests/test_mir.cpp
+++ b/tests/test_mir.cpp
@@ -1,5 +1,6 @@
 // MIR reader over the transformed-MIR sexp of eight schools.
 #include <stanli/mir.hpp>
+#include <stanli/mir_interp.hpp>
 #include <stanli/sexp.hpp>
 
 #include <cstdio>
@@ -94,6 +95,174 @@ int main(int argc, char** argv) {
   };
   for (const auto& s : p.log_prob) swalk(s);
   check(n_propto == 4, "4 propto lpdf calls");
+
+  // A scalar broadcasts over the container's logical geometry, including a
+  // zero-width vector. Flat width alone cannot identify the scalar when the
+  // vector has zero or one element.
+  {
+    std::map<std::string, const mir::FunDef*> functions;
+    MirInterp<double> interp(functions, "broadcast test");
+    auto real_value = [&](const std::string& name, std::vector<double> values,
+                          std::vector<int64_t> dims) {
+      DataMap::Entry value;
+      value.r = std::move(values);
+      value.dims = std::move(dims);
+      interp.env()[name] = std::move(value);
+    };
+    DataMap::Entry empty;
+    empty.dims = {0};
+    interp.env()["empty"] = empty;
+    real_value("one", {3.0}, {1});
+
+    mir::Expr scalar;
+    scalar.kind = mir::Expr::LitReal;
+    scalar.lit = 2.0;
+    scalar.type_ = "UReal";
+    scalar.unsized.leaf = mir::UnsizedLeaf::Real;
+    scalar.data_only = true;
+    for (const std::string& name : {"Plus__", "Times__"}) {
+      for (const std::string& variable : {"empty", "one"}) {
+        mir::Expr vector;
+        vector.kind = mir::Expr::Var;
+        vector.name = variable;
+        vector.type_ = "UVector";
+        vector.unsized.leaf = mir::UnsizedLeaf::Vector;
+        vector.data_only = true;
+        for (bool scalar_first : {false, true}) {
+          mir::Expr call;
+          call.kind = mir::Expr::FunApp;
+          call.name = name;
+          call.type_ = "UVector";
+          call.unsized.leaf = mir::UnsizedLeaf::Vector;
+          call.data_only = true;
+          call.args = scalar_first ? std::vector<mir::Expr>{scalar, vector}
+                                   : std::vector<mir::Expr>{vector, scalar};
+          const DataMap::Entry got = interp.eval(call);
+          const size_t want_size = variable == "empty" ? 0 : 1;
+          check(got.r.size() == want_size && got.dims.size() == 1 &&
+                    got.dims[0] == (int64_t)want_size,
+                name + " scalar/vector geometry");
+          if (want_size)
+            check(got.r[0] == (name == "Plus__" ? 5.0 : 6.0),
+                  name + " scalar/vector value");
+        }
+      }
+    }
+    for (const std::string& variable : {"empty", "one"}) {
+      mir::Expr vector;
+      vector.kind = mir::Expr::Var;
+      vector.name = variable;
+      vector.type_ = "UVector";
+      vector.unsized.leaf = mir::UnsizedLeaf::Vector;
+      vector.data_only = true;
+      for (int container_arg = 0; container_arg < 3; ++container_arg) {
+        mir::Expr call;
+        call.kind = mir::Expr::FunApp;
+        call.name = "fma";
+        call.type_ = "UVector";
+        call.unsized.leaf = mir::UnsizedLeaf::Vector;
+        call.data_only = true;
+        call.args = {scalar, scalar, scalar};
+        call.args[(size_t)container_arg] = vector;
+        const DataMap::Entry got = interp.eval(call);
+        const size_t want_size = variable == "empty" ? 0 : 1;
+        check(got.r.size() == want_size && got.dims.size() == 1 &&
+                  got.dims[0] == (int64_t)want_size,
+              "fma scalar/vector geometry");
+        if (want_size)
+          check(got.r[0] == (container_arg == 2 ? 7.0 : 8.0),
+                "fma scalar/vector value");
+      }
+    }
+
+    auto variable = [](const std::string& name, const std::string& type) {
+      mir::Expr e;
+      e.kind = mir::Expr::Var;
+      e.name = name;
+      e.type_ = type;
+      e.data_only = true;
+      return e;
+    };
+    auto times = [&](const std::string& lhs, const std::string& lhs_type,
+                     const std::string& rhs, const std::string& rhs_type,
+                     const std::string& result_type) {
+      mir::Expr e;
+      e.kind = mir::Expr::FunApp;
+      e.name = "Times__";
+      e.type_ = result_type;
+      e.data_only = true;
+      e.args = {variable(lhs, lhs_type), variable(rhs, rhs_type)};
+      return interp.eval(e);
+    };
+    real_value("m11", {2.0}, {1, 1});
+    real_value("m12", {3.0, 4.0}, {1, 2});
+    DataMap::Entry matrix =
+        times("m11", "UMatrix", "m12", "UMatrix", "UMatrix");
+    check(matrix.dims == std::vector<int64_t>({1, 2}) &&
+              matrix.r == std::vector<double>({6.0, 8.0}),
+          "Times__ width-one matrix product");
+    real_value("rv1", {2.0}, {1});
+    real_value("v1", {3.0}, {1});
+    DataMap::Entry dot = times("rv1", "URowVector", "v1", "UVector", "UReal");
+    check(dot.dims.empty() && dot.r == std::vector<double>({6.0}),
+          "Times__ width-one dot product");
+
+    real_value("v2", {4.0, 5.0}, {2});
+    auto refuses_elementwise =
+        [&](const std::string& name, const std::string& lhs,
+            const std::string& rhs, const std::string& type) {
+          mir::Expr call;
+          call.kind = mir::Expr::FunApp;
+          call.name = name;
+          call.type_ = type;
+          call.data_only = true;
+          call.args = {variable(lhs, type), variable(rhs, type)};
+          if (name == "fma") call.args.push_back(scalar);
+          bool refused = false;
+          try {
+            (void)interp.eval(call);
+          } catch (const std::exception&) {
+            refused = true;
+          }
+          return refused;
+        };
+    for (const std::string& name : {"Plus__", "fma"}) {
+      check(refuses_elementwise(name, "one", "v2", "UVector"),
+            name + " refuses vector[1]/vector[2] broadcast");
+    }
+
+    real_value("m23", {1, 2, 3, 4, 5, 6}, {2, 3});
+    real_value("m32", {1, 2, 3, 4, 5, 6}, {3, 2});
+    real_value("m03", {}, {0, 3});
+    real_value("m02", {}, {0, 2});
+    for (const std::string& name : {"Plus__", "fma"}) {
+      check(refuses_elementwise(name, "m23", "m32", "UMatrix"),
+            name + " refuses equal-width unequal matrix shapes");
+      check(refuses_elementwise(name, "m03", "m02", "UMatrix"),
+            name + " refuses unequal zero-width matrix shapes");
+    }
+
+    // The positional ODE fallback entry point reconstructs scalar/container
+    // geometry from each formal rather than flattening every argument.
+    mir::FunDef scale;
+    scale.name = "scale";
+    scale.arg_names = {"a", "x"};
+    scale.arg_views = {{0, mir::UnsizedLeaf::Real},
+                       {0, mir::UnsizedLeaf::Vector}};
+    scale.arg_types = {"UReal", "UVector"};
+    mir::Stmt returned;
+    returned.kind = mir::Stmt::Return;
+    returned.has_init = true;
+    returned.rhs.kind = mir::Expr::FunApp;
+    returned.rhs.name = "Times__";
+    returned.rhs.type_ = "UVector";
+    returned.rhs.args = {variable("a", "UReal"), variable("x", "UVector")};
+    scale.body = {returned};
+    const std::vector<double> scaled =
+        interp.call(scale, {{2.0}, {3.0, 4.0}}, {});
+    check(scaled == std::vector<double>({6.0, 8.0}),
+          "ODE call scalar formal broadcasts over vector");
+  }
 
   if (failures == 0) std::printf("test_mir OK\n");
   return failures == 0 ? 0 : 1;

--- a/tests/test_mir.cpp
+++ b/tests/test_mir.cpp
@@ -262,6 +262,34 @@ int main(int argc, char** argv) {
         interp.call(scale, {{2.0}, {3.0, 4.0}}, {});
     check(scaled == std::vector<double>({6.0, 8.0}),
           "ODE call scalar formal broadcasts over vector");
+
+    // stanc may reconstruct a scalar data declaration through a flat
+    // FnReadData assignment. The declaration still owns scalar geometry;
+    // treating its one value as vector[1] breaks later scalar broadcasts.
+    DataMap::Entry scale_data;
+    scale_data.r = {2.0};
+    MirHooks hooks;
+    hooks.data = [&](const std::string& name) {
+      return name == "scale_data" ? &scale_data : nullptr;
+    };
+    MirInterp<double> read_interp(functions, "scalar data read", hooks);
+    mir::Stmt scale_decl;
+    scale_decl.kind = mir::Stmt::Decl;
+    scale_decl.decl_id = "scale_data";
+    scale_decl.decl_type.base = "SReal";
+    mir::Stmt scale_read;
+    scale_read.kind = mir::Stmt::Assignment;
+    scale_read.lhs = "scale_data";
+    scale_read.rhs.kind = mir::Expr::FunApp;
+    scale_read.rhs.name = "FnReadData";
+    scale_read.rhs.fn_lib = mir::Expr::Lib::Internal;
+    mir::Expr data_name;
+    data_name.kind = mir::Expr::LitStr;
+    data_name.lit_s = "scale_data";
+    scale_read.rhs.args = {data_name};
+    read_interp.run({scale_decl, scale_read});
+    check(read_interp.env().at("scale_data").dims.empty(),
+          "flat data read preserves declared scalar geometry");
   }
 
   if (failures == 0) std::printf("test_mir OK\n");

--- a/tests/test_reroll.cpp
+++ b/tests/test_reroll.cpp
@@ -1076,6 +1076,38 @@ static void test_bail_extra_root() {
   }
 }
 
+static void test_bail_categorical_ops() {
+  Graph g;
+  Fills fills;
+  const int outcome = g.add_slot(1, false);
+  const int theta = g.add_slot(3, false);
+  const int mu = g.add_slot(1, true);
+  const int sigma = g.add_slot(1, true);
+  fills.emplace_back(outcome, std::vector<double>{2.0});
+  fills.emplace_back(theta, std::vector<double>{0.2, 0.3, 0.5});
+  auto spec = std::make_shared<CategoricalSpec>();
+  spec->scalar_outcome = true;
+  std::vector<int> terms;
+  for (int lane = 0; lane < 8; ++lane) {
+    const int checked = g.add_slot(1, false);
+    const int op = g.add_op(OP_CATEGORICAL, {outcome, theta}, checked);
+    g.ops[(size_t)op].udata = spec.get();
+    const int y = g.add_slot(1, false);
+    fills.emplace_back(y, std::vector<double>{0.1 * lane});
+    const int lp = g.add_slot(1, false);
+    const int density = g.add_op(OP_NORMAL_LPDF, {y, mu, sigma}, lp);
+    g.ops[(size_t)density].variant = 0x06;
+    terms.push_back(lp);
+  }
+  g.udata_pool.push_back(std::move(spec));
+
+  const size_t before = g.ops.size();
+  RerollStats st = reroll(g, fills, terms, {});
+  expect("categorical ops are not rerolled", st.regions == 0);
+  expect("categorical ops survive", g.ops.size() == before);
+  expect("categorical terms survive", terms.size() == 8);
+}
+
 int main() {
   test_radon_shape();
   test_ark_shape();
@@ -1091,6 +1123,7 @@ int main() {
   test_first_lane_anomalous();
   test_block_structured();
   test_bail_extra_root();
+  test_bail_categorical_ops();
   test_lda_shape_gradients();
   test_lda_shape_cost();
   test_write_fusion();


### PR DESCRIPTION
## Summary

- add one exact categorical/categorical-logit graph op for scalar and array outcomes
- preserve normalized vs propto semantics across graph execution, native reverse, value-only execution, UDFs, interpreted write_array, C API, and BridgeStan
- keep validation at evaluation time instead of erasing checks or moving failures to model construction
- make categorical effects execute once and protect the op from constfold/reroll rewrites
- validate MIR categorical/UDF signatures and bindings before fallback
- preserve true scalar vs shaped-container geometry in MirInterp broadcasts, including empty and length-one values
- preserve declared scalar geometry through flat data reconstruction
- reject incompatible logical shapes even when flattened widths match

## Characterization and parity coverage

- independent Stan Math value and pullback oracles, including repeated array outcomes and exact callback topology
- normalized/propto, scalar/array, valid/invalid, empty, UDF, promotion, and effect-once cases
- compiled and interpreted write_array paths
- C API and BridgeStan facade tests
- constfold, reroll, value-only, malformed-MIR, ODE interpreter-boundary, and scalar data-reconstruction regressions

## Scope

Three focused commits in one PR at the requester’s direction. Production diff: 454 additions / 110 deletions; tests and handwritten MIR fixtures are measured separately. No generated MIR was added.