### PR TITLE
fix: a row_vector answers rows=1, cols=n, in every engine

### DIFF
--- a/runtime/include/stanli/mir_interp.hpp
+++ b/runtime/include/stanli/mir_interp.hpp
@@ -1680,11 +1680,27 @@ class MirInterp {
         e.name == "num_elements" || e.name == "FnLength") {
       Value a = eval(e.args[0]);
       long v = 0;
-      if (e.name == "rows")
-        v = a.dims.size() == 2 ? a.dims[0] : (long)a.r.size();
-      else if (e.name == "cols")
-        v = a.dims.size() == 2 ? a.dims[1] : 1;
-      else
+      if (e.name == "rows" || e.name == "cols") {
+        // A vector's orientation is type-level, not storage-level: both
+        // kinds are stored rank-1, so dims cannot say which way one points.
+        // The MIR type can, and it is where the graph keeps orientation too
+        // -- lower.cpp stamps ViewKind::RowVector from this same string and
+        // its logical_dims answers {1, len} off the view, never off dims.
+        // This restates that function, so the two paths cannot drift.
+        // Reading rows() off the storage rank alone made every row_vector an
+        // n-by-1 column, and through a transformed-data `int r = rows(rv)`
+        // that is a silently wrong log density.
+        const long n = (long)a.r.size();
+        std::pair<long, long> rc =
+            a.dims.size() == 2
+                ? std::pair<long, long>{(long)a.dims[0], (long)a.dims[1]}
+                : std::pair<long, long>{n, 1};
+        if (e.args[0].type_ == "URowVector")
+          rc = {1, n};
+        else if (e.args[0].type_ == "UVector")
+          rc = {n, 1};
+        v = e.name == "rows" ? rc.first : rc.second;
+      } else
         v = a.dims.empty() ? (long)std::max(a.r.size(), a.i.size())
                            : (long)a.dims[0];
       if (e.name == "num_elements" || e.name == "FnLength")

--- a/runtime/src/lower.cpp
+++ b/runtime/src/lower.cpp
@@ -389,13 +389,12 @@ struct Lowering {
             if (e.name == "cols") return dims.cols;
             return sh.len;
           }
-          DataMap::Entry* en = td.find(e.args[0].name);
-          if (en) {
-            if (e.name == "rows")
-              return en->dims.size() == 2 ? en->dims[0] : (long)en->r.size();
-            if (e.name == "cols") return en->dims.size() == 2 ? en->dims[1] : 1;
-            return (long)std::max(en->r.size(), en->i.size());
-          }
+          // A name td knows but neither scope nor decls does falls through
+          // to the data_only case below, which asks the one interpreter.
+          // bind_data records every input var and every prepare_data decl,
+          // so nothing with an orientation to lose lands there; the copy
+          // that used to answer here read rows/cols off DataMap::Entry::dims
+          // and so carried the rank-1 bug the interpreter just shed.
         }
         // Shape query on a COMPUTED value: --O1 inlining substitutes call
         // arguments into the callee's size expressions, so `rows(beta)`

--- a/tests/cross_path_ledger.json
+++ b/tests/cross_path_ledger.json
@@ -28,7 +28,7 @@
     "quantity": "write_array",
     "pair": "graph/wa_interp",
     "bound_ulp": -1,
-    "cause": "OPEN BUG: on `array[0] matrix[2, 3]` the interpreter throws 'index 2 out of bounds for size 1' evaluating dims() of the empty array, where the graph answers from the declaration. mir_interp.hpp keeps no shape for a zero-length array of matrices.",
+    "cause": "OPEN BUG, and the GRAPH is the wrong side: on `array[0] matrix[2, 3]` the interpreter throws 'index 2 out of bounds for size 1' evaluating dims() of the empty array, where the graph answers {0, 2, 3} from the declaration. CmdStan agrees with the interpreter -- stan::math::dims on a std::vector recurses into element 0 only `if (x.size() > 0)`, so dims(x) is {0} and the generated `rvalue(stan::math::dims(x), \"dims(x)\", index_uni(2))` throws out_of_range. Retire by teaching the graph to stop answering from the declaration for a zero-length array, not by giving the interpreter the declared shape. Unrelated to the rows()/cols() orientation bug retired 2026-08-23: that one was rank-1 storage losing a vector's orientation, this one is a declared shape the value no longer carries.",
     "since": "2026-08-23"
   }
 ]

