### PR TITLE
fix: vectorized wiener evaluated every observation at element 0's parameters

### DIFF
--- a/runtime/kernels/matrix_fns.cpp
+++ b/runtime/kernels/matrix_fns.cpp
@@ -12,6 +12,7 @@
 
 #include <stan/math.hpp>
 
+#include <variant>
 #include <vector>
 
 namespace stanli {
@@ -625,19 +626,40 @@ double oprobit_eval(KernelCtx& ctx) {
   return finish_tail_density<Grad>(ctx, out, lambda, c);
 }
 
-// wiener(y | alpha, tau, beta, delta): five real arguments, all scalars.
+// wiener(y | alpha, tau, beta, delta): five real arguments, and every one
+// of them vectorizes in the language. A length-1 slot must enter stan-math
+// as a scalar: its sequence views broadcast scalars but require vectors to
+// match sizes, and the conformance sweep caught the old scalar-only tail
+// silently evaluating every observation with element 0's parameters.
 template <bool Grad>
 double wiener_eval(KernelCtx& ctx) {
   const bool propto = (ctx.variant & 0x80u) != 0;
   stan::math::nested_rev_autodiff nested;
   using stan::math::var;
-  const int64_t n = ctx.in[0].len;
-  VarV y = tail_v(ctx, 0, n);
-  var alpha = ctx.in[1].data[0], tau = ctx.in[2].data[0];
-  var beta = ctx.in[3].data[0], delta = ctx.in[4].data[0];
-  var out = propto ? stan::math::wiener_lpdf<true>(y, alpha, tau, beta, delta)
-                   : stan::math::wiener_lpdf<false>(y, alpha, tau, beta, delta);
-  return finish_tail_density<Grad>(ctx, out, y, alpha, tau, beta, delta);
+  using Arg = std::variant<var, VarV>;
+  auto load = [&](int k) -> Arg {
+    if (ctx.in[k].len == 1) return var(ctx.in[k].data[0]);
+    return tail_v(ctx, k, ctx.in[k].len);
+  };
+  Arg y = load(0), alpha = load(1), tau = load(2), beta = load(3),
+      delta = load(4);
+  var out = std::visit(
+      [&](const auto&... a) -> var {
+        return propto ? stan::math::wiener_lpdf<true>(a...)
+                      : stan::math::wiener_lpdf<false>(a...);
+      },
+      y, alpha, tau, beta, delta);
+  const double value = out.val();
+  if constexpr (Grad) {
+    var seeded = out * ctx.out_adj;
+    stan::math::grad(seeded.vi_);
+    int slot = 0;
+    for (const Arg* p : {&y, &alpha, &tau, &beta, &delta}) {
+      std::visit([&](const auto& a) { tail_scatter(ctx, slot, a); }, *p);
+      ++slot;
+    }
+  }
+  return value;
 }
 
 #define STANLI_TAIL_KERNEL(name, fn, kind)                                    \

--- a/tests/test_densities.cpp
+++ b/tests/test_densities.cpp
@@ -593,10 +593,12 @@ int main() {
         if (vectors[k]) {
           for (int i = 0; i < vectors[k]->size(); ++i)
             expect_eq(tag + " g" + std::to_string(gi), r.grad[gi],
-                      (*vectors[k])(i).adj()), ++gi;
+                      (*vectors[k])(i).adj()),
+                ++gi;
         } else {
           expect_eq(tag + " g" + std::to_string(gi), r.grad[gi],
-                    scalars[k]->adj()), ++gi;
+                    scalars[k]->adj()),
+              ++gi;
         }
       }
       return r;
@@ -616,9 +618,9 @@ int main() {
       var a = wa[0], t = wt[0], b = wb[0], d = wd[0];
       var lp = stan::math::wiener_lpdf<false>(y, a, t, b, d);
       lp.grad();
-      auto r = grads("wiener y-vector", {wy, {wa[0]}, {wt[0]}, {wb[0]}, {wd[0]}},
-                     {nullptr, &a, &t, &b, &d},
-                     {&y, nullptr, nullptr, nullptr, nullptr});
+      auto r = grads(
+          "wiener y-vector", {wy, {wa[0]}, {wt[0]}, {wb[0]}, {wd[0]}},
+          {nullptr, &a, &t, &b, &d}, {&y, nullptr, nullptr, nullptr, nullptr});
       expect_eq("wiener y-vector lp", r.value, lp.val());
       stan::math::recover_memory();
     }
@@ -626,10 +628,9 @@ int main() {
       var y = wy[0], a = wa[0], t = wt[0], b = wb[0], d = wd[0];
       var lp = stan::math::wiener_lpdf<false>(y, a, t, b, d);
       lp.grad();
-      auto r = grads("wiener scalar",
-                     {{wy[0]}, {wa[0]}, {wt[0]}, {wb[0]}, {wd[0]}},
-                     {&y, &a, &t, &b, &d},
-                     {nullptr, nullptr, nullptr, nullptr, nullptr});
+      auto r = grads(
+          "wiener scalar", {{wy[0]}, {wa[0]}, {wt[0]}, {wb[0]}, {wd[0]}},
+          {&y, &a, &t, &b, &d}, {nullptr, nullptr, nullptr, nullptr, nullptr});
       expect_eq("wiener scalar lp", r.value, lp.val());
       stan::math::recover_memory();
     }

