### PR TITLE
fix: reject non-integer data for a declared-int variable at binding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,15 @@ the matrix row range also accepts hi < lo as empty now, completing the
 empty-range semantics. The interpreter's index paths get the same
 named errors in place of a bare std::out_of_range("vector").
 
+### Non-integer data for an int variable is a data error
+
+A declared-int variable supplied with non-integer values (JSON 1.0 is
+not an int, matching CmdStan's var_context) used to bind as typeless
+reals, and the failure surfaced at whatever consumer touched it first,
+e.g. "gather index must be int data". It is rejected at data binding
+now, as std::invalid_argument naming the variable, the same contract
+as the existing dimension check.
+
 ### Matrix division is a linear solve again
 
 `B / A` on two matrices in the model block computed elementwise

--- a/runtime/src/lower.cpp
+++ b/runtime/src/lower.cpp
@@ -715,6 +715,16 @@ struct Lowering {
   void validate_data_dims(const std::string& name, const mir::SizedType& t) {
     if (!data.has(name)) return;
     const DataMap::Entry& en = data.at(name);
+    // A declared-int variable must arrive integer-typed, as CmdStan's
+    // var_context requires (JSON 1.0 is not an int there either). Without
+    // this the entry binds as typeless reals and the failure surfaces at
+    // whatever consumer touches it first, e.g. the gather index guard.
+    if ((t.base == "SInt" || (t.base == "SArray" && t.elem_base == "SInt")) &&
+        !en.is_int)
+      throw std::invalid_argument(
+          "int variable contained non-int values; processing stage=data "
+          "initialization; variable name=" +
+          name + "; base type=int");
     const int64_t found = (int64_t)std::max(en.r.size(), en.i.size());
     const std::vector<int64_t> declared = sized_dims(t);
     int64_t want = 1;

--- a/tests/test_lower.cpp
+++ b/tests/test_lower.cpp
@@ -3840,6 +3840,32 @@ int main() {
   }
 
   {
+    // A declared-int variable supplied with non-integer values. CmdStan's
+    // var_context rejects this at read time; stanli used to bind it as a
+    // typeless real entry, and the failure surfaced later as whatever
+    // consumer touched it first ("gather index must be int data").
+    DataMap d = DataMap::from_json(
+        R"({"k": 2, "idx": [1.0, 2.5], "lo": 2, "hi": 3, "i1": 1, "j1": 2,
+            "rl": 2, "rh": 3, "m": 3, "Y": [1.5, -0.5, 2.0, 0.25],
+            "Zm": [[1, 5], [2, 6], [3, 7], [4, 8]]})");
+    bool rejected = false;
+    std::string msg;
+    try {
+      compile_model(slurp("tests/fixtures/oob.tmir.sexp"), d);
+    } catch (const std::invalid_argument& e) {
+      rejected = true;
+      msg = e.what();
+    } catch (const std::exception& e) {
+      msg = e.what();
+    }
+    check(rejected, "non-int data for int variable rejected: " + msg);
+    check(msg.find("int variable contained non-int values") !=
+                  std::string::npos &&
+              msg.find("name=idx") != std::string::npos,
+          "the rejection names the int variable: " + msg);
+  }
+
+  {
     // Data whose JSON shape disagrees with its declaration. CmdStan's
     // var_context validates every declared dimension before it reads a
     // value and throws std::invalid_argument naming the variable and both


### PR DESCRIPTION
Last piece of the #133 audit. A declared-int variable supplied with non-integer values used to bind as a typeless real entry, and the failure surfaced at whatever consumer touched it first, e.g. "gather index must be int data" from the gather guard, with no hint the data was the problem.

CmdStan's var_context rejects such data at read time (JSON 1.0 is not an int there either), so the binding does too now: std::invalid_argument naming the variable, the same exception contract as the dimension check next to it, so a host distinguishing bad data from a broken model keeps working.

Verified: new test drives an int array with [1.0, 2.5] through compile_model and requires the named rejection; all 50 tests pass; corpus replay 129/129 with zero drift, which is the no-false-positives check for the new rejection.
