### PR TITLE
conformance: one command to run the sweep locally, on Linux or macOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@ build-rel/
 # measurement needs next. Named entries above are kept for clarity.
 build-*/
 python/stanli/_bin/
+# The conformance reference client, pinned separately from the host
+# interpreter (tools/dev_setup.sh --conformance).
+.venv-conformance/
 dist/
 *.egg-info/
 compile_commands.json

--- a/harnesses/conformance/README.md
+++ b/harnesses/conformance/README.md
@@ -30,31 +30,64 @@ their dedicated domain and reduction cases are added.
 
 ## Setup and run
 
-Fetch stanli's pinned dependencies first. The helper then prepares the exact
-CmdStan/Stan/Stan Math combination used by BridgeStan, and builds the
-conformance stanc from source at `STANC3_SRC_SHA` (`tools/dev_setup.sh`) --
-the same revision the wheels embed -- rather than trusting any downloaded
-binary. The build needs opam and takes ~30 minutes once per pin; it is a
-no-op when `deps/stanc3/stanc-pinned` already matches the pin. The workflow
-likewise pins the public BridgeStan Python client used to drive stanli's
-facade.
+One command, on Linux or macOS:
+
+```sh
+tools/dev_setup.sh --conformance
+```
+
+That prepares the exact CmdStan/Stan/Stan Math combination BridgeStan uses,
+builds the conformance stanc from source at `STANC3_SRC_SHA`
+(`tools/dev_setup.sh`) -- the same revision the wheels embed, rather than
+trusting any downloaded binary -- pins the public BridgeStan Python client
+in a venv, and stages the runtime the harness drives. It prints the
+invocation to run afterwards.
+
+The stanc build needs opam and takes ~30 minutes, but only the first time:
+it is a no-op once `deps/stanc3/stanc-pinned` matches the pin, so the cost
+is once per machine per pin advance, not once per run. `--all` includes it.
+
+Only the nightly *workflow* is pinned to Linux. Nothing in the harness is:
+`fetch_cmdstan.sh` selects the TBB target per `uname`, and a full local run
+on macOS reproduces the same statuses.
 
 `signature_watch.sh` is the other half: it diffs stanc3's checked-in
 signature dump between the pin and upstream master, so new language surface
 is reported nightly without executing anything unreviewed. Adopting what it
 reports is a pin advance: bump `STANC3_SRC_SHA` and rerun this suite.
 
-```sh
-./deps/fetch.sh
-./harnesses/conformance/fetch_cmdstan.sh
-python3 -m pip install -r harnesses/conformance/requirements.txt
+The full sweep, once set up (`$VENV` is `.venv-conformance` by default):
 
-python3 harnesses/stan_conformance.py \
+```sh
+$VENV/bin/python harnesses/stan_conformance.py \
   --stanc deps/stanc3/stanc-pinned \
   --cmdstan deps/cmdstan \
   --build build-rel \
