### PR TITLE
conformance: 10 ULP default gate; calibrated ODE, wiener, and inv_Phi gates

### DIFF
--- a/harnesses/conformance/compare.py
+++ b/harnesses/conformance/compare.py
@@ -36,12 +36,15 @@ class Gate:
 
 
 # The gate a case gets when no policy rule names one. Reviewed decision
-# (2026-08-15): a lane within 5 ULP of the reference is green -- the same
-# order of tolerance the corpus oracle runs at -- so the mismatch bucket
-# holds disagreements someone should read, not accumulated last-bit noise
-# from equivalent-but-differently-grouped arithmetic. Anything looser than
-# this stays a reviewed [[numeric_gate]] rule in policy.toml.
-DEFAULT_GATE = Gate(max_ulp=5)
+# (2026-08-15, raised from 5 the same day): a lane within 10 ULP of the
+# reference is green, so the mismatch bucket holds disagreements someone
+# should read, not accumulated last-bit noise from equivalent-but-
+# differently-grouped arithmetic. The raise absorbed the 6-9 ULP class the
+# first live runs surfaced -- deep probe expression trees over functions
+# whose forward is literally the same stan-math call (inv_Phi at 6-7 ULP
+# was the type case). Anything looser than this stays a reviewed
+# [[numeric_gate]] rule in policy.toml.
+DEFAULT_GATE = Gate(max_ulp=10)
 
 
 @dataclasses.dataclass(frozen=True)

--- a/harnesses/conformance/policy.toml
+++ b/harnesses/conformance/policy.toml
@@ -1,5 +1,5 @@
 schema_version = 1
-policy_version = "2026-08-12.1"
+policy_version = "2026-08-15.1"
 
 # Stan parameters are real-valued today.  Complex signatures need a separate
 # source convention and a real projection before log-density parity has a
@@ -20,11 +20,41 @@ reason = "Tuple-valued results are not represented by stanli's value graph."
 return_kind = "tuple"
 contains_complex = false
 
-# Matched solvers at matched tolerances agree closely but are not bitwise
-# operations.  These values are inherited from harnesses/ode_sweep.py.
+# Two correct adaptive integrators at rtol 1e-6 each carry their own
+# O(rtol) discretization error, so their answers may legitimately differ
+# by that order even when both converge to the same solution.  Measured
+# on the mixed variadic rk45 construct at theta = 0: the reference moves
+# 2.8e-7 between rtol 1e-6 and 1e-12, and stanli's loose answer sits
+# 2.5e-8 from the converged solution -- eight times closer than the
+# reference's own 2.1e-7.  The earlier 1e-9 was inherited from
+# harnesses/ode_sweep.py, which measures the SAME implementation against
+# itself and so never sees cross-implementation step-control differences.
 [[numeric_gate]]
 id = "iterative-ode-solvers"
-reason = "ODE integration is iterative and has a measured near-zero floor."
+reason = "Adaptive integrators carry O(rtol) discretization error each; the difference of two correct solves is that order."
 name_regex = "^(ode_|integrate_ode)"
-abs_tol = 1e-12
-rel_tol = 1e-9
+abs_tol = 1e-9
+rel_tol = 1e-6
+
+# The wiener first-passage density's gradients on near-zero lanes differ
+# by up to a few hundred ULP between stanli's kernel and the reference:
+# same stan-math templates, different container instantiations and
+# optimization contexts (reference models compile at O=1, the runtime at
+# O2/O3).  Verified value-level agreement on arm64/clang where the same
+# rows are bitwise-adjacent; the divergence is toolchain-level, not
+# semantic.  The 0.11-relative element-broadcast bug this suite caught
+# in the same kernel sits eleven orders of magnitude above this gate.
+[[numeric_gate]]
+id = "wiener-instantiation-drift"
+reason = "Cross-instantiation/toolchain drift on near-zero gradient lanes; hundreds of ULP at ~1e-17 absolute."
+name_regex = "^wiener_lpdf$"
+rel_tol = 1e-12
+
+# inv_Phi's forward is literally the same stan-math call on both sides;
+# the deep-vectorized probes' weighted-sum trees leave up to ~7e-15
+# relative between the two evaluations of the same arithmetic.
+[[numeric_gate]]
+id = "inv-phi-probe-depth"
+reason = "Deep probe expression trees over an identical forward call; last-bit accumulation only."
+name_regex = "^inv_Phi$"
+rel_tol = 1e-13

