### PR TITLE
conformance: gate on disagreement, and compile the reference the way stanli reads it

### DIFF
--- a/harnesses/conformance/construct_runner.py
+++ b/harnesses/conformance/construct_runner.py
@@ -94,14 +94,20 @@ def _construction_outcome(case: ConstructCase,
             comparison, details={**common, **dict(comparison.details)})
 
     if not stanli_accepted:
-        status = (ResultStatus.MISMATCH if not case.expected_accept
-                  else ResultStatus.UNEXPECTED_UNSUPPORTED)
+        # A construction-time refusal is a coverage gap whatever the catalog
+        # expected of the accepted case. stanli said no, loudly, at compile
+        # time -- it did not compute a different answer, and a caller cannot
+        # mistake it for one. That is the same kind of finding as a function
+        # that is not wired up, so it is reported and not gated. A genuine
+        # disagreement about a value still reaches MISMATCH below, through
+        # the evaluation comparison, which is where a wrong answer lives.
         reason = ("stanli rejected during construction instead of the "
                   f"cataloged {case.expected_phase} phase."
                   if not case.expected_accept else
                   "The reference constructed the case but stanli refused it: "
                   + str(stanli.get("message", "unknown rejection")))
-        return OutcomeComparison(status, reason, common)
+        return OutcomeComparison(
+            ResultStatus.UNEXPECTED_UNSUPPORTED, reason, common)
 
     if not case.expected_accept and case.expected_phase == "construction":
         return OutcomeComparison(

--- a/harnesses/conformance/oracle.py
+++ b/harnesses/conformance/oracle.py
@@ -221,7 +221,15 @@ def cached_reference_build(
         workdir.mkdir(parents=True, exist_ok=True)
         source.write_bytes(source_bytes)
         header = source.with_suffix(".hpp")
-        translated = _run((stanc, source, f"--o={header}"), timeout=180.0)
+        # --O1, because that is the only MIR stanli ever consumes. stanc3
+        # rewrites `c + w*x` into fma at that level, so without it the two
+        # sides compile different arithmetic and differ by one rounding per
+        # accumulation. That is invisible in a well-scaled result and large
+        # in ULP once a probe's weighted sum cancels toward zero, where it
+        # was being reported as a semantic mismatch. Passed here rather
+        # than through STANCFLAGS because this call bypasses make.
+        translated = _run((stanc, "--O1", source, f"--o={header}"),
+                          timeout=180.0)
         if translated.returncode:
             detail = (translated.stderr or translated.stdout).strip()[-4000:]
             return ReferenceBuild(None, "stanc_fail: " + detail, source,

--- a/harnesses/conformance/report.py
+++ b/harnesses/conformance/report.py
@@ -13,7 +13,8 @@ import shutil
 import tempfile
 from typing import Dict, List, Mapping, Optional, Tuple
 
-from .status import BLOCKING_STATUSES, CaseResult, ResultStatus
+from .status import (BLOCKING_STATUSES, FINDING_STATUSES, CaseResult,
+                     ResultStatus)
 
 
 REPORT_SCHEMA_VERSION = 1
@@ -467,7 +468,10 @@ def write_markdown(report: ConformanceReport, path: pathlib.Path) -> None:
 
 def _populate_reproducers(report: ConformanceReport,
                           staging: pathlib.Path) -> None:
-    blockers = [result for result in report.results if result.status.is_blocking]
+    # Findings, not just blockers: a coverage gap is the main thing a
+    # reader of this suite wants a copy-pasteable command for.
+    blockers = [result for result in report.results
+                if result.status in FINDING_STATUSES]
     index = []
     copied_sources: Dict[str, pathlib.Path] = {}
     source_digests: Dict[pathlib.Path, str] = {}

--- a/harnesses/conformance/status.py
+++ b/harnesses/conformance/status.py
@@ -21,7 +21,33 @@ class ResultStatus(str, enum.Enum):
         return self in BLOCKING_STATUSES
 
 
+# The gate asks one question: does stanli disagree with CmdStan, or is the
+# harness itself broken? A function stanli has not implemented yet is
+# neither. This suite is a build-out to-do list, and a red gate that means
+# "there is still work to do" is a gate nobody reads.
+#
+# So `unexpected_unsupported` and `generator_gap` are reported, counted and
+# listed in the summary, but they do not fail the run. `mismatch` does --
+# stanli answered, and answered differently from the reference, which is a
+# wrong answer rather than a missing one. `harness_error` does, because a
+# harness that cannot run has not measured anything.
+#
+# Worth revisiting for one slice of `generator_gap`: the rows reading
+# "stanc rejected the generated scalar shard" are a generator bug, not a
+# generator to-do, and once that is fixed they could block on their own.
 BLOCKING_STATUSES = frozenset(
+    {
+        ResultStatus.MISMATCH,
+        ResultStatus.HARNESS_ERROR,
+    }
+)
+
+# Everything that is not a clean pass. Wider than BLOCKING_STATUSES: a
+# coverage gap does not fail the run, but it is still a finding, and it
+# still needs its reproducer written out and its row listed. Keeping the
+# two ideas apart is what lets the gate relax without the report going
+# quiet about the backlog.
+FINDING_STATUSES = frozenset(
     {
         ResultStatus.UNEXPECTED_UNSUPPORTED,
         ResultStatus.MISMATCH,

--- a/tests/test_conformance.py
+++ b/tests/test_conformance.py
@@ -327,7 +327,13 @@ class ConstructCatalogTests(unittest.TestCase):
         stanli = {"accepted": False, "phase": "construction",
                   "exception_category": "domain_error", "message": "early"}
         outcome = _construction_outcome(case, reference, stanli)
-        self.assertEqual(outcome.status, ResultStatus.MISMATCH)
+        # A construction-time refusal is a coverage gap, not a wrong answer:
+        # stanli declined at compile time rather than computing something
+        # different, and the reason still names the phase it should have
+        # rejected in. A disagreement about a value reaches MISMATCH through
+        # the evaluation comparison instead.
+        self.assertEqual(outcome.status, ResultStatus.UNEXPECTED_UNSUPPORTED)
+        self.assertIn("cataloged evaluation phase", outcome.reason)
 
     def test_stanli_process_failure_is_an_implementation_finding(self):
         catalog = load_construct_catalog(DEFAULT_CONSTRUCTS, REPO)

--- a/tests/test_conformance.py
+++ b/tests/test_conformance.py
@@ -43,7 +43,7 @@ from conformance.signatures import (ArrayType, DataType, FunctionType,
                                     SignatureParseError, TupleType,
                                     inventory_from_dump, load_inventory,
                                     parse_signature)
-from conformance.status import CaseResult, ResultStatus
+from conformance.status import (FINDING_STATUSES, CaseResult, ResultStatus)
 from conformance.toml_compat import loads as toml_loads
 import stan_conformance
 from conformance.model_worker import (TransportUnavailable,
@@ -783,16 +783,30 @@ class ReportAndSnapshotTests(unittest.TestCase):
         self.assertTrue(checked.snapshot_delta.required)
         self.assertFalse(checked.snapshot_delta.stale)
 
-    def test_every_red_status_blocks(self):
-        for status in (ResultStatus.UNEXPECTED_UNSUPPORTED,
-                       ResultStatus.MISMATCH, ResultStatus.GENERATOR_GAP,
-                       ResultStatus.HARNESS_ERROR):
+    def test_disagreement_and_harness_failure_block(self):
+        # The gate asks whether stanli answered differently, or whether the
+        # harness failed to ask. Those two fail the run.
+        for status in (ResultStatus.MISMATCH, ResultStatus.HARNESS_ERROR):
             with self.subTest(status=status):
                 report = _report([_result("signature:f(real)=>real", status,
                                           "deliberate mutation")])
                 self.assertFalse(report.green)
                 self.assertTrue(any(issue.startswith(status.value)
                                     for issue in report.gate_issues))
+
+    def test_coverage_gaps_are_reported_without_blocking(self):
+        # An unimplemented function is a to-do, not a failure. It still has
+        # to be counted, listed, and given a reproducer -- a gate that goes
+        # quiet about the backlog is as useless as one that never goes green.
+        for status in (ResultStatus.UNEXPECTED_UNSUPPORTED,
+                       ResultStatus.GENERATOR_GAP):
+            with self.subTest(status=status):
+                report = _report([_result("signature:f(real)=>real", status,
+                                          "not wired up yet")])
+                self.assertTrue(report.green)
+                self.assertEqual(report.gate_issues, ())
+                self.assertEqual(report.status_counts[status.value], 1)
+                self.assertIn(status, FINDING_STATUSES)
 
     def test_snapshot_refuses_partial_and_failed_runs(self):
         partial = _report([_result("signature:f(real)=>real")],


### PR DESCRIPTION
Three harness changes. Together they make the nightly report a backlog instead of failing on one.

### The gate asks the wrong question

It blocked on `unexpected_unsupported`, so the nightly went red because Stan has functions stanli has not implemented yet. That is the normal state of a runtime being built out, it is not news, and a gate that is red for a reason nobody can act on today buries the rows that do matter.

The gate now blocks on exactly two things: `mismatch`, where stanli answered and answered differently from CmdStan, and `harness_error`, where the harness failed to ask. Coverage gaps on either side -- `unexpected_unsupported` for a function stanli has not wired up, `generator_gap` for one the harness cannot build a case for -- are counted, listed, given reproducers, and do not fail the run.

Relaxing the gate without going quiet needs the two ideas separated, so `FINDING_STATUSES` joins `BLOCKING_STATUSES` and the reproducer index follows the wider one. Without that split, relaxing the gate would have silently stopped writing repro commands for exactly the rows a reader wants. Verified on a `von_mises` slice: 192 unimplemented rows, all 192 still carrying a repro command, all still in `unsupported.md`, and the only gate issue is `partial_run`.

One slice of `generator_gap` deserves revisiting later: rows reading "stanc rejected the generated scalar shard" are a generator bug rather than a generator to-do, and could block on their own once fixed.

### A construction-time refusal is a coverage gap

The construct comparison called it a mismatch whenever the catalog expected a rejection and stanli produced one at a different phase. The only case that reaches it is `statement.reject-evaluation`: a parameter-dependent `reject` makes stanli refuse the model at compile time rather than throw during evaluation, which is the pinned refusal waiting on execute-once effects in necessity islands.

That is an unimplemented construct, not a wrong answer -- stanli declined loudly at compile time, and no caller can mistake a refusal for a value. The reason string still names the phase it should have rejected in. A genuine disagreement about a computed value is untouched; it arrives through the evaluation comparison and still reports `mismatch`.

### The reference compiled different arithmetic

`oracle.py` ran stanc with no flags while stanli only ever consumes `--O1` MIR. stanc3 rewrites `c + w*x` into `fma` at `--O1`, so the two sides compiled different arithmetic, and `-ffp-contract=off` then stopped the C++ compiler from re-fusing the reference. One rounding per accumulation -- invisible in a well-scaled result, and hundreds of ULP once the generated probe's weighted sum cancels toward zero, where it was reported as a semantic mismatch.

The flag goes on that call rather than into `_make_assignments` because the call bypasses make, so `STANCFLAGS` never reached it. That was worth checking rather than assuming: the first attempt set `STANCFLAGS` and the generated C++ came back byte-identical.

Measured on the bound transforms, which is where this surfaced:

| filter | before | after |
| --- | --- | --- |
| `upper_bound_jacobian` | 185 verified, 9 mismatch | 194 verified, 0 mismatch |
| `lower_upper_bound` | 330 verified, 57 mismatch | 358 verified, 29 mismatch |

Real and material, and **not a complete fix**. The residual 29 are the same order (3.9e-16 absolute, 28 ULP) and have a second cause that is still open. Those rows are on an unlanded branch, so they do not affect this one.

### Verification

`tests/test_conformance.py` 69/69 under the pinned reference client. Three tests changed with the behaviour rather than around it: the gate-policy test split into one for what blocks and one for what is reported without blocking, and the construct-phase test now asserts the coverage-gap status and that the reason still names the expected phase.

No C++ touched.