### PR TITLE
test: the corpus replay evaluates every point, and the suite runs under ASan

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -570,6 +570,67 @@ jobs:
           name: runtime-windows-x86_64
           path: runtime-dist/*.tar.gz
 
+  # The test suite with AddressSanitizer's shadow map on. Nothing else in
+  # the repo builds with a sanitizer, and the memory bugs that reach this
+  # project answer with WRONG NUMBERS rather than a crash: a GLM outcome
+  # mapping `rows` integers out of a three-integer group returned -29.48
+  # where the array form gives -16.22, with no diagnostic, and every test
+  # and every corpus model stayed green. Rebuilt against the parent of
+  # that fix, this configuration reports it on contact -- READ of size 4,
+  # zero bytes after a 12-byte region, straight out of
+  # poisson_log_glm_lpmf.
+  #
+  # On pull requests, unlike the wasm job: the point of a sanitizer is to
+  # see the overflow before it merges. It runs ctest and nothing else --
+  # no corpus check, no conformance, no wheel -- because those are covered
+  # by jobs that are not paying for instrumentation, and the 51 test
+  # binaries are the target.
+  asan:
+    name: ctest under AddressSanitizer
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - name: Restore the compiler cache
+        uses: actions/cache@v4
+        with:
+          # Its own key: these objects carry -fsanitize=address and must
+          # never be handed to, or taken from, the wheel build's cache.
+          path: .ccache
+          key: ccache-asan-${{ github.sha }}
+          restore-keys: ccache-asan-
+      - name: Fetch pinned dependencies
+        run: ./deps/fetch.sh
+      - name: Build with -fsanitize=address
+        run: |
+          which ccache || sudo apt-get install -y ccache
+          export CCACHE_DIR="$PWD/.ccache" CCACHE_COMPRESS=1 CCACHE_MAXSIZE=600M
+          # RelWithDebInfo, not Release: -g is what turns a report into an
+          # actionable stack, and none of this is shipped. STANLI_SANITIZE
+          # adds the flags globally, so the vendored SUNDIALS C is
+          # instrumented on the same terms as the kernels.
+          cmake -B build-asan -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+            -DSTANLI_SANITIZE=address \
+            -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+          # -j2 for the reason the wheel build gives: one densities shard
+          # peaks near 4 GB uninstrumented, and the shadow bookkeeping
+          # does not make that number smaller.
+          cmake --build build-asan -j2
+          ccache -s
+      - name: ctest
+        run: ctest --test-dir build-asan --output-on-failure
+        env:
+          # LeakSanitizer, which is a separate tool that ASan turns on by
+          # default on Linux. What it would find is stan-math's autodiff
+          # arena: it allocates blocks it deliberately never returns
+          # (stack_alloc's free_all runs only from a static's destructor),
+          # so every run would report it and nobody would read the rest.
+          # Off wholesale rather than suppressed entry by entry, because
+          # this job is here for overflows and use-after-free and a leak
+          # is neither. macOS arm64 has no LSan to turn off, which is why
+          # a local run needs nothing.
+          ASAN_OPTIONS: detect_leaks=0
+
   # Not on pull requests: 265 s, of which 200 is emscripten linking the
   # module, and ccache cannot touch a link. It is safe to run this after
   # the merge because the Pages deploy needs it: a broken browser build

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -269,6 +269,15 @@ jobs:
       # This class of check has caught what unit tests missed: eight
       # models silently wrong by up to 1.7e5 relative reached main with
       # every test green, and only the corpus diff flagged them.
+      #
+      # Every model runs at all three deterministic points, not only the
+      # one its reference was recorded at -- the recorder stops at the
+      # first point that works, so an unreferenced point is exactly where
+      # a crash hides (reductions_allowed, a month of green runs). There
+      # is no faster mode to pick instead: a strict mode nobody runs is
+      # the failure this replaces. Wall time 26s -> 77s at --jobs 4 on the
+      # development machine, and nn_rbm1bJ100's three points ARE that wall
+      # clock: the other 128 models total about 25 seconds between them.
       - name: Corpus verification against CmdStan references
         run: |
           python3 tools/verify_refs.py deps/posteriordb \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -428,5 +428,19 @@ if(Python3_Interpreter_FOUND)
   add_test(NAME test_conformance_harness
            COMMAND ${Python3_EXECUTABLE} tests/test_conformance.py
            WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+  # The corpus replay's per-point verdicts, over a stub stanli_check. The
+  # oracle itself needs posteriordb and a real binary and so runs in CI
+  # rather than here; what runs here is the classification it depends on,
+  # which is what let a segfault at an unreferenced point go unreported.
+  #
+  # Not on Windows: the stub is a /bin/sh script that kills itself with
+  # SIGSEGV, and what the test asserts is that a negative returncode is
+  # read as a crash. Both halves are POSIX, and so is the corpus check
+  # this defends, which only ever runs on Linux and macOS.
+  if(NOT WIN32)
+    add_test(NAME test_verify_refs
+             COMMAND ${Python3_EXECUTABLE} tests/test_verify_refs.py
+             WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+  endif()
 endif()
 endif()  # NOT EMSCRIPTEN

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,47 @@ if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE RelWithDebInfo)
 endif()
 
+# Sanitizers, for running the test suite under. Empty by default and never
+# a shipped flavour: this is a way to run ctest, not a build anyone
+# installs, so it deliberately does not touch STANLI_BUILD_ID.
+#
+# Global rather than an option on the stanmath interface target, because
+# the bugs worth catching do not respect target boundaries -- the vendored
+# SUNDIALS C and the C++20 walnuts translation unit have to be
+# instrumented on the same terms as the kernels.
+#
+# Address is what the two memory bugs that reached main in August wanted:
+# both produced WRONG NUMBERS rather than a crash in the common case (a
+# GLM outcome mapped `rows` integers out of a 3-integer group; the island
+# register file handed out a var from an already-recovered nested tape),
+# and only the first of those is a heap overflow ASan can see. The second
+# is invisible to any sanitizer, because stan-math's arena recovers by
+# rewinding a bump pointer (stack_alloc.hpp recover_nested) and never
+# returns the bytes to the allocator.
+#
+# `address,undefined` works too, and is clean: all 51 tests pass with zero
+# runtime errors on Apple clang 17, arm64, with -fno-sanitize-recover
+# below in force. CI runs `address` alone only because that result has not
+# been reproduced on the Linux toolchain, whose UBSan differs -- the two
+# bugs above are both ASan's kind, so the job leads with what it can show
+# working, and adding `,undefined` here is the whole change if someone
+# confirms it there.
+set(STANLI_SANITIZE "" CACHE STRING
+    "Sanitizers to build the tests with, e.g. `address` (empty: none)")
+if(STANLI_SANITIZE)
+  # -g even in Release: a sanitizer report without a symbolized stack is a
+  # bug number nobody can act on.
+  add_compile_options(-fsanitize=${STANLI_SANITIZE} -fno-omit-frame-pointer -g)
+  add_link_options(-fsanitize=${STANLI_SANITIZE})
+  # UndefinedBehaviorSanitizer prints and CARRIES ON by default, so a
+  # suite that trips it still exits 0 and CI still goes green. Trap it
+  # instead: a check nobody's exit code depends on is the failure this
+  # whole job exists to close.
+  if(STANLI_SANITIZE MATCHES "undefined")
+    add_compile_options(-fno-sanitize-recover=undefined)
+  endif()
+endif()
+
 set(DEPS ${CMAKE_CURRENT_SOURCE_DIR}/deps)
 file(GLOB _eigen ${DEPS}/math/lib/eigen_*)
 file(GLOB _boost ${DEPS}/math/lib/boost_*)

--- a/docs/hacking.md
+++ b/docs/hacking.md
@@ -454,6 +454,21 @@ runs in CI on every push, and
 through the WASM build. A change that claims to be a pure refactor
 should leave the replay's worst-deviation line exactly as it found it.
 
+If the change touches raw pointers, an `Eigen::Map` over a buffer
+somebody else sized, or the island register file, run the suite with
+AddressSanitizer as well. CI does this on every pull request, and it is
+one flag locally:
+
+```
+cmake -B build-asan -DCMAKE_BUILD_TYPE=RelWithDebInfo -DSTANLI_SANITIZE=address
+cmake --build build-asan -j8 && ctest --test-dir build-asan
+```
+
+`address,undefined` also passes clean. What ASan cannot see is a stale
+`var`: stan-math's arena recovers a nested tape by rewinding a bump
+pointer, so reading a `vari` from a tape that was already recovered
+lands inside a live allocation and reports nothing.
+
 If the change touches a density tier or anything about propto, also
 check the lite build, the smaller build variant that reports lp only
 up to a constant ([`docs/lite-lp.md`](lite-lp.md)). CI does not cover

--- a/tests/test_verify_refs.py
+++ b/tests/test_verify_refs.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""Tests for the corpus replay's per-point verdicts.
+
+tools/verify_refs.py is the strongest oracle in the project and had no
+test of its own. What is tested here is the part that decides whether a
+run at a point with no recorded reference passed -- in particular that a
+crash is reported as a crash, which is the failure a month of green
+corpus runs missed while reductions_allowed segfaulted at point 2.
+
+A stub stanli_check (a shell script that prints whatever the case wants,
+or kills itself) stands in for the real binary, so the verdicts are
+exercised without a build.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import stat
+import sys
+import tempfile
+import unittest
+
+REPO = pathlib.Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "tools"))
+
+from verify_refs import POINTS, check_model, probe_point  # noqa: E402
+
+# A model that exists under tests/stanc3, so model_files resolves real
+# paths without unpacking a posteriordb dataset. The stub never reads
+# them; they only have to be there.
+MODEL = "reductions_allowed"
+
+
+def stub(tmp, body):
+    """A stanli_check that runs `body` with $point set to --point's value."""
+    path = pathlib.Path(tmp) / "stanli_check_stub.sh"
+    path.write_text("#!/bin/sh\npoint=0\n"
+                    'while [ $# -gt 0 ]; do\n'
+                    '  [ "$1" = --point ] && point=$2\n'
+                    '  shift\n'
+                    "done\n" + body + "\n")
+    path.chmod(path.stat().st_mode | stat.S_IXUSR)
+    return path
+
+
+class ProbePointTest(unittest.TestCase):
+    """One run, one verdict. probe_point returns ("OK", "") or a failure."""
+
+    def verdict(self, body, point=1):
+        with tempfile.TemporaryDirectory() as tmp:
+            return probe_point(MODEL, REPO / "tests" / "stanc3" / f"{MODEL}.stan",
+                               REPO / "tests" / "stanc3" / f"{MODEL}.json",
+                               stub(tmp, body), point, 60)
+
+    def test_finite_lp_and_gradients_pass(self):
+        self.assertEqual(self.verdict('echo "OK -3.5 1 -2"')[0], "OK")
+
+    def test_signal_is_a_crash(self):
+        status, detail = self.verdict("kill -SEGV $$")
+        self.assertEqual(status, "CRASH")
+        self.assertIn("signal 11", detail)
+
+    def test_silent_nonzero_exit_is_a_crash(self):
+        status, detail = self.verdict("exit 3")
+        self.assertEqual(status, "CRASH")
+        self.assertIn("exit 3, no output", detail)
+
+    def test_clean_rejection_passes(self):
+        # The model is outside its declared support at this point and says
+        # so; CmdStan throws in the same place. Not a failure.
+        self.assertEqual(self.verdict('echo "EVAL_FAIL out of range"')[0], "OK")
+
+    def test_zero_density_passes(self):
+        # log(0) is a value both engines produce and agree on.
+        self.assertEqual(self.verdict('echo "OK -inf 0 0"')[0], "OK")
+
+    def test_nan_lp_fails(self):
+        self.assertEqual(self.verdict('echo "OK nan 0 0"')[0],
+                         "POINT_NONFINITE_LP")
+
+    def test_nonfinite_gradient_under_finite_lp_fails(self):
+        status, detail = self.verdict('echo "OK -3.5 1 nan"')
+        self.assertEqual(status, "POINT_NONFINITE_GRAD")
+        self.assertIn("1/2", detail)
+
+    def test_compile_fail_is_not_a_rejection(self):
+        # Compiling does not depend on the point, so a model that
+        # compiled at its recorded point must compile at every other one.
+        self.assertEqual(self.verdict('echo "COMPILE_FAIL no MIR"')[0],
+                         "POINT_COMPILE_FAIL")
+
+
+class CheckModelPointsTest(unittest.TestCase):
+    """The replay evaluates every point, not the recorded one alone."""
+
+    REF = {"point": 0, "values": ["-3.5", "1", "-2"]}
+
+    def run_check(self, body):
+        with tempfile.TemporaryDirectory() as tmp:
+            return check_model(MODEL, self.REF, REPO / "nonexistent-pdb",
+                               stub(tmp, body), pathlib.Path(tmp), 60)
+
+    def test_agreeing_at_every_point_passes(self):
+        self.assertEqual(self.run_check('echo "OK -3.5 1 -2"')[1], "OK")
+
+    def test_crash_away_from_the_recorded_point_fails(self):
+        # reductions_allowed in miniature: the recorded point matches the
+        # reference exactly, and the run still has to fail.
+        _, status, _, _, _, detail = self.run_check(
+            'if [ "$point" = 2 ]; then kill -SEGV $$; fi\necho "OK -3.5 1 -2"')
+        self.assertEqual(status, "CRASH")
+        self.assertIn("point 2", detail)
+        self.assertIn("signal 11", detail)
+
+    def test_every_point_is_visited(self):
+        # Each point appends its number to a witness file; all three must
+        # be there when the model passes.
+        with tempfile.TemporaryDirectory() as tmp:
+            seen = pathlib.Path(tmp) / "seen"
+            result = check_model(
+                MODEL, self.REF, REPO / "nonexistent-pdb",
+                stub(tmp, f'echo "$point" >> {seen}\necho "OK -3.5 1 -2"'),
+                pathlib.Path(tmp), 60)
+            self.assertEqual(result[1], "OK")
+            self.assertEqual(sorted(seen.read_text().split()),
+                             [str(p) for p in POINTS])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/verify_refs.py
+++ b/tools/verify_refs.py
@@ -16,18 +16,23 @@ corpus (silent in-place corruption at 1.7e+05 relative, quadratic
 recompute, dropped tape links) sits many orders of magnitude above it,
 and honest cross-libm drift sits well below.
 
+Every model is evaluated at all three deterministic points, not only at
+the one its reference was recorded at; see POINTS below for what the
+other two are held to.
+
 Usage: tools/verify_refs.py PDB_DIR [--check BIN] [--max-rel X]
                             [--jobs N] [--timeout S] [model ...]
        tools/verify_refs.py PDB_DIR --wa-report [--filter SUBSTR]
        tools/verify_refs.py PDB_DIR --wa-headers CMDSTAN_DIR [model ...]
-Exit nonzero if any referenced model fails to run, changes shape, or
-exceeds the gate.
+Exit nonzero if any referenced model fails to run at any point, changes
+shape, or exceeds the gate.
 """
 import argparse
 import collections
 import concurrent.futures
 import gzip
 import json
+import math
 import pathlib
 import re
 import struct
@@ -43,6 +48,46 @@ REPO = pathlib.Path(__file__).resolve().parent.parent
 # it, and a reference is keyed on the file name either way.
 LANG = REPO / "tests" / "stanc3"
 N_SAMPLER_COLS = 7
+# The deterministic unconstrained points stanli_check and ref_driver both
+# know (eval_point, defined identically in each). A reference exists at
+# exactly ONE of them: the recorder walks the list and stops at the first
+# point both engines accept and put the model inside its support, so 128
+# of the 129 references are point 0 and one is point 2.
+#
+# The replay evaluates all three anyway. Stopping where the recorder
+# stopped means the recorder's search actively selects AWAY from a point
+# that crashes -- which is how reductions_allowed segfaulted at point 2
+# for a month while the corpus ran green at point 0, and 25 of the 120
+# corpus models carry a conditional whose other side only some point
+# reaches. What the unreferenced points are held to is in probe_point.
+POINTS = (0, 1, 2)
+
+# (model, point) pairs excused from probe_point's finite-gradient rule.
+# Every entry was settled against a live CmdStan -- tools/ref_driver.cpp
+# compiled for that model and run at that point -- not by argument, and
+# the two entries came out opposite ways, which is why the rule is worth
+# keeping for everything else.
+NONFINITE_GRAD_OK = {
+    # Agreement. kronecker_gp is the corpus's one recorded MISMATCH: two
+    # of its 438 gradients flow through eigenvectors of a nearly
+    # degenerate covariance (see gate_for). At the all-zeros point that
+    # covariance is degenerate outright, and CmdStan answers with the
+    # identical lp (-187.85795069042379) and the identical 435 of 438
+    # nonfinite gradients. Both engines, same numbers: not a stanli bug.
+    ("kronecker_gp", 2): "CmdStan is nonfinite here too, 435/438, same lp",
+    # NOT agreement -- an open bug this check found on its first run.
+    # accel_gp's gradients for sdgp_1 and lscale_1 (unconstrained indices
+    # 1 and 2, the GP marginal SD and length scale, both through
+    # spd_cov_exp_quad) come back NaN at points 1 and 2 where CmdStan
+    # returns finite values, with lp bitwise equal on both sides. Point 0
+    # is clean, which is why the reference never saw it. Listed rather
+    # than left failing so the rule can gate the other 128 models
+    # meanwhile; delete these two lines with the fix.
+    #   deps/cmdstan ref_driver: grads 1,2 = -94.655, 94.951 at point 1
+    #                            and 0.99897, -1.10721 at point 2
+    ("accel_gp", 1): "OPEN BUG: CmdStan is finite here (grads 1, 2)",
+    ("accel_gp", 2): "OPEN BUG: CmdStan is finite here (grads 1, 2)",
+}
 
 
 def default_check_bin():
@@ -223,6 +268,86 @@ def check_wa_headers(pdb, check_bin, cmdstan, models, excluded=()):
     return 1 if bad else 0
 
 
+def fail_detail(proc, got):
+    """Why a stanli_check run did not print OK.
+
+    Say HOW it died, not just that it did: a negative returncode is a
+    signal (ldaK5's 49 GB compile came back as a bare RUN_FAIL because
+    the OOM killer leaves no stdout).
+    """
+    detail = " ".join(got[:3])
+    if not detail:
+        detail = (f"killed by signal {-proc.returncode}"
+                  if proc.returncode < 0
+                  else f"exit {proc.returncode}, no output")
+    err = proc.stderr.strip().splitlines()
+    if err:
+        detail += " | " + err[-1][:120]
+    return detail
+
+
+def probe_point(model, stan, dj, check_bin, point, timeout):
+    """Evaluate a point with no recorded reference. (status, detail).
+
+    No CmdStan values means no parity check, so the bar here is only what
+    the run can be held to on its own evidence:
+
+      * It must not crash. A signal, or a nonzero exit with none of
+        stanli_check's machine-readable lines on stdout, is a hard
+        failure. This is the whole reason the extra points are run: a
+        SIGSEGV is not a numerical disagreement anyone needs a reference
+        to adjudicate.
+      * A clean rejection passes. stanli_check prints EVAL_FAIL only when
+        evaluation THREW, which is how a model outside its declared
+        support at this point reports itself (an ODE solution dipping
+        below a lower bound, say). CmdStan's ref_driver throws in the
+        same place, and the recorder counts both engines refusing a point
+        as agreement rather than a stanli failure -- REJECTED_BOTH in
+        verify_sample.py. Only one engine is present here, so the
+        rejection is accepted, not confirmed.
+      * An lp of -inf passes for the same reason: a zero density is a
+        value both engines produce and agree on (bernoulli_lccdf(1|theta)
+        is log(0) by definition, and stanli_check deliberately prints
+        nonfinite values rather than refusing them so the two drivers
+        stay comparable). +inf or NaN does not pass -- no reference in
+        the corpus was recorded that way, and a NaN lp is exactly what an
+        unwritten register reads as.
+      * A finite lp must come with finite gradients. lp finite next to a
+        nonfinite gradient is the shape a dropped tape link takes, and
+        spotting it needs no reference. NONFINITE_GRAD_OK carries the two
+        (model, point) pairs excused from this, each with the CmdStan run
+        that settled it.
+
+    COMPILE_FAIL is a failure here rather than a rejection: compiling does
+    not depend on the evaluation point, so a model that compiled at its
+    recorded point must compile at every other one.
+    """
+    try:
+        proc = subprocess.run(
+            [str(check_bin), str(stan), str(dj), "--point", str(point)],
+            capture_output=True, text=True, cwd=REPO, timeout=timeout)
+    except subprocess.TimeoutExpired:
+        return ("POINT_TIMEOUT", "")
+    lines = proc.stdout.splitlines()
+    got = lines[0].split() if lines else []
+    kind = got[0] if got else ""
+    if kind == "EVAL_FAIL":
+        return ("OK", "")
+    if kind != "OK":
+        return ("POINT_COMPILE_FAIL" if kind == "COMPILE_FAIL" else "CRASH",
+                fail_detail(proc, got))
+    lp = float(got[1])
+    if math.isnan(lp) or lp == math.inf:
+        return ("POINT_NONFINITE_LP", f"lp {got[1]}")
+    if lp == -math.inf:
+        return ("OK", "")
+    bad = sum(1 for x in got[2:] if not math.isfinite(float(x)))
+    if bad and (model, point) not in NONFINITE_GRAD_OK:
+        return ("POINT_NONFINITE_GRAD",
+                f"lp {got[1]} but {bad}/{len(got) - 2} gradients nonfinite")
+    return ("OK", "")
+
+
 def check_model(model, ref, pdb, check_bin, tmp, timeout, no_wa=False,
                 no_lp=False):
     """Returns (model, status, max_rel, max_ulp, n_values, detail)."""
@@ -240,18 +365,7 @@ def check_model(model, ref, pdb, check_bin, tmp, timeout, no_wa=False,
     lines = proc.stdout.splitlines()
     got = lines[0].split() if lines else []
     if not got or got[0] != "OK":
-        # Say HOW it died, not just that it did: a negative returncode is
-        # a signal (ldaK5's 49 GB compile came back as a bare RUN_FAIL
-        # because the OOM killer leaves no stdout).
-        detail = " ".join(got[:3])
-        if not detail:
-            detail = (f"killed by signal {-proc.returncode}"
-                      if proc.returncode < 0
-                      else f"exit {proc.returncode}, no output")
-        err = proc.stderr.strip().splitlines()
-        if err:
-            detail += " | " + err[-1][:120]
-        return (model, "RUN_FAIL", 0.0, 0, 0, detail)
+        return (model, "RUN_FAIL", 0.0, 0, 0, fail_detail(proc, got))
     rv = [float(x) for x in ref["values"]]
     gv = [float(x) for x in got[1:]]
     if len(rv) != len(gv):
@@ -294,6 +408,20 @@ def check_model(model, ref, pdb, check_bin, tmp, timeout, no_wa=False,
             worst = max(worst, rel)
             worst_ulp = max(worst_ulp, ulp)
         n += len(wref)
+    # The two points with no reference. Sequential and in-process rather
+    # than separate pool tasks, because model_files unpacks the shared
+    # posteriordb data zip to one path per model and three workers writing
+    # it at once would race. The write_array section runs on every
+    # stanli_check invocation whether or not --wa-values asks for its
+    # numbers, so these points cover it against a crash for free.
+    for point in POINTS:
+        if point == int(ref["point"]):
+            continue
+        status, detail = probe_point(model, stan, dj, check_bin, point,
+                                     timeout)
+        if status != "OK":
+            return (model, status, worst, worst_ulp, n,
+                    f"point {point}: {detail}")
     return (model, "OK", worst, worst_ulp, n, "")
 
 
@@ -470,7 +598,8 @@ def main():
 
     ok = len(models) - len(failures)
     print(f"\n{ok}/{len(models)} models within {args.max_rel:.0e} of the "
-          f"CmdStan references"
+          f"CmdStan references, and clean at all "
+          f"{len(POINTS)} evaluation points"
           + (" (gradients only)" if args.no_lp else "")
           + (f"; worst {worst_overall[0]} at {worst_overall[1]:.2e} "
              f"({worst_overall[2]} ulp)" if worst_overall[0] else ""))


### PR DESCRIPTION
Two hardening changes, each closing a hole a real bug exploited. Plus one new bug found by the hardening itself, on a real posteriordb model.

## 1. The corpus replay evaluates all three points

The recording rig's first-OK-wins loop meant a crashing point was actively selected away from, and the replay then verified only the point known to pass -- which is how a SIGSEGV survived a month of green corpus runs. The replay now drives every model at all three deterministic points. The recorded point keeps full lp/gradient/write_array parity; the reference-free points get a bar stated in code: a signal or unexplained exit is a hard CRASH failure named by model and point; a clean rejection passes (both drivers throw in the same place, and both-engines-reject already counts as agreement elsewhere); `-inf` lp passes (zero density is an answer); NaN or `+inf` lp fails; finite lp requires finite gradients.

No fast/strict flag split -- the CI invocation is strict by construction, because a strict mode nobody runs is the exact failure this closes. Wall time at `--jobs 4`: 26.0s to 77.5s, dominated by one model.

**Crash demo** at the register-program fix's parent: old replay `1/1 within 1e-09`, exit 0; new replay `CRASH reductions_allowed point 2: killed by signal 11`, exit 1.

`verify_refs.py` gets its first tests: 11 cases over a stub driver, in ctest (POSIX-guarded).

### Found by the new points: `accel_gp` returns NaN gradients where CmdStan is finite

`sdgp_1` and `lscale_1`, both through `spd_cov_exp_quad`, are NaN at points 1 and 2 with lp bitwise EQUAL to CmdStan's on both sides. Point 0 is clean, which is why the recorded reference never saw it. Settled by running CmdStan, not by argument: it returns -94.655/94.951 at point 1. Independently reproduced during review. Listed in `NONFINITE_GRAD_OK` with a comment saying delete-on-fix, so the rule gates the other 128 models meanwhile. The other entry there, `kronecker_gp` at point 2, was checked the same way and CmdStan agrees bitwise including the SAME 435 nonfinite gradients -- agreement, not a bug.

**Recommendation carried, not taken**: record references at all three points. The reference-free bar caught `accel_gp` only because the wrong answer happened to be NaN; wrong-but-finite at an unrecorded point is still invisible. That means regenerating `docs/corpus-refs.json.gz` with CmdStan and is its own reviewed change.

## 2. ASan over the suite, in CI

`-DSTANLI_SANITIZE=address` applied globally (vendored SUNDIALS and the walnuts TU included), and an `asan` job in wheels.yml on pull requests: ubuntu-24.04, own ccache key, ctest only. macOS passes 51/51 under ASan with no options needed; the Linux job sets `detect_leaks=0` for stan-math's arena.

UBSan builds and passes 51/51 with `-fno-sanitize-recover=undefined` wired in (default UBSan prints and exits 0 -- the sanitizer form of a mode nobody runs), but ships out of CI until someone confirms it on the Linux toolchain; adding `,undefined` to the job is the whole change.

### The honest answer on the two motivating bugs

- **GLM Map overflow: ASan catches it on contact** -- `heap-buffer-overflow, READ of size 4, 0 bytes after a 12-byte region`, symbolized to the allocation site, at every row count including the fix's own test shape. BUT the pre-fix suite passes 49/49 under ASan, because no test then reached the shape. The job's value is bounded by test reach, not by the sanitizer.
- **Island stale vari: the crashing mode gets a symbolized SEGV; the silent wrong-numbers mode is invisible to any allocator-level sanitizer**, demonstrated with a 20-line probe -- stan-math's arena is a bump-pointer rewind, nothing returns to malloc, so a var read after its nested tape died returns stale-then-reused bytes and ASan says nothing. Not MSan (bytes initialized), not hardened asserts (no bound violated). Catching that class needs arena poisoning hooks upstream in stan-math. Report-only.

### Known risks, stated

The Linux asan job is unverified locally (no Docker); first run is a cold ccache and gcc ASan at `-j2` may need the memory estimate revisited -- fix forward. `asan` is deliberately NOT in `publish`'s `needs:`; gating a release tag on a sanitizer is a call worth making on purpose.

## Gates

`ctest` 51/51 · `verify_refs` 129/129 **and clean at all 3 points** (85s at `--jobs 8` during review) · `format.sh --check` clean · `gen_docs.py --check` clean. Sanitizer recipe documented in `docs/hacking.md`.