### PR TITLE
ci: make the ASan job able to finish

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -619,11 +619,16 @@ jobs:
       # of a dead runner; it is touched only if the spike happens.
       - name: Swap, so a compiler memory spike degrades instead of killing
         run: |
-          sudo fallocate -l 8G /swapfile
-          sudo chmod 600 /swapfile
-          sudo mkswap /swapfile
-          sudo swapon /swapfile
-          free -h
+          # Not /swapfile: the runner image already runs ~4 GB of swap
+          # there (fallocate on it says "Text file busy"), and the job
+          # OOM'd straight through that allowance. This adds 8 GB more
+          # beside it. The before/after prints are the capacity record.
+          swapon --show && free -h
+          sudo fallocate -l 8G /swapfile-asan
+          sudo chmod 600 /swapfile-asan
+          sudo mkswap /swapfile-asan
+          sudo swapon /swapfile-asan
+          swapon --show && free -h
       - name: Build with -fsanitize=address
         run: |
           which ccache || sudo apt-get install -y ccache
@@ -643,7 +648,21 @@ jobs:
             -DSTANLI_SANITIZE=address \
             -DCMAKE_C_COMPILER_LAUNCHER=ccache \
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
-          cmake --build build-asan -j2
+          # Peak of the largest single compile, the wheel build's own
+          # instrumentation: GNU time reports the largest child, which is
+          # exactly the number -j has to fit. This job has been OOM-killed
+          # by guessed ceilings twice; from here the number is read off
+          # the log. The same cache-hit caveat applies -- a warm build
+          # compiles nothing and its peak is not a memory ceiling.
+          /usr/bin/time -v cmake --build build-asan -j2 2>/tmp/build.err ||
+            { cat /tmp/build.err; exit 1; }
+          kb=$(awk '/[Mm]aximum resident/ {print $NF}' /tmp/build.err)
+          miss=$(ccache -s | awk '/^ *Misses:/ {print $2; exit}')
+          echo "ASan peak RSS $(( kb / 1024 )) MB on the largest single" \
+               "compile, over ${miss:-?} ccache misses" \
+               "$([ "${miss:-0}" -lt 20 ] && echo '(cached build:' \
+               'this peak is not a memory ceiling)')"
+          free -h && swapon --show
           ccache -s
       # Save even when the build or tests fail: the cache is compile
       # artifacts, not results, and the original save-on-success rule

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -639,18 +639,21 @@ jobs:
         run: |
           which ccache || sudo apt-get install -y ccache
           export CCACHE_DIR="$PWD/.ccache" CCACHE_COMPRESS=1 CCACHE_MAXSIZE=600M
-          # -O1 -g, the standard sanitizer configuration: ASan's checks do
-          # not depend on the optimizer, -g is what turns a report into an
-          # actionable stack, and gcc compiles the density shards several
-          # times faster than at -O2. None of this is shipped.
+          # -O1 -g1, and every number here was read off a failed run's
+          # log rather than guessed. -O1: ASan's checks do not depend on
+          # the optimizer, and gcc compiles the density shards several
+          # times faster than at -O2. -g1, not -g: line tables are what
+          # turn an ASan report into file:line, and they are ALL this job
+          # needs -- at full -g the 52 test binaries each carry stan-math's
+          # duplicated .debug_info and the build tree overran a disk that
+          # started with 86 GB free ("No space left on device" at the
+          # link, twice). -j2, not -j3: the largest single compile peaks
+          # at 10.3 GB, so two of them need the swap on a 16 GB VM and
+          # three of them killed the runner. None of this is shipped.
           # STANLI_SANITIZE adds the flags globally, so the vendored
           # SUNDIALS C is instrumented on the same terms as the kernels.
-          #
-          # -j2, not -j3: the first -j3 attempt is what proved the memory
-          # ceiling is real. Two instrumented density shards at once is
-          # the most this VM holds without leaning on the swap.
           cmake -B build-asan -DCMAKE_BUILD_TYPE=None \
