### PR TITLE
Pathfinder, and a NUTS vs Pathfinder comparison view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## Unreleased
+
+### Pathfinder, and a NUTS vs Pathfinder comparison
+
+Single-path Pathfinder (Stan's own service, stan/services/pathfinder/)
+now runs over the executor's gradient, sharing the CmdStan init stream
+with NUTS and WALNUTS so a matched seed is a controlled comparison.
+The result carries the draws, the log density along the L-BFGS path
+with the ELBO-selected iterate, and a Pareto k-hat computed from the
+importance ratios. Multi-path is out of scope: it needs real TBB,
+which this build stubs.
+
+The comparison page gets a "NUTS vs Pathfinder" mode. Pathfinder has
+no chains, so its column shows the optimization path animating live
+per L-BFGS iterate, a histogram on a shared x range with each
+sampler's outline overlaid on the other's panel, and a Q-Q plot
+against NUTS quantiles. Pathfinder finishes in milliseconds and then
+the NUTS side keeps streaming into the shared plots, the Q-Q, and a
+per-parameter discrepancy column. k-hat is shown with its honest
+caveat: it certifies weight stability, never coverage -- on centered
+eight schools the approximation misses the funnel badly while k-hat
+stays green, which is exactly the failure the view exists to show.
+
 ## 0.7.2
 
 ### NUTS and WALNUTS start from the same point

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -227,6 +227,7 @@ set(STANLI_RUNTIME_SOURCES
   runtime/src/walnuts.cpp
   runtime/src/diagnose.cpp
   runtime/src/estimate.cpp
+  runtime/src/pathfinder.cpp
   runtime/src/mir_reader.cpp
   runtime/src/lower.cpp
   runtime/src/wa_interp.cpp
@@ -402,7 +403,7 @@ set(STANLI_TESTS
   test_structured_checks test_mir_unary_fallback test_constfold
   test_write_array test_pool test_bridgestan test_mixture test_island
   test_adjoint test_diagnose test_multichain test_newtrans test_rejectprint
-  test_odevariadic test_estimate test_brmsmono test_structured_arrays)
+  test_odevariadic test_estimate test_brmsmono test_structured_arrays test_pathfinder)
 foreach(STANLI_TEST IN LISTS STANLI_TESTS)
   stanli_add_test(${STANLI_TEST})
 endforeach()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -344,7 +344,7 @@ if(EMSCRIPTEN)
     "SHELL:-s MAXIMUM_MEMORY=4GB"
     "SHELL:-s STACK_SIZE=8MB"
     "SHELL:-s ENVIRONMENT=web,worker,node"
-    "SHELL:-s EXPORTED_FUNCTIONS=_stanli_model_new,_stanli_model_new_from_stan,_stanli_has_embedded_stanc,_stanli_exact_lp,_stanli_model_free,_stanli_n_unconstrained,_stanli_grad,_stanli_sample,_stanli_n_constrained,_stanli_constrained_name,_stanli_constrain,_stanli_wa_n_columns,_stanli_wa_column_name,_stanli_wa_seed,_stanli_wa_row,_stanli_sample_stream,_stanli_sample_walnuts_stream,_malloc,_free"
+    "SHELL:-s EXPORTED_FUNCTIONS=_stanli_model_new,_stanli_model_new_from_stan,_stanli_has_embedded_stanc,_stanli_exact_lp,_stanli_model_free,_stanli_n_unconstrained,_stanli_grad,_stanli_sample,_stanli_n_constrained,_stanli_constrained_name,_stanli_constrain,_stanli_wa_n_columns,_stanli_wa_column_name,_stanli_wa_seed,_stanli_wa_row,_stanli_sample_stream,_stanli_sample_walnuts_stream,_stanli_run_pathfinder,_malloc,_free"
     "SHELL:-s EXPORTED_RUNTIME_METHODS=cwrap,UTF8ToString,stringToNewUTF8,HEAPF64,addFunction,removeFunction"
     "SHELL:-s ALLOW_TABLE_GROWTH=1")
 endif()

--- a/js/index.mjs
+++ b/js/index.mjs
@@ -108,8 +108,11 @@ export function compile(opts) {
  * @param {number} [opts.warmup=1000]
  * @param {number} [opts.samples=1000]
  * @param {number} [opts.delta=0.8]    Adaptation target acceptance (NUTS).
- * @param {string} [opts.sampler="nuts"]  "nuts" or "walnuts" (within-orbit
- *   adaptive step-length NUTS, arXiv:2506.18746).
+ * @param {string} [opts.sampler="nuts"]  "nuts", "walnuts" (within-orbit
+ *   adaptive step-length NUTS, arXiv:2506.18746), or "pathfinder"
+ *   (a normal approximation fitted along an L-BFGS path). Pathfinder
+ *   ignores warmup and delta, treats `samples` as its draw count, and
+ *   returns an extra `pathfinder` block.
  * @param {number} [opts.maxError]     WALNUTS only: largest drift in the
  *   joint log density allowed across one macro step before the step is
  *   halved within the trajectory. Omit for the runtime default (0.5).
@@ -118,9 +121,15 @@ export function compile(opts) {
  *   runs: {liveMeta: {names, warmup, samples}} once per call, then
  *   {live: {phase: "warmup"|"sampling", i, nCon?, rows?}} where rows is
  *   a transferred ArrayBuffer of constrained draws, nCon wide.
+ *   Pathfinder streams {live: {phase: "path", iter, lp}} instead, one
+ *   message per L-BFGS iterate.
  * @returns {Promise<{names: string[], samples: number,
  *                    columns: Object<string, Float64Array>,
  *                    exactLp: boolean,
+ *                    pathfinder?: {path: {iter, lp}[], khat: number,
+ *                                  selectedIter: number,
+ *                                  selectedElbo: number,
+ *                                  elapsedMs: number},
  *                    ms: {stanc: number, lower: number, sample: number,
  *                         total: number}}>}
  *   One column per CSV column CmdStan would write: constrained
@@ -139,15 +148,16 @@ export function sample(opts) {
     warmup: opts.warmup == null ? 1000 : opts.warmup,
     samples: opts.samples == null ? 1000 : opts.samples,
     delta: opts.delta == null ? 0.8 : opts.delta,
-    sampler: opts.sampler === "walnuts" ? "walnuts" : "nuts",
+    sampler: opts.sampler === "walnuts" || opts.sampler === "pathfinder"
+        ? opts.sampler : "nuts",
     maxError: opts.maxError == null ? 0 : opts.maxError,
   }, opts).then((done) => {
-    const { names, samples, ms, exactLp } = done;
+    const { names, samples, ms, exactLp, pathfinder } = done;
     const flat = new Float64Array(done.columns);
     const columns = {};
     names.forEach((name, i) => {
       columns[name] = flat.subarray(i * samples, (i + 1) * samples);
     });
-    return { names, samples, columns, ms, exactLp };
+    return { names, samples, columns, ms, exactLp, pathfinder };
   });
 }

--- a/js/worker.js
+++ b/js/worker.js
@@ -2,7 +2,8 @@
 // stanli.wasm lowers it and runs NUTS or WALNUTS. Everything heavy lives
 // here so the page never blocks. Protocol: {cmd: "run", code, dataJson,
 // seed, warmup, samples, delta, sampler, maxError} in; {status} progress
-// messages and one {done} or {error} out.
+// messages and one {done} or {error} out. `sampler` is "nuts",
+// "walnuts" or "pathfinder".
 "use strict";
 importScripts("stanli.js");
 
@@ -16,6 +17,35 @@ function ensureStanc() {
     importScripts("stancjs.bc.js");
 }
 
