### PR TITLE
conformance: one command to set the harness up locally

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@ build-rel/
 # measurement needs next. Named entries above are kept for clarity.
 build-*/
 python/stanli/_bin/
+# The conformance reference client, version-pinned separately from whatever
+# python3 the host happens to have (tools/dev_setup.sh --conformance).
+.venv-conformance/
 dist/
 *.egg-info/
 compile_commands.json

--- a/README.md
+++ b/README.md
@@ -268,11 +268,16 @@ python3 -m http.server -d web     # then open http://localhost:8000
 One-shot setup (fetches pinned deps, builds, runs tests):
 
 ```
-./tools/dev_setup.sh            # core build + tests
-./tools/dev_setup.sh --embed    # + OCaml toolchain, in-process stanc3
-./tools/dev_setup.sh --corpus   # + posteriordb and the CmdStan verify rig
+./tools/dev_setup.sh               # core build + tests
+./tools/dev_setup.sh --embed       # + OCaml toolchain, in-process stanc3
+./tools/dev_setup.sh --corpus      # + posteriordb and the CmdStan verify rig
+./tools/dev_setup.sh --conformance # + the Stan conformance reference stack
 ./tools/dev_setup.sh --all
 ```
+
+`--conformance` is what makes the differential Stan language sweep runnable
+here rather than only in the nightly; see
+[harnesses/conformance/README.md](harnesses/conformance/README.md).
 
 Or manually:
 

--- a/harnesses/conformance/README.md
+++ b/harnesses/conformance/README.md
@@ -30,45 +30,98 @@ their dedicated domain and reduction cases are added.
 
 ## Setup and run
 
-Fetch stanli's pinned dependencies first. The helper then prepares the exact
-CmdStan/Stan/Stan Math combination used by BridgeStan, and builds the
-conformance stanc from source at `STANC3_SRC_SHA` (`tools/dev_setup.sh`) --
-the same revision the wheels embed -- rather than trusting any downloaded
-binary. The build needs opam and takes ~30 minutes once per pin; it is a
-no-op when `deps/stanc3/stanc-pinned` already matches the pin. The workflow
-likewise pins the public BridgeStan Python client used to drive stanli's
-facade.
-
-`signature_watch.sh` is the other half: it diffs stanc3's checked-in
-signature dump between the pin and upstream master, so new language surface
-is reported nightly without executing anything unreviewed. Adopting what it
-reports is a pin advance: bump `STANC3_SRC_SHA` and rerun this suite.
+One command, on Linux or macOS:
 
 ```sh
-./deps/fetch.sh
-./harnesses/conformance/fetch_cmdstan.sh
-python3 -m pip install -r harnesses/conformance/requirements.txt
+tools/dev_setup.sh --conformance
+```
 
-python3 harnesses/stan_conformance.py \
+That prepares the whole oracle: the exact CmdStan/Stan/Stan Math combination
+BridgeStan compiles against, the conformance stanc built from source at
+`STANC3_SRC_SHA` -- the same revision the wheels embed, rather than a
+downloaded binary -- the version-pinned BridgeStan Python client in
+`.venv-conformance/`, and the stanli library staged where the harness drives
+it from. Every step is a no-op once its output exists, so the stanc build's
+half hour is paid once per machine per pin, not once per session, and
+`--embed` and `--corpus` pay most of it already. It ends by printing the
+invocation below with your paths filled in.
+
+Run the driver under the venv interpreter, not the host's `python3`. The
+harness reads its policy and catalog as TOML; `tomllib` arrived in Python
+3.11, and `requirements.txt` carries the backport for older hosts -- but
+into the venv, so on an older system `python3` the driver refuses to start
+at all. Running it from the venv also makes `--stanli-python` default to the
+same interpreter, which is where the pinned BridgeStan client lives.
+
+```sh
+.venv-conformance/bin/python harnesses/stan_conformance.py \
   --stanc deps/stanc3/stanc-pinned \
   --cmdstan deps/cmdstan \
   --build build-rel \
+  --stanli-pythonpath python \
   --jobs 4
 ```
 
