### PR TITLE
conformance: gate the bound transforms' probe cancellation

### DIFF
--- a/harnesses/conformance/policy.toml
+++ b/harnesses/conformance/policy.toml
@@ -63,3 +63,29 @@ id = "inv-phi-probe-depth"
 reason = "Deep probe expression trees over an identical forward call; last-bit accumulation only."
 name_regex = "^(inv_Phi|std_normal_qf)$"
 rel_tol = 1e-13
+
+# The bound transforms called as functions. stanli composes the inverse
+# direction from elementwise ops -- stan-math has no rev overloads for
+# lb_free/ub_free/lub_free, so its own `logit((y - lb) / (ub - lb))` is
+# ordinary var arithmetic and the composition is the reference rather than
+# an approximation of it. The formulas match term for term, and OP_LOGIT
+# calls stan::math::logit itself.
+#
+# What is left is the probe, not the transform. These signatures produce
+# outputs that straddle zero, so the generated model's weighted sum cancels
+# three digits out of lanes of order 0.1 and a last-bit difference becomes
+# a large relative one. Measured across the 29 rows: worst 1.735e-15
+# absolute, 3.69e-14 relative. An absolute gate is the honest metric for a
+# cancelling sum -- ULP and relative both describe the cancellation rather
+# than the disagreement -- and 1e-13 leaves two orders of headroom.
+#
+# The fma half of this class is fixed at source rather than gated: the
+# reference now compiles from the same --O1 MIR stanli reads. That removed
+# 28 of the original 57 here and all 9 on upper_bound_jacobian. The second
+# source of last-bit difference behind these 29 is not identified; it is a
+# gate on a known-small quantity, not an explanation.
+[[numeric_gate]]
+id = "bound-transform-probe-cancellation"
+reason = "Probe outputs straddle zero, so the weighted sum cancels and a last-bit difference reads as a large relative one."
+name_regex = "^(lower_bound|upper_bound|lower_upper_bound|offset_multiplier)_(constrain|unconstrain|jacobian)$"
+abs_tol = 1e-13


### PR DESCRIPTION
#116 landed the bound transforms and took the nightly to `mismatch:29`. This clears them.

They are not a transform error. stanli composes the inverse direction from elementwise ops, and that composition *is* the reference rather than an approximation of it: stan-math has no rev overloads for `lb_free`/`ub_free`/`lub_free`, so its own `logit((y - lb) / (ub - lb))` is ordinary var arithmetic. I checked the formulas match term for term against `prim/constraint/lub_free.hpp`, and that `OP_LOGIT` calls `stan::math::logit` itself rather than reimplementing it.

What is left is the probe. These signatures produce outputs that straddle zero, so the generated model's weighted sum cancels three digits out of lanes of order 0.1, and one last bit reads as a large relative difference. Measured across all 29 rows: **worst 1.735e-15 absolute, 3.69e-14 relative**. An absolute gate is the honest metric for a cancelling sum -- ULP and relative both describe the cancellation rather than the disagreement. `abs_tol = 1e-13` leaves two orders of headroom.

Same shape and same reason as the existing `inv-phi-probe-depth` rule.

### What this is and is not

The fma half of this class was fixed at source in #115, not gated: the reference now compiles from the same `--O1` MIR stanli reads. That removed 28 of the original 57 rows here and all 9 on `upper_bound_jacobian`.

The second source of last-bit difference behind these 29 is **not identified**. This gates a quantity measured to be small; it does not explain it. Worth someone's time if the same signature turns up elsewhere.

### Verification

`--filter lower_upper_bound` goes 358 verified + 29 mismatch to **387 verified, 0 mismatch**; `--filter upper_bound` 553 + 29 to **582 verified**. `policy_stale_rules` and `policy_improvements` both empty, so the rule is neither dead nor redundant. `tests/test_conformance.py` 70/70.