### PR TITLE
fix: vector inv_logit matched Eigen's packet exp, and a scalar GLM outcome read out of bounds

### DIFF
--- a/docs/coverage.md
+++ b/docs/coverage.md
@@ -99,6 +99,21 @@ and says why.
 scalar; stan-math also allows a per-row vector, and the kernels refuse
 that form by name.
 
+**A scalar outcome in those same three GLMs.** `y ~ poisson_log_glm(x, ...)`
+wants one outcome per row of `x`; stan-math also accepts a single `int` and
+broadcasts it, and the lowering refuses that form by name. The three share
+one integer-group layout and one length check, so they are refused together,
+and `poisson_log_glm` is why the check is a refusal rather than a
+replication: its non-`propto` form subtracts `lgamma(y + 1)` once for a
+scalar and once per row for an array -- on four rows of `y = 3`, -4.98
+against -10.36, with identical gradients -- so replicating would buy the
+right gradient and an lp a constant off CmdStan's. `bernoulli_logit_glm` and
+`neg_binomial_2_log_glm` were measured and do not have that problem; they are
+refused for uniformity, and either could be replicated if a model wanted it.
+`binomial_logit_glm` and `categorical_logit_glm` do replicate, and are
+checked to: for those two the scalar and array calls agree bitwise in both
+`propto` forms.
+
 ## Parameter transforms
 
 All of them, every one bitwise against CmdStan:

--- a/runtime/kernels/eltwise_expr.cpp
+++ b/runtime/kernels/eltwise_expr.cpp
@@ -4,8 +4,11 @@
 // Shape dispatch is runtime: len==1 broadcasts.
 #include <stanli/graph.hpp>
 #include <stanli/optable.hpp>
+#include <stanli/packet.hpp>
 
 #include <stan/math/prim.hpp>