--- a/tests/cross_path_ledger.json
+++ b/tests/cross_path_ledger.json
@@ -30,13 +30,5 @@
     "bound_ulp": -1,
     "cause": "OPEN BUG: on `array[0] matrix[2, 3]` the interpreter throws 'index 2 out of bounds for size 1' evaluating dims() of the empty array, where the graph answers from the declaration. mir_interp.hpp keeps no shape for a zero-length array of matrices.",
     "since": "2026-08-23"
-  },
-  {
-    "model": "view_gq_data_matrix",
-    "quantity": "shaped",
-    "pair": "graph/wa_interp",
-    "bound_ulp": -1,
-    "cause": "OPEN BUG: mir_interp.hpp:1683 reads rows()/cols() off Value::dims, which is rank 1 for a row_vector, so every row_vector answers rows=n, cols=1 where the graph answers rows=1, cols=n. Reproduced on a literal `[1.0, 2.0, 3.0]` as well as on row(M, 2), so it is the rank-1 assumption and not the transformed-data path.",
-    "since": "2026-08-23"
   }
 ]

--- a/tests/test_mir.cpp
+++ b/tests/test_mir.cpp
@@ -440,6 +440,64 @@ int main(int argc, char** argv) {
           "flat data read preserves declared scalar geometry");
   }
 
+  // rows()/cols() answer from the MIR type, not from the storage rank.
+  // Both vector kinds are stored rank-1 -- orientation is type-level here
+  // exactly as it is in the graph, where it lives in the slot view and not
+  // in the dims -- so reading rows() off dims alone called every
+  // row_vector[n] an n-by-1 column. That is a wrong int, and through a
+  // transformed-data `int r = rows(rv)` it is a wrong log density.
+  {
+    std::map<std::string, const mir::FunDef*> functions;
+    MirInterp<double> interp(functions, "rows/cols orientation test");
+    auto real_value = [&](const std::string& name, std::vector<double> values,
+                          std::vector<int64_t> dims) {
+      DataMap::Entry value;
+      value.r = std::move(values);
+      value.dims = std::move(dims);
+      interp.env()[name] = std::move(value);
+    };
+    real_value("v3", {1.0, 2.0, 3.0}, {3});
+    real_value("rv3", {1.0, 2.0, 3.0}, {3});
+    real_value("m23", {1.0, 2.0, 3.0, 4.0, 5.0, 6.0}, {2, 3});
+    auto query = [&](const std::string& name, const std::string& arg,
+                     const std::string& arg_type) {
+      mir::Expr a;
+      a.kind = mir::Expr::Var;
+      a.name = arg;
+      a.type_ = arg_type;
+      a.data_only = true;
+      mir::Expr call;
+      call.kind = mir::Expr::FunApp;
+      call.name = name;
+      call.type_ = "UInt";
+      call.data_only = true;
+      call.args = {a};
+      const DataMap::Entry got = interp.eval(call);
+      return got.is_int && got.i.size() == 1 ? (long)got.i[0] : -1;
+    };
+    check(query("rows", "v3", "UVector") == 3 &&
+              query("cols", "v3", "UVector") == 1,
+          "vector[3] is 3 rows by 1 col");
+    check(query("rows", "rv3", "URowVector") == 1 &&
+              query("cols", "rv3", "URowVector") == 3,
+          "row_vector[3] is 1 row by 3 cols");
+    check(query("rows", "m23", "UMatrix") == 2 &&
+              query("cols", "m23", "UMatrix") == 3,
+          "matrix[2, 3] is 2 rows by 3 cols");
+    // The task-shaped repro: `int r = rows(rv); int c = cols(rv);` folds to
+    // 13 for a row_vector[3], and folded to 31 while orientation was lost.
+    check(query("rows", "rv3", "URowVector") * 10 +
+                  query("cols", "rv3", "URowVector") ==
+              13,
+          "row_vector shape query reaches transformed data as 13");
+    // size()/num_elements() count elements and are orientation-blind; they
+    // must not move when rows()/cols() start consulting the type.
+    for (const std::string& name : {"size", "num_elements"})
+      check(query(name, "rv3", "URowVector") == 3 &&
+                query(name, "v3", "UVector") == 3,
+            name + " counts elements of either vector kind");
+  }
+
   if (failures == 0) std::printf("test_mir OK\n");
   return failures == 0 ? 0 : 1;
 }