--- a/tests/test_conformance.py
+++ b/tests/test_conformance.py
@@ -281,8 +281,12 @@ return_kind = "tuple"
         policy = load_policy(DEFAULT_POLICY)
         ode = parse_signature("ode_rk45(real, real) => real")
         normal = parse_signature("normal_lpdf(real, real, real) => real")
-        self.assertEqual(policy.numeric_gate_for(ode).rel_tol, 1e-9)
+        # O(rtol) discretization error each side; see the policy comment.
+        self.assertEqual(policy.numeric_gate_for(ode).rel_tol, 1e-6)
         self.assertIsNone(policy.numeric_gate_for(normal))
+        wiener = parse_signature(
+            "wiener_lpdf(real, real, real, real, real) => real")
+        self.assertEqual(policy.numeric_gate_for(wiener).rel_tol, 1e-12)
         self.assertEqual(policy.numeric_gate_named("iterative-ode-solvers"),
                          policy.numeric_gate_for(ode))
         with self.assertRaises(PolicyError):

--- a/tests/test_conformance.py
+++ b/tests/test_conformance.py
@@ -260,9 +260,10 @@ return_kind = "tuple"
             with self.assertRaises(PolicyError):
                 policy.classification_for(signature)
 
-    def test_default_gate_allows_five_ulp(self):
-        # Reviewed decision (2026-08-15): a lane within 5 ULP of the
-        # reference is green. Anything looser still needs a policy rule.
+    def test_default_gate_allows_ten_ulp(self):
+        # Reviewed decision (2026-08-15, raised from 5 the same day): a
+        # lane within 10 ULP of the reference is green. Anything looser
+        # still needs a policy rule.
         import types
         from conformance.scalar_runner import _gate as scalar_gate
         policy = load_policy(DEFAULT_POLICY)
@@ -270,10 +271,10 @@ return_kind = "tuple"
         case = types.SimpleNamespace(spec=types.SimpleNamespace(
             signature=normal))
         gate = scalar_gate(policy, case)
-        self.assertEqual(gate.max_ulp, 5)
-        self.assertTrue(compare_numeric(1.0, 1.0 + 5 * 2.0 ** -52,
+        self.assertEqual(gate.max_ulp, 10)
+        self.assertTrue(compare_numeric(1.0, 1.0 + 10 * 2.0 ** -52,
                                         gate).agrees)
-        self.assertFalse(compare_numeric(1.0, 1.0 + 6 * 2.0 ** -52,
+        self.assertFalse(compare_numeric(1.0, 1.0 + 11 * 2.0 ** -52,
                                          gate).agrees)
 
     def test_numeric_gate_is_narrow(self):


### PR DESCRIPTION
Two reviewed loosenings, both measured rather than guessed.

**Default gate 5 → 10 ULP** (user decision). The first live runs surfaced a 6-9 ULP class: deep probe expression trees over functions whose forward is literally the same stan-math call. 205 of 774 mismatches flip.

**`iterative-ode-solvers` rel 1e-9 → 1e-6.** The old value came from `ode_sweep`, which measures the same implementation against itself and never sees cross-implementation step control. The mixed variadic rk45 construct was red at 1.6e-7 — and the investigation showed **stanli being failed for being more accurate than the reference**: at theta 0, the reference moves 2.8e-7 between rtol 1e-6 and 1e-12, while stanli's loose answer sits 2.5e-8 from the converged solution (the reference's own loose answer is 2.1e-7 away). Two correct adaptive integrators at rtol 1e-6 each carry O(rtol) discretization error; the gate now says so.

**`wiener_lpdf` rel 1e-12**: hundreds of ULP at ~1e-17 absolute on near-zero gradient lanes; toolchain-level, not semantic — the same rows are bitwise-adjacent on arm64/clang and drift on x86_64/gcc (reference compiled O=1, runtime O2). Eleven orders below the element-broadcast bug the suite caught in this same kernel yesterday.

**`inv_Phi` rel 1e-13**: identical forward call on both sides; last-bit accumulation across deep probe trees.

Verified end to end through the real harness: the ODE construct, a previously-red wiener signature, and an inv_Phi signature all go `mismatch` → `verified`; 68 harness tests pass.

Still red after this, correctly: the three semantic construct rows (exception category, output ordering, reject phase), `generator_gap:1372`, and the remaining unsupported families.