### PR TITLE
conformance: a lane within 5 ULP of the reference is green

### DIFF
--- a/harnesses/conformance/compare.py
+++ b/harnesses/conformance/compare.py
@@ -35,6 +35,15 @@ class Gate:
             raise ValueError("numeric tolerances must be nonnegative")
 
 
+# The gate a case gets when no policy rule names one. Reviewed decision
+# (2026-08-15): a lane within 5 ULP of the reference is green -- the same
+# order of tolerance the corpus oracle runs at -- so the mismatch bucket
+# holds disagreements someone should read, not accumulated last-bit noise
+# from equivalent-but-differently-grouped arithmetic. Anything looser than
+# this stays a reviewed [[numeric_gate]] rule in policy.toml.
+DEFAULT_GATE = Gate(max_ulp=5)
+
+
 @dataclasses.dataclass(frozen=True)
 class NumericComparison:
     agrees: bool

--- a/harnesses/conformance/construct_runner.py
+++ b/harnesses/conformance/construct_runner.py
@@ -11,7 +11,8 @@ import time
 from typing import Dict, Mapping, Optional, Tuple
 
 from .catalog import ConstructCase, ConstructCatalog
-from .compare import (Expectation, Gate, Observation, OutcomeComparison,
+from .compare import (DEFAULT_GATE, Expectation, Gate, Observation,
+                      OutcomeComparison,
                       compare_observations)
 from .oracle import (OracleError, ReferenceBuild, ToolchainVersions,
                      cached_reference_build, prepare_reference_runtime,
@@ -68,7 +69,7 @@ def _observation(response: Mapping[str, object]) -> Observation:
 
 def _numeric_gate(case: ConstructCase, policy: CapabilityPolicy) -> Gate:
     if case.numeric_policy is None:
-        return Gate(max_ulp=0)
+        return DEFAULT_GATE
     configured = policy.numeric_gate_named(case.numeric_policy)
     return Gate(max_ulp=configured.max_ulp, abs_tol=configured.abs_tol,
                 rel_tol=configured.rel_tol)

--- a/harnesses/conformance/scalar_runner.py
+++ b/harnesses/conformance/scalar_runner.py
@@ -9,7 +9,7 @@ import pathlib
 import sys
 from typing import Mapping, Optional, Sequence, Tuple
 
-from .compare import Gate
+from .compare import DEFAULT_GATE, Gate
 from .evaluate import evaluate_generated_case
 from .generate import (GeneratedCase, GeneratedShard, VectorizedCaseSpec,
                        generated_inventory, make_scalar_shards,
@@ -51,7 +51,7 @@ def _failure(case, status: ResultStatus, reason: str,
 def _gate(policy: CapabilityPolicy, case) -> Gate:
     numeric = policy.numeric_gate_for(case.spec.signature)
     if numeric is None:
-        return Gate(max_ulp=0)
+        return DEFAULT_GATE
     return Gate(max_ulp=numeric.max_ulp, abs_tol=numeric.abs_tol,
                 rel_tol=numeric.rel_tol)
 

--- a/tests/test_conformance.py
+++ b/tests/test_conformance.py
@@ -260,6 +260,22 @@ return_kind = "tuple"
             with self.assertRaises(PolicyError):
                 policy.classification_for(signature)
 
+    def test_default_gate_allows_five_ulp(self):
+        # Reviewed decision (2026-08-15): a lane within 5 ULP of the
+        # reference is green. Anything looser still needs a policy rule.
+        import types
+        from conformance.scalar_runner import _gate as scalar_gate
+        policy = load_policy(DEFAULT_POLICY)
+        normal = parse_signature("normal_lpdf(real, real, real) => real")
+        case = types.SimpleNamespace(spec=types.SimpleNamespace(
+            signature=normal))
+        gate = scalar_gate(policy, case)
+        self.assertEqual(gate.max_ulp, 5)
+        self.assertTrue(compare_numeric(1.0, 1.0 + 5 * 2.0 ** -52,
+                                        gate).agrees)
+        self.assertFalse(compare_numeric(1.0, 1.0 + 6 * 2.0 ** -52,
+                                         gate).agrees)
+
     def test_numeric_gate_is_narrow(self):
         policy = load_policy(DEFAULT_POLICY)
         ode = parse_signature("ode_rk45(real, real) => real")


### PR DESCRIPTION
Reviewed decision: a lane within 5 ULP of the reference counts as agreement. The bitwise default buried the ~880 rows someone should read (wiener_lpdf at 0.11 *relative* error) under ~1,044 rows of last-bit noise from differently grouped but equivalent arithmetic.

`DEFAULT_GATE` in `compare.py` is the single place the number lives; both runners return it when no policy rule names a gate. Looser than 5 ULP still requires a reviewed `[[numeric_gate]]` rule in `policy.toml`; the ODE gate keeps its measured tolerances. A test pins the default and both sides of the boundary (5 ULP agrees, 6 does not).

Measured against the first live aggregate: 1,044 of 1,924 mismatches flip to green, including every `pareto_type_2` row. What stays is the catastrophic set, triaged separately: `wiener_lpdf` 748, `pow` 114, `inv_Phi` 12, 6 constructs.