### PR TITLE
fix: an empty index slice is a legitimate gather, not a type error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## Unreleased
+
+### Empty gathers compile
+
+A gather whose index slice is empty, such as `Y[Jevent[1:Nevent]]` with
+`Nevent == 0`, failed to compile with "gather index must be int data"
+(#133). The length is computed from the data, so whether the model
+compiled depended on the data: a survival model with no observed events
+in one censoring category refused to build. An empty index now lowers
+to a zero-length gather that contributes exactly zero to the density
+and the gradient; the guard still rejects an index whose int values
+disagree with its shape.
+
 ## 0.8.1
 
 ### Overloaded user-defined functions

--- a/runtime/src/lower.cpp
+++ b/runtime/src/lower.cpp
@@ -878,7 +878,8 @@ struct Lowering {
           if (sh.leaf != ViewKind::Flat || sh.dims.size() != 1)
             fail("unsupported index expression", e.raw);
           DataMap::Entry iv = eval_pure(e.args[1].args[0], "a gather index");
-          if (!iv.is_int) fail("gather index must be int data", e.raw);
+          if (!iv.is_int || iv.i.size() != iv.r.size())
+            fail("gather index must be int data", e.raw);
           std::vector<int> idata;
           idata.reserve(iv.i.size());
           for (int x : iv.i) {
@@ -892,8 +893,11 @@ struct Lowering {
         }
         // Gather by a data int array: v[idx].
         if (e.args.size() == 2 && e.args[1].name == "IndexMulti") {
+          // An empty index is a legitimate data-dependent gather (a slice
+          // whose computed length is zero); an int-flagged entry whose int
+          // mirror disagrees with its values is not.
           DataMap::Entry iv = eval_pure(e.args[1].args[0], "a gather index");
-          if (!iv.is_int || iv.i.empty())
+          if (!iv.is_int || iv.i.size() != iv.r.size())
             fail("gather index must be int data", e.raw);
           std::vector<int> idata;
           idata.reserve(iv.i.size());

--- a/tests/fixtures/emptygather.stan
+++ b/tests/fixtures/emptygather.stan
@@ -1,0 +1,32 @@
+// Data-dependent gather width (issue #133): Jev[1:Nev] gathers a slice
+// whose length is computed in transformed data, so whether the gather is
+// empty depends on the data, not the program. Nev == 0 must compile and
+// contribute exactly zero, matching CmdStan. One fixture, two datasets.
+functions {
+  real g_lpdf(vector y, vector m) {
+    return dot_product(y, exp(m)) + sum(m);
+  }
+}
+data {
+  int<lower=1> N;
+  vector[N] Y;
+  array[N] int cens;
+}
+transformed data {
+  int Nev = 0;
+  array[N] int Jev;
+  for (n in 1:N) {
+    if (cens[n] == 0) {
+      Nev += 1;
+      Jev[Nev] = n;
+    }
+  }
+}
+parameters {
+  vector[N] mu;
+}
+model {
+  vector[N] m2 = mu * 2.0;
+  target += g_lpdf(Y[Jev[1:Nev]] | m2[Jev[1:Nev]]);
+  target += normal_lpdf(mu | 0, 1);
+}

--- a/tests/fixtures/emptygather.tmir.sexp
+++ b/tests/fixtures/emptygather.tmir.sexp
@@ -1,0 +1,723 @@
+((functions_block
+  (((fdrt (ReturnType UReal)) (fdname g_lpdf) (fdsuffix (FnLpdf ()))
+    (fdargs ((AutoDiffable y UVector) (AutoDiffable m UVector)))
+    (fdbody
+     (((pattern
+        (Block
+         (((pattern
+            (Return
+             (((pattern
+                (FunApp (StanLib Plus__ FnPlain AoS)
+                 (((pattern
+                    (FunApp (StanLib dot_product FnPlain AoS)
+                     (((pattern (Var y))
+                       (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))
+                      ((pattern
+                        (FunApp (StanLib exp FnPlain AoS)
+                         (((pattern (Var m))
+                           (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+                       (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+                  ((pattern
+                    (FunApp (StanLib sum FnPlain AoS)
+                     (((pattern (Var m))
+                       (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
+           (meta <opaque>)))))
+       (meta <opaque>))))
+    (fdloc <opaque>))))
+ (input_vars
+  ((N <opaque> SInt)
+   (Y <opaque>
+    (SVector AoS
+     ((pattern (Var N)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+   (cens <opaque>
+    (SArray SInt
+     ((pattern (Var N)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+ (prepare_data
+  (((pattern
+     (Decl (decl_adtype DataOnly) (decl_id pos__) (decl_type (Sized SInt))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable pos__) ()) UInt
+      ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id N) (decl_type (Sized SInt))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable N) ()) UInt
+      ((pattern
+        (Indexed
+         ((pattern
+           (FunApp (CompilerInternal FnReadData)
+            (((pattern (Lit Str N))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+          (meta ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly))))
+         ((Single
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnCheck
+        (trans
+         (Lower
+          ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (var_name N)
+        (var ((pattern (Var N)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp (CompilerInternal FnValidateSize)
+      (((pattern (Lit Str Y)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+       ((pattern (Lit Str N)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+       ((pattern (Var N)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id Y)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Var N)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id Y_flat__)
+          (decl_type (Unsized (UArray UReal))) (initialize Uninit)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable Y_flat__) ()) (UArray UReal)
+          ((pattern
+            (FunApp (CompilerInternal FnReadData)
+             (((pattern (Lit Str Y))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable pos__) ()) UInt
+          ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar sym1__)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Var N)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (Assignment
+                  ((LVariable Y)
+                   ((Single
+                     ((pattern (Var sym1__))
+                      (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                  UVector
+                  ((pattern
+                    (Indexed
+                     ((pattern (Var Y_flat__))
+                      (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))
+                     ((Single
+                       ((pattern (Var pos__))
+                        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+                (meta <opaque>))
+               ((pattern
+                 (Assignment ((LVariable pos__) ()) UInt
+                  ((pattern
+                    (FunApp (StanLib Plus__ FnPlain AoS)
+                     (((pattern (Var pos__))
+                       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                      ((pattern (Lit Int 1))
+                       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp (CompilerInternal FnValidateSize)
+      (((pattern (Lit Str cens)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+       ((pattern (Lit Str N)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+       ((pattern (Var N)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id cens)
+      (decl_type
+       (Sized
+        (SArray SInt
+         ((pattern (Var N)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable cens) ()) (UArray UInt)
+      ((pattern
+        (FunApp (CompilerInternal FnReadData)
+         (((pattern (Lit Str cens))
+           (meta ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id Nev) (decl_type (Sized SInt))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable Nev) ()) UInt
+      ((pattern (Lit Int 0)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp (CompilerInternal FnValidateSize)
+      (((pattern (Lit Str Jev)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+       ((pattern (Lit Str N)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+       ((pattern (Var N)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id Jev)
+      (decl_type
+       (Sized
+        (SArray SInt
+         ((pattern (Var N)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (For (loopvar n)
+      (lower
+       ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+      (upper ((pattern (Var N)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+      (body
+       ((pattern
+         (Block
+          (((pattern
+             (IfElse
+              ((pattern
+                (FunApp (StanLib Equals__ FnPlain AoS)
+                 (((pattern
+                    (Indexed
+                     ((pattern (Var cens))
+                      (meta ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly))))
+                     ((Single
+                       ((pattern (Var n))
+                        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                  ((pattern (Lit Int 0))
+                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+              ((pattern
+                (Block
+                 (((pattern
+                    (Assignment ((LVariable Nev) ()) UInt
+                     ((pattern
+                       (FunApp (StanLib Plus__ FnPlain AoS)
+                        (((pattern (Var Nev))
+                          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                         ((pattern (Lit Int 1))
+                          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                      (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                   (meta <opaque>))
+                  ((pattern
+                    (Assignment
+                     ((LVariable Jev)
+                      ((Single
+                        ((pattern (Var Nev))
+                         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                     (UArray UInt)
+                     ((pattern (Var n))
+                      (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                   (meta <opaque>)))))
+               (meta <opaque>))
+              ()))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp (CompilerInternal FnValidateSize)
+      (((pattern (Lit Str mu)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+       ((pattern (Lit Str N)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+       ((pattern (Var N)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+    (meta <opaque>))))
+ (log_prob
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id mu)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Var N)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity)
+             (dims
+              (((pattern (Var N))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (NRFunApp (CompilerInternal FnValidateSize)
+          (((pattern (Lit Str m2))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+           ((pattern (Lit Str N))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+           ((pattern (Var N)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+        (meta <opaque>))
+       ((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id m2)
+          (decl_type
+           (Sized
+            (SVector AoS
+             ((pattern (Var N)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+          (initialize Uninit)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable m2) ()) UVector
+          ((pattern
+            (FunApp (StanLib Times__ FnPlain AoS)
+             (((pattern (Var mu))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))
+              ((pattern (Lit Real 2.0))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>))
+       ((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id inline_g_lpdf_return_sym3__)
+          (decl_type (Sized SReal)) (initialize Uninit)))
+        (meta <opaque>))
+       ((pattern
+         (Block
+          (((pattern
+             (Assignment ((LVariable inline_g_lpdf_return_sym3__) ()) UReal
+              ((pattern
+                (FunApp (StanLib Plus__ FnPlain AoS)
+                 (((pattern
+                    (FunApp (StanLib dot_product FnPlain AoS)
+                     (((pattern
+                        (Indexed
+                         ((pattern (Var Y))
+                          (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly))))
+                         ((MultiIndex
+                           ((pattern
+                             (Indexed
+                              ((pattern (Var Jev))
+                               (meta
+                                ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly))))
+                              ((Between
+                                ((pattern (Lit Int 1))
+                                 (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                                ((pattern (Var Nev))
+                                 (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                            (meta
+                             ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly))))))))
+                       (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly))))
+                      ((pattern
+                        (FunApp (StanLib exp FnPlain AoS)
+                         (((pattern
+                            (Indexed
+                             ((pattern (Var m2))
+                              (meta
+                               ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))
+                             ((MultiIndex
+                               ((pattern
+                                 (Indexed
+                                  ((pattern (Var Jev))
+                                   (meta
+                                    ((type_ (UArray UInt)) (loc <opaque>)
+                                     (adlevel DataOnly))))
+                                  ((Between
+                                    ((pattern (Lit Int 1))
+                                     (meta
+                                      ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                                    ((pattern (Var Nev))
+                                     (meta
+                                      ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                                (meta
+                                 ((type_ (UArray UInt)) (loc <opaque>)
+                                  (adlevel DataOnly))))))))
+                           (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+                       (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+                  ((pattern
+                    (FunApp (StanLib sum FnPlain AoS)
+                     (((pattern
+                        (Indexed
+                         ((pattern (Var m2))
+                          (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))
+                         ((MultiIndex
+                           ((pattern
+                             (Indexed
+                              ((pattern (Var Jev))
+                               (meta
+                                ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly))))
+                              ((Between
+                                ((pattern (Lit Int 1))
+                                 (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                                ((pattern (Var Nev))
+                                 (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                            (meta
+                             ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly))))))))
+                       (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+            (meta <opaque>)))))
+        (meta <opaque>))
+       ((pattern
+         (TargetPE
+          ((pattern (Var inline_g_lpdf_return_sym3__))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>))
+       ((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib normal_lpdf (FnLpdf false) AoS)
+             (((pattern (Var mu))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))
+              ((pattern
+                (Promotion
+                 ((pattern (Lit Int 0))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                 UReal DataOnly))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+              ((pattern
+                (Promotion
+                 ((pattern (Lit Int 1))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                 UReal DataOnly))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>)))))
+    (meta <opaque>))))
+ (reverse_mode_log_prob
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id mu)
+      (decl_type
+       (Sized
+        (SVector SoA
+         ((pattern (Var N)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity)
+             (dims
+              (((pattern (Var N))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern SoA)))
+           ()))
+         (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (NRFunApp (CompilerInternal FnValidateSize)
+          (((pattern (Lit Str m2))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+           ((pattern (Lit Str N))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+           ((pattern (Var N)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+        (meta <opaque>))
+       ((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id m2)
+          (decl_type
+           (Sized
+            (SVector SoA
+             ((pattern (Var N)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+          (initialize Uninit)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable m2) ()) UVector
+          ((pattern
+            (FunApp (StanLib Times__ FnPlain SoA)
+             (((pattern (Var mu))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))
+              ((pattern (Lit Real 2.0))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>))
+       ((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id inline_g_lpdf_return_sym1__)
+          (decl_type (Sized SReal)) (initialize Uninit)))
+        (meta <opaque>))
+       ((pattern
+         (Block
+          (((pattern
+             (Assignment ((LVariable inline_g_lpdf_return_sym1__) ()) UReal
+              ((pattern
+                (FunApp (StanLib Plus__ FnPlain SoA)
+                 (((pattern
+                    (FunApp (StanLib dot_product FnPlain SoA)
+                     (((pattern
+                        (Indexed
+                         ((pattern (Var Y))
+                          (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly))))
+                         ((MultiIndex
+                           ((pattern
+                             (Indexed
+                              ((pattern (Var Jev))
+                               (meta
+                                ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly))))
+                              ((Between
+                                ((pattern (Lit Int 1))
+                                 (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                                ((pattern (Var Nev))
+                                 (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                            (meta
+                             ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly))))))))
+                       (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly))))
+                      ((pattern
+                        (FunApp (StanLib exp FnPlain SoA)
+                         (((pattern
+                            (Indexed
+                             ((pattern (Var m2))
+                              (meta
+                               ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))
+                             ((MultiIndex
+                               ((pattern
+                                 (Indexed
+                                  ((pattern (Var Jev))
+                                   (meta
+                                    ((type_ (UArray UInt)) (loc <opaque>)
+                                     (adlevel DataOnly))))
+                                  ((Between
+                                    ((pattern (Lit Int 1))
+                                     (meta
+                                      ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                                    ((pattern (Var Nev))
+                                     (meta
+                                      ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                                (meta
+                                 ((type_ (UArray UInt)) (loc <opaque>)
+                                  (adlevel DataOnly))))))))
+                           (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+                       (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+                  ((pattern
+                    (FunApp (StanLib sum FnPlain SoA)
+                     (((pattern
+                        (Indexed
+                         ((pattern (Var m2))
+                          (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))
+                         ((MultiIndex
+                           ((pattern
+                             (Indexed
+                              ((pattern (Var Jev))
+                               (meta
+                                ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly))))
+                              ((Between
+                                ((pattern (Lit Int 1))
+                                 (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                                ((pattern (Var Nev))
+                                 (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                            (meta
+                             ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly))))))))
+                       (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+            (meta <opaque>)))))
+        (meta <opaque>))
+       ((pattern
+         (TargetPE
+          ((pattern (Var inline_g_lpdf_return_sym1__))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>))
+       ((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib normal_lpdf (FnLpdf false) SoA)
+             (((pattern (Var mu))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))
+              ((pattern
+                (Promotion
+                 ((pattern (Lit Int 0))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                 UReal DataOnly))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+              ((pattern
+                (Promotion
+                 ((pattern (Lit Int 1))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                 UReal DataOnly))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>)))))
+    (meta <opaque>))))
+ (generate_quantities
+  (((pattern
+     (Decl (decl_adtype DataOnly) (decl_id mu)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Var N)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity)
+             (dims
+              (((pattern (Var N))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt ())
+        (var
+         ((pattern (Var mu)) (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (IfElse
+      ((pattern
+        (FunApp (StanLib PNot__ FnPlain AoS)
+         (((pattern
+            (EOr
+             ((pattern (Var emit_transformed_parameters__))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+             ((pattern (Var emit_generated_quantities__))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+      ((pattern (Block (((pattern (Return ())) (meta <opaque>))))) (meta <opaque>)) ()))
+    (meta <opaque>))
+   ((pattern
+     (IfElse
+      ((pattern
+        (FunApp (StanLib PNot__ FnPlain AoS)
+         (((pattern (Var emit_generated_quantities__))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+      ((pattern (Block (((pattern (Return ())) (meta <opaque>))))) (meta <opaque>)) ()))
+    (meta <opaque>))))
+ (transform_inits
+  (((pattern
+     (Decl (decl_adtype DataOnly) (decl_id pos__) (decl_type (Sized SInt))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable pos__) ()) UInt
+      ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id mu)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Var N)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id mu_flat__)
+          (decl_type (Unsized (UArray UReal))) (initialize Uninit)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable mu_flat__) ()) (UArray UReal)
+          ((pattern
+            (FunApp (CompilerInternal FnReadData)
+             (((pattern (Lit Str mu))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable pos__) ()) UInt
+          ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar sym1__)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Var N)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (Assignment
+                  ((LVariable mu)
+                   ((Single
+                     ((pattern (Var sym1__))
+                      (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                  UVector
+                  ((pattern
+                    (Indexed
+                     ((pattern (Var mu_flat__))
+                      (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))
+                     ((Single
+                       ((pattern (Var pos__))
+                        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+                (meta <opaque>))
+               ((pattern
+                 (Assignment ((LVariable pos__) ()) UInt
+                  ((pattern
+                    (FunApp (StanLib Plus__ FnPlain AoS)
+                     (((pattern (Var pos__))
+                       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                      ((pattern (Lit Int 1))
+                       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var mu)) (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))))
+ (unconstrain_array
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id mu)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Var N)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable mu) ()) UVector
+      ((pattern
+        (FunApp (CompilerInternal FnReadDeserializer)
+         (((pattern (Var N)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var mu)) (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))))
+ (output_vars
+  ((mu <opaque>
+    ((out_unconstrained_st
+      (SVector AoS
+       ((pattern (Var N)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+     (out_constrained_st
+      (SVector AoS
+       ((pattern (Var N)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+     (out_block Parameters) (out_trans Identity)))))
+ (prog_name emptygather_model) (prog_path tests/fixtures/emptygather.stan))

--- a/tests/test_lower.cpp
+++ b/tests/test_lower.cpp
@@ -511,6 +511,51 @@ int main() {
     stan::math::recover_memory();
   }
 
+  // Data-dependent gather width (issue #133): the same program gathers a
+  // slice whose length transformed data computes from the data. Nev > 0 is
+  // an ordinary gather; Nev == 0 must compile and contribute exactly zero
+  // to lp and the gradient.
+  {
+    const double yv[4] = {1.5, -0.5, 2.0, 0.25};
+    const double q[4] = {0.3, -0.8, 0.1, 0.6};
+    for (int empty = 0; empty < 2; ++empty) {
+      DataMap d;
+      d.set_int("N", 4);
+      d.set_real_array("Y", {yv[0], yv[1], yv[2], yv[3]});
+      d.set_int_array("cens", empty ? std::vector<int>{1, 1, 1, 1}
+                                    : std::vector<int>{0, 1, 0, 1});
+      CompiledModel lm =
+          compile_model(slurp("tests/fixtures/emptygather.tmir.sexp"), d);
+      check(lm.n_unconstrained == 4, "emptygather 4 unconstrained");
+      Executor lex(std::move(lm.graph));
+      lm.bind(lex);
+      for (int i = 0; i < 4; ++i) lex.params_data()[i] = q[i];
+      double grad[4] = {0, 0, 0, 0};
+      const double lp = lex.gradient(grad);
+
+      using stan::math::var;
+      Eigen::Matrix<var, -1, 1> mu(4);
+      mu << q[0], q[1], q[2], q[3];
+      var acc = 0.0;
+      if (!empty) {
+        Eigen::Matrix<var, -1, 1> mg(2);
+        mg << mu(0) * 2.0, mu(2) * 2.0;
+        Eigen::VectorXd yg(2);
+        yg << yv[0], yv[2];
+        acc += stan::math::dot_product(yg, stan::math::exp(mg)) +
+               stan::math::sum(mg);
+      }
+      acc += stan::math::normal_lpdf<false>(mu, 0.0, 1.0);
+      acc.grad();
+      const std::string tag = empty ? "emptygather empty" : "emptygather full";
+      expect_ulp(tag + " lp", lp, acc.val());
+      for (int i = 0; i < 4; ++i)
+        check(std::fabs(grad[i] - mu(i).adj()) < 1e-12,
+              tag + " g" + std::to_string(i));
+      stan::math::recover_memory();
+    }
+  }
+
   // Index forms on parameters: gather, Between read/write, matrix row and
   // column slices, column writes.
   {


### PR DESCRIPTION
Fixes #133.

A gather index like `Jevent[1:Nevent]` has a data-dependent length, so whether it is empty is a property of the data, not the program. With `Nevent == 0` compilation failed with "gather index must be int data": a survival model with no observed events in one censoring category refused to build, while the identical program compiled fine on data with events.

The guard conflated "empty" with "not int". It predates the interpreter tracking int-ness explicitly, when an empty int mirror was the only signal an entry was not integer data. Both gather paths now accept an empty index and instead reject an int-flagged entry whose int mirror disagrees with its value shape, which keeps the defensive half of the old check. An empty gather emits a zero-length value; the kernels are length loops and the reductions initialize to zero, so it contributes exactly nothing.

Verified: new fixture with the issue's shape (transformed-data index build, gathers on a data vector and on parameter-dependent model-block locals through an overloaded user _lpdf) checked against a stan-math var reference for lp and all gradients in both the empty and the nonempty data case; the issue's exact reprex compiles, and its lp and gradients are bitwise identical to the same model with the gather term deleted; the nonempty case is bitwise unchanged from before the fix; all 50 tests pass; corpus replay 129/129 with zero drift.
