### PR TITLE
fix: a data argument to a scalar binary binds as double, not promoted var

### DIFF
--- a/runtime/kernels/scalar_binary.cpp
+++ b/runtime/kernels/scalar_binary.cpp
@@ -14,6 +14,7 @@
 
 #include <stan/math.hpp>
 
+#include <type_traits>
 #include <vector>
 
 namespace stanli {
@@ -29,15 +30,25 @@ void binary_fwd(KernelCtx& ctx, F&& f) {
     ctx.out.data[i] = f(ctx.in[0].data[s0 ? 0 : i], ctx.in[1].data[s1 ? 0 : i]);
 }
 
-template <typename F>
-void binary_bwd(KernelCtx& ctx, F&& f) {
+// A data argument binds as double, not a promoted var: stan-math's mixed
+// overloads are what CmdStan's generated code calls when one side is
+// data, and for the selection functions the distinction is observable --
+// fmax's var,double overload gives ties to the var, its var,var overload
+// gives them to b. Whether a side is data comes from the adjoint slot:
+// no in_adj means nothing upstream ever propagates to it.
+template <bool A0, bool A1, typename F>
+void binary_bwd_typed(KernelCtx& ctx, F&& f) {
+  using T0 = std::conditional_t<A0, var, double>;
+  using T1 = std::conditional_t<A1, var, double>;
   const bool s0 = ctx.in[0].len == 1, s1 = ctx.in[1].len == 1;
   const int64_t n = ctx.out.len;
   stan::math::nested_rev_autodiff nested;
   // A broadcast scalar is ONE var shared across lanes, so per-lane
   // partials accumulate into a single adjoint, exactly as stan-math's
   // scalar-vs-vector overloads accumulate theirs.
-  VecVar a, b, y;
+  std::vector<T0> a;
+  std::vector<T1> b;
+  VecVar y;
   a.reserve(s0 ? 1 : n);
   b.reserve(s1 ? 1 : n);
   y.reserve(n);
@@ -55,19 +66,37 @@ void binary_bwd(KernelCtx& ctx, F&& f) {
   const double* dout = n == 1 ? &ctx.out_adj : ctx.out_adj_vec.data;
   for (int64_t i = 0; i < n; ++i) seeded += y[i] * dout[i];
   stan::math::grad(seeded.vi_);
-  if (ctx.in_adj[0].data)
+  if constexpr (A0) {
     for (size_t i = 0; i < a.size(); ++i) ctx.in_adj[0].data[i] += a[i].adj();
-  if (ctx.in_adj[1].data)
+  }
+  if constexpr (A1) {
     for (size_t i = 0; i < b.size(); ++i) ctx.in_adj[1].data[i] += b[i].adj();
+  }
 }
 
-#define STANLI_DEFINE_BINARY(code, name, fn)                                   \
-  void name##_2fwd(KernelCtx& ctx) {                                           \
-    binary_fwd(ctx, [](double x, double z) { return stan::math::fn(x, z); });  \
-  }                                                                            \
-  void name##_2bwd(KernelCtx& ctx) {                                           \
-    binary_bwd(                                                                \
-        ctx, [](const var& x, const var& z) { return stan::math::fn(x, z); }); \
+template <typename F>
+void binary_bwd(KernelCtx& ctx, F&& f) {
+  const bool a0 = ctx.in_adj[0].data != nullptr;
+  const bool a1 = ctx.in_adj[1].data != nullptr;
+  if (a0 && a1) {
+    binary_bwd_typed<true, true>(ctx, f);
+  } else if (a0) {
+    binary_bwd_typed<true, false>(ctx, f);
+  } else if (a1) {
+    binary_bwd_typed<false, true>(ctx, f);
+  }
+}
+
+#define STANLI_DEFINE_BINARY(code, name, fn)                                  \
+  void name##_2fwd(KernelCtx& ctx) {                                          \
+    binary_fwd(ctx, [](double x, double z) { return stan::math::fn(x, z); }); \
+  }                                                                           \
+  void name##_2bwd(KernelCtx& ctx) {                                          \
+    /* Generic on purpose: each side is var or double per the dispatch     */ \
+    /* above, so stan-math picks the same overload CmdStan's C++ would.    */ \
+    binary_bwd(ctx, [](const auto& x, const auto& z) -> var {                 \
+      return stan::math::fn(x, z);                                            \
+    });                                                                       \
   }
 STANLI_SCALAR_BINARY_LIST(STANLI_DEFINE_BINARY)
 #undef STANLI_DEFINE_BINARY

--- a/tests/test_scalar_binary.cpp
+++ b/tests/test_scalar_binary.cpp
@@ -101,6 +101,43 @@ int main() {
   check_fn("owens_t", OP_OWENS_T, xs, ys, F(owens_t));
 #undef F
 
+  // A data argument must reach stan-math as a double, not a promoted var:
+  // the var,double overloads of fmax and fmin give TIES to the var side,
+  // and the var,var overloads give them to b. The conformance sweep hit
+  // this through int arrays (int slots are always data) probed at exact
+  // ties: fmax(2 + eps*theta, 2) at theta = 0.
+  {
+    auto r =
+        stanli::testutil::run_op_sum(OP_FMAX, 1, {{2.0}, {2.0}}, {true, false});
+    var a = 2.0;
+    var lp = stan::math::fmax(a, 2.0);
+    lp.grad();
+    expect_eq("fmax tie-vs-data lp", r.value, lp.val());
+    expect_eq("fmax tie-vs-data g0", r.grad[0], a.adj());
+    stan::math::recover_memory();
+  }
+  {
+    auto r =
+        stanli::testutil::run_op_sum(OP_FMIN, 1, {{2.0}, {2.0}}, {true, false});
+    var a = 2.0;
+    var lp = stan::math::fmin(a, 2.0);
+    lp.grad();
+    expect_eq("fmin tie-vs-data lp", r.value, lp.val());
+    expect_eq("fmin tie-vs-data g0", r.grad[0], a.adj());
+    stan::math::recover_memory();
+  }
+  {
+    // Data on the left, parameter on the right: dv overloads.
+    auto r =
+        stanli::testutil::run_op_sum(OP_FMAX, 1, {{2.0}, {2.0}}, {false, true});
+    var b = 2.0;
+    var lp = stan::math::fmax(2.0, b);
+    lp.grad();
+    expect_eq("fmax data-tie-v lp", r.value, lp.val());
+    expect_eq("fmax data-tie-v g0", r.grad[0], b.adj());
+    stan::math::recover_memory();
+  }
+
   if (failures == 0) std::printf("test_scalar_binary OK\n");
   return failures == 0 ? 0 : 1;
 }


### PR DESCRIPTION
The nightly after #109 reported `fmax`/`fmin` wrong at exact ties against integer data (18 rows, relative-1 gradient errors): `fmax(2 + eps*theta, 2)` at `theta = 0` sent the gradient nowhere; the reference sends it to the parameter. stan-math's `var,double` overload gives ties to the var, its `var,var` overload gives them to `b` — and the kernel promoted everything to var, taking the wrong branch exactly at ties, which the sweep's integer probes land on by construction.

`binary_bwd` now dispatches on which sides have adjoint slots and binds the inactive side as `double`, so stan-math resolves the same overload CmdStan's generated C++ calls. Smooth functions are unaffected; selection functions change branch.

Verified: tie cases in both orientations join `test_scalar_binary` (RED on the old kernel with exactly the CI gradient), full suite 50/50, both failing conformance shapes (`fmax(real,array[]int)`, `fmin(real,array[,,,,,]int)`) go `mismatch` → `verified` through the real harness.