### PR TITLE
conformance: gate the cancelling-sum reduction-order difference

### DIFF
--- a/harnesses/conformance/constructs.toml
+++ b/harnesses/conformance/constructs.toml
@@ -295,6 +295,7 @@ data = "tests/stanc3/reductions_allowed.json"
 oracle_gate = "write_array"
 expected_accept = true
 point_profile = "zeros-and-asymmetric"
+numeric_policy = "cancelling-reduction-order"
 
 [[case]]
 id = "stanc3.cholesky-covariance-parameters"

--- a/harnesses/conformance/policy.toml
+++ b/harnesses/conformance/policy.toml
@@ -1,5 +1,5 @@
 schema_version = 1
-policy_version = "2026-08-15.1"
+policy_version = "2026-08-23.1"
 
 # Stan parameters are real-valued today.  Complex signatures need a separate
 # source convention and a real projection before log-density parity has a
@@ -89,3 +89,19 @@ id = "bound-transform-probe-cancellation"
 reason = "Probe outputs straddle zero, so the weighted sum cancels and a last-bit difference reads as a large relative one."
 name_regex = "^(lower_bound|upper_bound|lower_upper_bound|offset_multiplier)_(constrain|unconstrain|jacobian)$"
 abs_tol = 1e-13
+
+# stanli reduces sums sequentially on the double path, deliberately: lp is
+# computed there, and CmdStan's lp comes from AoS sum_v_vari, which is also
+# sequential -- that pairing is what keeps lp bitwise (packet.hpp). CmdStan's
+# write_array, though, evaluates on plain doubles where Eigen's redux
+# vectorizes, so a write_array column whose sum cancels toward zero can
+# differ in its last bits while lp and every gradient agree. Measured on
+# reduction-autodiff-levels: 3.47e-18 absolute on an exactly-zero quantity.
+# Fixing it would mean one kernel reducing in two different orders by
+# context, which is a worse property than a named gate. Absolute, because
+# ULP and relative both describe the cancellation, not the disagreement.
+[[numeric_gate]]
+id = "cancelling-reduction-order"
+reason = "write_array sums that cancel to ~0; stanli reduces sequentially for lp parity, CmdStan's double path uses Eigen's redux."
+name_regex = "^sum$"
+abs_tol = 1e-15


### PR DESCRIPTION
The nightly went red by exactly one row -- the debt #132 left deliberately. Fixing the register-program segfault let `reduction-autodiff-levels` report the real difference underneath: a write_array column whose sum cancels to approximately zero differs by **3.47e-18 absolute**, with lp and every gradient in agreement. stanli reduces sequentially on the double path; CmdStan's write_array evaluates on plain doubles where Eigen's redux vectorizes.

## Why gate rather than fix

The fix-the-order option is foreclosed by parity: the same kernel's double path computes `lp`, and lp is bitwise against CmdStan precisely because both sides reduce sequentially there -- CmdStan's lp comes from AoS `sum_v_vari`, also sequential (`packet.hpp` documents the pairing). Only write_array's usage wants the vectorized order, and one kernel reducing in two different orders by context is a worse property than a reviewed gate with its mechanism named.

The gate is **absolute** (1e-15, three orders of headroom over the measured 3.47e-18), because ULP and relative error both describe the cancellation rather than the disagreement -- the same reasoning as the existing `bound-transform-probe-cancellation` and `inv-phi-probe-depth` rules. Scoped to `^sum$` on the signature side and attached to the construct via `numeric_policy`. `policy_version` bumped.

## Verified

The case reports `verified` under the gate against live BridgeStan; 74 harness tests pass; `format.sh --check` clean. The conformance ratchet records this row's `mismatch -> verified` as an improvement, so no baseline change rides along -- the next green nightly is the right place to advance it.