-By default `--cmdstan` selects the generated differential mode (the historical
-CLI spelling is `--mode scalar`) and also executes matching construct cases.
-Use `--mode inventory` for the fast classification-only pass. Development
-selectors are stable:
+`--stanli-pythonpath python` points the worker at this checkout's package
+instead of an installed wheel. The library it loads is the staged copy in
+`python/stanli/_bin`, not the one in `--build`; `--build` only labels the
+report and the reproduction commands. So restage after a rebuild, or the run
+measures the library from before it:
 
 ```sh
-python3 harnesses/stan_conformance.py \
-  --stanc deps/stanc3/stanc-pinned --cmdstan deps/cmdstan --build build-rel \
-  --case 'abs(real)=>real'
+cmake --build build-rel --target stanli_shared
+cp build-rel/libstanli.* python/stanli/_bin/
+```
 
-python3 harnesses/stan_conformance.py \
+`signature_watch.sh` is the other half of the pin story: it diffs stanc3's
+checked-in signature dump between the pin and upstream master, so new
+language surface is reported nightly without executing anything unreviewed.
+Adopting what it reports is a pin advance: bump `STANC3_SRC_SHA` and rerun
+this suite.
+
+### Selecting what to run
+
+The full differential sweep is a nightly-sized job. Day to day you want a
+slice, and three stable selectors give you one:
+
+| selector | meaning |
+| --- | --- |
+| `--filter SUBSTR` | case-insensitive substring of the signature; the one you usually want |
+| `--case CASE` | one exact canonical or case ID |
+| `--shard N/M` | stable one-based partition, the same split the nightly uses |
+
+```sh
+.venv-conformance/bin/python harnesses/stan_conformance.py \
+  --stanc deps/stanc3/stanc-pinned --cmdstan deps/cmdstan --build build-rel \
+  --stanli-pythonpath python --filter log1p
+
+.venv-conformance/bin/python harnesses/stan_conformance.py \
+  --stanc deps/stanc3/stanc-pinned --cmdstan deps/cmdstan --build build-rel \
+  --stanli-pythonpath python --case 'abs(real)=>real'
+
+.venv-conformance/bin/python harnesses/stan_conformance.py \
   --stanc deps/stanc3/stanc-pinned --mode inventory --shard 2/8
 ```
+
+`--case` is not repeatable, and `--case` and `--filter` do not combine: one
+case per invocation, `--filter` for a group. Passing `--case` twice used to
+run only the second one silently, which reads as the harness disagreeing
+about the case you named first; it is now rejected.
+
+By default `--cmdstan` selects the generated differential mode (the historical
+CLI spelling is `--mode scalar`) and also executes matching construct cases.
+Use `--mode inventory` for the fast classification-only pass.
+
+Any selected run prints `RED` and `gate issues: partial_run`. That is the
+gate reporting its scope, not a finding: the suite is green only when it is
+complete, and a slice is by construction not complete. Read `status_counts`
+in `conformance-out/conformance.json` -- or the `verified=`/`mismatch=`
+summary on the first line of output -- for what the slice actually found.
+
+The `reproduce:` line printed under each blocking row spells the driver
+`python3`, because a report is read on machines other than the one that
+wrote it. Substitute your own interpreter, which on a pre-3.11 host means
+`.venv-conformance/bin/python`.
 
 The default output directory is `conformance-out/`. It contains the complete
 `conformance.json`, generated `unsupported.md`, raw `signatures.txt`, cached
@@ -86,8 +139,9 @@ snapshot. Generated reports and snapshots are build artifacts, not checked-in
 source. To freeze a run, pass an explicit ignored or externally retained path:
 
 ```sh
-python3 harnesses/stan_conformance.py \
+.venv-conformance/bin/python harnesses/stan_conformance.py \
   --stanc deps/stanc3/stanc-pinned --cmdstan deps/cmdstan --build build-rel \
+  --stanli-pythonpath python \
   --baseline conformance-out/conformance-baseline.json --update-snapshot
 ```
 
