### PR TITLE
conformance: resolve the reference cache root before handing paths to make

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,4 @@ __pycache__/
 *.py[cod]
 tests/fixtures/*_model.so
 tests/fixtures/*.hpp
+conformance-cache/

--- a/harnesses/conformance/oracle.py
+++ b/harnesses/conformance/oracle.py
@@ -198,7 +198,13 @@ def cached_reference_build(
     key = hashlib.sha256(json.dumps(
         payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
                          ).hexdigest()
-    workdir = pathlib.Path(cache_root) / namespace / key
+    # Absolute, unconditionally: the library path below is handed to
+    # `make -C deps/bridgestan`, and -C makes a relative target resolve
+    # inside the bridgestan tree, where no generated source exists. make
+    # then reports "No rule to make target" for every shard -- which is
+    # exactly what the nightly did from its first run, since the workflow
+    # passes `--resume conformance-cache`.
+    workdir = pathlib.Path(cache_root).resolve() / namespace / key
     source = workdir / source_name
     library = source.with_name(source.stem + "_model.so")
     metadata = workdir / "build-metadata.json"


### PR DESCRIPTION
Every nightly since the harness landed in #91 reported 18,519 of 24,277 rows as `harness_error: Reference shard compilation failed`. No reference model was ever compiled in CI, so the differential suite was measuring nothing on those rows, and the aggregate distribution was byte-identical from the first run to last night's.

The workflow passes `--resume conformance-cache`, a relative path. `cached_reference_build` used it unresolved, and the `_model.so` target goes to `make -C deps/bridgestan`, where `-C` makes a relative target resolve inside the bridgestan tree. No generated source lives there, so make answered `No rule to make target` for every shard, in a seventh of a second each.

One `resolve()` at the workdir derivation. Verification, most specific first:

* the make invocation reproduced in isolation: identical command succeeds with an absolute target and fails with a relative one
* the repro command from a failing aggregate row (`construct:assignment.index-slice-gather-layout`) goes `harness_error` to `verified`, reference built through BridgeStan in 4.8s, every numeric lane bitwise (`abs_tol 0.0, max_ulp 0`)
* a generated scalar case (`abs(real)=>real`) verifies the same way
* the 67 harness tests pass

No stale cache concern: only successful builds write metadata, so the failed CI runs left nothing poisoned behind. Also gitignores `conformance-cache/`, which the workflow creates at the repo root.

Heads up on the first post-merge nightly: with the reference side alive for the first time, the partitions will actually compile ~19k signatures' worth of reference shards. The content-addressed cache makes that a one-time cost, but the first run will be much slower than the 15-minute failures we have been getting, and its aggregate will show the suite's first real verdict on stanli. Findings from that run are new information, not regressions.