### PR TITLE
conformance: build the pinned stanc from source; watch upstream signatures

### DIFF
--- a/.github/workflows/stan-conformance-nightly.yml
+++ b/.github/workflows/stan-conformance-nightly.yml
@@ -8,16 +8,37 @@ on:
 permissions:
   contents: read
 
+env:
+  # Must match tools/dev_setup.sh and wheels.yml; only used when the
+  # toolchain cache misses and the pinned stanc is rebuilt from source.
+  OPAM_VERSION: 2.5.2
+
 concurrency:
   group: stan-conformance-${{ github.ref }}
   cancel-in-progress: false
 
 jobs:
+  # What has the Stan language grown that the pinned toolchain cannot
+  # see? stanc3 checks its full signature dump into its own repository,
+  # so this is a text diff between our pin and upstream master: nothing
+  # is downloaded but two files, and no unreviewed compiler runs. Its
+  # own job, so a toolchain-build failure cannot hide the report.
+  # Reporting only: a frozen toolchain cannot *test* a new signature --
+  # that is a reviewed pin advance (STANC3_SRC_SHA in dev_setup.sh).
+  signature-watch:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - name: Diff pinned signatures against upstream master
+        run: ./harnesses/conformance/signature_watch.sh
+
   inventory:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
 
+      # dev_setup.sh is in the key: the stanc pin (STANC3_SRC_SHA)
+      # lives there, so advancing it rolls this cache.
       - name: Restore pinned Stan and CmdStan sources
         uses: actions/cache@v4
         with:
@@ -27,7 +48,18 @@ jobs:
             deps/stanc3
             deps/cmdstan
             deps/bridgestan
-          key: conformance-deps-linux-x86_64-${{ hashFiles('deps/fetch.sh', 'harnesses/conformance/fetch_cmdstan.sh') }}
+          key: conformance-deps-linux-x86_64-${{ hashFiles('deps/fetch.sh', 'harnesses/conformance/fetch_cmdstan.sh', 'harnesses/conformance/build_stanc.sh', 'tools/dev_setup.sh') }}
+
+      # Only exercised when the cache misses: fetch_cmdstan.sh builds
+      # the pinned stanc from source then, and the build needs opam.
+      # Same pinned opam release the wheels use.
+      - name: opam (for a cold stanc build)
+        run: |
+          url=https://github.com/ocaml/opam/releases/download
+          curl -fsSL --retry 5 -o /tmp/opam \
+            "$url/$OPAM_VERSION/opam-$OPAM_VERSION-x86_64-linux"
+          chmod +x /tmp/opam
+          sudo install -m 755 /tmp/opam /usr/local/bin/opam
 
       - name: Validate the complete pinned reference toolchain
         run: |
@@ -40,12 +72,12 @@ jobs:
           cmake --build build-rel --target stanli_shared -j2
           mkdir -p python/stanli/_bin
           cp build-rel/libstanli.so python/stanli/_bin/
-          cp deps/stanc3/stanc python/stanli/_bin/stanc
+          cp deps/stanc3/stanc-pinned python/stanli/_bin/stanc
 
       - name: Emit the deterministic partition manifest
         run: |
           python3 harnesses/stan_conformance.py \
-            --stanc deps/stanc3/stanc \
+            --stanc deps/stanc3/stanc-pinned \
             --cmdstan deps/cmdstan \
             --write-manifest 8 \
             --output conformance-manifest
@@ -70,6 +102,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # Identical key to the inventory job, so this restores what that
+      # job built and saved -- including the source-built stanc, whose
+      # provenance file makes the revalidation below a no-op.
       - name: Restore pinned Stan and CmdStan sources
         uses: actions/cache@v4
         with:
@@ -79,7 +114,18 @@ jobs:
             deps/stanc3
             deps/cmdstan
             deps/bridgestan
-          key: conformance-deps-linux-x86_64-${{ hashFiles('deps/fetch.sh', 'harnesses/conformance/fetch_cmdstan.sh') }}
+          key: conformance-deps-linux-x86_64-${{ hashFiles('deps/fetch.sh', 'harnesses/conformance/fetch_cmdstan.sh', 'harnesses/conformance/build_stanc.sh', 'tools/dev_setup.sh') }}
+
+      # Insurance for the cache evaporating between inventory and here:
+      # revalidation would then rebuild stanc from source, which needs
+      # opam. On the ordinary path this binary is installed and unused.
+      - name: opam (for a cold stanc build)
+        run: |
+          url=https://github.com/ocaml/opam/releases/download
+          curl -fsSL --retry 5 -o /tmp/opam \
+            "$url/$OPAM_VERSION/opam-$OPAM_VERSION-x86_64-linux"
+          chmod +x /tmp/opam
+          sudo install -m 755 /tmp/opam /usr/local/bin/opam
 
       - name: Revalidate restored reference inputs
         run: |
