### PR TITLE
conformance: the var-tape distribution functions, and the operator aliases

### DIFF
--- a/docs/coverage.md
+++ b/docs/coverage.md
@@ -63,7 +63,16 @@ the shared helpers (`tail_m`, `tail_v`, `tail_scatter_*` in
 `runtime/kernels/matrix_fns.cpp`) reduce each kernel to about twenty
 lines. Unlike the recorder, this tier has no restriction on what the
 density does with its scalar type: `ordered_probit` and `wiener` use
-operators `rvar` deliberately lacks, and both work on a var tape. These
+operators `rvar` deliberately lacks, and both work on a var tape. So do
+the five distribution functions that build their result with arithmetic
+on the scalar -- `von_mises_cdf`, `von_mises_lcdf`, `von_mises_lccdf`
+(`res *= 0.0`) and `neg_binomial_2_lcdf`, `neg_binomial_2_lccdf`
+(`phi / (phi + mu)`). Whether a distribution function needs this tier is
+mechanical rather than a judgement: `grep -c operands_and_partials` on
+its prim header is 2 for everything the recorder takes and 0 for these
+five. The price is a nested tape per gradient call, so they are slower
+than a listed cdf by roughly the cost of building and sweeping that
+tape. These
 kernels are **compact** (one instantiation, every argument bound as
 autodiff), so `lp__` carries a per-model constant while gradients stay
 exact; [docs/compact-densities.md](compact-densities.md) is the
@@ -75,16 +84,6 @@ contract.
 constant zero, but Stan Math performs support checks first. Until Stanli has
 an exact checked implementation, lowering refuses rather than silently
 accepting invalid data.
-
-**Five distribution functions the recorder cannot evaluate.**
-`von_mises_cdf`, `von_mises_lcdf`, `von_mises_lccdf`,
-`neg_binomial_2_lcdf` and `neg_binomial_2_lccdf` build their result with
-arithmetic on the autodiff scalar -- `res *= 0.0`, `phi / (phi + mu)` --
-rather than through stan-math's partials propagator. `rvar` deliberately
-has no operators, so these do not compile against it however they are
-listed. The same var-tape treatment `ordered_probit` and `wiener` get
-would take them; nobody has written it. `neg_binomial_2_cdf` is not in
-this group -- it does use the propagator, and it works.
 
 **`discrete_range`'s three.** Integers all the way down, so there is no
 real edge for a kernel to differentiate and no layout for one yet.

--- a/docs/hacking.md
+++ b/docs/hacking.md
@@ -410,8 +410,11 @@ density kernels call stan-math's own code with a recording scalar type
 that computes in plain doubles and has no arithmetic operators, so a
 function whose implementation does arithmetic on the scalar type
 itself (`von_mises_cdf`, `wiener_lpdf`) fails to compile rather than
-silently losing derivatives. [`docs/coverage.md`](coverage.md) lists
-which functions and why.
+silently losing derivatives. Those go on `STANLI_TAIL_CDF_LIST` or
+beside `wiener` instead, and get a nested var tape in
+[`matrix_fns.cpp`](../runtime/kernels/matrix_fns.cpp);
+[`docs/coverage.md`](coverage.md) says how to tell which list a
+function belongs on.
 
 Everything else takes four steps:
 

--- a/runtime/include/stanli/mir_interp.hpp
+++ b/runtime/include/stanli/mir_interp.hpp
@@ -937,11 +937,17 @@ class MirInterp {
         return T(f(val(x), val(y)) ? 1.0 : 0.0);
       });
     };
-    if (e.name == "Plus__")
+    // add/subtract/multiply/elt_multiply/divide/elt_divide are the named
+    // spellings of the binary operators, and they are taught here beside
+    // the operators rather than in a table of their own: the graph
+    // lowering knows them too, and teaching only one side is what let a
+    // vectorized log_sum_exp answer transformed data with the wrong value
+    // and no exception.
+    if (e.name == "Plus__" || e.name == "add")
       return bin([](const T& x, const T& y) { return x + y; });
-    if (e.name == "Minus__")
+    if (e.name == "Minus__" || e.name == "subtract")
       return bin([](const T& x, const T& y) { return x - y; });
