### PR TITLE
fix: reject out-of-bounds indices at compile time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,18 @@ rvalue semantics: hi < lo is an empty slice whatever the endpoints,
 bounds are checked only when a range is nonempty, and an empty slice
 contributes exactly nothing.
 
+### Out-of-bounds indices are rejected at compile time
+
+Every index the graph lowering sees is a bind-time constant, but most
+index forms never checked it: v[7] on a length-4 vector, a gather by
+[1, 9], Y[2:9], M[1:2, 5], and their friends silently read a
+neighboring arena slot and produced a wrong log density with no error.
+CmdStan rejects all of these at runtime. Every indexing path now
+checks its bounds at compile time and names the index and the extent;
+the matrix row range also accepts hi < lo as empty now, completing the
+empty-range semantics. The interpreter's index paths get the same
+named errors in place of a bare std::out_of_range("vector").
+
 ### Matrix division is a linear solve again
 
 `B / A` on two matrices in the model block computed elementwise

--- a/runtime/include/stanli/mir_interp.hpp
+++ b/runtime/include/stanli/mir_interp.hpp
@@ -463,6 +463,16 @@ class MirInterp {
                        (raw.empty() ? "" : " | in: " + raw));
   }
 
+  // The .at() reads in eval_indexed would throw a bare
+  // std::out_of_range("vector"); check first so an out-of-range index
+  // names the index and the extent instead.
+  void bounds(long i, int64_t n, const mir::Expr& e) const {
+    if (i < 1 || i > n)
+      fail("index " + std::to_string(i) + " out of bounds for size " +
+               std::to_string(n),
+           e.raw);
+  }
+
   static double val(const T& x) { return stan::math::value_of(x); }
 
   // Arity of a bound transform called as a function, or 0 for any other
