### PR TITLE
fix: vectorized pow computed one lane and no gradient

### DIFF
--- a/runtime/kernels/eltwise_expr.cpp
+++ b/runtime/kernels/eltwise_expr.cpp
@@ -210,15 +210,36 @@ void div_bwd(KernelCtx& ctx) {
   }
 }
 
+// Scalar libm per element, like the transcendental unaries: stan-math's
+// vectorized pow applies its scalar op elementwise, so packet math would
+// break bitwise parity. Partials keep the scalar grouping (b*v/a and
+// log(a)*v), which is what the ss case has always matched.
 void pow_fwd(KernelCtx& ctx) {
-  ctx.out.data[0] = std::pow(ctx.in[0].data[0], ctx.in[1].data[0]);
+  const bool s0 = scal(ctx, 0), s1 = scal(ctx, 1);
+  for (int64_t i = 0; i < ctx.out.len; ++i)
+    ctx.out.data[i] = std::pow(ctx.in[0].data[s0 ? 0 : i],
+                               ctx.in[1].data[s1 ? 0 : i]);
 }
 void pow_bwd(KernelCtx& ctx) {
-  const double a = ctx.in[0].data[0], b = ctx.in[1].data[0];
-  const double v = ctx.out.data[0];
-  if (ctx.in_adj[0].data) ctx.in_adj[0].data[0] += ctx.out_adj * b * v / a;
-  if (ctx.in_adj[1].data)
-    ctx.in_adj[1].data[0] += ctx.out_adj * std::log(a) * v;
+  const bool s0 = scal(ctx, 0), s1 = scal(ctx, 1);
+  if (ctx.out.len == 1) {
+    const double a = ctx.in[0].data[0], b = ctx.in[1].data[0];
+    const double v = ctx.out.data[0];
+    if (ctx.in_adj[0].data) ctx.in_adj[0].data[0] += ctx.out_adj * b * v / a;
+    if (ctx.in_adj[1].data)
+      ctx.in_adj[1].data[0] += ctx.out_adj * std::log(a) * v;
+    return;
+  }
+  for (int64_t i = 0; i < ctx.out.len; ++i) {
+    const double a = ctx.in[0].data[s0 ? 0 : i];
+    const double b = ctx.in[1].data[s1 ? 0 : i];
+    const double v = ctx.out.data[i];
+    const double dout = ctx.out_adj_vec.data[i];
+    if (ctx.in_adj[0].data)
+      ctx.in_adj[0].data[s0 ? 0 : i] += dout * b * v / a;
+    if (ctx.in_adj[1].data)
+      ctx.in_adj[1].data[s1 ? 0 : i] += dout * std::log(a) * v;
+  }
 }
 
 void dot_fwd(KernelCtx& ctx) {

--- a/runtime/kernels/eltwise_expr.cpp
+++ b/runtime/kernels/eltwise_expr.cpp
@@ -217,8 +217,8 @@ void div_bwd(KernelCtx& ctx) {
 void pow_fwd(KernelCtx& ctx) {
   const bool s0 = scal(ctx, 0), s1 = scal(ctx, 1);
   for (int64_t i = 0; i < ctx.out.len; ++i)
-    ctx.out.data[i] = std::pow(ctx.in[0].data[s0 ? 0 : i],
-                               ctx.in[1].data[s1 ? 0 : i]);
+    ctx.out.data[i] =
+        std::pow(ctx.in[0].data[s0 ? 0 : i], ctx.in[1].data[s1 ? 0 : i]);
 }
 void pow_bwd(KernelCtx& ctx) {
   const bool s0 = scal(ctx, 0), s1 = scal(ctx, 1);
@@ -235,8 +235,7 @@ void pow_bwd(KernelCtx& ctx) {
     const double b = ctx.in[1].data[s1 ? 0 : i];
     const double v = ctx.out.data[i];
     const double dout = ctx.out_adj_vec.data[i];
-    if (ctx.in_adj[0].data)
-      ctx.in_adj[0].data[s0 ? 0 : i] += dout * b * v / a;
+    if (ctx.in_adj[0].data) ctx.in_adj[0].data[s0 ? 0 : i] += dout * b * v / a;
     if (ctx.in_adj[1].data)
       ctx.in_adj[1].data[s1 ? 0 : i] += dout * std::log(a) * v;
   }

--- a/tests/test_eltwise.cpp
+++ b/tests/test_eltwise.cpp
@@ -99,7 +99,18 @@ int main() {
   });
   check_case("div ss", OP_DIV, 1, {{S}, {T}},
              [](auto& v) { return v[0](0) / v[1](0); });
-  // POW (ss)
+  // POW: all shape combos, like the binaries above. Bases stay positive so
+  // fractional exponents remain in support on both sides of the comparison.
+  const std::vector<double> P{0.5, 1.2, 2.0, 0.3};
+  check_case("pow vv", OP_POW, N, {P, B}, [](auto& v) {
+    return stan::math::sum(stan::math::pow(v[0], v[1]));
+  });
+  check_case("pow vs", OP_POW, N, {P, {T}}, [](auto& v) {
+    return stan::math::sum(stan::math::pow(v[0], v[1](0)));
+  });
+  check_case("pow sv", OP_POW, N, {{S}, B}, [](auto& v) {
+    return stan::math::sum(stan::math::pow(v[0](0), v[1]));
+  });
   check_case("pow ss", OP_POW, 1, {{S}, {T}},
              [](auto& v) { return stan::math::pow(v[0](0), v[1](0)); });
 


### PR DESCRIPTION
First catch from the now-live conformance suite (114 of the 880 catastrophic mismatches). `pow_fwd` wrote `out.data[0]` and stopped; `pow_bwd` only accumulated the scalar lane. Every vectorized `pow` returned the first element's power in lane 0, zeros elsewhere, and a zero gradient. The corpus never caught it because no corpus model raises a parameter-dependent array to a power.

Forward is a scalar libm loop like the transcendental unaries (stan-math's vectorized pow applies its scalar op per element; packet math would break bitwise parity). Backward keeps the scalar grouping (`b*v/a`, `log(a)*v`) per lane, which the ss case has always matched bitwise.

Verified: `test_eltwise` grows vv/vs/sv combos next to the other binaries, bitwise against the stan-math var reference (RED with exactly the observed failure, then GREEN); full suite 48/48; the deep-array conformance case `pow(array[,,,,,,,]int,real)` goes `mismatch` (0.53 relative, zero grad) to `verified` through the real harness.