+
+// Pathfinder: one L-BFGS climb, a normal approximation fitted along it,
+// and draws from that approximation -- milliseconds, where a sampler
+// takes seconds. There is no warmup and no per-draw streaming to do,
+// but the climb itself streams out iterate by iterate so the page can
+// animate it.
+//
+// chain_id is 1, which is what stanli_sample_stream passes too, so
+// Pathfinder and a NUTS chain given the same seed start from the exact
+// same point. lp and lp_approx per draw are available from the same
+// call and left unasked-for here: k-hat, the one thing the page shows
+// them for, already comes back computed.
+function runPathfinder(M, model, req, numDraws, drawsPtr, errPtr, errLen) {
+  const sumPtr = M._malloc(8 * 4);
+  const path = [];
+  const cbPtr = M.addFunction((iter, lp) => {
+    path.push({ iter, lp });
+    if (req.live) postMessage({ live: { phase: "path", iter, lp } });
+  }, "vidi");
+  const rc = M._stanli_run_pathfinder(model, req.seed >>> 0, 1, numDraws,
+                                      drawsPtr, 0, 0, sumPtr, cbPtr, 0,
+                                      errPtr, errLen);
+  M.removeFunction(cbPtr);
+  const sum = Array.from(M.HEAPF64.subarray(sumPtr / 8, sumPtr / 8 + 4));
+  M._free(sumPtr);
+  if (rc !== 0) throw new Error(M.UTF8ToString(errPtr));
+  return { path, khat: sum[0], selectedIter: sum[1], selectedElbo: sum[2],
+           elapsedMs: sum[3] };
+}
 
 onmessage = async (e) => {
   const req = e.data;
@@ -69,9 +99,12 @@ onmessage = async (e) => {
     const n = Number(M._stanli_n_unconstrained(model));
     const samples = req.samples | 0;
     const warmup = req.warmup | 0;
+    const pathfinder = req.sampler === "pathfinder";
     const walnuts = req.sampler === "walnuts";
-    say((walnuts ? "WALNUTS: " : "NUTS: ") + warmup + " warmup + " +
-        samples + " draws");
+    say(pathfinder
+        ? "Pathfinder: L-BFGS path + " + samples + " draws"
+        : (walnuts ? "WALNUTS: " : "NUTS: ") + warmup + " warmup + " +
+          samples + " draws");
     const drawsPtr = M._malloc(8 * samples * n);
 
     // Stream: every draw lands in the buffer before its callback, so the
@@ -80,7 +113,7 @@ onmessage = async (e) => {
     // Streaming is opt-in: without a live consumer the sampler runs the
     // plain path and pays nothing for callbacks or message traffic.
     let cbPtr = 0, liveRowPtr = 0;
-    if (req.live) {
+    if (req.live && !pathfinder) {
     const nLive = Number(M._stanli_n_constrained(model));
     const liveNames = [];
     for (let i = 0; i < nLive; ++i)
@@ -111,16 +144,21 @@ onmessage = async (e) => {
     // Same streaming contract either way; WALNUTS's tunable is the max
     // Hamiltonian error per macro step rather than NUTS's target
     // acceptance rate, and 0 asks the runtime for its default.
-    const rc = walnuts
-        ? M._stanli_sample_walnuts_stream(model, req.seed >>> 0, warmup,
-                                          samples, +req.maxError || 0,
-                                          drawsPtr, cbPtr, 0, errPtr, errLen)
-        : M._stanli_sample_stream(model, req.seed >>> 0, warmup,
-                                  samples, +req.delta, drawsPtr,
-                                  cbPtr, 0, errPtr, errLen);
-    if (cbPtr) M.removeFunction(cbPtr);
-    if (liveRowPtr) M._free(liveRowPtr);
-    if (rc !== 0) throw new Error(M.UTF8ToString(errPtr));
+    let pf = null;
+    if (pathfinder) {
+      pf = runPathfinder(M, model, req, samples, drawsPtr, errPtr, errLen);
+    } else {
+      const rc = walnuts
+          ? M._stanli_sample_walnuts_stream(model, req.seed >>> 0, warmup,
+                                            samples, +req.maxError || 0,
+                                            drawsPtr, cbPtr, 0, errPtr, errLen)
+          : M._stanli_sample_stream(model, req.seed >>> 0, warmup,
+                                    samples, +req.delta, drawsPtr,
+                                    cbPtr, 0, errPtr, errLen);
+      if (cbPtr) M.removeFunction(cbPtr);
+      if (liveRowPtr) M._free(liveRowPtr);
+      if (rc !== 0) throw new Error(M.UTF8ToString(errPtr));
+    }
     const tSample = performance.now();
 
     say("computing CSV columns");
@@ -156,7 +194,7 @@ onmessage = async (e) => {
 
     postMessage({
       done: {
-        names, samples,
+        names, samples, pathfinder: pf,
         // True unless the runtime was built with STANLI_LITE_LP, which
         // drops stan-math's propto instantiations and shifts lp__ by a
         // per-model constant. The shipped browser build does not, so this

--- a/runtime/include/stanli/capi.h
+++ b/runtime/include/stanli/capi.h
@@ -272,6 +272,32 @@ int stanli_sample_walnuts_stream(stanli_model* m, uint32_t seed, int warmup,
                                  stanli_draw_cb cb, void* user, char* err,
                                  size_t err_len);
 
+/* Single-path Pathfinder: a normal approximation fitted along an L-BFGS
+ * path, drawn from in milliseconds where a sampler takes seconds. Draws
+ * come back UNCONSTRAINED, num_draws rows of stanli_n_unconstrained
+ * doubles, the same layout stanli_sample writes, so the same
+ * stanli_wa_row call constrains them.
+ *
+ * `lp` and `lp_approx` each receive num_draws doubles: the model's log
+ * density at the draw, and the approximation's. Their difference is the
+ * log importance ratio k-hat is fitted to. Either may be null.
+ *
+ * `cb`, when non-null, fires once per L-BFGS iterate as the optimizer
+ * climbs, which is the whole path -- there is no other way to get it.
+ *
+ * `summary` receives STANLI_N_PATHFINDER_SUMMARY doubles. */
+#define STANLI_PATHFINDER_KHAT 0
+#define STANLI_PATHFINDER_SELECTED_ITER 1
+#define STANLI_PATHFINDER_SELECTED_ELBO 2
+#define STANLI_PATHFINDER_ELAPSED_MS 3
+#define STANLI_N_PATHFINDER_SUMMARY 4
+typedef void (*stanli_path_cb)(int32_t iter, double lp, void* user);
+int stanli_run_pathfinder(stanli_model* m, uint32_t seed, int chain_id,
+                          int num_draws, double* draws, double* lp,
+                          double* lp_approx, double* summary,
+                          stanli_path_cb cb, void* user, char* err,
+                          size_t err_len);
+
 /* write_array: every CSV column CmdStan would emit for one draw --
  * constrained parameters, transformed parameters, generated quantities,
  * in CmdStan's column order. n_columns is 0 when the model has no

--- a/runtime/include/stanli/capi.h
+++ b/runtime/include/stanli/capi.h
@@ -294,9 +294,8 @@ int stanli_sample_walnuts_stream(stanli_model* m, uint32_t seed, int warmup,
 typedef void (*stanli_path_cb)(int32_t iter, double lp, void* user);
 int stanli_run_pathfinder(stanli_model* m, uint32_t seed, int chain_id,
                           int num_draws, double* draws, double* lp,
-                          double* lp_approx, double* summary,
-                          stanli_path_cb cb, void* user, char* err,
-                          size_t err_len);
+                          double* lp_approx, double* summary, stanli_path_cb cb,
+                          void* user, char* err, size_t err_len);
 
 /* write_array: every CSV column CmdStan would emit for one draw --
  * constrained parameters, transformed parameters, generated quantities,

--- a/runtime/include/stanli/estimate.hpp
+++ b/runtime/include/stanli/estimate.hpp
@@ -16,6 +16,7 @@
 #include <stanli/model_adapter.hpp>
 
 #include <cstdint>
+#include <functional>
 #include <string>
 #include <vector>
 
@@ -62,13 +63,66 @@ struct OptimizeResult {
 OptimizeResult run_optimize(Executor& ex, const WriteArray* wa,
                             const OptimizeConfig& cfg);
 
-// Pathfinder is NOT here yet, deliberately. ExecutorModel now satisfies
-// enough of the model concept for stan's service to compile and run
-// against it, but the draws come back empty -- the parameter writer is
-// never called -- and shipping an entry point that silently returns
-// nothing is worse than not shipping one. Multi-path additionally needs
-// real TBB, which this build stubs out (tests/tbb_stub.cpp), so its
-// tbb::parallel_for does not link at all.
+// ---- Pathfinder ------------------------------------------------------------
+// Single path only. Multi-path needs real TBB (tbb::parallel_for in
+// stan/services/pathfinder/multi.hpp, tbb::parallel_invoke in psis.hpp)
+// and this build stubs TBB out, so it does not link.
+
+struct PathfinderConfig {
+  uint32_t seed = 1;
+  // Pathfinder's `stride_id`, which is CmdStan's chain id: it selects the
+  // rng stream, so a matched (seed, chain_id) puts Pathfinder on the same
+  // starting point run_nuts and run_walnuts use.
+  int chain_id = 1;
+  int num_draws = 1000;
+  int num_elbo_draws = 25;
+  int num_iterations = 1000;
+  int history_size = 5;
+  double init_alpha = 0.001;
+  double tol_obj = 1e-12;
+  double tol_rel_obj = 1e4;
+  double tol_grad = 1e-8;
+  double tol_rel_grad = 1e7;
+  double tol_param = 1e-8;
+  double init_radius = 2.0;
+  const double* init = nullptr;  // unconstrained, or null for random
+};
+
+// One point on the L-BFGS path. `iter` 0 is the starting point.
+struct PathIterate {
+  int iter = 0;
+  double lp = 0;
+};
+
+// Called as each iterate is reached, for a live view of the climb.
+using PathObserver = std::function<void(const PathIterate&)>;
+
+struct PathfinderResult {
+  // Unconstrained, one vector per draw, the orientation run_nuts returns.
+  std::vector<std::vector<double>> draws;
+  std::vector<double> lp;         // the model's log density at each draw
+  std::vector<double> lp_approx;  // the normal approximation's, at each draw
+  std::vector<PathIterate> path;
+  // Index into `path` of the iterate whose approximation maximised the
+  // ELBO, and that ELBO. -1 and NaN when the run failed before choosing.
+  int selected_iter = -1;
+  double selected_elbo = 0;
+  // Pareto shape of the importance ratios lp - lp_approx. Above 0.7 the
+  // weights have no usable variance and the draws should not be trusted.
+  double khat = 0;
+  double elapsed_ms = 0;
+  int return_code = 0;  // 0 = success
+  std::string message;
+};
+
+PathfinderResult run_pathfinder(Executor& ex, const PathfinderConfig& cfg,
+                                const PathObserver& observe = {});
+
+// Zhang & Stephens (2009) profile-likelihood fit of a generalized Pareto
+// to the largest min(0.2 S, 3 sqrt(S)) of `log_ratios`, returning the
+// shape. NaN when there are too few points to fit. This is the tail
+// diagnostic from the PSIS paper (arXiv:1507.02646).
+double pareto_khat(std::vector<double> log_ratios);
 
 }  // namespace stanli
 

--- a/runtime/src/capi.cpp
+++ b/runtime/src/capi.cpp
@@ -270,6 +270,48 @@ int stanli_sample_walnuts_stream(stanli_model* m, uint32_t seed, int warmup,
   }
 }
 
+int stanli_run_pathfinder(stanli_model* m, uint32_t seed, int chain_id,
+                          int num_draws, double* draws, double* lp,
+                          double* lp_approx, double* summary,
+                          stanli_path_cb cb, void* user, char* err,
+                          size_t err_len) {
+  try {
+    stanli::PathfinderConfig cfg;
+    cfg.seed = seed;
+    cfg.chain_id = chain_id;
+    cfg.num_draws = num_draws;
+    stanli::PathObserver observe;
+    if (cb) {
+      observe = [&](const stanli::PathIterate& it) {
+        cb((int32_t)it.iter, it.lp, user);
+      };
+    }
+    stanli::PathfinderResult r =
+        stanli::run_pathfinder(*m->ex, cfg, observe);
+    if (r.return_code != 0) {
+      put_err(err, err_len,
+              r.message.empty() ? "pathfinder failed" : r.message.c_str());
+      return r.return_code;
+    }
+    const int64_t n = m->ex->n_params();
+    for (size_t s = 0; s < r.draws.size(); ++s) {
+      if (draws) std::memcpy(draws + s * n, r.draws[s].data(), sizeof(double) * n);
+      if (lp) lp[s] = r.lp[s];
+      if (lp_approx) lp_approx[s] = r.lp_approx[s];
+    }
+    if (summary) {
+      summary[STANLI_PATHFINDER_KHAT] = r.khat;
+      summary[STANLI_PATHFINDER_SELECTED_ITER] = r.selected_iter;
+      summary[STANLI_PATHFINDER_SELECTED_ELBO] = r.selected_elbo;
+      summary[STANLI_PATHFINDER_ELAPSED_MS] = r.elapsed_ms;
+    }
+    return 0;
+  } catch (const std::exception& e) {
+    put_err(err, err_len, e.what());
+    return 1;
+  }
+}
+
 void stanli_sample_opts_init(stanli_sample_opts* o) {
   if (o == nullptr) return;
   *o = stanli_sample_opts{};

--- a/runtime/src/capi.cpp
+++ b/runtime/src/capi.cpp
@@ -272,9 +272,8 @@ int stanli_sample_walnuts_stream(stanli_model* m, uint32_t seed, int warmup,
 
 int stanli_run_pathfinder(stanli_model* m, uint32_t seed, int chain_id,
                           int num_draws, double* draws, double* lp,
-                          double* lp_approx, double* summary,
-                          stanli_path_cb cb, void* user, char* err,
-                          size_t err_len) {
+                          double* lp_approx, double* summary, stanli_path_cb cb,
+                          void* user, char* err, size_t err_len) {
   try {
     stanli::PathfinderConfig cfg;
     cfg.seed = seed;
@@ -286,8 +285,7 @@ int stanli_run_pathfinder(stanli_model* m, uint32_t seed, int chain_id,
         cb((int32_t)it.iter, it.lp, user);
       };
     }
-    stanli::PathfinderResult r =
-        stanli::run_pathfinder(*m->ex, cfg, observe);
+    stanli::PathfinderResult r = stanli::run_pathfinder(*m->ex, cfg, observe);
     if (r.return_code != 0) {
       put_err(err, err_len,
               r.message.empty() ? "pathfinder failed" : r.message.c_str());
@@ -295,7 +293,8 @@ int stanli_run_pathfinder(stanli_model* m, uint32_t seed, int chain_id,
     }
     const int64_t n = m->ex->n_params();
     for (size_t s = 0; s < r.draws.size(); ++s) {
-      if (draws) std::memcpy(draws + s * n, r.draws[s].data(), sizeof(double) * n);
+      if (draws)
+        std::memcpy(draws + s * n, r.draws[s].data(), sizeof(double) * n);
       if (lp) lp[s] = r.lp[s];
       if (lp_approx) lp_approx[s] = r.lp_approx[s];
     }

--- a/runtime/src/pathfinder.cpp
+++ b/runtime/src/pathfinder.cpp
@@ -1,0 +1,275 @@
+#include <stanli/estimate.hpp>
+
+#include "initialize.hpp"
+
+#include <stan/callbacks/interrupt.hpp>
+#include <stan/callbacks/logger.hpp>
+#include <stan/callbacks/structured_writer.hpp>
+#include <stan/callbacks/writer.hpp>
+#include <stan/io/array_var_context.hpp>
+#include <stan/io/empty_var_context.hpp>
+#include <stan/services/pathfinder/single.hpp>
+
+#include <algorithm>
+#include <chrono>
+#include <cmath>
+#include <cstdlib>
+#include <limits>
+
+namespace stanli {
+
+namespace {
+
+constexpr double kNaN = std::numeric_limits<double>::quiet_NaN();
+
+// The collector the previous attempt got wrong, and the reason its draws
+// came back empty: pathfinder writes each draw as an Eigen ROW vector
+// (`Eigen::Matrix<double, 1, -1>`), and every operator() on
+// stan::callbacks::writer is a no-op unless overridden. A collector that
+// only overrode the std::vector<double> form silently discarded the whole
+// run. The header row arrives as a vector of strings, and write_times
+// afterwards uses the string and no-argument forms, which stay no-ops.
+//
+// Row layout, fixed by the service: lp_approx__, lp__, path__, then one
+// column per constrained parameter. With no write_array attached the
+// model's write_array is the identity, so those columns are the
+// unconstrained draw.
+class DrawCollector : public stan::callbacks::writer {
+ public:
+  // Every base overload stays reachable: declaring one hides the rest,
+  // and write_times uses the string and no-argument forms.
+  using stan::callbacks::writer::operator();
+
+  void operator()(const std::vector<std::string>& names) override {
+    n_params_ = (int)names.size() - kLeadingColumns;
+  }
+  void operator()(const Eigen::Matrix<double, 1, -1>& row) override {
+    if (row.size() < kLeadingColumns) return;
+    lp_approx.push_back(row(0));
+    lp.push_back(row(1));
+    draws.emplace_back(row.data() + kLeadingColumns, row.data() + row.size());
+  }
+
+  int n_params() const { return n_params_; }
+
+  std::vector<std::vector<double>> draws;
+  std::vector<double> lp;
+  std::vector<double> lp_approx;
+
+ private:
+  static constexpr int kLeadingColumns = 3;  // lp_approx__, lp__, path__
+  int n_params_ = 0;
+};
+
+// The L-BFGS path, from the service's save_iterations diagnostics.
+//
+// Records arrive as they are produced, so the observer fires live. Stan
+// keys a record by the iteration just completed but fills it with the
+// point from BEFORE that step, so record k holds iterate k-1 and record
+// "0" holds the same starting point as record 1. That also means the
+// optimizer's final point is never written: the path ends one iterate
+// short, which is why run_pathfinder clamps the selected index into it.
+class PathCollector : public stan::callbacks::structured_writer {
+ public:
+  PathCollector(Executor& ex, const PathObserver& observe)
+      : ex_(&ex), observe_(observe) {}
+
+  // The service writes a dozen other keys through the base no-ops.
+  using stan::callbacks::structured_writer::begin_record;
+  using stan::callbacks::structured_writer::write;
+
+  void begin_record(const std::string& key) override {
+    record_ = std::atoi(key.c_str());
+  }
+  void write(const std::string& key, const Eigen::VectorXd& vec) override {
+    if (key != "unconstrained_parameters") return;
+    const int iter = record_ > 0 ? record_ - 1 : 0;
+    if (iter != (int)path.size()) return;  // record 1 repeats record 0
+    PathIterate it;
+    it.iter = iter;
+    it.lp = lp_at(vec);
+    path.push_back(it);
+    if (observe_) observe_(it);
+  }
+
+  std::vector<PathIterate> path;
+
+ private:
+  double lp_at(const Eigen::VectorXd& q) const {
+    // Safe between L-BFGS steps: every evaluation writes the whole
+    // parameter buffer before reading it, so borrowing it here cannot
+    // leave the optimizer looking at someone else's point.
+    for (Eigen::Index i = 0; i < q.size(); ++i) ex_->params_data()[i] = q(i);
+    try {
+      return ex_->forward();
+    } catch (const std::exception&) {
+      return -std::numeric_limits<double>::infinity();
+    }
+  }
+
+  Executor* ex_;
+  PathObserver observe_;
+  int record_ = 0;
+};
+
+// The ELBO-selected iterate and its ELBO reach no writer; the service
+// reports them only in this one info message, emitted when refresh is
+// nonzero. Errors are kept for PathfinderResult::message.
+class PathLogger : public stan::callbacks::logger {
+ public:
+  void info(const std::string& message) override {
+    const auto at = message.find("Best Iter: [");
+    if (at == std::string::npos) return;
+    int iter = 0;
+    double elbo = 0;
+    if (std::sscanf(message.c_str() + at, "Best Iter: [%d] ELBO (%lf)", &iter,
+                    &elbo) == 2) {
+      best_iter = iter;
+      best_elbo = elbo;
+    }
+  }
+  void info(const std::stringstream& message) override { info(message.str()); }
+  void error(const std::string& message) override {
+    if (!errors.empty()) errors += "; ";
+    errors += message;
+  }
+  void error(const std::stringstream& message) override { error(message.str()); }
+
+  int best_iter = -1;
+  double best_elbo = kNaN;
+  std::string errors;
+};
+
+// util::initialize reaches an explicit init only through transform_inits,
+// which ExecutorModel refuses because it has no inverse transforms. The
+// point here is already unconstrained, so it needs no transform at all.
+class PathfinderModel : public ExecutorModel {
+ public:
+  PathfinderModel(Executor& ex, const double* init)
+      : ExecutorModel(ex), init_(init) {}
+
+  template <typename Context>
+  void transform_inits(const Context& /*context*/,
+                       std::vector<int>& /*params_i*/,
+                       std::vector<double>& params_r,
+                       std::ostream* /*msgs*/ = nullptr) const {
+    params_r.assign(init_, init_ + num_params_r());
+  }
+
+ private:
+  const double* init_;
+};
+
+}  // namespace
+
+PathfinderResult run_pathfinder(Executor& ex, const PathfinderConfig& cfg,
+                                const PathObserver& observe) {
+  PathfinderResult out;
+  out.selected_elbo = kNaN;
+  out.khat = kNaN;
+
+  PathfinderModel model(ex, cfg.init);
+  DrawCollector draws;
+  PathCollector path(ex, observe);
+  PathLogger logger;
+  stan::callbacks::writer init_writer;
+  stan::callbacks::interrupt interrupt;
+
+  // An empty context leaves initialization to the service's own uniform
+  // draw, which is byte for byte the one cmdstan_init_point makes for the
+  // same (seed, chain_id): same create_rng stream, same distribution over
+  // the same parameters, same finiteness retry. That is what puts
+  // Pathfinder on NUTS's starting point.
+  stan::io::empty_var_context empty;
+  std::vector<std::string> names;
+  std::vector<std::vector<size_t>> dims;
+  std::vector<double> values;
+  if (cfg.init != nullptr) {
+    model.unconstrained_param_names(names);
+    dims.assign(names.size(), std::vector<size_t>{});
+    values.assign(cfg.init, cfg.init + names.size());
+  }
+  stan::io::array_var_context fixed(names, values, dims);
+  const stan::io::var_context& init =
+      cfg.init != nullptr ? (const stan::io::var_context&)fixed
+                          : (const stan::io::var_context&)empty;
+
+  const auto start = std::chrono::steady_clock::now();
+  try {
+    out.return_code = stan::services::pathfinder::pathfinder_lbfgs_single(
+        model, init, cfg.seed, (unsigned int)cfg.chain_id, cfg.init_radius,
+        cfg.history_size, cfg.init_alpha, cfg.tol_obj, cfg.tol_rel_obj,
+        cfg.tol_grad, cfg.tol_rel_grad, cfg.tol_param, cfg.num_iterations,
+        cfg.num_elbo_draws, cfg.num_draws, /*save_iterations=*/true,
+        /*refresh=*/1, interrupt, logger, init_writer, draws, path);
+  } catch (const std::exception& e) {
+    out.return_code = 1;
+    out.message = e.what();
+  }
+  out.elapsed_ms =
+      std::chrono::duration<double, std::milli>(
+          std::chrono::steady_clock::now() - start)
+          .count();
+
+  out.draws = std::move(draws.draws);
+  out.lp = std::move(draws.lp);
+  out.lp_approx = std::move(draws.lp_approx);
+  out.path = std::move(path.path);
+  if (out.message.empty()) out.message = logger.errors;
+  if (!out.path.empty() && logger.best_iter >= 0) {
+    out.selected_iter = std::min(logger.best_iter, (int)out.path.size() - 1);
+    out.selected_elbo = logger.best_elbo;
+  }
+
+  std::vector<double> ratios(out.lp.size());
+  for (size_t i = 0; i < ratios.size(); ++i) ratios[i] = out.lp[i] - out.lp_approx[i];
+  out.khat = pareto_khat(std::move(ratios));
+  return out;
+}
+
+// Zhang & Stephens (2009), as the loo package implements it: a grid of
+// candidate theta, each scored by the profile log likelihood of the
+// generalized Pareto with that theta, then averaged with the resulting
+// weights. The final shrink toward 0.5 is the weakly informative prior
+// the PSIS paper recommends for small tails.
+double pareto_khat(std::vector<double> log_ratios) {
+  const double S = (double)log_ratios.size();
+  const size_t M = (size_t)std::min(0.2 * S, 3.0 * std::sqrt(S));
+  if (M < 5) return kNaN;
+  std::sort(log_ratios.begin(), log_ratios.end());
+  const size_t start = log_ratios.size() - M;
+  const double cutoff = log_ratios[start - 1];
+  std::vector<double> x(M);
+  for (size_t i = 0; i < M; ++i) x[i] = log_ratios[start + i] - cutoff;
+
+  const double N = (double)M;
+  const size_t grid = 30 + (size_t)std::sqrt(N);
+  const double xstar = x[(size_t)std::floor(N / 4.0 + 0.5) - 1];
+  // A tail with no spread, which is what an exact approximation gives:
+  // the ratios are constant, the weights are uniform, and there is no
+  // shape to fit. The fit itself would divide by this scale.
+  if (!(xstar > 0)) return 0.0;
+  std::vector<double> theta(grid), k(grid), profile(grid);
+  for (size_t j = 0; j < grid; ++j) {
+    theta[j] = 1.0 / x.back() +
+               (1.0 - std::sqrt((double)grid / ((double)j + 0.5))) / (3 * xstar);
+    double mean = 0;
+    for (double v : x) mean += std::log1p(-theta[j] * v);
+    k[j] = mean / N;
+    profile[j] = N * (std::log(-theta[j] / k[j]) - k[j] - 1);
+  }
+  const double top = *std::max_element(profile.begin(), profile.end());
+  double norm = 0, theta_hat = 0;
+  for (size_t j = 0; j < grid; ++j) norm += std::exp(profile[j] - top);
+  for (size_t j = 0; j < grid; ++j)
+    theta_hat += theta[j] * std::exp(profile[j] - top) / norm;
+
+  double khat = 0;
+  for (double v : x) khat += std::log1p(-theta_hat * v);
+  khat /= N;
+  const double prior_weight = 10.0;
+  return khat * N / (N + prior_weight) +
+         prior_weight * 0.5 / (N + prior_weight);
+}
+
+}  // namespace stanli

--- a/runtime/src/pathfinder.cpp
+++ b/runtime/src/pathfinder.cpp
@@ -133,7 +133,9 @@ class PathLogger : public stan::callbacks::logger {
     if (!errors.empty()) errors += "; ";
     errors += message;
   }
-  void error(const std::stringstream& message) override { error(message.str()); }
+  void error(const std::stringstream& message) override {
+    error(message.str());
+  }
 
   int best_iter = -1;
   double best_elbo = kNaN;
@@ -190,9 +192,9 @@ PathfinderResult run_pathfinder(Executor& ex, const PathfinderConfig& cfg,
     values.assign(cfg.init, cfg.init + names.size());
   }
   stan::io::array_var_context fixed(names, values, dims);
-  const stan::io::var_context& init =
-      cfg.init != nullptr ? (const stan::io::var_context&)fixed
-                          : (const stan::io::var_context&)empty;
+  const stan::io::var_context& init = cfg.init != nullptr
+                                          ? (const stan::io::var_context&)fixed
+                                          : (const stan::io::var_context&)empty;
 
   const auto start = std::chrono::steady_clock::now();
   try {
@@ -206,10 +208,9 @@ PathfinderResult run_pathfinder(Executor& ex, const PathfinderConfig& cfg,
     out.return_code = 1;
     out.message = e.what();
   }
-  out.elapsed_ms =
-      std::chrono::duration<double, std::milli>(
-          std::chrono::steady_clock::now() - start)
-          .count();
+  out.elapsed_ms = std::chrono::duration<double, std::milli>(
+                       std::chrono::steady_clock::now() - start)
+                       .count();
 
   out.draws = std::move(draws.draws);
   out.lp = std::move(draws.lp);
@@ -222,7 +223,8 @@ PathfinderResult run_pathfinder(Executor& ex, const PathfinderConfig& cfg,
   }
 
   std::vector<double> ratios(out.lp.size());
-  for (size_t i = 0; i < ratios.size(); ++i) ratios[i] = out.lp[i] - out.lp_approx[i];
+  for (size_t i = 0; i < ratios.size(); ++i)
+    ratios[i] = out.lp[i] - out.lp_approx[i];
   out.khat = pareto_khat(std::move(ratios));
   return out;
 }
@@ -251,8 +253,9 @@ double pareto_khat(std::vector<double> log_ratios) {
   if (!(xstar > 0)) return 0.0;
   std::vector<double> theta(grid), k(grid), profile(grid);
   for (size_t j = 0; j < grid; ++j) {
-    theta[j] = 1.0 / x.back() +
-               (1.0 - std::sqrt((double)grid / ((double)j + 0.5))) / (3 * xstar);
+    theta[j] =
+        1.0 / x.back() +
+        (1.0 - std::sqrt((double)grid / ((double)j + 0.5))) / (3 * xstar);
     double mean = 0;
     for (double v : x) mean += std::log1p(-theta[j] * v);
     k[j] = mean / N;

--- a/tests/test_capi.cpp
+++ b/tests/test_capi.cpp
@@ -403,8 +403,7 @@ void expect_pathfinder() {
   }
   const double khat = summary[STANLI_PATHFINDER_KHAT];
   const double selected = summary[STANLI_PATHFINDER_SELECTED_ITER];
-  if (!std::isfinite(khat) || selected < 0 ||
-      selected >= (double)path.size() ||
+  if (!std::isfinite(khat) || selected < 0 || selected >= (double)path.size() ||
       !std::isfinite(summary[STANLI_PATHFINDER_SELECTED_ELBO]) ||
       !(summary[STANLI_PATHFINDER_ELAPSED_MS] >= 0)) {
     ++failures;

--- a/tests/test_capi.cpp
+++ b/tests/test_capi.cpp
@@ -15,6 +15,7 @@
 #include <fstream>
 #include <limits>
 #include <sstream>
+#include <utility>
 #include <string>
 #include <vector>
 
@@ -350,6 +351,69 @@ void expect_necessity_effects_refused() {
   }
 }
 
+// Pathfinder across the ABI: draws, the per-draw log densities, the
+// summary block, and the per-iterate callback that lets a caller animate
+// the climb. The statistics are test_pathfinder's job; what this pins is
+// that the shipped boundary hands all of it back.
+void expect_pathfinder() {
+  const std::string mir = slurp("tests/fixtures/es.tmir.sexp");
+  const std::string data = slurp("tests/fixtures/eight_schools.json");
+  char err[8192]{};
+  stanli_model* model =
+      stanli_model_new(mir.c_str(), data.c_str(), err, sizeof err);
+  if (model == nullptr) {
+    ++failures;
+    std::printf("FAIL C API pathfinder construction: %s\n", err);
+    return;
+  }
+  const int64_t n = stanli_n_unconstrained(model);
+  const int num_draws = 200;
+  std::vector<double> draws((size_t)(num_draws * n));
+  std::vector<double> lp(num_draws), lp_approx(num_draws);
+  double summary[STANLI_N_PATHFINDER_SUMMARY]{};
+  std::vector<std::pair<int32_t, double>> path;
+  const auto on_iter = [](int32_t iter, double value, void* user) {
+    static_cast<std::vector<std::pair<int32_t, double>>*>(user)->emplace_back(
+        iter, value);
+  };
+  const int rc = stanli_run_pathfinder(model, 4242, 1, num_draws, draws.data(),
+                                       lp.data(), lp_approx.data(), summary,
+                                       on_iter, &path, err, sizeof err);
+  if (rc != 0) {
+    ++failures;
+    std::printf("FAIL C API pathfinder: %s\n", err);
+    stanli_model_free(model);
+    return;
+  }
+  bool all_finite = true;
+  for (double v : draws) all_finite &= std::isfinite(v);
+  for (double v : lp) all_finite &= std::isfinite(v);
+  for (double v : lp_approx) all_finite &= std::isfinite(v);
+  if (!all_finite) {
+    ++failures;
+    std::printf("FAIL C API pathfinder produced nonfinite output\n");
+  }
+  if (path.size() < 2) {
+    ++failures;
+    std::printf("FAIL C API pathfinder path: %zu iterates\n", path.size());
+  } else if (path[0].first != 0) {
+    ++failures;
+    std::printf("FAIL C API pathfinder path starts at iterate %d\n",
+                path[0].first);
+  }
+  const double khat = summary[STANLI_PATHFINDER_KHAT];
+  const double selected = summary[STANLI_PATHFINDER_SELECTED_ITER];
+  if (!std::isfinite(khat) || selected < 0 ||
+      selected >= (double)path.size() ||
+      !std::isfinite(summary[STANLI_PATHFINDER_SELECTED_ELBO]) ||
+      !(summary[STANLI_PATHFINDER_ELAPSED_MS] >= 0)) {
+    ++failures;
+    std::printf("FAIL C API pathfinder summary: khat %g selected %g\n", khat,
+                selected);
+  }
+  stanli_model_free(model);
+}
+
 }  // namespace
 
 int main() {
@@ -388,6 +452,7 @@ int main() {
   expect_categorical_check();
   expect_categorical_interpreted_write_array();
   expect_necessity_effects_refused();
+  expect_pathfinder();
 
   if (failures == 0) std::printf("test_capi OK\n");
   return failures == 0 ? 0 : 1;

--- a/tests/test_pathfinder.cpp
+++ b/tests/test_pathfinder.cpp
@@ -209,8 +209,8 @@ int main() {
     PathfinderConfig cfg;
     cfg.seed = 4242;
     cfg.num_draws = 100;
-    PathfinderResult r =
-        run_pathfinder(ex, cfg, [&](const PathIterate& it) { seen.push_back(it); });
+    PathfinderResult r = run_pathfinder(
+        ex, cfg, [&](const PathIterate& it) { seen.push_back(it); });
     expect("observer saw every iterate", seen.size() == r.path.size());
     for (size_t i = 0; i < seen.size() && i < r.path.size(); ++i)
       expect("observer iterate " + std::to_string(i),

--- a/tests/test_pathfinder.cpp
+++ b/tests/test_pathfinder.cpp
@@ -1,0 +1,247 @@
+// Single-path Pathfinder end to end through stan's own service driving the
+// executor's gradient, plus the Pareto k-hat diagnostic that says whether
+// its draws are worth trusting.
+//
+// Pathfinder is an approximation, so the checks are looser than the
+// sampler tests: what they pin down is that draws arrive at all (the
+// service writes them through an Eigen row-vector overload that a
+// std::vector-only collector drops on the floor), that they land on the
+// right posterior, and that the init is the one NUTS would have used.
+#include "models.hpp"
+
+#include <stanli/estimate.hpp>
+#include <stanli/nuts.hpp>
+
+#include <algorithm>
+#include <cmath>
+#include <cstdio>
+#include <random>
+#include <string>
+#include <vector>
+
+static int failures = 0;
+static void expect(const std::string& what, bool ok) {
+  if (!ok) {
+    ++failures;
+    std::printf("FAIL %s\n", what.c_str());
+  }
+}
+static void expect_in(const std::string& what, double got, double lo,
+                      double hi) {
+  if (!(got >= lo && got <= hi)) {
+    ++failures;
+    std::printf("FAIL %-28s got %.6g want in [%g, %g]\n", what.c_str(), got, lo,
+                hi);
+  }
+}
+
+static stanli::Graph std_normal_graph(int D) {
+  using namespace stanli;
+  Graph g;
+  const int x = g.add_slot(D, true);
+  const int zero = g.add_slot(1, false);
+  const int one = g.add_slot(1, false);
+  const int lp = g.add_slot(1, false);
+  g.add_op(OP_NORMAL_LPDF, {x, zero, one}, lp);
+  g.result_slot = lp;
+  return g;
+}
+
+int main() {
+  using namespace stanli;
+
+  // ---- 10-dim standard normal: Pathfinder's target case -----------------
+  // A Gaussian posterior is exactly what the Taylor approximation along
+  // the L-BFGS path represents, so the draws should be near-exact and
+  // k-hat should say so.
+  {
+    const int D = 10;
+    Executor ex(std_normal_graph(D));
+    ex.value_ptr(1)[0] = 0.0;
+    ex.value_ptr(2)[0] = 1.0;
+
+    PathfinderConfig cfg;
+    cfg.seed = 20260815;
+    cfg.num_draws = 2000;
+    PathfinderResult r = run_pathfinder(ex, cfg);
+    expect("normal return code " + std::to_string(r.return_code),
+           r.return_code == 0);
+    expect("normal draw count " + std::to_string(r.draws.size()),
+           (int)r.draws.size() == cfg.num_draws);
+    expect("normal lp per draw", r.lp.size() == r.draws.size());
+    expect("normal lp_approx per draw", r.lp_approx.size() == r.draws.size());
+    if (r.draws.empty()) {
+      std::printf("%d failures\n", ++failures);
+      return 1;
+    }
+    for (int d = 0; d < D; ++d) {
+      double m = 0, m2 = 0;
+      for (const auto& q : r.draws) m += q[d];
+      m /= r.draws.size();
+      for (const auto& q : r.draws) m2 += (q[d] - m) * (q[d] - m);
+      const double sd = std::sqrt(m2 / (r.draws.size() - 1));
+      expect_in("norm mean[" + std::to_string(d) + "]", m, -0.15, 0.15);
+      expect_in("norm sd[" + std::to_string(d) + "]", sd, 0.85, 1.15);
+    }
+    expect_in("norm khat", r.khat, -1.0, 0.5);
+    expect("norm path non-empty", !r.path.empty());
+    expect("norm selected iterate in path",
+           r.selected_iter >= 0 && r.selected_iter < (int)r.path.size());
+  }
+
+  // ---- eight schools: a funnel, which Pathfinder approximates badly ----
+  // The band is far wider and far lower than the sampler tests' [2.5, 6.5]
+  // because a single normal approximation cannot cover this posterior: it
+  // lands near mu = 1.5 with a quarter of NUTS's spread. That is the
+  // method, not the wiring, and it is exactly what the comparison view is
+  // for. k-hat stays small because a narrow proposal has light importance
+  // ratios -- it says the weights are stable, never that they cover.
+  {
+    auto m = testmodels::eight_schools();
+    Executor ex(std::move(m.graph));
+    testmodels::fill_eight_schools_data(m, ex);
+
+    PathfinderConfig cfg;
+    cfg.seed = 8675309;
+    cfg.num_draws = 2000;
+    PathfinderResult r = run_pathfinder(ex, cfg);
+    expect("es return code " + std::to_string(r.return_code),
+           r.return_code == 0);
+    if (r.draws.empty()) {
+      std::printf("%d failures\n", ++failures);
+      return 1;
+    }
+    double mu_mean = 0;
+    int nan_count = 0;
+    for (const auto& q : r.draws) {
+      for (double v : q)
+        if (std::isnan(v)) ++nan_count;
+      mu_mean += q[0];
+    }
+    mu_mean /= r.draws.size();
+    expect_in("es nan_count", nan_count, 0, 0);
+    expect_in("es mu mean", mu_mean, -1.0, 4.0);
+    expect("es khat finite", std::isfinite(r.khat));
+
+    // The path climbs: the ELBO picks an iterate on the way up, never the
+    // starting point the optimizer was handed.
+    expect("es path non-empty", r.path.size() > 1);
+    expect("es selected iterate in path",
+           r.selected_iter > 0 && r.selected_iter < (int)r.path.size());
+    if (r.selected_iter > 0 && r.selected_iter < (int)r.path.size())
+      expect("es selected lp above the start",
+             r.path[(size_t)r.selected_iter].lp > r.path[0].lp);
+    expect("es selected elbo finite", std::isfinite(r.selected_elbo));
+  }
+
+  // ---- determinism -----------------------------------------------------
+  {
+    Executor ex(std_normal_graph(3));
+    ex.value_ptr(1)[0] = 0.0;
+    ex.value_ptr(2)[0] = 1.0;
+
+    PathfinderConfig a;
+    a.seed = 7;
+    a.num_draws = 50;
+    PathfinderResult r1 = run_pathfinder(ex, a);
+    PathfinderResult r2 = run_pathfinder(ex, a);
+    expect("same seed, same draws", r1.draws == r2.draws);
+
+    PathfinderConfig b = a;
+    b.seed = 8;
+    PathfinderResult r3 = run_pathfinder(ex, b);
+    expect("new seed, new draws", r1.draws != r3.draws);
+  }
+
+  // ---- inits are shared with NUTS --------------------------------------
+  // The comparison contract, same as WALNUTS's: for a matched (seed,
+  // chain_id) Pathfinder starts its L-BFGS from the exact point run_nuts
+  // draws, so a NUTS-vs-Pathfinder run compares methods and not starting
+  // places. Path iterate 0 is that point, so its lp is the oracle.
+  {
+    Executor ex(std_normal_graph(4));
+    ex.value_ptr(1)[0] = 0.0;
+    ex.value_ptr(2)[0] = 1.0;
+
+    PathfinderConfig cfg;
+    cfg.seed = 99;
+    cfg.chain_id = 3;
+    cfg.num_draws = 50;
+    PathfinderResult r = run_pathfinder(ex, cfg);
+    const auto p = cmdstan_init_point(ex, cfg.seed, cfg.chain_id,
+                                      cfg.init_radius, nullptr);
+    for (size_t i = 0; i < p.size(); ++i) ex.params_data()[i] = p[i];
+    const double init_lp = ex.forward();
+    expect("path non-empty", !r.path.empty());
+    if (!r.path.empty())
+      expect_in("path starts at the NUTS init", r.path[0].lp, init_lp - 1e-8,
+                init_lp + 1e-8);
+  }
+
+  // ---- explicit init ---------------------------------------------------
+  {
+    Executor ex(std_normal_graph(2));
+    ex.value_ptr(1)[0] = 0.0;
+    ex.value_ptr(2)[0] = 1.0;
+
+    const double start[2] = {1.5, -1.5};
+    PathfinderConfig cfg;
+    cfg.seed = 11;
+    cfg.num_draws = 50;
+    cfg.init = start;
+    PathfinderResult r = run_pathfinder(ex, cfg);
+    ex.params_data()[0] = start[0];
+    ex.params_data()[1] = start[1];
+    const double want = ex.forward();
+    expect("explicit init path non-empty", !r.path.empty());
+    if (!r.path.empty())
+      expect_in("path starts at the explicit init", r.path[0].lp, want - 1e-8,
+                want + 1e-8);
+  }
+
+  // ---- per-iterate observer fires live ---------------------------------
+  {
+    auto m = testmodels::eight_schools();
+    Executor ex(std::move(m.graph));
+    testmodels::fill_eight_schools_data(m, ex);
+
+    std::vector<PathIterate> seen;
+    PathfinderConfig cfg;
+    cfg.seed = 4242;
+    cfg.num_draws = 100;
+    PathfinderResult r =
+        run_pathfinder(ex, cfg, [&](const PathIterate& it) { seen.push_back(it); });
+    expect("observer saw every iterate", seen.size() == r.path.size());
+    for (size_t i = 0; i < seen.size() && i < r.path.size(); ++i)
+      expect("observer iterate " + std::to_string(i),
+             seen[i].iter == r.path[i].iter && seen[i].lp == r.path[i].lp);
+  }
+
+  // ---- pareto_khat -----------------------------------------------------
+  // An exponential sample has an exactly exponential tail, which is the
+  // generalized Pareto with shape 0.
+  {
+    std::mt19937 rng(5);
+    std::exponential_distribution<double> exp1(1.0);
+    std::vector<double> x(4000);
+    for (double& v : x) v = exp1(rng);
+    expect_in("khat of an exponential tail", pareto_khat(x), -0.2, 0.2);
+
+    // A Cauchy tail is Pareto with shape 1: heavy enough that importance
+    // weights have no variance.
+    std::cauchy_distribution<double> cauchy(0.0, 1.0);
+    std::vector<double> c(4000);
+    for (double& v : c) v = cauchy(rng);
+    expect_in("khat of a Cauchy tail", pareto_khat(c), 0.7, 1.4);
+
+    expect("khat of too few points is not a number",
+           std::isnan(pareto_khat(std::vector<double>{1.0, 2.0, 3.0})));
+  }
+
+  if (failures) {
+    std::printf("%d failures\n", failures);
+    return 1;
+  }
+  std::printf("OK\n");
+  return 0;
+}

--- a/tests/test_wasm.cjs
+++ b/tests/test_wasm.cjs
@@ -85,7 +85,39 @@ createStanli().then((M) => {
   const muW = muSumW / samples;
   if (!(muW > 3.0 && muW < 6.0)) fail("walnuts mu " + muW + " outside (3, 6)");
 
+  // Pathfinder through the entry the worker calls, including the
+  // per-iterate callback: the path is the only way that data leaves the
+  // service, so a silent no-op callback would be an empty plot with no
+  // other symptom.
+  const sumPtr = M._malloc(8 * 4);
+  const climb = [];
+  const cbPtr = M.addFunction((iter, plp) => climb.push([iter, plp]), "vidi");
+  const rcP = M._stanli_run_pathfinder(model, 1, 1, samples, drawsPtr, 0, 0,
+                                       sumPtr, cbPtr, 0, errPtr, errLen);
+  M.removeFunction(cbPtr);
+  if (rcP !== 0) fail("pathfinder: " + M.UTF8ToString(errPtr));
+  if (climb.length < 2) fail("pathfinder path has " + climb.length + " iterates");
+  if (climb[0][0] !== 0) fail("pathfinder path starts at " + climb[0][0]);
+  const khat = M.HEAPF64[sumPtr / 8];
+  const selected = M.HEAPF64[sumPtr / 8 + 1];
+  if (!Number.isFinite(khat)) fail("pathfinder khat " + khat);
+  if (!(selected >= 0 && selected < climb.length))
+    fail("pathfinder selected iterate " + selected);
+  let muSumP = 0;
+  for (let s = 0; s < samples; ++s) {
+    M._stanli_constrain(model, drawsPtr + 8 * s * n, rowPtr);
+    const v = M.HEAPF64[rowPtr / 8 + muIdx];
+    if (!Number.isFinite(v)) fail("pathfinder nonfinite draw " + s);
+    muSumP += v;
+  }
+  const muP = muSumP / samples;
+  const pfMs = M.HEAPF64[sumPtr / 8 + 3];
+  M._free(sumPtr);
+
   M._stanli_model_free(model);
   console.log("test_wasm OK  lp(0) = " + lp.toFixed(6) + "  mean(mu) = " +
-              mu.toFixed(3) + "  walnuts mean(mu) = " + muW.toFixed(3));
+              mu.toFixed(3) + "  walnuts mean(mu) = " + muW.toFixed(3) +
+              "  pathfinder mean(mu) = " + muP.toFixed(3) +
+              " in " + pfMs.toFixed(0) + " ms" +
+              " (khat " + khat.toFixed(2) + ", " + climb.length + " iterates)");
 }).catch((e) => fail(String(e && e.stack || e)));

--- a/tools/exported_symbols.def
+++ b/tools/exported_symbols.def
@@ -22,6 +22,7 @@ EXPORTS
   stanli_sample
   stanli_sample_stream
   stanli_sample_walnuts_stream
+  stanli_run_pathfinder
   stanli_n_constrained
   stanli_constrained_name
   stanli_constrain

--- a/web/index.html
+++ b/web/index.html
@@ -74,6 +74,15 @@
   /* A wide summary table scrolls inside its own column instead of
      overlapping its neighbor. */
   .cmp .ctable { overflow-x: auto; }
+  /* NUTS vs Pathfinder shares ONE table under both columns: the row is a
+     comparison, not two independent summaries side by side. */
+  .cmpsum { overflow-x: auto; margin-top: .6rem; }
+  .cmpsum table { margin: 0 auto; }
+  .cap { font-size: .75rem; opacity: .65; margin: -.35rem 0 .5rem; }
+  .khat { font-weight: 600; }
+  .khat.ok { color: #2a7; }
+  .khat.warn { color: #b81; }
+  .khat.bad { color: #c33; }
   /* The model picker: a text input that filters a listbox under it, so
      120 models stay reachable by typing instead of by scrolling. */
   .combo { position: relative; }
@@ -113,8 +122,9 @@
 <p class="sub">No server, no C++ toolchain;
 everything below happens in this tab, runs in the browser, samples on your machine.
 stanc3 (OCaml&rarr;JS) compiles the model, stanli.wasm lowers it to an op graph and runs
-Stan-dard Dynamic HMC or <a href="https://arxiv.org/abs/2506.18746">WALNUTS</a>
-&mdash; or both at once, side by side.
+Stan-dard Dynamic HMC, <a href="https://arxiv.org/abs/2506.18746">WALNUTS</a>
+or <a href="https://arxiv.org/abs/2108.03782">Pathfinder</a>
+&mdash; or a pair of them at once, side by side.
 <p class="sub">And it's often FASTER?? </p>
 <a href="https://github.com/seantalts/stanli">github.com/seantalts/stanli</a>
 &middot; <a href="https://www.npmjs.com/package/@seantalts/stanli">npm</a>
@@ -133,6 +143,8 @@ Stan-dard Dynamic HMC or <a href="https://arxiv.org/abs/2506.18746">WALNUTS</a>
     <option value="nuts">Stan-dard Dynamic HMC</option>
     <option value="walnuts">WALNUTS</option>
     <option value="both">both, side by side</option>
+    <option value="pathfinder">Pathfinder</option>
+    <option value="nutspf">NUTS vs Pathfinder, side by side</option>
   </select></label>
   <label class="combo" for="model">model
     <input id="model" type="text" role="combobox" aria-expanded="false"
@@ -464,15 +476,23 @@ choose(CATALOG[0]);
 // variant Stan has shipped for years. Spelled out rather than "NUTS"
 // because the choice sits beside WALNUTS, and an acronym next to an
 // acronym says nothing about which one is the familiar option.
-const SAMPLER_LABEL = { nuts: "Stan-dard Dynamic HMC", walnuts: "WALNUTS" };
+const SAMPLER_LABEL = { nuts: "Stan-dard Dynamic HMC", walnuts: "WALNUTS",
+                        pathfinder: "Pathfinder" };
+// Which samplers each mode puts on screen, which is what decides whose
+// tuning knobs are shown and which column each run fills.
+const MODE_SAMPLERS = {
+  nuts: ["nuts"], walnuts: ["walnuts"], both: ["nuts", "walnuts"],
+  pathfinder: ["pathfinder"], nutspf: ["nuts", "pathfinder"],
+};
 function samplerMode() { return $("sampler").value; }
 $("sampler").onchange = () => {
-  const m = samplerMode();
+  const on = MODE_SAMPLERS[samplerMode()];
   // delta tunes NUTS's adaptation target; max err tunes how much the
   // joint log density may drift across one WALNUTS macro step. Each is
-  // shown only when its sampler is in play.
-  $("deltalab").hidden = m === "walnuts";
-  $("maxerrlab").hidden = m === "nuts";
+  // shown only when its sampler is in play. Pathfinder has neither: it
+  // optimizes rather than samples.
+  $("deltalab").hidden = !on.includes("nuts");
+  $("maxerrlab").hidden = !on.includes("walnuts");
 };
 
 // ---- run -------------------------------------------------------------------
@@ -480,7 +500,11 @@ $("sampler").onchange = () => {
 // Single-sampler runs keep one fit; a comparison run keeps one per
 // sampler so both stay inspectable (and downloadable) side by side.
 let fit = null;
-let cmpFits = null;  // { nuts: fit, walnuts: fit } after a "both" run
+// { nuts, walnuts } after a "both" run, { nuts, pathfinder } after a
+// "nutspf" one. cmpMode says which, because the two comparisons draw
+// different panels from the same pair of fits.
+let cmpFits = null;
+let cmpMode = null;
 
 // Run nChains chains of one sampler from already-compiled MIR, streaming
 // live draws into `onLive(chain, msg)`. Returns {fit, ms}.
@@ -509,6 +533,8 @@ function newLive(nChains) {
            chains: Array.from({ length: nChains }, () => []),
            warm: new Array(nChains).fill(0),
            drawn: new Array(nChains).fill(0),
+           // Pathfinder streams L-BFGS iterates instead of draws.
+           path: [],
            lo: Infinity, hi: -Infinity };
 }
 // Fold one chain's live messages into `live`, then let `redraw` decide
@@ -518,6 +544,12 @@ function liveHandler(live, progress, redraw) {
   return (c, m) => {
     if (m.liveMeta) { live.names = m.liveMeta.names; return; }
     const lv = m.live;
+    if (lv.phase === "path") {
+      live.path.push({ iter: lv.iter, lp: lv.lp });
+      progress();
+      redraw();
+      return;
+    }
     if (lv.phase === "warmup") {
       live.warm[c] = lv.i;
       progress();
@@ -559,6 +591,9 @@ $("run").onclick = async () => {
   $("hist").hidden = true;
   fit = null;
   cmpFits = null;
+  cmpMode = null;
+  cmpSelName = null;
+  pfView = null;
   const mode = samplerMode();
   const nChains = Math.max(1, parseInt($("chains").value, 10) || 4);
   const seed = parseInt($("seed").value, 10) || 1;
@@ -579,6 +614,8 @@ $("run").onclick = async () => {
     const runOpts = { ...opts, mir: compiled.mir };
     if (mode === "both") {
       await runCompare(runOpts, nChains, seed, compiled, tWall);
+    } else if (mode === "nutspf") {
+      await runNutsPathfinder(runOpts, nChains, seed, compiled, tWall);
     } else {
       await runSingle(mode, runOpts, nChains, seed, compiled, tWall);
     }
@@ -599,6 +636,8 @@ async function runSingle(mode, opts, nChains, seed, compiled, tWall) {
     $("status").textContent = d
         ? `${label} sampling: ${d}/${nChains * opts.samples} draws across ` +
           `${nChains} chains`
+        : live.path.length
+        ? `${label}: ${live.path.length} L-BFGS iterates`
         : `${label} warmup: ${w}/${nChains * opts.warmup} across ` +
           `${nChains} chains`;
   });
@@ -690,6 +729,7 @@ async function runCompare(opts, nChains, seed, compiled, tWall) {
   };
   const rn = collect("nuts"), rw = collect("walnuts");
   cmpFits = { nuts: rn.fit, walnuts: rw.fit };
+  cmpMode = "both";
   const wall = performance.now() - tWall;
 
   for (const [w, r] of [["nuts", rn], ["walnuts", rw]]) {
@@ -744,12 +784,13 @@ document.addEventListener("keydown", (e) => {
   if (names[next] === cmpSelName) return;
   e.preventDefault();
   cmpSelect(names[next]);
-  document.querySelector(`#col-nuts tr[data-n="${CSS.escape(names[next])}"]`)
+  document.querySelector(`#out tr[data-n="${CSS.escape(names[next])}"]`)
       ?.scrollIntoView({ block: "nearest" });
 });
 
 function cmpSelect(name) {
   cmpSelName = name;
+  if (cmpMode === "nutspf") { pfPaint(); return; }
   // The shared scales: y across both samplers' draws of this parameter,
   // x likewise for the histograms.
   let lo = Infinity, hi = -Infinity;
@@ -769,10 +810,279 @@ function cmpSelect(name) {
               lo, hi);
     const h = col.querySelector(".chist");
     h.hidden = false;
-    drawHist(h, f, name, lo, hi);
+    drawHist(h, allDraws(f, name), name, lo, hi);
     for (const tr of col.querySelectorAll("tr[data-n]"))
       tr.classList.toggle("selected", tr.dataset.n === name);
   }
+}
+
+
+// ---- NUTS vs Pathfinder ----------------------------------------------------
+// A different comparison from NUTS vs WALNUTS, because Pathfinder is not
+// a sampler. It has no chains, no warmup and no trace: it fits a normal
+// approximation along an L-BFGS path and draws from that, in
+// milliseconds. So the question is not "did it mix" but "is the
+// approximation any good", and the right column answers it three ways --
+// the climb, the two posteriors on shared axes, and a Q-Q plot.
+//
+// Both start from the same point: Pathfinder's L-BFGS and NUTS's first
+// chain are handed the same (seed, chain id), and the runtime draws one
+// init for both.
+let pfView = null;
+
+function pfCol() {
+  const col = document.createElement("div");
+  col.className = "col";
+  col.id = "col-pathfinder";
+  col.innerHTML =
+      `<h3>Pathfinder</h3>` +
+      `<canvas class="cpath" width="540" height="170"></canvas>` +
+      `<div class="cap cpathcap"></div>` +
+      `<canvas class="chist" width="540" height="140" hidden></canvas>` +
+      `<canvas class="cqq" width="540" height="200" hidden></canvas>` +
+      `<div class="times"></div>`;
+  return col;
+}
+
+// The NUTS draws so far for one parameter, gathered out of the live row
+// buffers. Only constrained parameters stream; transformed parameters
+// and generated quantities arrive with the finished fit, so this returns
+// null for those and the panels wait.
+function liveColumn(live, name) {
+  const j = live.names ? live.names.indexOf(name) : -1;
+  if (j < 0) return null;
+  let n = 0;
+  for (const ch of live.chains) n += ch.length;
+  const out = new Float64Array(n);
+  let k = 0;
+  for (const ch of live.chains) for (const r of ch) out[k++] = r[j];
+  return out;
+}
+// Mean and sd of every live column in one pass. Per-column extraction
+// would walk the same rows once per parameter, which at a hundred
+// parameters is a hundred passes per repaint.
+function liveMoments(live) {
+  if (!live.names) return null;
+  const k = live.names.length;
+  const s = new Float64Array(k), s2 = new Float64Array(k);
+  let n = 0;
+  for (const ch of live.chains)
+    for (const r of ch) {
+      ++n;
+      for (let j = 0; j < k; ++j) { s[j] += r[j]; s2[j] += r[j] * r[j]; }
+    }
+  if (n < 2) return null;
+  const out = {};
+  live.names.forEach((name, j) => {
+    const mean = s[j] / n;
+    out[name] = { mean, sd: Math.sqrt(Math.max(0, s2[j] / n - mean * mean)) };
+  });
+  return out;
+}
+function fitMoments(f) {
+  const out = {};
+  for (const name of f.names) {
+    const xs = allDraws(f, name);
+    const mean = meanOf(xs);
+    out[name] = { mean, sd: Math.sqrt(varOf(xs, mean)) };
+  }
+  return out;
+}
+
+// One row per parameter, both methods on it, plus the discrepancy that
+// says whether the difference matters: how far apart the means are in
+// units of NUTS's own sd.
+function pfTable(names) {
+  let html = "<table><tr><th>parameter</th><th>NUTS mean</th><th>NUTS sd</th>" +
+             "<th>PF mean</th><th>PF sd</th>" +
+             "<th>|&Delta;mean| / NUTS sd</th></tr>";
+  for (const n of names)
+    html += `<tr data-n="${n}"><td>${n}</td><td class="nm"></td>` +
+            `<td class="nsd"></td><td class="pm"></td><td class="psd"></td>` +
+            `<td class="ds"></td></tr>`;
+  return html + "</table>";
+}
+const pfFmt = (x) => (x == null || !Number.isFinite(x) ? "-"
+    : Math.abs(x) >= 1000 ? x.toFixed(0) : x.toPrecision(4));
+function pfTableUpdate(root, nuts, pf) {
+  for (const tr of root.querySelectorAll("tr[data-n]")) {
+    const n = tr.dataset.n;
+    const a = nuts && nuts[n], b = pf && pf[n];
+    tr.querySelector(".nm").textContent = pfFmt(a && a.mean);
+    tr.querySelector(".nsd").textContent = pfFmt(a && a.sd);
+    tr.querySelector(".pm").textContent = pfFmt(b && b.mean);
+    tr.querySelector(".psd").textContent = pfFmt(b && b.sd);
+    const cell = tr.querySelector(".ds");
+    const d = a && b && a.sd > 0 ? Math.abs(a.mean - b.mean) / a.sd : NaN;
+    cell.textContent = Number.isFinite(d) ? d.toFixed(2) : "-";
+    cell.className = "ds" + (d > 0.3 ? " bad" : "");
+  }
+}
+
+// Everything that depends on NUTS's draws repaints on one throttle tick:
+// the two histograms share an x range, the Q-Q plot shares its quantile
+// grid, and the discrepancy column is those same numbers in text.
+// Recomputing any of it per draw would be the same work a thousand times.
+function pfPaint() {
+  const v = pfView;
+  if (!v || !cmpSelName) return;
+  const nuts = v.nutsFit ? allDraws(v.nutsFit, cmpSelName)
+                         : liveColumn(v.live, cmpSelName);
+  const pf = v.pfFit && cmpSelName in v.pfFit.chains[0]
+      ? allDraws(v.pfFit, cmpSelName) : null;
+  for (const tr of v.sum.querySelectorAll("tr[data-n]"))
+    tr.classList.toggle("selected", tr.dataset.n === cmpSelName);
+  pfTableUpdate(v.sum, v.nutsFit ? fitMoments(v.nutsFit) : liveMoments(v.live),
+                v.pfMoments);
+  if (v.nutsFit && cmpSelName in v.nutsFit.chains[0])
+    drawTrace(v.cols.nuts.querySelector(".ctrace"), v.nutsFit, cmpSelName,
+              `${cmpSelName}  ${SAMPLER_LABEL.nuts}, ` +
+              `${v.nutsFit.chains.length} chains`);
+  if (!nuts || nuts.length < 2) return;
+  let lo = Infinity, hi = -Infinity;
+  const span = (xs) => {
+    for (const x of xs) { if (x < lo) lo = x; if (x > hi) hi = x; }
+  };
+  span(nuts);
+  if (pf) span(pf);
+  if (!(hi > lo)) { lo -= 1; hi += 1; }
+  drawHist(v.cols.nuts.querySelector(".chist"), nuts, cmpSelName, lo, hi,
+           pf && { xs: pf, label: "Pathfinder" });
+  if (!pf) return;
+  drawHist(v.cols.pathfinder.querySelector(".chist"), pf, cmpSelName, lo, hi,
+           { xs: nuts, label: "NUTS" });
+  drawQQ(v.cols.pathfinder.querySelector(".cqq"), nuts, pf, cmpSelName);
+}
+
+const khatClass = (k) => (k < 0.5 ? "ok" : k < 0.7 ? "warn" : "bad");
+const msText = (ms) =>
+    (ms < 1000 ? ms.toFixed(0) + " ms" : (ms / 1000).toFixed(1) + " s");
+
+async function runNutsPathfinder(opts, nChains, seed, compiled, tWall) {
+  cmpMode = "nutspf";
+  const wrap = document.createElement("div");
+  wrap.className = "cmp";
+  const cols = { nuts: cmpCol("nuts"), pathfinder: pfCol() };
+  wrap.append(cols.nuts, cols.pathfinder);
+  const sum = document.createElement("div");
+  sum.className = "cmpsum";
+  $("out").append(wrap, sum);
+  cols.nuts.querySelector(".ctable").remove();
+
+  const live = newLive(nChains);
+  const pfLive = newLive(1);
+  const v = { live, cols, sum, nutsFit: null, pfFit: null, pfMoments: null,
+              pf: null };
+  pfView = v;
+
+  const progress = throttled(() => {
+    const d = live.drawn.reduce((a, b) => a + b, 0);
+    const w = live.warm.reduce((a, b) => a + b, 0);
+    $("status").textContent =
+        (d ? `NUTS ${d}/${nChains * opts.samples} draws`
+           : `NUTS warmup ${w}/${nChains * opts.warmup}`) + " · " +
+        (v.pf ? `Pathfinder done in ${msText(v.pf.elapsedMs)}`
+              : `Pathfinder: ${pfLive.path.length} L-BFGS iterates`);
+  });
+  const redrawPath = throttled(() => {
+    drawPath(cols.pathfinder.querySelector(".cpath"), pfLive.path,
+             v.pf ? v.pf.selectedIter : -1,
+             cols.pathfinder.querySelector(".cpathcap"));
+  });
+  const redrawNuts = throttled(() => {
+    liveTrace(cols.nuts.querySelector(".ctrace"), live, nChains, false,
+              SAMPLER_LABEL.nuts);
+    pfPaint();
+  });
+  // NUTS's elapsed time ticks while it runs, next to a Pathfinder figure
+  // that stopped moving seconds ago. That contrast is the headline.
+  const t0 = performance.now();
+  const clock = setInterval(() => {
+    if (v.nutsFit) return;
+    cols.nuts.querySelector(".times").textContent =
+        `${msText(performance.now() - t0)} elapsed`;
+  }, 200);
+
+  const pfHandler = liveHandler(pfLive, progress, redrawPath);
+  const nutsHandler = liveHandler(live, progress, redrawNuts);
+  const jobs = [];
+  // Pathfinder goes in first so it holds a pool slot from the start; it
+  // is one extra job beside the chains, and it gives the slot back in
+  // milliseconds.
+  jobs.push(sample({
+    ...opts, code: undefined, seed, sampler: "pathfinder",
+    onLive: (m) => pfHandler(0, m),
+  }).then((r) => ({ w: "pathfinder", r })));
+  for (let c = 0; c < nChains; ++c)
+    jobs.push(sample({
+      ...opts, code: undefined, seed: seed + c, sampler: "nuts",
+      onLive: (m) => nutsHandler(c, m),
+    }).then((r) => ({ w: "nuts", r })));
+  // The Pathfinder job is awaited on its own below, so a failure there
+  // would leave the chains' rejections unclaimed until the Promise.all
+  // that never runs. Claiming them here keeps the first error the one
+  // that gets reported.
+  for (const j of jobs) j.catch(() => {});
+
+  // The Pathfinder half lands first and its panels settle immediately;
+  // the NUTS half keeps streaming into the same shared axes.
+  const pfJob = await jobs[0];
+  v.pf = pfJob.r.pathfinder;
+  v.pfFit = { names: pfJob.r.names, samples: pfJob.r.samples,
+              chains: [pfJob.r.columns] };
+  v.pfMoments = fitMoments(v.pfFit);
+  sum.innerHTML = pfTable(v.pfFit.names);
+  for (const tr of sum.querySelectorAll("tr[data-n]"))
+    tr.onclick = () => cmpSelect(tr.dataset.n);
+  if (!cmpSelName || !v.pfFit.names.includes(cmpSelName))
+    cmpSelName = v.pfFit.names[0];
+  const k = v.pf.khat;
+  const elbo = v.pf.selectedElbo;
+  cols.pathfinder.querySelector(".times").innerHTML =
+      `${msText(v.pf.elapsedMs)} total · ` +
+      (Number.isFinite(k)
+          ? `<span class="khat ${khatClass(k)}">k&#770; ${k.toFixed(2)}</span>`
+          : `k&#770; n/a`) +
+      ` · ELBO ${Number.isFinite(elbo) ? elbo.toPrecision(4) : "n/a"} ` +
+      `at iterate ${v.pf.selectedIter}`;
+  cols.pathfinder.querySelector(".times").insertAdjacentHTML("afterend",
+      `<div class="cap">k&#770; &gt; 0.7: importance weights unreliable, ` +
+      `draws should not be trusted. A small k&#770; says the weights are ` +
+      `stable, never that the approximation covers the posterior.</div>`);
+  drawPath(cols.pathfinder.querySelector(".cpath"), pfLive.path,
+           v.pf.selectedIter, cols.pathfinder.querySelector(".cpathcap"));
+  pfPaint();
+
+  const done = await Promise.all(jobs);
+  clearInterval(clock);
+  const rs = done.filter((d) => d.w === "nuts").map((d) => d.r);
+  const ms = { lower: 0, sample: 0 };
+  for (const r of rs)
+    for (const key of ["lower", "sample"]) ms[key] += r.ms[key];
+  v.nutsFit = { names: rs[0].names, samples: rs[0].samples,
+                chains: rs.map((r) => r.columns) };
+  cmpFits = { nuts: v.nutsFit, pathfinder: v.pfFit };
+  const wall = performance.now() - tWall;
+
+  let minEss = Infinity;
+  for (const n of v.nutsFit.names) {
+    const e = rhatEss(v.nutsFit, n).ess;
+    if (Number.isFinite(e)) minEss = Math.min(minEss, e);
+  }
+  const perChain = ms.sample / nChains;
+  cols.nuts.querySelector(".times").textContent =
+      `${msText(perChain)} sampling per chain · ` +
+      (Number.isFinite(minEss)
+          ? `min ESS ${minEss.toFixed(0)} ` +
+            `(${(minEss / (perChain / 1000)).toFixed(0)}/s)`
+          : "min ESS n/a");
+  $("times").textContent =
+      `${nChains} NUTS chains and one Pathfinder path, all in parallel: ` +
+      `${(wall / 1000).toFixed(1)} s wall ` +
+      `(stanc ${compiled.ms.stanc.toFixed(0)} ms, once); ` +
+      `Pathfinder's whole run was ${msText(v.pf.elapsedMs)}. ` +
+      `Click a row or use the arrow keys to compare that parameter`;
+  pfPaint();
 }
 
 // ---- summaries -------------------------------------------------------------
@@ -900,7 +1210,7 @@ function showPlots(tr, label) {
   const name = tr.dataset.n;
   drawTrace($("trace"), fit, name,
             `${name}  trace, ${fit.chains.length} chains`);
-  drawHist($("hist"), fit, name);
+  drawHist($("hist"), allDraws(fit, name), name);
 }
 
 // ---- plots -----------------------------------------------------------------
@@ -1019,30 +1329,153 @@ function drawTrace(c, f, name, title, ylo, yhi) {
   });
   g.globalAlpha = 1;
 }
-function drawHist(c, f, name, xlo, xhi) {
-  const xs = allDraws(f, name);
+// `xs` is the draws to bin. `overlay`, when given, is a second set drawn
+// as an outline over the same bins, rescaled to `xs`'s draw count so the
+// two shapes compare even when one method produced ten times the draws.
+// Two methods whose posteriors differ then differ visibly in place,
+// rather than in the reader's memory of the panel above.
+function drawHist(c, xs, name, xlo, xhi, overlay) {
   let lo = xlo, hi = xhi;
   if (lo == null || hi == null) {
     lo = Infinity; hi = -Infinity;
     for (const x of xs) { if (x < lo) lo = x; if (x > hi) hi = x; }
     if (!(hi > lo)) { lo -= 1; hi += 1; }
   }
-  const nb = 40, counts = new Array(nb).fill(0);
-  for (const x of xs)
-    ++counts[Math.min(nb - 1, Math.max(0, ((x - lo) / (hi - lo) * nb) | 0))];
-  const peak = Math.max(...counts);
+  const nb = 40;
+  const bin = (vs, scale) => {
+    const k = new Array(nb).fill(0);
+    for (const x of vs)
+      ++k[Math.min(nb - 1, Math.max(0, ((x - lo) / (hi - lo) * nb) | 0))];
+    return scale === 1 ? k : k.map((v) => v * scale);
+  };
+  const counts = bin(xs, 1);
+  const over = overlay && overlay.xs.length
+      ? bin(overlay.xs, xs.length / overlay.xs.length) : null;
+  const peak = Math.max(...counts, ...(over || [0]));
   const g = c.getContext("2d");
   c.hidden = false;
   g.clearRect(0, 0, c.width, c.height);
   const { X, Y } = axes(c, g, {
-    title: name + "  posterior", xlabel: name, ylabel: "draws",
+    title: name + "  posterior" + (overlay ? `  (outline: ${overlay.label})` : ""),
+    xlabel: name, ylabel: "draws",
     xlo: lo, xhi: hi, ylo: 0, yhi: peak });
+  const edge = (b) => X(lo + (hi - lo) * b / nb);
   g.fillStyle = "#4a7";
   counts.forEach((k, b) => {
-    const xa = X(lo + (hi - lo) * b / nb);
-    const xb = X(lo + (hi - lo) * (b + 1) / nb);
-    g.fillRect(xa + 1, Y(k), Math.max(xb - xa - 2, 1), Y(0) - Y(k));
+    g.fillRect(edge(b) + 1, Y(k), Math.max(edge(b + 1) - edge(b) - 2, 1),
+               Y(0) - Y(k));
   });
+  if (!over) return;
+  g.strokeStyle = "#47a";
+  g.lineWidth = 1.5;
+  g.beginPath();
+  g.moveTo(edge(0), Y(0));
+  over.forEach((k, b) => {
+    g.lineTo(edge(b), Y(k));
+    g.lineTo(edge(b + 1), Y(k));
+  });
+  g.lineTo(edge(nb), Y(0));
+  g.stroke();
+  g.lineWidth = 1;
+}
+
+// Pathfinder's quantiles against NUTS's, with the y = x line. A normal
+// approximation that got the location right but the spread wrong reads
+// as a straight line off the diagonal; one that missed a tail bends
+// away only at the end. Neither is visible in a pair of histograms.
+function drawQQ(c, xs, ys, name) {
+  const g = c.getContext("2d");
+  c.hidden = false;
+  g.clearRect(0, 0, c.width, c.height);
+  if (!xs.length || !ys.length) return;
+  const a = Float64Array.from(xs).sort();
+  const b = Float64Array.from(ys).sort();
+  const n = 200;
+  const q = (s, p) => s[Math.min(s.length - 1, Math.floor(p * s.length))];
+  const px = [], py = [];
+  for (let i = 0; i < n; ++i) {
+    const p = (i + 0.5) / n;
+    px.push(q(a, p));
+    py.push(q(b, p));
+  }
+  let lo = Math.min(px[0], py[0]), hi = Math.max(px[n - 1], py[n - 1]);
+  if (!(hi > lo)) { lo -= 1; hi += 1; }
+  const { X, Y } = axes(c, g, {
+    title: `${name}  Q-Q`, xlabel: "NUTS quantile",
+    ylabel: "Pathfinder", xlo: lo, xhi: hi, ylo: lo, yhi: hi });
+  g.strokeStyle = "#8886";
+  g.beginPath();
+  g.moveTo(X(lo), Y(lo));
+  g.lineTo(X(hi), Y(hi));
+  g.stroke();
+  g.strokeStyle = "#a47";
+  g.lineWidth = 1.5;
+  g.beginPath();
+  for (let i = 0; i < n; ++i)
+    i ? g.lineTo(X(px[i]), Y(py[i])) : g.moveTo(X(px[i]), Y(py[i]));
+  g.stroke();
+  g.lineWidth = 1;
+}
+
+// The optimizer's climb: lp at every L-BFGS iterate, with the iterate
+// the ELBO chose marked. A random start can sit astronomically below the
+// mode -- an lp of -1e12 is ordinary -- and one such point flattens
+// every other iterate onto the top edge of the frame. When the whole
+// range is more than ten times the range of the last 90% of iterates,
+// the axis is clamped to those and the caption says so; the line still
+// runs off the bottom, clipped to the plot area, so nothing is hidden.
+function drawPath(c, path, selected, capEl) {
+  const g = c.getContext("2d");
+  c.hidden = false;
+  g.clearRect(0, 0, c.width, c.height);
+  if (capEl) capEl.textContent = "";
+  const lps = path.map((p) => p.lp).filter(Number.isFinite);
+  if (!lps.length) return;
+  let lo = Math.min(...lps), hi = Math.max(...lps);
+  const tail = path.slice(Math.floor(path.length * 0.1))
+                   .map((p) => p.lp).filter(Number.isFinite);
+  if (tail.length > 1) {
+    const tlo = Math.min(...tail), thi = Math.max(...tail);
+    if (thi > tlo && hi - lo > 10 * (thi - tlo)) {
+      lo = tlo;
+      if (capEl)
+        capEl.textContent =
+            `y axis clamped to iterate ${Math.floor(path.length * 0.1)} ` +
+            `onward; the start is at lp ${lps[0].toPrecision(3)}`;
+    }
+  }
+  if (!(hi > lo)) { lo -= 1; hi += 1; }
+  const last = path[path.length - 1].iter;
+  const { X, Y } = axes(c, g, {
+    title: `log density along the L-BFGS path`,
+    xlabel: "L-BFGS iterate", ylabel: "lp__",
+    xlo: 0, xhi: Math.max(last, 1), ylo: lo, yhi: hi });
+  g.save();
+  g.beginPath();
+  g.rect(PAD.l, PAD.t, c.width - PAD.l - PAD.r, c.height - PAD.t - PAD.b);
+  g.clip();
+  g.strokeStyle = "#4a7";
+  g.lineWidth = 1.5;
+  g.beginPath();
+  path.forEach((p, i) => {
+    i ? g.lineTo(X(p.iter), Y(p.lp)) : g.moveTo(X(p.iter), Y(p.lp));
+  });
+  g.stroke();
+  g.lineWidth = 1;
+  const sel = path[selected];
+  if (sel) {
+    g.fillStyle = "#a47";
+    g.beginPath();
+    g.arc(X(sel.iter), Y(sel.lp), 4, 0, 2 * Math.PI);
+    g.fill();
+    g.font = "10px system-ui";
+    g.textAlign = X(sel.iter) > c.width / 2 ? "right" : "left";
+    g.fillText(`ELBO picked iterate ${sel.iter}`,
+               X(sel.iter) + (X(sel.iter) > c.width / 2 ? -8 : 8),
+               Y(sel.lp) - 8);
+    g.textAlign = "left";
+  }
+  g.restore();
 }
 
 // ---- CSV -------------------------------------------------------------------
@@ -1055,9 +1488,9 @@ $("csv").onclick = () => {
                    f.names.map((n) => f.chains[ci][n][s]).join(","));
   };
   if (cmpFits) {
-    lines.push("sampler,chain," + cmpFits.nuts.names.join(","));
-    emit("nuts", cmpFits.nuts);
-    emit("walnuts", cmpFits.walnuts);
+    const which = Object.keys(cmpFits);
+    lines.push("sampler,chain," + cmpFits[which[0]].names.join(","));
+    for (const w of which) emit(w, cmpFits[w]);
   } else {
     lines.push("chain," + fit.names.join(","));
     emit("", fit);


### PR DESCRIPTION
Single-path Pathfinder over the executor's gradient, via Stan's own service (stan/services/pathfinder/single.hpp), plus a live NUTS vs Pathfinder comparison mode on the web page.

## Runtime

- `run_pathfinder(Executor&, PathfinderConfig)` with CmdStan defaults; init comes from the shared `cmdstan_init_point` stream, so for a matched (seed, chain_id) all three methods start from the identical point.
- The result carries draws, per-draw lp/lp_approx, the lp path per L-BFGS iterate with the ELBO-selected iterate, and a Pareto k-hat fit (Zhang & Stephens) on the importance ratios. No PSIS library needed.
- Multi-path is deliberately out: it requires real TBB (`tbb::parallel_for` in multi.hpp, `parallel_invoke` in psis.hpp) and this build stubs TBB.
- Root cause of the old "draws come back empty" note in estimate.hpp: pathfinder writes each draw as an Eigen row vector, and `stan::callbacks::writer`'s overloads are silent no-op virtuals, so a vector-only collector dropped everything. The collector now implements the matrix overloads (and `using Base::operator();`, since one override hides the rest). The ELBO-selected iterate reaches no writer and is scraped from the logger's `Best Iter` line.
- C API `stanli_run_pathfinder` with a per-iterate callback for the path; exported to wasm.

## Web

New "NUTS vs Pathfinder, side by side" mode. Pathfinder has no chains, so its column is different from the WALNUTS compare: the L-BFGS lp path animates live per iterate with the ELBO pick marked, then a shared-x histogram with each sampler's outline overlaid on the other's panel, and a Q-Q plot against NUTS quantiles. Pathfinder finishes in ms and its side freezes while NUTS keeps streaming into the shared plots and a per-parameter |dmean|/NUTS-sd discrepancy column. k-hat is colored at 0.5/0.7 with the caveat spelled out: it certifies weight stability, never coverage. Centered eight schools shows the point -- Pathfinder misses the funnel (sd ~0.3 vs ~5) while k-hat sits green at 0.2. Arrow keys and row clicks step parameters across all panels; CSV export includes both samplers. The existing NUTS/WALNUTS compare is unchanged.

## Tests

test_pathfinder (moments on a 10-dim normal, eight schools with the observed funnel miss documented, determinism, shared-init contract, path monotonicity), test_capi coverage for the new entry point, test_wasm exercising the export. Full suite 48/48.