### PR TITLE
fix: pow's adjoint at a zero base no longer poisons gradients

### DIFF
--- a/runtime/kernels/eltwise_expr.cpp
+++ b/runtime/kernels/eltwise_expr.cpp
@@ -223,11 +223,22 @@ void pow_fwd(KernelCtx& ctx) {
     ctx.out.data[i] =
         std::pow(ctx.in[0].data[s0 ? 0 : i], ctx.in[1].data[s1 ? 0 : i]);
 }
+// A zero base contributes nothing to either partial. Every one of
+// stan-math's four rev pow overloads says so -- the scalar and the
+// (scalar base, matrix exponent) ones return early on
+// `value_of(base) == 0.0`, the two matrix ones `select` on
+// `value_of(base) != 0.0` -- and both partials would otherwise be
+// nonfinite there: b*v/a is 0/0 when a is 0, and log(a) is -inf meeting
+// v = 0. The skip is elementwise because the base is, and it is a skip
+// rather than a multiply by a zero mask for the reason sqrtv_bwd's is:
+// multiplying an inf by zero is the NaN being avoided. A NaN base still
+// propagates, since `NaN == 0.0` is false.
 void pow_bwd(KernelCtx& ctx) {
   const bool s0 = scal(ctx, 0), s1 = scal(ctx, 1);
   if (ctx.out.len == 1) {
     const double a = ctx.in[0].data[0], b = ctx.in[1].data[0];
     const double v = ctx.out.data[0];
+    if (a == 0.0) return;
     if (ctx.in_adj[0].data) ctx.in_adj[0].data[0] += ctx.out_adj * b * v / a;
     if (ctx.in_adj[1].data)
       ctx.in_adj[1].data[0] += ctx.out_adj * std::log(a) * v;
@@ -238,6 +249,7 @@ void pow_bwd(KernelCtx& ctx) {
     const double b = ctx.in[1].data[s1 ? 0 : i];
     const double v = ctx.out.data[i];
     const double dout = ctx.out_adj_vec.data[i];
+    if (a == 0.0) continue;
     if (ctx.in_adj[0].data) ctx.in_adj[0].data[s0 ? 0 : i] += dout * b * v / a;
     if (ctx.in_adj[1].data)
       ctx.in_adj[1].data[s1 ? 0 : i] += dout * std::log(a) * v;

--- a/tests/test_eltwise.cpp
+++ b/tests/test_eltwise.cpp
@@ -113,6 +113,30 @@ int main() {
   });
   check_case("pow ss", OP_POW, 1, {{S}, {T}},
              [](auto& v) { return stan::math::pow(v[0](0), v[1](0)); });
+  // pow at a base of exactly zero, one shape per guard site. Both partials
+  // are nonfinite there -- b*v/a is 0/0, and log(a) is -inf meeting v = 0 --
+  // and stan-math answers with a zero contribution instead, in all four of
+  // its rev overloads. The bases carrying the zero sit next to nonzero
+  // neighbours so the vector shapes cannot pass with a whole-op skip, and
+  // the exponents opposite a zero base stay positive so the FORWARD stays
+  // finite: this is a gradient bug, and 0^-1.7 = inf would hide it behind a
+  // nonfinite lp. stanc3's pow.stan, validate_exponentiation_good.stan and
+  // mem_patterns/ad_scalar_data_matrix.stan all reach this at the
+  // all-zeros evaluation point, where CmdStan returns 0 and stanli did not.
+  const std::vector<double> Z{0.0, 1.2, 2.0, 0.3};
+  const std::vector<double> E{1.5, 0.7, 2.4, 2.2};
+  const double U = 2.3;
+  check_case("pow vv at zero", OP_POW, N, {Z, E}, [](auto& v) {
+    return stan::math::sum(stan::math::pow(v[0], v[1]));
+  });
+  check_case("pow vs at zero", OP_POW, N, {Z, {U}}, [](auto& v) {
+    return stan::math::sum(stan::math::pow(v[0], v[1](0)));
+  });
+  check_case("pow sv at zero", OP_POW, N, {{0.0}, E}, [](auto& v) {
+    return stan::math::sum(stan::math::pow(v[0](0), v[1]));
+  });
+  check_case("pow ss at zero", OP_POW, 1, {{0.0}, {U}},
+             [](auto& v) { return stan::math::pow(v[0](0), v[1](0)); });
 
   // Unaries, vector + scalar shapes.
   check_case("neg v", OP_NEG, N, {A},


### PR DESCRIPTION
The sibling of #144, with the RED that fix's author lacked. `pow_bwd` computed both partials unconditionally, so at `base == 0` (where the output is 0 too) the base side is `dout * b * 0 / 0` = NaN and the exponent side is `dout * -inf * 0` = NaN. A dead output does not save it: `dout = 0` gives `0/0` just the same. All four of stan-math's rev pow overloads guard this; the kernel was the only stanli engine that did not -- the island machine already guards (`adjoint.cpp:397`) and the interpreter calls `stan::math::pow` on vars and inherits the guard by construction. There is no third pow adjoint: `std::pow` appears exactly once in the runtime.

The fix matches #144's shape: a skip, not a zero-mask multiply, since multiplying the inf is the NaN being avoided; NaN bases still propagate because `NaN == 0.0` is false.

## RED, from the census

No corpus model reaches a zero base, which is why #144 could only report this. The model census (#146) provided three of stanc3's own integration models that do, all at the all-zeros point:

| model | before | after |
| --- | --- | --- |
| `function-signatures/math/functions/pow.stan` | mismatch, max_rel=inf | **verified** |
| `validate_exponentiation_good.stan` (the `^` spelling) | mismatch, max_rel=inf | **verified** |
| `mem_patterns/ad_scalar_data_matrix.stan` | mismatch, max_rel=inf | **verified** |

Post-fix values are bitwise CmdStan's, including `30.321635080829839` on the mem_patterns gradient. The remaining NaNs in those models are shared with CmdStan (`pow(negative, fractional)` forward NaN) and score as agreement. Unit tests cover all four kernel shapes with a zero base among nonzero neighbours -- the pinning case fails under a whole-op skip -- and showed 11 `got nan` failures with the fix stashed.

## The neighbour audit, with a corrected claim

The rule applied is **parity, not finiteness**: a guard stan-math lacks would also be a bug. Sweeping every `rev/fun/*.hpp` for value-boundary guards yields exactly four headers, and stanli now matches all four (`pow`, `sqrt` via #144, `binary_log_loss` via the nested-tape replay, `fabs` via its edgeless zero node).

Checked and deliberately unguarded on both sides, expression for expression, so both engines go nonfinite identically: `log`, `log1m`, `logit`, `log1p`, `log2`, `log10`, `log1m_exp`, `inv`, `inv_square`, `cbrt`, `atanh`, `asin`, `acos`, `acosh`, `tanh`, division's `dout/b`, plus the no-boundary set.

**Correction to #144's record:** its argument that `OP_INV_SQRT` is safe because the forward is already inf at zero is incomplete -- a dead output yields a gradient NaN while lp stays finite. It is safe anyway, by parity: `rev/fun/inv_sqrt.hpp` divides by `a.val() * sqrt(a.val())` unguarded, character for character what the optable entry does, so CmdStan produces the identical NaN.

## Found, not fixed

`logitv_bwd` computes `d / (x * (1 - x))` where stan-math computes `1 / (x - square(x))` then multiplies. Identical boundary behaviour, but not the same rounding -- a 1-ulp-class parity risk in the family the `inv_logit` fix (#145's sibling) came from. Reported for a separate look.

## Gates

`ctest` 52/52 · `verify_refs` 129/129 at all 3 points, 800,674 values, worst unchanged at 1.79e-11 · `format.sh --check` clean. Independently re-verified during review.