### PR TITLE
test: pin effectful necessity island refusals

### DIFF
--- a/tests/fixtures/necessity_effects.tmir.sexp
+++ b/tests/fixtures/necessity_effects.tmir.sexp
@@ -2,7 +2,7 @@
  (prepare_data
   (((pattern
      (Decl (decl_adtype DataOnly) (decl_id mode) (decl_type (Sized SInt))
-      (initialize Default)))
+      (initialize Uninit)))
     (meta <opaque>))
    ((pattern
      (Assignment ((LVariable mode) ()) UInt
@@ -147,7 +147,7 @@
         ((pattern
           (FunApp
            (CompilerInternal
-            (FnReadParam (constrain Identity) (dims ()) (mem_pattern AoS)))
+            (FnReadParam (constrain Identity) (dims ()) (mem_pattern SoA)))
            ()))
          (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))))
     (meta <opaque>))
@@ -156,7 +156,7 @@
       (((pattern
          (IfElse
           ((pattern
-            (FunApp (StanLib Equals__ FnPlain AoS)
+            (FunApp (StanLib Equals__ FnPlain SoA)
              (((pattern (Var mode))
                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
               ((pattern (Lit Int 1))
@@ -167,7 +167,7 @@
              (((pattern
                 (IfElse
                  ((pattern
-                   (FunApp (StanLib Greater__ FnPlain AoS)
+                   (FunApp (StanLib Greater__ FnPlain SoA)
                     (((pattern (Var x))
                       (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
                      ((pattern (Lit Int 0))
@@ -203,7 +203,7 @@
               (((pattern
                  (IfElse
                   ((pattern
-                    (FunApp (StanLib Less__ FnPlain AoS)
+                    (FunApp (StanLib Less__ FnPlain SoA)
                      (((pattern (Var x))
                        (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
                       ((pattern (Lit Int 0))
@@ -282,7 +282,7 @@
  (transform_inits
   (((pattern
      (Decl (decl_adtype AutoDiffable) (decl_id x) (decl_type (Sized SReal))
-      (initialize Default)))
+      (initialize Uninit)))
     (meta <opaque>))
    ((pattern
      (Assignment ((LVariable x) ()) UReal
@@ -309,7 +309,7 @@
  (unconstrain_array
   (((pattern
      (Decl (decl_adtype AutoDiffable) (decl_id x) (decl_type (Sized SReal))
-      (initialize Default)))
+      (initialize Uninit)))
     (meta <opaque>))
    ((pattern
      (Assignment ((LVariable x) ()) UReal

--- a/tests/test_bridgestan.cpp
+++ b/tests/test_bridgestan.cpp
@@ -641,6 +641,42 @@ void test_print_callback() {
   bs_model_destruct(m);
 }
 
+void test_necessity_effects_refused() {
+  const std::string mir = slurp("tests/fixtures/necessity_effects.tmir.sexp");
+  char* err = nullptr;
+  expect_eq_int("necessity callback install",
+                bs_set_print_callback(&collect_print, &err), 0);
+
+  for (int mode = 1; mode <= 2; ++mode) {
+    const std::string effect = mode == 1 ? "FnPrint" : "FnReject";
+    nlohmann::json root = {{"mode", mode}};
+    root["__stanli"] = {{"build_id", stanli::bs_build_id()},
+                        {"mir", mir},
+                        {"name", "necessity_effects"}};
+    g_printed.clear();
+    err = nullptr;
+    bs_model* m = bs_model_construct(root.dump().c_str(), 1, &err);
+    if (m != nullptr) {
+      fail("BridgeStan accepted necessity island containing " + effect);
+      bs_model_destruct(m);
+    } else if (err == nullptr ||
+               std::string(err).find("parameter-dependent region") ==
+                   std::string::npos ||
+               std::string(err).find(effect) == std::string::npos) {
+      fail("BridgeStan necessity " + effect +
+           " error: " + (err != nullptr ? err : "(no message)"));
+    }
+    bs_free_error_msg(err);
+    if (!g_printed.empty())
+      fail("BridgeStan executed " + effect + " while refusing: [" + g_printed +
+           "]");
+  }
+
+  err = nullptr;
+  expect_eq_int("necessity callback clear",
+                bs_set_print_callback(nullptr, &err), 0);
+}
+
 // The manifest reader on its own: the manifest is read and its build id
 // checked before anything is compiled.
 void test_manifest() {
@@ -927,6 +963,7 @@ int main() {
   test_unsupported();
   test_initialize();
   test_print_callback();
+  test_necessity_effects_refused();
   test_manifest();
   test_embedded_manifest();
   test_construct_errors();

--- a/tests/test_capi.cpp
+++ b/tests/test_capi.cpp
@@ -326,6 +326,30 @@ void expect_categorical_interpreted_write_array() {
   stanli_model_free(model);
 }
 
+void expect_necessity_effects_refused() {
+  const std::string mir = slurp("tests/fixtures/necessity_effects.tmir.sexp");
+  for (int mode = 1; mode <= 2; ++mode) {
+    const std::string effect = mode == 1 ? "FnPrint" : "FnReject";
+    const std::string data = "{\"mode\":" + std::to_string(mode) + "}";
+    char err[8192]{};
+    stanli_model* model =
+        stanli_model_new(mir.c_str(), data.c_str(), err, sizeof err);
+    if (model != nullptr) {
+      ++failures;
+      std::printf("FAIL C API accepted necessity island containing %s\n",
+                  effect.c_str());
+      stanli_model_free(model);
+      continue;
+    }
+    const std::string msg = err;
+    if (msg.find("parameter-dependent region") == std::string::npos ||
+        msg.find(effect) == std::string::npos) {
+      ++failures;
+      std::printf("FAIL C API necessity %s error: %s\n", effect.c_str(), err);
+    }
+  }
+}
+
 }  // namespace
 
 int main() {
@@ -363,6 +387,7 @@ int main() {
   expect_structured_checks();
   expect_categorical_check();
   expect_categorical_interpreted_write_array();
+  expect_necessity_effects_refused();
 
   if (failures == 0) std::printf("test_capi OK\n");
   return failures == 0 ? 0 : 1;

--- a/tests/test_rejectprint.cpp
+++ b/tests/test_rejectprint.cpp
@@ -175,6 +175,17 @@ int main() {
   // mode, so they cannot preserve that contract yet. Refusal is the honest
   // boundary: silently dropping either effect changes observable behavior,
   // and dropping reject changes the posterior support.
+  //
+  // The generated-Stan oracle at x=0.1 and x=-0.04 is:
+  //
+  //   mode  x      target  grad  observable effect
+  //      1   0.10    0.10     1  prints once
+  //      1  -0.04   -0.04     1  none (print arm untaken)
+  //      2   0.10    0.10     1  none (reject arm untaken)
+  //      2  -0.04       -     -  throws domain_error once
+  //
+  // Construction cannot know which parameter point a host will evaluate,
+  // so it must refuse both models before either arm can run.
   {
     const std::string effect_mir =
         slurp("tests/fixtures/necessity_effects.tmir.sexp");


### PR DESCRIPTION
## Summary
- refresh the necessity-effects MIR fixture from the pinned current optimized-MIR frontend
- record the generated-Stan taken/untaken print and reject oracle
- pin fail-loud construction through compile_model, the shared C ABI, and the public BridgeStan manifest path

Current main already has the correct production refusal from #75. This PR adds the missing current-frontend and facade regression coverage without changing lowering.

## Verification
- ./tools/format.sh --check
- cmake -S . -B build-rel -DCMAKE_BUILD_TYPE=RelWithDebInfo
- cmake --build build-rel -j2
- ctest --test-dir build-rel --output-on-failure -j2 (46/46)
- python3 tools/verify_refs.py deps/posteriordb --check build-rel/stanli_check --jobs 8 (129/129; worst 3.63e-12)
- python3 harnesses/wa_coverage.py deps/posteriordb (119/119 complete)
- python3 harnesses/ab_corpus.py deps/posteriordb (no flags; worst 3.46e-13)
