### PR TITLE
fix: a register program must write every register it reads

### DIFF
--- a/.github/workflows/stan-conformance-nightly.yml
+++ b/.github/workflows/stan-conformance-nightly.yml
@@ -251,7 +251,7 @@ jobs:
           artifact_url = os.environ.get("ARTIFACT_URL", "")
           missing_statuses = {"generator_gap", "unexpected_unsupported"}
           blocking_statuses = {
-              "generator_gap", "harness_error", "mismatch",
+              "crashed", "generator_gap", "harness_error", "mismatch",
               "unexpected_unsupported",
           }
 
@@ -317,8 +317,8 @@ jobs:
               and row["case_id"] not in missing_ids
           ]
           other_priority = {
-              "harness_error": 0, "mismatch": 1,
-              "unexpected_unsupported": 2, "generator_gap": 3,
+              "harness_error": 0, "crashed": 1, "mismatch": 2,
+              "unexpected_unsupported": 3, "generator_gap": 4,
           }
           other_blocking.sort(key=lambda row: (
               other_priority[row["status"]], row["case_id"],
@@ -329,8 +329,8 @@ jobs:
           if other_blocking:
               findings_table(other_blocking, 20)
           else:
-              print("No mismatches, construct gaps, or infrastructure "
-                    "errors were found.")
+              print("No crashes, mismatches, construct gaps, or "
+                    "infrastructure errors were found.")
           PY
 
       - name: Enforce the aggregate gate

--- a/harnesses/conformance/README.md
+++ b/harnesses/conformance/README.md
@@ -139,16 +139,23 @@ command. Generated Stan sources are content-addressed once under
 
 ## Gates and snapshots
 
-Every inventory row has exactly one of the seven design statuses. A run is
+Every inventory row has exactly one of the eight design statuses. A run is
 green only when it is complete, carries no blocking status, has no stale
 policy exception, and does not lose ground against its baseline.
 
-The gate blocks on two things: `mismatch`, where stanli answered and
-answered differently from CmdStan, and `harness_error`, where the harness
-failed to ask. A function stanli has not implemented yet is neither, and
-this suite is a build-out to-do list -- so `unexpected_unsupported` and
+The gate blocks on three things: `mismatch`, where stanli answered and
+answered differently from CmdStan, `crashed`, where the stanli worker
+stopped answering at all, and `harness_error`, where the harness failed to
+ask. A function stanli has not implemented yet is none of them, and this
+suite is a build-out to-do list -- so `unexpected_unsupported` and
 `generator_gap` are counted, listed and given reproducers without failing
 the run.
+
+`crashed` is separate from both of its neighbours on purpose. A refusal is
+a response that says "not implemented"; a segfault is no response, and
+folding the two together let a SIGSEGV read as a coverage gap and pass the
+gate. It is separate from `harness_error` because the process that died is
+the runtime under test rather than the rig measuring it.
 
 That leaves a hole the baseline closes. A lowering regression which turns a
 verified function into a compile refusal lands in `unexpected_unsupported`,

--- a/harnesses/conformance/construct_runner.py
+++ b/harnesses/conformance/construct_runner.py
@@ -29,10 +29,11 @@ CONSTRUCT_GENERATOR_VERSION = "construct-catalog-v2-bridgestan"
 
 _PRECEDENCE = {
     ResultStatus.HARNESS_ERROR: 0,
-    ResultStatus.GENERATOR_GAP: 1,
-    ResultStatus.MISMATCH: 2,
-    ResultStatus.UNEXPECTED_UNSUPPORTED: 3,
-    ResultStatus.VERIFIED: 4,
+    ResultStatus.CRASHED: 1,
+    ResultStatus.GENERATOR_GAP: 2,
+    ResultStatus.MISMATCH: 3,
+    ResultStatus.UNEXPECTED_UNSUPPORTED: 4,
+    ResultStatus.VERIFIED: 5,
 }
 
 
@@ -135,19 +136,18 @@ def _stanli_transport_outcome(case: ConstructCase,
                               reference: Mapping[str, object],
                               phase: str, error: ProtocolError) \
         -> OutcomeComparison:
+    # The worker stopped answering: it died, timed out, or spoke nonsense.
+    # None of those is a refusal, so this does not go through
+    # compare_observations -- a refusal carries a message stanli chose to
+    # send, and reading a dead process as one that declined the case is
+    # what let a SIGSEGV here count as a coverage gap (status.py).
+    del case
     message = f"stanli transport failed during {phase}: {error}"
-    comparison = compare_observations(
-        Observation(accepted=False, message=message),
-        _observation(reference),
-        Expectation(should_accept=case.expected_accept,
-                    phase=case.expected_phase,
-                    exception_category=case.expected_exception), Gate())
-    reason = (comparison.reason + "; " + message
-              if comparison.status == ResultStatus.GENERATOR_GAP
-              else message)
-    return dataclasses.replace(
-        comparison, reason=reason,
-        details={**dict(comparison.details), "transport_phase": phase})
+    return OutcomeComparison(
+        ResultStatus.CRASHED, message,
+        {"stanli": Observation(accepted=False, message=message).to_dict(),
+         "reference": _observation(reference).to_dict(),
+         "transport_phase": phase})
 
 
 def _result(case: ConstructCase, status: ResultStatus, reason: str,

--- a/harnesses/conformance/evaluate.py
+++ b/harnesses/conformance/evaluate.py
@@ -28,12 +28,13 @@ class _PointResult:
 
 _PRECEDENCE = {
     ResultStatus.HARNESS_ERROR: 0,
-    ResultStatus.GENERATOR_GAP: 1,
-    ResultStatus.MISMATCH: 2,
-    ResultStatus.UNEXPECTED_UNSUPPORTED: 3,
-    ResultStatus.EXPECTED_UNSUPPORTED: 4,
-    ResultStatus.INAPPLICABLE: 5,
-    ResultStatus.VERIFIED: 6,
+    ResultStatus.CRASHED: 1,
+    ResultStatus.GENERATOR_GAP: 2,
+    ResultStatus.MISMATCH: 3,
+    ResultStatus.UNEXPECTED_UNSUPPORTED: 4,
+    ResultStatus.EXPECTED_UNSUPPORTED: 5,
+    ResultStatus.INAPPLICABLE: 6,
+    ResultStatus.VERIFIED: 7,
 }
 
 
@@ -88,15 +89,15 @@ def _point_outcome(case: GeneratedCase, point_index: int,
     try:
         stanli_response = stanli_client.request(payload)
     except Exception as exc:
+        # The worker stopped answering rather than declining the case: a
+        # refusal comes back as a response with accepted=False. Blocking
+        # either way, whatever the reference did with the point -- a
+        # process that died reported no capability (status.py).
         details["reference"] = _compact_observation(reference, case)
-        status = (ResultStatus.UNEXPECTED_UNSUPPORTED if reference.accepted
-                  else ResultStatus.GENERATOR_GAP)
-        reason = ("stanli failed after the reference accepted the case: "
-                  if reference.accepted else
-                  "The reference rejected the nominal case before stanli "
-                  "transport failed: ")
         return _PointResult(OutcomeComparison(
-            status, reason + str(exc), details), reference)
+            ResultStatus.CRASHED,
+            f"point {point_index}: the stanli worker stopped answering: "
+            + str(exc), details), reference)
 
     try:
         if stanli_response.get("protocol_error"):

--- a/harnesses/conformance/protocol.py
+++ b/harnesses/conformance/protocol.py
@@ -6,6 +6,7 @@ import collections
 import json
 import pathlib
 import queue
+import signal
 import subprocess
 import threading
 from typing import Deque, Dict, Mapping, Optional, Sequence
@@ -16,6 +17,24 @@ class ProtocolError(RuntimeError):
 
 
 _EOF = object()
+
+
+def _exit_description(code: Optional[int]) -> str:
+    """How a worker ended, in words.
+
+    A negative returncode is a signal, and "exit -11" is a poor way to say
+    "it segfaulted" -- poor enough that a crash in this suite read as a
+    missing feature for a month.
+    """
+    if code is None:
+        return "still running"
+    if code >= 0:
+        return f"exit {code}"
+    try:
+        name = signal.Signals(-code).name
+    except ValueError:
+        name = "unknown signal"
+    return f"killed by signal {-code} ({name})"
 
 
 class JsonLinesClient:
@@ -100,9 +119,9 @@ class JsonLinesClient:
                     f"{self.label} protocol timed out after {self.timeout:g}s"
                     f"{self._context()}") from exc
             if raw is _EOF:
-                code = self.process.poll()
                 raise ProtocolError(
-                    f"{self.label} process exited before replying (exit {code})"
+                    f"{self.label} process exited before replying "
+                    f"({_exit_description(self.process.poll())})"
                     f"{self._context()}")
             try:
                 response = json.loads(str(raw))

--- a/harnesses/conformance/report.py
+++ b/harnesses/conformance/report.py
@@ -283,6 +283,7 @@ def live_classifications(report: ConformanceReport) \
         # comparison; snapshot creation is refused before this can be written.
         blocking_precedence = (
             ResultStatus.HARNESS_ERROR,
+            ResultStatus.CRASHED,
             ResultStatus.MISMATCH,
             ResultStatus.UNEXPECTED_UNSUPPORTED,
             ResultStatus.GENERATOR_GAP,
@@ -440,6 +441,7 @@ _SECTION_TITLES = {
     ResultStatus.INAPPLICABLE: "Inapplicable",
     ResultStatus.GENERATOR_GAP: "Generator gaps",
     ResultStatus.MISMATCH: "Mismatches",
+    ResultStatus.CRASHED: "Crashes",
     ResultStatus.HARNESS_ERROR: "Harness errors",
 }
 

--- a/harnesses/conformance/scalar_runner.py
+++ b/harnesses/conformance/scalar_runner.py
@@ -176,26 +176,23 @@ def _evaluate_shard(shard: GeneratedShard, reference: ReferenceBuild,
                             raise ProtocolError(
                                 "reference description omitted acceptance "
                                 "status")
+                        # A worker that stopped answering did not decline
+                        # the signature -- a refusal returns a response
+                        # saying so -- and no capability policy covers a
+                        # dead process, so the rule is not consulted here
+                        # (status.py). What the reference made of the same
+                        # case goes in the reason and not in the status: a
+                        # generated case the oracle rejects is a generator
+                        # gap when stanli merely disagrees, and still a
+                        # crash when stanli died.
+                        policy_rule = None
+                        status = ResultStatus.CRASHED
+                        reason = ("the stanli worker stopped answering while "
+                                  "loading the isolated case: "
+                                  + stanli_failure)
                         if not reference_description["accepted"]:
-                            return (_failure(
-                                case, ResultStatus.GENERATOR_GAP,
-                                "The reference rejected the isolated case "
-                                "while stanli's transport failed.",
-                                {"shard": shard.result_metadata(),
-                                 "source_path": str(reference.source),
-                                 "reference_description":
-                                     reference_description,
-                                 "stanli_transport_error": stanli_failure},
-                                repros[case.case_id],
-                                probe_attempted=True),)
-                        policy_rule = policy.classification_for(
-                            case.spec.signature)
-                        status = (ResultStatus.EXPECTED_UNSUPPORTED
-                                  if policy_rule is not None else
-                                  ResultStatus.UNEXPECTED_UNSUPPORTED)
-                        reason = (policy_rule.reason if policy_rule is not None
-                                  else "stanli failed while loading the "
-                                  "isolated case: " + stanli_failure)
+                            reason += ("; the reference rejected the isolated "
+                                       "case as well")
                         return (_failure(
                             case, status, reason,
                             {"shard": shard.result_metadata(),

--- a/harnesses/conformance/status.py
+++ b/harnesses/conformance/status.py
@@ -14,6 +14,7 @@ class ResultStatus(str, enum.Enum):
     UNEXPECTED_UNSUPPORTED = "unexpected_unsupported"
     MISMATCH = "mismatch"
     GENERATOR_GAP = "generator_gap"
+    CRASHED = "crashed"
     HARNESS_ERROR = "harness_error"
 
     @property
@@ -32,12 +33,24 @@ class ResultStatus(str, enum.Enum):
 # wrong answer rather than a missing one. `harness_error` does, because a
 # harness that cannot run has not measured anything.
 #
+# `crashed` is the third blocking one, and it exists because a refusal and
+# a dead process arrive at this vocabulary through the same door. A worker
+# that segfaults never replies, so the transport raises where a refusal
+# would have returned a message -- and folding that into
+# unexpected_unsupported (which it was, until it stopped blocking) let a
+# SIGSEGV read as "this function is not wired up yet" and pass the gate. A
+# process that died made no capability statement at all. It stays separate
+# from harness_error because the process that failed is the runtime under
+# test, not the rig measuring it, and pointing the reader at the wrong one
+# is most of what a status is for.
+#
 # Worth revisiting for one slice of `generator_gap`: the rows reading
 # "stanc rejected the generated scalar shard" are a generator bug, not a
 # generator to-do, and once that is fixed they could block on their own.
 BLOCKING_STATUSES = frozenset(
     {
         ResultStatus.MISMATCH,
+        ResultStatus.CRASHED,
         ResultStatus.HARNESS_ERROR,
     }
 )
@@ -52,6 +65,7 @@ FINDING_STATUSES = frozenset(
         ResultStatus.UNEXPECTED_UNSUPPORTED,
         ResultStatus.MISMATCH,
         ResultStatus.GENERATOR_GAP,
+        ResultStatus.CRASHED,
         ResultStatus.HARNESS_ERROR,
     }
 )

--- a/runtime/include/stanli/mir_prog.hpp
+++ b/runtime/include/stanli/mir_prog.hpp
@@ -76,6 +76,12 @@ struct ProgramCompiler {
   // Where `target +=` accumulates, or -1 when the region may not have
   // one. Set by the caller, which also seeds it to zero.
   int target_reg = -1;
+  // Register runs allocated by the zero-length adoption in Assignment,
+  // which is the one allocation site whose write can sit under a jump.
+  // finish() fills them with NaN ahead of the program, restoring the
+  // contract run_program states (program.hpp): every register is written
+  // before it is read.
+  std::vector<std::pair<int, int>> late_bound;
 
   // Registers are never recycled. Right-hand sides are a few lines over a
   // handful of states, so the count stays in the dozens; the cap is a
@@ -110,10 +116,14 @@ struct ProgramCompiler {
   }
 
   // dst[0..n) = the given values, as one instruction.
+  Program::Instr const_instr(int dst, const double* v, int n) {
+    return Program::Instr{
+        n == 1 ? Program::CONST : Program::CONSTR, dst, pool_at(v, n), 0, 0, n};
+  }
+
   void emit_const(int dst, const double* v, int n) {
     if (n == 0) return;
-    p.code.push_back(Program::Instr{n == 1 ? Program::CONST : Program::CONSTR,
-                                    dst, pool_at(v, n), 0, 0, n});
+    p.code.push_back(const_instr(dst, v, n));
   }
 
   int konst(double v) {
@@ -594,6 +604,30 @@ struct ProgramCompiler {
     return r;
   }
 
+  // Close the program: prepend the NaN fills the zero-length adoption in
+  // Assignment (below) deferred.
+  // Every caller runs this once the region has compiled and before the
+  // program runs; it is idempotent, and a region with no adoption pays
+  // nothing. The fills go in front rather than at the declaration because
+  // the width is only known once the assignment inside the branch has
+  // compiled, and the jumps are the only instructions that name a code
+  // position (CONST/CONSTR's `a` is a pool index, CALL's is a call index).
+  void finish() {
+    if (late_bound.empty()) return;
+    std::vector<Program::Instr> prologue;
+    for (const auto& [reg, len] : late_bound) {
+      const std::vector<double> nan((size_t)len,
+                                    std::numeric_limits<double>::quiet_NaN());
+      prologue.push_back(const_instr(reg, nan.data(), len));
+    }
+    const int n = (int)prologue.size();
+    for (auto& instr : p.code)
+      if (instr.code == Program::JZ || instr.code == Program::JMP)
+        instr.dst += n;
+    p.code.insert(p.code.begin(), prologue.begin(), prologue.end());
+    late_bound.clear();
+  }
+
   void stmt(const mir::Stmt& s) {
     switch (s.kind) {
       case mir::Stmt::Decl: {
@@ -654,8 +688,18 @@ struct ProgramCompiler {
             // assignment to size; adopt the assigned shape. The inliner
             // assigns it exactly once, right where the call was, so no
             // two branch arms can disagree about the size.
+            //
+            // That one assignment can still sit inside a data-dependent
+            // branch -- `cond ? udf(x) : y` inlines to an assignment under
+            // `if (cond)` -- and then the arm that does not run leaves
+            // these registers unwritten. They are the variable's live-out,
+            // so the harvest reads them anyway: under the backward's var
+            // replay that is a null (or a previous call's, already
+            // recovered) vari. finish() fills them with NaN, which is what
+            // Stan holds in a value it never computed.
             Range nd = v;
             nd.reg = alloc(v.len);
+            late_bound.emplace_back(nd.reg, v.len);
             for (int k = 0; k < v.len; ++k)
               emit(Program::MOV, nd.reg + k, v.reg + k);
             it->second = nd;

--- a/runtime/src/lower.cpp
+++ b/runtime/src/lower.cpp
@@ -1154,6 +1154,7 @@ struct Lowering {
         for (int k = 0; k < expr_out->len; ++k)
           prog->out_regs.push_back(expr_out->reg + k);
       }
+      c.finish();
     } catch (Bail& b) {
       fail("parameter-dependent region: " + b.why, s ? s->raw : e->raw);
     }

--- a/runtime/src/ode_prog.cpp
+++ b/runtime/src/ode_prog.cpp
@@ -110,6 +110,7 @@ RhsProgram compile_rhs_args(
       c.bail("right-hand side returns " + std::to_string(out.len) +
              " values for " + std::to_string(n_y) + " states");
     for (int k = 0; k < out.len; ++k) p.out_regs.push_back(out.reg + k);
+    c.finish();
     p.ok = true;
   } catch (Bail& b) {
     p.ok = false;

--- a/tests/fixtures/branchudf.stan
+++ b/tests/fixtures/branchudf.stan
@@ -1,0 +1,16 @@
+functions {
+  matrix ident(matrix x) {
+    return x;
+  }
+}
+parameters {
+  matrix[5, 10] a;
+  matrix[5, 10] b;
+  matrix[5, 10] c;
+}
+transformed parameters {
+  matrix[5, 10] mix = sum(a) > 0 ? ident(b + c) : c;
+}
+model {
+  target += sum(mix);
+}

--- a/tests/fixtures/branchudf.tmir.sexp
+++ b/tests/fixtures/branchudf.tmir.sexp
@@ -1,0 +1,905 @@
+((functions_block
+  (((fdrt (ReturnType UMatrix)) (fdname ident) (fdsuffix FnPlain)
+    (fdargs ((AutoDiffable x UMatrix)))
+    (fdbody
+     (((pattern
+        (Block
+         (((pattern
+            (Return
+             (((pattern (Var x))
+               (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable)))))))
+           (meta <opaque>)))))
+       (meta <opaque>))))
+    (fdloc <opaque>))))
+ (input_vars ()) (prepare_data ())
+ (log_prob
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id a)
+      (decl_type
+       (Sized
+        (SMatrix AoS
+         ((pattern (Lit Int 5)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+         ((pattern (Lit Int 10)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity)
+             (dims
+              (((pattern (Lit Int 5))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+               ((pattern (Lit Int 10))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id b)
+      (decl_type
+       (Sized
+        (SMatrix AoS
+         ((pattern (Lit Int 5)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+         ((pattern (Lit Int 10)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity)
+             (dims
+              (((pattern (Lit Int 5))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+               ((pattern (Lit Int 10))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id c)
+      (decl_type
+       (Sized
+        (SMatrix AoS
+         ((pattern (Lit Int 5)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+         ((pattern (Lit Int 10)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity)
+             (dims
+              (((pattern (Lit Int 5))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+               ((pattern (Lit Int 10))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id mix)
+      (decl_type
+       (Sized
+        (SMatrix AoS
+         ((pattern (Lit Int 5)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+         ((pattern (Lit Int 10)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id inline_ident_return_sym5__)
+      (decl_type
+       (Sized
+        (SMatrix AoS
+         ((pattern (Lit Int 0)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+         ((pattern (Lit Int 0)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (IfElse
+      ((pattern
+        (FunApp (StanLib Greater__ FnPlain AoS)
+         (((pattern
+            (FunApp (StanLib sum FnPlain AoS)
+             (((pattern (Var a))
+               (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+          ((pattern (Lit Int 0)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UInt) (loc <opaque>) (adlevel AutoDiffable))))
+      ((pattern
+        (Block
+         (((pattern
+            (Block
+             (((pattern
+                (Assignment ((LVariable inline_ident_return_sym5__) ()) UMatrix
+                 ((pattern
+                   (FunApp (StanLib Plus__ FnPlain AoS)
+                    (((pattern (Var b))
+                      (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))
+                     ((pattern (Var c))
+                      (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable)))))))
+                  (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))))
+               (meta <opaque>)))))
+           (meta <opaque>)))))
+       (meta <opaque>))
+      (((pattern Skip) (meta <opaque>)))))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable mix) ()) UMatrix
+      ((pattern
+        (TernaryIf
+         ((pattern
+           (FunApp (StanLib Greater__ FnPlain AoS)
+            (((pattern
+               (FunApp (StanLib sum FnPlain AoS)
+                (((pattern (Var a))
+                  (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable)))))))
+              (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+             ((pattern (Lit Int 0))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+          (meta ((type_ UInt) (loc <opaque>) (adlevel AutoDiffable))))
+         ((pattern (Var inline_ident_return_sym5__))
+          (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))
+         ((pattern (Var c))
+          (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))))
+       (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib sum FnPlain AoS)
+             (((pattern (Var mix))
+               (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>)))))
+    (meta <opaque>))))
+ (reverse_mode_log_prob
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id a)
+      (decl_type
+       (Sized
+        (SMatrix SoA
+         ((pattern (Lit Int 5)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+         ((pattern (Lit Int 10)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity)
+             (dims
+              (((pattern (Lit Int 5))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+               ((pattern (Lit Int 10))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern SoA)))
+           ()))
+         (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id b)
+      (decl_type
+       (Sized
+        (SMatrix AoS
+         ((pattern (Lit Int 5)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+         ((pattern (Lit Int 10)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity)
+             (dims
+              (((pattern (Lit Int 5))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+               ((pattern (Lit Int 10))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id c)
+      (decl_type
+       (Sized
+        (SMatrix AoS
+         ((pattern (Lit Int 5)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+         ((pattern (Lit Int 10)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity)
+             (dims
+              (((pattern (Lit Int 5))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+               ((pattern (Lit Int 10))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id mix)
+      (decl_type
+       (Sized
+        (SMatrix AoS
+         ((pattern (Lit Int 5)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+         ((pattern (Lit Int 10)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id inline_ident_return_sym3__)
+      (decl_type
+       (Sized
+        (SMatrix AoS
+         ((pattern (Lit Int 0)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+         ((pattern (Lit Int 0)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (IfElse
+      ((pattern
+        (FunApp (StanLib Greater__ FnPlain SoA)
+         (((pattern
+            (FunApp (StanLib sum FnPlain SoA)
+             (((pattern (Var a))
+               (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+          ((pattern (Lit Int 0)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UInt) (loc <opaque>) (adlevel AutoDiffable))))
+      ((pattern
+        (Block
+         (((pattern
+            (Block
+             (((pattern
+                (Assignment ((LVariable inline_ident_return_sym3__) ()) UMatrix
+                 ((pattern
+                   (FunApp (StanLib Plus__ FnPlain AoS)
+                    (((pattern (Var b))
+                      (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))
+                     ((pattern (Var c))
+                      (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable)))))))
+                  (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))))
+               (meta <opaque>)))))
+           (meta <opaque>)))))
+       (meta <opaque>))
+      (((pattern Skip) (meta <opaque>)))))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable mix) ()) UMatrix
+      ((pattern
+        (TernaryIf
+         ((pattern
+           (FunApp (StanLib Greater__ FnPlain AoS)
+            (((pattern
+               (FunApp (StanLib sum FnPlain AoS)
+                (((pattern (Var a))
+                  (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable)))))))
+              (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+             ((pattern (Lit Int 0))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+          (meta ((type_ UInt) (loc <opaque>) (adlevel AutoDiffable))))
+         ((pattern (Var inline_ident_return_sym3__))
+          (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))
+         ((pattern (Var c))
+          (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))))
+       (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib sum FnPlain AoS)
+             (((pattern (Var mix))
+               (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>)))))
+    (meta <opaque>))))
+ (generate_quantities
+  (((pattern
+     (Decl (decl_adtype DataOnly) (decl_id a)
+      (decl_type
+       (Sized
+        (SMatrix AoS
+         ((pattern (Lit Int 5)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+         ((pattern (Lit Int 10)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity)
+             (dims
+              (((pattern (Lit Int 5))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+               ((pattern (Lit Int 10))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id b)
+      (decl_type
+       (Sized
+        (SMatrix AoS
+         ((pattern (Lit Int 5)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+         ((pattern (Lit Int 10)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity)
+             (dims
+              (((pattern (Lit Int 5))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+               ((pattern (Lit Int 10))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id c)
+      (decl_type
+       (Sized
+        (SMatrix AoS
+         ((pattern (Lit Int 5)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+         ((pattern (Lit Int 10)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity)
+             (dims
+              (((pattern (Lit Int 5))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+               ((pattern (Lit Int 10))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id mix)
+      (decl_type
+       (Sized
+        (SMatrix AoS
+         ((pattern (Lit Int 5)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+         ((pattern (Lit Int 10)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt ())
+        (var
+         ((pattern (Var a)) (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt ())
+        (var
+         ((pattern (Var b)) (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt ())
+        (var
+         ((pattern (Var c)) (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (IfElse
+      ((pattern
+        (FunApp (StanLib PNot__ FnPlain AoS)
+         (((pattern
+            (EOr
+             ((pattern (Var emit_transformed_parameters__))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+             ((pattern (Var emit_generated_quantities__))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+      ((pattern (Block (((pattern (Return ())) (meta <opaque>))))) (meta <opaque>)) ()))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id inline_ident_return_sym1__)
+      (decl_type
+       (Sized
+        (SMatrix AoS
+         ((pattern (Lit Int 0)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+         ((pattern (Lit Int 0)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (IfElse
+      ((pattern
+        (FunApp (StanLib Greater__ FnPlain AoS)
+         (((pattern
+            (FunApp (StanLib sum FnPlain AoS)
+             (((pattern (Var a))
+               (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+          ((pattern (Lit Int 0)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UInt) (loc <opaque>) (adlevel AutoDiffable))))
+      ((pattern
+        (Block
+         (((pattern
+            (Block
+             (((pattern
+                (Assignment ((LVariable inline_ident_return_sym1__) ()) UMatrix
+                 ((pattern
+                   (FunApp (StanLib Plus__ FnPlain AoS)
+                    (((pattern (Var b))
+                      (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))
+                     ((pattern (Var c))
+                      (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable)))))))
+                  (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))))
+               (meta <opaque>)))))
+           (meta <opaque>)))))
+       (meta <opaque>))
+      (((pattern Skip) (meta <opaque>)))))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable mix) ()) UMatrix
+      ((pattern
+        (TernaryIf
+         ((pattern
+           (FunApp (StanLib Greater__ FnPlain AoS)
+            (((pattern
+               (FunApp (StanLib sum FnPlain AoS)
+                (((pattern (Var a))
+                  (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable)))))))
+              (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+             ((pattern (Lit Int 0))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+          (meta ((type_ UInt) (loc <opaque>) (adlevel AutoDiffable))))
+         ((pattern (Var inline_ident_return_sym1__))
+          (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly))))
+         ((pattern (Var c))
+          (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))))
+       (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))))
+    (meta <opaque>))
+   ((pattern
+     (IfElse
+      ((pattern (Var emit_transformed_parameters__))
+       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+      ((pattern
+        (Block
+         (((pattern
+            (NRFunApp
+             (CompilerInternal
+              (FnWriteParam (unconstrain_opt ())
+               (var
+                ((pattern (Var mix))
+                 (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly)))))))
+             ()))
+           (meta <opaque>)))))
+       (meta <opaque>))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (IfElse
+      ((pattern
+        (FunApp (StanLib PNot__ FnPlain AoS)
+         (((pattern (Var emit_generated_quantities__))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+      ((pattern (Block (((pattern (Return ())) (meta <opaque>))))) (meta <opaque>)) ()))
+    (meta <opaque>))))
+ (transform_inits
+  (((pattern
+     (Decl (decl_adtype DataOnly) (decl_id pos__) (decl_type (Sized SInt))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id a)
+      (decl_type
+       (Sized
+        (SMatrix AoS
+         ((pattern (Lit Int 5)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+         ((pattern (Lit Int 10)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id a_flat__)
+          (decl_type (Unsized (UArray UReal))) (initialize Uninit)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable a_flat__) ()) (UArray UReal)
+          ((pattern
+            (FunApp (CompilerInternal FnReadData)
+             (((pattern (Lit Str a))
+               (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable pos__) ()) UInt
+          ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar sym1__)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Lit Int 10))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (For (loopvar sym2__)
+                  (lower
+                   ((pattern (Lit Int 1))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (upper
+                   ((pattern (Lit Int 5))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (body
+                   ((pattern
+                     (Block
+                      (((pattern
+                         (Assignment
+                          ((LVariable a)
+                           ((Single
+                             ((pattern (Var sym2__))
+                              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                            (Single
+                             ((pattern (Var sym1__))
+                              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                          UMatrix
+                          ((pattern
+                            (Indexed
+                             ((pattern (Var a_flat__))
+                              (meta
+                               ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))
+                             ((Single
+                               ((pattern (Var pos__))
+                                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                           (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+                        (meta <opaque>))
+                       ((pattern
+                         (Assignment ((LVariable pos__) ()) UInt
+                          ((pattern
+                            (FunApp (StanLib Plus__ FnPlain AoS)
+                             (((pattern (Var pos__))
+                               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                              ((pattern (Lit Int 1))
+                               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                        (meta <opaque>)))))
+                    (meta <opaque>)))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var a)) (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id b)
+      (decl_type
+       (Sized
+        (SMatrix AoS
+         ((pattern (Lit Int 5)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+         ((pattern (Lit Int 10)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id b_flat__)
+          (decl_type (Unsized (UArray UReal))) (initialize Uninit)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable b_flat__) ()) (UArray UReal)
+          ((pattern
+            (FunApp (CompilerInternal FnReadData)
+             (((pattern (Lit Str b))
+               (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable pos__) ()) UInt
+          ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar sym1__)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Lit Int 10))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (For (loopvar sym2__)
+                  (lower
+                   ((pattern (Lit Int 1))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (upper
+                   ((pattern (Lit Int 5))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (body
+                   ((pattern
+                     (Block
+                      (((pattern
+                         (Assignment
+                          ((LVariable b)
+                           ((Single
+                             ((pattern (Var sym2__))
+                              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                            (Single
+                             ((pattern (Var sym1__))
+                              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                          UMatrix
+                          ((pattern
+                            (Indexed
+                             ((pattern (Var b_flat__))
+                              (meta
+                               ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))
+                             ((Single
+                               ((pattern (Var pos__))
+                                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                           (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+                        (meta <opaque>))
+                       ((pattern
+                         (Assignment ((LVariable pos__) ()) UInt
+                          ((pattern
+                            (FunApp (StanLib Plus__ FnPlain AoS)
+                             (((pattern (Var pos__))
+                               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                              ((pattern (Lit Int 1))
+                               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                        (meta <opaque>)))))
+                    (meta <opaque>)))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var b)) (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id c)
+      (decl_type
+       (Sized
+        (SMatrix AoS
+         ((pattern (Lit Int 5)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+         ((pattern (Lit Int 10)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id c_flat__)
+          (decl_type (Unsized (UArray UReal))) (initialize Uninit)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable c_flat__) ()) (UArray UReal)
+          ((pattern
+            (FunApp (CompilerInternal FnReadData)
+             (((pattern (Lit Str c))
+               (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable pos__) ()) UInt
+          ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar sym1__)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Lit Int 10))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (For (loopvar sym2__)
+                  (lower
+                   ((pattern (Lit Int 1))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (upper
+                   ((pattern (Lit Int 5))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (body
+                   ((pattern
+                     (Block
+                      (((pattern
+                         (Assignment
+                          ((LVariable c)
+                           ((Single
+                             ((pattern (Var sym2__))
+                              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                            (Single
+                             ((pattern (Var sym1__))
+                              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                          UMatrix
+                          ((pattern
+                            (Indexed
+                             ((pattern (Var c_flat__))
+                              (meta
+                               ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))
+                             ((Single
+                               ((pattern (Var pos__))
+                                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                           (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+                        (meta <opaque>))
+                       ((pattern
+                         (Assignment ((LVariable pos__) ()) UInt
+                          ((pattern
+                            (FunApp (StanLib Plus__ FnPlain AoS)
+                             (((pattern (Var pos__))
+                               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                              ((pattern (Lit Int 1))
+                               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                        (meta <opaque>)))))
+                    (meta <opaque>)))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var c)) (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))))
+ (unconstrain_array
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id a)
+      (decl_type
+       (Sized
+        (SMatrix AoS
+         ((pattern (Lit Int 5)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+         ((pattern (Lit Int 10)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable a) ()) UMatrix
+      ((pattern
+        (FunApp (CompilerInternal FnReadDeserializer)
+         (((pattern (Lit Int 5)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+          ((pattern (Lit Int 10))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var a)) (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id b)
+      (decl_type
+       (Sized
+        (SMatrix AoS
+         ((pattern (Lit Int 5)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+         ((pattern (Lit Int 10)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable b) ()) UMatrix
+      ((pattern
+        (FunApp (CompilerInternal FnReadDeserializer)
+         (((pattern (Lit Int 5)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+          ((pattern (Lit Int 10))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var b)) (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id c)
+      (decl_type
+       (Sized
+        (SMatrix AoS
+         ((pattern (Lit Int 5)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+         ((pattern (Lit Int 10)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable c) ()) UMatrix
+      ((pattern
+        (FunApp (CompilerInternal FnReadDeserializer)
+         (((pattern (Lit Int 5)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+          ((pattern (Lit Int 10))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var c)) (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))))
+ (output_vars
+  ((a <opaque>
+    ((out_unconstrained_st
+      (SMatrix AoS
+       ((pattern (Lit Int 5)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+       ((pattern (Lit Int 10)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+     (out_constrained_st
+      (SMatrix AoS
+       ((pattern (Lit Int 5)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+       ((pattern (Lit Int 10)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+     (out_block Parameters) (out_trans Identity)))
+   (b <opaque>
+    ((out_unconstrained_st
+      (SMatrix AoS
+       ((pattern (Lit Int 5)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+       ((pattern (Lit Int 10)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+     (out_constrained_st
+      (SMatrix AoS
+       ((pattern (Lit Int 5)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+       ((pattern (Lit Int 10)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+     (out_block Parameters) (out_trans Identity)))
+   (c <opaque>
+    ((out_unconstrained_st
+      (SMatrix AoS
+       ((pattern (Lit Int 5)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+       ((pattern (Lit Int 10)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+     (out_constrained_st
+      (SMatrix AoS
+       ((pattern (Lit Int 5)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+       ((pattern (Lit Int 10)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+     (out_block Parameters) (out_trans Identity)))
+   (mix <opaque>
+    ((out_unconstrained_st
+      (SMatrix AoS
+       ((pattern (Lit Int 5)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+       ((pattern (Lit Int 10)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+     (out_constrained_st
+      (SMatrix AoS
+       ((pattern (Lit Int 5)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+       ((pattern (Lit Int 10)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+     (out_block TransformedParameters) (out_trans Identity)))))
+ (prog_name branchudf_model) (prog_path tests/fixtures/branchudf.stan))

--- a/tests/test_conformance.py
+++ b/tests/test_conformance.py
@@ -31,7 +31,8 @@ from conformance.generate import (generated_inventory, make_scalar_shards,
                                   make_subshard_source, scalar_case_for,
                                   scalar_inventory)
 from conformance.policy import PolicyError, load_policy
-from conformance.protocol import JsonLinesClient, ProtocolError
+from conformance.protocol import (JsonLinesClient, ProtocolError,
+                                  _exit_description)
 from conformance.report import (ConformanceReport, ReportError, Scope,
                                 SnapshotRefused, compare_snapshot,
                                 render_markdown, snapshot_for, with_snapshot,
@@ -335,16 +336,26 @@ class ConstructCatalogTests(unittest.TestCase):
         self.assertEqual(outcome.status, ResultStatus.UNEXPECTED_UNSUPPORTED)
         self.assertIn("cataloged evaluation phase", outcome.reason)
 
-    def test_stanli_process_failure_is_an_implementation_finding(self):
+    def test_stanli_process_failure_blocks_as_a_crash(self):
         catalog = load_construct_catalog(DEFAULT_CONSTRUCTS, REPO)
         case = next(case for case in catalog.cases
                     if case.id == "phase.data.valid")
         outcome = _stanli_transport_outcome(
             case, {"accepted": True}, "evaluation",
-            ProtocolError("stanli process exited before replying"))
-        self.assertEqual(outcome.status,
-                         ResultStatus.UNEXPECTED_UNSUPPORTED)
-        self.assertIn("stanli transport failed", outcome.reason)
+            ProtocolError("stanli process exited before replying "
+                          "(killed by signal 11 (SIGSEGV))"))
+        # A worker that died said nothing about the construct, so it is not
+        # a coverage gap: coverage gaps do not block, and a segfault
+        # wearing that status passed the gate for a month.
+        self.assertEqual(outcome.status, ResultStatus.CRASHED)
+        self.assertTrue(outcome.status.is_blocking)
+        self.assertIn("SIGSEGV", outcome.reason)
+
+    def test_signal_deaths_are_named_not_numbered(self):
+        self.assertEqual(_exit_description(-11),
+                         "killed by signal 11 (SIGSEGV)")
+        self.assertEqual(_exit_description(2), "exit 2")
+        self.assertEqual(_exit_description(None), "still running")
 
     def test_worker_normalizes_public_error_categories(self):
         self.assertEqual(worker_category(RuntimeError(
@@ -719,11 +730,14 @@ class GeneratedEvaluationTests(unittest.TestCase):
             def request(self, payload):
                 raise ProtocolError(f"{self.label} process exited")
 
+        # Both block, and which process died stays readable: the rig
+        # failing and the runtime under test failing are different
+        # findings for whoever reads the report.
         scenarios = (
             (FailingClient("reference"), self.Client(),
              ResultStatus.HARNESS_ERROR, "reference"),
             (self.Client(), FailingClient("stanli"),
-             ResultStatus.UNEXPECTED_UNSUPPORTED, "stanli"),
+             ResultStatus.CRASHED, "stanli"),
         )
         for reference, stanli, status, label in scenarios:
             with self.subTest(label=label):

--- a/tests/test_island.cpp
+++ b/tests/test_island.cpp
@@ -3,6 +3,7 @@
 // safe must stay untouched.
 #include "env_helpers.hpp"
 #include "graph_helpers.hpp"
+#include <stanli/compile.hpp>
 #include <stanli/graph.hpp>
 #include <stanli/island.hpp>
 #include <stanli/optable.hpp>
@@ -10,6 +11,8 @@
 #include <cmath>
 #include <cstdio>
 #include <cstdlib>
+#include <fstream>
+#include <sstream>
 #include <string>
 #include <utility>
 #include <vector>
@@ -36,6 +39,43 @@ using stanli::testutil::Fills;
 static double fill_at(int64_t i) { return 0.3 + 0.15 * (i % 4); }
 static std::vector<double> run_grad(Graph g, const Fills& fills) {
   return testutil::run_grad(std::move(g), fills, fill_at);
+}
+
+static std::string slurp(const std::string& path) {
+  std::ifstream f(path);
+  std::ostringstream ss;
+  ss << f.rdbuf();
+  return ss.str();
+}
+
+// A necessity island whose live-out is written only inside the branch:
+// `sum(a) > 0 ? ident(b + c) : c` inlines to an assignment of the --O1
+// inliner's zero-length return symbol under `if (sum(a) > 0)`, and the
+// program compiler sizes that symbol where it is assigned. At the zero
+// point the condition is false, so those registers are the arm that did
+// not run -- and the live-out harvest reads them regardless. Before the
+// prologue fill (mir_prog.hpp) the backward's var replay read a register
+// file no one had written and dereferenced a null vari: SIGSEGV, not a
+// wrong number. Runs first so the replay's thread_local register file is
+// still empty, which is the state that makes that a null rather than a
+// vari from an already-recovered nested tape.
+static void test_branch_bound_live_out() {
+  CompiledModel cm =
+      compile_model(slurp("tests/fixtures/branchudf.tmir.sexp"), DataMap());
+  Executor ex(std::move(cm.graph));
+  cm.bind(ex);
+  const int64_t n = ex.n_params();
+  expect("branchudf params", n == 150);
+  for (int64_t i = 0; i < n; ++i) ex.params_data()[i] = 0.0;
+  std::vector<double> grad((size_t)n, 0.0);
+  const double lp = ex.gradient(grad.data());
+  // The untaken arm contributes nothing: mix is c, so the target is
+  // sum(c) = 0 and only c's 50 entries carry an adjoint.
+  expect("branchudf lp", lp == 0.0);
+  int64_t wrong = 0;
+  for (int64_t i = 0; i < n; ++i)
+    if (grad[(size_t)i] != (i < 100 ? 0.0 : 1.0)) ++wrong;
+  expect("branchudf grad", wrong == 0);
 }
 
 // A mini HMM forward pass: per step, index the previous state pair, take
@@ -443,6 +483,7 @@ int main() {
   // What the compiler does with a region, on graphs small enough to
   // reason about. The cost estimate would refuse most of them -- it is
   // policy, tested separately below, and these are about correctness.
+  test_branch_bound_live_out();
   test_setenv("STANLI_ISLAND_ALWAYS", "1", 1);
   test_hmm_parity();
   test_env_disable();


### PR DESCRIPTION
A SIGSEGV in `log_prob`, and behind it a silent wrong gradient. Two commits: the crash, and the classification that let it hide.

## What I got wrong going in

This was filed as "a `write_array` crash in the transport or facade, since `stanli_check` on the same model is clean." Both halves are false, and the correction is the diagnosis.

**`stanli_check` crashes too.** It defaults to point 0, where `sum(soa_x) > 0` is true; the harness starts at all-zeros, where it is false. On current main:

```
./build/stanli_check tests/stanc3/reductions_allowed.stan ... --point 2   ->  exit 139
./build/stanli_check tests/stanc3/reductions_allowed.stan ...             ->  exit 0
```

The asymmetry was never the layer, it was the point. And it is **not a `write_array` bug**: the stack is in `Executor::gradient`. The harness said "during write_array" only because `oracle_gate = "write_array"` set `include_outputs` on the request that killed the child. Nothing in the facade, the probe, `ExecutorPool` or threading is involved.

## Root cause

```
EXC_BAD_ACCESS (code=1, address=0x8)
#0  multiply_vd_vari(avi=0x0, b=0)     operator_multiplication.hpp:34
#3  stanli::island_bwd(ctx=...)        runtime/kernels/island.cpp:110
#5  stanli::Executor::gradient(...)    runtime/src/executor.cpp:367
```

`island_bwd`'s var replay does `j += vout[m] * ctx.out_adj_vec.data[m]` and `vout[m]` is a default-constructed `var` with a null `vi_`.

`mir_prog.hpp`'s zero-length adoption is why. stanc3's `--O1` inliner declares a UDF return symbol as `matrix[0,0]` and the program compiler sizes it where it is assigned. For `cond ? udf(x) : y` the inliner puts that assignment under `if (cond)`, so `alloc()` happens **inside a data-dependent branch** and nothing writes those registers on the other path -- while `lower_island` harvests them as live-outs regardless.

`program.hpp` states the contract this breaks: *"The compilers guarantee every register is written before it is read."* The island dump shows it exactly: `JZ -> end`, branch body writes `r154..r203` and MOVs to live-outs `r204..r253`, `JMP -> end`. No path writes `r204+` when the branch is not taken.

**The crash is the lucky outcome.** `run_island<T>`'s register file is `static thread_local`, so what you get depends on register indices: fresh slots give a null `vi_` and segfault; slots another island already grew give **varis from an already-recovered nested tape** -- a use-after-free that returns a wrong gradient and no diagnostic. That quieter variant is reproduced too (`udfbranch`).

**General, not model-specific.** Any model where the `--O1` inliner's return symbol is assigned only under a parameter-dependent branch. The minimal repro `tests/fixtures/branchudf.stan` is three matrix parameters and `sum(a) > 0 ? ident(b + c) : c`, with no relation to the upstream test's subject matter.

## Fix

`ProgramCompiler` records each adopted register run and `finish()` prepends a NaN `CONSTR` fill, shifting `JZ`/`JMP` targets by the prologue length -- jumps are the only instructions naming a code position. NaN is what Stan holds in a value it never computed, and it is free at gradient time: the constant has no upstream, so the replay's `0 * NaN` seeds no adjoint. Wired into both compiler entry points, `lower_island` and `compile_rhs_args` -- a branchy ODE right-hand side reaches the same adoption.

RED: with the runtime stashed and the test in place, `./build/test_island` exits **139**. The test runs first in `main()` so the replay's `thread_local` file is empty and the null is deterministic rather than index-dependent, and it asserts values (lp `0.0`, gradient `1.0` on `c` only) so it pins semantics rather than survival.

## A dead worker is not a coverage gap

Three sites turned a killed child into a refusal -- `_stanli_transport_outcome`, `_point_outcome`, and the shard loader, the last of which could hand it to a capability policy and call it `expected_unsupported`. Under the current gate that means **a segfault reads as "not implemented yet" and does not fail CI**, which is how this sat in every nightly this month.

New blocking status `crashed`, kept distinct from `harness_error` because the process that died is the runtime under test, not the rig. `protocol.py` now says `killed by signal 11 (SIGSEGV)` rather than `exit -11`. Verified end to end by making the worker signal itself: `RED: crashed=1`, `gate issues: crashed:1`.

## Gates

`ctest` 50/50 · `verify_refs` 129/129 with `hmm_gaussian` unchanged · `format.sh --check` clean · `test_conformance.py` 74 OK · all 31 construct cases: 24 verified, 1 inapplicable, 5 unexpected_unsupported, no crashes, no harness errors.

## One row now goes red, deliberately

With the crash gone, the case reports `mismatch` on a real numeric difference at point 1: `outputs[203]`, stanli `6.9389e-18` against CmdStan `1.0408e-17`, **3.47e-18 absolute** on a quantity whose exact value is zero.

Traced rather than gated: stanli's `sum` is sequential, CmdStan's `write_array` uses Eigen's vectorized redux on doubles, and `Eigen::Map<const VectorXd>(v,50).sum()` reproduces the reference bit for bit. The **var** path agrees -- AoS `sum_v_vari` also reduces sequentially -- which is why lp and gradients match and only a `write_array` column differs.

Left red rather than papered over, because `packet.hpp` documents sequential reduction as a deliberate parity choice and a gate here would loosen every `sum` row in the sweep. It is general: any TP or GQ with a cancelling `sum()` over 8+ elements can differ in its last bits. Options are an `abs_tol` numeric gate keyed on `^sum$`, or fixing the double-path reduction order -- which would also need the island and interpreter paths, since both unroll `sum` into scalar adds.

The baseline needs no update either way: `unexpected_unsupported -> mismatch` is not a regression under the directional rule.