### PR TITLE
release: 0.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.8.1
 
 ### Overloaded user-defined functions
 

--- a/issue-125-reply-draft.md
+++ b/issue-125-reply-draft.md
@@ -1,0 +1,7 @@
+Thanks for the report and the clean reprex, that made this quick to track down.
+
+Root cause: stanc3 keeps every overload of a user-defined function under the same name in its IR, and stanli looked functions up by name alone, so the last definition won. Your model ends up storing the vector overload of `cox_lccdf`; the body of `cox_lcdf` calls the scalar overload, and that call is what failed the type check. That is why declaring `cox_lcdf` was enough to trigger the error even though it is never invoked: the `target += cox_lccdf(Y | ...)` line was fine on its own.
+
+Fixed in #126: calls now resolve to the overload their argument types select. Your reprex compiles and evaluates correctly, with the model block resolving to the vector overload as expected.
+
+The fix will be in the next release. Once that is tagged, rerun `stanli_install(overwrite = TRUE)` to pick up the new runtime.

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@seantalts/stanli",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Full Stan in the browser: stanc3 compiles the model in JS, a WASM runtime lowers it to an op graph and runs NUTS. No server, no C++ toolchain.",
   "type": "module",
   "main": "index.mjs",

--- a/python/stanli/__init__.py
+++ b/python/stanli/__init__.py
@@ -21,7 +21,7 @@ __all__ = ["Model", "Fit", "Summary", "OptimizeResult",
            "SAMPLER_COLUMNS", "__version__"]
 # The one place the version lives. setup.py and the release workflow both
 # read it from here.
-__version__ = "0.8.0"
+__version__ = "0.8.1"
 
 _BIN = pathlib.Path(__file__).parent / "_bin"
 

--- a/r/DESCRIPTION
+++ b/r/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: stanli
 Type: Package
 Title: The Stan Language Interpreter
-Version: 0.8.0
+Version: 0.8.1
 Authors@R: person("Sean", "Talts", email = "xitrium@gmail.com",
                   role = c("aut", "cre"))
 Description: Compile and sample Stan models without a C++ toolchain. Stan

--- a/r/R/install.R
+++ b/r/R/install.R
@@ -17,7 +17,7 @@
 # pinned binding with a runtime that has moved. The release workflow
 # asserts this equals the tag being cut, so bumping one without the
 # other fails there rather than at a user's install.
-stanli_runtime_release <- "v0.8.0"
+stanli_runtime_release <- "v0.8.1"
 
 runtime_filename <- function() {
   switch(Sys.info()[["sysname"]],


### PR DESCRIPTION
Version bump for the 0.8.1 patch release: the overloaded user-defined function fix (#125, #126). Tag v0.8.1 follows once this merges.