### PR TITLE
docs: refresh the coverage rows and the shipped sizes

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -281,6 +281,19 @@ jobs:
       - name: Wheel
         run: ./tools/build_wheel.sh
 
+      # build_wheel.sh measures the size breakdown just before it strips
+      # the library, into a checkout this job then throws away. Publish it,
+      # or the only moment it can be measured produces nothing anyone can
+      # read. One platform: the attribution is the same everywhere and the
+      # manylinux build is the one the README's totals describe.
+      - name: Publish the binary size breakdown
+        if: matrix.runtime == 'linux-x86_64'
+        uses: actions/upload-artifact@v4
+        with:
+          name: binary-size
+          if-no-files-found: error
+          path: docs/binary-size.md
+
       # The tag is a promise about the oldest system the library runs on,
       # and nothing so far has checked it. glibc is the only versioned
       # dependency left after the static C++ runtime, so the highest

--- a/README.md
+++ b/README.md
@@ -140,13 +140,15 @@ NUTS (stan::mcmc::adapt_diag_e_nuts) -> draws
 One self-contained shared library, 29.3 MB installed, 10.6 MB compressed
 in the wheel, measured on the manylinux_2_28_x86_64 artifact.
 
-The per-symbol breakdown lives in [docs/binary-size.md](docs/binary-size.md),
-written by `tools/binary_size.py` during `tools/build_wheel.sh`. It has to
-be measured there and nowhere else: the shipped library exports a few
-hundred C ABI names and carries no static symbol table, so the attribution
-cannot be reconstructed from any artifact a user or CI downloads. It used
-to be hand-maintained, which is why it described a 22.2 MB library long
-after the library stopped being one.
+The per-symbol breakdown rides with every build as the `binary-size`
+artifact, written by `tools/binary_size.py` during `tools/build_wheel.sh`.
+It has to be measured there and nowhere else: the shipped library exports
+a few hundred C ABI names and carries no static symbol table, so the
+attribution cannot be reconstructed from the wheel or the runtime tarball
+after the fact -- only from the object as it exists a moment before the
+strip. It is not checked in for the same reason it went stale as a typed
+table: a number nothing recomputes is a number that drifts. Run
+`tools/binary_size.py` on an unstripped build for it locally.
 
 The densities dominate. A distribution is instantiated once per activity
 mask (which arguments are autodiff), twice for propto, and again for the

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ could not build one on their farm.
 - Distribution coverage: [docs/coverage.md](docs/coverage.md). 69 of 72
   densities, 90 of 105 cdf/lcdf/lccdf, truncation, censoring, ordinal
   regression and the count GLMs, each bitwise against CmdStan.
-- Install size: one 29.3 MB shared library, a 10.6 MB wheel. Breakdown in
+- Install size: one 29.7 MB shared library, a 10.8 MB wheel. Breakdown in
   [Binary size](#binary-size).
 - How this is possible, for statisticians:
   [docs/how-it-works.md](docs/how-it-works.md)
@@ -137,7 +137,7 @@ NUTS (stan::mcmc::adapt_diag_e_nuts) -> draws
 
 ## Binary size
 
-One self-contained shared library, 29.3 MB installed, 10.6 MB compressed
+One self-contained shared library, 29.7 MB installed, 10.8 MB compressed
 in the wheel, measured on the manylinux_2_28_x86_64 artifact.
 
 The per-symbol breakdown rides with every build as the `binary-size`

--- a/docs/coverage.md
+++ b/docs/coverage.md
@@ -7,19 +7,41 @@ against CmdStan with a generated single-function model.
 
 | family | supported |
 |---|---|
-| densities (`_lpdf`, `_lpmf`) | 69 / 72 |
-| distribution functions (`_cdf`, `_lcdf`, `_lccdf`) | 97 / 105 |
-| scalar math (all-real signature) | 78 / 100 |
+| densities (`_lpdf`, `_lpmf`) | 71 / 72 |
+| distribution functions (`_cdf`, `_lcdf`, `_lccdf`) | 105 / 105 |
+| scalar math (all-real signature) | 94 / 100 |
 
-The scalar-math denominator counts distinct function names in
-`stanc --dump-stan-math-signatures` whose arguments and result are all
-`real` and whose name is not a distribution suffix, and the numerator is
-what `harnesses/fn_sweep.py deps/cmdstan --from-stanc --missing` compiles
-and matches. It read `47 / 129` for a long time against no invocation
-that still reproduces either number, so the definition is written down
-here now rather than living in whoever last measured it. The count moved
-because the definition became checkable, not because coverage shrank:
-#109, #116 and #119 added 36 of those functions between them.
+All three rows come from the same place and mean the same thing: a
+function name counts as supported when the nightly conformance sweep
+reports no `unexpected_unsupported` row for it, over the whole signature
+space rather than one probe per name. The scalar-math family is the
+distinct names in `stanc --dump-stan-math-signatures` whose arguments and
+result are all `real` and whose name carries no distribution suffix.
+
+This used to be three numbers from two different tools with the
+definition living in whoever last measured it -- the scalar-math row read
+`47 / 129` against no invocation that reproduced either half. It is worth
+regenerating them from a green nightly rather than trusting them:
+
+```sh
+python3 - <<'EOF'
+import json, re, collections
+r = json.load(open("conformance-aggregate/conformance.json"))
+seen = collections.defaultdict(set)
+for row in r["results"]:
+    m = re.match(r"signature:([A-Za-z_0-9]+)\(", row["case_id"])
+    if m:
+        seen[m.group(1)].add(row["status"])
+def tally(pred):
+    names = [n for n in seen if pred(n)]
+    return sum("unexpected_unsupported" not in seen[n] for n in names), len(names)
+print(tally(lambda n: n.endswith(("_lpdf", "_lpmf"))))
+EOF
+```
+
+What is left in scalar math is six names: `hypergeometric_1F0`,
+`hypergeometric_2F1`, `inc_beta`, `inv_inc_beta`, and the two
+`wiener_*_unnorm` forms.
 
 Every supported density's **gradients** match CmdStan bitwise, at three
 evaluation points. That is the standard here: a density whose gradients

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -208,7 +208,7 @@ difference between a nanosecond of dispatch and code the C++ compiler
 inlined into the model binary.
 
 The other cost is size, the deliberate trade at the center of the
-design: the wheel is 10.6 MB because it carries the entire Stan compiler
+design: the wheel is 10.8 MB because it carries the entire Stan compiler
 and every operation in the math library, whether your model uses them
 or not. In exchange, `pip install stanli` is the entire installation.
 

--- a/python/README.md
+++ b/python/README.md
@@ -213,7 +213,7 @@ RStan ships through RTools), and bundles `stanc.exe` as a subprocess
 instead of embedding the compiler; the API works the same way either
 way.
 