--- a/tests/test_densities.cpp
+++ b/tests/test_densities.cpp
@@ -568,6 +568,73 @@ int main() {
         [&](int64_t i) { return std::vector<int>{-1, counts[i], -1, 20}; });
   }
 
+  // wiener: every argument vectorizes in the language, and a length-1 slot
+  // must enter stan-math as a scalar (vectors do not broadcast there).
+  {
+    using stan::math::var;
+    using VecV = Eigen::Matrix<var, -1, 1>;
+    std::vector<double> wy{1.45, 1.54}, wa{1.15, 1.24}, wt{0.15, 0.24},
+        wb{0.40, 0.49}, wd{0.05, 0.14};
+    auto vec = [](const std::vector<double>& v) {
+      VecV x(v.size());
+      for (size_t i = 0; i < v.size(); ++i) x(i) = v[i];
+      return x;
+    };
+    auto grads = [&](const std::string& tag,
+                     const std::vector<std::vector<double>>& vals,
+                     const std::vector<var*>& scalars,
+                     const std::vector<VecV*>& vectors) {
+      // Slot order: any vector slot's elements then the next slot's, matching
+      // run_op_sum's parameter concatenation.
+      auto r = stanli::testutil::run_op_sum(OP_WIENER_LPDF, 1, vals,
+                                            std::vector<bool>(5, true));
+      size_t gi = 0;
+      for (size_t k = 0; k < 5; ++k) {
+        if (vectors[k]) {
+          for (int i = 0; i < vectors[k]->size(); ++i)
+            expect_eq(tag + " g" + std::to_string(gi), r.grad[gi],
+                      (*vectors[k])(i).adj()), ++gi;
+        } else {
+          expect_eq(tag + " g" + std::to_string(gi), r.grad[gi],
+                    scalars[k]->adj()), ++gi;
+        }
+      }
+      return r;
+    };
+    {
+      VecV y = vec(wy), a = vec(wa), t = vec(wt), b = vec(wb), d = vec(wd);
+      var lp = stan::math::wiener_lpdf<false>(y, a, t, b, d);
+      lp.grad();
+      auto r = grads("wiener all-vector", {wy, wa, wt, wb, wd},
+                     {nullptr, nullptr, nullptr, nullptr, nullptr},
+                     {&y, &a, &t, &b, &d});
+      expect_eq("wiener all-vector lp", r.value, lp.val());
+      stan::math::recover_memory();
+    }
+    {
+      VecV y = vec(wy);
+      var a = wa[0], t = wt[0], b = wb[0], d = wd[0];
+      var lp = stan::math::wiener_lpdf<false>(y, a, t, b, d);
+      lp.grad();
+      auto r = grads("wiener y-vector", {wy, {wa[0]}, {wt[0]}, {wb[0]}, {wd[0]}},
+                     {nullptr, &a, &t, &b, &d},
+                     {&y, nullptr, nullptr, nullptr, nullptr});
+      expect_eq("wiener y-vector lp", r.value, lp.val());
+      stan::math::recover_memory();
+    }
+    {
+      var y = wy[0], a = wa[0], t = wt[0], b = wb[0], d = wd[0];
+      var lp = stan::math::wiener_lpdf<false>(y, a, t, b, d);
+      lp.grad();
+      auto r = grads("wiener scalar",
+                     {{wy[0]}, {wa[0]}, {wt[0]}, {wb[0]}, {wd[0]}},
+                     {&y, &a, &t, &b, &d},
+                     {nullptr, nullptr, nullptr, nullptr, nullptr});
+      expect_eq("wiener scalar lp", r.value, lp.val());
+      stan::math::recover_memory();
+    }
+  }
+
   if (failures == 0) std::printf("test_densities OK\n");
   return failures == 0 ? 0 : 1;
 }


### PR DESCRIPTION
Second catch from the conformance suite, and the largest: all 748 vectorized `wiener_lpdf` signatures disagreed with CmdStan at ~0.11 relative error. The kernel vectorized `y` but hardwired `alpha/tau/beta/delta` to `data[0]` (its comment believed those are always scalars; every argument vectorizes in Stan). Observation 0 was computed correctly and every later observation reused its parameters — visible in the failing row as `grad[0]` matching the reference exactly while later lanes repeated it or were zero.

Each slot now enters stan-math with its own shape: scalar `var` when length 1 (stan-math's sequence views broadcast scalars but require vectors to match sizes), `VarV` otherwise, dispatched through a `std::variant` so both the density call and the adjoint scatter see the true per-argument types.

Verification: new `test_densities` cases (all-vector, y-vector + scalar params, all-scalar) bitwise against the stan-math var reference — the all-vector case is RED on the old kernel with exactly the observed pathology; full suite 48/48; the conformance case `wiener_lpdf(array[]real ×5)` goes `mismatch` → `verified` through the real harness.