@@ -114,8 +168,11 @@ including their reasons and copy-paste reproduction commands.
 ## Fast harness tests
 
 ```sh
-python3 tests/test_conformance.py
+.venv-conformance/bin/python tests/test_conformance.py
 ```
+
+Any Python 3.11 or newer works; the venv is simply the one the setup step
+leaves you with, and on an older host it is the only one that imports.
 
 The tests cover recursive signature parsing, policy mutation guards,
 deterministic generation and sharding, catalog validation, construct phase and

--- a/harnesses/conformance/README.md
+++ b/harnesses/conformance/README.md
@@ -46,6 +46,13 @@ half hour is paid once per machine per pin, not once per session, and
 `--embed` and `--corpus` pay most of it already. It ends by printing the
 invocation below with your paths filled in.
 
+Only the nightly *workflow* is pinned to Linux. Nothing in the harness is:
+`fetch_cmdstan.sh` selects its TBB target per `uname` and has handled Darwin
+all along, and a full local run on macOS reproduces the same statuses. The
+half-hour figure above reads like a wall and is not one, which is how this
+suite ended up treated as CI-only and its findings argued from the last
+nightly's recorded rows instead of being checked.
+
 Run the driver under the venv interpreter, not the host's `python3`. The
 harness reads its policy and catalog as TOML; `tomllib` arrived in Python
 3.11, and `requirements.txt` carries the backport for older hosts -- but

--- a/harnesses/conformance/toml_compat.py
+++ b/harnesses/conformance/toml_compat.py
@@ -8,8 +8,15 @@ except ImportError:  # Python 3.10 and earlier.
     try:
         import tomli as tomllib  # type: ignore
     except ImportError as exc:
+        # Reached by anyone whose system python3 predates 3.11 and who ran
+        # the driver with it, which is the documented invocation everywhere
+        # but here. Naming the fix costs one line and saves the detour of
+        # discovering that requirements.txt already carries the backport.
         raise RuntimeError(
-            "Python before 3.11 requires the 'tomli' package") from exc
+            "Python before 3.11 requires the 'tomli' package; run the "
+            "harness under the interpreter that has it, which is the one "
+            "tools/dev_setup.sh --conformance installs into "
+            ".venv-conformance/bin/python") from exc
 
 
 loads = tomllib.loads

--- a/harnesses/stan_conformance.py
+++ b/harnesses/stan_conformance.py
@@ -61,6 +61,24 @@ def _shard(value: str) -> Tuple[int, int]:
             "shard must be one-based N/M, for example 1/8") from exc
 
 
+class _Once(argparse.Action):
+    """Refuse a repeated selector instead of silently keeping the last one.
+
+    Mutual exclusion catches --case beside --filter, but a second --case is
+    only an assignment over the first, so `--case A --case B` runs B and
+    never mentions A. Selecting cases is the commonest interactive use of
+    this harness, and a dropped selector does not look like a dropped
+    selector: it looks like the harness disagreeing about the case you named
+    first. One case per invocation; --filter takes a group.
+    """
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        if getattr(namespace, self.dest) is not None:
+            parser.error(f"{option_string} may be given only once "
+                         "(it is not repeatable; use --filter for a group)")
+        setattr(namespace, self.dest, values)
+
+
 def _parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         description="Discover and differentially classify Stan signatures")
@@ -83,8 +101,10 @@ def _parser() -> argparse.ArgumentParser:
                         default="auto",
                         help="auto runs scalar parity when --cmdstan is given")
     selection = parser.add_mutually_exclusive_group()
-    selection.add_argument("--case", help="one exact canonical or case ID")
-    selection.add_argument("--filter", help="case-insensitive signature substring")
+    selection.add_argument("--case", action=_Once,
+                           help="one exact canonical or case ID")
+    selection.add_argument("--filter", action=_Once,
+                           help="case-insensitive signature substring")
     parser.add_argument("--shard", type=_shard,
                         help="stable one-based distributed partition N/M")
     parser.add_argument("--jobs", type=int, default=1)

