### PR TITLE
fix: resolve user-defined function overloads by argument type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## Unreleased
+
+### Overloaded user-defined functions
+
+Models that overload a user-defined function no longer fail to compile
+with "mir: user function argument type mismatch" (#125). stanc3 keeps
+every overload under the same function name in the MIR; the reader now
+gives each overload a distinct internal name and resolves every call
+site to the overload its argument types select.
+
 ## 0.8.0
 
 ### Pathfinder, and a NUTS vs Pathfinder comparison

--- a/runtime/src/mir_reader.cpp
+++ b/runtime/src/mir_reader.cpp
@@ -591,6 +591,121 @@ void validate_bindings(const std::vector<Stmt>& body, Bindings& bindings,
   for (const auto& s : body) validate_bindings(s, bindings, functions);
 }
 
+// stanc3 keeps every overload of a user function under one fdname, and calls
+// carry only that name, so the by-name function maps downstream would
+// collide (last definition wins). Give each overload a distinct internal
+// name and rewrite every call site to the overload its argument types
+// select. stanc3 already ran overload resolution and inserted promotions at
+// typecheck time, so a call's (leaf, depth) views match exactly one
+// signature; parenthesized signatures cannot collide with Stan identifiers.
+
+using Overloads = std::map<std::string, std::vector<FunDef*>>;
+
+std::string signature(const std::vector<UnsizedView>& views) {
+  std::string out = "(";
+  for (size_t i = 0; i < views.size(); ++i) {
+    if (i) out += ',';
+    switch (views[i].leaf) {
+      case UnsizedLeaf::Int:
+        out += "int";
+        break;
+      case UnsizedLeaf::Real:
+        out += "real";
+        break;
+      case UnsizedLeaf::Complex:
+        out += "complex";
+        break;
+      case UnsizedLeaf::Vector:
+        out += "vector";
+        break;
+      case UnsizedLeaf::RowVector:
+        out += "row_vector";
+        break;
+      case UnsizedLeaf::Matrix:
+        out += "matrix";
+        break;
+      default:
+        out += "?";
+        break;
+    }
+    for (uint8_t d = 0; d < views[i].depth; ++d) out += "[]";
+  }
+  return out + ")";
+}
+
+bool views_match(const std::vector<UnsizedView>& a,
+                 const std::vector<UnsizedView>& b) {
+  if (a.size() != b.size()) return false;
+  for (size_t i = 0; i < a.size(); ++i)
+    if (a[i].depth != b[i].depth || a[i].leaf != b[i].leaf) return false;
+  return true;
+}
+
+bool views_match(const std::vector<Expr>& args,
+                 const std::vector<UnsizedView>& views) {
+  if (args.size() != views.size()) return false;
+  for (size_t i = 0; i < args.size(); ++i)
+    if (args[i].unsized.depth != views[i].depth ||
+        args[i].unsized.leaf != views[i].leaf)
+      return false;
+  return true;
+}
+
+void resolve_calls(Expr& e, const Overloads& overloads) {
+  for (Expr& a : e.args) resolve_calls(a, overloads);
+  if (e.kind != Expr::FunApp || e.fn_lib != Expr::Lib::UserDefined) return;
+  const auto it = overloads.find(e.name);
+  if (it == overloads.end()) return;
+  const FunDef* match = nullptr;
+  for (const FunDef* f : it->second) {
+    if (!views_match(e.args, f->arg_views)) continue;
+    if (match)
+      throw std::runtime_error("mir: ambiguous overload for " + e.name);
+    match = f;
+  }
+  if (!match)
+    throw std::runtime_error("mir: no overload of " + it->first +
+                             " matches its call");
+  e.name = match->name;
+}
+
+void resolve_calls(Stmt& s, const Overloads& overloads) {
+  for (Expr* e : {&s.init, &s.rhs, &s.target, &s.lower, &s.upper, &s.cond})
+    resolve_calls(*e, overloads);
+  for (auto* exprs : {&s.read_dims, &s.lhs_idx, &s.fn_args})
+    for (Expr& e : *exprs) resolve_calls(e, overloads);
+  for (Expr& e : s.decl_type.dims) resolve_calls(e, overloads);
+  for (Transform* t : {s.read_transform ? &*s.read_transform : nullptr,
+                       s.check_transform ? &*s.check_transform : nullptr})
+    if (t)
+      for (Expr& e : t->args) resolve_calls(e, overloads);
+  for (Stmt& k : s.body) resolve_calls(k, overloads);
+}
+
+void resolve_overloads(Program& prog) {
+  std::map<std::string, std::vector<FunDef*>> by_name;
+  for (FunDef& f : prog.fun_defs) by_name[f.name].push_back(&f);
+  Overloads overloads;
+  for (auto& [name, defs] : by_name) {
+    if (defs.size() < 2) continue;
+    for (size_t i = 0; i < defs.size(); ++i)
+      for (size_t j = i + 1; j < defs.size(); ++j)
+        if (views_match(defs[i]->arg_views, defs[j]->arg_views))
+          throw std::runtime_error("mir: indistinguishable overloads of " +
+                                   name);
+    for (FunDef* f : defs) f->name += signature(f->arg_views);
+    overloads[name] = std::move(defs);
+  }
+  if (overloads.empty()) return;
+  for (auto& [name, type] : prog.input_vars)
+    for (Expr& d : type.dims) resolve_calls(d, overloads);
+  for (auto* body :
+       {&prog.prepare_data, &prog.log_prob, &prog.generate_quantities})
+    for (Stmt& s : *body) resolve_calls(s, overloads);
+  for (FunDef& f : prog.fun_defs)
+    for (Stmt& s : f.body) resolve_calls(s, overloads);
+}
+
 }  // namespace
 
 Program read_program(const sexp::Node& root) {
@@ -632,6 +747,7 @@ Program read_program(const sexp::Node& root) {
   read_stmt_list((*lp)[1], prog.log_prob);
   if (const Node* gq = field(root, "generate_quantities"))
     read_stmt_list((*gq)[1], prog.generate_quantities);
+  resolve_overloads(prog);
   Functions functions;
   for (const auto& f : prog.fun_defs) functions[f.name] = &f;
   Bindings inputs;

--- a/tests/fixtures/overload.stan
+++ b/tests/fixtures/overload.stan
@@ -1,0 +1,29 @@
+// Overloaded user-defined functions (issue #125): stanc3 keeps every
+// overload under the same fdname, so calls must resolve by argument type.
+// The unused-looking cox_lcdf matters: its body calls the scalar overload,
+// which is what exposed the last-def-wins collision.
+functions {
+  real cox_lccdf(real y, real mu, real bhaz, real cbhaz) {
+    return -cbhaz * mu;
+  }
+  real cox_lccdf(vector y, vector mu, vector bhaz, vector cbhaz) {
+    return -dot_product(cbhaz, mu);
+  }
+  real cox_lcdf(real y, real mu, real bhaz, real cbhaz) {
+    return log1m_exp(cox_lccdf(y | mu, bhaz, cbhaz));
+  }
+}
+data {
+  int<lower=1> N;
+  vector[N] Y;
+  vector[N] bhaz;
+  vector[N] cbhaz;
+}
+parameters {
+  real alpha;
+}
+model {
+  target += cox_lccdf(Y | alpha * bhaz, bhaz, cbhaz);
+  target += cox_lcdf(Y[1] | alpha, bhaz[1], cbhaz[1]);
+  target += normal_lpdf(alpha | 0, 1);
+}

--- a/tests/fixtures/overload.tmir.sexp
+++ b/tests/fixtures/overload.tmir.sexp
@@ -1,0 +1,629 @@
+((functions_block
+  (((fdrt (ReturnType UReal)) (fdname cox_lccdf) (fdsuffix FnPlain)
+    (fdargs
+     ((AutoDiffable y UReal) (AutoDiffable mu UReal) (AutoDiffable bhaz UReal)
+      (AutoDiffable cbhaz UReal)))
+    (fdbody
+     (((pattern
+        (Block
+         (((pattern
+            (Return
+             (((pattern
+                (FunApp (StanLib Times__ FnPlain AoS)
+                 (((pattern
+                    (FunApp (StanLib PMinus__ FnPlain AoS)
+                     (((pattern (Var cbhaz))
+                       (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+                  ((pattern (Var mu))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
+           (meta <opaque>)))))
+       (meta <opaque>))))
+    (fdloc <opaque>))
+   ((fdrt (ReturnType UReal)) (fdname cox_lccdf) (fdsuffix FnPlain)
+    (fdargs
+     ((AutoDiffable y UVector) (AutoDiffable mu UVector) (AutoDiffable bhaz UVector)
+      (AutoDiffable cbhaz UVector)))
+    (fdbody
+     (((pattern
+        (Block
+         (((pattern
+            (Return
+             (((pattern
+                (FunApp (StanLib PMinus__ FnPlain AoS)
+                 (((pattern
+                    (FunApp (StanLib dot_product FnPlain AoS)
+                     (((pattern (Var cbhaz))
+                       (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))
+                      ((pattern (Var mu))
+                       (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
+           (meta <opaque>)))))
+       (meta <opaque>))))
+    (fdloc <opaque>))
+   ((fdrt (ReturnType UReal)) (fdname cox_lcdf) (fdsuffix FnPlain)
+    (fdargs
+     ((AutoDiffable y UReal) (AutoDiffable mu UReal) (AutoDiffable bhaz UReal)
+      (AutoDiffable cbhaz UReal)))
+    (fdbody
+     (((pattern
+        (Block
+         (((pattern
+            (Return
+             (((pattern
+                (FunApp (StanLib log1m_exp FnPlain AoS)
+                 (((pattern
+                    (FunApp (UserDefined cox_lccdf FnPlain)
+                     (((pattern (Var y))
+                       (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+                      ((pattern (Var mu))
+                       (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+                      ((pattern (Var bhaz))
+                       (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+                      ((pattern (Var cbhaz))
+                       (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
+           (meta <opaque>)))))
+       (meta <opaque>))))
+    (fdloc <opaque>))))
+ (input_vars
+  ((N <opaque> SInt)
+   (Y <opaque>
+    (SVector AoS
+     ((pattern (Var N)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+   (bhaz <opaque>
+    (SVector AoS
+     ((pattern (Var N)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+   (cbhaz <opaque>
+    (SVector AoS
+     ((pattern (Var N)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+ (prepare_data
+  (((pattern
+     (Decl (decl_adtype DataOnly) (decl_id pos__) (decl_type (Sized SInt))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable pos__) ()) UInt
+      ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id N) (decl_type (Sized SInt))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable N) ()) UInt
+      ((pattern
+        (Indexed
+         ((pattern
+           (FunApp (CompilerInternal FnReadData)
+            (((pattern (Lit Str N))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+          (meta ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly))))
+         ((Single
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnCheck
+        (trans
+         (Lower
+          ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (var_name N)
+        (var ((pattern (Var N)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp (CompilerInternal FnValidateSize)
+      (((pattern (Lit Str Y)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+       ((pattern (Lit Str N)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+       ((pattern (Var N)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id Y)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Var N)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id Y_flat__)
+          (decl_type (Unsized (UArray UReal))) (initialize Uninit)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable Y_flat__) ()) (UArray UReal)
+          ((pattern
+            (FunApp (CompilerInternal FnReadData)
+             (((pattern (Lit Str Y))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable pos__) ()) UInt
+          ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar sym1__)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Var N)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (Assignment
+                  ((LVariable Y)
+                   ((Single
+                     ((pattern (Var sym1__))
+                      (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                  UVector
+                  ((pattern
+                    (Indexed
+                     ((pattern (Var Y_flat__))
+                      (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))
+                     ((Single
+                       ((pattern (Var pos__))
+                        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+                (meta <opaque>))
+               ((pattern
+                 (Assignment ((LVariable pos__) ()) UInt
+                  ((pattern
+                    (FunApp (StanLib Plus__ FnPlain AoS)
+                     (((pattern (Var pos__))
+                       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                      ((pattern (Lit Int 1))
+                       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp (CompilerInternal FnValidateSize)
+      (((pattern (Lit Str bhaz)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+       ((pattern (Lit Str N)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+       ((pattern (Var N)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id bhaz)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Var N)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id bhaz_flat__)
+          (decl_type (Unsized (UArray UReal))) (initialize Uninit)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable bhaz_flat__) ()) (UArray UReal)
+          ((pattern
+            (FunApp (CompilerInternal FnReadData)
+             (((pattern (Lit Str bhaz))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable pos__) ()) UInt
+          ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar sym1__)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Var N)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (Assignment
+                  ((LVariable bhaz)
+                   ((Single
+                     ((pattern (Var sym1__))
+                      (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                  UVector
+                  ((pattern
+                    (Indexed
+                     ((pattern (Var bhaz_flat__))
+                      (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))
+                     ((Single
+                       ((pattern (Var pos__))
+                        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+                (meta <opaque>))
+               ((pattern
+                 (Assignment ((LVariable pos__) ()) UInt
+                  ((pattern
+                    (FunApp (StanLib Plus__ FnPlain AoS)
+                     (((pattern (Var pos__))
+                       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                      ((pattern (Lit Int 1))
+                       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp (CompilerInternal FnValidateSize)
+      (((pattern (Lit Str cbhaz))
+        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+       ((pattern (Lit Str N)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+       ((pattern (Var N)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id cbhaz)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Var N)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id cbhaz_flat__)
+          (decl_type (Unsized (UArray UReal))) (initialize Uninit)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable cbhaz_flat__) ()) (UArray UReal)
+          ((pattern
+            (FunApp (CompilerInternal FnReadData)
+             (((pattern (Lit Str cbhaz))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable pos__) ()) UInt
+          ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar sym1__)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Var N)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (Assignment
+                  ((LVariable cbhaz)
+                   ((Single
+                     ((pattern (Var sym1__))
+                      (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                  UVector
+                  ((pattern
+                    (Indexed
+                     ((pattern (Var cbhaz_flat__))
+                      (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))
+                     ((Single
+                       ((pattern (Var pos__))
+                        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+                (meta <opaque>))
+               ((pattern
+                 (Assignment ((LVariable pos__) ()) UInt
+                  ((pattern
+                    (FunApp (StanLib Plus__ FnPlain AoS)
+                     (((pattern (Var pos__))
+                       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                      ((pattern (Lit Int 1))
+                       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))))
+ (log_prob
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id alpha) (decl_type (Sized SReal))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity) (dims ()) (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (UserDefined cox_lccdf FnPlain)
+             (((pattern (Var Y))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly))))
+              ((pattern
+                (FunApp (StanLib Times__ FnPlain AoS)
+                 (((pattern (Var alpha))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+                  ((pattern (Var bhaz))
+                   (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))
+              ((pattern (Var bhaz))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly))))
+              ((pattern (Var cbhaz))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>))
+       ((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id inline_cox_lcdf_return_sym3__)
+          (decl_type (Sized SReal)) (initialize Uninit)))
+        (meta <opaque>))
+       ((pattern
+         (Block
+          (((pattern
+             (Assignment ((LVariable inline_cox_lcdf_return_sym3__) ()) UReal
+              ((pattern
+                (FunApp (StanLib log1m_exp FnPlain AoS)
+                 (((pattern
+                    (FunApp (UserDefined cox_lccdf FnPlain)
+                     (((pattern
+                        (Indexed
+                         ((pattern (Var Y))
+                          (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly))))
+                         ((Single
+                           ((pattern (Lit Int 1))
+                            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                       (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+                      ((pattern (Var alpha))
+                       (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+                      ((pattern
+                        (Indexed
+                         ((pattern (Var bhaz))
+                          (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly))))
+                         ((Single
+                           ((pattern (Lit Int 1))
+                            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                       (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+                      ((pattern
+                        (Indexed
+                         ((pattern (Var cbhaz))
+                          (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly))))
+                         ((Single
+                           ((pattern (Lit Int 1))
+                            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                       (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+            (meta <opaque>)))))
+        (meta <opaque>))
+       ((pattern
+         (TargetPE
+          ((pattern (Var inline_cox_lcdf_return_sym3__))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>))
+       ((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib normal_lpdf (FnLpdf false) AoS)
+             (((pattern (Var alpha))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+              ((pattern
+                (Promotion
+                 ((pattern (Lit Int 0))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                 UReal DataOnly))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+              ((pattern
+                (Promotion
+                 ((pattern (Lit Int 1))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                 UReal DataOnly))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>)))))
+    (meta <opaque>))))
+ (reverse_mode_log_prob
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id alpha) (decl_type (Sized SReal))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity) (dims ()) (mem_pattern SoA)))
+           ()))
+         (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (UserDefined cox_lccdf FnPlain)
+             (((pattern (Var Y))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly))))
+              ((pattern
+                (FunApp (StanLib Times__ FnPlain SoA)
+                 (((pattern (Var alpha))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+                  ((pattern (Var bhaz))
+                   (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))
+              ((pattern (Var bhaz))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly))))
+              ((pattern (Var cbhaz))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>))
+       ((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id inline_cox_lcdf_return_sym1__)
+          (decl_type (Sized SReal)) (initialize Uninit)))
+        (meta <opaque>))
+       ((pattern
+         (Block
+          (((pattern
+             (Assignment ((LVariable inline_cox_lcdf_return_sym1__) ()) UReal
+              ((pattern
+                (FunApp (StanLib log1m_exp FnPlain SoA)
+                 (((pattern
+                    (FunApp (UserDefined cox_lccdf FnPlain)
+                     (((pattern
+                        (Indexed
+                         ((pattern (Var Y))
+                          (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly))))
+                         ((Single
+                           ((pattern (Lit Int 1))
+                            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                       (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+                      ((pattern (Var alpha))
+                       (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+                      ((pattern
+                        (Indexed
+                         ((pattern (Var bhaz))
+                          (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly))))
+                         ((Single
+                           ((pattern (Lit Int 1))
+                            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                       (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+                      ((pattern
+                        (Indexed
+                         ((pattern (Var cbhaz))
+                          (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly))))
+                         ((Single
+                           ((pattern (Lit Int 1))
+                            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                       (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+            (meta <opaque>)))))
+        (meta <opaque>))
+       ((pattern
+         (TargetPE
+          ((pattern (Var inline_cox_lcdf_return_sym1__))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>))
+       ((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib normal_lpdf (FnLpdf false) SoA)
+             (((pattern (Var alpha))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+              ((pattern
+                (Promotion
+                 ((pattern (Lit Int 0))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                 UReal DataOnly))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+              ((pattern
+                (Promotion
+                 ((pattern (Lit Int 1))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                 UReal DataOnly))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>)))))
+    (meta <opaque>))))
+ (generate_quantities
+  (((pattern
+     (Decl (decl_adtype DataOnly) (decl_id alpha) (decl_type (Sized SReal))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity) (dims ()) (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt ())
+        (var
+         ((pattern (Var alpha)) (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (IfElse
+      ((pattern
+        (FunApp (StanLib PNot__ FnPlain AoS)
+         (((pattern
+            (EOr
+             ((pattern (Var emit_transformed_parameters__))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+             ((pattern (Var emit_generated_quantities__))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+      ((pattern (Block (((pattern (Return ())) (meta <opaque>))))) (meta <opaque>)) ()))
+    (meta <opaque>))
+   ((pattern
+     (IfElse
+      ((pattern
+        (FunApp (StanLib PNot__ FnPlain AoS)
+         (((pattern (Var emit_generated_quantities__))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+      ((pattern (Block (((pattern (Return ())) (meta <opaque>))))) (meta <opaque>)) ()))
+    (meta <opaque>))))
+ (transform_inits
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id alpha) (decl_type (Sized SReal))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable alpha) ()) UReal
+      ((pattern
+        (Indexed
+         ((pattern
+           (FunApp (CompilerInternal FnReadData)
+            (((pattern (Lit Str alpha))
+              (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+          (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))
+         ((Single
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+       (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var alpha)) (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))))
+ (unconstrain_array
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id alpha) (decl_type (Sized SReal))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable alpha) ()) UReal
+      ((pattern (FunApp (CompilerInternal FnReadDeserializer) ()))
+       (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var alpha)) (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))))
+ (output_vars
+  ((alpha <opaque>
+    ((out_unconstrained_st SReal) (out_constrained_st SReal) (out_block Parameters)
+     (out_trans Identity)))))
+ (prog_name overload_model) (prog_path tests/fixtures/overload.stan))

--- a/tests/test_lower.cpp
+++ b/tests/test_lower.cpp
@@ -416,6 +416,42 @@ int main() {
     stan::math::recover_memory();
   }
 
+  // Overloaded user functions (issue #125): stanc3 keeps every overload of
+  // cox_lccdf under the same fdname, and --O1 inlines the lcdf wrapper so
+  // log_prob calls both the vector and the scalar overload directly.
+  // Resolution must go by argument type, not last-definition-wins.
+  {
+    DataMap d = DataMap::from_json(
+        R"({"N": 3, "Y": [1.0, 2.0, 3.0], "bhaz": [0.4, 0.5, 0.6],
+            "cbhaz": [0.2, 0.3, 0.4]})");
+    CompiledModel lm =
+        compile_model(slurp("tests/fixtures/overload.tmir.sexp"), d);
+    check(lm.n_unconstrained == 1, "overload 1 unconstrained");
+    Executor lex(std::move(lm.graph));
+    lm.bind(lex);
+    lex.params_data()[0] = 0.7;
+    double grad[1] = {0};
+    const double lp = lex.gradient(grad);
+
+    using stan::math::var;
+    var alpha = 0.7;
+    Eigen::VectorXd bh(3), cb(3);
+    bh << 0.4, 0.5, 0.6;
+    cb << 0.2, 0.3, 0.4;
+    Eigen::Matrix<var, -1, 1> mu = alpha * bh;
+    var acc = -stan::math::dot_product(cb, mu) +
+              stan::math::log1m_exp(-cb(0) * alpha) +
+              stan::math::normal_lpdf<false>(alpha, 0.0, 1.0);
+    acc.grad();
+    expect_ulp("overload lp", lp, acc.val());
+    // alpha collects adjoints from three terms; the graph and the var tape
+    // associate that sum differently, so this is a few-ulp comparison.
+    check(std::fabs(grad[0] - alpha.adj()) < 1e-12,
+          "overload galpha " + std::to_string(grad[0]) + " vs " +
+              std::to_string(alpha.adj()));
+    stan::math::recover_memory();
+  }
+
   // Index forms on parameters: gather, Between read/write, matrix row and
   // column slices, column writes.
   {


### PR DESCRIPTION
Fixes #125.

stanc3 keeps every overload of a user function under the same fdname in the MIR, and calls carry only that name. The reader's by-name function map therefore collided on overloaded functions: the last definition won, and any call to a different overload failed validation with "mir: user function argument type mismatch". The reprex in #125 hits this because the lcdf wrapper's body calls the scalar cox_lccdf overload while the map holds the vector one.

The reader now gives each overload a distinct internal name (the original name plus a parenthesized signature, which cannot collide with a Stan identifier) and rewrites every call site to the overload its argument types select, before validation runs. stanc3 already ran overload resolution and inserted promotions at typecheck time, so a call's argument views match exactly one signature; zero or multiple matches fail loudly, as do overloads whose signatures the MIR cannot distinguish. Programs without overloads pass through byte-identical, and any call-site slot the rewrite might miss would surface as a loud "call to unknown user function" from the existing validation, never a miscompile.

Verified: new fixture (the issue's model shape, with a parameter so both overloads execute in log_prob) passes with lp and gradient checked against a stan-math var reference; the issue's exact reprex compiles and evaluates correctly through stanli_check; all 49 tests pass; corpus replay is 129/129 with zero drift.

One edge stays unsupported, now with a loud error instead of a silent wrong pick: passing an overloaded function by name as an ODE right-hand side fails at lowering as an unknown function.