@@ -714,6 +724,7 @@ class MirInterp {
     if (e.args.size() == 2 && e.args[1].name == "IndexSingle" &&
         base.dims.size() <= 1) {
       const long ix = as_int(e.args[1].args[0]);
+      bounds(ix, (int64_t)base.r.size(), e);
       r.is_int = base.is_int;
       if (base.is_int) r.i = {base.i.at(ix - 1)};
       r.r = {base.r.at(ix - 1)};
@@ -727,6 +738,7 @@ class MirInterp {
           e.args[2].name == "IndexAll"))) {
       const long i = as_int(e.args[1].args[0]);
       const int64_t R = base.dims[0], C = base.dims[1];
+      bounds(i, R, e);
       r.is_int = base.is_int;
       r.dims = {C};
       for (int64_t j = 0; j < C; ++j) {
@@ -744,7 +756,9 @@ class MirInterp {
       if (all_single) {
         int64_t flatpos = 0, stride = 1;
         for (size_t d = 0; d < base.dims.size(); ++d) {
-          flatpos += (as_int(e.args[1 + d].args[0]) - 1) * stride;
+          const long ixd = as_int(e.args[1 + d].args[0]);
+          bounds(ixd, base.dims[d], e);
+          flatpos += (ixd - 1) * stride;
           stride *= base.dims[d];
         }
         r.is_int = base.is_int;
@@ -758,6 +772,7 @@ class MirInterp {
         e.args[2].name == "IndexSingle" && base.dims.size() == 2) {
       const long j = as_int(e.args[2].args[0]);
       const int64_t R = base.dims[0];
+      bounds(j, base.dims[1], e);
       r.is_int = base.is_int;
       r.dims = {R};
       r.r.assign(base.r.begin() + (j - 1) * R, base.r.begin() + j * R);
@@ -772,6 +787,7 @@ class MirInterp {
         base.dims.size() > 2) {
       const long i = as_int(e.args[1].args[0]);
       const int64_t d0 = base.dims[0];
+      bounds(i, d0, e);
       int64_t rest = 1;
       for (size_t d = 1; d < base.dims.size(); ++d) rest *= base.dims[d];
       r.is_int = base.is_int;
@@ -791,6 +807,7 @@ class MirInterp {
       r.dims = {(int64_t)n};
       for (size_t k = 0; k < n; ++k) {
         const long p = k < ix.i.size() ? ix.i[k] : (long)val(ix.r.at(k));
+        bounds(p, (int64_t)base.r.size(), e);
         r.r.push_back(base.r.at((size_t)(p - 1)));
         if (base.is_int) r.i.push_back(base.i.at((size_t)(p - 1)));
       }
@@ -801,6 +818,10 @@ class MirInterp {
         base.dims.size() <= 1) {
       const long a = as_int(e.args[1].args[0]);
       const long b = as_int(e.args[1].args[1]);
+      if (b >= a) {
+        bounds(a, (int64_t)base.r.size(), e);
+        bounds(b, (int64_t)base.r.size(), e);
+      }
       r.is_int = base.is_int;
       r.dims = {b >= a ? b - a + 1 : 0};  // b < a is an empty range
       for (long k = a; k <= b; ++k) {
@@ -816,6 +837,11 @@ class MirInterp {
       const long a = as_int(e.args[2].args[0]);
       const long b = as_int(e.args[2].args[1]);
       const int64_t R = base.dims[0];
+      bounds(i, R, e);
+      if (b >= a) {
+        bounds(a, base.dims[1], e);
+        bounds(b, base.dims[1], e);
+      }
       r.is_int = base.is_int;
       r.dims = {b >= a ? b - a + 1 : 0};  // b < a is an empty range
       for (long j = a; j <= b; ++j) {
@@ -831,6 +857,11 @@ class MirInterp {
       const long b = as_int(e.args[1].args[1]);
       const long j = as_int(e.args[2].args[0]);
       const int64_t R = base.dims[0];
+      bounds(j, base.dims[1], e);
+      if (b >= a) {
+        bounds(a, R, e);
+        bounds(b, R, e);
+      }
       r.is_int = base.is_int;
       r.dims = {b >= a ? b - a + 1 : 0};  // b < a is an empty range
       for (long k = a; k <= b; ++k) {

--- a/runtime/src/lower.cpp
+++ b/runtime/src/lower.cpp
@@ -271,6 +271,26 @@ struct Lowering {
                        (raw.empty() ? "" : " | in: " + raw));
   }
 
+  // Every index the graph lowering sees is a bind-time constant, so the
+  // bounds CmdStan checks at runtime are checked here, before an op that
+  // would silently read a neighboring arena slot can be emitted.
+  void check_index(int64_t i, int64_t n, const char* what,
+                   const std::string& raw) {
+    if (i < 1 || i > n)
+      fail(std::string(what) + ": index " + std::to_string(i) +
+               " out of bounds for size " + std::to_string(n),
+           raw);
+  }
+  // A range with hi < lo is empty and never reads, whatever the endpoints.
+  void check_range(int64_t lo, int64_t hi, int64_t n, const char* what,
+                   const std::string& raw) {
+    if (hi >= lo && (lo < 1 || hi > n))
+      fail(std::string(what) + ": range [" + std::to_string(lo) + ", " +
+               std::to_string(hi) + "] out of bounds for size " +
+               std::to_string(n),
+           raw);
+  }
+
   int const_slot(double v) {
     auto it = const_cache.find(v);
     if (it != const_cache.end()) return it->second;
@@ -822,8 +842,7 @@ struct Lowering {
           if (e.args[1].name == "IndexBetween") {
             const int64_t lo = eval_int(e.args[1].args[0]);
             const int64_t hi = eval_int(e.args[1].args[1]);
-            if (lo < 1 || hi < lo || hi > base.si.rows)
-              fail("matrix row range out of bounds", e.raw);
+            check_range(lo, hi, base.si.rows, "matrix row range", e.raw);
             for (int64_t i = lo; i <= hi; ++i) rows.push_back((int)i - 1);
           } else {
             DataMap::Entry iv = eval_pure(e.args[1].args[0], "a gather index");
@@ -871,6 +890,7 @@ struct Lowering {
         if (e.args.size() == 2 && e.args[1].name == "IndexBetween") {
           const int64_t lo = eval_int(e.args[1].args[0]);
           const int64_t hi = eval_int(e.args[1].args[1]);
+          check_range(lo, hi, g.slots[base.slot].len, "range", e.raw);
           const int64_t len = hi >= lo ? hi - lo + 1 : 0;
           return emit_value(OP_SLICE, {base}, len, view_of(e.type_),
                             {(int)(len ? lo - 1 : 0)});
@@ -907,7 +927,10 @@ struct Lowering {
             fail("gather index must be int data", e.raw);
           std::vector<int> idata;
           idata.reserve(iv.i.size());
-          for (int x : iv.i) idata.push_back(x - 1);
+          for (int x : iv.i) {
+            check_index(x, g.slots[base.slot].len, "gather index", e.raw);
+            idata.push_back(x - 1);
+          }
           return emit_value(OP_GATHER, {base}, (int64_t)idata.size(),
                             view_of(e.type_), idata);
         }
@@ -915,15 +938,18 @@ struct Lowering {
         // storage remains column-major even when either extent is zero.
         if (e.args.size() == 3 && is_matrix(base.si) &&
             e.args[1].name == "IndexSingle" && e.args[2].name == "IndexAll") {
-          const int64_t i = eval_int(e.args[1].args[0]) - 1;
+          const int64_t i = eval_int(e.args[1].args[0]);
+          check_index(i, base.si.rows, "matrix row", e.raw);
           return emit_value(OP_SLICE_STRIDED, {base}, base.si.cols,
-                            view_of(e.type_), {(int)i, (int)base.si.rows});
+                            view_of(e.type_),
+                            {(int)(i - 1), (int)base.si.rows});
         }
         if (e.args.size() == 3 && is_matrix(base.si) &&
             e.args[1].name == "IndexAll" && e.args[2].name == "IndexSingle") {
-          const int64_t j = eval_int(e.args[2].args[0]) - 1;
+          const int64_t j = eval_int(e.args[2].args[0]);
+          check_index(j, base.si.cols, "matrix column", e.raw);
           return emit_value(OP_SLICE, {base}, base.si.rows, view_of(e.type_),
-                            {(int)(j * base.si.rows)});
+                            {(int)((j - 1) * base.si.rows)});
         }
         // Column of a canonical graph-order 2-D array (array[N, S] real):
         // each outer element is contiguous, so successive rows sit S apart.
@@ -942,10 +968,12 @@ struct Lowering {
             e.args[2].name == "IndexSingle") {
           const int64_t lo = eval_int(e.args[1].args[0]);
           const int64_t hi = eval_int(e.args[1].args[1]);
-          const int64_t j = eval_int(e.args[2].args[0]) - 1;
+          const int64_t j = eval_int(e.args[2].args[0]);
+          check_index(j, base.si.cols, "matrix column", e.raw);
+          check_range(lo, hi, base.si.rows, "matrix row range", e.raw);
           const int64_t len = hi >= lo ? hi - lo + 1 : 0;
           return emit_value(OP_SLICE, {base}, len, view_of(e.type_),
-                            {(int)(len ? j * base.si.rows + lo - 1 : 0)});
+                            {(int)(len ? (j - 1) * base.si.rows + lo - 1 : 0)});
         }
         // Params/locals with recorded dims, laid out by flat_addr above.
         // Matrix views are col-major and never take this array-major path.
@@ -954,8 +982,11 @@ struct Lowering {
           const auto& D = *bdims;
           const bool mat = array_shape(base.si).leaf == ViewKind::Matrix;
           std::vector<int64_t> ix;
-          for (size_t d = 0; d < n_idx; ++d)
-            ix.push_back(eval_int(e.args[1 + d].args[0]) - 1);
+          for (size_t d = 0; d < n_idx; ++d) {
+            const int64_t one = eval_int(e.args[1 + d].args[0]);
+            check_index(one, D[d], "array index", e.raw);
+            ix.push_back(one - 1);
+          }
           const Addr a = flat_addr(D, mat, ix);
           if (a.stride != 1)
             return emit_value(OP_SLICE_STRIDED, {base}, a.len,
@@ -973,9 +1004,11 @@ struct Lowering {
         // Row of a column-major data matrix / 2-D array: strided slice.
         if (all_single && e.args.size() == 2 && is_matrix(base.si) &&
             e.type_ != "UReal" && e.type_ != "UInt") {
-          const int64_t t = eval_int(e.args[1].args[0]) - 1;
+          const int64_t t = eval_int(e.args[1].args[0]);
+          check_index(t, base.si.rows, "matrix row", e.raw);
           return emit_value(OP_SLICE_STRIDED, {base}, base.si.cols,
-                            view_of(e.type_), {(int)t, (int)base.si.rows});
+                            view_of(e.type_),
+                            {(int)(t - 1), (int)base.si.rows});
         }
         // Data-only slicing with no native path (e.g. one matrix out of a
         // data array of matrices) evaluates at compile time.
@@ -983,11 +1016,16 @@ struct Lowering {
         int64_t flat = 0;
         if (all_single && e.args.size() == 2 &&
             (e.type_ == "UReal" || e.type_ == "UInt")) {
-          flat = eval_int(e.args[1].args[0]) - 1;
+          const int64_t one = eval_int(e.args[1].args[0]);
+          check_index(one, g.slots[base.slot].len, "element", e.raw);
+          flat = one - 1;
         } else if (all_single && e.args.size() == 3 && is_matrix(base.si) &&
                    (e.type_ == "UReal" || e.type_ == "UInt")) {
-          flat = (eval_int(e.args[2].args[0]) - 1) * base.si.rows +
-                 (eval_int(e.args[1].args[0]) - 1);
+          const int64_t ri = eval_int(e.args[1].args[0]);
+          const int64_t cj = eval_int(e.args[2].args[0]);
+          check_index(ri, base.si.rows, "matrix row", e.raw);
+          check_index(cj, base.si.cols, "matrix column", e.raw);
+          flat = (cj - 1) * base.si.rows + (ri - 1);
         } else {
           std::string desc =
               "unsupported index expression: base=" +

--- a/tests/fixtures/oob.stan
+++ b/tests/fixtures/oob.stan
@@ -1,0 +1,38 @@
+// Index bounds are data: every index form on a parameter-dependent value,
+// with the index values supplied by the data. CmdStan rejects an
+// out-of-bounds index at runtime; the graph lowering knows every index at
+// bind time, so it must reject then -- silently reading a neighboring
+// arena slot is the alternative. hi < lo ranges stay empty, not errors.
+data {
+  int k;
+  array[2] int idx;
+  int lo;
+  int hi;
+  int i1;
+  int j1;
+  int rl;
+  int rh;
+  int m;
+  vector[4] Y;
+  matrix[4, 2] Zm;
+}
+transformed data {
+  array[3] real xs = {1.0, 2.0, 3.0};
+  real tds = xs[m];
+}
+parameters {
+  real mu;
+}
+model {
+  vector[4] v = Y + rep_vector(mu, 4);
+  matrix[4, 2] M = Zm + rep_matrix(mu, 4, 2);
+  target += normal_lpdf(v[k] | 0, 1);
+  target += normal_lpdf(v[idx] | 0, 1);
+  target += normal_lpdf(v[lo:hi] | 0, 1);
+  target += normal_lpdf(sum(M[i1]) | 0, 1);
+  target += normal_lpdf(sum(M[ : , j1]) | 0, 1);
+  target += normal_lpdf(sum(M[rl:rh]) | 0, 1);
+  target += normal_lpdf(sum(M[rl:rh, j1]) | 0, 1);
+  target += normal_lpdf(tds | 0, 1);
+  target += normal_lpdf(mu | 0, 2);
+}

--- a/tests/fixtures/oob.tmir.sexp
+++ b/tests/fixtures/oob.tmir.sexp
@@ -1,0 +1,1083 @@
+((functions_block ())
+ (input_vars
+  ((k <opaque> SInt)
+   (idx <opaque>
+    (SArray SInt
+     ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+   (lo <opaque> SInt) (hi <opaque> SInt) (i1 <opaque> SInt) (j1 <opaque> SInt)
+   (rl <opaque> SInt) (rh <opaque> SInt) (m <opaque> SInt)
+   (Y <opaque>
+    (SVector AoS
+     ((pattern (Lit Int 4)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+   (Zm <opaque>
+    (SMatrix AoS
+     ((pattern (Lit Int 4)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+     ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+ (prepare_data
+  (((pattern
+     (Decl (decl_adtype DataOnly) (decl_id pos__) (decl_type (Sized SInt))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable pos__) ()) UInt
+      ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id k) (decl_type (Sized SInt))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable k) ()) UInt
+      ((pattern
+        (Indexed
+         ((pattern
+           (FunApp (CompilerInternal FnReadData)
+            (((pattern (Lit Str k))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+          (meta ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly))))
+         ((Single
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id idx)
+      (decl_type
+       (Sized
+        (SArray SInt
+         ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable idx) ()) (UArray UInt)
+      ((pattern
+        (FunApp (CompilerInternal FnReadData)
+         (((pattern (Lit Str idx))
+           (meta ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id lo) (decl_type (Sized SInt))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable lo) ()) UInt
+      ((pattern
+        (Indexed
+         ((pattern
+           (FunApp (CompilerInternal FnReadData)
+            (((pattern (Lit Str lo))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+          (meta ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly))))
+         ((Single
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id hi) (decl_type (Sized SInt))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable hi) ()) UInt
+      ((pattern
+        (Indexed
+         ((pattern
+           (FunApp (CompilerInternal FnReadData)
+            (((pattern (Lit Str hi))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+          (meta ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly))))
+         ((Single
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id i1) (decl_type (Sized SInt))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable i1) ()) UInt
+      ((pattern
+        (Indexed
+         ((pattern
+           (FunApp (CompilerInternal FnReadData)
+            (((pattern (Lit Str i1))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+          (meta ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly))))
+         ((Single
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id j1) (decl_type (Sized SInt))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable j1) ()) UInt
+      ((pattern
+        (Indexed
+         ((pattern
+           (FunApp (CompilerInternal FnReadData)
+            (((pattern (Lit Str j1))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+          (meta ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly))))
+         ((Single
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id rl) (decl_type (Sized SInt))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable rl) ()) UInt
+      ((pattern
+        (Indexed
+         ((pattern
+           (FunApp (CompilerInternal FnReadData)
+            (((pattern (Lit Str rl))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+          (meta ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly))))
+         ((Single
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id rh) (decl_type (Sized SInt))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable rh) ()) UInt
+      ((pattern
+        (Indexed
+         ((pattern
+           (FunApp (CompilerInternal FnReadData)
+            (((pattern (Lit Str rh))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+          (meta ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly))))
+         ((Single
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id m) (decl_type (Sized SInt))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable m) ()) UInt
+      ((pattern
+        (Indexed
+         ((pattern
+           (FunApp (CompilerInternal FnReadData)
+            (((pattern (Lit Str m))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+          (meta ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly))))
+         ((Single
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id Y)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Lit Int 4)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id Y_flat__)
+          (decl_type (Unsized (UArray UReal))) (initialize Uninit)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable Y_flat__) ()) (UArray UReal)
+          ((pattern
+            (FunApp (CompilerInternal FnReadData)
+             (((pattern (Lit Str Y))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable pos__) ()) UInt
+          ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar sym1__)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Lit Int 4))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (Assignment
+                  ((LVariable Y)
+                   ((Single
+                     ((pattern (Var sym1__))
+                      (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                  UVector
+                  ((pattern
+                    (Indexed
+                     ((pattern (Var Y_flat__))
+                      (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))
+                     ((Single
+                       ((pattern (Var pos__))
+                        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+                (meta <opaque>))
+               ((pattern
+                 (Assignment ((LVariable pos__) ()) UInt
+                  ((pattern
+                    (FunApp (StanLib Plus__ FnPlain AoS)
+                     (((pattern (Var pos__))
+                       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                      ((pattern (Lit Int 1))
+                       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id Zm)
+      (decl_type
+       (Sized
+        (SMatrix AoS
+         ((pattern (Lit Int 4)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+         ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id Zm_flat__)
+          (decl_type (Unsized (UArray UReal))) (initialize Uninit)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable Zm_flat__) ()) (UArray UReal)
+          ((pattern
+            (FunApp (CompilerInternal FnReadData)
+             (((pattern (Lit Str Zm))
+               (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable pos__) ()) UInt
+          ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar sym1__)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Lit Int 2))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (For (loopvar sym2__)
+                  (lower
+                   ((pattern (Lit Int 1))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (upper
+                   ((pattern (Lit Int 4))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (body
+                   ((pattern
+                     (Block
+                      (((pattern
+                         (Assignment
+                          ((LVariable Zm)
+                           ((Single
+                             ((pattern (Var sym2__))
+                              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                            (Single
+                             ((pattern (Var sym1__))
+                              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                          UMatrix
+                          ((pattern
+                            (Indexed
+                             ((pattern (Var Zm_flat__))
+                              (meta
+                               ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))
+                             ((Single
+                               ((pattern (Var pos__))
+                                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                           (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+                        (meta <opaque>))
+                       ((pattern
+                         (Assignment ((LVariable pos__) ()) UInt
+                          ((pattern
+                            (FunApp (StanLib Plus__ FnPlain AoS)
+                             (((pattern (Var pos__))
+                               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                              ((pattern (Lit Int 1))
+                               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                        (meta <opaque>)))))
+                    (meta <opaque>)))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id xs)
+      (decl_type
+       (Sized
+        (SArray SReal
+         ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable xs) ()) (UArray UReal)
+      ((pattern
+        (FunApp (CompilerInternal FnMakeArray)
+         (((pattern (Lit Real 1.0))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+          ((pattern (Lit Real 2.0))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+          ((pattern (Lit Real 3.0))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id tds) (decl_type (Sized SReal))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable tds) ()) UReal
+      ((pattern
+        (Indexed
+         ((pattern (Var xs))
+          (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))
+         ((Single
+           ((pattern (Var m)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+       (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))))
+ (log_prob
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id mu) (decl_type (Sized SReal))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity) (dims ()) (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id v)
+          (decl_type
+           (Sized
+            (SVector AoS
+             ((pattern (Lit Int 4))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+          (initialize Uninit)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable v) ()) UVector
+          ((pattern
+            (FunApp (StanLib Plus__ FnPlain AoS)
+             (((pattern (Var Y))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly))))
+              ((pattern
+                (FunApp (StanLib rep_vector FnPlain AoS)
+                 (((pattern (Var mu))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+                  ((pattern (Lit Int 4))
+                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+           (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>))
+       ((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id M)
+          (decl_type
+           (Sized
+            (SMatrix AoS
+             ((pattern (Lit Int 4))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+             ((pattern (Lit Int 2))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+          (initialize Uninit)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable M) ()) UMatrix
+          ((pattern
+            (FunApp (StanLib Plus__ FnPlain AoS)
+             (((pattern (Var Zm))
+               (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly))))
+              ((pattern
+                (FunApp (StanLib rep_matrix FnPlain AoS)
+                 (((pattern (Var mu))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+                  ((pattern (Lit Int 4))
+                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                  ((pattern (Lit Int 2))
+                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+               (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable)))))))
+           (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>))
+       ((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib normal_lpdf (FnLpdf false) AoS)
+             (((pattern
+                (Indexed
+                 ((pattern (Var v))
+                  (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))
+                 ((Single
+                   ((pattern (Var k))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+              ((pattern
+                (Promotion
+                 ((pattern (Lit Int 0))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                 UReal DataOnly))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+              ((pattern
+                (Promotion
+                 ((pattern (Lit Int 1))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                 UReal DataOnly))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>))
+       ((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib normal_lpdf (FnLpdf false) AoS)
+             (((pattern
+                (Indexed
+                 ((pattern (Var v))
+                  (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))
+                 ((MultiIndex
+                   ((pattern (Var idx))
+                    (meta ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly))))))))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))
+              ((pattern
+                (Promotion
+                 ((pattern (Lit Int 0))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                 UReal DataOnly))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+              ((pattern
+                (Promotion
+                 ((pattern (Lit Int 1))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                 UReal DataOnly))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>))
+       ((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib normal_lpdf (FnLpdf false) AoS)
+             (((pattern
+                (Indexed
+                 ((pattern (Var v))
+                  (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))
+                 ((Between
+                   ((pattern (Var lo))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                   ((pattern (Var hi))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))
+              ((pattern
+                (Promotion
+                 ((pattern (Lit Int 0))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                 UReal DataOnly))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+              ((pattern
+                (Promotion
+                 ((pattern (Lit Int 1))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                 UReal DataOnly))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>))
+       ((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib normal_lpdf (FnLpdf false) AoS)
+             (((pattern
+                (FunApp (StanLib sum FnPlain AoS)
+                 (((pattern
+                    (Indexed
+                     ((pattern (Var M))
+                      (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))
+                     ((Single
+                       ((pattern (Var i1))
+                        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                   (meta ((type_ URowVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+              ((pattern
+                (Promotion
+                 ((pattern (Lit Int 0))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                 UReal DataOnly))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+              ((pattern
+                (Promotion
+                 ((pattern (Lit Int 1))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                 UReal DataOnly))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>))
+       ((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib normal_lpdf (FnLpdf false) AoS)
+             (((pattern
+                (FunApp (StanLib sum FnPlain AoS)
+                 (((pattern
+                    (Indexed
+                     ((pattern (Var M))
+                      (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))
+                     (All
+                      (Single
+                       ((pattern (Var j1))
+                        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                   (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+              ((pattern
+                (Promotion
+                 ((pattern (Lit Int 0))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                 UReal DataOnly))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+              ((pattern
+                (Promotion
+                 ((pattern (Lit Int 1))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                 UReal DataOnly))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>))
+       ((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib normal_lpdf (FnLpdf false) AoS)
+             (((pattern
+                (FunApp (StanLib sum FnPlain AoS)
+                 (((pattern
+                    (Indexed
+                     ((pattern (Var M))
+                      (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))
+                     ((Between
+                       ((pattern (Var rl))
+                        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                       ((pattern (Var rh))
+                        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                   (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable)))))))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+              ((pattern
+                (Promotion
+                 ((pattern (Lit Int 0))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                 UReal DataOnly))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+              ((pattern
+                (Promotion
+                 ((pattern (Lit Int 1))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                 UReal DataOnly))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>))
+       ((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib normal_lpdf (FnLpdf false) AoS)
+             (((pattern
+                (FunApp (StanLib sum FnPlain AoS)
+                 (((pattern
+                    (Indexed
+                     ((pattern (Var M))
+                      (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))
+                     ((Between
+                       ((pattern (Var rl))
+                        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                       ((pattern (Var rh))
+                        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                      (Single
+                       ((pattern (Var j1))
+                        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                   (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+              ((pattern
+                (Promotion
+                 ((pattern (Lit Int 0))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                 UReal DataOnly))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+              ((pattern
+                (Promotion
+                 ((pattern (Lit Int 1))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                 UReal DataOnly))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>))
+       ((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib normal_lpdf (FnLpdf false) AoS)
+             (((pattern (Var tds))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+              ((pattern
+                (Promotion
+                 ((pattern (Lit Int 0))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                 UReal DataOnly))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+              ((pattern
+                (Promotion
+                 ((pattern (Lit Int 1))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                 UReal DataOnly))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib normal_lpdf (FnLpdf false) AoS)
+             (((pattern (Var mu))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+              ((pattern
+                (Promotion
+                 ((pattern (Lit Int 0))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                 UReal DataOnly))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+              ((pattern
+                (Promotion
+                 ((pattern (Lit Int 2))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                 UReal DataOnly))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>)))))
+    (meta <opaque>))))
+ (reverse_mode_log_prob
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id mu) (decl_type (Sized SReal))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity) (dims ()) (mem_pattern SoA)))
+           ()))
+         (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id v)
+          (decl_type
+           (Sized
+            (SVector SoA
+             ((pattern (Lit Int 4))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+          (initialize Uninit)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable v) ()) UVector
+          ((pattern
+            (FunApp (StanLib Plus__ FnPlain SoA)
+             (((pattern (Var Y))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly))))
+              ((pattern
+                (FunApp (StanLib rep_vector FnPlain SoA)
+                 (((pattern (Var mu))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+                  ((pattern (Lit Int 4))
+                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+           (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>))
+       ((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id M)
+          (decl_type
+           (Sized
+            (SMatrix SoA
+             ((pattern (Lit Int 4))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+             ((pattern (Lit Int 2))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+          (initialize Uninit)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable M) ()) UMatrix
+          ((pattern
+            (FunApp (StanLib Plus__ FnPlain SoA)
+             (((pattern (Var Zm))
+               (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly))))
+              ((pattern
+                (FunApp (StanLib rep_matrix FnPlain SoA)
+                 (((pattern (Var mu))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+                  ((pattern (Lit Int 4))
+                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                  ((pattern (Lit Int 2))
+                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+               (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable)))))))
+           (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>))
+       ((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib normal_lpdf (FnLpdf false) SoA)
+             (((pattern
+                (Indexed
+                 ((pattern (Var v))
+                  (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))
+                 ((Single
+                   ((pattern (Var k))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+              ((pattern
+                (Promotion
+                 ((pattern (Lit Int 0))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                 UReal DataOnly))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+              ((pattern
+                (Promotion
+                 ((pattern (Lit Int 1))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                 UReal DataOnly))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>))
+       ((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib normal_lpdf (FnLpdf false) SoA)
+             (((pattern
+                (Indexed
+                 ((pattern (Var v))
+                  (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))
+                 ((MultiIndex
+                   ((pattern (Var idx))
+                    (meta ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly))))))))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))
+              ((pattern
+                (Promotion
+                 ((pattern (Lit Int 0))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                 UReal DataOnly))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+              ((pattern
+                (Promotion
+                 ((pattern (Lit Int 1))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                 UReal DataOnly))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>))
+       ((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib normal_lpdf (FnLpdf false) SoA)
+             (((pattern
+                (Indexed
+                 ((pattern (Var v))
+                  (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))
+                 ((Between
+                   ((pattern (Var lo))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                   ((pattern (Var hi))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))
+              ((pattern
+                (Promotion
+                 ((pattern (Lit Int 0))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                 UReal DataOnly))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+              ((pattern
+                (Promotion
+                 ((pattern (Lit Int 1))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                 UReal DataOnly))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>))
+       ((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib normal_lpdf (FnLpdf false) SoA)
+             (((pattern
+                (FunApp (StanLib sum FnPlain SoA)
+                 (((pattern
+                    (Indexed
+                     ((pattern (Var M))
+                      (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))
+                     ((Single
+                       ((pattern (Var i1))
+                        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                   (meta ((type_ URowVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+              ((pattern
+                (Promotion
+                 ((pattern (Lit Int 0))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                 UReal DataOnly))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+              ((pattern
+                (Promotion
+                 ((pattern (Lit Int 1))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                 UReal DataOnly))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>))
+       ((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib normal_lpdf (FnLpdf false) SoA)
+             (((pattern
+                (FunApp (StanLib sum FnPlain SoA)
+                 (((pattern
+                    (Indexed
+                     ((pattern (Var M))
+                      (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))
+                     (All
+                      (Single
+                       ((pattern (Var j1))
+                        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                   (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+              ((pattern
+                (Promotion
+                 ((pattern (Lit Int 0))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                 UReal DataOnly))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+              ((pattern
+                (Promotion
+                 ((pattern (Lit Int 1))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                 UReal DataOnly))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>))
+       ((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib normal_lpdf (FnLpdf false) SoA)
+             (((pattern
+                (FunApp (StanLib sum FnPlain SoA)
+                 (((pattern
+                    (Indexed
+                     ((pattern (Var M))
+                      (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))
+                     ((Between
+                       ((pattern (Var rl))
+                        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                       ((pattern (Var rh))
+                        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                   (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable)))))))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+              ((pattern
+                (Promotion
+                 ((pattern (Lit Int 0))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                 UReal DataOnly))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+              ((pattern
+                (Promotion
+                 ((pattern (Lit Int 1))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                 UReal DataOnly))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>))
+       ((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib normal_lpdf (FnLpdf false) SoA)
+             (((pattern
+                (FunApp (StanLib sum FnPlain SoA)
+                 (((pattern
+                    (Indexed
+                     ((pattern (Var M))
+                      (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))
+                     ((Between
+                       ((pattern (Var rl))
+                        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                       ((pattern (Var rh))
+                        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                      (Single
+                       ((pattern (Var j1))
+                        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                   (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+              ((pattern
+                (Promotion
+                 ((pattern (Lit Int 0))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                 UReal DataOnly))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+              ((pattern
+                (Promotion
+                 ((pattern (Lit Int 1))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                 UReal DataOnly))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>))
+       ((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib normal_lpdf (FnLpdf false) SoA)
+             (((pattern (Var tds))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+              ((pattern
+                (Promotion
+                 ((pattern (Lit Int 0))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                 UReal DataOnly))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+              ((pattern
+                (Promotion
+                 ((pattern (Lit Int 1))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                 UReal DataOnly))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib normal_lpdf (FnLpdf false) SoA)
+             (((pattern (Var mu))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+              ((pattern
+                (Promotion
+                 ((pattern (Lit Int 0))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                 UReal DataOnly))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+              ((pattern
+                (Promotion
+                 ((pattern (Lit Int 2))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                 UReal DataOnly))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>)))))
+    (meta <opaque>))))
+ (generate_quantities
+  (((pattern
+     (Decl (decl_adtype DataOnly) (decl_id mu) (decl_type (Sized SReal))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity) (dims ()) (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt ())
+        (var
+         ((pattern (Var mu)) (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (IfElse
+      ((pattern
+        (FunApp (StanLib PNot__ FnPlain AoS)
+         (((pattern
+            (EOr
+             ((pattern (Var emit_transformed_parameters__))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+             ((pattern (Var emit_generated_quantities__))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+      ((pattern (Block (((pattern (Return ())) (meta <opaque>))))) (meta <opaque>)) ()))
+    (meta <opaque>))
+   ((pattern
+     (IfElse
+      ((pattern
+        (FunApp (StanLib PNot__ FnPlain AoS)
+         (((pattern (Var emit_generated_quantities__))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+      ((pattern (Block (((pattern (Return ())) (meta <opaque>))))) (meta <opaque>)) ()))
+    (meta <opaque>))))
+ (transform_inits
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id mu) (decl_type (Sized SReal))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable mu) ()) UReal
+      ((pattern
+        (Indexed
+         ((pattern
+           (FunApp (CompilerInternal FnReadData)
+            (((pattern (Lit Str mu))
+              (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+          (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))
+         ((Single
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+       (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var mu)) (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))))
+ (unconstrain_array
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id mu) (decl_type (Sized SReal))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable mu) ()) UReal
+      ((pattern (FunApp (CompilerInternal FnReadDeserializer) ()))
+       (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var mu)) (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))))
+ (output_vars
+  ((mu <opaque>
+    ((out_unconstrained_st SReal) (out_constrained_st SReal) (out_block Parameters)
+     (out_trans Identity)))))
+ (prog_name oob_model) (prog_path tests/fixtures/oob.stan))

--- a/tests/test_lower.cpp
+++ b/tests/test_lower.cpp
@@ -645,6 +645,112 @@ int main() {
     }
   }
 
+  // Index bounds are data, so the lowering must reject an out-of-bounds
+  // index at bind time the way CmdStan rejects it at runtime; the silent
+  // alternative is reading a neighboring arena slot. hi < lo ranges stay
+  // empty. One fixture; the base dataset is in bounds and each violation
+  // overrides one index.
+  {
+    const auto base_data = [] {
+      DataMap d = DataMap::from_json(
+          R"({"k": 2, "idx": [1, 4], "lo": 2, "hi": 3, "i1": 1, "j1": 2,
+              "rl": 2, "rh": 3, "m": 3, "Y": [1.5, -0.5, 2.0, 0.25],
+              "Zm": [[1, 5], [2, 6], [3, 7], [4, 8]]})");
+      return d;
+    };
+    const std::string mir = slurp("tests/fixtures/oob.tmir.sexp");
+
+    const auto reference = [&](bool rows_empty, double q) {
+      using stan::math::var;
+      var mu = q;
+      const double yv[4] = {1.5, -0.5, 2.0, 0.25};
+      const double zm[4][2] = {{1, 5}, {2, 6}, {3, 7}, {4, 8}};
+      Eigen::Matrix<var, -1, 1> v(4);
+      for (int i = 0; i < 4; ++i) v(i) = yv[i] + mu;
+      Eigen::Matrix<var, -1, -1> M(4, 2);
+      for (int i = 0; i < 4; ++i)
+        for (int j = 0; j < 2; ++j) M(i, j) = zm[i][j] + mu;
+      var acc = stan::math::normal_lpdf<false>(v(1), 0.0, 1.0);
+      Eigen::Matrix<var, -1, 1> vg(2);
+      vg << v(0), v(3);
+      acc += stan::math::normal_lpdf<false>(vg, 0.0, 1.0);
+      Eigen::Matrix<var, -1, 1> vs(2);
+      vs << v(1), v(2);
+      acc += stan::math::normal_lpdf<false>(vs, 0.0, 1.0);
+      acc += stan::math::normal_lpdf<false>(M(0, 0) + M(0, 1), 0.0, 1.0);
+      acc += stan::math::normal_lpdf<false>(
+          M(0, 1) + M(1, 1) + M(2, 1) + M(3, 1), 0.0, 1.0);
+      if (rows_empty) {
+        // sum over the empty row range is 0 on both terms.
+        acc += stan::math::normal_lpdf<false>(0.0, 0.0, 1.0) * 2.0;
+      } else {
+        acc += stan::math::normal_lpdf<false>(
+            M(1, 0) + M(2, 0) + M(1, 1) + M(2, 1), 0.0, 1.0);
+        acc += stan::math::normal_lpdf<false>(M(1, 1) + M(2, 1), 0.0, 1.0);
+      }
+      acc += stan::math::normal_lpdf<false>(3.0, 0.0, 1.0);  // tds = xs[3]
+      acc += stan::math::normal_lpdf<false>(mu, 0.0, 2.0);
+      return acc;
+    };
+
+    const auto run_case = [&](DataMap d, bool rows_empty,
+                              const std::string& tag) {
+      CompiledModel lm = compile_model(mir, d);
+      Executor lex(std::move(lm.graph));
+      lm.bind(lex);
+      lex.params_data()[0] = 0.35;
+      double grad[1] = {0};
+      const double lp = lex.gradient(grad);
+      using stan::math::var;
+      var acc = reference(rows_empty, 0.35);
+      acc.grad();
+      expect_ulp(tag + " lp", lp, acc.val());
+      stan::math::recover_memory();
+    };
+    run_case(base_data(), false, "oob ctrl");
+    {
+      DataMap d = base_data();
+      d.set_int("rl", 5);
+      d.set_int("rh", 2);
+      run_case(std::move(d), true, "oob rows-empty");
+    }
+
+    const auto expect_oob = [&](const char* name, long v,
+                                const std::string& tag) {
+      DataMap d = base_data();
+      d.set_int(name, v);
+      bool threw = false;
+      try {
+        compile_model(mir, d);
+      } catch (const std::exception& ex) {
+        threw =
+            std::string(ex.what()).find("out of bounds") != std::string::npos;
+        if (!threw)
+          std::printf("  %s threw without 'out of bounds': %s\n", tag.c_str(),
+                      ex.what());
+      }
+      check(threw, tag + " rejected");
+    };
+    expect_oob("k", 7, "oob v[7]");
+    expect_oob("hi", 9, "oob v[2:9]");
+    expect_oob("i1", 5, "oob M[5]");
+    expect_oob("j1", 5, "oob M[:,5]");
+    expect_oob("rh", 9, "oob M[2:9]");
+    expect_oob("m", 9, "oob interp xs[9]");
+    {
+      DataMap d = base_data();
+      d.set_int_array("idx", {1, 9});
+      bool threw = false;
+      try {
+        compile_model(mir, d);
+      } catch (const std::exception& ex) {
+        threw =
+            std::string(ex.what()).find("out of bounds") != std::string::npos;
+      }
+      check(threw, "oob v[[1,9]] rejected");
+    }
+  }
+
   // Index forms on parameters: gather, Between read/write, matrix row and
   // column slices, column writes.
   {


### PR DESCRIPTION
Follow-up to #136, the second half of the audit: the graph lowering never bounds-checked indices, and every index it sees is a bind-time constant. `v[7]` on a length-4 vector, a gather by `[1, 9]`, `Y[2:9]`, `M[1:2, 5]`, the flat element paths, and the flat_addr array path all silently read a neighboring arena slot and produced a wrong log density with no error. CmdStan rejects every one of these at runtime.

All indexing paths now check bounds through two shared helpers that name the index and the extent, e.g. "gather index: index 9 out of bounds for size 4". Ranges follow the rvalue rule from #136: hi < lo is empty and never reads, so bounds apply only to nonempty ranges; single indices are always checked. This also converts the matrix row-range path's hi < lo rejection into an empty slice, the last holdout of the empty-range family. The interpreter's nine index paths get the same named errors in place of a bare std::out_of_range("vector"), which used to surface as "COMPILE_FAIL vector".

Verified: the new oob fixture drives every index form from data. An in-bounds dataset and an empty-row-range dataset check lp against var references; seven single-violation datasets must each be rejected with an error naming the bounds. All 50 tests pass, and the corpus replay is 129/129 with zero drift, which doubles as the no-false-positives proof for the new rejections.
