### PR TITLE
fix: sqrt's adjoint at exactly zero no longer poisons gradients

### DIFF
--- a/runtime/kernels/eltwise_expr.cpp
+++ b/runtime/kernels/eltwise_expr.cpp
@@ -371,10 +371,20 @@ void sqrtv_fwd(KernelCtx& ctx) { out_a(ctx) = in_a(ctx, 0).sqrt(); }
 void sqrtv_bwd(KernelCtx& ctx) {
   if (!ctx.in_adj[0].data) return;
   CMapA out_v(ctx.out.data, ctx.out.len);
-  if (ctx.out.len == 1)
-    ctx.in_adj[0].data[0] += ctx.out_adj / (2.0 * ctx.out.data[0]);
-  else
-    dx_a(ctx, 0) += dout_a(ctx) / (2.0 * out_v);
+  // sqrt(0) contributes nothing rather than 1/(2*0) = inf. That is what
+  // stan-math's rev overload does (rev/fun/sqrt.hpp guards on
+  // `vi.val() != 0.0`), and matching it is what keeps a model whose input
+  // underflows to exact zero differentiable: the inf would meet the zero
+  // value on the way back through the op that produced it and become NaN.
+  // accel_gp is the corpus case -- spd_cov_exp_quad's exp() underflows for
+  // the largest Laplacian eigenvalue. select, not a mask multiply, because
+  // multiplying an inf by zero is the NaN we are avoiding.
+  if (ctx.out.len == 1) {
+    if (ctx.out.data[0] != 0.0)
+      ctx.in_adj[0].data[0] += ctx.out_adj / (2.0 * ctx.out.data[0]);
+  } else {
+    dx_a(ctx, 0) += (out_v != 0.0).select(dout_a(ctx) / (2.0 * out_v), 0.0);
+  }
 }
 void squarev_fwd(KernelCtx& ctx) { out_a(ctx) = in_a(ctx, 0).square(); }
 void squarev_bwd(KernelCtx& ctx) {

--- a/tests/test_eltwise.cpp
+++ b/tests/test_eltwise.cpp
@@ -143,6 +143,19 @@ int main() {
              [](auto& v) { return stan::math::inv_logit(v[0](0)); });
   check_case("sqrt v", OP_SQRT, N, {{0.5, 1.2, 2.0, 0.3}},
              [](auto& v) { return stan::math::sum(stan::math::sqrt(v[0])); });
+  // sqrt at exactly zero, both shapes. d/dx sqrt(x) is 1/(2 sqrt(x)), which
+  // at x = 0 is a division by zero; stan-math's rev overload answers with a
+  // zero contribution instead (rev/fun/sqrt.hpp: `if (vi.val() != 0.0)`),
+  // and a kernel that divides anyway hands +inf back to whatever produced
+  // the zero, where inf * 0 turns into NaN one op later. accel_gp reaches
+  // this: its spd_cov_exp_quad underflows exp() to exact zero for the
+  // largest Laplacian eigenvalue, and sqrt of that fed NaN into the
+  // sdgp/lscale gradients. Nonzero neighbours in the same vector keep the
+  // vector branch honest -- the guard has to be elementwise.
+  check_case("sqrt v at zero", OP_SQRT, N, {{0.0, 1.2, 2.0, 0.3}},
+             [](auto& v) { return stan::math::sum(stan::math::sqrt(v[0])); });
+  check_case("sqrt s at zero", OP_SQRT, 1, {{0.0}},
+             [](auto& v) { return stan::math::sqrt(v[0](0)); });
   check_case("square v", OP_SQUARE, N, {A},
              [](auto& v) { return stan::math::sum(stan::math::square(v[0])); });
   check_case("log1m v", OP_LOG1M, N, {{0.2, -0.5, 0.7, 0.05}},

--- a/tools/verify_refs.py
+++ b/tools/verify_refs.py
@@ -63,10 +63,11 @@ N_SAMPLER_COLS = 7
 POINTS = (0, 1, 2)
 
 # (model, point) pairs excused from probe_point's finite-gradient rule.
-# Every entry was settled against a live CmdStan -- tools/ref_driver.cpp
-# compiled for that model and run at that point -- not by argument, and
-# the two entries came out opposite ways, which is why the rule is worth
-# keeping for everything else.
+# The one entry was settled against a live CmdStan -- tools/ref_driver.cpp
+# compiled for that model and run at that point -- not by argument. The
+# other entry this list once held, accel_gp, came out the opposite way and
+# was a real bug (sqrt's adjoint at exactly zero, sqrtv_bwd), which is why
+# the rule is worth keeping for everything else.
 NONFINITE_GRAD_OK = {
     # Agreement. kronecker_gp is the corpus's one recorded MISMATCH: two
     # of its 438 gradients flow through eigenvectors of a nearly
@@ -75,18 +76,6 @@ NONFINITE_GRAD_OK = {
     # identical lp (-187.85795069042379) and the identical 435 of 438
     # nonfinite gradients. Both engines, same numbers: not a stanli bug.
     ("kronecker_gp", 2): "CmdStan is nonfinite here too, 435/438, same lp",
-    # NOT agreement -- an open bug this check found on its first run.
-    # accel_gp's gradients for sdgp_1 and lscale_1 (unconstrained indices
-    # 1 and 2, the GP marginal SD and length scale, both through
-    # spd_cov_exp_quad) come back NaN at points 1 and 2 where CmdStan
-    # returns finite values, with lp bitwise equal on both sides. Point 0
-    # is clean, which is why the reference never saw it. Listed rather
-    # than left failing so the rule can gate the other 128 models
-    # meanwhile; delete these two lines with the fix.
-    #   deps/cmdstan ref_driver: grads 1,2 = -94.655, 94.951 at point 1
-    #                            and 0.99897, -1.10721 at point 2
-    ("accel_gp", 1): "OPEN BUG: CmdStan is finite here (grads 1, 2)",
-    ("accel_gp", 2): "OPEN BUG: CmdStan is finite here (grads 1, 2)",
 }
 
 
@@ -314,7 +303,7 @@ def probe_point(model, stan, dj, check_bin, point, timeout):
         unwritten register reads as.
       * A finite lp must come with finite gradients. lp finite next to a
         nonfinite gradient is the shape a dropped tape link takes, and
-        spotting it needs no reference. NONFINITE_GRAD_OK carries the two
+        spotting it needs no reference. NONFINITE_GRAD_OK carries the
         (model, point) pairs excused from this, each with the CmdStan run
         that settled it.
 


### PR DESCRIPTION
`accel_gp` -- a real posteriordb posterior -- returned NaN gradients for `sdgp_1` and `lscale_1` at evaluation points 1 and 2, with lp bitwise equal to CmdStan's. Found by the multi-point corpus replay the day it landed (#143); the recorded reference sits at point 0, which is clean.

## Root cause

`sqrtv_bwd` computed `dout / (2.0 * out)` with no guard at `out == 0`.

The model's path is `sqrt(spd_cov_exp_quad(...))`. For the largest Laplacian eigenvalue the spectral density is `constant * exp(-877.30)` at `lscale = 1` -- which underflows to **exactly zero**. Forward is fine (`sqrt(0) = 0`, lp untouched, hence the bitwise-equal lp). Backward: `dout/(2*0) = +inf`, then the multiply that produced the zero computes `inf * 0 = NaN`, landing on exactly the two parameters feeding the constant and the exponent.

**Why point 0 escaped -- scale, not kind.** There `lscale = exp(-0.1)`, the exponent is `-718.27`, and the result is `1.145e-312`: subnormal but nonzero, so the reciprocal is huge-but-finite. One representable-number difference between a clean gradient and NaN, invisible to any single-point oracle.

## Fix

Guard both shapes on the output value, mirroring stan-math's own `rev/fun/sqrt.hpp` (`if (vi.val() != 0.0)`). The vector branch uses `select`, not a mask multiply -- multiplying the inf by a zero mask is the NaN being avoided. The island machine already had this guard and the interpreter routes through stan-math's guarded `sqrt(var)`; this kernel was the only hole.

## Verified

Gradients now match CmdStan at both failing points (e.g. point 1: `-94.655011547014723` vs CmdStan's `-94.655`); point 0 unchanged bitwise. Unit tests pin both kernel shapes bitwise against a stan-math var reference at `{0.0, 1.2, 2.0, 0.3}` -- nonzero neighbours force the guard to be elementwise -- RED-verified (`got inf want 0`). The `accel_gp` quarantine in `NONFINITE_GRAD_OK` is **deleted**, leaving `kronecker_gp` (whose nonfinite gradients CmdStan shares) as the sole entry; that deletion was separately RED-verified against the unfixed kernel.

`ctest` 52/52 · `verify_refs` 129/129, clean at all 3 points, `hmm_gaussian` unchanged at 3.63e-12 · `format.sh --check` clean.

## Found, not fixed

- `pow_bwd` in the same file has the same class of hole at `base == 0` (`0/0` NaN, and `log(0)` meeting a zero the same way); stan-math guards its matrix pow with `select` on `base != 0.0`. No corpus model reaches it -- no RED available -- so it is reported rather than patched blind.
- `OP_INV_SQRT` is unguarded but a different class: at zero the forward is already inf, so lp goes nonfinite first and the finite-lp rule never fires.