### PR DESCRIPTION
The MIR interpreter's `Value::rows()`/`cols()` read orientation off storage rank, and `Value::dims` is rank-1 for both vector kinds -- so every `row_vector[n]` answered `rows=n, cols=1`. Through transformed data that reaches the log density: `int r = rows(rv);` on a `row_vector[3]` gave 3, and a target term built from it graded 31 where CmdStan gives 13. A silent wrong posterior, found by the cross-path harness on its first sweep (#142), invisible to the conformance sweep because int-returning signatures classify `inapplicable`.

## Fix shape: consult the type, not re-shape the representation

The consumer audit is the substance of this PR. Making dims `{1,n}` for row_vectors would have turned every row_vector into a 1x2 matrix at a dozen sites that spell "is a matrix" as `dims.size() == 2` -- indexed row-writes, 2-D indexing, `Transpose__`, `broadcast_dims`, `gp_exp_quad_cov`, `append_col` -- and on `double`, `Value` IS `DataMap::Entry`, so the new rank would leak into JSON reads, `graph_order`, and every entry consumer. The graph side does not put orientation in dims either: it lives in `SlotInfo`'s ViewKind, stamped from the MIR type string, and `logical_dims` answers off the view.

So the interpreter now restates `logical_dims`: check the argument's MIR `type_` for `URowVector`/`UVector` first, fall back to stored dims for matrices. Type-first is deliberate -- it also answers correctly where a value's dims contradict its type, which the append_col finding below shows is a live concern.

## The graph-side sibling, deleted rather than patched

`lower.cpp:392` carried a fallback with the identical rank-1 logic -- the same bug, latent on the graph side. Proved unreachable by replacing it with a hard `fail()` and running everything (52 suites including 91 cross-path fixtures, corpus at 3 points): `bind_data` records every input var and prepare_data decl, so anything with an orientation is found in `decls` first. The duplicate is gone; the definition with a test behind it remains.

## Ledger

`view_gq_data_matrix` retired -- the intended retire path, delete-and-go-green. `viewa_data_empty_matrix` kept with its cause corrected: different root, and **the graph is the wrong side** there -- `stan::math::dims` recurses into element 0 only when size > 0, and CmdStan's generated code (checked via `--print-cpp`) throws exactly as the interpreter does on `dims(array[0] matrix)[2]`. The graph's declaration-derived answer is the divergence; retire path is teaching the graph to stop answering from the declaration.

## Verification

RED three ways: deleting the ledger entry alone fails the cross-path suite; stashing the fix fails the new regression (`row_vector[3] is 1 row by 3 cols`, and the end-to-end repro grading 31); the repro now grades **13**, confirmed independently during review. `size`/`num_elements` are pinned unchanged so the fix cannot overcorrect.

`ctest` 52/52 · `verify_refs` 129/129 at all 3 points, `hmm_gaussian` unchanged · `format.sh --check` clean · rebased over #144.

## Found, not fixed

- **`append_col`/`append_row` have the same rank-1 assumption in a different consumer**: `append_col(row_vector, row_vector)` builds a `{3,2}` matrix where Stan gives `row_vector[6]`. Corrupts value shapes rather than ints -- a separate fix. Because this PR is type-first, shape *queries* on those wrong values already answer correctly; the constructors do not.
- **Both engines agree on rank-1 `dims(vector)`** where `stan::math::dims` returns rank-2 -- an agreed divergence the cross-path harness structurally cannot see, waiting to be a wrong-column-count bug. Needs a paired graph+interpreter change.