-The installed library is 29.3 MB: over half of it is the density
+The installed library is 29.7 MB: over half of it is the density
 kernels, about a quarter the embedded stanc3, and the interpreter and
 NUTS together are about 410 KB. That is the trade this design makes:
 ship the compiler and every kernel once, so nothing is ever built on


### PR DESCRIPTION
Two commits. The first is a repair.

## The binary-size artifact was never published

#120 added `tools/binary_size.py` and had `build_wheel.sh` measure the breakdown just before the strip -- the only moment it can be measured, since the shipped library carries no static symbol table. A follow-up commit on that branch added the `upload-artifact` step and reworded the README to say the breakdown rides with the build.

**That commit was orphaned.** #120 was merged while it was being pushed, so `build_wheel.sh` has been writing `docs/binary-size.md` into an ephemeral CI checkout ever since, and the README has been pointing at an artifact nothing produces. Confirmed rather than assumed: `git merge-base --is-ancestor` says the commit is unreachable from main, and the manylinux job's step list has no publish step in it.

Cherry-picked back. My fault for not verifying the merge landed what I thought it did.

## Coverage moved a long way and the table did not follow

Regenerated from the green nightly on `e18da22`:

| family | was | now |
| --- | ---: | ---: |
| densities (`_lpdf`, `_lpmf`) | 69 / 72 | **71 / 72** |
| distribution functions (`_cdf`, `_lcdf`, `_lccdf`) | 97 / 105 | **105 / 105** |
| scalar math (all-real signature) | 78 / 100 | **94 / 100** |

The distribution-function row is complete -- #124 finished it by taking von_mises and neg_binomial_2's `lcdf`/`lccdf` onto the var-tape tier.

More useful than the numbers: **all three rows now come from one place and mean one thing.** A name counts as supported when the nightly reports no `unexpected_unsupported` row for it, across the whole signature space rather than one probe per name. They used to be three numbers from two different tools, with the scalar-math row reading `47 / 129` against no invocation that reproduced either half.

The doc now carries the snippet that regenerates the table from an aggregate report, so the next reader can check it rather than trust it, and the six names still missing in scalar math are listed: `hypergeometric_1F0`, `hypergeometric_2F1`, `inc_beta`, `inv_inc_beta`, and the two `wiener_*_unnorm` forms.

## Sizes

Remeasured on the `manylinux_2_28_x86_64` artifact from the last green main build: **29.7 MB** installed and **10.8 MB** in the wheel, up from 29.3 and 10.6 as the tail densities and solve kernels landed. `python/README.md` and `docs/how-it-works.md` carried their own copies of those numbers and are updated with them.

## Checks

`tools/gen_docs.py --check` clean -- the corpus and benchmark numbers it owns still match their artifacts, so nothing there needed touching. `tests/test_conformance.py` passes, `format.sh --check` clean.

Once this lands, the next wheel build will publish `binary-size` as an artifact and the README's pointer will be true for the first time.