### PR TITLE
feat: the two-argument scalar math library, through stan-math's own autodiff

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -213,6 +213,7 @@ set(STANLI_RUNTIME_SOURCES
   runtime/kernels/densities_cdf_b.cpp
   runtime/kernels/legacy_fns.cpp
   runtime/kernels/matrix_fns.cpp
+  runtime/kernels/scalar_binary.cpp
   runtime/kernels/ode.cpp
   runtime/src/ode_prog.cpp
   runtime/kernels/constrain.cpp
@@ -396,7 +397,8 @@ install(DIRECTORY runtime/include/stanli
 set(STANLI_TESTS
   test_smoke test_executor test_recorder test_densities test_matvec
   test_legacy test_eight_schools test_glm test_nuts test_walnuts test_sexp
-  test_mir test_transforms test_eltwise test_lower test_lower_views
+  test_mir test_transforms test_eltwise test_scalar_binary test_lower
+  test_lower_views
   test_lower_view_contract test_lower_array_contract test_data test_e2e
   test_reroll test_profile test_inplace test_pass_safety test_sampling
   test_ode_prog test_mir_program_conformance test_mir_checks

--- a/runtime/include/stanli/mir_interp.hpp
+++ b/runtime/include/stanli/mir_interp.hpp
@@ -935,6 +935,50 @@ class MirInterp {
       return bin([](const T& x, const T& y) { return stan::math::fmax(x, y); });
     if (e.name == "fmin")
       return bin([](const T& x, const T& y) { return stan::math::fmin(x, y); });
+    if (e.name == "atan2")
+      return bin(
+          [](const T& x, const T& y) { return stan::math::atan2(x, y); });
+    if (e.name == "beta" && e.args.size() == 2)
+      return bin([](const T& x, const T& y) { return stan::math::beta(x, y); });
+    if (e.name == "fdim")
+      return bin([](const T& x, const T& y) { return stan::math::fdim(x, y); });
+    if (e.name == "fmod")
+      return bin([](const T& x, const T& y) { return stan::math::fmod(x, y); });
+    if (e.name == "gamma_p")
+      return bin(
+          [](const T& x, const T& y) { return stan::math::gamma_p(x, y); });
+    if (e.name == "gamma_q")
+      return bin(
+          [](const T& x, const T& y) { return stan::math::gamma_q(x, y); });
+    if (e.name == "hypot")
+      return bin(
+          [](const T& x, const T& y) { return stan::math::hypot(x, y); });
+    if (e.name == "lbeta")
+      return bin(
+          [](const T& x, const T& y) { return stan::math::lbeta(x, y); });
+    if (e.name == "lchoose" || e.name == "binomial_coefficient_log")
+      return bin([](const T& x, const T& y) {
+        return stan::math::binomial_coefficient_log(x, y);
+      });
+    if (e.name == "log_falling_factorial")
+      return bin([](const T& x, const T& y) {
+        return stan::math::log_falling_factorial(x, y);
+      });
+    if (e.name == "log_inv_logit_diff")
+      return bin([](const T& x, const T& y) {
+        return stan::math::log_inv_logit_diff(x, y);
+      });
+    if (e.name == "log_modified_bessel_first_kind")
+      return bin([](const T& x, const T& y) {
+        return stan::math::log_modified_bessel_first_kind(x, y);
+      });
+    if (e.name == "log_rising_factorial")
+      return bin([](const T& x, const T& y) {
+        return stan::math::log_rising_factorial(x, y);
+      });
+    if (e.name == "owens_t")
+      return bin(
+          [](const T& x, const T& y) { return stan::math::owens_t(x, y); });
     // --O1 partial evaluation rewrites `x * log(y)` to lmultiply(x, y);
     // multiply_log computes exactly x * log(y), so the value is bitwise
     // what the unoptimized form produced.

--- a/runtime/include/stanli/optable.hpp
+++ b/runtime/include/stanli/optable.hpp
@@ -95,6 +95,23 @@ namespace stanli {
   X(OP_TANHV)                       \
   X(OP_CUMSUM)                      \
   X(OP_FMA)                         \
+  X(OP_ATAN2)                       \
+  X(OP_BETA_FN)                     \
+  X(OP_FDIM)                        \
+  X(OP_FMAX)                        \
+  X(OP_FMIN)                        \
+  X(OP_FMOD)                        \
+  X(OP_GAMMA_P)                     \
+  X(OP_GAMMA_Q)                     \
+  X(OP_HYPOT)                       \
+  X(OP_LBETA)                       \
+  X(OP_LCHOOSE)                     \
+  X(OP_LMULTIPLY)                   \
+  X(OP_LOG_FALLING_FACTORIAL)       \
+  X(OP_LOG_INV_LOGIT_DIFF)          \
+  X(OP_LOG_MODIFIED_BESSEL_1)       \
+  X(OP_LOG_RISING_FACTORIAL)        \
+  X(OP_OWENS_T)                     \
   X(OP_CONSTRAIN_LOWER)             \
   X(OP_CONSTRAIN_UPPER)             \
   X(OP_CONSTRAIN_LU)                \
@@ -472,6 +489,35 @@ constexpr bool unary_has_pullback(UnaryTopology topology, double x) {
   X(OP_ROUND, round, std::round(x), 0.0, UnaryTopology::Disconnected)        \
   X(OP_TRUNC, trunc, std::trunc(x), 0.0, UnaryTopology::Disconnected)        \
   X(OP_STEP, step, x < 0 ? 0.0 : 1.0, 0.0, UnaryTopology::Disconnected)
+
+// Two-argument scalar math: opcode, language name, stan-math function.
+// Unlike the unary list, no hand-written derivative: the kernel evaluates
+// stan-math's own var overload on a nested tape, so the value and every
+// partial are the reference's by construction. That trade is deliberate --
+// these are long-tail functions (lchoose alone has a stability recursion
+// and five gradient edge cases), and a transcription error here is exactly
+// the class of bug the conformance sweep exists to catch. The language
+// name feeds the lowering table and the MIR interpreter; lchoose is
+// stanc3's name for stan-math's binomial_coefficient_log.
+#define STANLI_SCALAR_BINARY_LIST(X)                                        \
+  X(OP_ATAN2, atan2, atan2)                                                 \
+  X(OP_BETA_FN, beta, beta)                                                 \
+  X(OP_FDIM, fdim, fdim)                                                    \
+  X(OP_FMAX, fmax, fmax)                                                    \
+  X(OP_FMIN, fmin, fmin)                                                    \
+  X(OP_FMOD, fmod, fmod)                                                    \
+  X(OP_GAMMA_P, gamma_p, gamma_p)                                           \
+  X(OP_GAMMA_Q, gamma_q, gamma_q)                                           \
+  X(OP_HYPOT, hypot, hypot)                                                 \
+  X(OP_LBETA, lbeta, lbeta)                                                 \
+  X(OP_LCHOOSE, lchoose, binomial_coefficient_log)                          \
+  X(OP_LMULTIPLY, lmultiply, lmultiply)                                     \
+  X(OP_LOG_FALLING_FACTORIAL, log_falling_factorial, log_falling_factorial) \
+  X(OP_LOG_INV_LOGIT_DIFF, log_inv_logit_diff, log_inv_logit_diff)          \
+  X(OP_LOG_MODIFIED_BESSEL_1, log_modified_bessel_first_kind,               \
+    log_modified_bessel_first_kind)                                         \
+  X(OP_LOG_RISING_FACTORIAL, log_rising_factorial, log_rising_factorial)    \
+  X(OP_OWENS_T, owens_t, owens_t)
 
 // The tier a density is actually built at. STANLI_LITE_LP drops the
 // propto family from every one of them: about half the library, at the

--- a/runtime/kernels/scalar_binary.cpp
+++ b/runtime/kernels/scalar_binary.cpp
@@ -1,0 +1,84 @@
+// Two-argument scalar math through stan-math's own var overloads, from
+// STANLI_SCALAR_BINARY_LIST (optable.hpp). One nested tape per backward
+// call; the forward is the prim double call, which is the identical
+// computation the var overload's value constructor runs.
+//
+// Elementwise with scalar broadcast, like the arithmetic binaries in
+// eltwise_expr.cpp. Lanes are created ascending, so the reverse sweep
+// fires their callbacks descending -- the order the per-element varis of
+// stan-math's apply_scalar_binary fire in CmdStan's generated C++, which
+// is what makes a broadcast scalar's adjoint accumulate in the same
+// order there and here.
+#include <stanli/graph.hpp>
+#include <stanli/optable.hpp>
+
+#include <stan/math.hpp>
+
+#include <vector>
+
+namespace stanli {
+namespace {
+
+using stan::math::var;
+using VecVar = std::vector<var>;
+
+template <typename F>
+void binary_fwd(KernelCtx& ctx, F&& f) {
+  const bool s0 = ctx.in[0].len == 1, s1 = ctx.in[1].len == 1;
+  for (int64_t i = 0; i < ctx.out.len; ++i)
+    ctx.out.data[i] = f(ctx.in[0].data[s0 ? 0 : i], ctx.in[1].data[s1 ? 0 : i]);
+}
+
+template <typename F>
+void binary_bwd(KernelCtx& ctx, F&& f) {
+  const bool s0 = ctx.in[0].len == 1, s1 = ctx.in[1].len == 1;
+  const int64_t n = ctx.out.len;
+  stan::math::nested_rev_autodiff nested;
+  // A broadcast scalar is ONE var shared across lanes, so per-lane
+  // partials accumulate into a single adjoint, exactly as stan-math's
+  // scalar-vs-vector overloads accumulate theirs.
+  VecVar a, b, y;
+  a.reserve(s0 ? 1 : n);
+  b.reserve(s1 ? 1 : n);
+  y.reserve(n);
+  if (s0) a.emplace_back(ctx.in[0].data[0]);
+  if (s1) b.emplace_back(ctx.in[1].data[0]);
+  for (int64_t i = 0; i < n; ++i) {
+    if (!s0) a.emplace_back(ctx.in[0].data[i]);
+    if (!s1) b.emplace_back(ctx.in[1].data[i]);
+    y.push_back(f(a[s0 ? 0 : i], b[s1 ? 0 : i]));
+  }
+  // Seed each lane with its upstream adjoint. The products and the sum
+  // deposit exactly dout[i] into y[i]'s adjoint (their callbacks multiply
+  // by an adjoint of 1.0), then the lane callbacks run.
+  var seeded = 0.0;
+  const double* dout = n == 1 ? &ctx.out_adj : ctx.out_adj_vec.data;
+  for (int64_t i = 0; i < n; ++i) seeded += y[i] * dout[i];
+  stan::math::grad(seeded.vi_);
+  if (ctx.in_adj[0].data)
+    for (size_t i = 0; i < a.size(); ++i) ctx.in_adj[0].data[i] += a[i].adj();
+  if (ctx.in_adj[1].data)
+    for (size_t i = 0; i < b.size(); ++i) ctx.in_adj[1].data[i] += b[i].adj();
+}
+
+#define STANLI_DEFINE_BINARY(code, name, fn)                                   \
+  void name##_2fwd(KernelCtx& ctx) {                                           \
+    binary_fwd(ctx, [](double x, double z) { return stan::math::fn(x, z); });  \
+  }                                                                            \
+  void name##_2bwd(KernelCtx& ctx) {                                           \
+    binary_bwd(                                                                \
+        ctx, [](const var& x, const var& z) { return stan::math::fn(x, z); }); \
+  }
+STANLI_SCALAR_BINARY_LIST(STANLI_DEFINE_BINARY)
+#undef STANLI_DEFINE_BINARY
+
+}  // namespace
+
+void register_scalar_binary_kernels() {
+#define STANLI_REGISTER_BINARY(code, name, fn) \
+  register_kernel(code, Kernel{name##_2fwd, name##_2bwd, nullptr});
+  STANLI_SCALAR_BINARY_LIST(STANLI_REGISTER_BINARY)
+#undef STANLI_REGISTER_BINARY
+}
+
+}  // namespace stanli

--- a/runtime/src/executor.cpp
+++ b/runtime/src/executor.cpp
@@ -98,6 +98,7 @@ void register_matrix_kernels();
 void register_ode_kernels();
 void register_constrain_kernels();
 void register_eltwise_kernels();
+void register_scalar_binary_kernels();
 void register_mixture_kernels();
 void register_message_kernels();
 void register_island_kernel();
@@ -112,6 +113,7 @@ static void ensure_registered() {
     register_constrain_kernels();
     register_message_kernels();
     register_eltwise_kernels();
+    register_scalar_binary_kernels();
     register_mixture_kernels();
     register_island_kernel();
     return true;

--- a/runtime/src/lower.cpp
+++ b/runtime/src/lower.cpp
@@ -1981,9 +1981,20 @@ struct Lowering {
   std::optional<Val> lower_eltwise_fn(const mir::Expr& e) {
     // Elementwise binaries.
     static const std::map<std::string, uint16_t> kBin = {
-        {"Plus__", OP_ADD},     {"Minus__", OP_SUB},     {"Divide__", OP_DIV},
-        {"EltTimes__", OP_MUL}, {"EltDivide__", OP_DIV}, {"Pow__", OP_POW},
+        {"Plus__", OP_ADD},
+        {"Minus__", OP_SUB},
+        {"Divide__", OP_DIV},
+        {"EltTimes__", OP_MUL},
+        {"EltDivide__", OP_DIV},
+        {"Pow__", OP_POW},
         {"pow", OP_POW},
+// Generated from STANLI_SCALAR_BINARY_LIST (optable.hpp), which also made
+// the opcode and the kernel. multiply_log is the pre-optimizer spelling of
+// lmultiply, so it rides the same opcode.
+#define STANLI_BINARY_TABLE(code, name, fn) {#name, code},
+        STANLI_SCALAR_BINARY_LIST(STANLI_BINARY_TABLE)
+#undef STANLI_BINARY_TABLE
+            {"multiply_log", OP_LMULTIPLY},
     };
     if (e.name == "Times__") {
       Val a = lower_expr(e.args[0]);

--- a/tests/test_scalar_binary.cpp
+++ b/tests/test_scalar_binary.cpp
@@ -1,0 +1,106 @@
+// STANLI_SCALAR_BINARY_LIST ops vs the stan-math var overloads CmdStan's
+// generated C++ would run: value and every gradient lane, bitwise, across
+// the four shape combos (vv, vs, sv, ss). In-support inputs per function.
+#include "graph_helpers.hpp"
+
+#include <stanli/graph.hpp>
+#include <stanli/optable.hpp>
+
+#include <stan/math.hpp>
+#include <cstdio>
+#include <string>
+#include <vector>
+
+static int failures = 0;
+static void expect_eq(const std::string& what, double got, double want) {
+  if (got != want) {
+    ++failures;
+    std::printf("FAIL %-28s got %.17g want %.17g\n", what.c_str(), got, want);
+  }
+}
+
+using stan::math::var;
+
+template <typename F>
+static void check_shape(const std::string& tag, uint16_t opcode,
+                        const std::vector<double>& av,
+                        const std::vector<double>& bv, F&& f) {
+  const int64_t n = std::max((int64_t)av.size(), (int64_t)bv.size());
+  auto r = stanli::testutil::run_op_sum(opcode, n, {av, bv}, {true, true});
+  // Reference: scalar var call per lane, scalars shared -- the graph
+  // stan-math's own scalar overloads build for the same expression.
+  std::vector<var> a, b;
+  for (double x : av) a.emplace_back(x);
+  for (double x : bv) b.emplace_back(x);
+  var lp = 0.0;
+  for (int64_t i = 0; i < n; ++i)
+    lp += f(a[av.size() == 1 ? 0 : i], b[bv.size() == 1 ? 0 : i]);
+  lp.grad();
+  expect_eq(tag + " lp", r.value, lp.val());
+  size_t gi = 0;
+  for (const auto& x : a) {
+    expect_eq(tag + " g" + std::to_string(gi), r.grad[gi], x.adj());
+    ++gi;
+  }
+  for (const auto& x : b) {
+    expect_eq(tag + " g" + std::to_string(gi), r.grad[gi], x.adj());
+    ++gi;
+  }
+  stan::math::recover_memory();
+}
+
+template <typename F>
+static void check_fn(const std::string& name, uint16_t opcode,
+                     const std::vector<double>& av,
+                     const std::vector<double>& bv, F&& f) {
+  check_shape(name + " vv", opcode, av, bv, f);
+  check_shape(name + " vs", opcode, av, {bv[0]}, f);
+  check_shape(name + " sv", opcode, {av[0]}, bv, f);
+  check_shape(name + " ss", opcode, {av[0]}, {bv[0]}, f);
+}
+
+int main() {
+  using namespace stanli;
+#define F(fn) \
+  [](const var& x, const var& y) -> var { return stan::math::fn(x, y); }
+
+  // Free-sign pairs.
+  const std::vector<double> xs{0.5, -1.2, 2.0, 0.3};
+  const std::vector<double> ys{1.5, 0.7, -0.4, 2.2};
+  // Positive pairs, for the log-domain functions.
+  const std::vector<double> ps{0.9, 1.7, 0.35, 2.4};
+  const std::vector<double> qs{1.1, 0.6, 2.2, 0.8};
+  // n >= k >= 0, for lchoose.
+  const std::vector<double> ns{7.5, 4.0, 9.25, 6.0};
+  const std::vector<double> ks{2.5, 1.0, 3.0, 0.5};
+  // a > b elementwise AND against each other's first element, so every
+  // broadcast shape stays inside log_inv_logit_diff's support.
+  const std::vector<double> hi{1.5, 0.7, 2.0, 2.2};
+  const std::vector<double> lo{0.5, -1.2, -0.4, 0.3};
+
+  check_fn("atan2", OP_ATAN2, xs, ys, F(atan2));
+  check_fn("beta", OP_BETA_FN, ps, qs, F(beta));
+  check_fn("fdim", OP_FDIM, xs, ys, F(fdim));
+  check_fn("fmax", OP_FMAX, xs, ys, F(fmax));
+  check_fn("fmin", OP_FMIN, xs, ys, F(fmin));
+  check_fn("fmod", OP_FMOD, xs, ys, F(fmod));
+  check_fn("gamma_p", OP_GAMMA_P, ps, qs, F(gamma_p));
+  check_fn("gamma_q", OP_GAMMA_Q, ps, qs, F(gamma_q));
+  check_fn("hypot", OP_HYPOT, xs, ys, F(hypot));
+  check_fn("lbeta", OP_LBETA, ps, qs, F(lbeta));
+  check_fn("lchoose", OP_LCHOOSE, ns, ks, F(binomial_coefficient_log));
+  check_fn("lmultiply", OP_LMULTIPLY, xs, qs, F(lmultiply));
+  check_fn("log_falling_factorial", OP_LOG_FALLING_FACTORIAL, ns, ks,
+           F(log_falling_factorial));
+  check_fn("log_inv_logit_diff", OP_LOG_INV_LOGIT_DIFF, hi, lo,
+           F(log_inv_logit_diff));
+  check_fn("log_modified_bessel_first_kind", OP_LOG_MODIFIED_BESSEL_1, ps, qs,
+           F(log_modified_bessel_first_kind));
+  check_fn("log_rising_factorial", OP_LOG_RISING_FACTORIAL, ps, qs,
+           F(log_rising_factorial));
+  check_fn("owens_t", OP_OWENS_T, xs, ys, F(owens_t));
+#undef F
+
+  if (failures == 0) std::printf("test_scalar_binary OK\n");
+  return failures == 0 ? 0 : 1;
+}


### PR DESCRIPTION
Seventeen function families the conformance sweep reported `unexpected_unsupported` — `atan2`, `beta`, `fdim`, `fmax`, `fmin`, `fmod`, `gamma_p`, `gamma_q`, `hypot`, `lbeta`, `lchoose`, `lmultiply`, `log_falling_factorial`, `log_inv_logit_diff`, `log_modified_bessel_first_kind`, `log_rising_factorial`, `owens_t` — roughly 2,900 signature rows once vectorized overloads expand.

One X-macro list (`STANLI_SCALAR_BINARY_LIST`) makes the opcode, kernel, registration, lowering entry, and MIR interpreter branch, like the unary list. Unlike the unary list there is **no hand-written derivative**: the kernel evaluates stan-math's `var` overload on a nested tape, so the value and every partial are the reference's by construction. Deliberate trade — these are long-tail functions (`lchoose` alone hides a stability recursion and five gradient edge cases), a transcription slip is exactly the bug class the sweep catches, and slow-is-fine here. Lanes are created ascending so the reverse sweep fires descending, matching the order `apply_scalar_binary`'s per-element varis fire in CmdStan's generated C++ (broadcast-scalar adjoint accumulation order included).

`lchoose` is stanc3's name for `binomial_coefficient_log`; `multiply_log` is the pre-optimizer spelling of `lmultiply` and rides the same opcode.

Verification: `test_scalar_binary` checks all seventeen against the stan-math var reference across vv/vs/sv/ss, values and every gradient lane **bitwise** — first run green, which is the point of not transcribing. Full suite 49/49. Conformance spot checks through the real harness: `atan2`, `lbeta` (deep array + scalar broadcast), `hypot` (scalar + array), `lmultiply` all go `unexpected_unsupported` → `verified`.

Not in this PR: vectorized `log_sum_exp`/`log_diff_exp` (scalar forms already exist on their own opcodes), the int-argument families (`bessel_*`, `ldexp`, `lmgamma`, `falling_factorial`, …), and `student_t_qf`.