@@ -114,7 +160,7 @@ jobs:
         continue-on-error: true
         run: |
           python3 harnesses/stan_conformance.py \
-            --stanc deps/stanc3/stanc \
+            --stanc deps/stanc3/stanc-pinned \
             --cmdstan deps/cmdstan \
             --build build-rel \
             --shard ${{ matrix.partition }}/8 \

--- a/harnesses/conformance/README.md
+++ b/harnesses/conformance/README.md
@@ -31,10 +31,18 @@ their dedicated domain and reduction cases are added.
 ## Setup and run
 
 Fetch stanli's pinned dependencies first. The helper then prepares the exact
-CmdStan/Stan/Stan Math combination used by BridgeStan and verifies both
-the build ID and platform-specific SHA-256 of stanc instead of silently
-accepting a different nightly. The workflow likewise pins the public
-BridgeStan Python client used to drive stanli's facade.
+CmdStan/Stan/Stan Math combination used by BridgeStan, and builds the
+conformance stanc from source at `STANC3_SRC_SHA` (`tools/dev_setup.sh`) --
+the same revision the wheels embed -- rather than trusting any downloaded
+binary. The build needs opam and takes ~30 minutes once per pin; it is a
+no-op when `deps/stanc3/stanc-pinned` already matches the pin. The workflow
+likewise pins the public BridgeStan Python client used to drive stanli's
+facade.
+
+`signature_watch.sh` is the other half: it diffs stanc3's checked-in
+signature dump between the pin and upstream master, so new language surface
+is reported nightly without executing anything unreviewed. Adopting what it
+reports is a pin advance: bump `STANC3_SRC_SHA` and rerun this suite.
 
 ```sh
 ./deps/fetch.sh
@@ -42,7 +50,7 @@ BridgeStan Python client used to drive stanli's facade.
 python3 -m pip install -r harnesses/conformance/requirements.txt
 
 python3 harnesses/stan_conformance.py \
-  --stanc deps/stanc3/stanc \
+  --stanc deps/stanc3/stanc-pinned \
   --cmdstan deps/cmdstan \
   --build build-rel \
   --jobs 4
@@ -55,11 +63,11 @@ selectors are stable:
 
 ```sh
 python3 harnesses/stan_conformance.py \
-  --stanc deps/stanc3/stanc --cmdstan deps/cmdstan --build build-rel \
+  --stanc deps/stanc3/stanc-pinned --cmdstan deps/cmdstan --build build-rel \
   --case 'abs(real)=>real'
 
 python3 harnesses/stan_conformance.py \
-  --stanc deps/stanc3/stanc --mode inventory --shard 2/8
+  --stanc deps/stanc3/stanc-pinned --mode inventory --shard 2/8
 ```
 
 The default output directory is `conformance-out/`. It contains the complete
@@ -79,7 +87,7 @@ source. To freeze a run, pass an explicit ignored or externally retained path:
 
 ```sh
 python3 harnesses/stan_conformance.py \