--- a/tests/test_conformance.py
+++ b/tests/test_conformance.py
@@ -777,6 +777,26 @@ class ReportAndSnapshotTests(unittest.TestCase):
             stan_conformance._update_configured_snapshot(
                 _report([_result("signature:f(real)=>real")]), args)
 
+    def _rejected(self, argv) -> str:
+        stderr = io.StringIO()
+        with contextlib.redirect_stderr(stderr):
+            with self.assertRaises(SystemExit):
+                stan_conformance._parser().parse_args(argv)
+        return stderr.getvalue()
+
+    def test_selectors_are_single_use_and_mutually_exclusive(self):
+        parser = stan_conformance._parser()
+        self.assertEqual(parser.parse_args(["--case", "a"]).case, "a")
+        self.assertEqual(parser.parse_args(["--filter", "b"]).filter, "b")
+        # A second --case used to win silently, so `--case A --case B`
+        # reported on B while reading as a claim about A.
+        for argv in (["--case", "a", "--case", "b"],
+                     ["--filter", "a", "--filter", "b"]):
+            with self.subTest(argv=argv):
+                self.assertIn("only once", self._rejected(argv))
+        self.assertIn("not allowed", self._rejected(["--case", "a",
+                                                     "--filter", "b"]))
+
     def test_snapshot_is_optional_but_explicit_snapshot_is_enforced(self):
         report = _report([_result("signature:f(real)=>real")])
         self.assertTrue(report.green)

--- a/tools/dev_setup.sh
+++ b/tools/dev_setup.sh
@@ -2,15 +2,21 @@
 # One-shot dev environment setup. Safe to re-run; every step is
 # idempotent and skipped once its output exists.
 #
-#   tools/dev_setup.sh            core: vendored deps + cmake builds + tests
-#   tools/dev_setup.sh --embed    + OCaml toolchain and in-process stanc3
-#   tools/dev_setup.sh --corpus   + posteriordb and the CmdStan verify rig
-#   tools/dev_setup.sh --all      everything
-#   tools/dev_setup.sh --no-build stop before cmake (CI builds separately)
+#   tools/dev_setup.sh               core: vendored deps + cmake builds + tests
+#   tools/dev_setup.sh --embed       + OCaml toolchain and in-process stanc3
+#   tools/dev_setup.sh --corpus      + posteriordb and the CmdStan verify rig
+#   tools/dev_setup.sh --conformance + the Stan conformance reference stack
+#   tools/dev_setup.sh --all         everything
+#   tools/dev_setup.sh --no-build    stop before cmake (CI builds separately)
 #
 # Core needs: git, curl, cmake, a C++17 clang, python3.
 # --embed adds: opam (OCaml 5.5.0 switch built automatically).
 # --corpus adds: ~2 GB of checkouts under deps/ and a CmdStan build.
+# --conformance adds: opam, the pinned CmdStan/BridgeStan pair, and a venv
+#   holding the version-pinned reference client. It reuses the same
+#   deps/cmdstan checkout as --corpus and the same stanc3 source tree and
+#   opam switch as --embed, so with either of those already done most of
+#   it is a no-op.
 set -euo pipefail
 cd "$(dirname "$0")/.."
 REPO=$PWD
@@ -23,17 +29,28 @@ OCAML_VERSION=5.5.0
 
 WANT_EMBED=0
 WANT_CORPUS=0
+WANT_CONFORMANCE=0
 WANT_BUILD=1
 for arg in "$@"; do
   case "$arg" in
     --embed) WANT_EMBED=1 ;;
     --corpus) WANT_CORPUS=1 ;;
-    --all) WANT_EMBED=1; WANT_CORPUS=1 ;;
+    --conformance) WANT_CONFORMANCE=1 ;;
+    --all) WANT_EMBED=1; WANT_CORPUS=1; WANT_CONFORMANCE=1 ;;
     --no-build) WANT_BUILD=0 ;;
-    -h|--help) sed -n '2,13p' "$0"; exit 0 ;;
+    -h|--help) sed -n '2,19p' "$0"; exit 0 ;;
     *) echo "unknown flag: $arg (try --help)"; exit 2 ;;
   esac
 done
