### PR TITLE
Update sizeof assertions for i386 compat

### DIFF
--- a/runtime/src/lower.cpp
+++ b/runtime/src/lower.cpp
@@ -35,7 +35,7 @@ struct SlotInfo {
   ViewKind kind = ViewKind::Flat;
   ShapeId shape = 0;  // nonzero exactly for Array values
 };
-static_assert(sizeof(SlotInfo) == 24);
+static_assert(sizeof(SlotInfo) <= 24);
 
 bool is_matrix(const SlotInfo& si) { return si.kind == ViewKind::Matrix; }
 bool is_vector(const SlotInfo& si) { return si.kind == ViewKind::Vector; }
@@ -150,7 +150,7 @@ struct Lowering {
     bool autodiff = false;  // instantiated C++ scalar type carries var
     SlotInfo si;
   };
-  static_assert(sizeof(Val) == 32);
+  static_assert(sizeof(Val) <= 32);
 
   const DataMap& data;
   std::shared_ptr<ShapeInterner> shape_pool;


### PR DESCRIPTION
Compilation fails on `i386` targets with an error because `int64_t` is 4 byte aligned there instead of 8:

```
stanli/runtime/src/lower.cpp:151:17: error: static assertion failed due to requirement 'sizeof(stanli::(anonymous namespace)::Lowering::Val) == 32'
  151 |   static_assert(sizeof(Val) == 32);
      |                 ^~~~~~~~~~~~~~~~~
stanli/runtime/src/lower.cpp:151:29: note: expression evaluates to '28 == 32'
  151 |   static_assert(sizeof(Val) == 32);
```

This PR just updates the assert to use `<=` for compatibility.

I also checked across `aarch64`, `armhf`, `ppc64le`, `s390x` and `riscv64`, and the existing `sizeof(Val) == 32` assert is fine there - it's just `i386` being a unique pain!