-    if (e.name == "Times__") {
+    if (e.name == "Times__" || e.name == "multiply") {
       // Times on shaped operands is linear algebra, not elementwise; only
       // a scalar operand (either side) scales elementwise.
       Value a = eval(e.args[0]), b = eval(e.args[1]);
@@ -951,7 +957,7 @@ class MirInterp {
         const int64_t Ca = a_mat ? a.dims[1] : (int64_t)a.r.size();
         const int64_t Rb = b_mat ? b.dims[0] : (int64_t)b.r.size();
         const int64_t Cb = b_mat ? b.dims[1] : 1;
-        if (Ca != Rb) fail("Times__: inner dimension mismatch", e.raw);
+        if (Ca != Rb) fail(e.name + ": inner dimension mismatch", e.raw);
         // Col-major storage on both sides.
         r.r.assign((size_t)(Ra * Cb), T(0.0));
         for (int64_t j = 0; j < Cb; ++j)
@@ -980,7 +986,7 @@ class MirInterp {
         }
         if (e.type_ == "UReal" || e.type_ == "UInt") {
           if (a.r.size() != b.r.size())
-            fail("Times__: dot product length mismatch", e.raw);
+            fail(e.name + ": dot product length mismatch", e.raw);
           T s = T(0.0);
           for (size_t i = 0; i < a.r.size(); ++i) s += a.r[i] * b.r[i];
           r.r = {s};
@@ -990,7 +996,7 @@ class MirInterp {
       // Scalar scale, elementwise on the already-evaluated operands (an
       // argument may hold an RNG call; evaluating twice would draw twice).
       if (a.r.size() != b.r.size() && !is_scalar(a) && !is_scalar(b))
-        fail("Times__: incompatible lengths", e.raw);
+        fail(e.name + ": incompatible lengths", e.raw);
       const size_t n = broadcast_size(a, b);
       r.r.resize(n);
       for (size_t i = 0; i < n; ++i)
@@ -1002,7 +1008,7 @@ class MirInterp {
       }
       return r;
     }
-    if (e.name == "EltTimes__")
+    if (e.name == "EltTimes__" || e.name == "elt_multiply")
       return bin([](const T& x, const T& y) { return x * y; });
     // `A \ v` and `rv / A` are linear solves. stanc spells them with the
     // ordinary division operators, so the divisor's type is what tells a
@@ -1047,7 +1053,29 @@ class MirInterp {
         r.dims = {(int64_t)r.r.size()};
       return r;
     }
-    if (e.name == "Divide__" || e.name == "EltDivide__")
+    // `divide` reaches here and never the solve above: stan::math::divide
+    // divides by a scalar or divides a scalar elementwise, and has no
+    // matrix-divisor overload at all.
+    //
+    // Its int,int overload is the exception to that elementwise reading:
+    // it truncates and refuses a zero denominator, where the real
+    // division below would answer 3.5 for `divide(7, 2)`. The value the
+    // caller sees is `r`, not `i` -- lower.cpp's fold_const takes r[0]
+    // for a UInt result -- so the truncation has to land in both.
+    if ((e.name == "divide" || e.name == "elt_divide") && e.type_ == "UInt") {
+      const int x = (int)as_int(e.args[0]), y = (int)as_int(e.args[1]);
+      // divide is the one with the zero check; elt_divide is a bare `/`,
+      // so a zero denominator there is undefined behavior and refused.
+      if (e.name == "elt_divide" && y == 0)
+        fail("integer division by zero", e.raw);
+      const int q = e.name == "divide" ? stan::math::divide(x, y) : x / y;
+      r.is_int = true;
+      r.i = {q};
+      r.r = {T((double)q)};
+      return r;
+    }
+    if (e.name == "Divide__" || e.name == "EltDivide__" || e.name == "divide" ||
+        e.name == "elt_divide")
       return bin([](const T& x, const T& y) { return x / y; });
     // `%` and `%/%`. Both operands are int by stanc's typing, so these are
     // C++ integer operators -- truncated toward zero -- and not fmod and
@@ -1360,6 +1388,24 @@ class MirInterp {
         r.r.push_back(a.r.at((size_t)(off + k)));
         if (a.is_int) r.i.push_back(a.i.at((size_t)(off + k)));
       }
+      return r;
+    }
+    // squared_distance is dot_self of the difference, which is how the
+    // graph lowers it too (lower.cpp); the two spellings agreeing keeps
+    // transformed data and the log density on the same summation order.
+    // A vector may be paired with a row_vector, and neither view carries
+    // anything but a length, so there is nothing to reorder. No
+    // broadcasting: the language has no scalar-against-container overload.
+    if (e.name == "squared_distance" && e.args.size() == 2) {
+      Value a = eval(e.args[0]), b = eval(e.args[1]);
+      if (a.r.size() != b.r.size())
+        fail("squared_distance: length mismatch", e.raw);
+      T s = T(0.0);
+      for (size_t i = 0; i < a.r.size(); ++i) {
+        const T d = a.r[i] - b.r[i];
+        s += d * d;
+      }
+      r.r = {s};
       return r;
     }
     if ((e.name == "dot_product" || e.name == "dot_self")) {

--- a/runtime/include/stanli/mir_prog.hpp
+++ b/runtime/include/stanli/mir_prog.hpp
@@ -147,10 +147,17 @@ struct ProgramCompiler {
       }
       case mir::Expr::FunApp:
         if (e.args.size() == 2) {
-          if (e.name == "Plus__") return cint(e.args[0]) + cint(e.args[1]);
-          if (e.name == "Minus__") return cint(e.args[0]) - cint(e.args[1]);
-          if (e.name == "Times__") return cint(e.args[0]) * cint(e.args[1]);
-          if (e.name == "IntDivide__" || e.name == "Divide__")
+          // Each operator with the named spelling beside it: on ints the
+          // alias is the operator, down to `divide`'s truncation.
+          if (e.name == "Plus__" || e.name == "add")
+            return cint(e.args[0]) + cint(e.args[1]);
+          if (e.name == "Minus__" || e.name == "subtract")
+            return cint(e.args[0]) - cint(e.args[1]);
+          if (e.name == "Times__" || e.name == "multiply" ||
+              e.name == "elt_multiply")
+            return cint(e.args[0]) * cint(e.args[1]);
+          if (e.name == "IntDivide__" || e.name == "Divide__" ||
+              e.name == "divide" || e.name == "elt_divide")
             return cint(e.args[0]) / cint(e.args[1]);
         }
         if (e.args.size() == 1 && e.name == "PMinus__") return -cint(e.args[0]);
@@ -449,6 +456,14 @@ struct ProgramCompiler {
       return typed(out, e.type_);
     }
     if (e.args.size() == 2) {
+      // An int-typed binary is integer arithmetic, and `divide` truncates
+      // where the real DIV below does not: `divide(7, 2)` is 3, not 3.5.
+      // The register file holds only reals, so fold the integer answer
+      // whenever cint can reach it rather than emitting real arithmetic.
+      if (e.type_ == "UInt") {
+        long v;
+        if (try_cint(e, &v)) return {konst((double)v), 1};
+      }
       const Range a = expr(e.args[0]), b = expr(e.args[1]);
       const bool a_scalar = is_scalar(a);
       const bool b_scalar = is_scalar(b);
@@ -456,20 +471,30 @@ struct ProgramCompiler {
         bail("array arithmetic is unsupported by the register program");
       if (!a_scalar && !b_scalar && !same_view(a, b))
         bail("binary " + e.name + " on different logical views");
-      if (e.name == "Times__" && !a_scalar && !b_scalar) {
+      // `multiply` rides with `Times__` here for the same reason it does
+      // in the graph lowering: on two containers it is linear algebra,
+      // not the elementwise MUL the register file would emit.
+      if ((e.name == "Times__" || e.name == "multiply") && !a_scalar &&
+          !b_scalar) {
         if (a.kind == ViewKind::Matrix || b.kind == ViewKind::Matrix)
           bail("matrix multiplication is unsupported by the register program");
         bail("container multiplication is unsupported by the register program");
       }
       const int n = a_scalar ? b.len : (b_scalar ? a.len : a.len);
       Program::Code c;
-      if (e.name == "Plus__")
+      // The named spellings of the operators, on the same opcodes: a
+      // region whose control flow depends on a parameter has to compile
+      // here or not at all, so a gap is a hard error rather than a slow
+      // path.
+      if (e.name == "Plus__" || e.name == "add")
         c = Program::ADD;
-      else if (e.name == "Minus__")
+      else if (e.name == "Minus__" || e.name == "subtract")
         c = Program::SUB;
-      else if (e.name == "Times__" || e.name == "EltTimes__")
+      else if (e.name == "Times__" || e.name == "EltTimes__" ||
+               e.name == "multiply" || e.name == "elt_multiply")
         c = Program::MUL;
-      else if (e.name == "Divide__" || e.name == "EltDivide__")
+      else if (e.name == "Divide__" || e.name == "EltDivide__" ||
+               e.name == "divide" || e.name == "elt_divide")
         c = Program::DIV;
       else if (e.name == "Pow__" || e.name == "pow")
         c = Program::POW;

--- a/runtime/include/stanli/optable.hpp
+++ b/runtime/include/stanli/optable.hpp
@@ -404,6 +404,31 @@ namespace stanli {
   X(OP_BINOMIAL_LCCDF, binomial_lccdf, 1, 0)           \
   X(OP_BINOMIAL_LCDF, binomial_lcdf, 1, 0)
 
+// The distribution functions that cannot go through the recorder at all,
+// whatever list they are put on. These build their result with arithmetic
+// on the autodiff scalar rather than through stan-math's partials
+// propagator -- von_mises_cdf writes `res *= 0.0` and compares
+// `x_n == -pi`, neg_binomial_2_lcdf forms `phi_vec[i] / (phi_vec[i] +
+// mu_vec[i])` -- and rvar deliberately has no operators (recorder.hpp),
+// so listing them above produces a compile error rather than a wrong
+// answer. The discriminator is mechanical: `grep -c
+// operands_and_partials` on the prim header is 2 for everything on the
+// lists above and 0 for these five.
+//
+// They get the nested var tape ordered_probit and wiener get, in
+// matrix_fns.cpp, which has no restriction on what a density does with
+// its scalar type and costs a tape per gradient call. Field 3 is the
+// count of REAL arguments; the int list carries one integer group on top
+// of that, exactly as STANLI_INT_CDF_LIST does.
+#define STANLI_TAIL_CDF_LIST(X)                \
+  X(OP_VON_MISES_CDF, von_mises_cdf, 3, 0)     \
+  X(OP_VON_MISES_LCCDF, von_mises_lccdf, 3, 0) \
+  X(OP_VON_MISES_LCDF, von_mises_lcdf, 3, 0)
+
+#define STANLI_TAIL_INT_CDF_LIST(X)                      \
+  X(OP_NEG_BINOMIAL_2_LCCDF, neg_binomial_2_lccdf, 2, 0) \
+  X(OP_NEG_BINOMIAL_2_LCDF, neg_binomial_2_lcdf, 2, 0)
+
 // Ordinal regression. Two things make these different from the list
 // above, and both are expressed in the kernel rather than here: the
 // cutpoint argument is a whole vector whatever its length (field 4 is
@@ -628,6 +653,8 @@ constexpr bool exact_lp_build() {
   STANLI_SCALAR_CDF_LIST(DENSITY)                 \
   STANLI_INT_CDF_LIST(DENSITY)                    \
   STANLI_TWO_INT_CDF_LIST(DENSITY)                \
+  STANLI_TAIL_CDF_LIST(DENSITY)                   \
+  STANLI_TAIL_INT_CDF_LIST(DENSITY)               \
   STANLI_ORDERED_DENSITY_LIST(DENSITY)            \
   STANLI_SCALAR_UNARY_LIST(UNARY)
 

--- a/runtime/kernels/matrix_fns.cpp
+++ b/runtime/kernels/matrix_fns.cpp
@@ -759,6 +759,79 @@ void olglm_fwd(KernelCtx& ctx) {
 }
 void olglm_bwd(KernelCtx& ctx) { tglm_eval<true, kOrdLogisticGlm>(ctx); }
 
+// ---- the cdfs the recorder cannot take ---------------------------------
+// Same reason ordered_probit and wiener are here, one step further out:
+// von_mises_cdf writes `res *= 0.0` and compares `x_n == -pi` on the
+// scalar type, and neg_binomial_2_lcdf forms `phi / (phi + mu)`. Neither
+// builds its result through stan-math's partials propagator, so neither
+// can be handed an rvar. See STANLI_TAIL_CDF_LIST in optable.hpp.
+//
+// A length-1 slot enters stan-math as a scalar rather than a
+// one-element vector: the sequence views broadcast a scalar but require
+// vectors to match sizes. That is the same rule bind_args_m follows in
+// densities_impl.hpp, and getting it wrong is not a size error -- it is
+// every observation evaluated with element 0's parameters, which is what
+// the sweep caught in the old scalar-only wiener tail.
+using TailArg = std::variant<stan::math::var, VarV>;
+TailArg tail_arg(const KernelCtx& ctx, int k) {
+  if (ctx.in[k].len == 1) return stan::math::var(ctx.in[k].data[0]);
+  return tail_v(ctx, k, ctx.in[k].len);
+}
+
+// finish_tail_density's shape, over arguments that are variants: one
+// visit picks the scalar-or-vector instantiation, a second scatters each
+// argument's adjoints back through the overload its own alternative
+// selects.
+template <bool Grad, typename F, typename... A>
+double tail_visit(KernelCtx& ctx, F&& f, const A&... a) {
+  stan::math::var out = std::visit(
+      [&](const auto&... x) -> stan::math::var { return f(x...); }, a...);
+  const double value = out.val();
+  if constexpr (Grad) {
+    stan::math::var seeded = out * ctx.out_adj;
+    stan::math::grad(seeded.vi_);
+    int slot = 0;
+    ((std::visit([&](const auto& x) { tail_scatter(ctx, slot, x); }, a),
+      ++slot),
+     ...);
+  }
+  return value;
+}
+
+#define STANLI_TAIL_CDF_KERNEL(code, fn, nreal, tier)                        \
+  template <bool Grad>                                                       \
+  double fn##_eval(KernelCtx& ctx) {                                         \
+    stan::math::nested_rev_autodiff nested;                                  \
+    const TailArg a0 = tail_arg(ctx, 0), a1 = tail_arg(ctx, 1),              \
+                  a2 = tail_arg(ctx, 2);                                     \
+    return tail_visit<Grad>(                                                 \
+        ctx, [](const auto&... x) { return stan::math::fn(x...); }, a0, a1,  \
+        a2);                                                                 \
+  }                                                                          \
+  void fn##_fwd(KernelCtx& ctx) { ctx.out.data[0] = fn##_eval<false>(ctx); } \
+  void fn##_bwd(KernelCtx& ctx) { fn##_eval<true>(ctx); }
+STANLI_TAIL_CDF_LIST(STANLI_TAIL_CDF_KERNEL)
+#undef STANLI_TAIL_CDF_KERNEL
+
+// The integer outcome rides in idata as one whole group, the way the
+// other integer-outcome cdfs read theirs; the lowering has already
+// replicated a language-level scalar to the lane count.
+#define STANLI_TAIL_INT_CDF_KERNEL(code, fn, nreal, tier)                    \
+  template <bool Grad>                                                       \
+  double fn##_eval(KernelCtx& ctx) {                                         \
+    stan::math::nested_rev_autodiff nested;                                  \
+    Eigen::Map<const Eigen::VectorXi> y(                                     \
+        ctx.idata, static_cast<Eigen::Index>(ctx.n_idata));                  \
+    const TailArg a0 = tail_arg(ctx, 0), a1 = tail_arg(ctx, 1);              \
+    return tail_visit<Grad>(                                                 \
+        ctx, [&](const auto&... x) { return stan::math::fn(y, x...); }, a0,  \
+        a1);                                                                 \
+  }                                                                          \
+  void fn##_fwd(KernelCtx& ctx) { ctx.out.data[0] = fn##_eval<false>(ctx); } \
+  void fn##_bwd(KernelCtx& ctx) { fn##_eval<true>(ctx); }
+STANLI_TAIL_INT_CDF_LIST(STANLI_TAIL_INT_CDF_KERNEL)
+#undef STANLI_TAIL_INT_CDF_KERNEL
+
 }  // namespace
 
 void register_matrix_kernels() {
@@ -781,6 +854,11 @@ void register_matrix_kernels() {
   register_kernel(OP_ORDERED_PROBIT_LPMF,
                   Kernel{oprobit_fwd, oprobit_bwd, nullptr});
   register_kernel(OP_WIENER_LPDF, Kernel{wiener_fwd, wiener_bwd, nullptr});
+#define STANLI_REGISTER_TAIL_CDF(code, fn, nreal, tier) \
+  register_kernel(code, Kernel{fn##_fwd, fn##_bwd, nullptr});
+  STANLI_TAIL_CDF_LIST(STANLI_REGISTER_TAIL_CDF)
+  STANLI_TAIL_INT_CDF_LIST(STANLI_REGISTER_TAIL_CDF)
+#undef STANLI_REGISTER_TAIL_CDF
   register_kernel(OP_LKJ_COV_LPDF, Kernel{lkjcov_fwd, lkjcov_bwd, nullptr});
   register_kernel(OP_BINOMIAL_LOGIT_GLM_LPMF,
                   Kernel{blglm_fwd, blglm_bwd, nullptr});

--- a/runtime/src/lower.cpp
+++ b/runtime/src/lower.cpp
@@ -1951,6 +1951,20 @@ struct Lowering {
 #define STANLI_TWO_INT_CDF_TABLE(code, fn, nreal, t) {#fn, {code, nreal + 2, 2}},
         STANLI_TWO_INT_CDF_LIST(STANLI_TWO_INT_CDF_TABLE)
 #undef STANLI_TWO_INT_CDF_TABLE
+        // The var-tape cdfs. Same argument shapes as the two lists above,
+        // and a fixed all-active mask because their kernel binds every
+        // argument as var whatever the MIR says: one instantiation, no
+        // activity-mask expansion, and a data argument's partials
+        // computed and dropped.
+#define STANLI_TAIL_CDF_TABLE(code, fn, n, t) \
+  {#fn, {code, n, 0, false, DensityShape::Plain, (1 << n) - 1}},
+        STANLI_TAIL_CDF_LIST(STANLI_TAIL_CDF_TABLE)
+#undef STANLI_TAIL_CDF_TABLE
+#define STANLI_TAIL_INT_CDF_TABLE(code, fn, nreal, t)                        \
+  {#fn,                                                                      \
+   {code, nreal + 1, 1, false, DensityShape::Plain, (1 << nreal) - 1, true}},
+        STANLI_TAIL_INT_CDF_LIST(STANLI_TAIL_INT_CDF_TABLE)
+#undef STANLI_TAIL_INT_CDF_TABLE
         // The ordinal densities have the same argument counts but not the
         // same meaning: their trailing cutpoint vector is one argument, so
         // a scalar outcome stays one lane whatever its length.

--- a/runtime/src/lower.cpp
+++ b/runtime/src/lower.cpp
@@ -2235,6 +2235,16 @@ struct Lowering {
         {"EltDivide__", OP_DIV},
         {"Pow__", OP_POW},
         {"pow", OP_POW},
+        // The named spellings of the same operators. `divide` is the one
+        // that is not simply the operator renamed: `rv / A` is a solve,
+        // but stan::math::divide only ever divides by a scalar or divides
+        // a scalar elementwise, so it is OP_DIV on every one of its
+        // overloads (deps/math/stan/math/prim/fun/divide.hpp).
+        {"add", OP_ADD},
+        {"subtract", OP_SUB},
+        {"divide", OP_DIV},
+        {"elt_multiply", OP_MUL},
+        {"elt_divide", OP_DIV},
 // Generated from STANLI_SCALAR_BINARY_LIST (optable.hpp), which also made
 // the opcode and the kernel. multiply_log is the pre-optimizer spelling of
 // lmultiply, so it rides the same opcode.
@@ -2243,7 +2253,10 @@ struct Lowering {
 #undef STANLI_BINARY_TABLE
             {"multiply_log", OP_LMULTIPLY},
     };
-    if (e.name == "Times__") {
+    // multiply is the named spelling of `*`, including its linear algebra:
+    // the branches below pick matvec, GEMM, outer and inner products off
+    // the operand views and the result type, which the alias shares.
+    if (e.name == "Times__" || (e.name == "multiply" && e.args.size() == 2)) {
       Val a = lower_expr(e.args[0]);
       Val b = lower_expr(e.args[1]);
       // Scalar on either side is an elementwise scale, whatever shape the
@@ -2262,7 +2275,7 @@ struct Lowering {
           // Data matrix * vector keeps the tuned MATVEC kernel (its
           // accumulation order is matched to the var path).
           if (g.slots[b.slot].len != a.si.cols)
-            fail("Times__: inner dimension mismatch", e.raw);
+            fail(e.name + ": inner dimension mismatch", e.raw);
           return emit_value(OP_MATVEC, {a, b}, a.si.rows, view_of("UVector"),
                             {(int)a.si.rows, (int)a.si.cols});
         }
@@ -2270,7 +2283,7 @@ struct Lowering {
         const int64_t cb = is_matrix(b.si) ? b.si.cols : 1;
         const int64_t rb = is_matrix(b.si) ? b.si.rows : g.slots[b.slot].len;
         if (rb != a.si.cols)
-          fail("Times__: inner dimension mismatch (" +
+          fail(e.name + ": inner dimension mismatch (" +
                    std::to_string(a.si.rows) + "x" + std::to_string(a.si.cols) +
                    " times " + std::to_string(rb) + "x" + std::to_string(cb) +
                    ")",
@@ -2288,7 +2301,7 @@ struct Lowering {
       }
       if (is_row_vector(a.si) && is_matrix(b.si)) {
         const int64_t k = g.slots[a.slot].len;
-        if (k != b.si.rows) fail("Times__: inner dimension mismatch", e.raw);
+        if (k != b.si.rows) fail(e.name + ": inner dimension mismatch", e.raw);
         return emit_value(OP_GEMM, {a, b}, b.si.cols, view_of("URowVector"),
                           {1, (int)k, (int)b.si.cols});
       }
@@ -2296,11 +2309,11 @@ struct Lowering {
       if (is_row_vector(a.si) && is_vector(b.si) &&
           (e.type_ == "UReal" || e.type_ == "UInt")) {
         if (g.slots[a.slot].len != g.slots[b.slot].len)
-          fail("Times__: inner dimension mismatch", e.raw);
+          fail(e.name + ": inner dimension mismatch", e.raw);
         return emit_value(OP_DOT, {a, b}, 1);
       }
       if (a.si.kind != ViewKind::Flat || b.si.kind != ViewKind::Flat)
-        fail("Times__: unsupported container product", e.raw);
+        fail(e.name + ": unsupported container product", e.raw);
       const int64_t len = std::max(g.slots[a.slot].len, g.slots[b.slot].len);
       return emit_value(OP_MUL, {a, b}, len);
     }
@@ -2436,6 +2449,24 @@ struct Lowering {
     if (e.name == "dot_self") {
       Val a = lower_expr(e.args[0]);
       return emit_value(OP_DOT, {a, a}, 1);
+    }
+
+    // squared_distance(x, y) = dot_self(x - y). Two graph kernels that
+    // already carry native adjoints, so no new opcode. It does not go
+    // through shape_of: the language pairs a vector with a row_vector
+    // here, which same_view rejects and stan-math accepts, and the only
+    // thing the difference could change -- element order -- is the same
+    // on both sides because a length is all either view carries.
+    if (e.name == "squared_distance" && e.args.size() == 2) {
+      Val a = lower_expr(e.args[0]);
+      Val b = lower_expr(e.args[1]);
+      const int64_t la = g.slots[a.slot].len, lb = g.slots[b.slot].len;
+      if (la != lb) fail(e.name + ": arguments must match in size", e.raw);
+      SlotInfo si;
+      si.param_free = a.si.param_free && b.si.param_free;
+      if (la > 1) si.kind = ViewKind::Vector;
+      Val d = emit_value(OP_SUB, {a, b}, la, si);
+      return emit_value(OP_DOT, {d, d}, 1);
     }
     return std::nullopt;
   }

--- a/tests/fixtures/dcdf.stan
+++ b/tests/fixtures/dcdf.stan
@@ -14,7 +14,8 @@
 // neg_binomial_2's lcdf and lccdf are absent on purpose. Unlike the cdf
 // they compute their result by arithmetic on the autodiff scalar rather
 // than through stan-math's partials propagator, which the recorder
-// scalar does not implement. See docs/coverage.md.
+// scalar does not implement, so they are on the nested var tape instead
+// and are pinned by tests/fixtures/tcdf.stan.
 //
 // theta reaches the densities directly rather than through inv_logit,
 // which would put a one-ULP unary divergence between this model and its

--- a/tests/fixtures/opalias.stan
+++ b/tests/fixtures/opalias.stan
@@ -1,0 +1,59 @@
+// The named-function spellings of Stan's binary operators -- add,
+// subtract, multiply, elt_multiply, divide, elt_divide -- and
+// squared_distance, which is not one of them but rides the same two
+// kernels.
+//
+// Every call appears twice: once on data in transformed data, where the
+// MIR interpreter answers, and once on parameters in the model block,
+// where the graph kernels do. The transformed-data results are summed
+// into the target rather than left in a declaration, because that is
+// what makes a disagreement between the two halves move lp. Teaching the
+// graph lowering and not the interpreter is how a vectorized
+// log_sum_exp once reported 2.6252 where the answer was 2.9302, with no
+// exception anywhere.
+data {
+  vector[2] dv;
+  row_vector[2] drv;
+  matrix[2, 2] dm;
+}
+transformed data {
+  real td_acc = sum(add(dv, 0.5)) + sum(add(dv, dv))
+                + sum(subtract(dv, 0.25)) + sum(subtract(0.75, dv))
+                + sum(multiply(dm, dv)) + multiply(drv, dv)
+                + sum(multiply(dv, drv)) + sum(multiply(dm, dm))
+                + sum(elt_multiply(dv, dv)) + sum(elt_multiply(2.0, dv))
+                + sum(divide(dv, 2.0)) + sum(divide(1.5, dm))
+                + sum(elt_divide(dv, dv)) + sum(elt_divide(1.0, dv))
+                + squared_distance(dv, drv) + squared_distance(dv[1], dv[2]);
+}
+parameters {
+  vector[2] p;
+  real q;
+}
+model {
+  target += td_acc;
+  // Elementwise, both broadcast directions, all four container shapes.
+  target += sum(add(p, q));
+  target += sum(add(p, dv));
+  target += sum(subtract(q, p));
+  target += sum(elt_multiply(p, p));
+  target += sum(elt_multiply(q, p));
+  target += sum(divide(p, q));
+  target += sum(elt_divide(q, p));
+  target += sum(divide(q, dm));
+  // multiply's linear algebra: matvec against a data matrix, inner
+  // product, outer product.
+  target += sum(multiply(dm, p));
+  target += multiply(p', p);
+  target += sum(multiply(p, p'));
+  // squared_distance pairs a vector with a row_vector in the language,
+  // which the elementwise view check would reject.
+  target += squared_distance(p, drv);
+  target += squared_distance(p', dv);
+  target += squared_distance(q, p[1]);
+  // A region whose control flow depends on a parameter compiles to the
+  // register program or not at all, so the aliases have to be there too.
+  if (q > -100.0) {
+    target += add(p[1], q) - divide(p[2], q);
+  }
+}

--- a/tests/fixtures/opalias.tmir.sexp
+++ b/tests/fixtures/opalias.tmir.sexp
@@ -1,0 +1,1378 @@
+((functions_block ())
+ (input_vars
+  ((dv <opaque>
+    (SVector AoS
+     ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+   (drv <opaque>
+    (SRowVector AoS
+     ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+   (dm <opaque>
+    (SMatrix AoS
+     ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+     ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+ (prepare_data
+  (((pattern
+     (Decl (decl_adtype DataOnly) (decl_id pos__) (decl_type (Sized SInt))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable pos__) ()) UInt
+      ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id dv)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id dv_flat__)
+          (decl_type (Unsized (UArray UReal))) (initialize Uninit)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable dv_flat__) ()) (UArray UReal)
+          ((pattern
+            (FunApp (CompilerInternal FnReadData)
+             (((pattern (Lit Str dv))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable pos__) ()) UInt
+          ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar sym1__)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Lit Int 2))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (Assignment
+                  ((LVariable dv)
+                   ((Single
+                     ((pattern (Var sym1__))
+                      (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                  UVector
+                  ((pattern
+                    (Indexed
+                     ((pattern (Var dv_flat__))
+                      (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))
+                     ((Single
+                       ((pattern (Var pos__))
+                        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+                (meta <opaque>))
+               ((pattern
+                 (Assignment ((LVariable pos__) ()) UInt
+                  ((pattern
+                    (FunApp (StanLib Plus__ FnPlain AoS)
+                     (((pattern (Var pos__))
+                       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                      ((pattern (Lit Int 1))
+                       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id drv)
+      (decl_type
+       (Sized
+        (SRowVector AoS
+         ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id drv_flat__)
+          (decl_type (Unsized (UArray UReal))) (initialize Uninit)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable drv_flat__) ()) (UArray UReal)
+          ((pattern
+            (FunApp (CompilerInternal FnReadData)
+             (((pattern (Lit Str drv))
+               (meta ((type_ URowVector) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable pos__) ()) UInt
+          ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar sym1__)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Lit Int 2))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (Assignment
+                  ((LVariable drv)
+                   ((Single
+                     ((pattern (Var sym1__))
+                      (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                  URowVector
+                  ((pattern
+                    (Indexed
+                     ((pattern (Var drv_flat__))
+                      (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))
+                     ((Single
+                       ((pattern (Var pos__))
+                        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+                (meta <opaque>))
+               ((pattern
+                 (Assignment ((LVariable pos__) ()) UInt
+                  ((pattern
+                    (FunApp (StanLib Plus__ FnPlain AoS)
+                     (((pattern (Var pos__))
+                       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                      ((pattern (Lit Int 1))
+                       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id dm)
+      (decl_type
+       (Sized
+        (SMatrix AoS
+         ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+         ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id dm_flat__)
+          (decl_type (Unsized (UArray UReal))) (initialize Uninit)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable dm_flat__) ()) (UArray UReal)
+          ((pattern
+            (FunApp (CompilerInternal FnReadData)
+             (((pattern (Lit Str dm))
+               (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable pos__) ()) UInt
+          ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar sym1__)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Lit Int 2))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (For (loopvar sym2__)
+                  (lower
+                   ((pattern (Lit Int 1))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (upper
+                   ((pattern (Lit Int 2))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (body
+                   ((pattern
+                     (Block
+                      (((pattern
+                         (Assignment
+                          ((LVariable dm)
+                           ((Single
+                             ((pattern (Var sym2__))
+                              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                            (Single
+                             ((pattern (Var sym1__))
+                              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                          UMatrix
+                          ((pattern
+                            (Indexed
+                             ((pattern (Var dm_flat__))
+                              (meta
+                               ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))
+                             ((Single
+                               ((pattern (Var pos__))
+                                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                           (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+                        (meta <opaque>))
+                       ((pattern
+                         (Assignment ((LVariable pos__) ()) UInt
+                          ((pattern
+                            (FunApp (StanLib Plus__ FnPlain AoS)
+                             (((pattern (Var pos__))
+                               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                              ((pattern (Lit Int 1))
+                               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                        (meta <opaque>)))))
+                    (meta <opaque>)))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id td_acc) (decl_type (Sized SReal))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable td_acc) ()) UReal
+      ((pattern
+        (FunApp (StanLib Plus__ FnPlain AoS)
+         (((pattern
+            (FunApp (StanLib Plus__ FnPlain AoS)
+             (((pattern
+                (FunApp (StanLib Plus__ FnPlain AoS)
+                 (((pattern
+                    (FunApp (StanLib Plus__ FnPlain AoS)
+                     (((pattern
+                        (FunApp (StanLib Plus__ FnPlain AoS)
+                         (((pattern
+                            (FunApp (StanLib Plus__ FnPlain AoS)
+                             (((pattern
+                                (FunApp (StanLib Plus__ FnPlain AoS)
+                                 (((pattern
+                                    (FunApp (StanLib Plus__ FnPlain AoS)
+                                     (((pattern
+                                        (FunApp (StanLib Plus__ FnPlain AoS)
+                                         (((pattern
+                                            (FunApp (StanLib Plus__ FnPlain AoS)
+                                             (((pattern
+                                                (FunApp (StanLib Plus__ FnPlain AoS)
+                                                 (((pattern
+                                                    (FunApp (StanLib Plus__ FnPlain AoS)
+                                                     (((pattern
+                                                        (FunApp
+                                                         (StanLib Plus__ FnPlain AoS)
+                                                         (((pattern
+                                                            (FunApp
+                                                             (StanLib Plus__ FnPlain AoS)
+                                                             (((pattern
+                                                                (FunApp
+                                                                 (StanLib Plus__ FnPlain
+                                                                  AoS)
+                                                                 (((pattern
+                                                                    (FunApp
+                                                                    (StanLib sum FnPlain
+                                                                    AoS)
+                                                                    (((pattern
+                                                                    (FunApp
+                                                                    (StanLib add FnPlain
+                                                                    AoS)
+                                                                    (((pattern (Var dv))
+                                                                    (meta
+                                                                    ((type_ UVector)
+                                                                    (loc <opaque>)
+                                                                    (adlevel DataOnly))))
+                                                                    ((pattern
+                                                                    (Lit Real 0.5))
+                                                                    (meta
+                                                                    ((type_ UReal)
+                                                                    (loc <opaque>)
+                                                                    (adlevel DataOnly)))))))
+                                                                    (meta
+                                                                    ((type_ UVector)
+                                                                    (loc <opaque>)
+                                                                    (adlevel DataOnly)))))))
+                                                                   (meta
+                                                                    ((type_ UReal)
+                                                                    (loc <opaque>)
+                                                                    (adlevel DataOnly))))
+                                                                  ((pattern
+                                                                    (FunApp
+                                                                    (StanLib sum FnPlain
+                                                                    AoS)
+                                                                    (((pattern
+                                                                    (FunApp
+                                                                    (StanLib add FnPlain
+                                                                    AoS)
+                                                                    (((pattern (Var dv))
+                                                                    (meta
+                                                                    ((type_ UVector)
+                                                                    (loc <opaque>)
+                                                                    (adlevel DataOnly))))
+                                                                    ((pattern (Var dv))
+                                                                    (meta
+                                                                    ((type_ UVector)
+                                                                    (loc <opaque>)
+                                                                    (adlevel DataOnly)))))))
+                                                                    (meta
+                                                                    ((type_ UVector)
+                                                                    (loc <opaque>)
+                                                                    (adlevel DataOnly)))))))
+                                                                   (meta
+                                                                    ((type_ UReal)
+                                                                    (loc <opaque>)
+                                                                    (adlevel DataOnly)))))))
+                                                               (meta
+                                                                ((type_ UReal)
+                                                                 (loc <opaque>)
+                                                                 (adlevel DataOnly))))
+                                                              ((pattern
+                                                                (FunApp
+                                                                 (StanLib sum FnPlain
+                                                                  AoS)
+                                                                 (((pattern
+                                                                    (FunApp
+                                                                    (StanLib subtract
+                                                                    FnPlain AoS)
+                                                                    (((pattern (Var dv))
+                                                                    (meta
+                                                                    ((type_ UVector)
+                                                                    (loc <opaque>)
+                                                                    (adlevel DataOnly))))
+                                                                    ((pattern
+                                                                    (Lit Real 0.25))
+                                                                    (meta
+                                                                    ((type_ UReal)
+                                                                    (loc <opaque>)
+                                                                    (adlevel DataOnly)))))))
+                                                                   (meta
+                                                                    ((type_ UVector)
+                                                                    (loc <opaque>)
+                                                                    (adlevel DataOnly)))))))
+                                                               (meta
+                                                                ((type_ UReal)
+                                                                 (loc <opaque>)
+                                                                 (adlevel DataOnly)))))))
+                                                           (meta
+                                                            ((type_ UReal) 
+                                                             (loc <opaque>)
+                                                             (adlevel DataOnly))))
+                                                          ((pattern
+                                                            (FunApp
+                                                             (StanLib sum FnPlain AoS)
+                                                             (((pattern
+                                                                (FunApp
+                                                                 (StanLib subtract
+                                                                  FnPlain AoS)
+                                                                 (((pattern
+                                                                    (Lit Real 0.75))
+                                                                   (meta
+                                                                    ((type_ UReal)
+                                                                    (loc <opaque>)
+                                                                    (adlevel DataOnly))))
+                                                                  ((pattern (Var dv))
+                                                                   (meta
+                                                                    ((type_ UVector)
+                                                                    (loc <opaque>)
+                                                                    (adlevel DataOnly)))))))
+                                                               (meta
+                                                                ((type_ UVector)
+                                                                 (loc <opaque>)
+                                                                 (adlevel DataOnly)))))))
+                                                           (meta
+                                                            ((type_ UReal) 
+                                                             (loc <opaque>)
+                                                             (adlevel DataOnly)))))))
+                                                       (meta
+                                                        ((type_ UReal) 
+                                                         (loc <opaque>)
+                                                         (adlevel DataOnly))))
+                                                      ((pattern
+                                                        (FunApp (StanLib sum FnPlain AoS)
+                                                         (((pattern
+                                                            (FunApp
+                                                             (StanLib multiply FnPlain
+                                                              AoS)
+                                                             (((pattern (Var dm))
+                                                               (meta
+                                                                ((type_ UMatrix)
+                                                                 (loc <opaque>)
+                                                                 (adlevel DataOnly))))
+                                                              ((pattern (Var dv))
+                                                               (meta
+                                                                ((type_ UVector)
+                                                                 (loc <opaque>)
+                                                                 (adlevel DataOnly)))))))
+                                                           (meta
+                                                            ((type_ UVector)
+                                                             (loc <opaque>)
+                                                             (adlevel DataOnly)))))))
+                                                       (meta
+                                                        ((type_ UReal) 
+                                                         (loc <opaque>)
+                                                         (adlevel DataOnly)))))))
+                                                   (meta
+                                                    ((type_ UReal) (loc <opaque>)
+                                                     (adlevel DataOnly))))
+                                                  ((pattern
+                                                    (FunApp
+                                                     (StanLib multiply FnPlain AoS)
+                                                     (((pattern (Var drv))
+                                                       (meta
+                                                        ((type_ URowVector)
+                                                         (loc <opaque>)
+                                                         (adlevel DataOnly))))
+                                                      ((pattern (Var dv))
+                                                       (meta
+                                                        ((type_ UVector) 
+                                                         (loc <opaque>)
+                                                         (adlevel DataOnly)))))))
+                                                   (meta
+                                                    ((type_ UReal) (loc <opaque>)
+                                                     (adlevel DataOnly)))))))
+                                               (meta
+                                                ((type_ UReal) (loc <opaque>)
+                                                 (adlevel DataOnly))))
+                                              ((pattern
+                                                (FunApp (StanLib sum FnPlain AoS)
+                                                 (((pattern
+                                                    (FunApp
+                                                     (StanLib multiply FnPlain AoS)
+                                                     (((pattern (Var dv))
+                                                       (meta
+                                                        ((type_ UVector) 
+                                                         (loc <opaque>)
+                                                         (adlevel DataOnly))))
+                                                      ((pattern (Var drv))
+                                                       (meta
+                                                        ((type_ URowVector)
+                                                         (loc <opaque>)
+                                                         (adlevel DataOnly)))))))
+                                                   (meta
+                                                    ((type_ UMatrix) 
+                                                     (loc <opaque>) (adlevel DataOnly)))))))
+                                               (meta
+                                                ((type_ UReal) (loc <opaque>)
+                                                 (adlevel DataOnly)))))))
+                                           (meta
+                                            ((type_ UReal) (loc <opaque>)
+                                             (adlevel DataOnly))))
+                                          ((pattern
+                                            (FunApp (StanLib sum FnPlain AoS)
+                                             (((pattern
+                                                (FunApp (StanLib multiply FnPlain AoS)
+                                                 (((pattern (Var dm))
+                                                   (meta
+                                                    ((type_ UMatrix) 
+                                                     (loc <opaque>) (adlevel DataOnly))))
+                                                  ((pattern (Var dm))
+                                                   (meta
+                                                    ((type_ UMatrix) 
+                                                     (loc <opaque>) (adlevel DataOnly)))))))
+                                               (meta
+                                                ((type_ UMatrix) (loc <opaque>)
+                                                 (adlevel DataOnly)))))))
+                                           (meta
+                                            ((type_ UReal) (loc <opaque>)
+                                             (adlevel DataOnly)))))))
+                                       (meta
+                                        ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+                                      ((pattern
+                                        (FunApp (StanLib sum FnPlain AoS)
+                                         (((pattern
+                                            (FunApp (StanLib elt_multiply FnPlain AoS)
+                                             (((pattern (Var dv))
+                                               (meta
+                                                ((type_ UVector) (loc <opaque>)
+                                                 (adlevel DataOnly))))
+                                              ((pattern (Var dv))
+                                               (meta
+                                                ((type_ UVector) (loc <opaque>)
+                                                 (adlevel DataOnly)))))))
+                                           (meta
+                                            ((type_ UVector) (loc <opaque>)
+                                             (adlevel DataOnly)))))))
+                                       (meta
+                                        ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+                                   (meta
+                                    ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+                                  ((pattern
+                                    (FunApp (StanLib sum FnPlain AoS)
+                                     (((pattern
+                                        (FunApp (StanLib elt_multiply FnPlain AoS)
+                                         (((pattern (Lit Real 2.0))
+                                           (meta
+                                            ((type_ UReal) (loc <opaque>)
+                                             (adlevel DataOnly))))
+                                          ((pattern (Var dv))
+                                           (meta
+                                            ((type_ UVector) (loc <opaque>)
+                                             (adlevel DataOnly)))))))
+                                       (meta
+                                        ((type_ UVector) (loc <opaque>)
+                                         (adlevel DataOnly)))))))
+                                   (meta
+                                    ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+                               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+                              ((pattern
+                                (FunApp (StanLib sum FnPlain AoS)
+                                 (((pattern
+                                    (FunApp (StanLib divide FnPlain AoS)
+                                     (((pattern (Var dv))
+                                       (meta
+                                        ((type_ UVector) (loc <opaque>)
+                                         (adlevel DataOnly))))
+                                      ((pattern (Lit Real 2.0))
+                                       (meta
+                                        ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+                                   (meta
+                                    ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+                               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+                           (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+                          ((pattern
+                            (FunApp (StanLib sum FnPlain AoS)
+                             (((pattern
+                                (FunApp (StanLib divide FnPlain AoS)
+                                 (((pattern (Lit Real 1.5))
+                                   (meta
+                                    ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+                                  ((pattern (Var dm))
+                                   (meta
+                                    ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly)))))))
+                               (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly)))))))
+                           (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+                       (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+                      ((pattern
+                        (FunApp (StanLib sum FnPlain AoS)
+                         (((pattern
+                            (FunApp (StanLib elt_divide FnPlain AoS)
+                             (((pattern (Var dv))
+                               (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly))))
+                              ((pattern (Var dv))
+                               (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+                           (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+                       (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+                  ((pattern
+                    (FunApp (StanLib sum FnPlain AoS)
+                     (((pattern
+                        (FunApp (StanLib elt_divide FnPlain AoS)
+                         (((pattern (Lit Real 1.0))
+                           (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+                          ((pattern (Var dv))
+                           (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+                       (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+              ((pattern
+                (FunApp (StanLib squared_distance FnPlain AoS)
+                 (((pattern (Var dv))
+                   (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly))))
+                  ((pattern (Var drv))
+                   (meta ((type_ URowVector) (loc <opaque>) (adlevel DataOnly)))))))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+          ((pattern
+            (FunApp (StanLib squared_distance FnPlain AoS)
+             (((pattern
+                (Indexed
+                 ((pattern (Var dv))
+                  (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly))))
+                 ((Single
+                   ((pattern (Lit Int 1))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+              ((pattern
+                (Indexed
+                 ((pattern (Var dv))
+                  (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly))))
+                 ((Single
+                   ((pattern (Lit Int 2))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))))
+ (log_prob
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id p)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity)
+             (dims
+              (((pattern (Lit Int 2))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id q) (decl_type (Sized SReal))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity) (dims ()) (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (TargetPE
+          ((pattern (Var td_acc))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib sum FnPlain AoS)
+             (((pattern
+                (FunApp (StanLib add FnPlain AoS)
+                 (((pattern (Var p))
+                   (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))
+                  ((pattern (Var q))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>))
+       ((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib sum FnPlain AoS)
+             (((pattern
+                (FunApp (StanLib add FnPlain AoS)
+                 (((pattern (Var p))
+                   (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))
+                  ((pattern (Var dv))
+                   (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>))
+       ((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib sum FnPlain AoS)
+             (((pattern
+                (FunApp (StanLib subtract FnPlain AoS)
+                 (((pattern (Var q))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+                  ((pattern (Var p))
+                   (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>))
+       ((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib sum FnPlain AoS)
+             (((pattern
+                (FunApp (StanLib elt_multiply FnPlain AoS)
+                 (((pattern (Var p))
+                   (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))
+                  ((pattern (Var p))
+                   (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>))
+       ((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib sum FnPlain AoS)
+             (((pattern
+                (FunApp (StanLib elt_multiply FnPlain AoS)
+                 (((pattern (Var q))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+                  ((pattern (Var p))
+                   (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>))
+       ((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib sum FnPlain AoS)
+             (((pattern
+                (FunApp (StanLib divide FnPlain AoS)
+                 (((pattern (Var p))
+                   (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))
+                  ((pattern (Var q))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>))
+       ((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib sum FnPlain AoS)
+             (((pattern
+                (FunApp (StanLib elt_divide FnPlain AoS)
+                 (((pattern (Var q))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+                  ((pattern (Var p))
+                   (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>))
+       ((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib sum FnPlain AoS)
+             (((pattern
+                (FunApp (StanLib divide FnPlain AoS)
+                 (((pattern (Var q))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+                  ((pattern (Var dm))
+                   (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly)))))))
+               (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>))
+       ((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib sum FnPlain AoS)
+             (((pattern
+                (FunApp (StanLib multiply FnPlain AoS)
+                 (((pattern (Var dm))
+                   (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly))))
+                  ((pattern (Var p))
+                   (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>))
+       ((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib multiply FnPlain AoS)
+             (((pattern
+                (FunApp (StanLib Transpose__ FnPlain AoS)
+                 (((pattern (Var p))
+                   (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+               (meta ((type_ URowVector) (loc <opaque>) (adlevel AutoDiffable))))
+              ((pattern (Var p))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>))
+       ((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib sum FnPlain AoS)
+             (((pattern
+                (FunApp (StanLib multiply FnPlain AoS)
+                 (((pattern (Var p))
+                   (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))
+                  ((pattern
+                    (FunApp (StanLib Transpose__ FnPlain AoS)
+                     (((pattern (Var p))
+                       (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+                   (meta ((type_ URowVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+               (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>))
+       ((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib squared_distance FnPlain AoS)
+             (((pattern (Var p))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))
+              ((pattern (Var drv))
+               (meta ((type_ URowVector) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>))
+       ((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib squared_distance FnPlain AoS)
+             (((pattern
+                (FunApp (StanLib Transpose__ FnPlain AoS)
+                 (((pattern (Var p))
+                   (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+               (meta ((type_ URowVector) (loc <opaque>) (adlevel AutoDiffable))))
+              ((pattern (Var dv))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>))
+       ((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib squared_distance FnPlain AoS)
+             (((pattern (Var q))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+              ((pattern
+                (Indexed
+                 ((pattern (Var p))
+                  (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))
+                 ((Single
+                   ((pattern (Lit Int 1))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>))
+       ((pattern
+         (IfElse
+          ((pattern
+            (FunApp (StanLib Greater__ FnPlain AoS)
+             (((pattern (Var q))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+              ((pattern (Lit Real -100.))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel AutoDiffable))))
+          ((pattern
+            (Block
+             (((pattern
+                (TargetPE
+                 ((pattern
+                   (FunApp (StanLib Minus__ FnPlain AoS)
+                    (((pattern
+                       (FunApp (StanLib add FnPlain AoS)
+                        (((pattern
+                           (Indexed
+                            ((pattern (Var p))
+                             (meta
+                              ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))
+                            ((Single
+                              ((pattern (Lit Int 1))
+                               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                          (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+                         ((pattern (Var q))
+                          (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
+                      (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+                     ((pattern
+                       (FunApp (StanLib divide FnPlain AoS)
+                        (((pattern
+                           (Indexed
+                            ((pattern (Var p))
+                             (meta
+                              ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))
+                            ((Single
+                              ((pattern (Lit Int 2))
+                               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                          (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+                         ((pattern (Var q))
+                          (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
+                      (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
+                  (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+               (meta <opaque>)))))
+           (meta <opaque>))
+          ()))
+        (meta <opaque>)))))
+    (meta <opaque>))))
+ (reverse_mode_log_prob
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id p)
+      (decl_type
+       (Sized
+        (SVector SoA
+         ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity)
+             (dims
+              (((pattern (Lit Int 2))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern SoA)))
+           ()))
+         (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id q) (decl_type (Sized SReal))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity) (dims ()) (mem_pattern SoA)))
+           ()))
+         (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (TargetPE
+          ((pattern (Var td_acc))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib sum FnPlain SoA)
+             (((pattern
+                (FunApp (StanLib add FnPlain SoA)
+                 (((pattern (Var p))
+                   (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))
+                  ((pattern (Var q))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>))
+       ((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib sum FnPlain SoA)
+             (((pattern
+                (FunApp (StanLib add FnPlain SoA)
+                 (((pattern (Var p))
+                   (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))
+                  ((pattern (Var dv))
+                   (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>))
+       ((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib sum FnPlain SoA)
+             (((pattern
+                (FunApp (StanLib subtract FnPlain SoA)
+                 (((pattern (Var q))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+                  ((pattern (Var p))
+                   (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>))
+       ((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib sum FnPlain SoA)
+             (((pattern
+                (FunApp (StanLib elt_multiply FnPlain SoA)
+                 (((pattern (Var p))
+                   (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))
+                  ((pattern (Var p))
+                   (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>))
+       ((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib sum FnPlain SoA)
+             (((pattern
+                (FunApp (StanLib elt_multiply FnPlain SoA)
+                 (((pattern (Var q))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+                  ((pattern (Var p))
+                   (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>))
+       ((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib sum FnPlain SoA)
+             (((pattern
+                (FunApp (StanLib divide FnPlain SoA)
+                 (((pattern (Var p))
+                   (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))
+                  ((pattern (Var q))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>))
+       ((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib sum FnPlain SoA)
+             (((pattern
+                (FunApp (StanLib elt_divide FnPlain SoA)
+                 (((pattern (Var q))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+                  ((pattern (Var p))
+                   (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>))
+       ((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib sum FnPlain SoA)
+             (((pattern
+                (FunApp (StanLib divide FnPlain SoA)
+                 (((pattern (Var q))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+                  ((pattern (Var dm))
+                   (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly)))))))
+               (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>))
+       ((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib sum FnPlain SoA)
+             (((pattern
+                (FunApp (StanLib multiply FnPlain SoA)
+                 (((pattern (Var dm))
+                   (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly))))
+                  ((pattern (Var p))
+                   (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>))
+       ((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib multiply FnPlain SoA)
+             (((pattern
+                (FunApp (StanLib Transpose__ FnPlain SoA)
+                 (((pattern (Var p))
+                   (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+               (meta ((type_ URowVector) (loc <opaque>) (adlevel AutoDiffable))))
+              ((pattern (Var p))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>))
+       ((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib sum FnPlain SoA)
+             (((pattern
+                (FunApp (StanLib multiply FnPlain SoA)
+                 (((pattern (Var p))
+                   (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))
+                  ((pattern
+                    (FunApp (StanLib Transpose__ FnPlain SoA)
+                     (((pattern (Var p))
+                       (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+                   (meta ((type_ URowVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+               (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>))
+       ((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib squared_distance FnPlain SoA)
+             (((pattern (Var p))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))
+              ((pattern (Var drv))
+               (meta ((type_ URowVector) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>))
+       ((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib squared_distance FnPlain SoA)
+             (((pattern
+                (FunApp (StanLib Transpose__ FnPlain SoA)
+                 (((pattern (Var p))
+                   (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+               (meta ((type_ URowVector) (loc <opaque>) (adlevel AutoDiffable))))
+              ((pattern (Var dv))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>))
+       ((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib squared_distance FnPlain SoA)
+             (((pattern (Var q))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+              ((pattern
+                (Indexed
+                 ((pattern (Var p))
+                  (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))
+                 ((Single
+                   ((pattern (Lit Int 1))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>))
+       ((pattern
+         (IfElse
+          ((pattern
+            (FunApp (StanLib Greater__ FnPlain SoA)
+             (((pattern (Var q))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+              ((pattern (Lit Real -100.))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel AutoDiffable))))
+          ((pattern
+            (Block
+             (((pattern
+                (TargetPE
+                 ((pattern
+                   (FunApp (StanLib Minus__ FnPlain SoA)
+                    (((pattern
+                       (FunApp (StanLib add FnPlain SoA)
+                        (((pattern
+                           (Indexed
+                            ((pattern (Var p))
+                             (meta
+                              ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))
+                            ((Single
+                              ((pattern (Lit Int 1))
+                               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                          (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+                         ((pattern (Var q))
+                          (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
+                      (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+                     ((pattern
+                       (FunApp (StanLib divide FnPlain SoA)
+                        (((pattern
+                           (Indexed
+                            ((pattern (Var p))
+                             (meta
+                              ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))
+                            ((Single
+                              ((pattern (Lit Int 2))
+                               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                          (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+                         ((pattern (Var q))
+                          (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
+                      (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
+                  (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+               (meta <opaque>)))))
+           (meta <opaque>))
+          ()))
+        (meta <opaque>)))))
+    (meta <opaque>))))
+ (generate_quantities
+  (((pattern
+     (Decl (decl_adtype DataOnly) (decl_id p)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity)
+             (dims
+              (((pattern (Lit Int 2))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id q) (decl_type (Sized SReal))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity) (dims ()) (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt ())
+        (var
+         ((pattern (Var p)) (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt ())
+        (var
+         ((pattern (Var q)) (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (IfElse
+      ((pattern
+        (FunApp (StanLib PNot__ FnPlain AoS)
+         (((pattern
+            (EOr
+             ((pattern (Var emit_transformed_parameters__))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+             ((pattern (Var emit_generated_quantities__))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+      ((pattern (Block (((pattern (Return ())) (meta <opaque>))))) (meta <opaque>)) ()))
+    (meta <opaque>))
+   ((pattern
+     (IfElse
+      ((pattern
+        (FunApp (StanLib PNot__ FnPlain AoS)
+         (((pattern (Var emit_generated_quantities__))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+      ((pattern (Block (((pattern (Return ())) (meta <opaque>))))) (meta <opaque>)) ()))
+    (meta <opaque>))))
+ (transform_inits
+  (((pattern
+     (Decl (decl_adtype DataOnly) (decl_id pos__) (decl_type (Sized SInt))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable pos__) ()) UInt
+      ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id p)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id p_flat__)
+          (decl_type (Unsized (UArray UReal))) (initialize Uninit)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable p_flat__) ()) (UArray UReal)
+          ((pattern
+            (FunApp (CompilerInternal FnReadData)
+             (((pattern (Lit Str p))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable pos__) ()) UInt
+          ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar sym1__)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Lit Int 2))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (Assignment
+                  ((LVariable p)
+                   ((Single
+                     ((pattern (Var sym1__))
+                      (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                  UVector
+                  ((pattern
+                    (Indexed
+                     ((pattern (Var p_flat__))
+                      (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))
+                     ((Single
+                       ((pattern (Var pos__))
+                        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+                (meta <opaque>))
+               ((pattern
+                 (Assignment ((LVariable pos__) ()) UInt
+                  ((pattern
+                    (FunApp (StanLib Plus__ FnPlain AoS)
+                     (((pattern (Var pos__))
+                       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                      ((pattern (Lit Int 1))
+                       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var p)) (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id q) (decl_type (Sized SReal))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable q) ()) UReal
+      ((pattern
+        (Indexed
+         ((pattern
+           (FunApp (CompilerInternal FnReadData)
+            (((pattern (Lit Str q))
+              (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+          (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))
+         ((Single
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+       (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var q)) (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))))
+ (unconstrain_array
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id p)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable p) ()) UVector
+      ((pattern
+        (FunApp (CompilerInternal FnReadDeserializer)
+         (((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var p)) (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id q) (decl_type (Sized SReal))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable q) ()) UReal
+      ((pattern (FunApp (CompilerInternal FnReadDeserializer) ()))
+       (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var q)) (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))))
+ (output_vars
+  ((p <opaque>
+    ((out_unconstrained_st
+      (SVector AoS
+       ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+     (out_constrained_st
+      (SVector AoS
+       ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+     (out_block Parameters) (out_trans Identity)))
+   (q <opaque>
+    ((out_unconstrained_st SReal) (out_constrained_st SReal) (out_block Parameters)
+     (out_trans Identity)))))
+ (prog_name opalias_model) (prog_path tests/fixtures/opalias.stan))

--- a/tests/fixtures/tcdf.stan
+++ b/tests/fixtures/tcdf.stan
@@ -1,0 +1,48 @@
+// The five distribution functions the recorder cannot evaluate at all.
+// von_mises's three write `res *= 0.0` and compare `x_n == -pi` on the
+// scalar type, and neg_binomial_2's lcdf and lccdf form
+// `phi / (phi + mu)`; none of that goes through stan-math's partials
+// propagator, and `rvar` has no operators, so listing them beside the
+// generated cdfs is a compile error rather than a wrong answer. They get
+// the nested var tape instead, in matrix_fns.cpp.
+//
+// Both the vectorized and the scalar form of every one, because the
+// kernel binds a length-1 slot as a scalar rather than a one-element
+// vector: stan-math's sequence views broadcast a scalar but require a
+// vector to match the other arguments' size, so getting that wrong is
+// every lane evaluated with element 0's parameters rather than an error.
+//
+// No parameter feeds two of these calls. Each density evaluates on its
+// own nested tape and adds its adjoints into the slot, so a shared
+// parameter would be summed op by op here and in one reverse sweep in
+// the var reference -- a reassociation of a few ULP that would cost the
+// test its bitwise comparison for nothing.
+data {
+  int n;
+  array[3] int ns;
+}
+parameters {
+  vector[3] y1;
+  vector[3] k1;
+  vector[3] y2;
+  vector[3] k2;
+  real y3;
+  real k3;
+  vector[3] m4;
+  vector[3] p4;
+  real m5;
+  vector[3] m6;
+}
+model {
+  target += von_mises_cdf(y1 | 0.1, exp(k1));
+  target += von_mises_lcdf(y2 | [0.1, 0.2, 0.3]', exp(k2));
+  target += von_mises_lccdf(y3 | 0.1, exp(k3));
+  target += neg_binomial_2_lcdf(ns | exp(m4), exp(p4));
+  target += neg_binomial_2_lccdf(n | exp(m5), 2.0);
+  // A language-level scalar outcome against vectorized reals:
+  // the lowering replicates it to the lane count, because the
+  // kernel maps the whole integer group as one vector and a
+  // size-1 container loses to a longer argument on
+  // check_consistent_sizes.
+  target += neg_binomial_2_lccdf(n | exp(m6), 2.0);
+}

--- a/tests/fixtures/tcdf.tmir.sexp
+++ b/tests/fixtures/tcdf.tmir.sexp
@@ -1,0 +1,1734 @@
+((functions_block ())
+ (input_vars
+  ((n <opaque> SInt)
+   (ns <opaque>
+    (SArray SInt
+     ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+ (prepare_data
+  (((pattern
+     (Decl (decl_adtype DataOnly) (decl_id n) (decl_type (Sized SInt))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable n) ()) UInt
+      ((pattern
+        (Indexed
+         ((pattern
+           (FunApp (CompilerInternal FnReadData)
+            (((pattern (Lit Str n))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+          (meta ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly))))
+         ((Single
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id ns)
+      (decl_type
+       (Sized
+        (SArray SInt
+         ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable ns) ()) (UArray UInt)
+      ((pattern
+        (FunApp (CompilerInternal FnReadData)
+         (((pattern (Lit Str ns))
+           (meta ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))))
+ (log_prob
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id y1)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity)
+             (dims
+              (((pattern (Lit Int 3))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id k1)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity)
+             (dims
+              (((pattern (Lit Int 3))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id y2)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity)
+             (dims
+              (((pattern (Lit Int 3))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id k2)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity)
+             (dims
+              (((pattern (Lit Int 3))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id y3) (decl_type (Sized SReal))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity) (dims ()) (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id k3) (decl_type (Sized SReal))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity) (dims ()) (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id m4)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity)
+             (dims
+              (((pattern (Lit Int 3))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id p4)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity)
+             (dims
+              (((pattern (Lit Int 3))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id m5) (decl_type (Sized SReal))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity) (dims ()) (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id m6)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity)
+             (dims
+              (((pattern (Lit Int 3))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib von_mises_cdf FnPlain AoS)
+             (((pattern (Var y1))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))
+              ((pattern (Lit Real 0.1))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+              ((pattern
+                (FunApp (StanLib exp FnPlain AoS)
+                 (((pattern (Var k1))
+                   (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>))
+       ((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib von_mises_lcdf FnPlain AoS)
+             (((pattern (Var y2))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))
+              ((pattern
+                (FunApp (StanLib Transpose__ FnPlain AoS)
+                 (((pattern
+                    (FunApp (CompilerInternal FnMakeRowVec)
+                     (((pattern (Lit Real 0.1))
+                       (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+                      ((pattern (Lit Real 0.2))
+                       (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+                      ((pattern (Lit Real 0.3))
+                       (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+                   (meta ((type_ URowVector) (loc <opaque>) (adlevel DataOnly)))))))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly))))
+              ((pattern
+                (FunApp (StanLib exp FnPlain AoS)
+                 (((pattern (Var k2))
+                   (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>))
+       ((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib von_mises_lccdf FnPlain AoS)
+             (((pattern (Var y3))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+              ((pattern (Lit Real 0.1))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+              ((pattern
+                (FunApp (StanLib exp FnPlain AoS)
+                 (((pattern (Var k3))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>))
+       ((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib neg_binomial_2_lcdf FnPlain AoS)
+             (((pattern (Var ns))
+               (meta ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly))))
+              ((pattern
+                (FunApp (StanLib exp FnPlain AoS)
+                 (((pattern (Var m4))
+                   (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))
+              ((pattern
+                (FunApp (StanLib exp FnPlain AoS)
+                 (((pattern (Var p4))
+                   (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>))
+       ((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib neg_binomial_2_lccdf FnPlain AoS)
+             (((pattern (Var n)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+              ((pattern
+                (FunApp (StanLib exp FnPlain AoS)
+                 (((pattern (Var m5))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+              ((pattern (Lit Real 2.0))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>))
+       ((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib neg_binomial_2_lccdf FnPlain AoS)
+             (((pattern (Var n)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+              ((pattern
+                (FunApp (StanLib exp FnPlain AoS)
+                 (((pattern (Var m6))
+                   (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))
+              ((pattern (Lit Real 2.0))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>)))))
+    (meta <opaque>))))
+ (reverse_mode_log_prob
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id y1)
+      (decl_type
+       (Sized
+        (SVector SoA
+         ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity)
+             (dims
+              (((pattern (Lit Int 3))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern SoA)))
+           ()))
+         (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id k1)
+      (decl_type
+       (Sized
+        (SVector SoA
+         ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity)
+             (dims
+              (((pattern (Lit Int 3))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern SoA)))
+           ()))
+         (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id y2)
+      (decl_type
+       (Sized
+        (SVector SoA
+         ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity)
+             (dims
+              (((pattern (Lit Int 3))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern SoA)))
+           ()))
+         (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id k2)
+      (decl_type
+       (Sized
+        (SVector SoA
+         ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity)
+             (dims
+              (((pattern (Lit Int 3))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern SoA)))
+           ()))
+         (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id y3) (decl_type (Sized SReal))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity) (dims ()) (mem_pattern SoA)))
+           ()))
+         (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id k3) (decl_type (Sized SReal))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity) (dims ()) (mem_pattern SoA)))
+           ()))
+         (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id m4)
+      (decl_type
+       (Sized
+        (SVector SoA
+         ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity)
+             (dims
+              (((pattern (Lit Int 3))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern SoA)))
+           ()))
+         (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id p4)
+      (decl_type
+       (Sized
+        (SVector SoA
+         ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity)
+             (dims
+              (((pattern (Lit Int 3))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern SoA)))
+           ()))
+         (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id m5) (decl_type (Sized SReal))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity) (dims ()) (mem_pattern SoA)))
+           ()))
+         (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id m6)
+      (decl_type
+       (Sized
+        (SVector SoA
+         ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity)
+             (dims
+              (((pattern (Lit Int 3))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern SoA)))
+           ()))
+         (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib von_mises_cdf FnPlain SoA)
+             (((pattern (Var y1))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))
+              ((pattern (Lit Real 0.1))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+              ((pattern
+                (FunApp (StanLib exp FnPlain SoA)
+                 (((pattern (Var k1))
+                   (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>))
+       ((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib von_mises_lcdf FnPlain SoA)
+             (((pattern (Var y2))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))
+              ((pattern
+                (FunApp (StanLib Transpose__ FnPlain SoA)
+                 (((pattern
+                    (FunApp (CompilerInternal FnMakeRowVec)
+                     (((pattern (Lit Real 0.1))
+                       (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+                      ((pattern (Lit Real 0.2))
+                       (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+                      ((pattern (Lit Real 0.3))
+                       (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+                   (meta ((type_ URowVector) (loc <opaque>) (adlevel DataOnly)))))))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly))))
+              ((pattern
+                (FunApp (StanLib exp FnPlain SoA)
+                 (((pattern (Var k2))
+                   (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>))
+       ((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib von_mises_lccdf FnPlain SoA)
+             (((pattern (Var y3))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+              ((pattern (Lit Real 0.1))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+              ((pattern
+                (FunApp (StanLib exp FnPlain SoA)
+                 (((pattern (Var k3))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>))
+       ((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib neg_binomial_2_lcdf FnPlain SoA)
+             (((pattern (Var ns))
+               (meta ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly))))
+              ((pattern
+                (FunApp (StanLib exp FnPlain SoA)
+                 (((pattern (Var m4))
+                   (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))
+              ((pattern
+                (FunApp (StanLib exp FnPlain SoA)
+                 (((pattern (Var p4))
+                   (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>))
+       ((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib neg_binomial_2_lccdf FnPlain SoA)
+             (((pattern (Var n)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+              ((pattern
+                (FunApp (StanLib exp FnPlain SoA)
+                 (((pattern (Var m5))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+              ((pattern (Lit Real 2.0))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>))
+       ((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib neg_binomial_2_lccdf FnPlain SoA)
+             (((pattern (Var n)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+              ((pattern
+                (FunApp (StanLib exp FnPlain SoA)
+                 (((pattern (Var m6))
+                   (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))
+              ((pattern (Lit Real 2.0))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>)))))
+    (meta <opaque>))))
+ (generate_quantities
+  (((pattern
+     (Decl (decl_adtype DataOnly) (decl_id y1)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity)
+             (dims
+              (((pattern (Lit Int 3))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id k1)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity)
+             (dims
+              (((pattern (Lit Int 3))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id y2)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity)
+             (dims
+              (((pattern (Lit Int 3))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id k2)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity)
+             (dims
+              (((pattern (Lit Int 3))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id y3) (decl_type (Sized SReal))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity) (dims ()) (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id k3) (decl_type (Sized SReal))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity) (dims ()) (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id m4)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity)
+             (dims
+              (((pattern (Lit Int 3))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id p4)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity)
+             (dims
+              (((pattern (Lit Int 3))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id m5) (decl_type (Sized SReal))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity) (dims ()) (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id m6)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity)
+             (dims
+              (((pattern (Lit Int 3))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt ())
+        (var
+         ((pattern (Var y1)) (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt ())
+        (var
+         ((pattern (Var k1)) (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt ())
+        (var
+         ((pattern (Var y2)) (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt ())
+        (var
+         ((pattern (Var k2)) (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt ())
+        (var
+         ((pattern (Var y3)) (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt ())
+        (var
+         ((pattern (Var k3)) (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt ())
+        (var
+         ((pattern (Var m4)) (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt ())
+        (var
+         ((pattern (Var p4)) (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt ())
+        (var
+         ((pattern (Var m5)) (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt ())
+        (var
+         ((pattern (Var m6)) (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (IfElse
+      ((pattern
+        (FunApp (StanLib PNot__ FnPlain AoS)
+         (((pattern
+            (EOr
+             ((pattern (Var emit_transformed_parameters__))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+             ((pattern (Var emit_generated_quantities__))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+      ((pattern (Block (((pattern (Return ())) (meta <opaque>))))) (meta <opaque>)) ()))
+    (meta <opaque>))
+   ((pattern
+     (IfElse
+      ((pattern
+        (FunApp (StanLib PNot__ FnPlain AoS)
+         (((pattern (Var emit_generated_quantities__))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+      ((pattern (Block (((pattern (Return ())) (meta <opaque>))))) (meta <opaque>)) ()))
+    (meta <opaque>))))
+ (transform_inits
+  (((pattern
+     (Decl (decl_adtype DataOnly) (decl_id pos__) (decl_type (Sized SInt))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id y1)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id y1_flat__)
+          (decl_type (Unsized (UArray UReal))) (initialize Uninit)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable y1_flat__) ()) (UArray UReal)
+          ((pattern
+            (FunApp (CompilerInternal FnReadData)
+             (((pattern (Lit Str y1))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable pos__) ()) UInt
+          ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar sym1__)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Lit Int 3))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (Assignment
+                  ((LVariable y1)
+                   ((Single
+                     ((pattern (Var sym1__))
+                      (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                  UVector
+                  ((pattern
+                    (Indexed
+                     ((pattern (Var y1_flat__))
+                      (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))
+                     ((Single
+                       ((pattern (Var pos__))
+                        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+                (meta <opaque>))
+               ((pattern
+                 (Assignment ((LVariable pos__) ()) UInt
+                  ((pattern
+                    (FunApp (StanLib Plus__ FnPlain AoS)
+                     (((pattern (Var pos__))
+                       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                      ((pattern (Lit Int 1))
+                       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var y1)) (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id k1)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id k1_flat__)
+          (decl_type (Unsized (UArray UReal))) (initialize Uninit)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable k1_flat__) ()) (UArray UReal)
+          ((pattern
+            (FunApp (CompilerInternal FnReadData)
+             (((pattern (Lit Str k1))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable pos__) ()) UInt
+          ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar sym1__)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Lit Int 3))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (Assignment
+                  ((LVariable k1)
+                   ((Single
+                     ((pattern (Var sym1__))
+                      (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                  UVector
+                  ((pattern
+                    (Indexed
+                     ((pattern (Var k1_flat__))
+                      (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))
+                     ((Single
+                       ((pattern (Var pos__))
+                        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+                (meta <opaque>))
+               ((pattern
+                 (Assignment ((LVariable pos__) ()) UInt
+                  ((pattern
+                    (FunApp (StanLib Plus__ FnPlain AoS)
+                     (((pattern (Var pos__))
+                       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                      ((pattern (Lit Int 1))
+                       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var k1)) (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id y2)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id y2_flat__)
+          (decl_type (Unsized (UArray UReal))) (initialize Uninit)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable y2_flat__) ()) (UArray UReal)
+          ((pattern
+            (FunApp (CompilerInternal FnReadData)
+             (((pattern (Lit Str y2))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable pos__) ()) UInt
+          ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar sym1__)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Lit Int 3))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (Assignment
+                  ((LVariable y2)
+                   ((Single
+                     ((pattern (Var sym1__))
+                      (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                  UVector
+                  ((pattern
+                    (Indexed
+                     ((pattern (Var y2_flat__))
+                      (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))
+                     ((Single
+                       ((pattern (Var pos__))
+                        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+                (meta <opaque>))
+               ((pattern
+                 (Assignment ((LVariable pos__) ()) UInt
+                  ((pattern
+                    (FunApp (StanLib Plus__ FnPlain AoS)
+                     (((pattern (Var pos__))
+                       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                      ((pattern (Lit Int 1))
+                       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var y2)) (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id k2)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id k2_flat__)
+          (decl_type (Unsized (UArray UReal))) (initialize Uninit)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable k2_flat__) ()) (UArray UReal)
+          ((pattern
+            (FunApp (CompilerInternal FnReadData)
+             (((pattern (Lit Str k2))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable pos__) ()) UInt
+          ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar sym1__)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Lit Int 3))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (Assignment
+                  ((LVariable k2)
+                   ((Single
+                     ((pattern (Var sym1__))
+                      (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                  UVector
+                  ((pattern
+                    (Indexed
+                     ((pattern (Var k2_flat__))
+                      (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))
+                     ((Single
+                       ((pattern (Var pos__))
+                        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+                (meta <opaque>))
+               ((pattern
+                 (Assignment ((LVariable pos__) ()) UInt
+                  ((pattern
+                    (FunApp (StanLib Plus__ FnPlain AoS)
+                     (((pattern (Var pos__))
+                       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                      ((pattern (Lit Int 1))
+                       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var k2)) (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id y3) (decl_type (Sized SReal))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable y3) ()) UReal
+      ((pattern
+        (Indexed
+         ((pattern
+           (FunApp (CompilerInternal FnReadData)
+            (((pattern (Lit Str y3))
+              (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+          (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))
+         ((Single
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+       (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var y3)) (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id k3) (decl_type (Sized SReal))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable k3) ()) UReal
+      ((pattern
+        (Indexed
+         ((pattern
+           (FunApp (CompilerInternal FnReadData)
+            (((pattern (Lit Str k3))
+              (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+          (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))
+         ((Single
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+       (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var k3)) (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id m4)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id m4_flat__)
+          (decl_type (Unsized (UArray UReal))) (initialize Uninit)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable m4_flat__) ()) (UArray UReal)
+          ((pattern
+            (FunApp (CompilerInternal FnReadData)
+             (((pattern (Lit Str m4))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable pos__) ()) UInt
+          ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar sym1__)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Lit Int 3))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (Assignment
+                  ((LVariable m4)
+                   ((Single
+                     ((pattern (Var sym1__))
+                      (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                  UVector
+                  ((pattern
+                    (Indexed
+                     ((pattern (Var m4_flat__))
+                      (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))
+                     ((Single
+                       ((pattern (Var pos__))
+                        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+                (meta <opaque>))
+               ((pattern
+                 (Assignment ((LVariable pos__) ()) UInt
+                  ((pattern
+                    (FunApp (StanLib Plus__ FnPlain AoS)
+                     (((pattern (Var pos__))
+                       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                      ((pattern (Lit Int 1))
+                       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var m4)) (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id p4)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id p4_flat__)
+          (decl_type (Unsized (UArray UReal))) (initialize Uninit)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable p4_flat__) ()) (UArray UReal)
+          ((pattern
+            (FunApp (CompilerInternal FnReadData)
+             (((pattern (Lit Str p4))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable pos__) ()) UInt
+          ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar sym1__)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Lit Int 3))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (Assignment
+                  ((LVariable p4)
+                   ((Single
+                     ((pattern (Var sym1__))
+                      (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                  UVector
+                  ((pattern
+                    (Indexed
+                     ((pattern (Var p4_flat__))
+                      (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))
+                     ((Single
+                       ((pattern (Var pos__))
+                        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+                (meta <opaque>))
+               ((pattern
+                 (Assignment ((LVariable pos__) ()) UInt
+                  ((pattern
+                    (FunApp (StanLib Plus__ FnPlain AoS)
+                     (((pattern (Var pos__))
+                       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                      ((pattern (Lit Int 1))
+                       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var p4)) (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id m5) (decl_type (Sized SReal))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable m5) ()) UReal
+      ((pattern
+        (Indexed
+         ((pattern
+           (FunApp (CompilerInternal FnReadData)
+            (((pattern (Lit Str m5))
+              (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+          (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))
+         ((Single
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+       (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var m5)) (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id m6)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id m6_flat__)
+          (decl_type (Unsized (UArray UReal))) (initialize Uninit)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable m6_flat__) ()) (UArray UReal)
+          ((pattern
+            (FunApp (CompilerInternal FnReadData)
+             (((pattern (Lit Str m6))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable pos__) ()) UInt
+          ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar sym1__)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Lit Int 3))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (Assignment
+                  ((LVariable m6)
+                   ((Single
+                     ((pattern (Var sym1__))
+                      (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                  UVector
+                  ((pattern
+                    (Indexed
+                     ((pattern (Var m6_flat__))
+                      (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))
+                     ((Single
+                       ((pattern (Var pos__))
+                        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+                (meta <opaque>))
+               ((pattern
+                 (Assignment ((LVariable pos__) ()) UInt
+                  ((pattern
+                    (FunApp (StanLib Plus__ FnPlain AoS)
+                     (((pattern (Var pos__))
+                       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                      ((pattern (Lit Int 1))
+                       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var m6)) (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))))
+ (unconstrain_array
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id y1)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable y1) ()) UVector
+      ((pattern
+        (FunApp (CompilerInternal FnReadDeserializer)
+         (((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var y1)) (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id k1)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable k1) ()) UVector
+      ((pattern
+        (FunApp (CompilerInternal FnReadDeserializer)
+         (((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var k1)) (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id y2)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable y2) ()) UVector
+      ((pattern
+        (FunApp (CompilerInternal FnReadDeserializer)
+         (((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var y2)) (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id k2)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable k2) ()) UVector
+      ((pattern
+        (FunApp (CompilerInternal FnReadDeserializer)
+         (((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var k2)) (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id y3) (decl_type (Sized SReal))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable y3) ()) UReal
+      ((pattern (FunApp (CompilerInternal FnReadDeserializer) ()))
+       (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var y3)) (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id k3) (decl_type (Sized SReal))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable k3) ()) UReal
+      ((pattern (FunApp (CompilerInternal FnReadDeserializer) ()))
+       (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var k3)) (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id m4)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable m4) ()) UVector
+      ((pattern
+        (FunApp (CompilerInternal FnReadDeserializer)
+         (((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var m4)) (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id p4)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable p4) ()) UVector
+      ((pattern
+        (FunApp (CompilerInternal FnReadDeserializer)
+         (((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var p4)) (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id m5) (decl_type (Sized SReal))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable m5) ()) UReal
+      ((pattern (FunApp (CompilerInternal FnReadDeserializer) ()))
+       (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var m5)) (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id m6)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable m6) ()) UVector
+      ((pattern
+        (FunApp (CompilerInternal FnReadDeserializer)
+         (((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var m6)) (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))))
+ (output_vars
+  ((y1 <opaque>
+    ((out_unconstrained_st
+      (SVector AoS
+       ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+     (out_constrained_st
+      (SVector AoS
+       ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+     (out_block Parameters) (out_trans Identity)))
+   (k1 <opaque>
+    ((out_unconstrained_st
+      (SVector AoS
+       ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+     (out_constrained_st
+      (SVector AoS
+       ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+     (out_block Parameters) (out_trans Identity)))
+   (y2 <opaque>
+    ((out_unconstrained_st
+      (SVector AoS
+       ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+     (out_constrained_st
+      (SVector AoS
+       ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+     (out_block Parameters) (out_trans Identity)))
+   (k2 <opaque>
+    ((out_unconstrained_st
+      (SVector AoS
+       ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+     (out_constrained_st
+      (SVector AoS
+       ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+     (out_block Parameters) (out_trans Identity)))
+   (y3 <opaque>
+    ((out_unconstrained_st SReal) (out_constrained_st SReal) (out_block Parameters)
+     (out_trans Identity)))
+   (k3 <opaque>
+    ((out_unconstrained_st SReal) (out_constrained_st SReal) (out_block Parameters)
+     (out_trans Identity)))
+   (m4 <opaque>
+    ((out_unconstrained_st
+      (SVector AoS
+       ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+     (out_constrained_st
+      (SVector AoS
+       ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+     (out_block Parameters) (out_trans Identity)))
+   (p4 <opaque>
+    ((out_unconstrained_st
+      (SVector AoS
+       ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+     (out_constrained_st
+      (SVector AoS
+       ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+     (out_block Parameters) (out_trans Identity)))
+   (m5 <opaque>
+    ((out_unconstrained_st SReal) (out_constrained_st SReal) (out_block Parameters)
+     (out_trans Identity)))
+   (m6 <opaque>
+    ((out_unconstrained_st
+      (SVector AoS
+       ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+     (out_constrained_st
+      (SVector AoS
+       ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+     (out_block Parameters) (out_trans Identity)))))
+ (prog_name tcdf_model) (prog_path tests/fixtures/tcdf.stan))

--- a/tests/test_densities.cpp
+++ b/tests/test_densities.cpp
@@ -746,6 +746,168 @@ int main() {
     }
   }
 
+  // The var-tape cdfs: von_mises_{cdf,lcdf,lccdf} and
+  // neg_binomial_2_{lcdf,lccdf}. The recorder cannot evaluate these at all
+  // -- they do arithmetic on the autodiff scalar rather than going through
+  // stan-math's partials propagator -- so the kernel binds every argument
+  // as var on a nested tape (matrix_fns.cpp). The reference below binds
+  // every argument as var too, so this is same-activity and bitwise: no
+  // tolerance, and no evaluation-order divergence to bound.
+  {
+    using stan::math::var;
+    using VecV = Eigen::Matrix<var, -1, 1>;
+    auto vec = [](const std::vector<double>& v) {
+      VecV x((Eigen::Index)v.size());
+      for (size_t i = 0; i < v.size(); ++i) x((Eigen::Index)i) = v[i];
+      return x;
+    };
+    auto ivec = [](std::vector<int> v) {
+      Eigen::VectorXi x((Eigen::Index)v.size());
+      for (size_t i = 0; i < v.size(); ++i) x((Eigen::Index)i) = v[i];
+      return x;
+    };
+    const std::vector<double> vy{0.30, -0.50}, vmu{0.10, 0.20}, vk{1.50, 2.50};
+    // Every argument a vector, then a length-1 slot beside them: that slot
+    // has to reach stan-math as a scalar, because its sequence views
+    // broadcast a scalar but require a vector to match the others' size.
+    struct VonMises {
+      uint16_t opcode;
+      const char* tag;
+      std::function<var(const VecV&, const VecV&, const VecV&)> vvv;
+      std::function<var(const VecV&, const var&, const var&)> vss;
+      std::function<var(const var&, const var&, const var&)> sss;
+    };
+    const VonMises kVm[3] = {{OP_VON_MISES_CDF, "von_mises_cdf",
+                              [](const VecV& y, const VecV& m, const VecV& k) {
+                                return stan::math::von_mises_cdf(y, m, k);
+                              },
+                              [](const VecV& y, const var& m, const var& k) {
+                                return stan::math::von_mises_cdf(y, m, k);
+                              },
+                              [](const var& y, const var& m, const var& k) {
+                                return stan::math::von_mises_cdf(y, m, k);
+                              }},
+                             {OP_VON_MISES_LCDF, "von_mises_lcdf",
+                              [](const VecV& y, const VecV& m, const VecV& k) {
+                                return stan::math::von_mises_lcdf(y, m, k);
+                              },
+                              [](const VecV& y, const var& m, const var& k) {
+                                return stan::math::von_mises_lcdf(y, m, k);
+                              },
+                              [](const var& y, const var& m, const var& k) {
+                                return stan::math::von_mises_lcdf(y, m, k);
+                              }},
+                             {OP_VON_MISES_LCCDF, "von_mises_lccdf",
+                              [](const VecV& y, const VecV& m, const VecV& k) {
+                                return stan::math::von_mises_lccdf(y, m, k);
+                              },
+                              [](const VecV& y, const var& m, const var& k) {
+                                return stan::math::von_mises_lccdf(y, m, k);
+                              },
+                              [](const var& y, const var& m, const var& k) {
+                                return stan::math::von_mises_lccdf(y, m, k);
+                              }}};
+    for (const VonMises& c : kVm) {
+      {
+        auto r = stanli::testutil::run_one_op(c.opcode, {vy, vmu, vk},
+                                              {true, true, true});
+        VecV y = vec(vy), m = vec(vmu), k = vec(vk);
+        var lp = c.vvv(y, m, k);
+        lp.grad();
+        expect_eq(std::string(c.tag) + " vvv value", r.value, lp.val());
+        for (int i = 0; i < 2; ++i) {
+          expect_eq(std::string(c.tag) + " vvv dy" + std::to_string(i),
+                    r.grad[(size_t)i], y(i).adj());
+          expect_eq(std::string(c.tag) + " vvv dmu" + std::to_string(i),
+                    r.grad[(size_t)(2 + i)], m(i).adj());
+          expect_eq(std::string(c.tag) + " vvv dk" + std::to_string(i),
+                    r.grad[(size_t)(4 + i)], k(i).adj());
+        }
+        stan::math::recover_memory();
+      }
+      {
+        auto r = stanli::testutil::run_one_op(c.opcode, {vy, {vmu[0]}, {vk[0]}},
+                                              {true, true, true});
+        VecV y = vec(vy);
+        var m = vmu[0], k = vk[0];
+        var lp = c.vss(y, m, k);
+        lp.grad();
+        expect_eq(std::string(c.tag) + " vss value", r.value, lp.val());
+        for (int i = 0; i < 2; ++i)
+          expect_eq(std::string(c.tag) + " vss dy" + std::to_string(i),
+                    r.grad[(size_t)i], y(i).adj());
+        expect_eq(std::string(c.tag) + " vss dmu", r.grad[2], m.adj());
+        expect_eq(std::string(c.tag) + " vss dk", r.grad[3], k.adj());
+        stan::math::recover_memory();
+      }
+      {
+        auto r = stanli::testutil::run_one_op(
+            c.opcode, {{vy[0]}, {vmu[0]}, {vk[0]}}, {true, true, true});
+        var y = vy[0], m = vmu[0], k = vk[0];
+        var lp = c.sss(y, m, k);
+        lp.grad();
+        expect_eq(std::string(c.tag) + " sss value", r.value, lp.val());
+        expect_eq(std::string(c.tag) + " sss dy", r.grad[0], y.adj());
+        expect_eq(std::string(c.tag) + " sss dmu", r.grad[1], m.adj());
+        expect_eq(std::string(c.tag) + " sss dk", r.grad[2], k.adj());
+        stan::math::recover_memory();
+      }
+    }
+    // neg_binomial_2: the outcome rides in idata, so the real arguments are
+    // the only propagator edges. Both a per-lane outcome and the scalar
+    // form the lowering replicates to the lane count.
+    const std::vector<double> vmn{2.00, 3.00}, vphi{1.50, 2.50};
+    struct Nb2 {
+      uint16_t opcode;
+      const char* tag;
+      std::function<var(const Eigen::VectorXi&, const VecV&, const VecV&)> vv;
+      std::function<var(const Eigen::VectorXi&, const var&, const var&)> ss;
+    };
+    const Nb2 kNb[2] = {
+        {OP_NEG_BINOMIAL_2_LCDF, "neg_binomial_2_lcdf",
+         [](const Eigen::VectorXi& n, const VecV& m, const VecV& p) {
+           return stan::math::neg_binomial_2_lcdf(n, m, p);
+         },
+         [](const Eigen::VectorXi& n, const var& m, const var& p) {
+           return stan::math::neg_binomial_2_lcdf(n, m, p);
+         }},
+        {OP_NEG_BINOMIAL_2_LCCDF, "neg_binomial_2_lccdf",
+         [](const Eigen::VectorXi& n, const VecV& m, const VecV& p) {
+           return stan::math::neg_binomial_2_lccdf(n, m, p);
+         },
+         [](const Eigen::VectorXi& n, const var& m, const var& p) {
+           return stan::math::neg_binomial_2_lccdf(n, m, p);
+         }}};
+    for (const Nb2& c : kNb) {
+      {
+        auto r = stanli::testutil::run_one_op(c.opcode, {vmn, vphi},
+                                              {true, true}, {1, 3});
+        VecV m = vec(vmn), p = vec(vphi);
+        var lp = c.vv(ivec({1, 3}), m, p);
+        lp.grad();
+        expect_eq(std::string(c.tag) + " vv value", r.value, lp.val());
+        for (int i = 0; i < 2; ++i) {
+          expect_eq(std::string(c.tag) + " vv dmu" + std::to_string(i),
+                    r.grad[(size_t)i], m(i).adj());
+          expect_eq(std::string(c.tag) + " vv dphi" + std::to_string(i),
+                    r.grad[(size_t)(2 + i)], p(i).adj());
+        }
+        stan::math::recover_memory();
+      }
+      {
+        auto r = stanli::testutil::run_one_op(c.opcode, {{vmn[0]}, {vphi[0]}},
+                                              {true, true}, {2});
+        var m = vmn[0], p = vphi[0];
+        var lp = c.ss(ivec({2}), m, p);
+        lp.grad();
+        expect_eq(std::string(c.tag) + " ss value", r.value, lp.val());
+        expect_eq(std::string(c.tag) + " ss dmu", r.grad[0], m.adj());
+        expect_eq(std::string(c.tag) + " ss dphi", r.grad[1], p.adj());
+        stan::math::recover_memory();
+      }
+    }
+  }
+
   if (failures == 0) std::printf("test_densities OK\n");
   return failures == 0 ? 0 : 1;
 }

--- a/tests/test_lower.cpp
+++ b/tests/test_lower.cpp
@@ -1820,6 +1820,97 @@ int main() {
     }
   }
 
+  // The named spellings of the binary operators, plus squared_distance.
+  // See tests/fixtures/opalias.stan: every call is made twice, once on
+  // data in transformed data and once on parameters in the model block,
+  // and the transformed-data results are summed into the target. That is
+  // what makes this test cover both halves -- the graph lowering and the
+  // MIR interpreter -- rather than only the one the log density walks.
+  // Teaching a function to one of them and not the other is silent: a
+  // vectorized log_sum_exp taught only to the lowering reported lp
+  // 2.6252 where the answer was 2.9302, with no exception raised.
+  {
+    const std::vector<double> dvv = {0.4, -0.7};
+    const std::vector<double> drvv = {0.25, 0.6};
+    // Column-major: dm = [[1.5, 0.5], [-0.25, 2.0]].
+    const std::vector<double> dmv = {1.5, -0.25, 0.5, 2.0};
+    DataMap d;
+    d.set_real_array("dv", dvv, {2});
+    d.set_real_array("drv", drvv, {2});
+    d.set_real_array("dm", dmv, {2, 2});
+    CompiledModel lm =
+        compile_model(slurp("tests/fixtures/opalias.tmir.sexp"), d);
+    Executor lex(std::move(lm.graph));
+    lm.bind(lex);
+
+    using stan::math::var;
+    using MatV = Eigen::Matrix<var, Eigen::Dynamic, Eigen::Dynamic>;
+    using VecV = Eigen::Matrix<var, Eigen::Dynamic, 1>;
+    Eigen::VectorXd DV(2), DRVc(2);
+    Eigen::RowVectorXd DRV(2);
+    Eigen::MatrixXd DM(2, 2);
+    DV << dvv[0], dvv[1];
+    DRV << drvv[0], drvv[1];
+    DRVc << drvv[0], drvv[1];
+    DM << dmv[0], dmv[2], dmv[1], dmv[3];
+
+    // Declaration order: p[2], q.
+    const double pts[2][3] = {{0.4, -0.7, 0.6}, {-0.3, 0.9, -0.45}};
+    for (int c = 0; c < 2; ++c) {
+      for (int i = 0; i < 3; ++i) lex.params_data()[i] = pts[c][i];
+      double grad[3] = {0, 0, 0};
+      const double lp = lex.gradient(grad);
+
+      using stan::math::add;
+      using stan::math::divide;
+      using stan::math::elt_divide;
+      using stan::math::elt_multiply;
+      using stan::math::multiply;
+      using stan::math::squared_distance;
+      using stan::math::subtract;
+      using stan::math::sum;
+      // stan-math's own answer for both halves. Transformed data is
+      // doubles on either side, so it is the same call with the same
+      // types the interpreter makes.
+      double td = sum(add(DV, 0.5)) + sum(add(DV, DV)) +
+                  sum(subtract(DV, 0.25)) + sum(subtract(0.75, DV)) +
+                  sum(multiply(DM, DV)) + multiply(DRV, DV) +
+                  sum(multiply(DV, DRV)) + sum(multiply(DM, DM)) +
+                  sum(elt_multiply(DV, DV)) + sum(elt_multiply(2.0, DV)) +
+                  sum(divide(DV, 2.0)) + sum(divide(1.5, DM)) +
+                  sum(elt_divide(DV, DV)) + sum(elt_divide(1.0, DV)) +
+                  squared_distance(DV, DRV) + squared_distance(dvv[0], dvv[1]);
+
+      VecV P(2);
+      P << pts[c][0], pts[c][1];
+      var q = pts[c][2];
+      var acc = td;
+      acc += sum(add(P, q));
+      acc += sum(add(P, DV));
+      acc += sum(subtract(q, P));
+      acc += sum(elt_multiply(P, P));
+      acc += sum(elt_multiply(q, P));
+      acc += sum(divide(P, q));
+      acc += sum(elt_divide(q, P));
+      acc += sum(divide(q, DM));
+      acc += sum(multiply(DM, P));
+      acc += multiply(P.transpose().eval(), P);
+      acc += sum(MatV(multiply(P, P.transpose().eval())));
+      acc += squared_distance(P, DRVc);
+      acc += squared_distance(P, DV);
+      acc += squared_distance(q, P(0));
+      acc += add(P(0), q) - divide(P(1), q);
+      acc.grad();
+
+      const std::string tag = "opalias c" + std::to_string(c);
+      expect_ulp(tag + " gp0", grad[0], P(0).adj());
+      expect_ulp(tag + " gp1", grad[1], P(1).adj());
+      expect_ulp(tag + " gq", grad[2], q.adj());
+      const double tol = 8 * 2.220446049250313e-16 * std::abs(acc.val());
+      check(std::abs(lp - acc.val()) <= tol, tag + " lp");
+    }
+  }
+
   // Two-argument scalar math with an int argument. See
   // tests/fixtures/binint.stan. The int side has no derivative, so the
   // whole gradient belongs to the real side, and the interesting case is

--- a/tests/test_lower.cpp
+++ b/tests/test_lower.cpp
@@ -1751,6 +1751,77 @@ int main() {
     }
   }
 
+  // The five distribution functions the recorder cannot evaluate at all.
+  // See tests/fixtures/tcdf.stan: these go to the nested var tape in
+  // matrix_fns.cpp, which is the tier ordered_probit and wiener already
+  // use, so what this checks past the value is the plumbing -- argument
+  // counts, the one integer group, and a length-1 slot entering stan-math
+  // as a scalar rather than a one-element vector.
+  {
+    DataMap d;
+    d.set_int("n", 3);
+    d.set_int_array("ns", {1, 2, 3});
+    CompiledModel tm = compile_model(slurp("tests/fixtures/tcdf.tmir.sexp"), d);
+    Executor tex(std::move(tm.graph));
+    tm.bind(tex);
+    // Declaration order: y1[3], k1[3], y2[3], k2[3], y3, k3, m4[3], p4[3],
+    // m5, m6[3].
+    const int kNP = 24;
+    const double pts[2][kNP] = {
+        {0.30, 0.45, 0.70,  -0.20, 0.15, 0.35, -0.40, 0.25,
+         0.60, 0.10, -0.30, 0.50,  0.20, 0.55, -0.10, 0.40,
+         0.05, 0.28, -0.12, 0.34,  0.18, 0.22, -0.18, 0.46},
+        {-0.25, 0.60,  -0.15, 0.30, -0.45, 0.20, 0.35, -0.05,
+         0.50,  -0.35, 0.15,  0.65, -0.20, 0.45, 0.25, -0.30,
+         0.55,  -0.08, 0.42,  0.12, -0.22, 0.38, 0.08, -0.28}};
+    for (int c = 0; c < 2; ++c) {
+      for (int i = 0; i < kNP; ++i) tex.params_data()[i] = pts[c][i];
+      double grad[kNP] = {0};
+      const double lp = tex.gradient(grad);
+
+      using stan::math::var;
+      using VecV = Eigen::Matrix<var, Eigen::Dynamic, 1>;
+      std::vector<var> th((size_t)kNP);
+      for (int i = 0; i < kNP; ++i) th[(size_t)i] = pts[c][i];
+      const auto seg = [&](int at) {
+        VecV v(3);
+        for (int i = 0; i < 3; ++i) v(i) = th[(size_t)(at + i)];
+        return v;
+      };
+      // The tail kernels bind every argument as var, data or not, so the
+      // reference binds the literals as var too and this stays bitwise.
+      VecV mu3(3);
+      mu3 << 0.1, 0.2, 0.3;
+      Eigen::VectorXi ns(3);
+      ns << 1, 2, 3;
+      Eigen::VectorXi n1(1);
+      n1 << 3;
+      var acc = stan::math::von_mises_cdf(seg(0), var(0.1),
+                                          VecV(stan::math::exp(seg(3))));
+      acc += stan::math::von_mises_lcdf(seg(6), mu3,
+                                        VecV(stan::math::exp(seg(9))));
+      acc += stan::math::von_mises_lccdf(th[12], var(0.1),
+                                         stan::math::exp(th[13]));
+      acc += stan::math::neg_binomial_2_lcdf(ns, VecV(stan::math::exp(seg(14))),
+                                             VecV(stan::math::exp(seg(17))));
+      acc += stan::math::neg_binomial_2_lccdf(n1, stan::math::exp(th[20]),
+                                              var(2.0));
+      // The scalar outcome replicated to the lane count, which is what the
+      // lowering does before the kernel ever sees the integer group.
+      Eigen::VectorXi n3(3);
+      n3 << 3, 3, 3;
+      acc += stan::math::neg_binomial_2_lccdf(
+          n3, VecV(stan::math::exp(seg(21))), var(2.0));
+      acc.grad();
+
+      // Same activity on both sides and no parameter shared between two
+      // densities, so this is bitwise: no tolerance.
+      for (int i = 0; i < kNP; ++i)
+        expect_eq("tcdf g" + std::to_string(i), grad[i], th[(size_t)i].adj());
+      expect_eq("tcdf lp", lp, acc.val());
+    }
+  }
+
   // Two-argument log_sum_exp / log_diff_exp on containers. See
   // tests/fixtures/lsepair.stan: Stan vectorizes both elementwise with
   // scalar broadcast, and the lowering used to emit them at width 1, so


### PR DESCRIPTION
320 rows from `unexpected_unsupported` to `verified`, zero mismatches. Two unrelated clusters, batched because they both extend tables in `lower.cpp`.

## Operator aliases (64 rows)

`add`, `subtract`, `multiply`, `divide`, `elt_multiply`, `elt_divide`, `squared_distance` -- the named spellings of operators the runtime already had. **Three** dispatch tables were keyed on the operator spelling alone, not one: the graph lowering, the MIR interpreter, and the register program that a parameter-dependent region must compile to or fail outright.

`squared_distance` is not a pure alias: it lowers to `OP_SUB` into `OP_DOT`, two existing kernels with native adjoints and no new opcode, and it skips `shape_of`/`same_view` because the language pairs a vector with a row_vector there.

`divide` is never a solve -- `prim/fun/divide.hpp` only divides by a scalar or divides a scalar elementwise -- so `OP_DIV` covers all 7 rows including `divide(real,matrix)`.

**Found and fixed on the way:** `fold_const` read `en.r[0]` for a `UInt` result, so `real z = divide(7,2)` folded to **3.5**. Truncation now lands in both `r` and `i`, and the register program folds int-typed binaries through `cint`.

The both-halves test is a mutation test rather than an assertion of intent: `tests/fixtures/opalias.stan` calls every alias on data in transformed data and on parameters in the model block, and sums the transformed-data results into the target. Making only the interpreter's `add` wrong fails `lp` **with no exception** -- the log_sum_exp bug shape. Making only the register program's `add` wrong fails `gq` by exactly 2.0, proving that third path is exercised too.

64 and not 68 because the rest are not misses: complex-typed rows are `expected_unsupported`, `(int,int)` rows are `inapplicable`.

## The var-tape distribution functions (256 rows)

`von_mises_{cdf,lcdf,lccdf}` and `neg_binomial_2_{lcdf,lccdf}`. These compute on the autodiff scalar rather than through stan-math's partials propagator, and `rvar` has no operators, so no list line can reach them. They go on the nested-var-tape tier beside `wiener` and `ordered_probit`. The discriminator is now documented: `grep -c operands_and_partials` on the prim header is 2 for everything the recorder takes and 0 for these five.

Pinned **bitwise** -- value and every gradient against the same stan-math call on `var`, in three shapes each -- both at the op level and end to end through the lowering. No tolerance anywhere.

### These are slow, and that is the point of saying so

| model, 100 lanes / 100 params | stanli ns/grad | BridgeStan -O1 ns/grad |
| --- | ---: | ---: |
| `neg_binomial_2_lcdf` (var tape) | 870,844 | 24,125 |
| `neg_binomial_2_cdf` (recorder) | 27,119 | 24,633 |
| `von_mises_lcdf` (var tape) | 270,434 | 158,537 |
| `normal_lcdf` (recorder) | 2,406 | 16,406 |

`neg_binomial_2_lcdf` is **~36x slower than CmdStan** and 32x slower than its own `_cdf` sibling on the recorder. `von_mises_lcdf` is ~1.7x, that function being expensive on both sides. The reference is built at `-O1` per harness convention and CmdStan defaults to `-O3`, so the real gap is wider. Correct by construction, on the same tier `wiener` already occupies -- but nobody should reach for these in a hot loop without knowing.

Roughly half that cost is a tape the forward sweep builds and throws away. A double-only forward would nearly halve the tier; not done here because `lp` would then come from a prim evaluation while gradients come from the var one, risking last-bit drift against CmdStan.

## Separate bug found, not fixed: `B / A` in the model block is silently wrong

**This one deserves attention independently of this PR.** stanc3 emits `Divide__` for `matrix / matrix` and its own codegen lowers it to `stan::math::mdivide_right(B, A)`. `lower.cpp:2233` maps `Divide__` to `OP_DIV`, which is elementwise. The model block computes the wrong thing with no exception.

I verified this independently of the agent that found it, at `stanli_check`'s default probe point: stanli returns `-0.066666666666666582`, exactly the elementwise sum, where `mdivide_right` gives `0.07272727272727275`.

The two halves of the runtime also disagree with each other, because the MIR interpreter's solve is correct: a data-only `B / A` in transformed data gives one answer and the same line in the model block gives another.

Related and loud rather than silent: `row_vector / matrix` fails with "incompatible logical views", and `LDivide__` (`A \ v`) is absent from `lower.cpp` entirely. Fixing all three means one `mdivide` graph kernel with the standard `A^-T` backsubstitution adjoint.

## Known limitation, stated rather than half-done

The MIR interpreter was **not** taught the five tail cdfs, deliberately. The interpreter has no cdf at all -- only a hardcoded `student_t_lccdf` -- so the gap is uniform across ~100 functions and it is loud, not silent: `transformed data { real c = normal_lcdf(z | 0, 1); }` already fails today. Adding five of a hundred would create an asymmetry rather than remove one. Transformed parameters and `write_array` take the graph path and work.

## Gates

`ctest` 49/49, `verify_refs` 129/129 with `hmm_gaussian` unchanged at 3.63e-12, `format.sh --check` clean. Cluster B re-verified against the final library after Cluster A landed.

## Baseline

This changes 320 classifications, all in the improving direction, so the ratchet from #121 stays green without a bump. I will regenerate `docs/conformance-baseline.json.gz` from the next full nightly so the new floor is actually protected.