### PR TITLE
test: make fake stanc launcher portable to Windows

### DIFF
--- a/tests/test_conformance.py
+++ b/tests/test_conformance.py
@@ -8,6 +8,7 @@ import dataclasses
 import io
 import json
 import math
+import os
 import pathlib
 import stat
 import sys
@@ -151,15 +152,22 @@ class SignatureParserTests(unittest.TestCase):
     def test_fake_stanc_inventory_process(self):
         with tempfile.TemporaryDirectory() as raw:
             root = pathlib.Path(raw)
-            executable = root / "stanc"
-            executable.write_text(
+            script = root / "fake_stanc.py"
+            script.write_text(
                 "#!/usr/bin/env python3\n"
                 "import sys\n"
                 "if '--version' in sys.argv: print('stanc3 fake')\n"
                 "elif '--dump-stan-math-signatures' in sys.argv:\n"
                 " print('f(real) => real')\n"
                 "else: sys.exit(2)\n", encoding="utf-8")
-            executable.chmod(executable.stat().st_mode | stat.S_IXUSR)
+            if os.name == "nt":
+                executable = root / "stanc.cmd"
+                executable.write_text(
+                    f'@"{sys.executable}" "{script}" %*\r\n',
+                    encoding="utf-8")
+            else:
+                executable = script
+                executable.chmod(executable.stat().st_mode | stat.S_IXUSR)
             inventory = load_inventory(executable)
             self.assertEqual(inventory.signature_count, 1)
             self.assertEqual(inventory.name_count, 1)


### PR DESCRIPTION
## Summary

- fix the conformance harness's fake-stanc subprocess test on Windows
- use a `.cmd` launcher there to invoke the current Python interpreter explicitly
- retain the executable Python fixture on POSIX

## Cause

Post-merge CI failed only in `win_amd64`: Windows attempted to execute the extensionless Python fixture as a native Win32 binary and returned `WinError 193`. All runtime tests and other platforms passed.

## Validation

- `python3.11 tests/test_conformance.py` — 67 tests pass
- `ctest --test-dir build-rel -R test_conformance_harness --output-on-failure` — passes
- `./tools/format.sh --check` — passes
