### PR TITLE
ci: opam init without sandboxing in the conformance nightly

### DIFF
--- a/.github/workflows/stan-conformance-nightly.yml
+++ b/.github/workflows/stan-conformance-nightly.yml
@@ -60,6 +60,8 @@ jobs:
             "$url/$OPAM_VERSION/opam-$OPAM_VERSION-x86_64-linux"
           chmod +x /tmp/opam
           sudo install -m 755 /tmp/opam /usr/local/bin/opam
+          # Runner images lack bubblewrap; same flag the wheels use.
+          opam init --bare --disable-sandboxing --no-setup -y
 
       - name: Validate the complete pinned reference toolchain
         run: |
@@ -126,6 +128,8 @@ jobs:
             "$url/$OPAM_VERSION/opam-$OPAM_VERSION-x86_64-linux"
           chmod +x /tmp/opam
           sudo install -m 755 /tmp/opam /usr/local/bin/opam
+          # Runner images lack bubblewrap; same flag the wheels use.
+          opam init --bare --disable-sandboxing --no-setup -y
 
       - name: Revalidate restored reference inputs
         run: |


### PR DESCRIPTION
The first cold run of #98's toolchain build died at `opam init`: the runner image has no bubblewrap. Initialize in the workflow step with `--disable-sandboxing` (the same flag the wheels build uses, for the same reason); `build_stanc.sh` then finds an existing `~/.opam` and leaves sandboxing alone on workstations. The signature-watch job passed on that run, so this is the only thing between the nightly and its first full pass.