-  --stanc deps/stanc3/stanc --cmdstan deps/cmdstan --build build-rel \
+  --stanc deps/stanc3/stanc-pinned --cmdstan deps/cmdstan --build build-rel \
   --baseline conformance-out/conformance-baseline.json --update-snapshot
 ```
 

--- a/harnesses/conformance/build_stanc.sh
+++ b/harnesses/conformance/build_stanc.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Build the conformance stanc from source at the pinned stanc3 revision.
+#
+# The old arrangement downloaded a binary from stanc3's `nightly` release
+# tag and pinned it by version string and sha256. That tag is reassigned
+# on every upstream publish and old assets are deleted with it, so the
+# pin was only satisfiable while a CI cache happened to hold a copy; the
+# first cold cache after an upstream publish stranded the job with a
+# binary that no longer exists anywhere. A git SHA is fetchable forever.
+#
+# The pin is STANC3_SRC_SHA in tools/dev_setup.sh -- the same revision
+# the wheels embed -- so the conformance run exercises the frontend the
+# shipped runtime actually uses, not a nearby nightly.
+#
+# Output: deps/stanc3/stanc-pinned, with deps/stanc3/stanc-pinned.src
+# recording the revision it was built from. Rerunning with a matching
+# provenance file is a no-op, so callers can invoke this unconditionally.
+#
+# Usage: harnesses/conformance/build_stanc.sh [opam-switch]
+set -euo pipefail
+
+repo_root=$(cd "$(dirname "$0")/../.." && pwd)
+
+# The pin, the switch, and the OCaml version all come from dev_setup.sh
+# so there is exactly one place a pin advance edits.
+read_setup() {
+  sed -n "s/^$1=\\([^ ]*\\).*/\\1/p" "$repo_root/tools/dev_setup.sh"
+}
+switch=${1:-$(read_setup OPAM_SWITCH)}
+ocaml_version=$(read_setup OCAML_VERSION)
+src_sha=$(read_setup STANC3_SRC_SHA)
+if [[ -z "$src_sha" ]]; then
+  echo "Could not read STANC3_SRC_SHA from tools/dev_setup.sh" >&2
+  exit 1
+fi
+
+out="$repo_root/deps/stanc3/stanc-pinned"
+if [[ -x "$out" && -f "$out.src" && "$(cat "$out.src")" == "$src_sha" ]]; then
+  echo "conformance stanc already built from $src_sha"
+  exit 0
+fi
+
+src_dir="$repo_root/deps/stanc3-src"
+if [[ ! -d "$src_dir/.git" ]]; then
+  git clone https://github.com/stan-dev/stanc3.git "$src_dir"
+fi
+git -C "$src_dir" fetch -q origin "$src_sha"
+# reset first: dune subst (below) edits tracked files, and a leftover
+# subst from a previous build would make this checkout refuse.
+git -C "$src_dir" reset -q --hard
+git -C "$src_dir" checkout -q --detach "$src_sha"
+
+if [[ ! -d "$HOME/.opam" ]]; then opam init -y --bare --no-setup; fi
+if ! opam switch list --short 2>/dev/null | grep -qx "$switch"; then
+  # stanc3 pins its OCaml version exactly; other versions fail to solve.
+  opam switch create "$switch" "ocaml-base-compiler.$ocaml_version" -y
+fi
+eval "$(opam env --switch="$switch" --set-switch)"
+(cd "$src_dir" && opam install . --deps-only -y)
+# Fill the %%NAME%%/%%VERSION%% placeholders from git, as the release
+# pipeline would; without this every source build answers --version
+# identically and conformance reports cannot tell two pins apart.
+(cd "$src_dir" && dune subst)
+(cd "$src_dir" && dune build --profile release src/stanc/stanc.exe)
+
+mkdir -p "$repo_root/deps/stanc3"
+install -m 755 "$src_dir/_build/default/src/stanc/stanc.exe" "$out"
+printf '%s\n' "$src_sha" > "$out.src"
+echo "conformance stanc: $out ($("$out" --version)) from $src_sha"

--- a/harnesses/conformance/fetch_cmdstan.sh
+++ b/harnesses/conformance/fetch_cmdstan.sh
@@ -9,41 +9,21 @@ cmdstan_dir=${1:-"$repo_root/deps/cmdstan"}
 cmdstan_sha=11cb052d3e1fc8c799e0fec559e2ee5452b38d27
 stan_sha=c96d04115d35cb04f42e45c5a69a82f9704798f1
 math_sha=8f326d14599d3030c626c46532d8e8534c1cdbec
-stanc_build='stanc3 b96c001 (Unix)'
 bridgestan_sha=49e248f351d4dac18d7fd154dbc3a0ab39c5de10
 
-case "$(uname -s)-$(uname -m)" in
-  Darwin-arm64)
-    stanc_sha=d73ab1dfdd7ecbb7c750f978b1aaa09a263718e38c97a74eb83e427a7870761f ;;
-  Darwin-x86_64)
-    stanc_sha=292508d1dab4d31f0e051d4b44cc20013053c5e98d2ff90e78d67327c34bc805 ;;
-  Linux-x86_64)
-    stanc_sha=eadfb96fba274d51c0d8e46cfa0cfe9402a35701b94ed219c2e0990c47cf3905 ;;
-  Linux-aarch64)
-    stanc_sha=fa8e324752ba1dfdf9bb4ff118e79732c5d0851c358252e89c305971658d413e ;;
-  *)
-    echo "No reviewed stanc binary digest for $(uname -s)-$(uname -m)." >&2
-    exit 1
-    ;;
-esac
-
-if [[ ! -x "$repo_root/deps/stanc3/stanc" ]]; then
-  "$repo_root/deps/fetch.sh"
-fi
-
-actual_stanc=$("$repo_root/deps/stanc3/stanc" --version)
-if [[ "$actual_stanc" != "$stanc_build" ]]; then
-  echo "stanc pin mismatch: expected '$stanc_build', got '$actual_stanc'" >&2
-  echo "Refusing to build a reference for a moving nightly compiler." >&2
-  exit 1
-fi
-if command -v sha256sum >/dev/null 2>&1; then
-  actual_stanc_sha=$(sha256sum "$repo_root/deps/stanc3/stanc" | awk '{print $1}')
-else
-  actual_stanc_sha=$(shasum -a 256 "$repo_root/deps/stanc3/stanc" | awk '{print $1}')
-fi
-if [[ "$actual_stanc_sha" != "$stanc_sha" ]]; then
-  echo "stanc binary digest mismatch: expected $stanc_sha, got $actual_stanc_sha" >&2
+# The conformance stanc is built from source at STANC3_SRC_SHA -- the
+# revision the wheels embed -- not downloaded from stanc3's `nightly`
+# release tag. That tag is republished in place upstream, so a binary
+# pinned against it stops existing the first time no cache holds a
+# copy; a git SHA can be fetched and rebuilt forever, and the run then
+# tests the frontend the shipped runtime actually uses.
+"$repo_root/harnesses/conformance/build_stanc.sh"
+stanc_pinned="$repo_root/deps/stanc3/stanc-pinned"
+stanc3_src_sha=$(sed -n 's/^STANC3_SRC_SHA=\([0-9a-f]*\).*/\1/p' \
+                 "$repo_root/tools/dev_setup.sh")
+if [[ "$(cat "$stanc_pinned.src" 2>/dev/null)" != "$stanc3_src_sha" ]]; then
+  echo "conformance stanc provenance mismatch: built from" \
+       "'$(cat "$stanc_pinned.src" 2>/dev/null)', pin is '$stanc3_src_sha'" >&2
   exit 1
 fi
 
@@ -77,7 +57,10 @@ git -C "$bridgestan_dir" checkout -q --detach "$bridgestan_sha"
 verify_head "$bridgestan_dir" "$bridgestan_sha" BridgeStan
 
 mkdir -p "$cmdstan_dir/bin"
-cp "$repo_root/deps/stanc3/stanc" "$cmdstan_dir/bin/stanc"
+# Both sides of the differential compile with the identical frontend:
+# CmdStan gets the same source-built stanc that stanli lowers through,
+# in place of whatever make/stanc would download.
+cp "$stanc_pinned" "$cmdstan_dir/bin/stanc"
 
 case "$(uname -s)" in
   Darwin) tbb_target=stan/lib/stan_math/lib/tbb/libtbb.dylib ;;

--- a/harnesses/conformance/signature_watch.sh
+++ b/harnesses/conformance/signature_watch.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# What has the Stan language grown that the pinned toolchain cannot see?
+#
+# stanc3 checks its complete signature dump into its own repository as a
+# cram expectation (test/integration/signatures/stan_math_signatures.t),
+# updated in the same commit as any signature change. Diffing that file
+# between our pinned stanc3 revision and upstream master answers "what
+# are we missing" by reading text: no nightly binary is downloaded and
+# nothing unreviewed is executed.
+#
+# Reporting is this script's whole job. New signatures cannot be
+# *tested* by any frozen toolchain -- exercising them means adopting a
+# compiler and a stan-math that know them, which is a reviewed pin
+# advance (STANC3_SRC_SHA in tools/dev_setup.sh), not a CI action.
+#
+# Usage: harnesses/conformance/signature_watch.sh [upstream-ref]
+# Exit 0 always, unless a fetch itself fails.
+set -euo pipefail
+
+repo_root=$(cd "$(dirname "$0")/../.." && pwd)
+upstream_ref=${1:-master}
+
+pinned_sha=$(sed -n 's/^STANC3_SRC_SHA=\([0-9a-f]*\).*/\1/p' \
+             "$repo_root/tools/dev_setup.sh")
+if [[ -z "$pinned_sha" ]]; then
+  echo "Could not read STANC3_SRC_SHA from tools/dev_setup.sh" >&2
+  exit 1
+fi
+
+raw=https://raw.githubusercontent.com/stan-dev/stanc3
+file=test/integration/signatures/stan_math_signatures.t
+work=$(mktemp -d)
+trap 'rm -rf "$work"' EXIT
+
+# The cram file is the command plus its expected output; the signatures
+# are the two-space-indented lines. Everything else is header.
+fetch_signatures() { # ref outfile
+  curl -fsSL --retry 5 --retry-all-errors "$raw/$1/$file" |
+    sed -n 's/^  \([^$].*\)$/\1/p' | sort > "$2"
+}
+fetch_signatures "$pinned_sha" "$work/pinned"
+fetch_signatures "$upstream_ref" "$work/upstream"
+
+added=$(comm -13 "$work/pinned" "$work/upstream")
+removed=$(comm -23 "$work/pinned" "$work/upstream")
+n_added=$(printf '%s' "$added" | grep -c . || true)
+n_removed=$(printf '%s' "$removed" | grep -c . || true)
+
+{
+  echo "## Stan signature watch"
+  echo
+  echo "Pinned stanc3 \`${pinned_sha:0:7}\` vs upstream \`$upstream_ref\`:" \
+       "$(wc -l < "$work/pinned" | tr -d ' ') pinned signatures," \
+       "**$n_added added**, **$n_removed removed** upstream."
+  for section in Added Removed; do
+    body=$([ "$section" = Added ] && printf '%s' "$added" ||
+           printf '%s' "$removed")
+    [ -n "$body" ] || continue
+    echo
+    echo "### $section upstream"
+    echo '```'
+    printf '%s\n' "$body"
+    echo '```'
+  done
+  if [ "$n_added" -eq 0 ] && [ "$n_removed" -eq 0 ]; then
+    echo
+    echo "The pin covers everything upstream offers."
+  else
+    echo
+    echo "To adopt: advance STANC3_SRC_SHA in tools/dev_setup.sh and" \
+         "rerun the conformance suite against the new frontend."
+  fi
+} | tee -a "${GITHUB_STEP_SUMMARY:-/dev/null}"


