### PR TITLE
fix: stop deep array literals reaching their slot transposed

### DIFF
--- a/runtime/include/stanli/data.hpp
+++ b/runtime/include/stanli/data.hpp
@@ -42,7 +42,9 @@ class DataMap {
     m_[name] = std::move(e);
   }
   // `dims` defaults to one axis; pass it for a nested array, whose values
-  // are the row-major flattening the JSON reader also produces.
+  // are the first-index-fastest flattening the JSON reader also produces --
+  // one convention for every rank, which the lowering permutes into graph
+  // order once, at materialization.
   void set_int_array(const std::string& name, std::vector<int> v,
                      std::vector<int64_t> dims = {}) {
     Entry e;

--- a/runtime/include/stanli/mir_interp.hpp
+++ b/runtime/include/stanli/mir_interp.hpp
@@ -1500,12 +1500,14 @@ class MirInterp {
       o.is_int = true;
       bool rows_mode = false;
       int64_t row_len = 0;
+      std::vector<int64_t> elem_dims;  // shape of one element, once known
       for (const auto& a : e.args) {
         Value v2 = eval(a);
         if (v2.r.size() > 1 || rows_mode) {
           // Row-vector elements: build a matrix, row-major.
           rows_mode = true;
           row_len = (int64_t)v2.r.size();
+          elem_dims = v2.dims;
           o.is_int = false;
           o.r.insert(o.r.end(), v2.r.begin(), v2.r.end());
           continue;
@@ -1518,17 +1520,37 @@ class MirInterp {
       }
       if (!o.is_int) o.i.clear();
       if (rows_mode) {
-        // Rows arrived row-by-row; store column-major.
+        // Rows arrived row-by-row; store column-major. Each element is
+        // already first-index-fastest in itself, so sending its cell j to
+        // j*R+i makes the whole result first-index-fastest over {R} ++ the
+        // element's extents, at any rank.
         const int64_t R = (int64_t)e.args.size(), C = row_len;
         std::vector<T> cm(R * C);
         for (int64_t i = 0; i < R; ++i)
           for (int64_t j = 0; j < C; ++j) cm[j * R + i] = o.r[i * C + j];
         o.r = std::move(cm);
       }
-      if (rows_mode)
-        o.dims = {(int64_t)e.args.size(), row_len};
-      else
+      if (rows_mode) {
+        // Keep the element's own extents instead of collapsing them into
+        // one. The placement above does not pin them down -- Fortran order
+        // over {2,4} is byte-for-byte Fortran order over {2,2,2} -- but
+        // graph_order permutes by exactly these extents on the way to a
+        // slot, and eval_indexed strides by them, so a collapsed shape
+        // silently transposes the trailing two axes of every array literal
+        // of rank 3 or deeper.
+        // The extents still have to multiply out to the storage, because
+        // graph_order walks them to place every cell; one axis is the
+        // honest answer for anything that cannot say more.
+        o.dims = {(int64_t)e.args.size()};
+        int64_t elem_n = 1;
+        for (int64_t d : elem_dims) elem_n *= d;
+        if (elem_dims.empty() || elem_n != row_len)
+          o.dims.push_back(row_len);
+        else
+          o.dims.insert(o.dims.end(), elem_dims.begin(), elem_dims.end());
+      } else {
         o.dims = {(int64_t)o.r.size()};
+      }
       return o;
     }
     if (e.name == "Transpose__") {

--- a/tests/fixtures/ndlit.stan
+++ b/tests/fixtures/ndlit.stan
@@ -1,0 +1,55 @@
+// Deep array literals in transformed data, against data-block arrays of the
+// same shape. Every element's value is its own decimal index code, so any
+// permutation of the layout changes the weighted sums below.
+data {
+  array[2,2] real d2;
+  array[2,2,2] real d3;
+  array[2,2,2,2] real d4;
+  array[2,2] vector[3] dvv;
+  array[2] matrix[2,3] dm;
+}
+transformed data {
+  array[2,2] real t2 = {{11.,12.},{21.,22.}};
+  array[2,2,2] real t3
+      = {{{111.,112.},{121.,122.}},{{211.,212.},{221.,222.}}};
+  array[2,2,2,2] real t4
+      = {{{{1111.,1112.},{1121.,1122.}},{{1211.,1212.},{1221.,1222.}}},
+         {{{2111.,2112.},{2121.,2122.}},{{2211.,2212.},{2221.,2222.}}}};
+  array[2,2] vector[3] tvv
+      = {{[111.,112.,113.]',[121.,122.,123.]'},
+         {[211.,212.,213.]',[221.,222.,223.]'}};
+  array[2] matrix[2,3] tm
+      = {[[111.,112.,113.],[121.,122.,123.]],
+         [[211.,212.,213.],[221.,222.,223.]]};
+
+  // Reading the literal back through the interpreter's own N-D indexing.
+  real s3 = 0;
+  for (i in 1:2) for (j in 1:2) for (k in 1:2)
+    s3 += t3[i,j,k] * (100*i + 10*j + k);
+}
+parameters { real x; real y; real z; }
+model {
+  real diff = 0;
+  real wt = 0;
+  for (i in 1:2) for (j in 1:2) {
+    diff += (t2[i,j] - d2[i,j]) * (10*i + j);
+    wt += t2[i,j] * (10*i + j);
+  }
+  for (i in 1:2) for (j in 1:2) for (k in 1:2) {
+    diff += (t3[i,j,k] - d3[i,j,k]) * (100*i + 10*j + k);
+    wt += t3[i,j,k] * (100*i + 10*j + k);
+  }
+  for (i in 1:2) for (j in 1:2) for (k in 1:2) for (l in 1:2) {
+    diff += (t4[i,j,k,l] - d4[i,j,k,l]) * (1000*i + 100*j + 10*k + l);
+    wt += t4[i,j,k,l] * (1000*i + 100*j + 10*k + l);
+  }
+  for (i in 1:2) for (j in 1:2) for (k in 1:3) {
+    diff += (tvv[i,j,k] - dvv[i,j,k]) * (100*i + 10*j + k);
+    wt += tvv[i,j,k] * (100*i + 10*j + k);
+  }
+  for (i in 1:2) for (j in 1:2) for (k in 1:3) {
+    diff += (tm[i,j,k] - dm[i,j,k]) * (100*i + 10*j + k);
+    wt += tm[i,j,k] * (100*i + 10*j + k);
+  }
+  target += diff * x + wt * y + s3 * z;
+}

--- a/tests/fixtures/ndlit.tmir.sexp
+++ b/tests/fixtures/ndlit.tmir.sexp
@@ -1,0 +1,3662 @@
+((functions_block ())
+ (input_vars
+  ((d2 <opaque>
+    (SArray
+     (SArray SReal
+      ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+     ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+   (d3 <opaque>
+    (SArray
+     (SArray
+      (SArray SReal
+       ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+      ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+     ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+   (d4 <opaque>
+    (SArray
+     (SArray
+      (SArray
+       (SArray SReal
+        ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+       ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+      ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+     ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+   (dvv <opaque>
+    (SArray
+     (SArray
+      (SVector AoS
+       ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+      ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+     ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+   (dm <opaque>
+    (SArray
+     (SMatrix AoS
+      ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+      ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+     ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+ (prepare_data
+  (((pattern
+     (Decl (decl_adtype DataOnly) (decl_id pos__) (decl_type (Sized SInt))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable pos__) ()) UInt
+      ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id d2)
+      (decl_type
+       (Sized
+        (SArray
+         (SArray SReal
+          ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+         ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id d2_flat__)
+          (decl_type (Unsized (UArray UReal))) (initialize Uninit)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable d2_flat__) ()) (UArray UReal)
+          ((pattern
+            (FunApp (CompilerInternal FnReadData)
+             (((pattern (Lit Str d2))
+               (meta ((type_ (UArray (UArray UReal))) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable pos__) ()) UInt
+          ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar sym1__)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Lit Int 2))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (For (loopvar sym2__)
+                  (lower
+                   ((pattern (Lit Int 1))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (upper
+                   ((pattern (Lit Int 2))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (body
+                   ((pattern
+                     (Block
+                      (((pattern
+                         (Assignment
+                          ((LVariable d2)
+                           ((Single
+                             ((pattern (Var sym2__))
+                              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                            (Single
+                             ((pattern (Var sym1__))
+                              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                          (UArray (UArray UReal))
+                          ((pattern
+                            (Indexed
+                             ((pattern (Var d2_flat__))
+                              (meta
+                               ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))
+                             ((Single
+                               ((pattern (Var pos__))
+                                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                           (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+                        (meta <opaque>))
+                       ((pattern
+                         (Assignment ((LVariable pos__) ()) UInt
+                          ((pattern
+                            (FunApp (StanLib Plus__ FnPlain AoS)
+                             (((pattern (Var pos__))
+                               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                              ((pattern (Lit Int 1))
+                               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                        (meta <opaque>)))))
+                    (meta <opaque>)))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id d3)
+      (decl_type
+       (Sized
+        (SArray
+         (SArray
+          (SArray SReal
+           ((pattern (Lit Int 2))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+         ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id d3_flat__)
+          (decl_type (Unsized (UArray UReal))) (initialize Uninit)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable d3_flat__) ()) (UArray UReal)
+          ((pattern
+            (FunApp (CompilerInternal FnReadData)
+             (((pattern (Lit Str d3))
+               (meta
+                ((type_ (UArray (UArray (UArray UReal)))) (loc <opaque>)
+                 (adlevel DataOnly)))))))
+           (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable pos__) ()) UInt
+          ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar sym1__)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Lit Int 2))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (For (loopvar sym2__)
+                  (lower
+                   ((pattern (Lit Int 1))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (upper
+                   ((pattern (Lit Int 2))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (body
+                   ((pattern
+                     (Block
+                      (((pattern
+                         (For (loopvar sym3__)
+                          (lower
+                           ((pattern (Lit Int 1))
+                            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                          (upper
+                           ((pattern (Lit Int 2))
+                            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                          (body
+                           ((pattern
+                             (Block
+                              (((pattern
+                                 (Assignment
+                                  ((LVariable d3)
+                                   ((Single
+                                     ((pattern (Var sym3__))
+                                      (meta
+                                       ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                                    (Single
+                                     ((pattern (Var sym2__))
+                                      (meta
+                                       ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                                    (Single
+                                     ((pattern (Var sym1__))
+                                      (meta
+                                       ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                                  (UArray (UArray (UArray UReal)))
+                                  ((pattern
+                                    (Indexed
+                                     ((pattern (Var d3_flat__))
+                                      (meta
+                                       ((type_ (UArray UReal)) (loc <opaque>)
+                                        (adlevel DataOnly))))
+                                     ((Single
+                                       ((pattern (Var pos__))
+                                        (meta
+                                         ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                                   (meta
+                                    ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+                                (meta <opaque>))
+                               ((pattern
+                                 (Assignment ((LVariable pos__) ()) UInt
+                                  ((pattern
+                                    (FunApp (StanLib Plus__ FnPlain AoS)
+                                     (((pattern (Var pos__))
+                                       (meta
+                                        ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                                      ((pattern (Lit Int 1))
+                                       (meta
+                                        ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                                   (meta
+                                    ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                                (meta <opaque>)))))
+                            (meta <opaque>)))))
+                        (meta <opaque>)))))
+                    (meta <opaque>)))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id d4)
+      (decl_type
+       (Sized
+        (SArray
+         (SArray
+          (SArray
+           (SArray SReal
+            ((pattern (Lit Int 2))
+             (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+           ((pattern (Lit Int 2))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+         ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id d4_flat__)
+          (decl_type (Unsized (UArray UReal))) (initialize Uninit)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable d4_flat__) ()) (UArray UReal)
+          ((pattern
+            (FunApp (CompilerInternal FnReadData)
+             (((pattern (Lit Str d4))
+               (meta
+                ((type_ (UArray (UArray (UArray (UArray UReal))))) (loc <opaque>)
+                 (adlevel DataOnly)))))))
+           (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable pos__) ()) UInt
+          ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar sym1__)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Lit Int 2))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (For (loopvar sym2__)
+                  (lower
+                   ((pattern (Lit Int 1))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (upper
+                   ((pattern (Lit Int 2))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (body
+                   ((pattern
+                     (Block
+                      (((pattern
+                         (For (loopvar sym3__)
+                          (lower
+                           ((pattern (Lit Int 1))
+                            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                          (upper
+                           ((pattern (Lit Int 2))
+                            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                          (body
+                           ((pattern
+                             (Block
+                              (((pattern
+                                 (For (loopvar sym4__)
+                                  (lower
+                                   ((pattern (Lit Int 1))
+                                    (meta
+                                     ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                                  (upper
+                                   ((pattern (Lit Int 2))
+                                    (meta
+                                     ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                                  (body
+                                   ((pattern
+                                     (Block
+                                      (((pattern
+                                         (Assignment
+                                          ((LVariable d4)
+                                           ((Single
+                                             ((pattern (Var sym4__))
+                                              (meta
+                                               ((type_ UInt) (loc <opaque>)
+                                                (adlevel DataOnly)))))
+                                            (Single
+                                             ((pattern (Var sym3__))
+                                              (meta
+                                               ((type_ UInt) (loc <opaque>)
+                                                (adlevel DataOnly)))))
+                                            (Single
+                                             ((pattern (Var sym2__))
+                                              (meta
+                                               ((type_ UInt) (loc <opaque>)
+                                                (adlevel DataOnly)))))
+                                            (Single
+                                             ((pattern (Var sym1__))
+                                              (meta
+                                               ((type_ UInt) (loc <opaque>)
+                                                (adlevel DataOnly)))))))
+                                          (UArray (UArray (UArray (UArray UReal))))
+                                          ((pattern
+                                            (Indexed
+                                             ((pattern (Var d4_flat__))
+                                              (meta
+                                               ((type_ (UArray UReal)) 
+                                                (loc <opaque>) (adlevel DataOnly))))
+                                             ((Single
+                                               ((pattern (Var pos__))
+                                                (meta
+                                                 ((type_ UInt) (loc <opaque>)
+                                                  (adlevel DataOnly))))))))
+                                           (meta
+                                            ((type_ UReal) (loc <opaque>)
+                                             (adlevel DataOnly))))))
+                                        (meta <opaque>))
+                                       ((pattern
+                                         (Assignment ((LVariable pos__) ()) UInt
+                                          ((pattern
+                                            (FunApp (StanLib Plus__ FnPlain AoS)
+                                             (((pattern (Var pos__))
+                                               (meta
+                                                ((type_ UInt) (loc <opaque>)
+                                                 (adlevel DataOnly))))
+                                              ((pattern (Lit Int 1))
+                                               (meta
+                                                ((type_ UInt) (loc <opaque>)
+                                                 (adlevel DataOnly)))))))
+                                           (meta
+                                            ((type_ UInt) (loc <opaque>)
+                                             (adlevel DataOnly))))))
+                                        (meta <opaque>)))))
+                                    (meta <opaque>)))))
+                                (meta <opaque>)))))
+                            (meta <opaque>)))))
+                        (meta <opaque>)))))
+                    (meta <opaque>)))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id dvv)
+      (decl_type
+       (Sized
+        (SArray
+         (SArray
+          (SVector AoS
+           ((pattern (Lit Int 3))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+         ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id dvv_flat__)
+          (decl_type (Unsized (UArray UReal))) (initialize Uninit)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable dvv_flat__) ()) (UArray UReal)
+          ((pattern
+            (FunApp (CompilerInternal FnReadData)
+             (((pattern (Lit Str dvv))
+               (meta
+                ((type_ (UArray (UArray UVector))) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable pos__) ()) UInt
+          ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar sym1__)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Lit Int 3))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (For (loopvar sym2__)
+                  (lower
+                   ((pattern (Lit Int 1))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (upper
+                   ((pattern (Lit Int 2))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (body
+                   ((pattern
+                     (Block
+                      (((pattern
+                         (For (loopvar sym3__)
+                          (lower
+                           ((pattern (Lit Int 1))
+                            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                          (upper
+                           ((pattern (Lit Int 2))
+                            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                          (body
+                           ((pattern
+                             (Block
+                              (((pattern
+                                 (Assignment
+                                  ((LVariable dvv)
+                                   ((Single
+                                     ((pattern (Var sym3__))
+                                      (meta
+                                       ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                                    (Single
+                                     ((pattern (Var sym2__))
+                                      (meta
+                                       ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                                    (Single
+                                     ((pattern (Var sym1__))
+                                      (meta
+                                       ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                                  (UArray (UArray UVector))
+                                  ((pattern
+                                    (Indexed
+                                     ((pattern (Var dvv_flat__))
+                                      (meta
+                                       ((type_ (UArray UReal)) (loc <opaque>)
+                                        (adlevel DataOnly))))
+                                     ((Single
+                                       ((pattern (Var pos__))
+                                        (meta
+                                         ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                                   (meta
+                                    ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+                                (meta <opaque>))
+                               ((pattern
+                                 (Assignment ((LVariable pos__) ()) UInt
+                                  ((pattern
+                                    (FunApp (StanLib Plus__ FnPlain AoS)
+                                     (((pattern (Var pos__))
+                                       (meta
+                                        ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                                      ((pattern (Lit Int 1))
+                                       (meta
+                                        ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                                   (meta
+                                    ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                                (meta <opaque>)))))
+                            (meta <opaque>)))))
+                        (meta <opaque>)))))
+                    (meta <opaque>)))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id dm)
+      (decl_type
+       (Sized
+        (SArray
+         (SMatrix AoS
+          ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+          ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+         ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id dm_flat__)
+          (decl_type (Unsized (UArray UReal))) (initialize Uninit)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable dm_flat__) ()) (UArray UReal)
+          ((pattern
+            (FunApp (CompilerInternal FnReadData)
+             (((pattern (Lit Str dm))
+               (meta ((type_ (UArray UMatrix)) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable pos__) ()) UInt
+          ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar sym1__)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Lit Int 3))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (For (loopvar sym2__)
+                  (lower
+                   ((pattern (Lit Int 1))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (upper
+                   ((pattern (Lit Int 2))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (body
+                   ((pattern
+                     (Block
+                      (((pattern
+                         (For (loopvar sym3__)
+                          (lower
+                           ((pattern (Lit Int 1))
+                            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                          (upper
+                           ((pattern (Lit Int 2))
+                            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                          (body
+                           ((pattern
+                             (Block
+                              (((pattern
+                                 (Assignment
+                                  ((LVariable dm)
+                                   ((Single
+                                     ((pattern (Var sym3__))
+                                      (meta
+                                       ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                                    (Single
+                                     ((pattern (Var sym2__))
+                                      (meta
+                                       ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                                    (Single
+                                     ((pattern (Var sym1__))
+                                      (meta
+                                       ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                                  (UArray UMatrix)
+                                  ((pattern
+                                    (Indexed
+                                     ((pattern (Var dm_flat__))
+                                      (meta
+                                       ((type_ (UArray UReal)) (loc <opaque>)
+                                        (adlevel DataOnly))))
+                                     ((Single
+                                       ((pattern (Var pos__))
+                                        (meta
+                                         ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                                   (meta
+                                    ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+                                (meta <opaque>))
+                               ((pattern
+                                 (Assignment ((LVariable pos__) ()) UInt
+                                  ((pattern
+                                    (FunApp (StanLib Plus__ FnPlain AoS)
+                                     (((pattern (Var pos__))
+                                       (meta
+                                        ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                                      ((pattern (Lit Int 1))
+                                       (meta
+                                        ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                                   (meta
+                                    ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                                (meta <opaque>)))))
+                            (meta <opaque>)))))
+                        (meta <opaque>)))))
+                    (meta <opaque>)))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id t2)
+      (decl_type
+       (Sized
+        (SArray
+         (SArray SReal
+          ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+         ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable t2) ()) (UArray (UArray UReal))
+      ((pattern
+        (FunApp (CompilerInternal FnMakeArray)
+         (((pattern
+            (FunApp (CompilerInternal FnMakeArray)
+             (((pattern (Lit Real 11.))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+              ((pattern (Lit Real 12.))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))
+          ((pattern
+            (FunApp (CompilerInternal FnMakeArray)
+             (((pattern (Lit Real 21.))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+              ((pattern (Lit Real 22.))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ (UArray (UArray UReal))) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id t3)
+      (decl_type
+       (Sized
+        (SArray
+         (SArray
+          (SArray SReal
+           ((pattern (Lit Int 2))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+         ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable t3) ()) (UArray (UArray (UArray UReal)))
+      ((pattern
+        (FunApp (CompilerInternal FnMakeArray)
+         (((pattern
+            (FunApp (CompilerInternal FnMakeArray)
+             (((pattern
+                (FunApp (CompilerInternal FnMakeArray)
+                 (((pattern (Lit Real 111.))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+                  ((pattern (Lit Real 112.))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+               (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))
+              ((pattern
+                (FunApp (CompilerInternal FnMakeArray)
+                 (((pattern (Lit Real 121.))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+                  ((pattern (Lit Real 122.))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+               (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ (UArray (UArray UReal))) (loc <opaque>) (adlevel DataOnly))))
+          ((pattern
+            (FunApp (CompilerInternal FnMakeArray)
+             (((pattern
+                (FunApp (CompilerInternal FnMakeArray)
+                 (((pattern (Lit Real 211.))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+                  ((pattern (Lit Real 212.))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+               (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))
+              ((pattern
+                (FunApp (CompilerInternal FnMakeArray)
+                 (((pattern (Lit Real 221.))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+                  ((pattern (Lit Real 222.))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+               (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ (UArray (UArray UReal))) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta
+        ((type_ (UArray (UArray (UArray UReal)))) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id t4)
+      (decl_type
+       (Sized
+        (SArray
+         (SArray
+          (SArray
+           (SArray SReal
+            ((pattern (Lit Int 2))
+             (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+           ((pattern (Lit Int 2))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+         ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable t4) ()) (UArray (UArray (UArray (UArray UReal))))
+      ((pattern
+        (FunApp (CompilerInternal FnMakeArray)
+         (((pattern
+            (FunApp (CompilerInternal FnMakeArray)
+             (((pattern
+                (FunApp (CompilerInternal FnMakeArray)
+                 (((pattern
+                    (FunApp (CompilerInternal FnMakeArray)
+                     (((pattern (Lit Real 1111.))
+                       (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+                      ((pattern (Lit Real 1112.))
+                       (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+                   (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))
+                  ((pattern
+                    (FunApp (CompilerInternal FnMakeArray)
+                     (((pattern (Lit Real 1121.))
+                       (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+                      ((pattern (Lit Real 1122.))
+                       (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+                   (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly)))))))
+               (meta ((type_ (UArray (UArray UReal))) (loc <opaque>) (adlevel DataOnly))))
+              ((pattern
+                (FunApp (CompilerInternal FnMakeArray)
+                 (((pattern
+                    (FunApp (CompilerInternal FnMakeArray)
+                     (((pattern (Lit Real 1211.))
+                       (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+                      ((pattern (Lit Real 1212.))
+                       (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+                   (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))
+                  ((pattern
+                    (FunApp (CompilerInternal FnMakeArray)
+                     (((pattern (Lit Real 1221.))
+                       (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+                      ((pattern (Lit Real 1222.))
+                       (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+                   (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly)))))))
+               (meta ((type_ (UArray (UArray UReal))) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta
+            ((type_ (UArray (UArray (UArray UReal)))) (loc <opaque>) (adlevel DataOnly))))
+          ((pattern
+            (FunApp (CompilerInternal FnMakeArray)
+             (((pattern
+                (FunApp (CompilerInternal FnMakeArray)
+                 (((pattern
+                    (FunApp (CompilerInternal FnMakeArray)
+                     (((pattern (Lit Real 2111.))
+                       (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+                      ((pattern (Lit Real 2112.))
+                       (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+                   (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))
+                  ((pattern
+                    (FunApp (CompilerInternal FnMakeArray)
+                     (((pattern (Lit Real 2121.))
+                       (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+                      ((pattern (Lit Real 2122.))
+                       (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+                   (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly)))))))
+               (meta ((type_ (UArray (UArray UReal))) (loc <opaque>) (adlevel DataOnly))))
+              ((pattern
+                (FunApp (CompilerInternal FnMakeArray)
+                 (((pattern
+                    (FunApp (CompilerInternal FnMakeArray)
+                     (((pattern (Lit Real 2211.))
+                       (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+                      ((pattern (Lit Real 2212.))
+                       (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+                   (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))
+                  ((pattern
+                    (FunApp (CompilerInternal FnMakeArray)
+                     (((pattern (Lit Real 2221.))
+                       (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+                      ((pattern (Lit Real 2222.))
+                       (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+                   (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly)))))))
+               (meta ((type_ (UArray (UArray UReal))) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta
+            ((type_ (UArray (UArray (UArray UReal)))) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta
+        ((type_ (UArray (UArray (UArray (UArray UReal))))) (loc <opaque>)
+         (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id tvv)
+      (decl_type
+       (Sized
+        (SArray
+         (SArray
+          (SVector AoS
+           ((pattern (Lit Int 3))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+         ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable tvv) ()) (UArray (UArray UVector))
+      ((pattern
+        (FunApp (CompilerInternal FnMakeArray)
+         (((pattern
+            (FunApp (CompilerInternal FnMakeArray)
+             (((pattern
+                (FunApp (StanLib Transpose__ FnPlain AoS)
+                 (((pattern
+                    (FunApp (CompilerInternal FnMakeRowVec)
+                     (((pattern (Lit Real 111.))
+                       (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+                      ((pattern (Lit Real 112.))
+                       (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+                      ((pattern (Lit Real 113.))
+                       (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+                   (meta ((type_ URowVector) (loc <opaque>) (adlevel DataOnly)))))))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly))))
+              ((pattern
+                (FunApp (StanLib Transpose__ FnPlain AoS)
+                 (((pattern
+                    (FunApp (CompilerInternal FnMakeRowVec)
+                     (((pattern (Lit Real 121.))
+                       (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+                      ((pattern (Lit Real 122.))
+                       (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+                      ((pattern (Lit Real 123.))
+                       (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+                   (meta ((type_ URowVector) (loc <opaque>) (adlevel DataOnly)))))))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ (UArray UVector)) (loc <opaque>) (adlevel DataOnly))))
+          ((pattern
+            (FunApp (CompilerInternal FnMakeArray)
+             (((pattern
+                (FunApp (StanLib Transpose__ FnPlain AoS)
+                 (((pattern
+                    (FunApp (CompilerInternal FnMakeRowVec)
+                     (((pattern (Lit Real 211.))
+                       (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+                      ((pattern (Lit Real 212.))
+                       (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+                      ((pattern (Lit Real 213.))
+                       (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+                   (meta ((type_ URowVector) (loc <opaque>) (adlevel DataOnly)))))))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly))))
+              ((pattern
+                (FunApp (StanLib Transpose__ FnPlain AoS)
+                 (((pattern
+                    (FunApp (CompilerInternal FnMakeRowVec)
+                     (((pattern (Lit Real 221.))
+                       (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+                      ((pattern (Lit Real 222.))
+                       (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+                      ((pattern (Lit Real 223.))
+                       (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+                   (meta ((type_ URowVector) (loc <opaque>) (adlevel DataOnly)))))))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ (UArray UVector)) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ (UArray (UArray UVector))) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id tm)
+      (decl_type
+       (Sized
+        (SArray
+         (SMatrix AoS
+          ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+          ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+         ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable tm) ()) (UArray UMatrix)
+      ((pattern
+        (FunApp (CompilerInternal FnMakeArray)
+         (((pattern
+            (FunApp (CompilerInternal FnMakeRowVec)
+             (((pattern
+                (FunApp (CompilerInternal FnMakeRowVec)
+                 (((pattern (Lit Real 111.))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+                  ((pattern (Lit Real 112.))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+                  ((pattern (Lit Real 113.))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+               (meta ((type_ URowVector) (loc <opaque>) (adlevel DataOnly))))
+              ((pattern
+                (FunApp (CompilerInternal FnMakeRowVec)
+                 (((pattern (Lit Real 121.))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+                  ((pattern (Lit Real 122.))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+                  ((pattern (Lit Real 123.))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+               (meta ((type_ URowVector) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly))))
+          ((pattern
+            (FunApp (CompilerInternal FnMakeRowVec)
+             (((pattern
+                (FunApp (CompilerInternal FnMakeRowVec)
+                 (((pattern (Lit Real 211.))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+                  ((pattern (Lit Real 212.))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+                  ((pattern (Lit Real 213.))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+               (meta ((type_ URowVector) (loc <opaque>) (adlevel DataOnly))))
+              ((pattern
+                (FunApp (CompilerInternal FnMakeRowVec)
+                 (((pattern (Lit Real 221.))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+                  ((pattern (Lit Real 222.))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+                  ((pattern (Lit Real 223.))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+               (meta ((type_ URowVector) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ (UArray UMatrix)) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id s3) (decl_type (Sized SReal))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable s3) ()) UReal
+      ((pattern
+        (Promotion
+         ((pattern (Lit Int 0)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+         UReal DataOnly))
+       (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (For (loopvar i)
+      (lower
+       ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+      (upper
+       ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+      (body
+       ((pattern
+         (Block
+          (((pattern
+             (For (loopvar j)
+              (lower
+               ((pattern (Lit Int 1))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+              (upper
+               ((pattern (Lit Int 2))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+              (body
+               ((pattern
+                 (Block
+                  (((pattern
+                     (For (loopvar k)
+                      (lower
+                       ((pattern (Lit Int 1))
+                        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                      (upper
+                       ((pattern (Lit Int 2))
+                        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                      (body
+                       ((pattern
+                         (Block
+                          (((pattern
+                             (Assignment ((LVariable s3) ()) UReal
+                              ((pattern
+                                (FunApp (StanLib fma FnPlain AoS)
+                                 (((pattern
+                                    (Indexed
+                                     ((pattern (Var t3))
+                                      (meta
+                                       ((type_ (UArray (UArray (UArray UReal))))
+                                        (loc <opaque>) (adlevel DataOnly))))
+                                     ((Single
+                                       ((pattern (Var i))
+                                        (meta
+                                         ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                                      (Single
+                                       ((pattern (Var j))
+                                        (meta
+                                         ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                                      (Single
+                                       ((pattern (Var k))
+                                        (meta
+                                         ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                                   (meta
+                                    ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+                                  ((pattern
+                                    (Promotion
+                                     ((pattern
+                                       (FunApp (StanLib Plus__ FnPlain AoS)
+                                        (((pattern
+                                           (FunApp (StanLib fma FnPlain AoS)
+                                            (((pattern (Lit Int 100))
+                                              (meta
+                                               ((type_ UInt) (loc <opaque>)
+                                                (adlevel DataOnly))))
+                                             ((pattern (Var i))
+                                              (meta
+                                               ((type_ UInt) (loc <opaque>)
+                                                (adlevel DataOnly))))
+                                             ((pattern
+                                               (FunApp (StanLib Times__ FnPlain AoS)
+                                                (((pattern (Lit Int 10))
+                                                  (meta
+                                                   ((type_ UInt) (loc <opaque>)
+                                                    (adlevel DataOnly))))
+                                                 ((pattern (Var j))
+                                                  (meta
+                                                   ((type_ UInt) (loc <opaque>)
+                                                    (adlevel DataOnly)))))))
+                                              (meta
+                                               ((type_ UInt) (loc <opaque>)
+                                                (adlevel DataOnly)))))))
+                                          (meta
+                                           ((type_ UInt) (loc <opaque>)
+                                            (adlevel DataOnly))))
+                                         ((pattern (Var k))
+                                          (meta
+                                           ((type_ UInt) (loc <opaque>)
+                                            (adlevel DataOnly)))))))
+                                      (meta
+                                       ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                                     UReal DataOnly))
+                                   (meta
+                                    ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+                                  ((pattern (Var s3))
+                                   (meta
+                                    ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+                               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+                            (meta <opaque>)))))
+                        (meta <opaque>)))))
+                    (meta <opaque>)))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))))
+ (log_prob
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id x) (decl_type (Sized SReal))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity) (dims ()) (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id y) (decl_type (Sized SReal))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity) (dims ()) (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id z) (decl_type (Sized SReal))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity) (dims ()) (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id diff) (decl_type (Sized SReal))
+          (initialize Uninit)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable diff) ()) UReal
+          ((pattern
+            (Promotion
+             ((pattern (Lit Int 0))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel AutoDiffable))))
+             UReal AutoDiffable))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>))
+       ((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id wt) (decl_type (Sized SReal))
+          (initialize Uninit)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable wt) ()) UReal
+          ((pattern
+            (Promotion
+             ((pattern (Lit Int 0))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel AutoDiffable))))
+             UReal AutoDiffable))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar i)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Lit Int 2))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (For (loopvar j)
+                  (lower
+                   ((pattern (Lit Int 1))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (upper
+                   ((pattern (Lit Int 2))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (body
+                   ((pattern
+                     (Block
+                      (((pattern
+                         (Assignment ((LVariable diff) ()) UReal
+                          ((pattern
+                            (FunApp (StanLib fma FnPlain AoS)
+                             (((pattern
+                                (FunApp (StanLib Minus__ FnPlain AoS)
+                                 (((pattern
+                                    (Indexed
+                                     ((pattern (Var t2))
+                                      (meta
+                                       ((type_ (UArray (UArray UReal))) 
+                                        (loc <opaque>) (adlevel DataOnly))))
+                                     ((Single
+                                       ((pattern (Var i))
+                                        (meta
+                                         ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                                      (Single
+                                       ((pattern (Var j))
+                                        (meta
+                                         ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                                   (meta
+                                    ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+                                  ((pattern
+                                    (Indexed
+                                     ((pattern (Var d2))
+                                      (meta
+                                       ((type_ (UArray (UArray UReal))) 
+                                        (loc <opaque>) (adlevel DataOnly))))
+                                     ((Single
+                                       ((pattern (Var i))
+                                        (meta
+                                         ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                                      (Single
+                                       ((pattern (Var j))
+                                        (meta
+                                         ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                                   (meta
+                                    ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+                               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+                              ((pattern
+                                (Promotion
+                                 ((pattern
+                                   (FunApp (StanLib fma FnPlain AoS)
+                                    (((pattern (Lit Int 10))
+                                      (meta
+                                       ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                                     ((pattern (Var i))
+                                      (meta
+                                       ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                                     ((pattern (Var j))
+                                      (meta
+                                       ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                                 UReal DataOnly))
+                               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+                              ((pattern (Var diff))
+                               (meta
+                                ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
+                           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+                        (meta <opaque>))
+                       ((pattern
+                         (Assignment ((LVariable wt) ()) UReal
+                          ((pattern
+                            (FunApp (StanLib fma FnPlain AoS)
+                             (((pattern
+                                (Indexed
+                                 ((pattern (Var t2))
+                                  (meta
+                                   ((type_ (UArray (UArray UReal))) (loc <opaque>)
+                                    (adlevel DataOnly))))
+                                 ((Single
+                                   ((pattern (Var i))
+                                    (meta
+                                     ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                                  (Single
+                                   ((pattern (Var j))
+                                    (meta
+                                     ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+                              ((pattern
+                                (Promotion
+                                 ((pattern
+                                   (FunApp (StanLib fma FnPlain AoS)
+                                    (((pattern (Lit Int 10))
+                                      (meta
+                                       ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                                     ((pattern (Var i))
+                                      (meta
+                                       ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                                     ((pattern (Var j))
+                                      (meta
+                                       ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                                 UReal DataOnly))
+                               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+                              ((pattern (Var wt))
+                               (meta
+                                ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
+                           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+                        (meta <opaque>)))))
+                    (meta <opaque>)))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar i)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Lit Int 2))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (For (loopvar j)
+                  (lower
+                   ((pattern (Lit Int 1))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (upper
+                   ((pattern (Lit Int 2))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (body
+                   ((pattern
+                     (Block
+                      (((pattern
+                         (For (loopvar k)
+                          (lower
+                           ((pattern (Lit Int 1))
+                            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                          (upper
+                           ((pattern (Lit Int 2))
+                            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                          (body
+                           ((pattern
+                             (Block
+                              (((pattern
+                                 (Assignment ((LVariable diff) ()) UReal
+                                  ((pattern
+                                    (FunApp (StanLib fma FnPlain AoS)
+                                     (((pattern
+                                        (FunApp (StanLib Minus__ FnPlain AoS)
+                                         (((pattern
+                                            (Indexed
+                                             ((pattern (Var t3))
+                                              (meta
+                                               ((type_ (UArray (UArray (UArray UReal))))
+                                                (loc <opaque>) (adlevel DataOnly))))
+                                             ((Single
+                                               ((pattern (Var i))
+                                                (meta
+                                                 ((type_ UInt) (loc <opaque>)
+                                                  (adlevel DataOnly)))))
+                                              (Single
+                                               ((pattern (Var j))
+                                                (meta
+                                                 ((type_ UInt) (loc <opaque>)
+                                                  (adlevel DataOnly)))))
+                                              (Single
+                                               ((pattern (Var k))
+                                                (meta
+                                                 ((type_ UInt) (loc <opaque>)
+                                                  (adlevel DataOnly))))))))
+                                           (meta
+                                            ((type_ UReal) (loc <opaque>)
+                                             (adlevel DataOnly))))
+                                          ((pattern
+                                            (Indexed
+                                             ((pattern (Var d3))
+                                              (meta
+                                               ((type_ (UArray (UArray (UArray UReal))))
+                                                (loc <opaque>) (adlevel DataOnly))))
+                                             ((Single
+                                               ((pattern (Var i))
+                                                (meta
+                                                 ((type_ UInt) (loc <opaque>)
+                                                  (adlevel DataOnly)))))
+                                              (Single
+                                               ((pattern (Var j))
+                                                (meta
+                                                 ((type_ UInt) (loc <opaque>)
+                                                  (adlevel DataOnly)))))
+                                              (Single
+                                               ((pattern (Var k))
+                                                (meta
+                                                 ((type_ UInt) (loc <opaque>)
+                                                  (adlevel DataOnly))))))))
+                                           (meta
+                                            ((type_ UReal) (loc <opaque>)
+                                             (adlevel DataOnly)))))))
+                                       (meta
+                                        ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+                                      ((pattern
+                                        (Promotion
+                                         ((pattern
+                                           (FunApp (StanLib Plus__ FnPlain AoS)
+                                            (((pattern
+                                               (FunApp (StanLib fma FnPlain AoS)
+                                                (((pattern (Lit Int 100))
+                                                  (meta
+                                                   ((type_ UInt) (loc <opaque>)
+                                                    (adlevel DataOnly))))
+                                                 ((pattern (Var i))
+                                                  (meta
+                                                   ((type_ UInt) (loc <opaque>)
+                                                    (adlevel DataOnly))))
+                                                 ((pattern
+                                                   (FunApp (StanLib Times__ FnPlain AoS)
+                                                    (((pattern (Lit Int 10))
+                                                      (meta
+                                                       ((type_ UInt) 
+                                                        (loc <opaque>)
+                                                        (adlevel DataOnly))))
+                                                     ((pattern (Var j))
+                                                      (meta
+                                                       ((type_ UInt) 
+                                                        (loc <opaque>)
+                                                        (adlevel DataOnly)))))))
+                                                  (meta
+                                                   ((type_ UInt) (loc <opaque>)
+                                                    (adlevel DataOnly)))))))
+                                              (meta
+                                               ((type_ UInt) (loc <opaque>)
+                                                (adlevel DataOnly))))
+                                             ((pattern (Var k))
+                                              (meta
+                                               ((type_ UInt) (loc <opaque>)
+                                                (adlevel DataOnly)))))))
+                                          (meta
+                                           ((type_ UInt) (loc <opaque>)
+                                            (adlevel DataOnly))))
+                                         UReal DataOnly))
+                                       (meta
+                                        ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+                                      ((pattern (Var diff))
+                                       (meta
+                                        ((type_ UReal) (loc <opaque>)
+                                         (adlevel AutoDiffable)))))))
+                                   (meta
+                                    ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+                                (meta <opaque>))
+                               ((pattern
+                                 (Assignment ((LVariable wt) ()) UReal
+                                  ((pattern
+                                    (FunApp (StanLib fma FnPlain AoS)
+                                     (((pattern
+                                        (Indexed
+                                         ((pattern (Var t3))
+                                          (meta
+                                           ((type_ (UArray (UArray (UArray UReal))))
+                                            (loc <opaque>) (adlevel DataOnly))))
+                                         ((Single
+                                           ((pattern (Var i))
+                                            (meta
+                                             ((type_ UInt) (loc <opaque>)
+                                              (adlevel DataOnly)))))
+                                          (Single
+                                           ((pattern (Var j))
+                                            (meta
+                                             ((type_ UInt) (loc <opaque>)
+                                              (adlevel DataOnly)))))
+                                          (Single
+                                           ((pattern (Var k))
+                                            (meta
+                                             ((type_ UInt) (loc <opaque>)
+                                              (adlevel DataOnly))))))))
+                                       (meta
+                                        ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+                                      ((pattern
+                                        (Promotion
+                                         ((pattern
+                                           (FunApp (StanLib Plus__ FnPlain AoS)
+                                            (((pattern
+                                               (FunApp (StanLib fma FnPlain AoS)
+                                                (((pattern (Lit Int 100))
+                                                  (meta
+                                                   ((type_ UInt) (loc <opaque>)
+                                                    (adlevel DataOnly))))
+                                                 ((pattern (Var i))
+                                                  (meta
+                                                   ((type_ UInt) (loc <opaque>)
+                                                    (adlevel DataOnly))))
+                                                 ((pattern
+                                                   (FunApp (StanLib Times__ FnPlain AoS)
+                                                    (((pattern (Lit Int 10))
+                                                      (meta
+                                                       ((type_ UInt) 
+                                                        (loc <opaque>)
+                                                        (adlevel DataOnly))))
+                                                     ((pattern (Var j))
+                                                      (meta
+                                                       ((type_ UInt) 
+                                                        (loc <opaque>)
+                                                        (adlevel DataOnly)))))))
+                                                  (meta
+                                                   ((type_ UInt) (loc <opaque>)
+                                                    (adlevel DataOnly)))))))
+                                              (meta
+                                               ((type_ UInt) (loc <opaque>)
+                                                (adlevel DataOnly))))
+                                             ((pattern (Var k))
+                                              (meta
+                                               ((type_ UInt) (loc <opaque>)
+                                                (adlevel DataOnly)))))))
+                                          (meta
+                                           ((type_ UInt) (loc <opaque>)
+                                            (adlevel DataOnly))))
+                                         UReal DataOnly))
+                                       (meta
+                                        ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+                                      ((pattern (Var wt))
+                                       (meta
+                                        ((type_ UReal) (loc <opaque>)
+                                         (adlevel AutoDiffable)))))))
+                                   (meta
+                                    ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+                                (meta <opaque>)))))
+                            (meta <opaque>)))))
+                        (meta <opaque>)))))
+                    (meta <opaque>)))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar i)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Lit Int 2))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (For (loopvar j)
+                  (lower
+                   ((pattern (Lit Int 1))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (upper
+                   ((pattern (Lit Int 2))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (body
+                   ((pattern
+                     (Block
+                      (((pattern
+                         (For (loopvar k)
+                          (lower
+                           ((pattern (Lit Int 1))
+                            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                          (upper
+                           ((pattern (Lit Int 2))
+                            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                          (body
+                           ((pattern
+                             (Block
+                              (((pattern
+                                 (For (loopvar l)
+                                  (lower
+                                   ((pattern (Lit Int 1))
+                                    (meta
+                                     ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                                  (upper
+                                   ((pattern (Lit Int 2))
+                                    (meta
+                                     ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                                  (body
+                                   ((pattern
+                                     (Block
+                                      (((pattern
+                                         (Assignment ((LVariable diff) ()) UReal
+                                          ((pattern
+                                            (FunApp (StanLib fma FnPlain AoS)
+                                             (((pattern
+                                                (FunApp (StanLib Minus__ FnPlain AoS)
+                                                 (((pattern
+                                                    (Indexed
+                                                     ((pattern (Var t4))
+                                                      (meta
+                                                       ((type_
+                                                         (UArray
+                                                          (UArray
+                                                           (UArray (UArray UReal)))))
+                                                        (loc <opaque>)
+                                                        (adlevel DataOnly))))
+                                                     ((Single
+                                                       ((pattern (Var i))
+                                                        (meta
+                                                         ((type_ UInt) 
+                                                          (loc <opaque>)
+                                                          (adlevel DataOnly)))))
+                                                      (Single
+                                                       ((pattern (Var j))
+                                                        (meta
+                                                         ((type_ UInt) 
+                                                          (loc <opaque>)
+                                                          (adlevel DataOnly)))))
+                                                      (Single
+                                                       ((pattern (Var k))
+                                                        (meta
+                                                         ((type_ UInt) 
+                                                          (loc <opaque>)
+                                                          (adlevel DataOnly)))))
+                                                      (Single
+                                                       ((pattern (Var l))
+                                                        (meta
+                                                         ((type_ UInt) 
+                                                          (loc <opaque>)
+                                                          (adlevel DataOnly))))))))
+                                                   (meta
+                                                    ((type_ UReal) (loc <opaque>)
+                                                     (adlevel DataOnly))))
+                                                  ((pattern
+                                                    (Indexed
+                                                     ((pattern (Var d4))
+                                                      (meta
+                                                       ((type_
+                                                         (UArray
+                                                          (UArray
+                                                           (UArray (UArray UReal)))))
+                                                        (loc <opaque>)
+                                                        (adlevel DataOnly))))
+                                                     ((Single
+                                                       ((pattern (Var i))
+                                                        (meta
+                                                         ((type_ UInt) 
+                                                          (loc <opaque>)
+                                                          (adlevel DataOnly)))))
+                                                      (Single
+                                                       ((pattern (Var j))
+                                                        (meta
+                                                         ((type_ UInt) 
+                                                          (loc <opaque>)
+                                                          (adlevel DataOnly)))))
+                                                      (Single
+                                                       ((pattern (Var k))
+                                                        (meta
+                                                         ((type_ UInt) 
+                                                          (loc <opaque>)
+                                                          (adlevel DataOnly)))))
+                                                      (Single
+                                                       ((pattern (Var l))
+                                                        (meta
+                                                         ((type_ UInt) 
+                                                          (loc <opaque>)
+                                                          (adlevel DataOnly))))))))
+                                                   (meta
+                                                    ((type_ UReal) (loc <opaque>)
+                                                     (adlevel DataOnly)))))))
+                                               (meta
+                                                ((type_ UReal) (loc <opaque>)
+                                                 (adlevel DataOnly))))
+                                              ((pattern
+                                                (Promotion
+                                                 ((pattern
+                                                   (FunApp (StanLib Plus__ FnPlain AoS)
+                                                    (((pattern
+                                                       (FunApp (StanLib fma FnPlain AoS)
+                                                        (((pattern (Lit Int 10))
+                                                          (meta
+                                                           ((type_ UInt) 
+                                                            (loc <opaque>)
+                                                            (adlevel DataOnly))))
+                                                         ((pattern (Var k))
+                                                          (meta
+                                                           ((type_ UInt) 
+                                                            (loc <opaque>)
+                                                            (adlevel DataOnly))))
+                                                         ((pattern
+                                                           (FunApp
+                                                            (StanLib fma FnPlain AoS)
+                                                            (((pattern (Lit Int 1000))
+                                                              (meta
+                                                               ((type_ UInt)
+                                                                (loc <opaque>)
+                                                                (adlevel DataOnly))))
+                                                             ((pattern (Var i))
+                                                              (meta
+                                                               ((type_ UInt)
+                                                                (loc <opaque>)
+                                                                (adlevel DataOnly))))
+                                                             ((pattern
+                                                               (FunApp
+                                                                (StanLib Times__ FnPlain
+                                                                 AoS)
+                                                                (((pattern (Lit Int 100))
+                                                                  (meta
+                                                                   ((type_ UInt)
+                                                                    (loc <opaque>)
+                                                                    (adlevel DataOnly))))
+                                                                 ((pattern (Var j))
+                                                                  (meta
+                                                                   ((type_ UInt)
+                                                                    (loc <opaque>)
+                                                                    (adlevel DataOnly)))))))
+                                                              (meta
+                                                               ((type_ UInt)
+                                                                (loc <opaque>)
+                                                                (adlevel DataOnly)))))))
+                                                          (meta
+                                                           ((type_ UInt) 
+                                                            (loc <opaque>)
+                                                            (adlevel DataOnly)))))))
+                                                      (meta
+                                                       ((type_ UInt) 
+                                                        (loc <opaque>)
+                                                        (adlevel DataOnly))))
+                                                     ((pattern (Var l))
+                                                      (meta
+                                                       ((type_ UInt) 
+                                                        (loc <opaque>)
+                                                        (adlevel DataOnly)))))))
+                                                  (meta
+                                                   ((type_ UInt) (loc <opaque>)
+                                                    (adlevel DataOnly))))
+                                                 UReal DataOnly))
+                                               (meta
+                                                ((type_ UReal) (loc <opaque>)
+                                                 (adlevel DataOnly))))
+                                              ((pattern (Var diff))
+                                               (meta
+                                                ((type_ UReal) (loc <opaque>)
+                                                 (adlevel AutoDiffable)))))))
+                                           (meta
+                                            ((type_ UReal) (loc <opaque>)
+                                             (adlevel AutoDiffable))))))
+                                        (meta <opaque>))
+                                       ((pattern
+                                         (Assignment ((LVariable wt) ()) UReal
+                                          ((pattern
+                                            (FunApp (StanLib fma FnPlain AoS)
+                                             (((pattern
+                                                (Indexed
+                                                 ((pattern (Var t4))
+                                                  (meta
+                                                   ((type_
+                                                     (UArray
+                                                      (UArray (UArray (UArray UReal)))))
+                                                    (loc <opaque>) (adlevel DataOnly))))
+                                                 ((Single
+                                                   ((pattern (Var i))
+                                                    (meta
+                                                     ((type_ UInt) (loc <opaque>)
+                                                      (adlevel DataOnly)))))
+                                                  (Single
+                                                   ((pattern (Var j))
+                                                    (meta
+                                                     ((type_ UInt) (loc <opaque>)
+                                                      (adlevel DataOnly)))))
+                                                  (Single
+                                                   ((pattern (Var k))
+                                                    (meta
+                                                     ((type_ UInt) (loc <opaque>)
+                                                      (adlevel DataOnly)))))
+                                                  (Single
+                                                   ((pattern (Var l))
+                                                    (meta
+                                                     ((type_ UInt) (loc <opaque>)
+                                                      (adlevel DataOnly))))))))
+                                               (meta
+                                                ((type_ UReal) (loc <opaque>)
+                                                 (adlevel DataOnly))))
+                                              ((pattern
+                                                (Promotion
+                                                 ((pattern
+                                                   (FunApp (StanLib Plus__ FnPlain AoS)
+                                                    (((pattern
+                                                       (FunApp (StanLib fma FnPlain AoS)
+                                                        (((pattern (Lit Int 10))
+                                                          (meta
+                                                           ((type_ UInt) 
+                                                            (loc <opaque>)
+                                                            (adlevel DataOnly))))
+                                                         ((pattern (Var k))
+                                                          (meta
+                                                           ((type_ UInt) 
+                                                            (loc <opaque>)
+                                                            (adlevel DataOnly))))
+                                                         ((pattern
+                                                           (FunApp
+                                                            (StanLib fma FnPlain AoS)
+                                                            (((pattern (Lit Int 1000))
+                                                              (meta
+                                                               ((type_ UInt)
+                                                                (loc <opaque>)
+                                                                (adlevel DataOnly))))
+                                                             ((pattern (Var i))
+                                                              (meta
+                                                               ((type_ UInt)
+                                                                (loc <opaque>)
+                                                                (adlevel DataOnly))))
+                                                             ((pattern
+                                                               (FunApp
+                                                                (StanLib Times__ FnPlain
+                                                                 AoS)
+                                                                (((pattern (Lit Int 100))
+                                                                  (meta
+                                                                   ((type_ UInt)
+                                                                    (loc <opaque>)
+                                                                    (adlevel DataOnly))))
+                                                                 ((pattern (Var j))
+                                                                  (meta
+                                                                   ((type_ UInt)
+                                                                    (loc <opaque>)
+                                                                    (adlevel DataOnly)))))))
+                                                              (meta
+                                                               ((type_ UInt)
+                                                                (loc <opaque>)
+                                                                (adlevel DataOnly)))))))
+                                                          (meta
+                                                           ((type_ UInt) 
+                                                            (loc <opaque>)
+                                                            (adlevel DataOnly)))))))
+                                                      (meta
+                                                       ((type_ UInt) 
+                                                        (loc <opaque>)
+                                                        (adlevel DataOnly))))
+                                                     ((pattern (Var l))
+                                                      (meta
+                                                       ((type_ UInt) 
+                                                        (loc <opaque>)
+                                                        (adlevel DataOnly)))))))
+                                                  (meta
+                                                   ((type_ UInt) (loc <opaque>)
+                                                    (adlevel DataOnly))))
+                                                 UReal DataOnly))
+                                               (meta
+                                                ((type_ UReal) (loc <opaque>)
+                                                 (adlevel DataOnly))))
+                                              ((pattern (Var wt))
+                                               (meta
+                                                ((type_ UReal) (loc <opaque>)
+                                                 (adlevel AutoDiffable)))))))
+                                           (meta
+                                            ((type_ UReal) (loc <opaque>)
+                                             (adlevel AutoDiffable))))))
+                                        (meta <opaque>)))))
+                                    (meta <opaque>)))))
+                                (meta <opaque>)))))
+                            (meta <opaque>)))))
+                        (meta <opaque>)))))
+                    (meta <opaque>)))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar i)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Lit Int 2))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (For (loopvar j)
+                  (lower
+                   ((pattern (Lit Int 1))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (upper
+                   ((pattern (Lit Int 2))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (body
+                   ((pattern
+                     (Block
+                      (((pattern
+                         (For (loopvar k)
+                          (lower
+                           ((pattern (Lit Int 1))
+                            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                          (upper
+                           ((pattern (Lit Int 3))
+                            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                          (body
+                           ((pattern
+                             (Block
+                              (((pattern
+                                 (Assignment ((LVariable diff) ()) UReal
+                                  ((pattern
+                                    (FunApp (StanLib fma FnPlain AoS)
+                                     (((pattern
+                                        (FunApp (StanLib Minus__ FnPlain AoS)
+                                         (((pattern
+                                            (Indexed
+                                             ((pattern (Var tvv))
+                                              (meta
+                                               ((type_ (UArray (UArray UVector)))
+                                                (loc <opaque>) (adlevel DataOnly))))
+                                             ((Single
+                                               ((pattern (Var i))
+                                                (meta
+                                                 ((type_ UInt) (loc <opaque>)
+                                                  (adlevel DataOnly)))))
+                                              (Single
+                                               ((pattern (Var j))
+                                                (meta
+                                                 ((type_ UInt) (loc <opaque>)
+                                                  (adlevel DataOnly)))))
+                                              (Single
+                                               ((pattern (Var k))
+                                                (meta
+                                                 ((type_ UInt) (loc <opaque>)
+                                                  (adlevel DataOnly))))))))
+                                           (meta
+                                            ((type_ UReal) (loc <opaque>)
+                                             (adlevel DataOnly))))
+                                          ((pattern
+                                            (Indexed
+                                             ((pattern (Var dvv))
+                                              (meta
+                                               ((type_ (UArray (UArray UVector)))
+                                                (loc <opaque>) (adlevel DataOnly))))
+                                             ((Single
+                                               ((pattern (Var i))
+                                                (meta
+                                                 ((type_ UInt) (loc <opaque>)
+                                                  (adlevel DataOnly)))))
+                                              (Single
+                                               ((pattern (Var j))
+                                                (meta
+                                                 ((type_ UInt) (loc <opaque>)
+                                                  (adlevel DataOnly)))))
+                                              (Single
+                                               ((pattern (Var k))
+                                                (meta
+                                                 ((type_ UInt) (loc <opaque>)
+                                                  (adlevel DataOnly))))))))
+                                           (meta
+                                            ((type_ UReal) (loc <opaque>)
+                                             (adlevel DataOnly)))))))
+                                       (meta
+                                        ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+                                      ((pattern
+                                        (Promotion
+                                         ((pattern
+                                           (FunApp (StanLib Plus__ FnPlain AoS)
+                                            (((pattern
+                                               (FunApp (StanLib fma FnPlain AoS)
+                                                (((pattern (Lit Int 100))
+                                                  (meta
+                                                   ((type_ UInt) (loc <opaque>)
+                                                    (adlevel DataOnly))))
+                                                 ((pattern (Var i))
+                                                  (meta
+                                                   ((type_ UInt) (loc <opaque>)
+                                                    (adlevel DataOnly))))
+                                                 ((pattern
+                                                   (FunApp (StanLib Times__ FnPlain AoS)
+                                                    (((pattern (Lit Int 10))
+                                                      (meta
+                                                       ((type_ UInt) 
+                                                        (loc <opaque>)
+                                                        (adlevel DataOnly))))
+                                                     ((pattern (Var j))
+                                                      (meta
+                                                       ((type_ UInt) 
+                                                        (loc <opaque>)
+                                                        (adlevel DataOnly)))))))
+                                                  (meta
+                                                   ((type_ UInt) (loc <opaque>)
+                                                    (adlevel DataOnly)))))))
+                                              (meta
+                                               ((type_ UInt) (loc <opaque>)
+                                                (adlevel DataOnly))))
+                                             ((pattern (Var k))
+                                              (meta
+                                               ((type_ UInt) (loc <opaque>)
+                                                (adlevel DataOnly)))))))
+                                          (meta
+                                           ((type_ UInt) (loc <opaque>)
+                                            (adlevel DataOnly))))
+                                         UReal DataOnly))
+                                       (meta
+                                        ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+                                      ((pattern (Var diff))
+                                       (meta
+                                        ((type_ UReal) (loc <opaque>)
+                                         (adlevel AutoDiffable)))))))
+                                   (meta
+                                    ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+                                (meta <opaque>))
+                               ((pattern
+                                 (Assignment ((LVariable wt) ()) UReal
+                                  ((pattern
+                                    (FunApp (StanLib fma FnPlain AoS)
+                                     (((pattern
+                                        (Indexed
+                                         ((pattern (Var tvv))
+                                          (meta
+                                           ((type_ (UArray (UArray UVector)))
+                                            (loc <opaque>) (adlevel DataOnly))))
+                                         ((Single
+                                           ((pattern (Var i))
+                                            (meta
+                                             ((type_ UInt) (loc <opaque>)
+                                              (adlevel DataOnly)))))
+                                          (Single
+                                           ((pattern (Var j))
+                                            (meta
+                                             ((type_ UInt) (loc <opaque>)
+                                              (adlevel DataOnly)))))
+                                          (Single
+                                           ((pattern (Var k))
+                                            (meta
+                                             ((type_ UInt) (loc <opaque>)
+                                              (adlevel DataOnly))))))))
+                                       (meta
+                                        ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+                                      ((pattern
+                                        (Promotion
+                                         ((pattern
+                                           (FunApp (StanLib Plus__ FnPlain AoS)
+                                            (((pattern
+                                               (FunApp (StanLib fma FnPlain AoS)
+                                                (((pattern (Lit Int 100))
+                                                  (meta
+                                                   ((type_ UInt) (loc <opaque>)
+                                                    (adlevel DataOnly))))
+                                                 ((pattern (Var i))
+                                                  (meta
+                                                   ((type_ UInt) (loc <opaque>)
+                                                    (adlevel DataOnly))))
+                                                 ((pattern
+                                                   (FunApp (StanLib Times__ FnPlain AoS)
+                                                    (((pattern (Lit Int 10))
+                                                      (meta
+                                                       ((type_ UInt) 
+                                                        (loc <opaque>)
+                                                        (adlevel DataOnly))))
+                                                     ((pattern (Var j))
+                                                      (meta
+                                                       ((type_ UInt) 
+                                                        (loc <opaque>)
+                                                        (adlevel DataOnly)))))))
+                                                  (meta
+                                                   ((type_ UInt) (loc <opaque>)
+                                                    (adlevel DataOnly)))))))
+                                              (meta
+                                               ((type_ UInt) (loc <opaque>)
+                                                (adlevel DataOnly))))
+                                             ((pattern (Var k))
+                                              (meta
+                                               ((type_ UInt) (loc <opaque>)
+                                                (adlevel DataOnly)))))))
+                                          (meta
+                                           ((type_ UInt) (loc <opaque>)
+                                            (adlevel DataOnly))))
+                                         UReal DataOnly))
+                                       (meta
+                                        ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+                                      ((pattern (Var wt))
+                                       (meta
+                                        ((type_ UReal) (loc <opaque>)
+                                         (adlevel AutoDiffable)))))))
+                                   (meta
+                                    ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+                                (meta <opaque>)))))
+                            (meta <opaque>)))))
+                        (meta <opaque>)))))
+                    (meta <opaque>)))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar i)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Lit Int 2))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (For (loopvar j)
+                  (lower
+                   ((pattern (Lit Int 1))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (upper
+                   ((pattern (Lit Int 2))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (body
+                   ((pattern
+                     (Block
+                      (((pattern
+                         (For (loopvar k)
+                          (lower
+                           ((pattern (Lit Int 1))
+                            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                          (upper
+                           ((pattern (Lit Int 3))
+                            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                          (body
+                           ((pattern
+                             (Block
+                              (((pattern
+                                 (Assignment ((LVariable diff) ()) UReal
+                                  ((pattern
+                                    (FunApp (StanLib fma FnPlain AoS)
+                                     (((pattern
+                                        (FunApp (StanLib Minus__ FnPlain AoS)
+                                         (((pattern
+                                            (Indexed
+                                             ((pattern (Var tm))
+                                              (meta
+                                               ((type_ (UArray UMatrix)) 
+                                                (loc <opaque>) (adlevel DataOnly))))
+                                             ((Single
+                                               ((pattern (Var i))
+                                                (meta
+                                                 ((type_ UInt) (loc <opaque>)
+                                                  (adlevel DataOnly)))))
+                                              (Single
+                                               ((pattern (Var j))
+                                                (meta
+                                                 ((type_ UInt) (loc <opaque>)
+                                                  (adlevel DataOnly)))))
+                                              (Single
+                                               ((pattern (Var k))
+                                                (meta
+                                                 ((type_ UInt) (loc <opaque>)
+                                                  (adlevel DataOnly))))))))
+                                           (meta
+                                            ((type_ UReal) (loc <opaque>)
+                                             (adlevel DataOnly))))
+                                          ((pattern
+                                            (Indexed
+                                             ((pattern (Var dm))
+                                              (meta
+                                               ((type_ (UArray UMatrix)) 
+                                                (loc <opaque>) (adlevel DataOnly))))
+                                             ((Single
+                                               ((pattern (Var i))
+                                                (meta
+                                                 ((type_ UInt) (loc <opaque>)
+                                                  (adlevel DataOnly)))))
+                                              (Single
+                                               ((pattern (Var j))
+                                                (meta
+                                                 ((type_ UInt) (loc <opaque>)
+                                                  (adlevel DataOnly)))))
+                                              (Single
+                                               ((pattern (Var k))
+                                                (meta
+                                                 ((type_ UInt) (loc <opaque>)
+                                                  (adlevel DataOnly))))))))
+                                           (meta
+                                            ((type_ UReal) (loc <opaque>)
+                                             (adlevel DataOnly)))))))
+                                       (meta
+                                        ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+                                      ((pattern
+                                        (Promotion
+                                         ((pattern
+                                           (FunApp (StanLib Plus__ FnPlain AoS)
+                                            (((pattern
+                                               (FunApp (StanLib fma FnPlain AoS)
+                                                (((pattern (Lit Int 100))
+                                                  (meta
+                                                   ((type_ UInt) (loc <opaque>)
+                                                    (adlevel DataOnly))))
+                                                 ((pattern (Var i))
+                                                  (meta
+                                                   ((type_ UInt) (loc <opaque>)
+                                                    (adlevel DataOnly))))
+                                                 ((pattern
+                                                   (FunApp (StanLib Times__ FnPlain AoS)
+                                                    (((pattern (Lit Int 10))
+                                                      (meta
+                                                       ((type_ UInt) 
+                                                        (loc <opaque>)
+                                                        (adlevel DataOnly))))
+                                                     ((pattern (Var j))
+                                                      (meta
+                                                       ((type_ UInt) 
+                                                        (loc <opaque>)
+                                                        (adlevel DataOnly)))))))
+                                                  (meta
+                                                   ((type_ UInt) (loc <opaque>)
+                                                    (adlevel DataOnly)))))))
+                                              (meta
+                                               ((type_ UInt) (loc <opaque>)
+                                                (adlevel DataOnly))))
+                                             ((pattern (Var k))
+                                              (meta
+                                               ((type_ UInt) (loc <opaque>)
+                                                (adlevel DataOnly)))))))
+                                          (meta
+                                           ((type_ UInt) (loc <opaque>)
+                                            (adlevel DataOnly))))
+                                         UReal DataOnly))
+                                       (meta
+                                        ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+                                      ((pattern (Var diff))
+                                       (meta
+                                        ((type_ UReal) (loc <opaque>)
+                                         (adlevel AutoDiffable)))))))
+                                   (meta
+                                    ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+                                (meta <opaque>))
+                               ((pattern
+                                 (Assignment ((LVariable wt) ()) UReal
+                                  ((pattern
+                                    (FunApp (StanLib fma FnPlain AoS)
+                                     (((pattern
+                                        (Indexed
+                                         ((pattern (Var tm))
+                                          (meta
+                                           ((type_ (UArray UMatrix)) 
+                                            (loc <opaque>) (adlevel DataOnly))))
+                                         ((Single
+                                           ((pattern (Var i))
+                                            (meta
+                                             ((type_ UInt) (loc <opaque>)
+                                              (adlevel DataOnly)))))
+                                          (Single
+                                           ((pattern (Var j))
+                                            (meta
+                                             ((type_ UInt) (loc <opaque>)
+                                              (adlevel DataOnly)))))
+                                          (Single
+                                           ((pattern (Var k))
+                                            (meta
+                                             ((type_ UInt) (loc <opaque>)
+                                              (adlevel DataOnly))))))))
+                                       (meta
+                                        ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+                                      ((pattern
+                                        (Promotion
+                                         ((pattern
+                                           (FunApp (StanLib Plus__ FnPlain AoS)
+                                            (((pattern
+                                               (FunApp (StanLib fma FnPlain AoS)
+                                                (((pattern (Lit Int 100))
+                                                  (meta
+                                                   ((type_ UInt) (loc <opaque>)
+                                                    (adlevel DataOnly))))
+                                                 ((pattern (Var i))
+                                                  (meta
+                                                   ((type_ UInt) (loc <opaque>)
+                                                    (adlevel DataOnly))))
+                                                 ((pattern
+                                                   (FunApp (StanLib Times__ FnPlain AoS)
+                                                    (((pattern (Lit Int 10))
+                                                      (meta
+                                                       ((type_ UInt) 
+                                                        (loc <opaque>)
+                                                        (adlevel DataOnly))))
+                                                     ((pattern (Var j))
+                                                      (meta
+                                                       ((type_ UInt) 
+                                                        (loc <opaque>)
+                                                        (adlevel DataOnly)))))))
+                                                  (meta
+                                                   ((type_ UInt) (loc <opaque>)
+                                                    (adlevel DataOnly)))))))
+                                              (meta
+                                               ((type_ UInt) (loc <opaque>)
+                                                (adlevel DataOnly))))
+                                             ((pattern (Var k))
+                                              (meta
+                                               ((type_ UInt) (loc <opaque>)
+                                                (adlevel DataOnly)))))))
+                                          (meta
+                                           ((type_ UInt) (loc <opaque>)
+                                            (adlevel DataOnly))))
+                                         UReal DataOnly))
+                                       (meta
+                                        ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+                                      ((pattern (Var wt))
+                                       (meta
+                                        ((type_ UReal) (loc <opaque>)
+                                         (adlevel AutoDiffable)))))))
+                                   (meta
+                                    ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+                                (meta <opaque>)))))
+                            (meta <opaque>)))))
+                        (meta <opaque>)))))
+                    (meta <opaque>)))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>))
+       ((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib fma FnPlain AoS)
+             (((pattern (Var s3))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+              ((pattern (Var z))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+              ((pattern
+                (FunApp (StanLib fma FnPlain AoS)
+                 (((pattern (Var diff))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+                  ((pattern (Var x))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+                  ((pattern
+                    (FunApp (StanLib Times__ FnPlain AoS)
+                     (((pattern (Var wt))
+                       (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+                      ((pattern (Var y))
+                       (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>)))))
+    (meta <opaque>))))
+ (reverse_mode_log_prob
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id x) (decl_type (Sized SReal))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity) (dims ()) (mem_pattern SoA)))
+           ()))
+         (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id y) (decl_type (Sized SReal))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity) (dims ()) (mem_pattern SoA)))
+           ()))
+         (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id z) (decl_type (Sized SReal))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity) (dims ()) (mem_pattern SoA)))
+           ()))
+         (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id diff) (decl_type (Sized SReal))
+          (initialize Uninit)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable diff) ()) UReal
+          ((pattern
+            (Promotion
+             ((pattern (Lit Int 0))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel AutoDiffable))))
+             UReal AutoDiffable))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>))
+       ((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id wt) (decl_type (Sized SReal))
+          (initialize Uninit)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable wt) ()) UReal
+          ((pattern
+            (Promotion
+             ((pattern (Lit Int 0))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel AutoDiffable))))
+             UReal AutoDiffable))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar i)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Lit Int 2))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (For (loopvar j)
+                  (lower
+                   ((pattern (Lit Int 1))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (upper
+                   ((pattern (Lit Int 2))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (body
+                   ((pattern
+                     (Block
+                      (((pattern
+                         (Assignment ((LVariable diff) ()) UReal
+                          ((pattern
+                            (FunApp (StanLib fma FnPlain SoA)
+                             (((pattern
+                                (FunApp (StanLib Minus__ FnPlain SoA)
+                                 (((pattern
+                                    (Indexed
+                                     ((pattern (Var t2))
+                                      (meta
+                                       ((type_ (UArray (UArray UReal))) 
+                                        (loc <opaque>) (adlevel DataOnly))))
+                                     ((Single
+                                       ((pattern (Var i))
+                                        (meta
+                                         ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                                      (Single
+                                       ((pattern (Var j))
+                                        (meta
+                                         ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                                   (meta
+                                    ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+                                  ((pattern
+                                    (Indexed
+                                     ((pattern (Var d2))
+                                      (meta
+                                       ((type_ (UArray (UArray UReal))) 
+                                        (loc <opaque>) (adlevel DataOnly))))
+                                     ((Single
+                                       ((pattern (Var i))
+                                        (meta
+                                         ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                                      (Single
+                                       ((pattern (Var j))
+                                        (meta
+                                         ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                                   (meta
+                                    ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+                               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+                              ((pattern
+                                (Promotion
+                                 ((pattern
+                                   (FunApp (StanLib fma FnPlain SoA)
+                                    (((pattern (Lit Int 10))
+                                      (meta
+                                       ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                                     ((pattern (Var i))
+                                      (meta
+                                       ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                                     ((pattern (Var j))
+                                      (meta
+                                       ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                                 UReal DataOnly))
+                               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+                              ((pattern (Var diff))
+                               (meta
+                                ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
+                           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+                        (meta <opaque>))
+                       ((pattern
+                         (Assignment ((LVariable wt) ()) UReal
+                          ((pattern
+                            (FunApp (StanLib fma FnPlain SoA)
+                             (((pattern
+                                (Indexed
+                                 ((pattern (Var t2))
+                                  (meta
+                                   ((type_ (UArray (UArray UReal))) (loc <opaque>)
+                                    (adlevel DataOnly))))
+                                 ((Single
+                                   ((pattern (Var i))
+                                    (meta
+                                     ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                                  (Single
+                                   ((pattern (Var j))
+                                    (meta
+                                     ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+                              ((pattern
+                                (Promotion
+                                 ((pattern
+                                   (FunApp (StanLib fma FnPlain SoA)
+                                    (((pattern (Lit Int 10))
+                                      (meta
+                                       ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                                     ((pattern (Var i))
+                                      (meta
+                                       ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                                     ((pattern (Var j))
+                                      (meta
+                                       ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                                 UReal DataOnly))
+                               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+                              ((pattern (Var wt))
+                               (meta
+                                ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
+                           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+                        (meta <opaque>)))))
+                    (meta <opaque>)))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar i)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Lit Int 2))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (For (loopvar j)
+                  (lower
+                   ((pattern (Lit Int 1))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (upper
+                   ((pattern (Lit Int 2))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (body
+                   ((pattern
+                     (Block
+                      (((pattern
+                         (For (loopvar k)
+                          (lower
+                           ((pattern (Lit Int 1))
+                            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                          (upper
+                           ((pattern (Lit Int 2))
+                            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                          (body
+                           ((pattern
+                             (Block
+                              (((pattern
+                                 (Assignment ((LVariable diff) ()) UReal
+                                  ((pattern
+                                    (FunApp (StanLib fma FnPlain SoA)
+                                     (((pattern
+                                        (FunApp (StanLib Minus__ FnPlain SoA)
+                                         (((pattern
+                                            (Indexed
+                                             ((pattern (Var t3))
+                                              (meta
+                                               ((type_ (UArray (UArray (UArray UReal))))
+                                                (loc <opaque>) (adlevel DataOnly))))
+                                             ((Single
+                                               ((pattern (Var i))
+                                                (meta
+                                                 ((type_ UInt) (loc <opaque>)
+                                                  (adlevel DataOnly)))))
+                                              (Single
+                                               ((pattern (Var j))
+                                                (meta
+                                                 ((type_ UInt) (loc <opaque>)
+                                                  (adlevel DataOnly)))))
+                                              (Single
+                                               ((pattern (Var k))
+                                                (meta
+                                                 ((type_ UInt) (loc <opaque>)
+                                                  (adlevel DataOnly))))))))
+                                           (meta
+                                            ((type_ UReal) (loc <opaque>)
+                                             (adlevel DataOnly))))
+                                          ((pattern
+                                            (Indexed
+                                             ((pattern (Var d3))
+                                              (meta
+                                               ((type_ (UArray (UArray (UArray UReal))))
+                                                (loc <opaque>) (adlevel DataOnly))))
+                                             ((Single
+                                               ((pattern (Var i))
+                                                (meta
+                                                 ((type_ UInt) (loc <opaque>)
+                                                  (adlevel DataOnly)))))
+                                              (Single
+                                               ((pattern (Var j))
+                                                (meta
+                                                 ((type_ UInt) (loc <opaque>)
+                                                  (adlevel DataOnly)))))
+                                              (Single
+                                               ((pattern (Var k))
+                                                (meta
+                                                 ((type_ UInt) (loc <opaque>)
+                                                  (adlevel DataOnly))))))))
+                                           (meta
+                                            ((type_ UReal) (loc <opaque>)
+                                             (adlevel DataOnly)))))))
+                                       (meta
+                                        ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+                                      ((pattern
+                                        (Promotion
+                                         ((pattern
+                                           (FunApp (StanLib Plus__ FnPlain SoA)
+                                            (((pattern
+                                               (FunApp (StanLib fma FnPlain SoA)
+                                                (((pattern (Lit Int 100))
+                                                  (meta
+                                                   ((type_ UInt) (loc <opaque>)
+                                                    (adlevel DataOnly))))
+                                                 ((pattern (Var i))
+                                                  (meta
+                                                   ((type_ UInt) (loc <opaque>)
+                                                    (adlevel DataOnly))))
+                                                 ((pattern
+                                                   (FunApp (StanLib Times__ FnPlain SoA)
+                                                    (((pattern (Lit Int 10))
+                                                      (meta
+                                                       ((type_ UInt) 
+                                                        (loc <opaque>)
+                                                        (adlevel DataOnly))))
+                                                     ((pattern (Var j))
+                                                      (meta
+                                                       ((type_ UInt) 
+                                                        (loc <opaque>)
+                                                        (adlevel DataOnly)))))))
+                                                  (meta
+                                                   ((type_ UInt) (loc <opaque>)
+                                                    (adlevel DataOnly)))))))
+                                              (meta
+                                               ((type_ UInt) (loc <opaque>)
+                                                (adlevel DataOnly))))
+                                             ((pattern (Var k))
+                                              (meta
+                                               ((type_ UInt) (loc <opaque>)
+                                                (adlevel DataOnly)))))))
+                                          (meta
+                                           ((type_ UInt) (loc <opaque>)
+                                            (adlevel DataOnly))))
+                                         UReal DataOnly))
+                                       (meta
+                                        ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+                                      ((pattern (Var diff))
+                                       (meta
+                                        ((type_ UReal) (loc <opaque>)
+                                         (adlevel AutoDiffable)))))))
+                                   (meta
+                                    ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+                                (meta <opaque>))
+                               ((pattern
+                                 (Assignment ((LVariable wt) ()) UReal
+                                  ((pattern
+                                    (FunApp (StanLib fma FnPlain SoA)
+                                     (((pattern
+                                        (Indexed
+                                         ((pattern (Var t3))
+                                          (meta
+                                           ((type_ (UArray (UArray (UArray UReal))))
+                                            (loc <opaque>) (adlevel DataOnly))))
+                                         ((Single
+                                           ((pattern (Var i))
+                                            (meta
+                                             ((type_ UInt) (loc <opaque>)
+                                              (adlevel DataOnly)))))
+                                          (Single
+                                           ((pattern (Var j))
+                                            (meta
+                                             ((type_ UInt) (loc <opaque>)
+                                              (adlevel DataOnly)))))
+                                          (Single
+                                           ((pattern (Var k))
+                                            (meta
+                                             ((type_ UInt) (loc <opaque>)
+                                              (adlevel DataOnly))))))))
+                                       (meta
+                                        ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+                                      ((pattern
+                                        (Promotion
+                                         ((pattern
+                                           (FunApp (StanLib Plus__ FnPlain SoA)
+                                            (((pattern
+                                               (FunApp (StanLib fma FnPlain SoA)
+                                                (((pattern (Lit Int 100))
+                                                  (meta
+                                                   ((type_ UInt) (loc <opaque>)
+                                                    (adlevel DataOnly))))
+                                                 ((pattern (Var i))
+                                                  (meta
+                                                   ((type_ UInt) (loc <opaque>)
+                                                    (adlevel DataOnly))))
+                                                 ((pattern
+                                                   (FunApp (StanLib Times__ FnPlain SoA)
+                                                    (((pattern (Lit Int 10))
+                                                      (meta
+                                                       ((type_ UInt) 
+                                                        (loc <opaque>)
+                                                        (adlevel DataOnly))))
+                                                     ((pattern (Var j))
+                                                      (meta
+                                                       ((type_ UInt) 
+                                                        (loc <opaque>)
+                                                        (adlevel DataOnly)))))))
+                                                  (meta
+                                                   ((type_ UInt) (loc <opaque>)
+                                                    (adlevel DataOnly)))))))
+                                              (meta
+                                               ((type_ UInt) (loc <opaque>)
+                                                (adlevel DataOnly))))
+                                             ((pattern (Var k))
+                                              (meta
+                                               ((type_ UInt) (loc <opaque>)
+                                                (adlevel DataOnly)))))))
+                                          (meta
+                                           ((type_ UInt) (loc <opaque>)
+                                            (adlevel DataOnly))))
+                                         UReal DataOnly))
+                                       (meta
+                                        ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+                                      ((pattern (Var wt))
+                                       (meta
+                                        ((type_ UReal) (loc <opaque>)
+                                         (adlevel AutoDiffable)))))))
+                                   (meta
+                                    ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+                                (meta <opaque>)))))
+                            (meta <opaque>)))))
+                        (meta <opaque>)))))
+                    (meta <opaque>)))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar i)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Lit Int 2))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (For (loopvar j)
+                  (lower
+                   ((pattern (Lit Int 1))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (upper
+                   ((pattern (Lit Int 2))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (body
+                   ((pattern
+                     (Block
+                      (((pattern
+                         (For (loopvar k)
+                          (lower
+                           ((pattern (Lit Int 1))
+                            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                          (upper
+                           ((pattern (Lit Int 2))
+                            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                          (body
+                           ((pattern
+                             (Block
+                              (((pattern
+                                 (For (loopvar l)
+                                  (lower
+                                   ((pattern (Lit Int 1))
+                                    (meta
+                                     ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                                  (upper
+                                   ((pattern (Lit Int 2))
+                                    (meta
+                                     ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                                  (body
+                                   ((pattern
+                                     (Block
+                                      (((pattern
+                                         (Assignment ((LVariable diff) ()) UReal
+                                          ((pattern
+                                            (FunApp (StanLib fma FnPlain SoA)
+                                             (((pattern
+                                                (FunApp (StanLib Minus__ FnPlain SoA)
+                                                 (((pattern
+                                                    (Indexed
+                                                     ((pattern (Var t4))
+                                                      (meta
+                                                       ((type_
+                                                         (UArray
+                                                          (UArray
+                                                           (UArray (UArray UReal)))))
+                                                        (loc <opaque>)
+                                                        (adlevel DataOnly))))
+                                                     ((Single
+                                                       ((pattern (Var i))
+                                                        (meta
+                                                         ((type_ UInt) 
+                                                          (loc <opaque>)
+                                                          (adlevel DataOnly)))))
+                                                      (Single
+                                                       ((pattern (Var j))
+                                                        (meta
+                                                         ((type_ UInt) 
+                                                          (loc <opaque>)
+                                                          (adlevel DataOnly)))))
+                                                      (Single
+                                                       ((pattern (Var k))
+                                                        (meta
+                                                         ((type_ UInt) 
+                                                          (loc <opaque>)
+                                                          (adlevel DataOnly)))))
+                                                      (Single
+                                                       ((pattern (Var l))
+                                                        (meta
+                                                         ((type_ UInt) 
+                                                          (loc <opaque>)
+                                                          (adlevel DataOnly))))))))
+                                                   (meta
+                                                    ((type_ UReal) (loc <opaque>)
+                                                     (adlevel DataOnly))))
+                                                  ((pattern
+                                                    (Indexed
+                                                     ((pattern (Var d4))
+                                                      (meta
+                                                       ((type_
+                                                         (UArray
+                                                          (UArray
+                                                           (UArray (UArray UReal)))))
+                                                        (loc <opaque>)
+                                                        (adlevel DataOnly))))
+                                                     ((Single
+                                                       ((pattern (Var i))
+                                                        (meta
+                                                         ((type_ UInt) 
+                                                          (loc <opaque>)
+                                                          (adlevel DataOnly)))))
+                                                      (Single
+                                                       ((pattern (Var j))
+                                                        (meta
+                                                         ((type_ UInt) 
+                                                          (loc <opaque>)
+                                                          (adlevel DataOnly)))))
+                                                      (Single
+                                                       ((pattern (Var k))
+                                                        (meta
+                                                         ((type_ UInt) 
+                                                          (loc <opaque>)
+                                                          (adlevel DataOnly)))))
+                                                      (Single
+                                                       ((pattern (Var l))
+                                                        (meta
+                                                         ((type_ UInt) 
+                                                          (loc <opaque>)
+                                                          (adlevel DataOnly))))))))
+                                                   (meta
+                                                    ((type_ UReal) (loc <opaque>)
+                                                     (adlevel DataOnly)))))))
+                                               (meta
+                                                ((type_ UReal) (loc <opaque>)
+                                                 (adlevel DataOnly))))
+                                              ((pattern
+                                                (Promotion
+                                                 ((pattern
+                                                   (FunApp (StanLib Plus__ FnPlain SoA)
+                                                    (((pattern
+                                                       (FunApp (StanLib fma FnPlain SoA)
+                                                        (((pattern (Lit Int 10))
+                                                          (meta
+                                                           ((type_ UInt) 
+                                                            (loc <opaque>)
+                                                            (adlevel DataOnly))))
+                                                         ((pattern (Var k))
+                                                          (meta
+                                                           ((type_ UInt) 
+                                                            (loc <opaque>)
+                                                            (adlevel DataOnly))))
+                                                         ((pattern
+                                                           (FunApp
+                                                            (StanLib fma FnPlain SoA)
+                                                            (((pattern (Lit Int 1000))
+                                                              (meta
+                                                               ((type_ UInt)
+                                                                (loc <opaque>)
+                                                                (adlevel DataOnly))))
+                                                             ((pattern (Var i))
+                                                              (meta
+                                                               ((type_ UInt)
+                                                                (loc <opaque>)
+                                                                (adlevel DataOnly))))
+                                                             ((pattern
+                                                               (FunApp
+                                                                (StanLib Times__ FnPlain
+                                                                 SoA)
+                                                                (((pattern (Lit Int 100))
+                                                                  (meta
+                                                                   ((type_ UInt)
+                                                                    (loc <opaque>)
+                                                                    (adlevel DataOnly))))
+                                                                 ((pattern (Var j))
+                                                                  (meta
+                                                                   ((type_ UInt)
+                                                                    (loc <opaque>)
+                                                                    (adlevel DataOnly)))))))
+                                                              (meta
+                                                               ((type_ UInt)
+                                                                (loc <opaque>)
+                                                                (adlevel DataOnly)))))))
+                                                          (meta
+                                                           ((type_ UInt) 
+                                                            (loc <opaque>)
+                                                            (adlevel DataOnly)))))))
+                                                      (meta
+                                                       ((type_ UInt) 
+                                                        (loc <opaque>)
+                                                        (adlevel DataOnly))))
+                                                     ((pattern (Var l))
+                                                      (meta
+                                                       ((type_ UInt) 
+                                                        (loc <opaque>)
+                                                        (adlevel DataOnly)))))))
+                                                  (meta
+                                                   ((type_ UInt) (loc <opaque>)
+                                                    (adlevel DataOnly))))
+                                                 UReal DataOnly))
+                                               (meta
+                                                ((type_ UReal) (loc <opaque>)
+                                                 (adlevel DataOnly))))
+                                              ((pattern (Var diff))
+                                               (meta
+                                                ((type_ UReal) (loc <opaque>)
+                                                 (adlevel AutoDiffable)))))))
+                                           (meta
+                                            ((type_ UReal) (loc <opaque>)
+                                             (adlevel AutoDiffable))))))
+                                        (meta <opaque>))
+                                       ((pattern
+                                         (Assignment ((LVariable wt) ()) UReal
+                                          ((pattern
+                                            (FunApp (StanLib fma FnPlain SoA)
+                                             (((pattern
+                                                (Indexed
+                                                 ((pattern (Var t4))
+                                                  (meta
+                                                   ((type_
+                                                     (UArray
+                                                      (UArray (UArray (UArray UReal)))))
+                                                    (loc <opaque>) (adlevel DataOnly))))
+                                                 ((Single
+                                                   ((pattern (Var i))
+                                                    (meta
+                                                     ((type_ UInt) (loc <opaque>)
+                                                      (adlevel DataOnly)))))
+                                                  (Single
+                                                   ((pattern (Var j))
+                                                    (meta
+                                                     ((type_ UInt) (loc <opaque>)
+                                                      (adlevel DataOnly)))))
+                                                  (Single
+                                                   ((pattern (Var k))
+                                                    (meta
+                                                     ((type_ UInt) (loc <opaque>)
+                                                      (adlevel DataOnly)))))
+                                                  (Single
+                                                   ((pattern (Var l))
+                                                    (meta
+                                                     ((type_ UInt) (loc <opaque>)
+                                                      (adlevel DataOnly))))))))
+                                               (meta
+                                                ((type_ UReal) (loc <opaque>)
+                                                 (adlevel DataOnly))))
+                                              ((pattern
+                                                (Promotion
+                                                 ((pattern
+                                                   (FunApp (StanLib Plus__ FnPlain SoA)
+                                                    (((pattern
+                                                       (FunApp (StanLib fma FnPlain SoA)
+                                                        (((pattern (Lit Int 10))
+                                                          (meta
+                                                           ((type_ UInt) 
+                                                            (loc <opaque>)
+                                                            (adlevel DataOnly))))
+                                                         ((pattern (Var k))
+                                                          (meta
+                                                           ((type_ UInt) 
+                                                            (loc <opaque>)
+                                                            (adlevel DataOnly))))
+                                                         ((pattern
+                                                           (FunApp
+                                                            (StanLib fma FnPlain SoA)
+                                                            (((pattern (Lit Int 1000))
+                                                              (meta
+                                                               ((type_ UInt)
+                                                                (loc <opaque>)
+                                                                (adlevel DataOnly))))
+                                                             ((pattern (Var i))
+                                                              (meta
+                                                               ((type_ UInt)
+                                                                (loc <opaque>)
+                                                                (adlevel DataOnly))))
+                                                             ((pattern
+                                                               (FunApp
+                                                                (StanLib Times__ FnPlain
+                                                                 SoA)
+                                                                (((pattern (Lit Int 100))
+                                                                  (meta
+                                                                   ((type_ UInt)
+                                                                    (loc <opaque>)
+                                                                    (adlevel DataOnly))))
+                                                                 ((pattern (Var j))
+                                                                  (meta
+                                                                   ((type_ UInt)
+                                                                    (loc <opaque>)
+                                                                    (adlevel DataOnly)))))))
+                                                              (meta
+                                                               ((type_ UInt)
+                                                                (loc <opaque>)
+                                                                (adlevel DataOnly)))))))
+                                                          (meta
+                                                           ((type_ UInt) 
+                                                            (loc <opaque>)
+                                                            (adlevel DataOnly)))))))
+                                                      (meta
+                                                       ((type_ UInt) 
+                                                        (loc <opaque>)
+                                                        (adlevel DataOnly))))
+                                                     ((pattern (Var l))
+                                                      (meta
+                                                       ((type_ UInt) 
+                                                        (loc <opaque>)
+                                                        (adlevel DataOnly)))))))
+                                                  (meta
+                                                   ((type_ UInt) (loc <opaque>)
+                                                    (adlevel DataOnly))))
+                                                 UReal DataOnly))
+                                               (meta
+                                                ((type_ UReal) (loc <opaque>)
+                                                 (adlevel DataOnly))))
+                                              ((pattern (Var wt))
+                                               (meta
+                                                ((type_ UReal) (loc <opaque>)
+                                                 (adlevel AutoDiffable)))))))
+                                           (meta
+                                            ((type_ UReal) (loc <opaque>)
+                                             (adlevel AutoDiffable))))))
+                                        (meta <opaque>)))))
+                                    (meta <opaque>)))))
+                                (meta <opaque>)))))
+                            (meta <opaque>)))))
+                        (meta <opaque>)))))
+                    (meta <opaque>)))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar i)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Lit Int 2))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (For (loopvar j)
+                  (lower
+                   ((pattern (Lit Int 1))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (upper
+                   ((pattern (Lit Int 2))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (body
+                   ((pattern
+                     (Block
+                      (((pattern
+                         (For (loopvar k)
+                          (lower
+                           ((pattern (Lit Int 1))
+                            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                          (upper
+                           ((pattern (Lit Int 3))
+                            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                          (body
+                           ((pattern
+                             (Block
+                              (((pattern
+                                 (Assignment ((LVariable diff) ()) UReal
+                                  ((pattern
+                                    (FunApp (StanLib fma FnPlain SoA)
+                                     (((pattern
+                                        (FunApp (StanLib Minus__ FnPlain SoA)
+                                         (((pattern
+                                            (Indexed
+                                             ((pattern (Var tvv))
+                                              (meta
+                                               ((type_ (UArray (UArray UVector)))
+                                                (loc <opaque>) (adlevel DataOnly))))
+                                             ((Single
+                                               ((pattern (Var i))
+                                                (meta
+                                                 ((type_ UInt) (loc <opaque>)
+                                                  (adlevel DataOnly)))))
+                                              (Single
+                                               ((pattern (Var j))
+                                                (meta
+                                                 ((type_ UInt) (loc <opaque>)
+                                                  (adlevel DataOnly)))))
+                                              (Single
+                                               ((pattern (Var k))
+                                                (meta
+                                                 ((type_ UInt) (loc <opaque>)
+                                                  (adlevel DataOnly))))))))
+                                           (meta
+                                            ((type_ UReal) (loc <opaque>)
+                                             (adlevel DataOnly))))
+                                          ((pattern
+                                            (Indexed
+                                             ((pattern (Var dvv))
+                                              (meta
+                                               ((type_ (UArray (UArray UVector)))
+                                                (loc <opaque>) (adlevel DataOnly))))
+                                             ((Single
+                                               ((pattern (Var i))
+                                                (meta
+                                                 ((type_ UInt) (loc <opaque>)
+                                                  (adlevel DataOnly)))))
+                                              (Single
+                                               ((pattern (Var j))
+                                                (meta
+                                                 ((type_ UInt) (loc <opaque>)
+                                                  (adlevel DataOnly)))))
+                                              (Single
+                                               ((pattern (Var k))
+                                                (meta
+                                                 ((type_ UInt) (loc <opaque>)
+                                                  (adlevel DataOnly))))))))
+                                           (meta
+                                            ((type_ UReal) (loc <opaque>)
+                                             (adlevel DataOnly)))))))
+                                       (meta
+                                        ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+                                      ((pattern
+                                        (Promotion
+                                         ((pattern
+                                           (FunApp (StanLib Plus__ FnPlain SoA)
+                                            (((pattern
+                                               (FunApp (StanLib fma FnPlain SoA)
+                                                (((pattern (Lit Int 100))
+                                                  (meta
+                                                   ((type_ UInt) (loc <opaque>)
+                                                    (adlevel DataOnly))))
+                                                 ((pattern (Var i))
+                                                  (meta
+                                                   ((type_ UInt) (loc <opaque>)
+                                                    (adlevel DataOnly))))
+                                                 ((pattern
+                                                   (FunApp (StanLib Times__ FnPlain SoA)
+                                                    (((pattern (Lit Int 10))
+                                                      (meta
+                                                       ((type_ UInt) 
+                                                        (loc <opaque>)
+                                                        (adlevel DataOnly))))
+                                                     ((pattern (Var j))
+                                                      (meta
+                                                       ((type_ UInt) 
+                                                        (loc <opaque>)
+                                                        (adlevel DataOnly)))))))
+                                                  (meta
+                                                   ((type_ UInt) (loc <opaque>)
+                                                    (adlevel DataOnly)))))))
+                                              (meta
+                                               ((type_ UInt) (loc <opaque>)
+                                                (adlevel DataOnly))))
+                                             ((pattern (Var k))
+                                              (meta
+                                               ((type_ UInt) (loc <opaque>)
+                                                (adlevel DataOnly)))))))
+                                          (meta
+                                           ((type_ UInt) (loc <opaque>)
+                                            (adlevel DataOnly))))
+                                         UReal DataOnly))
+                                       (meta
+                                        ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+                                      ((pattern (Var diff))
+                                       (meta
+                                        ((type_ UReal) (loc <opaque>)
+                                         (adlevel AutoDiffable)))))))
+                                   (meta
+                                    ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+                                (meta <opaque>))
+                               ((pattern
+                                 (Assignment ((LVariable wt) ()) UReal
+                                  ((pattern
+                                    (FunApp (StanLib fma FnPlain SoA)
+                                     (((pattern
+                                        (Indexed
+                                         ((pattern (Var tvv))
+                                          (meta
+                                           ((type_ (UArray (UArray UVector)))
+                                            (loc <opaque>) (adlevel DataOnly))))
+                                         ((Single
+                                           ((pattern (Var i))
+                                            (meta
+                                             ((type_ UInt) (loc <opaque>)
+                                              (adlevel DataOnly)))))
+                                          (Single
+                                           ((pattern (Var j))
+                                            (meta
+                                             ((type_ UInt) (loc <opaque>)
+                                              (adlevel DataOnly)))))
+                                          (Single
+                                           ((pattern (Var k))
+                                            (meta
+                                             ((type_ UInt) (loc <opaque>)
+                                              (adlevel DataOnly))))))))
+                                       (meta
+                                        ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+                                      ((pattern
+                                        (Promotion
+                                         ((pattern
+                                           (FunApp (StanLib Plus__ FnPlain SoA)
+                                            (((pattern
+                                               (FunApp (StanLib fma FnPlain SoA)
+                                                (((pattern (Lit Int 100))
+                                                  (meta
+                                                   ((type_ UInt) (loc <opaque>)
+                                                    (adlevel DataOnly))))
+                                                 ((pattern (Var i))
+                                                  (meta
+                                                   ((type_ UInt) (loc <opaque>)
+                                                    (adlevel DataOnly))))
+                                                 ((pattern
+                                                   (FunApp (StanLib Times__ FnPlain SoA)
+                                                    (((pattern (Lit Int 10))
+                                                      (meta
+                                                       ((type_ UInt) 
+                                                        (loc <opaque>)
+                                                        (adlevel DataOnly))))
+                                                     ((pattern (Var j))
+                                                      (meta
+                                                       ((type_ UInt) 
+                                                        (loc <opaque>)
+                                                        (adlevel DataOnly)))))))
+                                                  (meta
+                                                   ((type_ UInt) (loc <opaque>)
+                                                    (adlevel DataOnly)))))))
+                                              (meta
+                                               ((type_ UInt) (loc <opaque>)
+                                                (adlevel DataOnly))))
+                                             ((pattern (Var k))
+                                              (meta
+                                               ((type_ UInt) (loc <opaque>)
+                                                (adlevel DataOnly)))))))
+                                          (meta
+                                           ((type_ UInt) (loc <opaque>)
+                                            (adlevel DataOnly))))
+                                         UReal DataOnly))
+                                       (meta
+                                        ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+                                      ((pattern (Var wt))
+                                       (meta
+                                        ((type_ UReal) (loc <opaque>)
+                                         (adlevel AutoDiffable)))))))
+                                   (meta
+                                    ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+                                (meta <opaque>)))))
+                            (meta <opaque>)))))
+                        (meta <opaque>)))))
+                    (meta <opaque>)))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar i)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Lit Int 2))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (For (loopvar j)
+                  (lower
+                   ((pattern (Lit Int 1))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (upper
+                   ((pattern (Lit Int 2))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (body
+                   ((pattern
+                     (Block
+                      (((pattern
+                         (For (loopvar k)
+                          (lower
+                           ((pattern (Lit Int 1))
+                            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                          (upper
+                           ((pattern (Lit Int 3))
+                            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                          (body
+                           ((pattern
+                             (Block
+                              (((pattern
+                                 (Assignment ((LVariable diff) ()) UReal
+                                  ((pattern
+                                    (FunApp (StanLib fma FnPlain SoA)
+                                     (((pattern
+                                        (FunApp (StanLib Minus__ FnPlain SoA)
+                                         (((pattern
+                                            (Indexed
+                                             ((pattern (Var tm))
+                                              (meta
+                                               ((type_ (UArray UMatrix)) 
+                                                (loc <opaque>) (adlevel DataOnly))))
+                                             ((Single
+                                               ((pattern (Var i))
+                                                (meta
+                                                 ((type_ UInt) (loc <opaque>)
+                                                  (adlevel DataOnly)))))
+                                              (Single
+                                               ((pattern (Var j))
+                                                (meta
+                                                 ((type_ UInt) (loc <opaque>)
+                                                  (adlevel DataOnly)))))
+                                              (Single
+                                               ((pattern (Var k))
+                                                (meta
+                                                 ((type_ UInt) (loc <opaque>)
+                                                  (adlevel DataOnly))))))))
+                                           (meta
+                                            ((type_ UReal) (loc <opaque>)
+                                             (adlevel DataOnly))))
+                                          ((pattern
+                                            (Indexed
+                                             ((pattern (Var dm))
+                                              (meta
+                                               ((type_ (UArray UMatrix)) 
+                                                (loc <opaque>) (adlevel DataOnly))))
+                                             ((Single
+                                               ((pattern (Var i))
+                                                (meta
+                                                 ((type_ UInt) (loc <opaque>)
+                                                  (adlevel DataOnly)))))
+                                              (Single
+                                               ((pattern (Var j))
+                                                (meta
+                                                 ((type_ UInt) (loc <opaque>)
+                                                  (adlevel DataOnly)))))
+                                              (Single
+                                               ((pattern (Var k))
+                                                (meta
+                                                 ((type_ UInt) (loc <opaque>)
+                                                  (adlevel DataOnly))))))))
+                                           (meta
+                                            ((type_ UReal) (loc <opaque>)
+                                             (adlevel DataOnly)))))))
+                                       (meta
+                                        ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+                                      ((pattern
+                                        (Promotion
+                                         ((pattern
+                                           (FunApp (StanLib Plus__ FnPlain SoA)
+                                            (((pattern
+                                               (FunApp (StanLib fma FnPlain SoA)
+                                                (((pattern (Lit Int 100))
+                                                  (meta
+                                                   ((type_ UInt) (loc <opaque>)
+                                                    (adlevel DataOnly))))
+                                                 ((pattern (Var i))
+                                                  (meta
+                                                   ((type_ UInt) (loc <opaque>)
+                                                    (adlevel DataOnly))))
+                                                 ((pattern
+                                                   (FunApp (StanLib Times__ FnPlain SoA)
+                                                    (((pattern (Lit Int 10))
+                                                      (meta
+                                                       ((type_ UInt) 
+                                                        (loc <opaque>)
+                                                        (adlevel DataOnly))))
+                                                     ((pattern (Var j))
+                                                      (meta
+                                                       ((type_ UInt) 
+                                                        (loc <opaque>)
+                                                        (adlevel DataOnly)))))))
+                                                  (meta
+                                                   ((type_ UInt) (loc <opaque>)
+                                                    (adlevel DataOnly)))))))
+                                              (meta
+                                               ((type_ UInt) (loc <opaque>)
+                                                (adlevel DataOnly))))
+                                             ((pattern (Var k))
+                                              (meta
+                                               ((type_ UInt) (loc <opaque>)
+                                                (adlevel DataOnly)))))))
+                                          (meta
+                                           ((type_ UInt) (loc <opaque>)
+                                            (adlevel DataOnly))))
+                                         UReal DataOnly))
+                                       (meta
+                                        ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+                                      ((pattern (Var diff))
+                                       (meta
+                                        ((type_ UReal) (loc <opaque>)
+                                         (adlevel AutoDiffable)))))))
+                                   (meta
+                                    ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+                                (meta <opaque>))
+                               ((pattern
+                                 (Assignment ((LVariable wt) ()) UReal
+                                  ((pattern
+                                    (FunApp (StanLib fma FnPlain SoA)
+                                     (((pattern
+                                        (Indexed
+                                         ((pattern (Var tm))
+                                          (meta
+                                           ((type_ (UArray UMatrix)) 
+                                            (loc <opaque>) (adlevel DataOnly))))
+                                         ((Single
+                                           ((pattern (Var i))
+                                            (meta
+                                             ((type_ UInt) (loc <opaque>)
+                                              (adlevel DataOnly)))))
+                                          (Single
+                                           ((pattern (Var j))
+                                            (meta
+                                             ((type_ UInt) (loc <opaque>)
+                                              (adlevel DataOnly)))))
+                                          (Single
+                                           ((pattern (Var k))
+                                            (meta
+                                             ((type_ UInt) (loc <opaque>)
+                                              (adlevel DataOnly))))))))
+                                       (meta
+                                        ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+                                      ((pattern
+                                        (Promotion
+                                         ((pattern
+                                           (FunApp (StanLib Plus__ FnPlain SoA)
+                                            (((pattern
+                                               (FunApp (StanLib fma FnPlain SoA)
+                                                (((pattern (Lit Int 100))
+                                                  (meta
+                                                   ((type_ UInt) (loc <opaque>)
+                                                    (adlevel DataOnly))))
+                                                 ((pattern (Var i))
+                                                  (meta
+                                                   ((type_ UInt) (loc <opaque>)
+                                                    (adlevel DataOnly))))
+                                                 ((pattern
+                                                   (FunApp (StanLib Times__ FnPlain SoA)
+                                                    (((pattern (Lit Int 10))
+                                                      (meta
+                                                       ((type_ UInt) 
+                                                        (loc <opaque>)
+                                                        (adlevel DataOnly))))
+                                                     ((pattern (Var j))
+                                                      (meta
+                                                       ((type_ UInt) 
+                                                        (loc <opaque>)
+                                                        (adlevel DataOnly)))))))
+                                                  (meta
+                                                   ((type_ UInt) (loc <opaque>)
+                                                    (adlevel DataOnly)))))))
+                                              (meta
+                                               ((type_ UInt) (loc <opaque>)
+                                                (adlevel DataOnly))))
+                                             ((pattern (Var k))
+                                              (meta
+                                               ((type_ UInt) (loc <opaque>)
+                                                (adlevel DataOnly)))))))
+                                          (meta
+                                           ((type_ UInt) (loc <opaque>)
+                                            (adlevel DataOnly))))
+                                         UReal DataOnly))
+                                       (meta
+                                        ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+                                      ((pattern (Var wt))
+                                       (meta
+                                        ((type_ UReal) (loc <opaque>)
+                                         (adlevel AutoDiffable)))))))
+                                   (meta
+                                    ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+                                (meta <opaque>)))))
+                            (meta <opaque>)))))
+                        (meta <opaque>)))))
+                    (meta <opaque>)))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>))
+       ((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib fma FnPlain SoA)
+             (((pattern (Var s3))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+              ((pattern (Var z))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+              ((pattern
+                (FunApp (StanLib fma FnPlain SoA)
+                 (((pattern (Var diff))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+                  ((pattern (Var x))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+                  ((pattern
+                    (FunApp (StanLib Times__ FnPlain SoA)
+                     (((pattern (Var wt))
+                       (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+                      ((pattern (Var y))
+                       (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>)))))
+    (meta <opaque>))))
+ (generate_quantities
+  (((pattern
+     (Decl (decl_adtype DataOnly) (decl_id x) (decl_type (Sized SReal))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity) (dims ()) (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id y) (decl_type (Sized SReal))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity) (dims ()) (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id z) (decl_type (Sized SReal))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity) (dims ()) (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt ())
+        (var
+         ((pattern (Var x)) (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt ())
+        (var
+         ((pattern (Var y)) (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt ())
+        (var
+         ((pattern (Var z)) (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (IfElse
+      ((pattern
+        (FunApp (StanLib PNot__ FnPlain AoS)
+         (((pattern
+            (EOr
+             ((pattern (Var emit_transformed_parameters__))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+             ((pattern (Var emit_generated_quantities__))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+      ((pattern (Block (((pattern (Return ())) (meta <opaque>))))) (meta <opaque>)) ()))
+    (meta <opaque>))
+   ((pattern
+     (IfElse
+      ((pattern
+        (FunApp (StanLib PNot__ FnPlain AoS)
+         (((pattern (Var emit_generated_quantities__))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+      ((pattern (Block (((pattern (Return ())) (meta <opaque>))))) (meta <opaque>)) ()))
+    (meta <opaque>))))
+ (transform_inits
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id x) (decl_type (Sized SReal))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable x) ()) UReal
+      ((pattern
+        (Indexed
+         ((pattern
+           (FunApp (CompilerInternal FnReadData)
+            (((pattern (Lit Str x))
+              (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+          (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))
+         ((Single
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+       (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var x)) (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id y) (decl_type (Sized SReal))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable y) ()) UReal
+      ((pattern
+        (Indexed
+         ((pattern
+           (FunApp (CompilerInternal FnReadData)
+            (((pattern (Lit Str y))
+              (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+          (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))
+         ((Single
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+       (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var y)) (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id z) (decl_type (Sized SReal))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable z) ()) UReal
+      ((pattern
+        (Indexed
+         ((pattern
+           (FunApp (CompilerInternal FnReadData)
+            (((pattern (Lit Str z))
+              (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+          (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))
+         ((Single
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+       (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var z)) (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))))
+ (unconstrain_array
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id x) (decl_type (Sized SReal))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable x) ()) UReal
+      ((pattern (FunApp (CompilerInternal FnReadDeserializer) ()))
+       (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var x)) (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id y) (decl_type (Sized SReal))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable y) ()) UReal
+      ((pattern (FunApp (CompilerInternal FnReadDeserializer) ()))
+       (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var y)) (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id z) (decl_type (Sized SReal))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable z) ()) UReal
+      ((pattern (FunApp (CompilerInternal FnReadDeserializer) ()))
+       (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var z)) (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))))
+ (output_vars
+  ((x <opaque>
+    ((out_unconstrained_st SReal) (out_constrained_st SReal) (out_block Parameters)
+     (out_trans Identity)))
+   (y <opaque>
+    ((out_unconstrained_st SReal) (out_constrained_st SReal) (out_block Parameters)
+     (out_trans Identity)))
+   (z <opaque>
+    ((out_unconstrained_st SReal) (out_constrained_st SReal) (out_block Parameters)
+     (out_trans Identity)))))
+ (prog_name ndlit_model) (prog_path tests/fixtures/ndlit.stan))

--- a/tests/test_lower.cpp
+++ b/tests/test_lower.cpp
@@ -378,6 +378,65 @@ int main() {
     stan::math::recover_memory();
   }
 
+  // Deep array literals in transformed data have to land in a slot with the
+  // same layout the JSON reader gives a data-block array of the same shape.
+  // Rank 2 cannot tell the two apart -- an array-of-arrays and a matrix share
+  // a flattening -- so the disagreement only shows from rank 3 down, where a
+  // literal reached its slot with the trailing two extents swapped: a wrong
+  // log density and wrong gradients, no error and no NaN.
+  {
+    DataMap d = DataMap::from_json(R"({
+      "d2": [[11.0,12.0],[21.0,22.0]],
+      "d3": [[[111.0,112.0],[121.0,122.0]],[[211.0,212.0],[221.0,222.0]]],
+      "d4": [[[[1111.0,1112.0],[1121.0,1122.0]],
+              [[1211.0,1212.0],[1221.0,1222.0]]],
+             [[[2111.0,2112.0],[2121.0,2122.0]],
+              [[2211.0,2212.0],[2221.0,2222.0]]]],
+      "dvv": [[[111.0,112.0,113.0],[121.0,122.0,123.0]],
+              [[211.0,212.0,213.0],[221.0,222.0,223.0]]],
+      "dm": [[[111.0,112.0,113.0],[121.0,122.0,123.0]],
+             [[211.0,212.0,213.0],[221.0,222.0,223.0]]]
+    })");
+    CompiledModel lm =
+        compile_model(slurp("tests/fixtures/ndlit.tmir.sexp"), d);
+    Executor lex(std::move(lm.graph));
+    lm.bind(lex);
+    const double q[3] = {0.3, 0.5, -0.25};
+    for (int i = 0; i < 3; ++i) lex.params_data()[i] = q[i];
+    double grad[3] = {0, 0, 0};
+    const double lp = lex.gradient(grad);
+
+    // Every element of both the literal and the data holds its own decimal
+    // index code, and each is weighted by that same code, so the reference is
+    // a sum of squares and any permutation of a layout moves it. Codes are
+    // small integers: the sums are exact, and expect_eq can be exact too.
+    double wt = 0, s3 = 0;
+    for (int i = 1; i <= 2; ++i)
+      for (int j = 1; j <= 2; ++j) {
+        const double c2 = 10 * i + j;
+        wt += c2 * c2;
+        for (int k = 1; k <= 2; ++k) {
+          const double c3 = 100 * i + 10 * j + k;
+          wt += c3 * c3;
+          s3 += c3 * c3;
+          for (int l = 1; l <= 2; ++l) {
+            const double c4 = 1000 * i + 100 * j + 10 * k + l;
+            wt += c4 * c4;
+          }
+        }
+        for (int k = 1; k <= 3; ++k) {
+          const double c = 100 * i + 10 * j + k;
+          wt += 2 * c * c;  // the array of vectors and the array of matrices
+        }
+      }
+    // literal minus data, element by element: zero only if both paths agree.
+    expect_eq("ndlit ddiff", grad[0], 0.0);
+    expect_eq("ndlit dwt", grad[1], wt);
+    // The interpreter's own N-D read of the literal, inside transformed data.
+    expect_eq("ndlit ds3", grad[2], s3);
+    expect_eq("ndlit lp", lp, wt * q[1] + s3 * q[2]);
+  }
+
   // Model-block UDFs on parameters, inlined: scalar chain, vector return,
   // statement body with local accumulator + loop.
   {


### PR DESCRIPTION
A rank-3 or deeper array literal in `transformed data` reached its slot with the trailing two extents transposed. Wrong log density, wrong gradients, no error and no NaN. The repro should give gradient 0 and gave **318**.

Invisible to both oracles: no posteriordb model writes a deep array literal, and the conformance sweep generates calls rather than declarations. It was found while writing a fixture for an unrelated change, and that author routed around it rather than build on it.

### Root cause -- the metadata, not the data

`runtime/include/stanli/mir_interp.hpp`, `FnMakeArray`: `o.dims = {(int64_t)e.args.size(), row_len}`.

The interpreter places element `i`'s cell `j` at `j*R+i`, which is correct first-index-fastest order at every rank. But the *shape* it recorded collapsed everything below the outer axis into one: a rank-3 literal got `dims = {2,4}` instead of `{2,2,2}`.

Flat storage cannot tell those apart -- Fortran order over `{2,4}` is byte-for-byte Fortran order over `{2,2,2}` -- so the collapse is layout-preserving and stays invisible until `graph_order` (`lower.cpp:132`) permutes the entry into graph order, because it permutes by exactly these extents. Rank 2 is unaffected: an array-of-arrays and a matrix share a flattening, so `{R,C}` was already right.

### Establishing which side was wrong

This mattered more than usual, because fixing `graph_order` or `flat_addr` instead would have corrupted the verified data path rather than the broken literal one. Three independent witnesses for the convention:

- `runtime/src/data.cpp:59-77` -- the JSON N-D reader is first-index-fastest with correct nested `dims` at every rank.
- `runtime/src/lower.cpp:106` `flat_addr` -- graph order is array-major with only an innermost matrix column-major, and `graph_order` is the one-way bridge.
- `tests/test_lower_view_contract.cpp:235` -- a pre-existing rank-3 fixture that decodes correctly only under first-index-fastest.

Then a hand trace of `FnMakeArray` on the repro: the bytes it produces are `[0,2,1,3,3,0,2,1]`, which *is* correct Fortran order for `{2,2,2}`. Only `dims` lied.

### Fix

Capture the element's `dims` in `rows_mode` and build `o.dims = {R} ++ elem_dims`, falling back to a single axis when the element's extents do not multiply out to its storage, so `graph_order`'s permutation stays in bounds. The placement loop is untouched.

Rides along, separable if you prefer it split: `runtime/include/stanli/data.hpp` had a comment claiming `set_*_array` takes "the row-major flattening the JSON reader also produces". The reader is first-index-fastest. That comment documents the exact convention this bug violated.

### RED evidence

The repro: `OK 31.800000000000001 318` before, `OK 0 0` after. A second, louder one: the interpreter's own N-D indexing was already failing outright on the collapsed shape -- `unsupported index: dims=2 [IndexSingle] [IndexSingle] [IndexSingle]`. And numerically, from a variant that gets past the throw:

```
FAIL ndlit ddiff  got -65434    want 0
FAIL ndlit ds3    got 0         want 241980
FAIL ndlit lp     got 24672193.8 want 24664046
```

### Test

`tests/fixtures/ndlit.stan`: rank 2, 3 and 4 real arrays, `array[2,2] vector[3]`, `array[2] matrix[2,3]`, each as a TD literal beside a data-block array of the same shape read from JSON, plus a TD-side `t3[i,j,k]` loop. Every element carries its own decimal index code and is weighted by it, so one gradient pins literal-against-data agreement, another pins absolute layout against a plain C++ reference, and a third pins the interpreter's N-D read. All values are exact integers, so the comparisons are bitwise with no tolerance.

### Gates

`ctest` 49/49, `verify_refs` **129/129** with `hmm_gaussian` unchanged at 3.63e-12, `format.sh --check` clean.

Conformance construct sweep against real CmdStan: `mismatch: 0`, `harness_error: 0`. Run again with `origin/main`'s `mir_interp.hpp` restored: byte-identical counts and an identical unsupported set, so the six unsupported constructs are pre-existing and unrelated.

Zero per-evaluation cost -- this is transformed-data interpretation, which runs once at compile.

### Found, not fixed

Both in the same area, both verified **loud** rather than silent, so neither is in this bug's class: `rep_array(container, n)` reads only the first scalar and is caught by `validate_view`; and nested int-array literals lose their int-ness, so `array[2,2] int c = {{1,2},{3,4}}` in transformed data is rejected downstream.