+
+# The conformance reference client gets its own interpreter rather than the
+# host's. Two reasons, and the second is the one that bites: requirements.txt
+# pins bridgestan and numpy exactly, for the same reason both sides of the
+# differential share one stanc; and the harness reads TOML through tomllib,
+# which arrived in 3.11, so on an older system python3 the driver does not
+# start at all. Relative to the repo root, which is where every command in
+# this script and in the conformance README runs from.
+CONFORMANCE_VENV=${CONFORMANCE_VENV:-.venv-conformance}
 
 step() { printf '\n== %s\n' "$*"; }
 have() { command -v "$1" >/dev/null 2>&1; }
@@ -43,7 +60,9 @@ step "checking prerequisites"
 missing=()
 for tool in git curl cmake python3; do have "$tool" || missing+=("$tool"); done
 if ! have clang++ && ! have g++; then missing+=("clang++ (Xcode CLT or clang)"); fi
-if [ "$WANT_EMBED" = 1 ] && ! have opam; then missing+=(opam); fi
+if [ "$WANT_EMBED" = 1 ] || [ "$WANT_CONFORMANCE" = 1 ]; then
+  have opam || missing+=(opam)
+fi
 if [ ${#missing[@]} -gt 0 ]; then
   if have brew; then
     echo "installing via homebrew: ${missing[*]}"
@@ -145,9 +164,72 @@ if [ "$WANT_CORPUS" = 1 ]; then
   python3 tools/corpus.py deps/posteriordb || true
 fi
 
+# --- Stan conformance reference stack (optional) ---------------------------
+# The nightly sweep's oracle, locally: the pinned stanc built from source,
+# the exact CmdStan/Stan/Stan Math triple BridgeStan compiles against, and
+# the pinned reference client. fetch_cmdstan.sh already does the first three
+# and already refuses to proceed on a pin mismatch, so this adds only the
+# client and the staged runtime -- and every part of it is a no-op on the
+# second run. The cost people remember is the one-time stanc build; it is
+# once per machine per pin, not once per session, and --embed pays it too.
+if [ "$WANT_CONFORMANCE" = 1 ]; then
+  step "conformance reference toolchain (stanc from source, CmdStan, BridgeStan)"
+  ./harnesses/conformance/fetch_cmdstan.sh
+
+  step "conformance reference client ($CONFORMANCE_VENV)"
+  [ -d "$CONFORMANCE_VENV" ] || python3 -m venv "$CONFORMANCE_VENV"
+  "$CONFORMANCE_VENV/bin/pip" install -q --disable-pip-version-check \
+    -r harnesses/conformance/requirements.txt
+  echo "reference client ready under $("$CONFORMANCE_VENV/bin/python" -V)"
+
+  # The harness never loads anything out of the build tree; it drives stanli
+  # through the public Python package, which finds its library and its stanc
+  # in python/stanli/_bin. Staging those is what makes the printed command
+  # work straight after setup, and it is the same pair the nightly stages.
+  # Restage after every rebuild: an unstaged rebuild silently measures the
+  # library from before it.
+  if [ "$WANT_BUILD" = 1 ]; then
+    step "staging the runtime the harness drives (python/stanli/_bin)"
+    cmake --build build-rel -j8 --target stanli_shared
+    LIB=""
+    for candidate in build-rel/libstanli.dylib build-rel/libstanli.so \
+                     build-rel/stanli.dll; do
+      if [ -f "$candidate" ]; then LIB=$candidate; break; fi
+    done
+    [ -n "$LIB" ] || { echo "no shared library in build-rel/"; exit 1; }
+    mkdir -p python/stanli/_bin
+    cp "$LIB" python/stanli/_bin/
+    cp deps/stanc3/stanc-pinned python/stanli/_bin/stanc
+    chmod +x python/stanli/_bin/stanc
+  else
+    step "--no-build: stage python/stanli/_bin before running the harness"
+    echo "  cmake --build build-rel --target stanli_shared"
+    echo "  cp build-rel/libstanli.* python/stanli/_bin/"
+    echo "  cp deps/stanc3/stanc-pinned python/stanli/_bin/stanc"
+  fi
+fi
+
 step "done"
 echo "dev build:   build/            (tests: ctest --test-dir build)"
 echo "bench build: build-rel/        (tools/bench_grad.cpp)"
 echo "corpus:      python3 tools/corpus.py deps/posteriordb"
 echo "verify:      python3 tools/verify_sample.py deps/cmdstan deps/posteriordb MODEL..."
 echo "wheel:       tools/build_wheel.sh"
+if [ "$WANT_CONFORMANCE" = 1 ]; then
+  # Run the driver under the venv interpreter, not the host's: the harness
+  # needs tomllib, and --stanli-python then defaults to the same interpreter,
+  # which is where the pinned BridgeStan client lives.
+  cat <<EOF
+
+conformance: one case, from the repo root, to prove the stack end to end:
+
+  $CONFORMANCE_VENV/bin/python harnesses/stan_conformance.py \\
+    --stanc deps/stanc3/stanc-pinned --cmdstan deps/cmdstan \\
+    --build build-rel --stanli-pythonpath python \\
+    --case 'abs(real)=>real'
+
+Swap --case for --filter SUBSTR to take a slice, or --shard N/M for a
+stable partition. A selected run reports "gate issues: partial_run"; that
+records the scope, not a failure. See harnesses/conformance/README.md.
+EOF
+fi


### PR DESCRIPTION
The conformance sweep was runnable locally the whole time and nobody knew, including me -- I asserted twice in review that it was Linux-only and briefed four agents that way. `fetch_cmdstan.sh` has an explicit `Darwin` branch and selects its TBB target per `uname`; what is pinned to `ubuntu-24.04` is the nightly *workflow*, which is a different thing. It built here first try, no patches.

The other half of why it went unused: the README's "needs opam and takes ~30 minutes once per pin" reads as a wall rather than as a one-time cost that `--embed` and `--corpus` already pay most of.

### `tools/dev_setup.sh --conformance`

Follows the existing shape exactly -- a `WANT_*` flag, opam in the prerequisite check, every step conditional on its output. It runs `fetch_cmdstan.sh`, creates `.venv-conformance/` and installs the pinned reference client into it, stages `python/stanli/_bin` the way the nightly does, and prints a copy-pasteable invocation. Gated on `WANT_BUILD`, so `--no-build` still stops before cmake and prints the three commands instead. Added to `--all`.

`--corpus` fully overlaps and nothing is duplicated: same `CMDSTAN_SHA`, same `deps/cmdstan`, both gate on `.git` existing, and `--corpus`'s full build is a superset of the TBB target. `--conformance` also shares `deps/stanc3-src` and the opam switch with `--embed`.

### Two traps this closes

**The driver must run under the venv interpreter.** `tomllib` arrived in 3.11 and `requirements.txt` carries the backport, but into the venv -- so on a host whose system `python3` is older the driver refuses to start with a message naming a package rather than the fix. It now names `.venv-conformance/bin/python` and how to create it.

**`--case` was silently last-wins.** Passing it twice ran only the second, which reads as the harness disagreeing about the case you named first. It is an error now, via a `_Once` action on both selectors, with a test covering single use, duplicate rejection on each, and the pre-existing mutex.

The README also documents that a filtered run always reports `gate issues: partial_run`, which is expected rather than a failure -- read `status_counts` instead. That one is genuinely confusing on first use.

### Verification

`tests/test_conformance.py` 70/70 under the pinned client. The new mode was run end to end from a clean tree: 7.3s, every step a correct no-op against already-built dependencies, and the command it printed then run verbatim -- `abs(real)=>real` comes back `verified=1` against real BridgeStan on macOS arm64, with `reference_backend: BridgeStan` and matching Stan/Math/CmdStan/stanc pins in the report.

One path is not exercised: the `WANT_BUILD=1` staging step never ran a real `cmake --build`, because the machine was saturated with other work. The library-picking loop was tested standalone in both its found and not-found branches, and the `cmake` line with its two `cp`s is byte-for-byte the pattern in `tools/build_wheel.sh` and the nightly workflow.

No C++ touched.