### PR DESCRIPTION
The conformance nightly went red Thursday with "stanc pin mismatch" through no change in this repo. The conformance stanc was downloaded from stanc3's `nightly` release tag and pinned by version string and sha256, but that tag is republished in place upstream and old assets are deleted with it. The pinned binary only existed while a CI cache held a copy; the first cold cache after an upstream publish stranded the job with a pin nothing could satisfy.

**The pin is now a source revision.** `fetch_cmdstan.sh` builds stanc from source at `STANC3_SRC_SHA` (`tools/dev_setup.sh`), the same revision the wheels embed, so the differential run also stops testing a nearby nightly binary in place of the frontend the shipped runtime actually uses (they had already drifted: embedded `ac69570` vs conformance binary `b96c001`). A provenance file makes the build a no-op when it matches; `dune subst` fills in `--version` so reports can tell two pins apart; the binary-digest table is gone, since a git SHA plus a from-source build is stronger than a digest of a file nobody can re-download.

**Tracking upstream still happens, by reading rather than executing.** stanc3 checks its complete signature dump into its own repo (`test/integration/signatures/stan_math_signatures.t`, updated in the same commit as any signature change). The new `signature_watch.sh` diffs it between the pin and master, and a new nightly job posts what the language grew to the run summary. Nothing frozen can *test* a new signature; adopting one is a reviewed pin advance, now a one-line bump of `STANC3_SRC_SHA`. (Today's diff is empty: the nightly churn that broke CI carried zero new language surface.)

Costs: one ~30 minute opam+dune build per pin advance, cached under the existing deps cache (`tools/dev_setup.sh` joins the key so advancing the pin rolls it). The partition jobs get the same key plus an opam install as insurance for a cache evicted mid-run.

Verified locally: the pinned build succeeds and self-identifies (`stanc3 v2.39.0-76-gac69570`), its `--dump-stan-math-signatures` output is byte-identical to the checked-in dump at that revision, the 67 harness tests pass, and `load_inventory` plus `--write-manifest` run against it end to end. Both watch-script diff directions exercised against a real old ref.

Note for after merge: the first nightly (or a `workflow_dispatch`) runs the cold 30 minute build once, then it is cached.
