### PR TITLE
conformance: pass a data-only argument as a literal, not a local

### DIFF
--- a/harnesses/conformance/generate.py
+++ b/harnesses/conformance/generate.py
@@ -324,10 +324,21 @@ class VectorizedCaseSpec:
             name = f"conformance_arg_{index + 1}"
             literal = _numeric_literal(argument, int(center), next_real,
                                        self.dimensions)
-            declarations.append(
-                f"{_type_declaration(argument, name, self.dimensions)} "
-                f"= {literal};")
-            arguments.append(name)
+            if data_only:
+                # Pass the literal straight to the call. A local is never
+                # data-only in Stan however it was initialized, so binding
+                # this one to a name loses exactly the property the
+                # signature requires -- "the Nth argument must be data-only"
+                # -- and stanc rejects the whole shard, taking every
+                # unrelated case packed beside it down as a generator gap.
+                # The scalar renderer already inlines these; this is the
+                # vectorized half catching up.
+                arguments.append(literal)
+            else:
+                declarations.append(
+                    f"{_type_declaration(argument, name, self.dimensions)} "
+                    f"= {literal};")
+                arguments.append(name)
 
         if theta_lane != self.parameter_count:
             raise ValueError(f"{self.inventory_id}: vectorized lane mismatch")

--- a/tests/test_conformance.py
+++ b/tests/test_conformance.py
@@ -610,6 +610,32 @@ class GeneratorTests(unittest.TestCase):
         self.assertIn(f"array[{outer}] vector[{inner}]", body)
         self.assertIn("conformance_result", body)
 
+    def test_data_only_argument_is_inlined_not_bound_to_a_local(self):
+        # Stan has no data-only local: binding the value to a name loses the
+        # property the signature demands, stanc rejects the whole shard, and
+        # every unrelated case packed beside it is reported as a generator
+        # gap. That cost 490 rows across two shards, 279 of them wiener's own
+        # and the rest collateral from weibull, von_mises and the bound
+        # transforms that happened to share them.
+        inventory = inventory_from_dump(
+            "wiener_lpdf(real, real, real, real, real, real, real) => real\n"
+            "wiener_lpdf(vector, vector, vector, vector, vector, vector, "
+            "real) => real\n", "test")
+        spec = next(spec for spec in generated_inventory(inventory)
+                    if spec.inventory_id.startswith("wiener_lpdf(vector"))
+        self.assertEqual(spec.data_positions, (6,))
+        body = "\n".join(spec.render_body(0, 1.0))
+        # The data-only argument is the only one without a declaration, and
+        # its literal reaches the call directly.
+        self.assertNotIn("conformance_arg_7 =", body)
+        for index in range(1, 7):
+            self.assertIn(f"conformance_arg_{index} =", body)
+        call = next(line for line in body.splitlines() if "wiener_lpdf(" in line)
+        self.assertNotIn("conformance_arg_7", call)
+        self.assertIn("1e-05", call.replace("1.0000000000000001e-05", "1e-05"))
+        # And it consumes no parameter lane, since it is not perturbed.
+        self.assertEqual(spec.parameter_count, 12)
+
     def test_mixed_depth_matrix_multiply_uses_compatible_square_shapes(self):
         inventory = inventory_from_dump(
             "multiply(real, real) => real\n"


### PR DESCRIPTION
Stan has no data-only local. The vectorized generator bound every argument to a name before the call, so a signature declaring "the Nth argument must be data-only" got a plain local there:

```stan
real conformance_arg_7 = 1.0000000000000001e-05;
contribution += ... wiener_lpdf(arg_1 | ..., conformance_arg_7);
```

stanc rejects that model, and the runner tags the **whole shard** a generator gap -- taking every unrelated case packed beside it down with it.

Two of 149 shards, and **490 rows**: 279 of them wiener's own, the rest collateral from weibull, von_mises and the bound transforms that happened to share those two shards. It is also why per-function counts moved between runs and could not be compared across them: which signatures a shard rejection takes out depends on how the packing fell, not on the language surface. That cost real time this week -- two agents measured local baselines that disagreed with the nightly, and three briefs went out with wrong counts.

The value was already right. `next_real()` returns a bare literal for a data position and consumes no parameter lane; only the binding was wrong. The scalar renderer already inlines these, so this is the vectorized half catching up.

### Measured

All 149 shards compile, against 147 before.

| filter | before | after |
| --- | --- | --- |
| `wiener` | 748 verified, 292 generator_gap | **1024 verified, 2 generator_gap** |
| `weibull` | 170 verified, 86 generator_gap | **256 verified, 0 generator_gap** |

The 14 wiener rows that become `unexpected_unsupported` rather than `verified` are the honest outcome: cases that could not be tested at all before, now testable, and genuinely not implemented (`unsupported function wiener_...`). Measurement unblocked is the point; not every unblocked row is a pass.

### How I found it

Worth recording, because the first diagnosis I was handed was almost right and pointed at the wrong place. It attributed this to `domains.py` declaring `data_positions_by_arity` for wiener while the vectorized renderer ignored it. The renderer does honour it -- for the *value*. I rendered a failing signature and it compiled clean on its own, then compiled all 490 individually and every one passed. The fault only appears in the packed shard, so I compiled all 149 and read the two that failed. Both point at the same line shape above.

### Test

`test_data_only_argument_is_inlined_not_bound_to_a_local` pins it: the data-only argument is the only one without a declaration, its literal reaches the call directly, and it consumes no parameter lane. Verified RED by stashing only `generate.py` -- it fails with `'conformance_arg_7 =' unexpectedly found`.

`tests/test_conformance.py` 71/71, `tools/format.sh --check` clean. Generator-only change; no runtime, no C++.

### Follow-on worth considering

With this fixed, the "stanc rejected the generated scalar shard" slice of `generator_gap` should be near zero and is a generator *bug* rather than a to-do whenever it reappears. It could reasonably block the gate on its own, which #115 deliberately left open pending exactly this.