+
+#include <cmath>
 
 namespace stanli {
 namespace {
@@ -326,13 +329,33 @@ void logv_bwd(KernelCtx& ctx) {
   else
     dx_a(ctx, 0) += dout_a(ctx) / in_a(ctx, 0);
 }
-// Matrix<var> inv_logit resolves to a vectorized overload (packet values);
-// scalar var inv_logit uses libm. Match the vectorized path for len > 1.
+// The one unary here whose two stan-math overloads compute DIFFERENT
+// expressions, so its two shapes cannot share a formula -- exactly the split
+// clu_fwd makes, and for the same reason (see constrain.cpp's header):
+//   scalar var  -> stan's `inv_logit(double)`, which branches on sign;
+//   Matrix<var> -> `x.val().array().logistic()`, Eigen's logistic functor,
+//                  `e/(1+e)` with an inf guard, no sign branch.
+// They disagree by a ulp on about a third of positive arguments.
+//
+// The len > 1 branch used to hand `logistic()` a CONTIGUOUS temporary, on the
+// belief that the Matrix<var> overload vectorized. It does not -- `.val()` is
+// strided, so Eigen runs the functor's SCALAR body with libm exp. Contiguous
+// doubles select Eigen's `pexp` instead, a ulp off libm on ~7% of arguments,
+// and that was the entire divergence: forward only, with the backward's exact
+// multiplies inheriting it. So the default spells the scalar functor out and
+// the vectorized form stays behind packet_math(), whose reference is varmat.
 void invlogit_fwd(KernelCtx& ctx) {
-  if (ctx.out.len == 1) {
+  const int64_t n = ctx.out.len;
+  if (n == 1) {
     ctx.out.data[0] = stan::math::inv_logit(ctx.in[0].data[0]);
-  } else {
+  } else if (packet_math()) {
     out_a(ctx) = stan::math::inv_logit(in_a(ctx, 0).matrix().eval().array());
+  } else {
+    const double* x = ctx.in[0].data;
+    for (int64_t i = 0; i < n; ++i) {
+      const double e = std::exp(x[i]);
+      ctx.out.data[i] = std::isinf(e) ? 1.0 : e / (1.0 + e);
+    }
   }
 }
 void invlogit_bwd(KernelCtx& ctx) {

--- a/runtime/src/lower.cpp
+++ b/runtime/src/lower.cpp
@@ -2100,6 +2100,29 @@ struct Lowering {
         const SlotInfo& xsi = shapes[0];
         if (!is_matrix(xsi) || !xsi.param_free)
           fail(e.name + ": X must be a data matrix");
+        // A GLM's outcome group is one value per ROW of X, and the kernels
+        // map exactly that many out of idata -- so a group of any other
+        // length is refused here rather than read past the end of the
+        // vector. These are the entries left lane_outcome = false, and not
+        // by oversight: that expansion sizes itself from the longest real
+        // argument, which for a GLM is X at rows*cols.
+        //
+        // Nor could poisson_log_glm simply replicate to `rows`. stan-math
+        // accepts a language-level scalar outcome and broadcasts it, but
+        // its <false> form then subtracts lgamma(y+1) ONCE rather than once
+        // per row (four rows of y = 3: -4.98, against the -10.36 the
+        // replicated array gives, with identical gradients). Replicating
+        // would buy the right gradients and an lp a constant off CmdStan's,
+        // which is the one thing these kernels exist to get right. The
+        // other two were measured and do not have that problem; they share
+        // this layout and this check, so they are refused with it. Refusing
+        // by name is what the vector-alpha form already gets; see
+        // docs/coverage.md.
+        if ((int64_t)idata.size() != xsi.rows)
+          fail(e.name + ": outcome has " + std::to_string(idata.size()) +
+                   " value(s) but X has " + std::to_string(xsi.rows) +
+                   " rows; a scalar or short outcome is unsupported",
+               e.raw);
         idata.push_back((int)xsi.rows);
         idata.push_back((int)xsi.cols);
       }
@@ -2171,9 +2194,18 @@ struct Lowering {
       Val beta = lower_expr(e.args[4]);
       if (!is_matrix(X.si)) fail("binomial_logit_glm needs a matrix", e.raw);
       // Both int groups are one value per row, so a scalar broadcasts.
+      // By value, as the lane_outcome expansion above is: assign() may
+      // reallocate, and a reference into the vector being assigned would
+      // dangle mid-fill.
       const int64_t rows = X.si.rows;
-      if ((int64_t)idata.size() == 1) idata.assign(rows, idata[0]);
-      if ((int64_t)NN.size() == 1) NN.assign(rows, NN[0]);
+      if ((int64_t)idata.size() == 1) {
+        const int outcome = idata[0];
+        idata.assign(rows, outcome);
+      }
+      if ((int64_t)NN.size() == 1) {
+        const int trials = NN[0];
+        NN.assign(rows, trials);
+      }
       idata.insert(idata.end(), NN.begin(), NN.end());
       idata.push_back((int)rows);
       idata.push_back((int)X.si.cols);
@@ -2190,7 +2222,13 @@ struct Lowering {
       Val a2 = lower_expr(e.args[2]);
       Val a3 = lower_expr(e.args[3]);
       if (!is_matrix(X.si)) fail(e.name + " needs a matrix", e.raw);
-      if ((int64_t)idata.size() == 1) idata.assign(X.si.rows, idata[0]);
+      if ((int64_t)idata.size() == 1) {
+        // By value, as the lane_outcome expansion is: assign() may
+        // reallocate, and a reference into the vector being assigned would
+        // dangle mid-fill.
+        const int outcome = idata[0];
+        idata.assign(X.si.rows, outcome);
+      }
       idata.push_back((int)X.si.rows);
       idata.push_back((int)X.si.cols);
       // categorical: (y, x, alpha, beta). ordered: (y, x, beta, cuts).

--- a/tests/fixtures/glmscalary.stan
+++ b/tests/fixtures/glmscalary.stan
@@ -1,0 +1,21 @@
+// A GLM with a LANGUAGE-LEVEL SCALAR outcome. Legal Stan -- stan-math
+// broadcasts the outcome over X's rows -- but the kernels map one integer
+// per row out of idata, so the shape used to read past the end of a
+// one-element group and return a silently wrong lp. This one cannot simply
+// be replicated either: stan-math's <false> poisson_log_glm subtracts
+// lgamma(y+1) once for a scalar and once per row for an array, so the
+// gradients would be right and the lp a constant off CmdStan's. The
+// lowering refuses it by name; see docs/coverage.md.
+data {
+  int<lower=1> N;
+  int<lower=1> K;
+  matrix[N, K] x;
+  int<lower=0> y;
+}
+parameters {
+  real alpha;
+  vector[K] beta;
+}
+model {
+  target += poisson_log_glm_lpmf(y | x, alpha, beta);
+}

--- a/tests/fixtures/glmscalary.tmir.sexp
+++ b/tests/fixtures/glmscalary.tmir.sexp
@@ -1,0 +1,534 @@
+((functions_block ())
+ (input_vars
+  ((N <opaque> SInt) (K <opaque> SInt)
+   (x <opaque>
+    (SMatrix AoS
+     ((pattern (Var N)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+     ((pattern (Var K)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+   (y <opaque> SInt)))
+ (prepare_data
+  (((pattern
+     (Decl (decl_adtype DataOnly) (decl_id pos__) (decl_type (Sized SInt))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable pos__) ()) UInt
+      ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id N) (decl_type (Sized SInt))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable N) ()) UInt
+      ((pattern
+        (Indexed
+         ((pattern
+           (FunApp (CompilerInternal FnReadData)
+            (((pattern (Lit Str N))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+          (meta ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly))))
+         ((Single
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnCheck
+        (trans
+         (Lower
+          ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (var_name N)
+        (var ((pattern (Var N)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id K) (decl_type (Sized SInt))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable K) ()) UInt
+      ((pattern
+        (Indexed
+         ((pattern
+           (FunApp (CompilerInternal FnReadData)
+            (((pattern (Lit Str K))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+          (meta ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly))))
+         ((Single
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnCheck
+        (trans
+         (Lower
+          ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (var_name K)
+        (var ((pattern (Var K)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp (CompilerInternal FnValidateSize)
+      (((pattern (Lit Str x)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+       ((pattern (Lit Str N)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+       ((pattern (Var N)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp (CompilerInternal FnValidateSize)
+      (((pattern (Lit Str x)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+       ((pattern (Lit Str K)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+       ((pattern (Var K)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id x)
+      (decl_type
+       (Sized
+        (SMatrix AoS
+         ((pattern (Var N)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+         ((pattern (Var K)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id x_flat__)
+          (decl_type (Unsized (UArray UReal))) (initialize Uninit)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable x_flat__) ()) (UArray UReal)
+          ((pattern
+            (FunApp (CompilerInternal FnReadData)
+             (((pattern (Lit Str x))
+               (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable pos__) ()) UInt
+          ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar sym1__)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Var K)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (For (loopvar sym2__)
+                  (lower
+                   ((pattern (Lit Int 1))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (upper
+                   ((pattern (Var N))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (body
+                   ((pattern
+                     (Block
+                      (((pattern
+                         (Assignment
+                          ((LVariable x)
+                           ((Single
+                             ((pattern (Var sym2__))
+                              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                            (Single
+                             ((pattern (Var sym1__))
+                              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                          UMatrix
+                          ((pattern
+                            (Indexed
+                             ((pattern (Var x_flat__))
+                              (meta
+                               ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))
+                             ((Single
+                               ((pattern (Var pos__))
+                                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                           (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+                        (meta <opaque>))
+                       ((pattern
+                         (Assignment ((LVariable pos__) ()) UInt
+                          ((pattern
+                            (FunApp (StanLib Plus__ FnPlain AoS)
+                             (((pattern (Var pos__))
+                               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                              ((pattern (Lit Int 1))
+                               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                        (meta <opaque>)))))
+                    (meta <opaque>)))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id y) (decl_type (Sized SInt))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable y) ()) UInt
+      ((pattern
+        (Indexed
+         ((pattern
+           (FunApp (CompilerInternal FnReadData)
+            (((pattern (Lit Str y))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+          (meta ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly))))
+         ((Single
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnCheck
+        (trans
+         (Lower
+          ((pattern (Lit Int 0)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (var_name y)
+        (var ((pattern (Var y)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (((pattern (Lit Int 0)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp (CompilerInternal FnValidateSize)
+      (((pattern (Lit Str beta)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+       ((pattern (Lit Str K)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+       ((pattern (Var K)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+    (meta <opaque>))))
+ (log_prob
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id alpha) (decl_type (Sized SReal))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity) (dims ()) (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id beta)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Var K)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity)
+             (dims
+              (((pattern (Var K))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib poisson_log_glm_lpmf (FnLpmf false) AoS)
+             (((pattern (Var y)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+              ((pattern (Var x))
+               (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly))))
+              ((pattern (Var alpha))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+              ((pattern (Var beta))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>)))))
+    (meta <opaque>))))
+ (reverse_mode_log_prob
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id alpha) (decl_type (Sized SReal))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity) (dims ()) (mem_pattern SoA)))
+           ()))
+         (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id beta)
+      (decl_type
+       (Sized
+        (SVector SoA
+         ((pattern (Var K)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity)
+             (dims
+              (((pattern (Var K))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern SoA)))
+           ()))
+         (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib poisson_log_glm_lpmf (FnLpmf false) SoA)
+             (((pattern (Var y)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+              ((pattern (Var x))
+               (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly))))
+              ((pattern (Var alpha))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+              ((pattern (Var beta))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>)))))
+    (meta <opaque>))))
+ (generate_quantities
+  (((pattern
+     (Decl (decl_adtype DataOnly) (decl_id alpha) (decl_type (Sized SReal))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity) (dims ()) (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id beta)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Var K)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity)
+             (dims
+              (((pattern (Var K))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt ())
+        (var
+         ((pattern (Var alpha)) (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt ())
+        (var
+         ((pattern (Var beta))
+          (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (IfElse
+      ((pattern
+        (FunApp (StanLib PNot__ FnPlain AoS)
+         (((pattern
+            (EOr
+             ((pattern (Var emit_transformed_parameters__))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+             ((pattern (Var emit_generated_quantities__))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+      ((pattern (Block (((pattern (Return ())) (meta <opaque>))))) (meta <opaque>)) ()))
+    (meta <opaque>))
+   ((pattern
+     (IfElse
+      ((pattern
+        (FunApp (StanLib PNot__ FnPlain AoS)
+         (((pattern (Var emit_generated_quantities__))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+      ((pattern (Block (((pattern (Return ())) (meta <opaque>))))) (meta <opaque>)) ()))
+    (meta <opaque>))))
+ (transform_inits
+  (((pattern
+     (Decl (decl_adtype DataOnly) (decl_id pos__) (decl_type (Sized SInt))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable pos__) ()) UInt
+      ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id alpha) (decl_type (Sized SReal))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable alpha) ()) UReal
+      ((pattern
+        (Indexed
+         ((pattern
+           (FunApp (CompilerInternal FnReadData)
+            (((pattern (Lit Str alpha))
+              (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+          (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))
+         ((Single
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+       (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var alpha)) (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id beta)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Var K)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id beta_flat__)
+          (decl_type (Unsized (UArray UReal))) (initialize Uninit)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable beta_flat__) ()) (UArray UReal)
+          ((pattern
+            (FunApp (CompilerInternal FnReadData)
+             (((pattern (Lit Str beta))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable pos__) ()) UInt
+          ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar sym1__)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Var K)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (Assignment
+                  ((LVariable beta)
+                   ((Single
+                     ((pattern (Var sym1__))
+                      (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                  UVector
+                  ((pattern
+                    (Indexed
+                     ((pattern (Var beta_flat__))
+                      (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))
+                     ((Single
+                       ((pattern (Var pos__))
+                        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+                (meta <opaque>))
+               ((pattern
+                 (Assignment ((LVariable pos__) ()) UInt
+                  ((pattern
+                    (FunApp (StanLib Plus__ FnPlain AoS)
+                     (((pattern (Var pos__))
+                       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                      ((pattern (Lit Int 1))
+                       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var beta))
+          (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))))
+ (unconstrain_array
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id alpha) (decl_type (Sized SReal))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable alpha) ()) UReal
+      ((pattern (FunApp (CompilerInternal FnReadDeserializer) ()))
+       (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var alpha)) (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id beta)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Var K)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable beta) ()) UVector
+      ((pattern
+        (FunApp (CompilerInternal FnReadDeserializer)
+         (((pattern (Var K)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var beta))
+          (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))))
+ (output_vars
+  ((alpha <opaque>
+    ((out_unconstrained_st SReal) (out_constrained_st SReal) (out_block Parameters)
+     (out_trans Identity)))
+   (beta <opaque>
+    ((out_unconstrained_st
+      (SVector AoS
+       ((pattern (Var K)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+     (out_constrained_st
+      (SVector AoS
+       ((pattern (Var K)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+     (out_block Parameters) (out_trans Identity)))))
+ (prog_name glmscalary_model) (prog_path tests/fixtures/glmscalary.stan))

--- a/tests/test_eltwise.cpp
+++ b/tests/test_eltwise.cpp
@@ -126,6 +126,21 @@ int main() {
   check_case("inv_logit v", OP_INV_LOGIT, N, {A}, [](auto& v) {
     return stan::math::sum(stan::math::inv_logit(v[0]));
   });
+  // inv_logit is the one unary whose container and scalar overloads compute
+  // different expressions, so its two shapes need values that separate them.
+  // -0.45 and -1.53 are points where Eigen's PACKET exp disagrees with libm's
+  // by a ulp -- they fail if the vector shape evaluates over contiguous
+  // doubles instead of mirroring the strided (scalar-libm) `.val()` the
+  // Matrix<var> overload gets. 1.1 and 2.0 are points where Eigen's logistic
+  // functor, `e/(1+e)`, disagrees with stan's scalar `inv_logit`, `1/(1+e^-x)`
+  // -- they fail if the vector shape is "simplified" to the scalar function.
+  check_case(
+      "inv_logit v ulp", OP_INV_LOGIT, N, {{-0.45, 2.0, 1.1, -1.53}},
+      [](auto& v) { return stan::math::sum(stan::math::inv_logit(v[0])); });
+  // And the mirror of that last point: at length 1 the reference IS the
+  // scalar function, so 1.1 fails here if the two shapes are unified.
+  check_case("inv_logit s", OP_INV_LOGIT, 1, {{1.1}},
+             [](auto& v) { return stan::math::inv_logit(v[0](0)); });
   check_case("sqrt v", OP_SQRT, N, {{0.5, 1.2, 2.0, 0.3}},
              [](auto& v) { return stan::math::sum(stan::math::sqrt(v[0])); });
   check_case("square v", OP_SQUARE, N, {A},

--- a/tests/test_lower.cpp
+++ b/tests/test_lower.cpp
@@ -2382,6 +2382,32 @@ int main() {
           "glm: lp matches the var path (propto reached the kernel)");
   }
 
+  // A GLM whose outcome is a language-level scalar rather than an array of
+  // one value per row. The kernels map `rows` integers out of idata, so a
+  // one-element group used to be read past the end and answered with
+  // whatever followed it in the vector -- on this fixture -29.48 where the
+  // equivalent array outcome gives -16.22, no diagnostic. It is refused at
+  // lowering rather than replicated because for poisson_log_glm stan-math's
+  // own broadcast is not the replicated call: its <false> form subtracts
+  // lgamma(y+1) once for a scalar and once per row for an array, so
+  // replicating would put stanli's lp a constant off CmdStan's. See
+  // docs/coverage.md.
+  {
+    DataMap d = DataMap::from_json(
+        R"({"N": 4, "K": 2,
+            "x": [[0.3, -0.2], [1.1, 0.4], [-0.5, 0.9], [0.2, 0.7]],
+            "y": 3})");
+    std::string msg;
+    try {
+      compile_model(slurp("tests/fixtures/glmscalary.tmir.sexp"), d);
+    } catch (const CompileError& e) {
+      msg = e.what();
+    }
+    check(msg.find("poisson_log_glm_lpmf") != std::string::npos &&
+              msg.find("4 rows") != std::string::npos,
+          "glm scalar outcome refused by name, not read past the end");
+  }
+
   // normal_id_glm with the OUTCOME as a parameter. stanc3's --O1 partial
   // evaluator rewrites `theta ~ normal(x * b, 1)` into
   // normal_id_glm_lupdf(theta | x, 0, b, 1), a shape the source language


### PR DESCRIPTION
Two independent fixes found in the same area. The second is much more serious than the first.

## 1. `inv_logit` on a vector was 1 ULP off CmdStan

Within the 2 ULP budget, so not a policy violation -- it matters because it makes bitwise fixtures impossible. It cost one agent a four-round bisect and forced a fixture to route its parameters around `inv_logit` to keep a bitwise comparison meaningful.

**The kernel's own comment was wrong about why it did what it did.** It claimed `Matrix<var>` `inv_logit` "resolves to a vectorized overload (packet values)". It does not: `stan::math::inv_logit(Matrix<var>)` computes `x.val().array().logistic()`, `.val()` reads through `vari` pointers, so the expression is strided, Eigen refuses to packetize it, and `scalar_logistic_op_impl<double>` runs its **scalar** body with libm `exp`. The kernel was handing that same functor a *contiguous* temporary, which selects `pexp<Packet2d>`.

At x = -0.45:

```
Matrix<var> inv_logit .val()   0x3fd8eb496b22267c   <- CmdStan (default AoS)
stanli contiguous logistic()   0x3fd8eb496b22267a
libm e/(1+e)                   0x3fd8eb496b22267c
```

Forward only; the backward is `dout * out * (1-out)` over the same tree and inherits it, which is why lp and gradient both moved. Does not reproduce at `len == 1`. Value-dependent rather than lane-dependent: 45 of 601 points in [-3, 3] separate the two.

The `packet_math()` flag was never involved -- `invlogit_fwd` did not consult it. `constrain.cpp` already documents this exact mechanism and `clu_fwd` already gets it right; this kernel was the one that missed it.

**The two shapes cannot be unified in either direction**, which is the thing to know before touching this again. Stan's scalar `inv_logit(double)` branches on sign; Eigen's functor is `e/(1+e)` everywhere, and they disagree bitwise on 105 of 301 points in [0, 3]. So `len == 1` must stay on stan's scalar function and `len > 1` must not. The test pins both directions: two cases fail if the vector shape re-packetizes, two more fail if someone simplifies it to per-element `stan::math::inv_logit`.

Cost: 1.27 to 2.05 ns/element in isolation, 6155 to 7530 ns/gradient on a synthetic `sum(inv_logit(vector[2000]))` built to be the worst case. **Zero corpus models measure any difference** -- instrumenting shows the vector shape is reached 37 times across the whole corpus, all in `write_array`, none in a gradient, none at a diverging argument. Same trade `expv_fwd` and `logv_fwd` already take unconditionally.

## 2. A scalar GLM outcome read past the end of its integer group

This one is a silent wrong answer, not a last-bit difference.

`poisson_log_glm_fwd` does `Map<const VectorXi> y(ctx.idata, rows)`, and a scalar outcome leaves `idata` three entries long (`{y, rows, cols}`). So it reads `rows` integers out of a length-3 buffer and answers with whatever follows. Measured on a six-row model: **`-29.475652907221878` where the equivalent array outcome gives `-16.21763928771659`**, no diagnostic. The `d/dalpha` delta is exactly 3.0, which is the garbage folded into `sum(y)`.

`lane_outcome = true` cannot serve these: that expansion sizes itself from the longest real argument, and for a GLM that is X at `rows*cols`. So the length check goes in the `glm_layout` branch, and the call is **refused** rather than replicated.

Refusing rather than replicating is forced by `poisson_log_glm` alone. stan-math's non-propto form subtracts `lgamma(y+1)` once for a scalar and once per row for an array (`poisson_log_glm_lpmf.hpp:121`): four rows of y = 3 gives -4.98 scalar against -10.36 replicated, with gradients bitwise identical either way. Replicating would buy correct gradients and an `lp__` a constant off CmdStan's.

I probed the others rather than assume: `bernoulli_logit_glm` and `neg_binomial_2_log_glm` agree bitwise scalar-against-array in both propto forms, so they are refused only for sharing the layout and the check -- the doc says so, so nobody later reads a warning that does not apply to them. `binomial_logit_glm` and `categorical_logit_glm` also agree bitwise, which is what makes their hand-written replication correct; they keep it, but now copy the value out before `assign()`, since they were passing a reference into the vector being reallocated.

The same guard closes a length-M array outcome with M != rows, which reached the identical map.

No conformance row exercises any of this, which is why it survived.

## Gates

`ctest` 49/49, `verify_refs` **129/129** with `hmm_gaussian` unchanged at 3.63e-12 -- and zero models changed a single bit, measured by diffing per-model deviations across a before and after build. `format.sh --check` clean.

RED confirmed for the `inv_logit` test before the fix, reporting exactly the number in the original finding: `FAIL inv_logit v ulp g0 got 0.2377589599111293 want 0.23775895991112933`.

## Left alone

`log1m_fwd`'s `.matrix().eval()` temporary is wasted work but not a bug -- its container overload is `apply_scalar_unary`, always scalar. And the 1-row-X GLM broadcast shape is now refused by the new length check rather than silently dropping outcomes.