+  --stanli-python $VENV/bin/python \
+  --stanli-pythonpath python \
   --jobs 4
 ```
+
+Drive the harness with the venv's interpreter, not the host's: it needs
+`tomllib`, which arrived in Python 3.11, and the pinned client besides.
+
+Chasing one finding is a `--case` away, which is the loop worth knowing --
+a single case runs in seconds against the real oracle, so a fix does not
+have to wait for a nightly to be confirmed:
+
+```sh
+$VENV/bin/python harnesses/stan_conformance.py \
+  --stanc deps/stanc3/stanc-pinned --cmdstan deps/cmdstan --build build-rel \
+  --stanli-python $VENV/bin/python --stanli-pythonpath python \
+  --case 'log_diff_exp(matrix,real)=>matrix'
+```
+
+`verified=1` means that case agrees with the reference. A single-case run
+also reports `RED` with `gate issues: partial_run`, which is the
+completeness gate noting the sweep was not exhaustive, not a failure. Note
+that `--build` points at the *staged* runtime: restage
+`python/stanli/_bin/libstanli.*` after rebuilding, or the harness measures
+the previous one.
 
 By default `--cmdstan` selects the generated differential mode (the historical
 CLI spelling is `--mode scalar`) and also executes matching construct cases.

--- a/tools/dev_setup.sh
+++ b/tools/dev_setup.sh
@@ -5,12 +5,17 @@
 #   tools/dev_setup.sh            core: vendored deps + cmake builds + tests
 #   tools/dev_setup.sh --embed    + OCaml toolchain and in-process stanc3
 #   tools/dev_setup.sh --corpus   + posteriordb and the CmdStan verify rig
+#   tools/dev_setup.sh --conformance + the Stan conformance reference stack
 #   tools/dev_setup.sh --all      everything
 #   tools/dev_setup.sh --no-build stop before cmake (CI builds separately)
 #
 # Core needs: git, curl, cmake, a C++17 clang, python3.
 # --embed adds: opam (OCaml 5.5.0 switch built automatically).
 # --corpus adds: ~2 GB of checkouts under deps/ and a CmdStan build.
+# --conformance adds: opam, the source-built pinned stanc, the pinned
+#   CmdStan/BridgeStan pair, and a venv holding the reference client.
+#   Linux and macOS both; the nightly workflow runs Linux, nothing else
+#   in the harness is specific to it.
 set -euo pipefail
 cd "$(dirname "$0")/.."
 REPO=$PWD
@@ -23,17 +28,24 @@ OCAML_VERSION=5.5.0
 
 WANT_EMBED=0
 WANT_CORPUS=0
+WANT_CONFORMANCE=0
 WANT_BUILD=1
 for arg in "$@"; do
   case "$arg" in
     --embed) WANT_EMBED=1 ;;
     --corpus) WANT_CORPUS=1 ;;
-    --all) WANT_EMBED=1; WANT_CORPUS=1 ;;
+    --conformance) WANT_CONFORMANCE=1 ;;
+    --all) WANT_EMBED=1; WANT_CORPUS=1; WANT_CONFORMANCE=1 ;;
     --no-build) WANT_BUILD=0 ;;
-    -h|--help) sed -n '2,13p' "$0"; exit 0 ;;
+    -h|--help) sed -n '2,18p' "$0"; exit 0 ;;
     *) echo "unknown flag: $arg (try --help)"; exit 2 ;;
   esac
 done
+
+# Where --conformance puts the reference client. Its own venv rather than
+# the host interpreter: the harness pins bridgestan and numpy exactly, and
+# the driver itself needs tomllib, which arrived in 3.11.
+CONFORMANCE_VENV=${CONFORMANCE_VENV:-$PWD/.venv-conformance}
 
 step() { printf '\n== %s\n' "$*"; }
 have() { command -v "$1" >/dev/null 2>&1; }
@@ -44,6 +56,7 @@ missing=()
 for tool in git curl cmake python3; do have "$tool" || missing+=("$tool"); done
 if ! have clang++ && ! have g++; then missing+=("clang++ (Xcode CLT or clang)"); fi
 if [ "$WANT_EMBED" = 1 ] && ! have opam; then missing+=(opam); fi
+if [ "$WANT_CONFORMANCE" = 1 ] && ! have opam; then missing+=(opam); fi
 if [ ${#missing[@]} -gt 0 ]; then
   if have brew; then
     echo "installing via homebrew: ${missing[*]}"
@@ -145,9 +158,45 @@ if [ "$WANT_CORPUS" = 1 ]; then
   python3 tools/corpus.py deps/posteriordb || true
 fi
 
+# --- Stan conformance reference stack (optional) ---------------------------
+# The nightly sweep's oracle: the pinned stanc built from source, the exact
+# CmdStan/Stan/Math triple BridgeStan compiles against, and the reference
+# client. fetch_cmdstan.sh does all three and is idempotent, so the cost is
+# paid once per pin -- and once per machine, not once per session, which is
+# the part that is easy to mistake for a wall.
+if [ "$WANT_CONFORMANCE" = 1 ]; then
+  step "conformance reference toolchain (stanc from source, CmdStan, BridgeStan)"
+  ./harnesses/conformance/fetch_cmdstan.sh
+
+  step "conformance reference client ($CONFORMANCE_VENV)"
+  [ -d "$CONFORMANCE_VENV" ] || python3 -m venv "$CONFORMANCE_VENV"
+  "$CONFORMANCE_VENV/bin/pip" install -q --disable-pip-version-check \
+    -r harnesses/conformance/requirements.txt
+
+  # The harness drives stanli through its public Python package, which
+  # loads the shared library out of python/stanli/_bin. Staging it here
+  # means a plain `--case` run works immediately after setup.
+  step "staging the runtime the harness drives"
+  cmake -B build-rel -DCMAKE_BUILD_TYPE=Release
+  cmake --build build-rel --target stanli_shared -j8
+  mkdir -p python/stanli/_bin
+  case "$(uname -s)" in
+    Darwin) cp build-rel/libstanli.dylib python/stanli/_bin/ ;;
+    *) cp build-rel/libstanli.so python/stanli/_bin/ ;;
+  esac
+  cp deps/stanc3/stanc-pinned python/stanli/_bin/stanc
+  chmod +x python/stanli/_bin/stanc
+fi
+
 step "done"
 echo "dev build:   build/            (tests: ctest --test-dir build)"
 echo "bench build: build-rel/        (tools/bench_grad.cpp)"
 echo "corpus:      python3 tools/corpus.py deps/posteriordb"
 echo "verify:      python3 tools/verify_sample.py deps/cmdstan deps/posteriordb MODEL..."
+if [ "$WANT_CONFORMANCE" = 1 ]; then
+  echo "conformance: $CONFORMANCE_VENV/bin/python harnesses/stan_conformance.py \\"
+  echo "               --stanc deps/stanc3/stanc-pinned --cmdstan deps/cmdstan \\"
+  echo "               --build build-rel --stanli-python $CONFORMANCE_VENV/bin/python \\"
+  echo "               --stanli-pythonpath python --case 'abs(real)=>real'"
+fi
 echo "wheel:       tools/build_wheel.sh"


### PR DESCRIPTION
The conformance sweep has been treated as CI-only, with findings argued from the last nightly's recorded rows rather than checked. That was never a real constraint.

`harnesses/conformance/fetch_cmdstan.sh` already selects its TBB target from `uname` and has handled Darwin all along. What made the sweep look Linux-only was that the workflow runs on `ubuntu-24.04` and the README's "needs opam and takes ~30 minutes once per pin" reads as a wall rather than as a cost paid once per machine.

### What this adds

`tools/dev_setup.sh --conformance` (also in `--all`):

- `fetch_cmdstan.sh`, which builds the pinned stanc from source and pins the CmdStan/Stan/Math triple BridgeStan compiles against
- the reference client, version-pinned, in `.venv-conformance`
- the Release shared library staged into `python/stanli/_bin`, which is where the harness's Python package loads it from

and it prints the invocation to run afterwards.

The venv is not a style preference. The driver imports `tomllib`, which arrived in Python 3.11, so on an older host `python3` the harness does not start at all; `requirements.txt` pins `bridgestan` and `numpy` besides.

### README

Says plainly that only the workflow is Linux-pinned, leads with the one-command setup, documents the `--case` loop -- a single case runs in seconds against the real oracle, so a fix does not have to wait for a nightly to be confirmed -- and explains that `verified=1` with `RED / gate issues: partial_run` is the completeness gate noting the sweep was not exhaustive, not a failure.

It also names the one real footgun: `--build` points at the *staged* runtime, so a rebuild that is not restaged silently measures the previous one.

### Verification

Ran `--conformance --no-build` from a cleared `python/stanli/_bin`, then the invocation it printed, verbatim: `abs(real)=>real` comes back `verified=1` against the real BridgeStan oracle on macOS arm64.

The same setup was used to confirm the four fixes in #113 directly rather than by inference: `declaration.data-shape-mismatch` and `stanc3.operators-and-linear-solves` both `verified`, `statement.reject-evaluation` still `mismatch:1` as expected, and representative rows from both coverage clusters -- including `log_diff_exp(array[,,,,,,,]int,real)` at depth eight and `log_sum_exp(array[,,]matrix,array[,,]matrix)` -- `verified=1`.