-            -DCMAKE_C_FLAGS="-O1 -g" -DCMAKE_CXX_FLAGS="-O1 -g" \
+            -DCMAKE_C_FLAGS="-O1 -g1" -DCMAKE_CXX_FLAGS="-O1 -g1" \
             -DSTANLI_SANITIZE=address \
             -DCMAKE_C_COMPILER_LAUNCHER=ccache \
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
@@ -669,6 +672,7 @@ jobs:
                "$([ "${miss:-0}" -lt 20 ] && echo '(cached build:' \
                'this peak is not a memory ceiling)')"
           free -h && swapon --show && df -h / /mnt
+          du -sh build-asan
           ccache -s
       # Save even when the build or tests fail: the cache is compile
       # artifacts, not results, and the original save-on-success rule

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -591,10 +591,17 @@ jobs:
   asan:
     name: ctest under AddressSanitizer
     runs-on: ubuntu-24.04
+    # The first shipped configuration could not finish: gcc at
+    # RelWithDebInfo (-O2 -g) with ASan took 8+ minutes per densities
+    # shard -- 18% built after half an hour, runner reclaimed before the
+    # end, and since the cache saved only on success, every subsequent
+    # run started cold again. The ceiling exists so a stuck build fails
+    # in bounded time instead of holding the concurrency queue.
+    timeout-minutes: 90
     steps:
       - uses: actions/checkout@v4
       - name: Restore the compiler cache
-        uses: actions/cache@v4
+        uses: actions/cache/restore@v4
         with:
           # Its own key: these objects carry -fsanitize=address and must
           # never be handed to, or taken from, the wheel build's cache.
@@ -607,19 +614,30 @@ jobs:
         run: |
           which ccache || sudo apt-get install -y ccache
           export CCACHE_DIR="$PWD/.ccache" CCACHE_COMPRESS=1 CCACHE_MAXSIZE=600M
-          # RelWithDebInfo, not Release: -g is what turns a report into an
-          # actionable stack, and none of this is shipped. STANLI_SANITIZE
-          # adds the flags globally, so the vendored SUNDIALS C is
-          # instrumented on the same terms as the kernels.
-          cmake -B build-asan -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+          # -O1 -g, the standard sanitizer configuration: ASan's checks do
+          # not depend on the optimizer, -g is what turns a report into an
+          # actionable stack, and gcc compiles the density shards several
+          # times faster than at -O2 while using less memory per TU --
+          # which is also what makes -j3 safe where the wheel build needs
+          # -j2. None of this is shipped. STANLI_SANITIZE adds the flags
+          # globally, so the vendored SUNDIALS C is instrumented on the
+          # same terms as the kernels.
+          cmake -B build-asan -DCMAKE_BUILD_TYPE=None \
+            -DCMAKE_C_FLAGS="-O1 -g" -DCMAKE_CXX_FLAGS="-O1 -g" \
             -DSTANLI_SANITIZE=address \
             -DCMAKE_C_COMPILER_LAUNCHER=ccache \
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
-          # -j2 for the reason the wheel build gives: one densities shard
-          # peaks near 4 GB uninstrumented, and the shadow bookkeeping
-          # does not make that number smaller.
-          cmake --build build-asan -j2
+          cmake --build build-asan -j3
           ccache -s
+      # Save even when the build or tests fail: the cache is compile
+      # artifacts, not results, and the original save-on-success rule
+      # meant one reclaimed runner kept every later run cold forever.
+      - name: Save the compiler cache
+        if: always()
+        uses: actions/cache/save@v4
+        with:
+          path: .ccache
+          key: ccache-asan-${{ github.sha }}
       - name: ctest
         run: ctest --test-dir build-asan --output-on-failure
         env:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -663,8 +663,15 @@ jobs:
           # by guessed ceilings twice; from here the number is read off
           # the log. The same cache-hit caveat applies -- a warm build
           # compiles nothing and its peak is not a memory ceiling.
+          # On failure, dump the capacity picture BEFORE exiting: five
+          # attempts in, every theory so far died for want of exactly the
+          # number a failed run did not print.
           /usr/bin/time -v cmake --build build-asan -j2 2>/tmp/build.err ||
