### PR TITLE
release: 0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.8.0
 
 ### Pathfinder, and a NUTS vs Pathfinder comparison
 
@@ -22,6 +22,11 @@ per-parameter discrepancy column. k-hat is shown with its honest
 caveat: it certifies weight stability, never coverage -- on centered
 eight schools the approximation misses the funnel badly while k-hat
 stays green, which is exactly the failure the view exists to show.
+
+Standalone Pathfinder mode draws no trace plots: its draws are
+importance resamples with no serial order, so a trace would read as
+perfect mixing by construction. It shows the live L-BFGS climb (one
+line per path, ELBO pick marked) and per-parameter histograms instead.
 
 ## 0.7.2
 

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@seantalts/stanli",
-  "version": "0.7.2",
+  "version": "0.8.0",
   "description": "Full Stan in the browser: stanc3 compiles the model in JS, a WASM runtime lowers it to an op graph and runs NUTS. No server, no C++ toolchain.",
   "type": "module",
   "main": "index.mjs",

--- a/python/stanli/__init__.py
+++ b/python/stanli/__init__.py
@@ -21,7 +21,7 @@ __all__ = ["Model", "Fit", "Summary", "OptimizeResult",
            "SAMPLER_COLUMNS", "__version__"]
 # The one place the version lives. setup.py and the release workflow both
 # read it from here.
-__version__ = "0.7.2"
+__version__ = "0.8.0"
 
 _BIN = pathlib.Path(__file__).parent / "_bin"
 

--- a/r/DESCRIPTION
+++ b/r/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: stanli
 Type: Package
 Title: The Stan Language Interpreter
-Version: 0.7.2
+Version: 0.8.0
 Authors@R: person("Sean", "Talts", email = "xitrium@gmail.com",
                   role = c("aut", "cre"))
 Description: Compile and sample Stan models without a C++ toolchain. Stan

--- a/r/R/install.R
+++ b/r/R/install.R
@@ -17,7 +17,7 @@
 # pinned binding with a runtime that has moved. The release workflow
 # asserts this equals the tag being cut, so bumping one without the
 # other fails there rather than at a user's install.
-stanli_runtime_release <- "v0.7.2"
+stanli_runtime_release <- "v0.8.0"
 
 runtime_filename <- function() {
   switch(Sys.info()[["sysname"]],


### PR DESCRIPTION
Pathfinder (single path, shared inits, live L-BFGS path, Pareto k-hat) and the NUTS vs Pathfinder comparison view (#103, #108). Version bumps + CHANGELOG.