-            { cat /tmp/build.err; exit 1; }
+            { cat /tmp/build.err
+              df -h /; du -sh build-asan 2>/dev/null
+              du -sh build-asan/* 2>/dev/null | sort -rh | head -15
+              du -sh /mnt/swapfile-asan /home/runner/work 2>/dev/null
+              exit 1; }
           kb=$(awk '/[Mm]aximum resident/ {print $NF}' /tmp/build.err)
           miss=$(ccache -s | awk '/^ *Misses:/ {print $2; exit}')
           echo "ASan peak RSS $(( kb / 1024 )) MB on the largest single" \

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -610,6 +610,20 @@ jobs:
           restore-keys: ccache-asan-
       - name: Fetch pinned dependencies
         run: ./deps/fetch.sh
+      # Both fatal runs of this job died at the same place -- the density
+      # shards -- with "the runner has received a shutdown signal" while
+      # the sibling manylinux job on its own runner sailed on. That is the
+      # face an OOM-killed runner service wears: gcc's ASan instrumentation
+      # multiplies compiler memory on exactly those TUs, and the 16 GB VM
+      # has no swap at all. Swap converts the spike into slowness instead
+      # of a dead runner; it is touched only if the spike happens.
+      - name: Swap, so a compiler memory spike degrades instead of killing
+        run: |
+          sudo fallocate -l 8G /swapfile
+          sudo chmod 600 /swapfile
+          sudo mkswap /swapfile
+          sudo swapon /swapfile
+          free -h
       - name: Build with -fsanitize=address
         run: |
           which ccache || sudo apt-get install -y ccache
@@ -617,17 +631,19 @@ jobs:
           # -O1 -g, the standard sanitizer configuration: ASan's checks do
           # not depend on the optimizer, -g is what turns a report into an
           # actionable stack, and gcc compiles the density shards several
-          # times faster than at -O2 while using less memory per TU --
-          # which is also what makes -j3 safe where the wheel build needs
-          # -j2. None of this is shipped. STANLI_SANITIZE adds the flags
-          # globally, so the vendored SUNDIALS C is instrumented on the
-          # same terms as the kernels.
+          # times faster than at -O2. None of this is shipped.
+          # STANLI_SANITIZE adds the flags globally, so the vendored
+          # SUNDIALS C is instrumented on the same terms as the kernels.
+          #
+          # -j2, not -j3: the first -j3 attempt is what proved the memory
+          # ceiling is real. Two instrumented density shards at once is
+          # the most this VM holds without leaning on the swap.
           cmake -B build-asan -DCMAKE_BUILD_TYPE=None \
             -DCMAKE_C_FLAGS="-O1 -g" -DCMAKE_CXX_FLAGS="-O1 -g" \
             -DSTANLI_SANITIZE=address \
             -DCMAKE_C_COMPILER_LAUNCHER=ccache \
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
-          cmake --build build-asan -j3
+          cmake --build build-asan -j2
           ccache -s
       # Save even when the build or tests fail: the cache is compile
       # artifacts, not results, and the original save-on-success rule

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -621,13 +621,19 @@ jobs:
         run: |
           # Not /swapfile: the runner image already runs ~4 GB of swap
           # there (fallocate on it says "Text file busy"), and the job
-          # OOM'd straight through that allowance. This adds 8 GB more
-          # beside it. The before/after prints are the capacity record.
-          swapon --show && free -h
-          sudo fallocate -l 8G /swapfile-asan
-          sudo chmod 600 /swapfile-asan
-          sudo mkswap /swapfile-asan
-          sudo swapon /swapfile-asan
+          # OOM'd straight through that allowance. And not on the root
+          # disk: 8 GB of swap there is exactly the 8 GB the link step
+          # later ran out of -- the debug-heavy ASan test binaries filled
+          # the rest ("No space left on device" at 88%). /mnt is the
+          # runner's ephemeral disk with room to spare. The before/after
+          # prints are the capacity record; measured on this job, the
+          # largest single compile peaks at 10.3 GB, so -j2 needs the
+          # swap and the swap needs to be off the build's disk.
+          swapon --show && free -h && df -h / /mnt
+          sudo fallocate -l 8G /mnt/swapfile-asan
+          sudo chmod 600 /mnt/swapfile-asan
+          sudo mkswap /mnt/swapfile-asan
+          sudo swapon /mnt/swapfile-asan
           swapon --show && free -h
       - name: Build with -fsanitize=address
         run: |
@@ -662,7 +668,7 @@ jobs:
                "compile, over ${miss:-?} ccache misses" \
                "$([ "${miss:-0}" -lt 20 ] && echo '(cached build:' \
                'this peak is not a memory ceiling)')"
-          free -h && swapon --show
+          free -h && swapon --show && df -h / /mnt
           ccache -s
       # Save even when the build or tests fail: the cache is compile
       # artifacts, not results, and the original save-on-success rule

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -347,7 +347,36 @@ endfunction()
 stanli_embed_stanc(stanli_shared)
 endif()  # NOT EMSCRIPTEN
 
-add_library(stanli STATIC ${STANLI_RUNTIME_SOURCES})
+# Static everywhere except under a sanitizer, where the library is
+# shared. The reason is disk, not elegance: 52 statically linked test
+# binaries each carry their own instrumented copy of the runtime and its
+# debug info, and under ASan that tree overran a disk which started with
+# 86 GB free -- the link step died of "No space left on device" three
+# runs straight. One shared object holds the single copy; the binaries
+# shrink to their own test code; CMake's build-tree RPATH makes ctest
+# find it with no further ceremony. Unlike stanli_shared this library
+# keeps every symbol visible, which is what the tests link against.
+if(STANLI_SANITIZE)
+  set(_stanli_kind SHARED)
+else()
+  set(_stanli_kind STATIC)
+endif()
+add_library(stanli ${_stanli_kind} ${STANLI_RUNTIME_SOURCES})
+if(STANLI_SANITIZE)
+  # Not libstanli: stanli_shared already owns that name -- it is the
+  # file the wheel ships -- and two targets writing one .dylib means the
+  # last one clobbers the first, which surfaced as test_capi failing to
+  # find the C ABI it links.
+  set_target_properties(stanli PROPERTIES OUTPUT_NAME stanli_core)
+  # The archive let every binary satisfy the TBB symbols with its own
+  # tests/tbb_stub.cpp; a shared library must either resolve them at
+  # link time or defer them to the executable. Defer, so the stub
+  # arrangement is unchanged: macOS needs it said out loud, Linux
+  # already allows undefined symbols in a shared object.
+  if(APPLE)
+    target_link_options(stanli PRIVATE -Wl,-undefined,dynamic_lookup)
+  endif()
+endif()
 target_include_directories(stanli PUBLIC runtime/include)
 target_compile_definitions(stanli PRIVATE STANLI_BUILD_ID="${STANLI_BUILD_ID}")
 # The BridgeStan facade is native-only: it finds its own sidecar manifest


### PR DESCRIPTION
The ASan job from #143 has never completed anywhere. The log from its first main run shows why: gcc at RelWithDebInfo with ASan took **8+ minutes per densities shard** -- 18% built after half an hour -- and the runner was reclaimed before the end. Compounding it, `actions/cache` saves only on job success, so that half hour of compilation was thrown away and every subsequent run, on every PR, started cold again. The job blocked the merge queue while structurally unable to go green.

Three changes:

- **`-O1 -g` instead of RelWithDebInfo.** The standard sanitizer configuration: ASan's checks do not depend on the optimizer, the stack traces are what `-g` buys, gcc compiles the shards several times faster than at `-O2`, and the lower per-TU memory is what makes `-j3` safe where the wheel build needs `-j2`.
- **Cache split into restore + an `always()` save.** Compile artifacts are worth keeping from a failed run -- that is the run whose work most needs preserving. The original rule guaranteed permanent coldness after any first failure.
- **`timeout-minutes: 90`**, so a stuck build fails in bounded time instead of holding the concurrency queue.

Verified locally under ASan at `-O1` (clang, arm64): **52/52 tests pass**, 21.9s ctest wall -- the optimizer level changes compile cost, not sanitizer semantics.

Also for the record, since this job's state caused it: the merge automation that landed #146-#148 parsed check statuses from `gh pr checks`' text columns, and job names with spaces (this job's included) shifted the status field, making "pending" invisible -- so those PRs merged with this job still running. Each had passed the full local suite (ctest, corpus at all three points, format) before push, and their `manylinux` CI was green; the automation now reads JSON states. The one CI "failure" among them was this job's runner being reclaimed mid-build, not a code failure.