### PR TITLE
perf: eliminate redundant preparation and adjoint work

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -443,6 +443,22 @@ add_executable(stanli_check tools/stanli_check.cpp tests/tbb_stub.cpp)
 target_link_libraries(stanli_check PRIVATE stanli)
 add_executable(bench_grad tools/bench_grad.cpp tests/tbb_stub.cpp)
 target_link_libraries(bench_grad PRIVATE stanli)
+add_test(NAME test_prep_only
+         COMMAND bench_grad tests/fixtures/ar1.tmir.sexp
+                 tests/fixtures/ar1.json --prep
+         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+set_tests_properties(test_prep_only PROPERTIES
+  ENVIRONMENT "STANLI_PROFILE_PREP=0"
+  PASS_REGULAR_EXPRESSION "[0-9]+\\.[0-9]+ 24"
+  FAIL_REGULAR_EXPRESSION "stanli_prep")
+add_test(NAME test_prep_profile
+         COMMAND bench_grad tests/fixtures/ar1.tmir.sexp
+                 tests/fixtures/ar1.json --prep
+         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+set_tests_properties(test_prep_profile PROPERTIES
+  ENVIRONMENT "STANLI_PROFILE_PREP=1"
+  PASS_REGULAR_EXPRESSION
+    "stanli_prep graph=driver stage=total ns=[0-9]+")
 add_executable(bench_opcost tools/bench_opcost.cpp tests/tbb_stub.cpp)
 target_link_libraries(bench_opcost PRIVATE stanli)
 add_executable(bench_dispatch tools/bench_dispatch.cpp)

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -12,6 +12,19 @@ recover_memory cycle `stan::model::gradient` performs per leapfrog
 step. Reproduce the whole table with
 `tools/bench_models.py deps/cmdstan deps/posteriordb`.
 
+The preparation cells in this 2026-08-06 snapshot predate the dedicated
+`bench_grad --prep` mode and include the old driver's warmup/evaluation work.
+The harness now records file read, parse, compile, construction, and binding
+only; that column should be refreshed as a unit rather than mixing definitions.
+Targeted preparation measurements later on this page use the new mode.
+
+One targeted 2026-08-23 remeasurement is newer than the full snapshot below.
+Packed row-wise `log_sum_exp` reduces `ldaK2` from 15,854 ops to 22 and
+154 to 94 us/gradient (1.11x CmdStan), and `ldaK5` from 434,126 ops to 156
+and 6.82 to 3.70 ms/gradient (1.51x CmdStan). `ldaK5` file-to-bound-model
+preparation also falls from about 0.59 s to 0.27 s. The committed full-corpus
+tables retain one measurement definition and will be refreshed as a unit.
+
 ## Per-gradient latency
 
 A representative slice; the complete 120-model table is at the bottom of
@@ -66,9 +79,15 @@ by the model's *shape*, not its size.
   vector element by element) arrives unrolled and is re-rolled back
   into the class above: the radon family up to 6.1x, `election88_full`
   3.0x, `dogs` 2.8x.
-- **Everything, on preparation.** Lowering takes 4-400 ms against a
-  ~7 s CmdStan compile, so short runs and iterative model development
-  are dominated by this regardless of gradient speed.
+- **Nested fixed-width mixtures.** LDA's per-document `gamma[K]` construction
+  and row `log_sum_exp` become two packed gathers, vector arithmetic, and one
+  row-reduction op. This takes `ldaK2` from 0.71x to 1.11x and `ldaK5` from
+  1.10x to 1.51x against the existing CmdStan measurements.
+- **Everything, on preparation.** Graph compilation takes 4-400 ms against a
+  ~7 s CmdStan compile, so short runs and iterative model development are
+  dominated by this regardless of gradient speed. The largest JSON input in
+  the corpus takes another ~2.6 s to read and parse; the benchmark reports
+  that complete file-to-bound-model path separately from graph compilation.
 
 **Near parity (0.9-1.3x), two shapes:**
 
@@ -90,10 +109,6 @@ by the model's *shape*, not its size.
 
 **Slower (a shrinking tail, mostly 0.5-0.9x):**
 
-- **Mixture models with K > 2 components** (`ldaK2`/`ldaK5`): their
-  inner `log_sum_exp` runs over K-vectors built per document, a
-  row-wise reduction the elementwise-lp fusion does not yet express.
-  The binary-mixture case is closed.
 - **ODE models**, at about 0.6x: our per-call dispatch of the compiled
   right-hand side against CmdStan's fully inlined one inside the same
   CVODES solver. (They were 0.015x before the right-hand side compiled;
@@ -276,12 +291,18 @@ removes a second, independently stepped solve. Anything the compiler
 cannot express keeps the interpreter, so coverage never shrinks;
 `STANLI_DEBUG_ODE=1` reports when that happens.
 
-Preparation scales too: the largest corpus model (`nn_rbm1bJ100`,
-MNIST, 60,000 rows, 79,411 parameters) lowers to a 192,030-op graph in
-20.7 s and evaluates its gradient in 0.43 s. Lowering used to be
-quadratic in data size (the transformed-data interpreter copied an
-indexed expression's whole base per read). Overall, stanli lowers a
-model in 4-200 ms against a 6.2-7.6 s CmdStan compile (warm precompiled
+Preparation scales too: the largest corpus model (`nn_rbm1bJ100`, MNIST,
+60,000 rows, 79,411 parameters) lowers to a 132,024-op graph. Its old 23.80 s
+compile was almost entirely stanc's generated loop reconstructing the
+47-million-element input matrix after `DataMap` had already parsed it. Direct
+typed input preload removes that loop; an indexed reroll candidate scan removes
+another empty 0.13 s pass over the resulting graph. Together they reduce graph
+compilation to 0.23 s (103x), and the full file-to-bound-executor path from
+26.33 s to 2.76 s (9.5x); JSON parsing is now the largest preparation stage.
+The same profiled A/B removes 1.34 GB of peak RSS. The log density and all
+79,411 gradient components remain within the existing CmdStan oracle
+tolerance. Overall, graph
+compilation is 4-400 ms against a 6.2-7.6 s CmdStan compile (warm precompiled
 header, after a multi-minute one-time `make build`); that gap is what
 time-to-first-draw is made of.
 

--- a/docs/hacking.md
+++ b/docs/hacking.md
@@ -159,6 +159,12 @@ The tools you will reach for most:
   gradient evaluation, printed.
 - [`stanli_run`](../tools/stanli_run.cpp): a full sampling run,
   CmdStan-style CSV out.
+- [`bench_grad`](../tools/bench_grad.cpp): gradient/forward timing. Pass
+  `--prep` instead of an evaluation count to measure file-to-bound-executor
+  preparation without warmup; `STANLI_PROFILE_PREP=1` splits that path into
+  JSON/MIR parsing, every lowering pass, Executor construction, and binding.
+  For compile timing, use `graph=compile stage=total`: the enclosing driver
+  call also includes emitting the buffered profile rows.
 - [`dump_ops`](../tools/dump_ops.cpp): print the op list a model
   lowered to. Usually the first thing to look at.
 - [`dump_islands`](../tools/dump_islands.cpp): print every island's
@@ -486,7 +492,8 @@ For sampler changes, use
 generated-quantities coverage, run the verifier with `--wa-report`.
 For a live CmdStan column-name comparison, use `--wa-headers deps/cmdstan`.
 Both modes default to `build-rel/stanli_check`. For any
-performance claim, measure with `STANLI_PROFILE=1` before and after;
+performance claim, measure with `STANLI_PROFILE=1` before and after for
+evaluation work, or `STANLI_PROFILE_PREP=1` for compilation and binding;
 [`docs/benchmarks.md`](benchmarks.md) has the harnesses.
 
 ## Landing a change

--- a/docs/lowering-walkthrough.md
+++ b/docs/lowering-walkthrough.md
@@ -114,10 +114,11 @@ Eight ops for the whole model. Read the columns first: each op writes
 one output slot (`out=s10(len1)`: slot 10, one element) and reads
 input slots; `P` marks a slot that is part of the unconstrained
 parameter vector; `l5` is a length. Slots are not variables -- they
-are offsets into one flat array, the *arena*, assigned at load time
-and never reassigned. There is a value arena and a parallel adjoint
-arena of the same shape; slot k's derivative lives at the same offset
-in the second array.
+are offsets into one flat value array, the *arena*, assigned at load
+time and never reassigned. Reverse mode has a second, compact arena:
+parameters first, then only slots surviving ops write (plus an otherwise
+constant result). Data and slots left behind by graph rewrites need no
+adjoint cell and are not cleared on every gradient.
 
 Now read the ops as the model:
 

--- a/harnesses/corpus_bench.py
+++ b/harnesses/corpus_bench.py
@@ -2,7 +2,8 @@
 """Corpus-wide head-to-head: stanli vs CmdStan on every posteriordb model.
 
 Per model, both engines get one column each for
-  - model preparation (stanli: lower+bind; CmdStan: stanc + full make)
+  - model preparation (stanli: file read + parse + compile + bind;
+    CmdStan: stanc + full make)
   - per-gradient latency
   - end to end 1000 warmup + 1000 draws
 Results stream to a TSV as they complete, so a partial run is still
@@ -121,9 +122,19 @@ def main():
             else:
                 n_params = int(probe.stdout.split()[-1])
                 row["params"] = n_params
-                t0 = time.perf_counter()
-                run([str(BENCH), str(sexp), str(dj), "1"], timeout)
-                row["stanli_prep_s"] = f"{time.perf_counter() - t0:.3f}"
+                # Compile and bind only. The old `1` invocation also ran a
+                # time-capped warmup plus one measured gradient, which made
+                # this column depend on model runtime and mislabeled ~200 ms
+                # as preparation even on small models.
+                prep = run([str(BENCH), str(sexp), str(dj), "--prep"], timeout)
+                prep_lines = ([line for line in prep.stdout.splitlines()
+                               if line.strip()]
+                              if prep and prep.returncode == 0 else [])
+                if prep_lines:
+                    row["stanli_prep_s"] = (
+                        f"{float(prep_lines[-1].split()[0]):.3f}")
+                else:
+                    notes.append("stanli_prep_fail")
                 g = run([str(BENCH), str(sexp), str(dj),
                          str(evals_for(n_params))], timeout)
                 if g:

--- a/runtime/include/stanli/graph.hpp
+++ b/runtime/include/stanli/graph.hpp
@@ -22,7 +22,7 @@ struct Desc {
 // A value in the graph. Slots with is_param are the unconstrained parameter
 // vector, in declaration order; everything else is data or an intermediate.
 struct Slot {
-  int64_t offset = 0;  // into the value / adjoint arenas (filled at bind)
+  int64_t offset = 0;  // into the value arena (filled at bind)
   int64_t len = 0;
   bool is_param = false;
 };
@@ -145,6 +145,12 @@ class Executor {
   Executor& operator=(const Executor&) = delete;
 
   int64_t n_params() const { return n_params_; }
+  // Number of doubles in the reverse-mode arena. This is intentionally
+  // observable: inactive data and slots left behind by graph rewrites must
+  // not silently return to the per-gradient clear path.
+  int64_t adjoint_storage_size() const {
+    return static_cast<int64_t>(adjoints_.size());
+  }
   // The bound graph, so a second executor over the same model can be
   // built without re-lowering. Multi-chain sampling needs one executor
   // per chain -- the arenas are mutable per-evaluation state -- and
@@ -190,7 +196,8 @@ class Executor {
 
  private:
   void bind_();
-  KernelCtx make_ctx_(const Op& op, const std::vector<char>& written);
+  KernelCtx make_ctx_(const Op& op, const std::vector<char>& written,
+                      const std::vector<int64_t>& adjoint_offsets);
 
   struct ProfEntry {
     int64_t calls = 0;  // forward invocations
@@ -202,6 +209,7 @@ class Executor {
   Graph graph_;
   std::vector<double> values_;
   std::vector<double> adjoints_;
+  int64_t result_adjoint_offset_ = -1;
   std::vector<double> scratch_;
   // One context per op, assembled once at bind. Every field in it is a
   // pointer into an arena that never moves after binding, or an immediate

--- a/runtime/include/stanli/mir_interp.hpp
+++ b/runtime/include/stanli/mir_interp.hpp
@@ -91,6 +91,14 @@ class MirInterp {
 
   std::map<std::string, Value>& env() { return env_; }
 
+  // A host may bind a typed value directly and skip stanc's generated input
+  // declaration/rebuild statements. Keep the declaration-owned geometry
+  // that FnCheck needs separately: an empty JSON array cannot encode trailing
+  // extents such as array[0] vector[3].
+  void set_declared_dims(const std::string& name, std::vector<int64_t> dims) {
+    decl_dims_[name] = std::move(dims);
+  }
+
   Value* find(const std::string& n) {
     auto it = env_.find(n);
     return it == env_.end() ? nullptr : &it->second;

--- a/runtime/include/stanli/optable.hpp
+++ b/runtime/include/stanli/optable.hpp
@@ -76,6 +76,7 @@ namespace stanli {
   X(OP_EIGENVALUES_SYM)             \
   X(OP_EIGENVECTORS_SYM)            \
   X(OP_LOG_SUM_EXP)                 \
+  X(OP_LOG_SUM_EXP_ROWS)            \
   X(OP_LSE2)                        \
   X(OP_LOG_DIFF_EXP)                \
   X(OP_LOG_MIX)                     \
@@ -745,6 +746,7 @@ constexpr uint8_t op_traits(uint16_t opcode) {
     case OP_SET_INDEX:
     case OP_SET_INDEX_INPLACE:
     case OP_LOG_SUM_EXP:
+    case OP_LOG_SUM_EXP_ROWS:
       return op_trait::kBackwardValueFree;
     default:
       return 0;

--- a/runtime/include/stanli/reroll.hpp
+++ b/runtime/include/stanli/reroll.hpp
@@ -15,6 +15,15 @@ namespace stanli {
 
 struct RerollStats {
   int regions = 0;
+  // Deterministic work in the exact packed-row recognizer. It counts one
+  // initial ownership scan plus the scalar ops inspected while matching rows;
+  // a long recognized or refused run must remain linear in its op count.
+  int64_t row_steps = 0;
+  // Deterministic work in the candidate index: one step per original op while
+  // building it, plus one per [i, i + P) window query. A graph with no
+  // candidate op returns after exactly g.ops.size() steps, before building the
+  // use/writer lists; sparse candidates keep every later query O(1).
+  int64_t candidate_steps = 0;
   // Entries of the per-slot use and writer lists the pass read. This is
   // the term that was once quadratic in the op count, and it is what
   // tests/test_reroll.cpp asserts near-linearity on: an exact integer,

--- a/runtime/kernels/mixture.cpp
+++ b/runtime/kernels/mixture.cpp
@@ -20,12 +20,12 @@
 // forward algorithm -- fill `acc` element by element, read it whole --
 // take the in-place path.
 #include <stanli/graph.hpp>
-#include <stanli/legacy.hpp>
 #include <stanli/optable.hpp>
 
 #include <stan/math.hpp>
 
 #include <array>
+#include <cassert>
 
 namespace stanli {
 namespace {
@@ -35,9 +35,20 @@ int64_t lse_scratch(const Op& op, const Slot* slots) {
   return slots[op.in[0]].len;
 }
 
+double lse_fwd_partials(const double* data, int64_t len, double* partials) {
+  stan::math::nested_rev_autodiff nested;
+  stan::math::var_value<Eigen::VectorXd> x(
+      Eigen::Map<const Eigen::VectorXd>(data, len));
+  stan::math::var out = stan::math::log_sum_exp(x);
+  const double value = out.val();
+  stan::math::grad(out.vi_);
+  Eigen::Map<Eigen::VectorXd>(partials, len) = x.adj();
+  return value;
+}
+
 void lse_fwd(KernelCtx& ctx) {
-  ctx.out.data[0] = legacy_fwd_partials_vec(
-      ctx, [](const auto& x) { return stan::math::log_sum_exp(x); });
+  ctx.out.data[0] =
+      lse_fwd_partials(ctx.in[0].data, ctx.in[0].len, ctx.scratch);
 }
 
 void lse_bwd(KernelCtx& ctx) {
@@ -45,6 +56,35 @@ void lse_bwd(KernelCtx& ctx) {
   const int64_t n = ctx.in[0].len;
   for (int64_t i = 0; i < n; ++i)
     ctx.in_adj[0].data[i] += ctx.out_adj * ctx.scratch[i];
+}
+
+// ---- log_sum_exp over packed rows -----------------------------------------
+// One flat row-major input, idata[0] = row width K, and one scalar output per
+// row. Each row takes the exact scalar OP_LOG_SUM_EXP path above. Reduction is
+// deliberately a separate op: this kernel maps rows and does not choose how
+// the caller groups their target terms.
+void lse_rows_fwd(KernelCtx& ctx) {
+  assert(ctx.n_idata == 1);
+  const int64_t K = ctx.idata[0];
+  assert(K > 0 && ctx.in[0].len == ctx.out.len * K);
+  for (int64_t r = 0; r < ctx.out.len; ++r) {
+    const int64_t off = r * K;
+    ctx.out.data[r] =
+        lse_fwd_partials(ctx.in[0].data + off, K, ctx.scratch + off);
+  }
+}
+
+void lse_rows_bwd(KernelCtx& ctx) {
+  if (!ctx.in_adj[0].data) return;
+  assert(ctx.n_idata == 1);
+  const int64_t K = ctx.idata[0];
+  assert(K > 0 && ctx.in[0].len == ctx.out.len * K);
+  for (int64_t r = 0; r < ctx.out.len; ++r) {
+    const int64_t off = r * K;
+    const double scale = ctx.out_adj_vec.data[r];
+    for (int64_t k = 0; k < K; ++k)
+      ctx.in_adj[0].data[off + k] += scale * ctx.scratch[off + k];
+  }
 }
 
 // ---- log_sum_exp(a, b) / log_mix(theta, a, b) -----------------------------
@@ -120,6 +160,8 @@ void log_mix_fwd(KernelCtx& ctx) {
 
 void register_mixture_kernels() {
   register_kernel(OP_LOG_SUM_EXP, Kernel{lse_fwd, lse_bwd, lse_scratch});
+  register_kernel(OP_LOG_SUM_EXP_ROWS,
+                  Kernel{lse_rows_fwd, lse_rows_bwd, lse_scratch});
   register_kernel(OP_LSE2, Kernel{lse2_fwd, mix_bwd<2>, mix_scratch<2>});
   register_kernel(OP_LOG_DIFF_EXP,
                   Kernel{log_diff_exp_fwd, mix_bwd<2>, mix_scratch<2>});

--- a/runtime/src/OPTIMIZATIONS.md
+++ b/runtime/src/OPTIMIZATIONS.md
@@ -5,6 +5,29 @@ people who have not worked on compilers. Each section says what the
 problem is, what the pass does, and how to turn it off when debugging.
 Measurements are in [`docs/benchmarks.md`](../../docs/benchmarks.md).
 
+## Data input preload (`lower.cpp`, disable: `STANLI_NO_DATA_PRELOAD=1`)
+
+stanc's transformed MIR contains a small program that reconstructs each input
+from a flat `FnReadData` buffer. That is useful to generated C++, but redundant
+here: `DataMap` has already parsed the JSON into the same typed, column-major
+layout. Replaying the program is especially expensive for matrices because it
+performs one interpreted assignment per element.
+
+Lowering therefore binds declared inputs directly and recognizes the statement
+and name envelope used by stanc's pinned hydration code: a direct
+scalar/vector load, or the generated flat-buffer container-copy loop. Anything
+with another statement kind, effect, data source, or written name still goes
+through the transformed-data interpreter. User-written transformed-data
+statements always run; `STANLI_NO_DATA_PRELOAD=1` remains the exact interpreter
+oracle for auditing future stanc output changes.
+
+On `nn_rbm1bJ100`, whose MNIST input is a 60,000 x 784 matrix, this reduces the
+`bind_data` stage from 23.56 s to 0.09 s and complete graph compilation from
+23.80 s to 0.23 s. It also avoids carrying an integer mirror merely because
+the JSON happened to spell a real matrix with integer tokens. Set
+`STANLI_NO_DATA_PRELOAD=1` to replay the generated hydration as a correctness
+oracle.
+
 ## Background: why op count matters
 
 stanli turns a Stan model into a list of operations ("ops"). Each op
@@ -140,6 +163,21 @@ usual, and one summing op replaces the N per-lane target entries. A
 density whose inputs are the same buffer in every lane stays one scalar
 op instead.
 
+Fixed-width row reductions get one deliberately narrower pre-pass. The LDA
+shape fills every element of a short `gamma` vector, then contributes
+`log_sum_exp(gamma)` once per document. Because K=2 is below the ordinary
+lane threshold and the scalar reduction separates the outer rows, the exact
+concrete grammar is recognized as a unit: two indexed reads, logs, an add,
+the complete element stores, and a target-only reduction. Consecutive rows
+become two gathers over packed row-major indices, vector logs/add, one
+`OP_LOG_SUM_EXP_ROWS`, and `OP_SUM_VEC`. Every removed temporary and the
+row scratch buffers must have only the proven readers/writers and no external
+root. Rows may continue one shared in-place chain or start from disjoint fresh
+scratch, but every accepted row overwrites indices 0 through K-1 before its
+reduction. Target terms must be one unique contiguous subsequence. Repeated
+gather indices are safe, while partial stores, recurrences, escaped values, or
+mixed bases refuse the rewrite.
+
 Anything the pass cannot prove safe it leaves alone. The common
 reasons: a lane reads a result computed by the previous lane (a
 recurrence involving parameters), a lane's intermediate is used outside
@@ -150,6 +188,15 @@ tries again on the rest, which handles data that comes in blocks.
 Scale: `radon_pooled` drops from 27,670 ops to 8, `radon_county` from
 25,152 to 10, `election88_full` from 289,165 to 65, `dogs` from 12,751
 to 261, `low_dim_gauss_mix` to 16.
+
+Candidate discovery is indexed once before classification. A period window can
+therefore ask in O(1) whether it contains any density, element store, or
+target-producing widenable op; a graph with none returns before allocating the
+reader/writer lists. This matters for large scalar residue the pass cannot
+express: `nn_rbm1bJ100`'s zero-region scan falls from 126 ms to 13 ms, and the
+candidate-free million-op LDA shape from 1.16 s to about 3.4 ms. The exact
+candidate-index, packed-row, and use-list work counters live in `RerollStats`
+and have deterministic scaling tests.
 
 ## Control flow that depends on a parameter (`lower.cpp`, `mir_prog.hpp`)
 
@@ -280,11 +327,21 @@ Together these made the ODE models 29-39x faster.
 - Each op's context (the pointers telling the kernel where its inputs,
   outputs, and scratch are) is built once at setup; nothing moves
   afterwards, so there is nothing to rebuild per evaluation.
-- All values live in one arena, all adjoints in another, both allocated
-  once. A steady-state gradient evaluation performs no allocation.
+- All values live in one arena. Adjoint storage is a separate compact
+  layout: parameters first, then only slots surviving ops write (plus a
+  constant result). Data and slots left behind by graph rewrites therefore
+  consume no adjoint memory and are absent from the one reset `memset`.
+  Both arenas are allocated once; a steady-state gradient evaluation
+  performs no allocation.
 - Kernel function pointers are resolved once at setup into two flat
   lists (forward order and reverse order, with backward-less ops left
   out of the second), and both sweeps are unrolled four at a time.
+
+On `iohmm_reg` this packs 1,604,979 adjoint doubles down to 3,084 and
+moves the median gradient from 282.9 to 233.7 us (1.21x). Values deliberately
+keep their original slot layout: a compiler-final value tombstone prototype
+was correct but shifted hot buffers and consistently slowed `Mtbh_model` by
+about 8%, so it is not part of this optimization.
 
 A tail-call threaded dispatch, the usual next step, measured slower
 than the unrolled loop (`tools/bench_dispatch.cpp` keeps the
@@ -311,7 +368,8 @@ silently. Three layers:
 - Direct verification against CmdStan (`tools/verify_sample.py`) for
   models a change affects.
 
-The env switches (`STANLI_NO_INPLACE`, `STANLI_NO_CONSTFOLD`,
-`STANLI_NO_REROLL`, `STANLI_NO_ISLAND`) exist so a wrong result can be
-attributed to one pass quickly, and they are how each pass is measured:
-every speed number is the same build with one variable set and unset.
+The env switches (`STANLI_NO_DATA_PRELOAD`, `STANLI_NO_INPLACE`,
+`STANLI_NO_CONSTFOLD`, `STANLI_NO_REROLL`, `STANLI_NO_ISLAND`) exist so a wrong
+result can be attributed to one optimization quickly, and they are how each
+one is measured: every speed number is the same build with one variable set
+and unset.

--- a/runtime/src/executor.cpp
+++ b/runtime/src/executor.cpp
@@ -157,7 +157,6 @@ void Executor::bind_() {
     }
   }
   values_.assign(off, 0.0);
-  adjoints_.assign(off, 0.0);
 
   // A slot carries adjoint if it is a parameter or an op writes it. Slots
   // that are neither are data: kernels see a null adjoint Desc and skip them.
@@ -165,6 +164,36 @@ void Executor::bind_() {
   for (const auto& op : graph_.ops) {
     written[op.out] = 1;
     if (op.out2 >= 0) written[op.out2] = 1;
+  }
+
+  // Adjoint addresses never escape the executor, so unlike values they do
+  // not need a hole for every externally addressable data slot or for slots
+  // whose producer an optimization pass removed. Pack the active cells into
+  // one arena. Keeping parameters first preserves the contiguous memcpy of
+  // the returned gradient; keeping one arena preserves the single fast
+  // memset on dense graphs.
+  std::vector<int64_t> adjoint_offsets(graph_.slots.size(), -1);
+  int64_t adj_off = 0;
+  for (size_t i = 0; i < graph_.slots.size(); ++i) {
+    const Slot& s = graph_.slots[i];
+    if (s.is_param) {
+      adjoint_offsets[i] = adj_off;
+      adj_off += s.len;
+    }
+  }
+  assert(adj_off == n_params_);
+  for (size_t i = 0; i < graph_.slots.size(); ++i) {
+    const Slot& s = graph_.slots[i];
+    if (!s.is_param && (written[i] || (int)i == graph_.result_slot)) {
+      adjoint_offsets[i] = adj_off;
+      adj_off += s.len;
+    }
+  }
+  adjoints_.assign(adj_off, 0.0);
+  result_adjoint_offset_ = -1;
+  if (graph_.result_slot >= 0) {
+    result_adjoint_offset_ = adjoint_offsets[graph_.result_slot];
+    assert(result_adjoint_offset_ >= 0);
   }
 
   int64_t scratch = 0;
@@ -191,9 +220,12 @@ void Executor::bind_() {
   ctx_.resize(graph_.ops.size());
   out2_adj_ptr_.assign(graph_.ops.size(), nullptr);
   for (size_t i = 0; i < graph_.ops.size(); ++i) {
-    ctx_[i] = make_ctx_(graph_.ops[i], written);
+    ctx_[i] = make_ctx_(graph_.ops[i], written, adjoint_offsets);
     const int o2 = graph_.ops[i].out2;
-    if (o2 >= 0) out2_adj_ptr_[i] = adjoints_.data() + graph_.slots[o2].offset;
+    if (o2 >= 0) {
+      assert(adjoint_offsets[o2] >= 0);
+      out2_adj_ptr_[i] = adjoints_.data() + adjoint_offsets[o2];
+    }
   }
   // Resolve dispatch now that ctx_ is final (it never reallocates after
   // this, so BwdStep may hold pointers into it).
@@ -208,7 +240,8 @@ void Executor::bind_() {
   }
 }
 
-KernelCtx Executor::make_ctx_(const Op& op, const std::vector<char>& written) {
+KernelCtx Executor::make_ctx_(const Op& op, const std::vector<char>& written,
+                              const std::vector<int64_t>& adjoint_offsets) {
   KernelCtx ctx;
   ctx.n_in = op.n_in;
   for (int i = 0; i < op.n_in; ++i) {
@@ -230,11 +263,18 @@ KernelCtx Executor::make_ctx_(const Op& op, const std::vector<char>& written) {
     const int si = op.in[i];
     const Slot& s = graph_.slots[si];
     const bool active = s.is_param || written[si];
-    ctx.in_adj[i] = Desc{active ? adjoints_.data() + s.offset : nullptr, s.len};
+    assert(!active || adjoint_offsets[si] >= 0);
+    ctx.in_adj[i] =
+        Desc{active ? adjoints_.data() + adjoint_offsets[si] : nullptr, s.len};
   }
-  if (so.len == 1) ctx.out_adj = adjoints_[so.offset];
-  ctx.out_adj_vec = Desc{adjoints_.data() + so.offset, so.len};
-  if (op.out2 >= 0) ctx.out2_adj = adjoints_[graph_.slots[op.out2].offset];
+  assert(adjoint_offsets[op.out] >= 0);
+  const int64_t out_adj_off = adjoint_offsets[op.out];
+  if (so.len == 1) ctx.out_adj = adjoints_[out_adj_off];
+  ctx.out_adj_vec = Desc{adjoints_.data() + out_adj_off, so.len};
+  if (op.out2 >= 0) {
+    assert(adjoint_offsets[op.out2] >= 0);
+    ctx.out2_adj = adjoints_[adjoint_offsets[op.out2]];
+  }
   return ctx;
 }
 
@@ -329,7 +369,8 @@ double Executor::gradient(double* grad_out) {
   ++n_grad_evals_;
   const double v = forward();
   std::memset(adjoints_.data(), 0, sizeof(double) * adjoints_.size());
-  adjoints_[graph_.slots[graph_.result_slot].offset] = 1.0;
+  assert(result_adjoint_offset_ >= 0);
+  adjoints_[result_adjoint_offset_] = 1.0;
   if (profile_) {
     for (size_t pi = graph_.ops.size(); pi-- > 0;) {
       const Kernel& k = kernel(graph_.ops[pi].opcode);

--- a/runtime/src/lower.cpp
+++ b/runtime/src/lower.cpp
@@ -15,6 +15,8 @@
 #include <algorithm>
 #include <cstdio>
 #include <cstdlib>
+#include <array>
+#include <chrono>
 #include <functional>
 #include <initializer_list>
 #include <limits>
@@ -29,6 +31,178 @@ namespace stanli {
 namespace {
 
 using ShapeId = uint32_t;
+
+// Opt-in lowering telemetry.  Preparation is normally too short to justify
+// putting clocks (or even formatting) on the path, so STANLI_PROFILE_PREP is
+// deliberately separate from the executor's STANLI_PROFILE and the disabled
+// path never calls the clock. Rows are buffered until every timed compile
+// stage is done: stderr I/O must not become part of a later pass's timing.
+struct PrepTrace {
+  using Clock = std::chrono::steady_clock;
+  using Time = Clock::time_point;
+
+  enum class Extra {
+    None,
+    Rewrites,
+    Removed,
+    ConstFold,
+    Reroll,
+    Regions,
+    Truncated,
+    MirBytes,
+  };
+
+  struct Row {
+    const char* graph = nullptr;
+    const char* stage = nullptr;
+    int64_t ns = 0;
+    int64_t ops = -1;
+    int64_t slots = -1;
+    int64_t fills = -1;
+    int64_t terms = -1;
+    int64_t views = -1;
+    Extra extra = Extra::None;
+    int64_t a = 0;
+    int64_t b = 0;
+    int64_t c = 0;
+    int64_t d = 0;
+    bool deep = false;
+    int64_t params = 0;
+    int64_t slot_elems = 0;
+    int64_t fill_elems = 0;
+    int64_t idata_arrays = 0;
+    int64_t idata_elems = 0;
+    int64_t udata = 0;
+  };
+
+  explicit PrepTrace(bool enabled) : enabled_(enabled) {}
+
+  Time start() const { return enabled_ ? Clock::now() : Time{}; }
+
+  void plain(const char* graph, const char* stage, Time from,
+             Extra extra = Extra::None, int64_t a = 0) {
+    if (!enabled_) return;
+    Row& r = next();
+    r.graph = graph;
+    r.stage = stage;
+    r.ns = elapsed(from);
+    r.extra = extra;
+    r.a = a;
+  }
+
+  void graph(const char* graph_name, const char* stage, Time from,
+             const Graph& g,
+             const std::vector<std::pair<int, std::vector<double>>>& fills,
+             size_t terms, size_t views, Extra extra = Extra::None,
+             int64_t a = 0, int64_t b = 0, bool deep = false,
+             int64_t params = 0, int64_t c = 0, int64_t d = 0) {
+    if (!enabled_) return;
+    Row& r = next();
+    r.graph = graph_name;
+    r.stage = stage;
+    // Stop the timer before any diagnostic scan below.
+    r.ns = elapsed(from);
+    r.ops = static_cast<int64_t>(g.ops.size());
+    r.slots = static_cast<int64_t>(g.slots.size());
+    r.fills = static_cast<int64_t>(fills.size());
+    r.terms = static_cast<int64_t>(terms);
+    r.views = static_cast<int64_t>(views);
+    r.extra = extra;
+    r.a = a;
+    r.b = b;
+    r.c = c;
+    r.d = d;
+    r.deep = deep;
+    r.params = params;
+    if (deep) {
+      for (const Slot& s : g.slots) r.slot_elems += s.len;
+      for (const auto& f : fills)
+        r.fill_elems += static_cast<int64_t>(f.second.size());
+      r.idata_arrays = static_cast<int64_t>(g.idata_pool.size());
+      for (const auto& v : g.idata_pool)
+        r.idata_elems += static_cast<int64_t>(v.size());
+      r.udata = static_cast<int64_t>(g.udata_pool.size());
+    }
+  }
+
+  void report() const {
+    if (!enabled_) return;
+    for (size_t i = 0; i < size_; ++i) {
+      const Row& r = rows_[i];
+      std::string line = "stanli_prep graph=" + std::string(r.graph) +
+                         " stage=" + r.stage + " ns=" + std::to_string(r.ns);
+      const auto field = [&](const char* name, int64_t value) {
+        line += " ";
+        line += name;
+        line += "=";
+        line += std::to_string(value);
+      };
+      if (r.ops >= 0) {
+        field("ops", r.ops);
+        field("slots", r.slots);
+        field("fills", r.fills);
+        field("terms", r.terms);
+        field("views", r.views);
+      }
+      switch (r.extra) {
+        case Extra::Rewrites:
+          field("rewrites", r.a);
+          break;
+        case Extra::Removed:
+          field("removed", r.a);
+          break;
+        case Extra::ConstFold:
+          field("ops_removed", r.a);
+          field("slots_folded", r.b);
+          break;
+        case Extra::Reroll:
+          field("regions", r.a);
+          field("row_steps", r.d);
+          field("list_steps", r.b);
+          field("candidate_steps", r.c);
+          break;
+        case Extra::Regions:
+          field("regions", r.a);
+          break;
+        case Extra::Truncated:
+          field("truncated", r.a);
+          break;
+        case Extra::MirBytes:
+          field("mir_bytes", r.a);
+          break;
+        case Extra::None:
+          break;
+      }
+      if (r.deep) {
+        field("params", r.params);
+        field("slot_elems", r.slot_elems);
+        field("fill_elems", r.fill_elems);
+        field("idata_arrays", r.idata_arrays);
+        field("idata_elems", r.idata_elems);
+        field("udata", r.udata);
+      }
+      std::fprintf(stderr, "%s\n", line.c_str());
+    }
+  }
+
+ private:
+  bool enabled_ = false;
+  std::array<Row, 32> rows_{};
+  size_t size_ = 0;
+
+  int64_t elapsed(Time from) const {
+    return std::chrono::duration_cast<std::chrono::nanoseconds>(Clock::now() -
+                                                                from)
+        .count();
+  }
+
+  Row& next() {
+    // There are currently 18 rows with a write_array graph. Keep this a fixed
+    // buffer so the profiler itself cannot show up as allocator work.
+    if (size_ >= rows_.size()) std::abort();
+    return rows_[size_++];
+  }
+};
 
 struct SlotInfo {
   int64_t rows = 0, cols = 0;  // set for matrices
@@ -155,6 +329,8 @@ struct Lowering {
 
   const DataMap& data;
   std::shared_ptr<ShapeInterner> shape_pool;
+  PrepTrace& prep;
+  const char* prep_graph;
   // The MIR interpreter instance for everything DataOnly: prepare_data,
   // data-only conditions, size expressions. Its environment doubles as the
   // lowering's view of transformed data. Hooks route FnReadData to the
@@ -238,9 +414,10 @@ struct Lowering {
     return autodiff;
   }
 
-  explicit Lowering(const DataMap& d, std::shared_ptr<ShapeInterner> pool =
-                                          std::make_shared<ShapeInterner>())
-      : data(d), shape_pool(std::move(pool)) {}
+  explicit Lowering(
+      const DataMap& d, PrepTrace& p, const char* graph_name,
+      std::shared_ptr<ShapeInterner> pool = std::make_shared<ShapeInterner>())
+      : data(d), shape_pool(std::move(pool)), prep(p), prep_graph(graph_name) {}
 
   void observe(const Val& v, DataMap::Entry en) {
     const int64_t len = g.slots[v.slot].len;
@@ -762,10 +939,164 @@ struct Lowering {
         tuple(en.dims.empty() ? std::vector<int64_t>{found} : en.dims));
   }
 
+  static void data_reads(const mir::Expr& e, std::set<std::string>& names) {
+    if (e.kind == mir::Expr::FunApp && e.fn_lib == mir::Expr::Lib::Internal &&
+        e.name == "FnReadData" && !e.args.empty() &&
+        e.args[0].kind == mir::Expr::LitStr)
+      names.insert(e.args[0].lit_s);
+    for (const auto& a : e.args) data_reads(a, names);
+  }
+
+  static bool direct_input_load(const mir::Stmt& s,
+                                const std::set<std::string>& inputs) {
+    if (s.kind != mir::Stmt::Assignment || !s.lhs_idx.empty() ||
+        !inputs.count(s.lhs))
+      return false;
+    std::set<std::string> reads;
+    data_reads(s.rhs, reads);
+    return reads.size() == 1 && *reads.begin() == s.lhs;
+  }
+
+  struct RebuildShape {
+    bool supported = true;
+    int loaders = 0;
+    std::string loader_lhs;
+    std::set<std::string> reads;
+    std::set<std::string> decls;
+    std::set<std::string> writes;
+  };
+
+  static void scan_rebuild(const mir::Stmt& s, RebuildShape& shape) {
+    switch (s.kind) {
+      case mir::Stmt::Block:
+      case mir::Stmt::SList:
+        for (const auto& k : s.body) scan_rebuild(k, shape);
+        return;
+      case mir::Stmt::For: {
+        std::set<std::string> bounds_reads;
+        data_reads(s.lower, bounds_reads);
+        data_reads(s.upper, bounds_reads);
+        if (!bounds_reads.empty()) shape.supported = false;
+        for (const auto& k : s.body) scan_rebuild(k, shape);
+        return;
+      }
+      case mir::Stmt::Decl: {
+        shape.decls.insert(s.decl_id);
+        if (!s.has_init) return;
+        std::set<std::string> reads;
+        data_reads(s.init, reads);
+        shape.reads.insert(reads.begin(), reads.end());
+        if (!reads.empty()) {
+          ++shape.loaders;
+          shape.loader_lhs = s.decl_id;
+        }
+        return;
+      }
+      case mir::Stmt::Assignment: {
+        shape.writes.insert(s.lhs);
+        std::set<std::string> reads;
+        data_reads(s.rhs, reads);
+        for (const auto& ix : s.lhs_idx) data_reads(ix, reads);
+        shape.reads.insert(reads.begin(), reads.end());
+        if (!reads.empty()) {
+          if (!s.lhs_idx.empty()) shape.supported = false;
+          ++shape.loaders;
+          shape.loader_lhs = s.lhs;
+        }
+        return;
+      }
+      default:
+        // A generated input rebuild has no effects, conditionals, target
+        // writes, validation calls, or returns. New statement kinds fall back
+        // to interpretation rather than guessing which children are safe.
+        shape.supported = false;
+        return;
+    }
+  }
+
+  static bool canonical_input_rebuild(const mir::Stmt& s,
+                                      const std::set<std::string>& inputs) {
+    if (s.kind != mir::Stmt::Block && s.kind != mir::Stmt::SList) return false;
+    RebuildShape shape;
+    scan_rebuild(s, shape);
+    if (!shape.supported || shape.loaders != 1 || shape.reads.size() != 1)
+      return false;
+    const std::string& input = *shape.reads.begin();
+    if (!inputs.count(input) || shape.loader_lhs.empty() ||
+        shape.loader_lhs == input || !shape.decls.count(shape.loader_lhs) ||
+        !shape.writes.count(input))
+      return false;
+    const auto allowed = [&](const std::string& name) {
+      return name == input || name == shape.loader_lhs || name == "pos__";
+    };
+    for (const auto& name : shape.decls)
+      if (!allowed(name)) return false;
+    for (const auto& name : shape.writes)
+      if (!allowed(name)) return false;
+    return true;
+  }
+
   void bind_data(const mir::Program& p) {
+    std::set<std::string> input_names;
+    bool all_inputs_bound = true;
+    bool use_prebound = std::getenv("STANLI_NO_DATA_PRELOAD") == nullptr;
     for (const auto& [name, type] : p.input_vars) {
-      (void)type;
-      if (data.has(name)) td.env()[name] = data.at(name);
+      input_names.insert(name);
+      if (!data.has(name)) {
+        all_inputs_bound = false;
+        continue;
+      }
+      // DataMap does not have the Stan schema, so JSON values spelled with
+      // integer tokens carry an int mirror even when the declaration is
+      // real. Reconstruct the typed value directly, without copying an
+      // irrelevant mirror for a large real matrix.
+      const DataMap::Entry& src = data.at(name);
+      if (!use_prebound) {
+        td.env()[name] = src;
+        continue;
+      }
+      DataMap::Entry dst;
+      const bool want_int = type.base == "SInt" ||
+                            (type.base == "SArray" && type.elem_base == "SInt");
+      dst.is_int = want_int;
+      dst.r = src.r;
+      dst.dims = src.dims;
+      if (want_int) {
+        if (!src.i.empty()) {
+          dst.i = src.i;
+        } else if (!src.r.empty()) {
+          // Preserve the interpreter's existing error/coercion behavior for
+          // malformed data instead of silently truncating real values here.
+          use_prebound = false;
+        }
+      }
+      td.env()[name] = std::move(dst);
+    }
+    use_prebound = use_prebound && all_inputs_bound;
+    if (use_prebound) {
+      // The generated reconstruction allocated the MIR-declared shape and
+      // copied exactly that many flat elements. Normalize to the same shape;
+      // a malformed length falls back to that checked interpreter path.
+      for (const auto& [name, type] : p.input_vars) {
+        DataMap::Entry& dst = td.env().at(name);
+        if (static_cast<int64_t>(dst.r.size()) != sized_len(type)) {
+          use_prebound = false;
+          break;
+        }
+        dst.dims.clear();
+        if (type.base != "SInt" && type.base != "SReal")
+          for (const auto& d : type.dims) dst.dims.push_back(eval_int(d));
+      }
+    }
+    if (use_prebound) {
+      // Skipping the generated declarations also skips MirInterp's normal
+      // declaration-geometry bookkeeping. Preserve it explicitly so checks
+      // on an empty outer array still see its trailing vector/matrix extents,
+      // which JSON [] cannot represent.
+      for (const auto& input : p.input_vars) {
+        const std::string& name = input.first;
+        td.set_declared_dims(name, td.env().at(name).dims);
+      }
     }
     auto record = [&](const std::string& name, const mir::SizedType& type) {
       if (type.base == "SInt") return;
@@ -780,6 +1111,19 @@ struct Lowering {
     }
     for (const auto& st : p.prepare_data) {
       if (st.kind == mir::Stmt::Decl) record(st.decl_id, st.decl_type);
+      // stanc's prepare_data first rebuilds every input from a flat
+      // FnReadData buffer. DataMap has already parsed that buffer into the
+      // same typed, column-major representation above. Replaying the
+      // canonical matrix reconstruction means one interpreted assignment
+      // per element (47 million for nn_rbm1bJ100) and used to dominate model
+      // preparation. FnReadData is compiler-internal and cannot occur in
+      // source transformed-data code, so a top-level statement containing it
+      // is input hydration, not user computation.
+      if (use_prebound &&
+          ((st.kind == mir::Stmt::Decl && input_names.count(st.decl_id)) ||
+           direct_input_load(st, input_names) ||
+           canonical_input_rebuild(st, input_names)))
+        continue;
       td.exec(st);
     }
     for (auto& [name, e] : td.env()) {
@@ -3855,6 +4199,7 @@ struct Lowering {
   // lowering, and the same passes, because generated quantities are unrolled
   // over the data exactly like the model block is.
   CompiledModel::WriteArray run_write_array(const mir::Program& p) {
+    const auto total_time = prep.start();
     for (const auto& f : p.fun_defs) fun_defs[f.name] = &f;
     in_write_array = true;
     // stanc3 guards the two emission groups on these flags; the sampler wants
@@ -3862,6 +4207,7 @@ struct Lowering {
     int_env["emit_transformed_parameters__"] = 1;
     int_env["emit_generated_quantities__"] = 1;
     CompiledModel::WriteArray wa;
+    const auto lower_time = prep.start();
     try {
       for (const auto& s : p.generate_quantities) lower_stmt(s);
     } catch (const CompileError& e) {
@@ -3872,13 +4218,35 @@ struct Lowering {
     }
     std::vector<int> roots = jac_slots;
     for (const auto& v : out.views) roots.push_back(v.slot);
-    make_inplace_updates(g, roots);
-    forward_stores_to_loads(g, roots);
-    reroll(g, out.fills, target_terms, roots);
+    prep.graph(prep_graph, "lower", lower_time, g, out.fills,
+               target_terms.size(), out.views.size(),
+               PrepTrace::Extra::Truncated, !wa.truncated.empty());
+    const auto inplace_time = prep.start();
+    const int inplace = make_inplace_updates(g, roots);
+    prep.graph(prep_graph, "inplace", inplace_time, g, out.fills,
+               target_terms.size(), out.views.size(),
+               PrepTrace::Extra::Rewrites, inplace);
+    const auto forward_time = prep.start();
+    const int forwarded = forward_stores_to_loads(g, roots);
+    prep.graph(prep_graph, "store_forward", forward_time, g, out.fills,
+               target_terms.size(), out.views.size(), PrepTrace::Extra::Removed,
+               forwarded);
+    const auto reroll_time = prep.start();
+    const RerollStats rerolled = reroll(g, out.fills, target_terms, roots);
+    prep.graph(prep_graph, "reroll", reroll_time, g, out.fills,
+               target_terms.size(), out.views.size(), PrepTrace::Extra::Reroll,
+               rerolled.regions, rerolled.list_steps, false, 0,
+               rerolled.candidate_steps, rerolled.row_steps);
+    const auto finalize_time = prep.start();
     // Nothing reads a result here, but forward() asserts a scalar result
     // slot, so point it at one.
     g.result_slot = const_slot(0.0);
     wa.n_unconstrained = out.n_unconstrained;
+    prep.graph(prep_graph, "finalize", finalize_time, g, out.fills,
+               target_terms.size(), out.views.size());
+    prep.graph(prep_graph, "total", total_time, g, out.fills,
+               target_terms.size(), out.views.size(), PrepTrace::Extra::None, 0,
+               0, true, out.n_unconstrained);
     wa.graph = std::move(g);
     // A section stanc did not emit a guard for (or one lowering stopped
     // short of) has no columns of its own: it starts where the CSV ends.
@@ -3893,9 +4261,16 @@ struct Lowering {
   }
 
   CompiledModel run(const mir::Program& p) {
+    const auto total_time = prep.start();
     for (const auto& f : p.fun_defs) fun_defs[f.name] = &f;
+    const auto bind_time = prep.start();
     bind_data(p);
+    prep.graph(prep_graph, "bind_data", bind_time, g, out.fills,
+               target_terms.size(), out.views.size());
+    const auto lower_time = prep.start();
     for (const auto& s : p.log_prob) lower_stmt(s);
+    prep.graph(prep_graph, "lower", lower_time, g, out.fills,
+               target_terms.size(), out.views.size());
     // Jacobian terms and constrained-parameter views are read straight out
     // of the arena, so no op consumes them and the pass cannot infer them.
     std::vector<int> roots = jac_slots;
@@ -3905,21 +4280,51 @@ struct Lowering {
     std::vector<int> update_roots = roots;
     update_roots.insert(update_roots.end(), target_terms.begin(),
                         target_terms.end());
-    make_inplace_updates(g, update_roots);  // off under STANLI_NO_INPLACE
+    const auto inplace_time = prep.start();
+    const int inplace =
+        make_inplace_updates(g, update_roots);  // off under STANLI_NO_INPLACE
+    prep.graph(prep_graph, "inplace", inplace_time, g, out.fills,
+               target_terms.size(), out.views.size(),
+               PrepTrace::Extra::Rewrites, inplace);
     // Deleting the write/read-back pairs first is what leaves a plain
     // arithmetic lane for reroll to vectorize.
-    forward_stores_to_loads(g, update_roots);
+    const auto forward_time = prep.start();
+    const int forwarded = forward_stores_to_loads(g, update_roots);
+    prep.graph(prep_graph, "store_forward", forward_time, g, out.fills,
+               target_terms.size(), out.views.size(), PrepTrace::Extra::Removed,
+               forwarded);
     // After the update chains collapse, so a data-only chain is one slot
     // rather than N; before reroll, so the lanes it sees have data operands.
-    const_fold(g, out.fills, update_roots);
-    reroll(g, out.fills, target_terms, roots);  // off under STANLI_NO_REROLL
+    const auto constfold_time = prep.start();
+    const ConstFoldStats constfolded = const_fold(g, out.fills, update_roots);
+    prep.graph(prep_graph, "constfold", constfold_time, g, out.fills,
+               target_terms.size(), out.views.size(),
+               PrepTrace::Extra::ConstFold, constfolded.ops_removed,
+               constfolded.slots_folded);
+    const auto reroll_time = prep.start();
+    const RerollStats rerolled =
+        reroll(g, out.fills, target_terms, roots);  // STANLI_NO_REROLL
+    prep.graph(prep_graph, "reroll", reroll_time, g, out.fills,
+               target_terms.size(), out.views.size(), PrepTrace::Extra::Reroll,
+               rerolled.regions, rerolled.list_steps, false, 0,
+               rerolled.candidate_steps, rerolled.row_steps);
     // LAST, after every other pass has had first crack: compile whatever
     // scalar residue survives (recurrences the re-roll can never widen)
     // into island ops. Off under STANLI_NO_ISLAND.
-    carve_islands(g, out.fills, target_terms, roots);
+    const auto island_time = prep.start();
+    const int islands = carve_islands(g, out.fills, target_terms, roots);
+    prep.graph(prep_graph, "island", island_time, g, out.fills,
+               target_terms.size(), out.views.size(), PrepTrace::Extra::Regions,
+               islands);
+    const auto reduce_time = prep.start();
     std::vector<int> all = target_terms;
     all.insert(all.end(), jac_slots.begin(), jac_slots.end());
     g.result_slot = reduce_terms(all);
+    prep.graph(prep_graph, "reduce", reduce_time, g, out.fills,
+               target_terms.size(), out.views.size());
+    prep.graph(prep_graph, "total", total_time, g, out.fills,
+               target_terms.size(), out.views.size(), PrepTrace::Extra::None, 0,
+               0, true, out.n_unconstrained);
     out.graph = std::move(g);
     return std::move(out);
   }
@@ -3928,24 +4333,32 @@ struct Lowering {
 }  // namespace
 
 CompiledModel compile_model(const std::string& tmir_text, const DataMap& data) {
+  const char* prep_env = std::getenv("STANLI_PROFILE_PREP");
+  PrepTrace prep(prep_env && prep_env[0] != '0');
+  const auto compile_time = prep.start();
   // Shared because the interpreted write_array fallback, when needed,
   // keeps the generate_quantities statements and UDF bodies alive for the
   // model's whole life.
+  const auto parse_time = prep.start();
   auto prog =
       std::make_shared<mir::Program>(mir::read_program(sexp::parse(tmir_text)));
-  Lowering lo(data);
+  prep.plain("compile", "parse_mir", parse_time, PrepTrace::Extra::MirBytes,
+             static_cast<int64_t>(tmir_text.size()));
+  Lowering lo(data, prep, "log_prob");
   CompiledModel cm = lo.run(*prog);
   if (!prog->generate_quantities.empty()) {
     // A second lowering, over the transformed data the first one already
     // interpreted: re-running prepare_data would double preparation time on
     // the models where preparation is the cost (nn_rbm1bJ100, 20.7 s).
-    Lowering wa(data, lo.shape_pool);
+    Lowering wa(data, prep, "write_array", lo.shape_pool);
+    const auto env_copy_time = prep.start();
     wa.td.env() = lo.td.env();
     wa.int_env = lo.int_env_data;
     // bind_data owns immutable declaration shape and physical-layout facts;
     // write_array skips that expensive pass, so its fresh lexical lowering
     // receives the facts together with the already-prepared environment.
     wa.decls = lo.decls;
+    prep.plain("write_array", "env_copy", env_copy_time);
     CompiledModel::WriteArray w = wa.run_write_array(*prog);
     if (w.n_unconstrained != cm.n_unconstrained) {
       // The two graphs read the same draw; if they disagree on its length the
@@ -3984,6 +4397,8 @@ CompiledModel compile_model(const std::string& tmir_text, const DataMap& data) {
     }
     cm.write_array = std::move(w);
   }
+  prep.plain("compile", "total", compile_time);
+  prep.report();
   return cm;
 }
 

--- a/runtime/src/reroll.cpp
+++ b/runtime/src/reroll.cpp
@@ -39,6 +39,7 @@
 
 #include <algorithm>
 #include <cstdlib>
+#include <limits>
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
@@ -107,6 +108,375 @@ bool ops_match(const Graph& g, const Op& a, const Op& b) {
   return true;
 }
 
+// LDA's likelihood is a small inner loop nested in a much larger document
+// loop:
+//
+//   gamma[k] = log(a[index_a[n,k]]) + log(b[index_b[n,k]]);
+//   target += log_sum_exp(gamma);
+//
+// K=2 is below the generic reroller's four-lane threshold, and for K=5 the
+// scalar LOG_SUM_EXP between rows prevents the outer loop from looking
+// periodic. Recognize this one exact scalar grammar before ordinary rerolling
+// and flatten the complete rows into two gathers, vector arithmetic, and one
+// packed row reduction. This is deliberately not a second symbolic loop
+// vectorizer: every removed producer, consumer, store index, and target term is
+// proven here against the already concrete graph.
+int fuse_log_sum_exp_rows(Graph& g, std::vector<int>& target_terms,
+                          const std::vector<int>& extra_roots,
+                          int64_t& row_steps) {
+  if (g.ops.empty() || (int64_t)target_terms.size() < kMinLanes) return 0;
+
+  // Most graphs have no row-store/LSE boundary at all. Keep their cost to one
+  // cache-friendly scan and, in particular, do not defeat the generic
+  // candidate fast path by building target sets or allocating dense ownership
+  // arrays first. Target membership is proven by the exact parser below.
+  bool maybe_rows = false;
+  for (size_t u = 1; u < g.ops.size(); ++u) {
+    ++row_steps;
+    const Op& lse = g.ops[u];
+    const Op& store = g.ops[u - 1];
+    if (lse.opcode == OP_LOG_SUM_EXP && lse.n_in == 1 &&
+        (store.opcode == OP_SET_INDEX ||
+         store.opcode == OP_SET_INDEX_INPLACE) &&
+        store.out == lse.in[0]) {
+      maybe_rows = true;
+      break;
+    }
+  }
+  if (!maybe_rows) return 0;
+
+  std::unordered_set<int> roots(extra_roots.begin(), extra_roots.end());
+  if (g.result_slot >= 0) roots.insert(g.result_slot);
+  std::unordered_set<int> term_set(target_terms.begin(), target_terms.end());
+
+  std::unordered_map<int, int> term_count;
+  for (int s : target_terms) ++term_count[s];
+
+  // Exact ownership for slots the rewrite deletes. Reader/writer counts and
+  // their last positions make reused/in-place hand-built graphs fail closed
+  // too.
+  std::vector<int64_t> read_count(g.slots.size(), 0);
+  std::vector<int64_t> write_count(g.slots.size(), 0);
+  std::vector<int64_t> last_reader(g.slots.size(), -1);
+  std::vector<int64_t> last_writer(g.slots.size(), -1);
+  for (size_t u = 0; u < g.ops.size(); ++u) {
+    ++row_steps;
+    const Op& op = g.ops[u];
+    for (int j = 0; j < op.n_in; ++j) {
+      if (op.in[j] < 0) continue;
+      ++read_count[(size_t)op.in[j]];
+      last_reader[(size_t)op.in[j]] = (int64_t)u;
+    }
+    const auto wrote = [&](int s) {
+      if (s < 0) return;
+      ++write_count[(size_t)s];
+      last_writer[(size_t)s] = (int64_t)u;
+    };
+    wrote(op.out);
+    wrote(op.out2);
+  }
+
+  struct Row {
+    size_t begin = 0;
+    size_t end = 0;
+    int K = 0;
+    int a_base = -1;
+    int b_base = -1;
+    int gamma_in = -1;
+    int gamma_out = -1;
+    int lse_out = -1;
+    bool functional_start = false;
+    std::vector<int> a_index;
+    std::vector<int> b_index;
+    std::vector<int> gamma_slots;
+    std::vector<int> deleted_slots;
+  };
+
+  const auto valid_slot = [&](int s) {
+    return s >= 0 && (size_t)s < g.slots.size();
+  };
+  const auto plain = [](const Op& op, uint16_t opcode, int n_in) {
+    return op.opcode == opcode && op.variant == 0 && op.n_in == n_in &&
+           op.n_idata == 0 && op.out2 < 0 && op.udata == nullptr;
+  };
+  const auto deleted_scalar = [&](int slot, size_t writer, size_t reader) {
+    return valid_slot(slot) && g.slots[(size_t)slot].len == 1 &&
+           !g.slots[(size_t)slot].is_param && !roots.count(slot) &&
+           !term_set.count(slot) && write_count[(size_t)slot] == 1 &&
+           last_writer[(size_t)slot] == (int64_t)writer &&
+           read_count[(size_t)slot] == 1 &&
+           last_reader[(size_t)slot] == (int64_t)reader;
+  };
+
+  const auto parse_row = [&](size_t start, int want_k, int want_a, int want_b,
+                             Row& row) {
+    ++row_steps;
+    if (start + 7 > g.ops.size()) return false;
+    // The first store reveals gamma's width, hence the number of six-op scalar
+    // lanes before the row's LOG_SUM_EXP.
+    const Op& first_store = g.ops[start + 5];
+    if ((first_store.opcode != OP_SET_INDEX &&
+         first_store.opcode != OP_SET_INDEX_INPLACE) ||
+        first_store.n_in != 2 || first_store.n_idata != 1 ||
+        first_store.out2 >= 0 || first_store.udata != nullptr ||
+        !valid_slot(first_store.in[0]))
+      return false;
+    const int64_t k64 = g.slots[(size_t)first_store.in[0]].len;
+    if (k64 <= 0 || k64 > std::numeric_limits<int>::max()) return false;
+    const int K = (int)k64;
+    if ((want_k > 0 && K != want_k) ||
+        start + (size_t)6 * (size_t)K + 1 > g.ops.size())
+      return false;
+
+    row = Row{};
+    row.begin = start;
+    row.K = K;
+    row.a_index.reserve((size_t)K);
+    row.b_index.reserve((size_t)K);
+    int gamma = first_store.in[0];
+    row.gamma_in = gamma;
+    row.functional_start = first_store.opcode == OP_SET_INDEX &&
+                           first_store.out != first_store.in[0];
+    row.gamma_slots.push_back(gamma);
+
+    for (int k = 0; k < K; ++k) {
+      row_steps += 6;
+      const size_t p = start + (size_t)6 * (size_t)k;
+      const Op& ai = g.ops[p];
+      const Op& al = g.ops[p + 1];
+      const Op& bi = g.ops[p + 2];
+      const Op& bl = g.ops[p + 3];
+      const Op& add = g.ops[p + 4];
+      const Op& store = g.ops[p + 5];
+      if (!plain(al, OP_LOGV, 1) || !plain(bl, OP_LOGV, 1) ||
+          !plain(add, OP_ADD, 2) || ai.opcode != OP_INDEX ||
+          bi.opcode != OP_INDEX || ai.variant != 0 || bi.variant != 0 ||
+          ai.n_in != 1 || bi.n_in != 1 || ai.n_idata != 1 || bi.n_idata != 1 ||
+          ai.out2 >= 0 || bi.out2 >= 0 || ai.udata != nullptr ||
+          bi.udata != nullptr || !valid_slot(ai.in[0]) ||
+          !valid_slot(bi.in[0]) || ai.idata[0] < 0 || bi.idata[0] < 0 ||
+          ai.idata[0] >= g.slots[(size_t)ai.in[0]].len ||
+          bi.idata[0] >= g.slots[(size_t)bi.in[0]].len || al.in[0] != ai.out ||
+          bl.in[0] != bi.out || add.in[0] != al.out || add.in[1] != bl.out ||
+          (store.opcode != OP_SET_INDEX &&
+           store.opcode != OP_SET_INDEX_INPLACE) ||
+          store.variant != 0 || store.n_in != 2 || store.n_idata != 1 ||
+          store.out2 >= 0 || store.udata != nullptr || store.in[0] != gamma ||
+          store.in[1] != add.out || store.idata[0] != k ||
+          !valid_slot(store.out) || g.slots[(size_t)store.out].len != K ||
+          (store.opcode == OP_SET_INDEX_INPLACE && store.out != gamma) ||
+          !deleted_scalar(ai.out, p, p + 1) ||
+          !deleted_scalar(al.out, p + 1, p + 4) ||
+          !deleted_scalar(bi.out, p + 2, p + 3) ||
+          !deleted_scalar(bl.out, p + 3, p + 4) ||
+          !deleted_scalar(add.out, p + 4, p + 5))
+        return false;
+
+      if (k == 0) {
+        row.a_base = ai.in[0];
+        row.b_base = bi.in[0];
+        if ((want_a >= 0 && row.a_base != want_a) ||
+            (want_b >= 0 && row.b_base != want_b))
+          return false;
+      } else if (ai.in[0] != row.a_base || bi.in[0] != row.b_base) {
+        return false;
+      }
+      row.a_index.push_back(ai.idata[0]);
+      row.b_index.push_back(bi.idata[0]);
+      row.deleted_slots.insert(row.deleted_slots.end(),
+                               {ai.out, al.out, bi.out, bl.out, add.out});
+      gamma = store.out;
+      row.gamma_slots.push_back(gamma);
+    }
+
+    const size_t lp_pos = start + (size_t)6 * (size_t)K;
+    ++row_steps;
+    const Op& lse = g.ops[lp_pos];
+    if (!plain(lse, OP_LOG_SUM_EXP, 1) || lse.in[0] != gamma ||
+        !valid_slot(lse.out) || g.slots[(size_t)lse.out].len != 1 ||
+        g.slots[(size_t)lse.out].is_param || roots.count(lse.out) ||
+        !term_set.count(lse.out) || term_count[lse.out] != 1 ||
+        write_count[(size_t)lse.out] != 1 ||
+        last_writer[(size_t)lse.out] != (int64_t)lp_pos ||
+        read_count[(size_t)lse.out] != 0)
+      return false;
+    row.gamma_out = gamma;
+    row.lse_out = lse.out;
+    row.deleted_slots.push_back(lse.out);
+    row.end = lp_pos + 1;
+    return true;
+  };
+
+  std::vector<Op> result;
+  result.reserve(g.ops.size());
+  int regions = 0;
+  size_t i = 0;
+  while (i < g.ops.size()) {
+    Row first;
+    if (!parse_row(i, -1, -1, -1, first)) {
+      result.push_back(g.ops[i++]);
+      continue;
+    }
+
+    std::vector<Row> rows;
+    rows.push_back(std::move(first));
+    std::unordered_set<int> run_gamma(rows[0].gamma_slots.begin(),
+                                      rows[0].gamma_slots.end());
+    while (true) {
+      Row next;
+      const Row& prev = rows.back();
+      if (!parse_row(prev.end, prev.K, prev.a_base, prev.b_base, next)) break;
+
+      // Lowering has two safe row-to-row forms. A declaration reused across
+      // the outer loop continues the previous row's gamma chain, normally
+      // entirely in place. An unrolled declaration starts each row from a
+      // distinct scratch slot with a functional first write; because indices
+      // 0..K-1 are then all overwritten before LOG_SUM_EXP, its old contents
+      // are immaterial. Do not accept a different in-place buffer or a fresh
+      // chain that aliases an earlier row: those are neither of the proven
+      // forms and can hide cross-row state.
+      const bool shared = next.gamma_in == prev.gamma_out;
+      bool compatible = shared || next.functional_start;
+      for (int s : next.gamma_slots)
+        if (run_gamma.count(s) && (!shared || s != prev.gamma_out)) {
+          compatible = false;
+          break;
+        }
+      if (!compatible) break;
+
+      run_gamma.insert(next.gamma_slots.begin(), next.gamma_slots.end());
+      rows.push_back(std::move(next));
+    }
+    if ((int64_t)rows.size() < kMinLanes) {
+      result.push_back(g.ops[i++]);
+      continue;
+    }
+
+    const size_t batch_end = rows.back().end;
+    std::unordered_set<int> gamma_slots;
+    std::unordered_set<int> deleted_slots;
+    for (const Row& row : rows) {
+      gamma_slots.insert(row.gamma_slots.begin(), row.gamma_slots.end());
+      deleted_slots.insert(row.deleted_slots.begin(), row.deleted_slots.end());
+    }
+    bool safe = true;
+    for (int s : gamma_slots) {
+      if (!valid_slot(s) || g.slots[(size_t)s].is_param || roots.count(s) ||
+          term_set.count(s) || last_reader[(size_t)s] >= (int64_t)batch_end ||
+          last_writer[(size_t)s] >= (int64_t)batch_end) {
+        safe = false;
+        break;
+      }
+    }
+    // Hoisting all scalar reads into two leading gathers is only valid when
+    // neither base is part of the mutable/deleted row state.
+    if (gamma_slots.count(rows[0].a_base) ||
+        gamma_slots.count(rows[0].b_base) ||
+        deleted_slots.count(rows[0].a_base) ||
+        deleted_slots.count(rows[0].b_base))
+      safe = false;
+
+    size_t term_at = target_terms.size();
+    for (size_t t = 0; t < target_terms.size(); ++t)
+      if (target_terms[t] == rows[0].lse_out) {
+        term_at = t;
+        break;
+      }
+    if (term_at + rows.size() > target_terms.size()) safe = false;
+    for (size_t r = 0; safe && r < rows.size(); ++r)
+      if (target_terms[term_at + r] != rows[r].lse_out) safe = false;
+
+    if (!safe) {
+      // A late safety refusal (an escaped gamma or interleaved target term)
+      // applies to this whole packed-row run. Copy it once rather than
+      // reparsing every suffix, which would turn a fail-closed path quadratic.
+      result.insert(result.end(), g.ops.begin() + (ptrdiff_t)i,
+                    g.ops.begin() + (ptrdiff_t)batch_end);
+      i = batch_end;
+      continue;
+    }
+
+    const int64_t total = (int64_t)rows.size() * rows[0].K;
+    std::vector<int> a_index;
+    std::vector<int> b_index;
+    a_index.reserve((size_t)total);
+    b_index.reserve((size_t)total);
+    for (const Row& row : rows) {
+      a_index.insert(a_index.end(), row.a_index.begin(), row.a_index.end());
+      b_index.insert(b_index.end(), row.b_index.begin(), row.b_index.end());
+    }
+    const auto attach_idata = [&](Op& op, std::vector<int> idata) {
+      g.idata_pool.push_back(std::move(idata));
+      op.idata = g.idata_pool.back().data();
+      op.n_idata = (int64_t)g.idata_pool.back().size();
+    };
+    const auto unary = [&](uint16_t opcode, int in, int64_t len) {
+      Op op;
+      op.opcode = opcode;
+      op.n_in = 1;
+      op.in[0] = in;
+      op.out = g.add_slot(len, false);
+      result.push_back(op);
+      return op.out;
+    };
+    Op gather_a;
+    gather_a.opcode = OP_GATHER;
+    gather_a.n_in = 1;
+    gather_a.in[0] = rows[0].a_base;
+    gather_a.out = g.add_slot(total, false);
+    attach_idata(gather_a, std::move(a_index));
+    result.push_back(gather_a);
+    const int log_a = unary(OP_LOGV, gather_a.out, total);
+
+    Op gather_b;
+    gather_b.opcode = OP_GATHER;
+    gather_b.n_in = 1;
+    gather_b.in[0] = rows[0].b_base;
+    gather_b.out = g.add_slot(total, false);
+    attach_idata(gather_b, std::move(b_index));
+    result.push_back(gather_b);
+    const int log_b = unary(OP_LOGV, gather_b.out, total);
+
+    Op add;
+    add.opcode = OP_ADD;
+    add.n_in = 2;
+    add.in[0] = log_a;
+    add.in[1] = log_b;
+    add.out = g.add_slot(total, false);
+    result.push_back(add);
+
+    Op lse;
+    lse.opcode = OP_LOG_SUM_EXP_ROWS;
+    lse.n_in = 1;
+    lse.in[0] = add.out;
+    lse.out = g.add_slot((int64_t)rows.size(), false);
+    attach_idata(lse, std::vector<int>{rows[0].K});
+    result.push_back(lse);
+
+    Op sum;
+    sum.opcode = OP_SUM_VEC;
+    sum.n_in = 1;
+    sum.in[0] = lse.out;
+    sum.out = g.add_slot(1, false);
+    result.push_back(sum);
+
+    std::vector<int> next_terms;
+    next_terms.reserve(target_terms.size() - rows.size() + 1);
+    next_terms.insert(next_terms.end(), target_terms.begin(),
+                      target_terms.begin() + (ptrdiff_t)term_at);
+    next_terms.push_back(sum.out);
+    next_terms.insert(next_terms.end(),
+                      target_terms.begin() + (ptrdiff_t)(term_at + rows.size()),
+                      target_terms.end());
+    target_terms = std::move(next_terms);
+    term_set.insert(sum.out);
+    i = batch_end;
+    ++regions;
+  }
+  g.ops = std::move(result);
+  return regions;
+}
+
 }  // namespace
 
 RerollStats reroll(Graph& g,
@@ -115,6 +485,33 @@ RerollStats reroll(Graph& g,
                    const std::vector<int>& extra_roots) {
   RerollStats st;
   if (std::getenv("STANLI_NO_REROLL")) return st;
+
+  st.regions +=
+      fuse_log_sum_exp_rows(g, target_terms, extra_roots, st.row_steps);
+
+  std::unordered_set<int> term_set(target_terms.begin(), target_terms.end());
+  const auto is_candidate_op = [&](const Op& t) {
+    const uint8_t traits = op_traits(t.opcode);
+    return (traits & op_trait::kRerollAnyDensity) != 0 || is_element_store(t) ||
+           ((traits & op_trait::kRerollWidenable) != 0 &&
+            term_set.count(t.out) != 0);
+  };
+
+  // Every profitable region must contain one of these ops in its first period.
+  // Index the next one at or after every position, making the [i, i + P)
+  // question below O(1) instead of rescanning up to P ops for every P. The
+  // target set can only lose original outputs from a region the scan then skips
+  // over, and gains only new result slots that are not outputs in g.ops, so the
+  // index stays valid as rewrites advance through the original graph.
+  const size_t no_candidate = g.ops.size();
+  std::vector<size_t> next_candidate(no_candidate + 1, no_candidate);
+  for (size_t u = g.ops.size(); u-- > 0;) {
+    ++st.candidate_steps;
+    next_candidate[u] = is_candidate_op(g.ops[u]) ? u : next_candidate[u + 1];
+  }
+  // If the whole graph contains none, no period can classify. Return before
+  // allocating dense reader/writer lists.
+  if (next_candidate[0] == no_candidate) return st;
 
   // The dedup'd constant pool: slot -> value, for len-1 fills.
   std::unordered_map<int, double> const_val;
@@ -186,8 +583,6 @@ RerollStats reroll(Graph& g,
     return first_at_or_after(v, x) != v.end();
   };
 
-  std::unordered_set<int> term_set(target_terms.begin(), target_terms.end());
-
   // Write-fusion renaming, done lazily. When a store region is fused, every
   // later reference to its vector means the fused value instead. Rewriting
   // the tail eagerly is quadratic when one vector chains through many
@@ -232,16 +627,8 @@ RerollStats reroll(Graph& g,
       // element write (which fuses into one vector store), or a widenable
       // op whose out is a target term (log_mix lanes over already-vector
       // lps: the region is INDEX/INDEX/LOG_MIX with no density at all).
-      bool candidate = false;
-      for (int p = 0; p < P && !candidate; ++p) {
-        const Op& t = g.ops[i + p];
-        const uint8_t traits = op_traits(t.opcode);
-        candidate = (traits & op_trait::kRerollAnyDensity) != 0 ||
-                    is_element_store(t) ||
-                    ((traits & op_trait::kRerollWidenable) != 0 &&
-                     term_set.count(t.out) != 0);
-      }
-      if (!candidate) continue;
+      ++st.candidate_steps;
+      if (next_candidate[i] >= i + (size_t)P) continue;
 
       // Count template-matching lanes.
       int64_t L = 1;

--- a/tests/test_executor.cpp
+++ b/tests/test_executor.cpp
@@ -4,6 +4,7 @@
 #include <stanli/optable.hpp>
 
 #include <cmath>
+#include <cstdint>
 #include <cstdio>
 
 static int failures = 0;
@@ -57,6 +58,35 @@ int main() {
   expect_eq("d/da after value-only", grad2[0], grad[0]);
   expect_eq("d/db after value-only", grad2[1], grad[1]);
 
+  // A large data slot between active slots used to occupy the adjoint arena
+  // and get cleared on every gradient even though kernels correctly receive
+  // a null adjoint for it. The private adjoint layout must contain only the
+  // parameter, the indexed scalar, and the result -- not the million data
+  // values. Repeating after changing both inputs catches stale compact cells.
+  Graph sparse;
+  const int sx = sparse.add_slot(1, true);
+  const int sd = sparse.add_slot(INT64_C(1) << 20, false);
+  const int sp = sparse.add_slot(1, false);
+  const int slp = sparse.add_slot(1, false);
+  sparse.add_op(OP_INDEX, {sd}, sp, {17});
+  sparse.add_op(OP_MUL, {sx, sp}, slp);
+  sparse.result_slot = slp;
+  Executor sparse_ex(std::move(sparse));
+  if (sparse_ex.adjoint_storage_size() != 3) {
+    ++failures;
+    std::printf("FAIL compact adjoints got %lld want 3\n",
+                (long long)sparse_ex.adjoint_storage_size());
+  }
+  *sparse_ex.param_ptr(sx) = 2.0;
+  sparse_ex.value_ptr(sd)[17] = 3.5;
+  double sparse_grad[1] = {0};
+  expect_eq("sparse value", sparse_ex.gradient(sparse_grad), 7.0);
+  expect_eq("sparse grad", sparse_grad[0], 3.5);
+  *sparse_ex.param_ptr(sx) = -4.0;
+  sparse_ex.value_ptr(sd)[17] = -1.25;
+  expect_eq("sparse value 2", sparse_ex.gradient(sparse_grad), 5.0);
+  expect_eq("sparse grad 2", sparse_grad[0], -1.25);
+
   // BCAST_FMA forward: out[i] = a + b * x[i].
   Graph g2;
   const int s_a = g2.add_slot(1, true);
@@ -77,6 +107,32 @@ int main() {
   expect_eq("fma[0]", o[0], 0.5 + 2.0 * 1.0);
   expect_eq("fma[1]", o[1], 0.5 + 2.0 * -2.0);
   expect_eq("fma[2]", o[2], 0.5 + 2.0 * 0.25);
+
+  // A forward-only graph need not designate a scalar result. Binding still
+  // compacts its written adjoints without indexing result_slot == -1.
+  Graph no_result;
+  const int nr_in = no_result.add_slot(1, false);
+  const int nr_out = no_result.add_slot(1, false);
+  no_result.add_op(OP_EXP, {nr_in}, nr_out);
+  Executor nr_ex(std::move(no_result));
+  *nr_ex.value_ptr(nr_in) = -0.4;
+  nr_ex.run_forward_only();
+  expect_eq("no-result forward", *nr_ex.value_ptr(nr_out), std::exp(-0.4));
+
+  // A zero-op constant graph still needs one seed cell even with no
+  // parameters or written slots.
+  Graph constant;
+  const int constant_result = constant.add_slot(1, false);
+  constant.result_slot = constant_result;
+  Executor constant_ex(std::move(constant));
+  *constant_ex.value_ptr(constant_result) = 2.75;
+  double no_grad = 0.0;
+  expect_eq("constant result", constant_ex.gradient(&no_grad), 2.75);
+  if (constant_ex.adjoint_storage_size() != 1) {
+    ++failures;
+    std::printf("FAIL constant adjoints got %lld want 1\n",
+                (long long)constant_ex.adjoint_storage_size());
+  }
 
   if (failures == 0) std::printf("test_executor OK\n");
   return failures == 0 ? 0 : 1;

--- a/tests/test_lower.cpp
+++ b/tests/test_lower.cpp
@@ -20,6 +20,8 @@
 #include <fstream>
 #include <sstream>
 #include <string>
+#include <utility>
+#include <vector>
 
 static int failures = 0;
 static void check(bool ok, const std::string& what) {
@@ -74,6 +76,79 @@ static stanli::DataMap bound_check_data(double raw = 0.0, int N = 1, int M = 1,
   return d;
 }
 
+// Compile and evaluate once with either the direct data preload or its
+// interpreter oracle.  The escape hatch is compile-time only; always clear it
+// before execution (and on exceptions) so one comparison cannot contaminate
+// the next test in this process.
+struct LowerSnapshot {
+  double lp = 0.0;
+  std::vector<double> grad;
+  size_t ops = 0;
+  size_t slots = 0;
+  std::vector<std::pair<int, std::vector<double>>> fills;
+};
+
+static LowerSnapshot lower_snapshot(const std::string& mir,
+                                    const stanli::DataMap& data,
+                                    const std::vector<double>& q,
+                                    bool disable_preload) {
+  if (disable_preload)
+    test_setenv("STANLI_NO_DATA_PRELOAD", "1", 1);
+  else
+    test_unsetenv("STANLI_NO_DATA_PRELOAD");
+  stanli::CompiledModel cm;
+  try {
+    cm = stanli::compile_model(mir, data);
+  } catch (...) {
+    test_unsetenv("STANLI_NO_DATA_PRELOAD");
+    throw;
+  }
+  test_unsetenv("STANLI_NO_DATA_PRELOAD");
+
+  LowerSnapshot out;
+  out.ops = cm.graph.ops.size();
+  out.slots = cm.graph.slots.size();
+  out.fills = cm.fills;
+  stanli::Executor ex(std::move(cm.graph));
+  cm.bind(ex);
+  check(ex.n_params() == static_cast<int64_t>(q.size()),
+        "data preload snapshot parameter count");
+  for (size_t i = 0; i < q.size(); ++i) ex.params_data()[i] = q[i];
+  out.grad.resize(q.size());
+  out.lp = ex.gradient(out.grad.data());
+  return out;
+}
+
+static std::string lower_error(const std::string& mir,
+                               const stanli::DataMap& data,
+                               bool disable_preload) {
+  if (disable_preload)
+    test_setenv("STANLI_NO_DATA_PRELOAD", "1", 1);
+  else
+    test_unsetenv("STANLI_NO_DATA_PRELOAD");
+  try {
+    (void)stanli::compile_model(mir, data);
+  } catch (const std::exception& e) {
+    test_unsetenv("STANLI_NO_DATA_PRELOAD");
+    return e.what();
+  }
+  test_unsetenv("STANLI_NO_DATA_PRELOAD");
+  return {};
+}
+
+static void expect_same_lowering(const std::string& tag,
+                                 const LowerSnapshot& fast,
+                                 const LowerSnapshot& oracle) {
+  check(fast.ops == oracle.ops, tag + " op count");
+  check(fast.slots == oracle.slots, tag + " slot count");
+  check(fast.fills == oracle.fills, tag + " fills bitwise");
+  expect_eq(tag + " lp", fast.lp, oracle.lp);
+  check(fast.grad.size() == oracle.grad.size(), tag + " gradient size");
+  const size_t n = std::min(fast.grad.size(), oracle.grad.size());
+  for (size_t i = 0; i < n; ++i)
+    expect_eq(tag + " g" + std::to_string(i), fast.grad[i], oracle.grad[i]);
+}
+
 static const double kY[8] = {28, 8, -3, 7, -1, 1, 18, 12};
 static const double kSigma[8] = {15, 10, 16, 11, 9, 11, 10, 18};
 
@@ -118,6 +193,70 @@ int main() {
   // to `stanc --O1` instead and is verified there.
   stanli::set_packet_math(false);
   using namespace stanli;
+
+  // Direct input preload must be an exact replacement for stanc's generated
+  // FnReadData reconstruction.  This one fixture covers a vector, a matrix,
+  // and two array-of-vector inputs; y is deliberately written with integer
+  // JSON tokens even though its Stan declaration is real, exercising the
+  // schema-based removal of the JSON reader's int mirror.
+  {
+    const DataMap d = DataMap::from_json(
+        R"({"N": 3, "K": 2,
+             "t": [0.5, 1.75, 2.25],
+             "y": [[1, 2], [3, 4], [5, 6]],
+             "p": [[0.3, 0.7], [0.4, 0.6], [0.2, 0.8]],
+             "Sigma": [[2.0, 0.5], [0.5, 1.0]]})");
+    const std::vector<double> q = {0.35, -0.2,  0.4,  0.15, -0.3,
+                                   0.5,  -0.45, 0.25, -0.1};
+    const std::string mir = slurp("tests/fixtures/shapes.tmir.sexp");
+    const LowerSnapshot fast = lower_snapshot(mir, d, q, false);
+    const LowerSnapshot oracle = lower_snapshot(mir, d, q, true);
+    expect_same_lowering("data preload shapes", fast, oracle);
+  }
+
+  // A future stanc version may put another effect in the same top-level block
+  // as an input rebuild.  Make that shape synthetically by changing the inner
+  // generated `pos__ = pos__ + 1` into `N = pos__ + 1`.  The conservative
+  // classifier must interpret the whole mixed block; skipping it would leave
+  // y as [3,4], while the interpreter rebuilds it as [3,3].
+  {
+    std::string mir = slurp("tests/fixtures/loopy.tmir.sexp");
+    const std::string from = "(Assignment ((LVariable pos__) ()) UInt";
+    const std::string to = "(Assignment ((LVariable N) ()) UInt";
+    size_t pos = 0;
+    for (int occurrence = 0; occurrence < 3 && pos != std::string::npos;
+         ++occurrence) {
+      pos = mir.find(from, pos);
+      if (occurrence < 2 && pos != std::string::npos) pos += from.size();
+    }
+    check(pos != std::string::npos, "data preload mixed-block mutation");
+    if (pos != std::string::npos) mir.replace(pos, from.size(), to);
+    const DataMap d = DataMap::from_json(R"({"N": 2, "y": [3, 4]})");
+    const LowerSnapshot fast = lower_snapshot(mir, d, {0.4}, false);
+    const LowerSnapshot oracle = lower_snapshot(mir, d, {0.4}, true);
+    expect_same_lowering("data preload mixed block", fast, oracle);
+  }
+
+  // A missing input and a real-valued JSON token for an integer input must
+  // take the checked interpreter path, not become a partial preload or a
+  // truncating cast.  The fast-path-on and escape-hatch diagnostics agree.
+  {
+    DataMap missing;
+    missing.set_int("N", 2);
+    const std::string mir = slurp("tests/fixtures/loopy.tmir.sexp");
+    const std::string fast = lower_error(mir, missing, false);
+    const std::string oracle = lower_error(mir, missing, true);
+    check(!fast.empty() && fast.find("y") != std::string::npos,
+          "data preload missing input rejected");
+    check(fast == oracle, "data preload missing input diagnostic");
+
+    const DataMap malformed = DataMap::from_json(R"({"K": 1.5})");
+    const std::string simp = slurp("tests/fixtures/simp.tmir.sexp");
+    const std::string fast_int = lower_error(simp, malformed, false);
+    const std::string oracle_int = lower_error(simp, malformed, true);
+    check(!fast_int.empty(), "data preload real token for int rejected");
+    check(fast_int == oracle_int, "data preload int diagnostic");
+  }
 
   DataMap data;
   data.set_int("J", 8);

--- a/tests/test_mixture.cpp
+++ b/tests/test_mixture.cpp
@@ -10,15 +10,23 @@
 
 #include <stan/math.hpp>
 
+#include <cmath>
 #include <cstdio>
+#include <limits>
 #include <string>
 #include <vector>
 
 using namespace stanli;
 
 static int failures = 0;
+static void expect(const std::string& what, bool ok) {
+  if (!ok) {
+    ++failures;
+    std::printf("FAIL %s\n", what.c_str());
+  }
+}
 static void expect_eq(const std::string& what, double got, double want) {
-  if (got != want) {
+  if (got != want && !(std::isnan(got) && std::isnan(want))) {
     ++failures;
     std::printf("FAIL %-28s got %.17g want %.17g\n", what.c_str(), got, want);
   }
@@ -154,6 +162,145 @@ static void check_bitwise(const std::string& tag, uint16_t opcode, int64_t n,
     expect_eq(tag + " g" + std::to_string(i), f.grad[i], u.grad[i]);
 }
 
+// ---- 3. Packed row-wise log_sum_exp ---------------------------------------
+struct RowsRun {
+  double value;
+  std::vector<double> out;
+  std::vector<double> grad;
+};
+
+static RowsRun run_rows(const std::vector<double>& x, int K,
+                        const std::vector<double>& weights = {}) {
+  const int64_t R = (int64_t)x.size() / K;
+  Graph g;
+  const int in = g.add_slot((int64_t)x.size(), true);
+  const int out = g.add_slot(R, false);
+  const int lp = g.add_slot(1, false);
+  g.add_op(OP_LOG_SUM_EXP_ROWS, {in}, out, {K});
+  int weight_slot = -1;
+  if (weights.empty()) {
+    g.add_op(OP_SUM_VEC, {out}, lp);
+  } else {
+    weight_slot = g.add_slot(R, false);
+    g.add_op(OP_DOT, {out, weight_slot}, lp);
+  }
+  g.result_slot = lp;
+
+  Executor ex(std::move(g));
+  for (size_t i = 0; i < x.size(); ++i) ex.param_ptr(in)[i] = x[i];
+  for (size_t i = 0; i < weights.size(); ++i)
+    ex.value_ptr(weight_slot)[i] = weights[i];
+  RowsRun r;
+  r.grad.resize(x.size());
+  r.value = ex.gradient(r.grad.data());
+  r.out.assign(ex.value_ptr(out), ex.value_ptr(out) + R);
+  return r;
+}
+
+static void check_row_edge(const std::string& tag,
+                           const std::vector<double>& x) {
+  const RowsRun got = run_rows(x, (int)x.size());
+  Eigen::Matrix<var, -1, 1> xv((int)x.size());
+  for (int i = 0; i < (int)x.size(); ++i) xv(i) = x[(size_t)i];
+  var want = stan::math::log_sum_exp(xv);
+  want.grad();
+  expect_eq(tag + " value", got.value, want.val());
+  expect_eq(tag + " row value", got.out[0], want.val());
+  for (int i = 0; i < (int)x.size(); ++i)
+    expect_eq(tag + " g" + std::to_string(i), got.grad[(size_t)i], xv(i).adj());
+  stan::math::recover_memory();
+}
+
+static void check_rows() {
+  const int K = 5;
+  const std::vector<double> x{-1.3,
+                              0.4,
+                              2.1,
+                              -0.7,
+                              0.2,  // ordinary
+                              1000.0,
+                              999.0,
+                              998.0,
+                              997.0,
+                              996.0,  // stable at large magnitudes
+                              -std::numeric_limits<double>::infinity(),
+                              -2.0,
+                              -3.0,
+                              -4.0,
+                              -5.0,
+                              0.1,
+                              0.1,
+                              0.1,
+                              0.1,
+                              0.1};  // ties
+  const int R = (int)x.size() / K;
+  const RowsRun got = run_rows(x, K);
+
+  Eigen::Matrix<var, -1, 1> xv((int)x.size());
+  for (int i = 0; i < (int)x.size(); ++i) xv(i) = x[(size_t)i];
+  std::vector<var> row_lp;
+  row_lp.reserve((size_t)R);
+  var lp = 0.0;
+  for (int r = 0; r < R; ++r) {
+    Eigen::Matrix<var, -1, 1> row(K);
+    for (int k = 0; k < K; ++k) row(k) = xv(r * K + k);
+    row_lp.push_back(stan::math::log_sum_exp(row));
+    lp += row_lp.back();
+  }
+  lp.grad();
+
+  expect_eq("rows lp", got.value, lp.val());
+  for (int r = 0; r < R; ++r)
+    expect_eq("rows out" + std::to_string(r), got.out[(size_t)r],
+              row_lp[(size_t)r].val());
+  for (int i = 0; i < (int)x.size(); ++i)
+    expect_eq("rows g" + std::to_string(i), got.grad[(size_t)i], xv(i).adj());
+  stan::math::recover_memory();
+
+  // A nonuniform consumer verifies that backward uses each row's own output
+  // adjoint rather than treating the rows as an implicit sum.
+  const std::vector<double> weights{0.5, -1.25, 2.0, 0.0};
+  const RowsRun weighted = run_rows(x, K, weights);
+  Eigen::Matrix<var, -1, 1> wx((int)x.size());
+  for (int i = 0; i < (int)x.size(); ++i) wx(i) = x[(size_t)i];
+  var weighted_lp = 0.0;
+  for (int r = 0; r < R; ++r) {
+    Eigen::Matrix<var, -1, 1> row(K);
+    for (int k = 0; k < K; ++k) row(k) = wx(r * K + k);
+    weighted_lp += weights[(size_t)r] * stan::math::log_sum_exp(row);
+  }
+  weighted_lp.grad();
+  for (int i = 0; i < (int)x.size(); ++i)
+    expect_eq("weighted rows g" + std::to_string(i), weighted.grad[(size_t)i],
+              wx(i).adj());
+  stan::math::recover_memory();
+
+  Graph shape;
+  const int in = shape.add_slot((int64_t)x.size(), true);
+  const int out = shape.add_slot(R, false);
+  const int oi = shape.add_op(OP_LOG_SUM_EXP_ROWS, {in}, out, {K});
+  const Kernel* kernel = find_kernel(OP_LOG_SUM_EXP_ROWS);
+  expect("rows kernel registered", kernel != nullptr);
+  if (kernel) {
+    expect("rows scratch callback", kernel->scratch_size != nullptr);
+    if (kernel->scratch_size)
+      expect("rows scratch=input len",
+             kernel->scratch_size(shape.ops[(size_t)oi], shape.slots.data()) ==
+                 (int64_t)x.size());
+  }
+  expect("rows backward is value-free",
+         has_op_trait(OP_LOG_SUM_EXP_ROWS, op_trait::kBackwardValueFree));
+  expect("rows opcode name", std::string(opcode_name(OP_LOG_SUM_EXP_ROWS)) ==
+                                 "OP_LOG_SUM_EXP_ROWS");
+
+  const double inf = std::numeric_limits<double>::infinity();
+  const double nan = std::numeric_limits<double>::quiet_NaN();
+  check_row_edge("rows K=1", {-3.25});
+  check_row_edge("rows all -inf", {-inf, -inf, -inf});
+  check_row_edge("rows +inf", {inf, 0.5, inf});
+  check_row_edge("rows nan", {-1.0, nan, 2.0});
+}
+
 int main() {
   const int64_t N = 4;
 
@@ -179,6 +326,8 @@ int main() {
   check_bitwise("unroll lse2 vs", OP_LSE2, N, {A, {S}});
   check_bitwise("unroll lmix svv", OP_LOG_MIX, N, {{S}, A, B});
   check_bitwise("unroll lmix vvv", OP_LOG_MIX, N, {TH, A, B});
+
+  check_rows();
 
   if (failures) {
     std::printf("%d failures\n", failures);

--- a/tests/test_multichain.cpp
+++ b/tests/test_multichain.cpp
@@ -81,6 +81,16 @@ int main() {
       same = same && g1[(size_t)i] == g2[(size_t)i];
     expect("clone gradient is bitwise identical", same);
 
+    // Copying after a reverse sweep must rebuild compact adjoint offsets and
+    // contexts, not inherit the source arena's interior pointers or dirt.
+    Executor post_grad_clone(src);
+    std::vector<double> g_after((size_t)n);
+    const double lp_after = post_grad_clone.gradient(g_after.data());
+    bool same_after = lp_after == lp1;
+    for (int64_t i = 0; i < n; ++i)
+      same_after = same_after && g_after[(size_t)i] == g1[(size_t)i];
+    expect("post-gradient clone is bitwise identical", same_after);
+
     // And the two arenas are independent: evaluating one must not move
     // the other.
     for (int64_t i = 0; i < n; ++i) clone.params_data()[i] = 5.0;

--- a/tests/test_pass_safety.cpp
+++ b/tests/test_pass_safety.cpp
@@ -90,6 +90,10 @@ static std::vector<double> route_adjoints(uint16_t oc, bool poison) {
     case OP_LOG_SUM_EXP:
       out_len = 1;
       break;
+    case OP_LOG_SUM_EXP_ROWS:
+      idata = {3};  // two packed rows of width three
+      out_len = 2;
+      break;
     case OP_LSE2:
       // Two scalar inputs; reuse the vector buffer's first element.
       ctx.n_in = 2;

--- a/tests/test_reroll.cpp
+++ b/tests/test_reroll.cpp
@@ -624,12 +624,12 @@ int count(const Graph& g, uint16_t oc) {
 
 }  // namespace writefuse
 
-// (n) ldaK5 shape: one shared gamma vector, refilled by every unrolled
-// iteration's inner loop and read once by LOG_SUM_EXP before the next
-// refill. N iterations chain N store regions through that single slot, so
-// eager tail renaming made the pass quadratic in both time and memory
-// (the real model: 32,877 iterations, 52 s and 49 GB to compile, which
-// OOM-killed every CI runner).
+// (n) ldaK5 shape: gamma may be one shared vector refilled by every outer
+// iteration, or a fresh unrolled declaration per row. Each inner loop writes
+// every element and LOG_SUM_EXP reads the completed row. The former chains N
+// store regions through one slot, so eager tail renaming made the pass
+// quadratic in both time and memory (the real model: 32,877 iterations, 52 s
+// and 49 GB to compile, which OOM-killed every CI runner).
 //
 // Both are linear now, but they were fixed in two separate goes: the
 // lazy renaming took the quadratic term out of the allocation and left
@@ -652,8 +652,10 @@ struct Built {
   std::vector<int> terms;
 };
 
-Built build(int N) {
-  const int K = 5, V = 7;
+enum class GammaMode { Shared, Fresh };
+
+Built build(int N, int K = 5, GammaMode mode = GammaMode::Shared) {
+  const int V = 7;
   Built b;
   Graph& g = b.g;
   const int t0 = g.add_slot(1, true);
@@ -662,9 +664,16 @@ Built build(int N) {
   g.add_op(OP_REP_VEC, {t0}, thetav);
   const int phiv = g.add_slot(V, false);
   g.add_op(OP_REP_VEC, {p0}, phiv);
-  const int gamma = g.add_slot(K, false);
-  b.fills.emplace_back(gamma, std::vector<double>(K, 0.0));
+  int gamma = -1;
+  if (mode == GammaMode::Shared) {
+    gamma = g.add_slot(K, false);
+    b.fills.emplace_back(gamma, std::vector<double>(K, 0.0));
+  }
   for (int n = 0; n < N; ++n) {
+    if (mode == GammaMode::Fresh) {
+      gamma = g.add_slot(K, false);
+      b.fills.emplace_back(gamma, std::vector<double>(K, 0.0));
+    }
     for (int k = 0; k < K; ++k) {
       const int i1 = g.add_slot(1, false);
       g.add_op(OP_INDEX, {thetav}, i1, {k});
@@ -676,7 +685,17 @@ Built build(int N) {
       g.add_op(OP_LOGV, {i2}, l2);
       const int s = g.add_slot(1, false);
       g.add_op(OP_ADD, {l1, l2}, s);
-      g.add_op(OP_SET_INDEX_INPLACE, {gamma, s}, gamma, {k});
+      if (k == 0 && (n == 0 || mode == GammaMode::Fresh)) {
+        // The in-place pass cannot mutate a fill-backed declaration on its
+        // first write: repeated evaluations would inherit the last draw. A
+        // shared declaration copies once; fresh unrolled declarations copy at
+        // the start of every row. Later writes share the copied output.
+        const int next = g.add_slot(K, false);
+        g.add_op(OP_SET_INDEX, {gamma, s}, next, {k});
+        gamma = next;
+      } else {
+        g.add_op(OP_SET_INDEX_INPLACE, {gamma, s}, gamma, {k});
+      }
     }
     const int lse = g.add_slot(1, false);
     g.add_op(OP_LOG_SUM_EXP, {gamma}, lse);
@@ -685,30 +704,172 @@ Built build(int N) {
   return b;
 }
 
+static void test_lda_shape_refusals() {
+  // Fewer than four row targets cannot amortize the packed form and should
+  // return before even scanning the graph for a row signature.
+  {
+    ldashape::Built b = ldashape::build(3, 2);
+    const size_t before = b.g.ops.size();
+    const RerollStats st = reroll(b.g, b.fills, b.terms, {});
+    expect("lda short rows do not pack",
+           writefuse::count(b.g, OP_LOG_SUM_EXP_ROWS) == 0);
+    expect("lda short rows skip recognizer", st.row_steps == 0);
+    expect("lda short rows keep graph", b.g.ops.size() == before);
+  }
+
+  // A graph-external view of gamma is invisible to op use counts. The explicit
+  // root must keep the complete mutable row chain intact.
+  {
+    ldashape::Built b = ldashape::build(12, 2);
+    int gamma = -1;
+    for (const Op& op : b.g.ops)
+      if (op.opcode == OP_SET_INDEX || op.opcode == OP_SET_INDEX_INPLACE)
+        gamma = op.out;
+    const size_t before = b.g.ops.size();
+    const RerollStats st = reroll(b.g, b.fills, b.terms, {gamma});
+    expect("lda rows refuse gamma root",
+           writefuse::count(b.g, OP_LOG_SUM_EXP_ROWS) == 0);
+    expect("lda gamma-root refusal keeps graph", b.g.ops.size() == before);
+    expect("lda gamma-root refusal stays linear",
+           st.row_steps < 4 * (int64_t)before);
+  }
+
+  // The gathers are hoisted ahead of every row. A base that is also the
+  // mutable gamma buffer would therefore turn a recurrence into independent
+  // reads and must be rejected explicitly.
+  {
+    ldashape::Built b = ldashape::build(12, 2);
+    int gamma = -1;
+    for (const Op& op : b.g.ops)
+      if (op.opcode == OP_SET_INDEX || op.opcode == OP_SET_INDEX_INPLACE)
+        gamma = op.out;
+    int seen_index = 0;
+    for (Op& op : b.g.ops)
+      if (op.opcode == OP_INDEX && (seen_index++ % 2) == 0) op.in[0] = gamma;
+    reroll(b.g, b.fills, b.terms, {});
+    expect("lda rows refuse mutable base",
+           writefuse::count(b.g, OP_LOG_SUM_EXP_ROWS) == 0);
+  }
+
+  // Full overwrite makes the old gamma contents dead, but its final contents
+  // are not dead when another op observes them after the candidate batch.
+  {
+    ldashape::Built b = ldashape::build(12, 2);
+    int gamma = -1;
+    for (const Op& op : b.g.ops)
+      if (op.opcode == OP_SET_INDEX || op.opcode == OP_SET_INDEX_INPLACE)
+        gamma = op.out;
+    const int escaped = b.g.add_slot(1, false);
+    b.g.add_op(OP_LOG_SUM_EXP, {gamma}, escaped);
+    reroll(b.g, b.fills, b.terms, {});
+    expect("lda rows refuse live gamma",
+           writefuse::count(b.g, OP_LOG_SUM_EXP_ROWS) == 0);
+  }
+
+  // Fresh scratch does not weaken the escape rule: observing any completed
+  // row buffer after the candidate run keeps all of its stores intact.
+  {
+    ldashape::Built b = ldashape::build(12, 2, ldashape::GammaMode::Fresh);
+    int gamma = -1;
+    int row = 0;
+    for (const Op& op : b.g.ops)
+      if (op.opcode == OP_SET_INDEX && ++row == 6) gamma = op.out;
+    const int escaped = b.g.add_slot(1, false);
+    b.g.add_op(OP_LOG_SUM_EXP, {gamma}, escaped);
+    reroll(b.g, b.fills, b.terms, {});
+    expect("lda fresh rows refuse live gamma",
+           writefuse::count(b.g, OP_LOG_SUM_EXP_ROWS) == 0);
+  }
+
+  // The packed SUM replaces one contiguous subsequence. A target list with
+  // the same slots in a different order must not be silently regrouped.
+  {
+    ldashape::Built b = ldashape::build(12, 2);
+    std::swap(b.terms[1], b.terms[2]);
+    const size_t before = b.g.ops.size();
+    reroll(b.g, b.fills, b.terms, {});
+    expect("lda rows refuse reordered targets",
+           writefuse::count(b.g, OP_LOG_SUM_EXP_ROWS) == 0);
+    expect("lda target-order refusal keeps graph", b.g.ops.size() == before);
+  }
+
+  // Every scalar intermediate must belong solely to its grammar consumer.
+  // Give one ADD per row a second reader; K=2 also prevents the generic inner
+  // reroller from obscuring the row recognizer's refusal.
+  {
+    ldashape::Built b = ldashape::build(12, 2);
+    int seen_add = 0;
+    std::vector<int> escaped;
+    for (const Op& op : b.g.ops)
+      if (op.opcode == OP_ADD && (seen_add++ % 2) == 0)
+        escaped.push_back(op.out);
+    for (int s : escaped) {
+      const int dead = b.g.add_slot(1, false);
+      b.g.add_op(OP_NEG, {s}, dead);
+    }
+    reroll(b.g, b.fills, b.terms, {});
+    expect("lda rows refuse escaped intermediates",
+           writefuse::count(b.g, OP_LOG_SUM_EXP_ROWS) == 0);
+  }
+
+  // One malformed first row is a boundary, not a model-wide bail: the exact
+  // suffix still fuses, while the incomplete row retains its scalar LSE.
+  {
+    ldashape::Built b = ldashape::build(12, 2);
+    for (Op& op : b.g.ops) {
+      if (op.opcode != OP_SET_INDEX) continue;
+      b.g.idata_pool.push_back(std::vector<int>{1});  // duplicate k=1
+      op.idata = b.g.idata_pool.back().data();
+      op.n_idata = 1;
+      break;
+    }
+    reroll(b.g, b.fills, b.terms, {});
+    expect("lda malformed row stays scalar",
+           writefuse::count(b.g, OP_LOG_SUM_EXP) == 1);
+    expect("lda valid suffix still packs",
+           writefuse::count(b.g, OP_LOG_SUM_EXP_ROWS) == 1);
+  }
+}
+
 }  // namespace ldashape
 
 static void test_lda_shape_gradients() {
   const int N = 40;
-  ldashape::Built b = ldashape::build(N);
-  Graph ref = b.g;
-  reduce_into_result(ref, b.terms);
-  const std::vector<double> want = run_grad(std::move(ref), b.fills);
+  for (ldashape::GammaMode mode :
+       {ldashape::GammaMode::Shared, ldashape::GammaMode::Fresh})
+    for (int K : {2, 5}) {
+      const std::string shape =
+          mode == ldashape::GammaMode::Shared ? "shared" : "fresh";
+      const std::string label = "lda " + shape + " K" + std::to_string(K);
+      ldashape::Built b = ldashape::build(N, K, mode);
+      expect((label + " fill shape").c_str(),
+             b.fills.size() ==
+                 (mode == ldashape::GammaMode::Shared ? 1u : (size_t)N));
+      Graph ref = b.g;
+      reduce_into_result(ref, b.terms);
+      const std::vector<double> want = run_grad(std::move(ref), b.fills);
 
-  std::vector<int> tt = b.terms;
-  Fills f2 = b.fills;
-  RerollStats st = reroll(b.g, f2, tt, {});
-  expect("lda one region per iteration", st.regions == N);
-  // Per iteration: LOGV(theta) + GATHER + LOGV + ADD + LOG_SUM_EXP, plus a
-  // SET_SLICE chaining gamma everywhere but the last iteration (nothing
-  // writes gamma after it, so its lanes' values ARE the vector).
-  expect("lda stores chain", writefuse::count(b.g, OP_SET_SLICE) == N - 1);
-  expect("lda no element writes left",
-         writefuse::count(b.g, OP_SET_INDEX_INPLACE) == 0);
-  reduce_into_result(b.g, tt);
-  const std::vector<double> got = run_grad(std::move(b.g), f2);
-  expect("lda sizes", got.size() == want.size());
-  for (size_t i = 0; i < want.size() && i < got.size(); ++i)
-    expect_close(("lda v" + std::to_string(i)).c_str(), got[i], want[i]);
+      std::vector<int> tt = b.terms;
+      Fills f2 = b.fills;
+      RerollStats st = reroll(b.g, f2, tt, {});
+      expect((label + " becomes one region").c_str(), st.regions == 1);
+      expect((label + " has seven fused ops plus inputs").c_str(),
+             b.g.ops.size() == 9);
+      expect((label + " has one packed reduction").c_str(),
+             writefuse::count(b.g, OP_LOG_SUM_EXP_ROWS) == 1);
+      expect((label + " has no scalar reductions").c_str(),
+             writefuse::count(b.g, OP_LOG_SUM_EXP) == 0);
+      expect((label + " has no stores").c_str(),
+             writefuse::count(b.g, OP_SET_INDEX) == 0 &&
+                 writefuse::count(b.g, OP_SET_INDEX_INPLACE) == 0);
+      expect((label + " has one target").c_str(), tt.size() == 1);
+      reduce_into_result(b.g, tt);
+      const std::vector<double> got = run_grad(std::move(b.g), f2);
+      expect((label + " gradient sizes").c_str(), got.size() == want.size());
+      for (size_t i = 0; i < want.size() && i < got.size(); ++i)
+        expect_close((label + " v" + std::to_string(i)).c_str(), got[i],
+                     want[i]);
+    }
 }
 
 // Peak resident set for the process in MB, or -1 where the platform does
@@ -728,11 +889,10 @@ static double peak_rss_mb() {
 #endif
 }
 
-// What reroll costs on the lda shape at size n: the list entries it looks
-// at, which is the term that was quadratic, and the wall clock, which is
-// reported but not asserted on. The region count is checked along the way
-// so a pass that got cheap by doing less is not mistaken for a pass that
-// got cheap.
+// What reroll costs on the lda shape at size n: deterministic row-recognizer
+// work and the wall clock, which is reported but not asserted on. The fused
+// graph shape is checked so a pass that got cheap by doing less is not mistaken
+// for a pass that got cheap.
 struct LdaCost {
   double sec;
   int64_t steps;
@@ -746,8 +906,9 @@ static LdaCost lda_reroll_cost(int n) {
   const double sec =
       std::chrono::duration<double>(std::chrono::steady_clock::now() - t0)
           .count();
-  expect("lda big all regions found", st.regions == n);
-  return {sec, st.list_steps};
+  expect("lda big rows fused", st.regions == 1);
+  expect("lda big fixed fused graph", b.g.ops.size() == 9 && tt.size() == 1);
+  return {sec, st.row_steps};
 }
 
 static void test_lda_shape_cost() {
@@ -771,11 +932,10 @@ static void test_lda_shape_cost() {
   // 12 GB at n=16000, so 1 GB separates them with room on both sides.
   if (rss > 0.0) expect("lda reroll space stays linear", rss < 1024.0);
 
-  // Count the work, do not time it. A doubling of n doubles the entries
-  // this pass reads (2.1x measured) against a quadrupling for the
-  // whole-list scan it replaced (4.0x measured), so 3x separates the two
-  // with room on both sides, and the count is the same integer on every
-  // machine.
+  // Count the work, do not time it. A doubling of n doubles the scalar row
+  // grammar and the ownership scan. The count is the same integer on every
+  // machine and also covers late fail-closed runs, which must not retry every
+  // suffix of one shared gamma chain.
   //
   // The wall clock is not. Two earlier versions of this check gated on
   // it, first as an absolute budget and then as a ratio, and between
@@ -784,6 +944,122 @@ static void test_lda_shape_cost() {
   // quiet laptop. The ratio formulation barely separated the two cases
   // even there: the quadratic scan timed 3.1x against a 3.0x bound.
   expect("lda reroll work stays near-linear", big.steps < 3 * small.steps);
+}
+
+// A graph with no density, element store, or target-term widenable op cannot
+// contain a profitable region at any period. LOG_SUM_EXP is deliberately not
+// in that allowlist: this is the scalar residue left by ldaK5 after its gamma
+// rows are built, and making every output a target proves the fast path is not
+// merely relying on an empty target list.
+struct NoCandidateCost {
+  double sec;
+  int64_t steps;
+};
+
+static NoCandidateCost no_candidate_cost(int n) {
+  Graph g;
+  Fills fills;
+  const int row = g.add_slot(5, true);
+  std::vector<int> terms;
+  terms.reserve((size_t)n);
+  for (int i = 0; i < n; ++i) {
+    const int out = g.add_slot(1, false);
+    g.add_op(OP_LOG_SUM_EXP, {row}, out);
+    terms.push_back(out);
+  }
+  const size_t before_ops = g.ops.size();
+  const std::vector<int> before_terms = terms;
+  const auto t0 = std::chrono::steady_clock::now();
+  const RerollStats st = reroll(g, fills, terms, {});
+  const double sec =
+      std::chrono::duration<double>(std::chrono::steady_clock::now() - t0)
+          .count();
+  expect("no-candidate finds no regions", st.regions == 0);
+  expect("no-candidate never reads use lists", st.list_steps == 0);
+  expect("no-candidate graph unchanged", g.ops.size() == before_ops);
+  expect("no-candidate terms unchanged", terms == before_terms);
+  return {sec, st.candidate_steps};
+}
+
+static void test_no_candidate_cost() {
+  const NoCandidateCost small = no_candidate_cost(8000);
+  const NoCandidateCost big = no_candidate_cost(16000);
+  std::printf(
+      "  no-candidate reroll: n=8000 %.6f s / %lld steps,"
+      " n=16000 %.6f s / %lld steps (%.1fx steps, %.1fx time)\n",
+      small.sec, (long long)small.steps, big.sec, (long long)big.steps,
+      small.steps > 0 ? (double)big.steps / (double)small.steps : 0.0,
+      small.sec > 0.0 ? big.sec / small.sec : 0.0);
+
+  // Count the work rather than asserting on a machine-dependent timer. The
+  // one viability pass examines every op exactly once; the old nested period
+  // scan performed O(kMaxPeriod^2 * n) checks after reaching the same answer.
+  expect("no-candidate small scans once", small.steps == 8000);
+  expect("no-candidate big scans once", big.steps == 16000);
+  expect("no-candidate work scales linearly", big.steps == 2 * small.steps);
+}
+
+// One early density makes the whole-graph guard pass, but the long tail has no
+// candidates. This is nn_rbm's shape: a few prior densities followed by a
+// large scalar residue. Candidate windows must be range queries over the index,
+// not repeated scans through that tail.
+struct SparseCandidateCost {
+  double sec;
+  int64_t steps;
+  int64_t expected;
+};
+
+static SparseCandidateCost sparse_candidate_cost(int n) {
+  Graph g;
+  Fills fills;
+  const int y = g.add_slot(1, false);
+  const int mu = g.add_slot(1, true);
+  const int sigma = g.add_slot(1, true);
+  const int lp = g.add_slot(1, false);
+  g.add_op(OP_NORMAL_LPDF, {y, mu, sigma}, lp);
+  std::vector<int> terms{lp};
+  const int row = g.add_slot(5, true);
+  terms.reserve((size_t)n + 1);
+  for (int i = 0; i < n; ++i) {
+    const int out = g.add_slot(1, false);
+    g.add_op(OP_LOG_SUM_EXP, {row}, out);
+    terms.push_back(out);
+  }
+
+  const size_t n_ops = g.ops.size();
+  int64_t expected = (int64_t)n_ops;  // build the next-candidate index
+  for (size_t i = 0; i < n_ops; ++i)
+    for (int P = 1; P <= 32 && i + 2 * (size_t)P <= n_ops; ++P) ++expected;
+
+  const size_t before_ops = g.ops.size();
+  const std::vector<int> before_terms = terms;
+  const auto t0 = std::chrono::steady_clock::now();
+  const RerollStats st = reroll(g, fills, terms, {});
+  const double sec =
+      std::chrono::duration<double>(std::chrono::steady_clock::now() - t0)
+          .count();
+  expect("sparse-candidate finds no regions", st.regions == 0);
+  expect("sparse-candidate never reads use lists", st.list_steps == 0);
+  expect("sparse-candidate graph unchanged", g.ops.size() == before_ops);
+  expect("sparse-candidate terms unchanged", terms == before_terms);
+  return {sec, st.candidate_steps, expected};
+}
+
+static void test_sparse_candidate_cost() {
+  const SparseCandidateCost small = sparse_candidate_cost(8000);
+  const SparseCandidateCost big = sparse_candidate_cost(16000);
+  std::printf(
+      "  sparse-candidate reroll: n=8000 %.6f s / %lld steps,"
+      " n=16000 %.6f s / %lld steps (%.1fx steps, %.1fx time)\n",
+      small.sec, (long long)small.steps, big.sec, (long long)big.steps,
+      small.steps > 0 ? (double)big.steps / (double)small.steps : 0.0,
+      small.sec > 0.0 ? big.sec / small.sec : 0.0);
+
+  expect("sparse-candidate small counts index queries",
+         small.steps == small.expected);
+  expect("sparse-candidate big counts index queries",
+         big.steps == big.expected);
+  expect("sparse-candidate work stays linear", big.steps < 3 * small.steps);
 }
 
 static void test_write_fusion() {
@@ -1125,7 +1401,10 @@ int main() {
   test_bail_extra_root();
   test_bail_categorical_ops();
   test_lda_shape_gradients();
+  ldashape::test_lda_shape_refusals();
   test_lda_shape_cost();
+  test_no_candidate_cost();
+  test_sparse_candidate_cost();
   test_write_fusion();
   test_write_fusion_bails();
   test_write_fusion_scalar_chain();

--- a/tests/test_structured_checks.cpp
+++ b/tests/test_structured_checks.cpp
@@ -4,6 +4,8 @@
 // transformed-parameter, or generated-quantity declaration. The value may be
 // an array, whose JSON/interpreter storage interleaves leaves even though the
 // lowered graph keeps each leaf contiguous.
+#include "env_helpers.hpp"
+
 #include <stanli/compile.hpp>
 #include <stanli/mir_interp.hpp>
 #include <stanli/sexp.hpp>
@@ -490,10 +492,22 @@ void test_data_arrays() {
     "d_cov":[], "d_cholesky_corr":[], "d_cholesky_cov":[],
     "d_sum_to_zero_matrix":[]
   })";
-  check(outcome([&] {
-          (void)stanli::compile_model(mir, DataMap::from_json(empty));
-        }) == Outcome::Accepted,
+  const auto compile_empty = [&](bool disable_preload) {
+    if (disable_preload)
+      test_setenv("STANLI_NO_DATA_PRELOAD", "1", 1);
+    else
+      test_unsetenv("STANLI_NO_DATA_PRELOAD");
+    const Outcome result = outcome(
+        [&] { (void)stanli::compile_model(mir, DataMap::from_json(empty)); });
+    test_unsetenv("STANLI_NO_DATA_PRELOAD");
+    return result;
+  };
+  const Outcome empty_fast = compile_empty(false);
+  const Outcome empty_oracle = compile_empty(true);
+  check(empty_fast == Outcome::Accepted,
         "zero outer batch executes zero structured leaf checks");
+  check(empty_fast == empty_oracle,
+        "preloaded empty structured arrays match interpreter oracle");
 
   std::string malformed = mir;
   const size_t gq = malformed.find("(decl_id gq_sum_to_zero)");

--- a/tests/test_transforms.cpp
+++ b/tests/test_transforms.cpp
@@ -76,6 +76,14 @@ static void run_case(const std::string& tag, uint16_t opcode, int n,
   expect_eq(tag + " lp", got, vlp.val());
   for (int i = 0; i < n; ++i)
     expect_eq(tag + " g" + std::to_string(i), grad[i], vx(i).adj());
+
+  // out2 carries the Jacobian adjoint. A second reverse sweep must start
+  // from a clean compact arena just like an ordinary single-output op.
+  double grad2[8];
+  const double got2 = ex.gradient(grad2);
+  expect_eq(tag + " lp repeat", got2, got);
+  for (int i = 0; i < n; ++i)
+    expect_eq(tag + " g repeat" + std::to_string(i), grad2[i], grad[i]);
   stan::math::recover_memory();
 }
 
@@ -167,6 +175,31 @@ static void run_bound_case(const std::string& tag, uint16_t opcode, int n,
   stan::math::recover_memory();
 }
 
+static void test_out2_is_result() {
+  using namespace stanli;
+  Graph g;
+  const int x = g.add_slot(1, true);
+  const int lb = g.add_slot(1, false);
+  const int constrained = g.add_slot(1, false);
+  const int jac = g.add_slot(1, false);
+  Op op;
+  op.opcode = OP_CONSTRAIN_LOWER;
+  op.out = constrained;
+  op.out2 = jac;
+  op.n_in = 2;
+  op.in[0] = x;
+  op.in[1] = lb;
+  g.ops.push_back(op);
+  g.result_slot = jac;
+
+  Executor ex(std::move(g));
+  *ex.param_ptr(x) = 0.7;
+  *ex.value_ptr(lb) = -2.0;
+  double grad = 0.0;
+  expect_eq("out2 result lp", ex.gradient(&grad), 0.7);
+  expect_eq("out2 result grad", grad, 1.0);
+}
+
 int main() {
   const double xs[3] = {0.3, -1.2, 2.0};
   const double x1[1] = {0.7};
@@ -175,6 +208,7 @@ int main() {
   run_case("upper vec", stanli::OP_CONSTRAIN_UPPER, 3, xs, 1.5, 0.0);
   run_case("lu vec", stanli::OP_CONSTRAIN_LU, 3, xs, -1.0, 2.0);
   run_case("lu scalar", stanli::OP_CONSTRAIN_LU, 1, x1, 0.0, 1.0);
+  test_out2_is_result();
 
   // Parameter-dependent bounds, shared and per-element, with and without
   // the jacobian.

--- a/tools/bench_grad.cpp
+++ b/tools/bench_grad.cpp
@@ -1,5 +1,5 @@
-// Per-gradient latency: compile model+data, evaluate log_prob gradient at a
-// fixed point N times, report ns/eval.
+// Per-gradient latency at a fixed point, or file-to-bound-executor latency
+// with --prep (no warmup or model evaluation).
 #include <stanli/compile.hpp>
 #include <stanli/graph.hpp>
 
@@ -20,14 +20,91 @@ static std::string slurp(const char* p) {
 
 int main(int argc, char** argv) {
   if (argc < 4) {
-    std::fprintf(stderr, "usage: bench_grad mir.sexp data.json N\n");
+    std::fprintf(stderr, "usage: bench_grad mir.sexp data.json N|--prep\n");
     return 2;
   }
-  const int N = std::atoi(argv[3]);
-  stanli::DataMap data = stanli::DataMap::from_json(slurp(argv[2]));
-  stanli::CompiledModel cm = stanli::compile_model(slurp(argv[1]), data);
+  const bool prep_only = std::string(argv[3]) == "--prep";
+  const int N = prep_only ? 0 : std::atoi(argv[3]);
+  if (!prep_only && N <= 0) {
+    std::fprintf(stderr, "bench_grad: N must be positive\n");
+    return 2;
+  }
+  using Clock = std::chrono::steady_clock;
+  using Time = Clock::time_point;
+  const char* prep_env = std::getenv("STANLI_PROFILE_PREP");
+  const bool prep_profile = prep_env && prep_env[0] != '0';
+  const bool measure_prep = prep_profile || prep_only;
+  const auto prep_now = [&]() { return measure_prep ? Clock::now() : Time{}; };
+  const auto prep_ns = [&](Time from) {
+    return measure_prep ? std::chrono::duration_cast<std::chrono::nanoseconds>(
+                              Clock::now() - from)
+                              .count()
+                        : int64_t{0};
+  };
+  const Time driver_start = prep_now();
+  Time pt = prep_now();
+  int64_t data_bytes = 0;
+  int64_t read_data_ns = 0;
+  int64_t parse_data_ns = 0;
+  stanli::DataMap data;
+  {
+    const std::string data_text = slurp(argv[2]);
+    read_data_ns = prep_ns(pt);
+    data_bytes = static_cast<int64_t>(data_text.size());
+    pt = prep_now();
+    data = stanli::DataMap::from_json(data_text);
+    parse_data_ns = prep_ns(pt);
+  }
+  int64_t mir_bytes = 0;
+  int64_t read_mir_ns = 0;
+  int64_t compile_ns = 0;
+  stanli::CompiledModel cm;
+  {
+    pt = prep_now();
+    const std::string mir_text = slurp(argv[1]);
+    read_mir_ns = prep_ns(pt);
+    mir_bytes = static_cast<int64_t>(mir_text.size());
+    pt = prep_now();
+    cm = stanli::compile_model(mir_text, data);
+    compile_ns = prep_ns(pt);
+  }
+  pt = prep_now();
   stanli::Executor ex(std::move(cm.graph));
+  const int64_t executor_ns = prep_ns(pt);
+  pt = prep_now();
   cm.bind(ex);
+  const int64_t bind_ns = prep_ns(pt);
+  const auto report_driver = [&](int64_t total_ns, int64_t warm_ns,
+                                 int warm_evals) {
+    if (!prep_profile) return;
+    std::fprintf(
+        stderr, "stanli_prep graph=driver stage=read_data ns=%lld bytes=%lld\n",
+        (long long)read_data_ns, (long long)data_bytes);
+    std::fprintf(stderr, "stanli_prep graph=driver stage=parse_data ns=%lld\n",
+                 (long long)parse_data_ns);
+    std::fprintf(stderr,
+                 "stanli_prep graph=driver stage=read_mir ns=%lld bytes=%lld\n",
+                 (long long)read_mir_ns, (long long)mir_bytes);
+    std::fprintf(stderr, "stanli_prep graph=driver stage=compile ns=%lld\n",
+                 (long long)compile_ns);
+    std::fprintf(stderr, "stanli_prep graph=driver stage=executor ns=%lld\n",
+                 (long long)executor_ns);
+    std::fprintf(stderr, "stanli_prep graph=driver stage=bind ns=%lld\n",
+                 (long long)bind_ns);
+    if (warm_ns >= 0)
+      std::fprintf(stderr,
+                   "stanli_prep graph=driver stage=warmup ns=%lld evals=%d\n",
+                   (long long)warm_ns, warm_evals);
+    std::fprintf(stderr, "stanli_prep graph=driver stage=total ns=%lld\n",
+                 (long long)total_ns);
+  };
+  if (prep_only) {
+    const int64_t total_ns = prep_ns(driver_start);
+    report_driver(total_ns, -1, 0);
+    const double seconds = total_ns / 1e9;
+    std::printf("%.9f %lld\n", seconds, (long long)ex.n_params());
+    return 0;
+  }
   // STANLI_PROFILE=1: per-opcode time/count/element accounting on stderr.
   // Enabled for the measured loop only, so warmup does not pollute it.
   const char* prof_env = std::getenv("STANLI_PROFILE");
@@ -39,15 +116,20 @@ int main(int argc, char** argv) {
   double sink = 0;
   // Warm up by time, not by count: 1000 evaluations is nothing on a scalar
   // model and 90 seconds on an ODE one.
+  int warmup_evals = 0;
+  const Time warmup_start = prep_now();
   {
     auto w0 = std::chrono::steady_clock::now();
     for (int i = 0; i < 1000; ++i) {
       sink += ex.gradient(grad.data());
+      ++warmup_evals;
       if (std::chrono::steady_clock::now() - w0 >
           std::chrono::milliseconds(200))
         break;
     }
   }
+  const int64_t warmup_ns = prep_ns(warmup_start);
+  const int64_t driver_ns = prep_ns(driver_start);
   if (profile) ex.set_profile(true);
   auto t0 = std::chrono::steady_clock::now();
   for (int i = 0; i < N; ++i) sink += ex.gradient(grad.data());
@@ -61,6 +143,7 @@ int main(int argc, char** argv) {
   auto t3 = std::chrono::steady_clock::now();
   const double fwd_ns =
       std::chrono::duration<double, std::nano>(t3 - t2).count() / N;
+  report_driver(driver_ns, warmup_ns, warmup_evals);
   // Machine-readable: <ns/grad> <sink> <ns/forward> <n_params>, consumed by
   // tools/bench_models.py (which reads field 0 and the last field).
   std::printf("%.1f %.6g %.1f %lld\n", ns, sink, fwd_ns, (long long)n);

--- a/tools/bench_models.py
+++ b/tools/bench_models.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
 """Per-gradient benchmark across a set of posteriordb models: stanli vs
 CmdStan, both at the same deterministic unconstrained point, both -O3 and
--ffp-contract=off. Also reports model-preparation time (stanli lowering vs
-CmdStan's stanc + clang compile), which is the time-to-first-draw term.
+-ffp-contract=off. Also reports model-preparation time (stanli file read,
+parse, graph compile, and bind vs CmdStan's stanc + clang compile), which is
+the time-to-first-draw term.
 
 Usage: tools/bench_models.py CMDSTAN_DIR PDB_DIR [model ...]
 
@@ -85,11 +86,17 @@ def main():
         rt_ns = float(out[0])
         t_rt_total = time.perf_counter() - t0
 
-        # stanli preparation: lowering only (one eval run, minus the eval).
-        t0 = time.perf_counter()
-        subprocess.run([str(REPO / "build-rel/bench_grad"), str(sexp),
-                        str(dj), "1"], capture_output=True, text=True)
-        t_lower = time.perf_counter() - t0
+        # File read + JSON parse + MIR compile + Executor construction/bind,
+        # with no gradient warmup or measured evaluation.
+        prep = subprocess.run(
+            [str(REPO / "build-rel/bench_grad"), str(sexp), str(dj),
+             "--prep"], capture_output=True, text=True)
+        prep_lines = [line for line in prep.stdout.splitlines() if line.strip()]
+        if prep.returncode != 0 or not prep_lines:
+            print(f"SKIP {model}: stanli preparation failed")
+            continue
+        # A transformed-data print may precede bench_grad's result line.
+        t_lower = float(prep_lines[-1].split()[0])
 
         # CmdStan: stanc to C++, clang compile, then time the same loop.
         hpp = tmp / f"{model}.hpp"


### PR DESCRIPTION
## Summary

- preload typed input data and skip the redundant stanc-generated hydration loops, with an interpreter oracle and opt-in preparation-stage tracing
- compact the reverse-mode arena to parameters and active graph outputs instead of allocating and clearing adjoints for data and dead slots
- make reroll candidate discovery linear on sparse/no-candidate graphs and fuse fixed-width row `log_sum_exp` likelihoods into a packed row kernel
- add a compile-and-bind-only `bench_grad --prep` mode and use it consistently in benchmark harnesses

## Measured impact

- `nn_rbm1bJ100`: input binding 23.56 s -> 0.09 s; graph compile 23.80 s -> 0.23 s; file-to-bound executor 26.33 s -> 2.76 s; peak RSS -1.34 GB
- `ldaK2`: 15,854 -> 22 ops and 154 -> 94 us/gradient
- `ldaK5`: 434,126 -> 156 ops and 6.82 -> 3.70 ms/gradient
- candidate-free million-op reroll residue: about 1.16 s -> 3.4 ms

The committed full-corpus benchmark table is intentionally not partially refreshed; the targeted measurements are documented separately.

## Correctness and safety

- preload validates declared element counts, preserves typed/container geometry including empty structured arrays, and falls back to the interpreter outside the pinned hydration envelope
- packed row fusion requires complete ordered stores, isolated scratch/intermediates, invariant bases, contiguous unique target terms, and no escaped roots or recurrences
- compact adjoints cover ordinary, sparse-data, constant-result, `out2`-result, repeated-gradient, clone, and multichain paths

## Validation

- clean Release configure/build: 291/291 actions
- CTest: 55/55 passed
- CmdStan reference replay: 129/129 models at all 3 points, 800,674 values compared within 1e-9
- randomized pass safety: 400 graphs, worst relative difference 1.14e-15
- `clang-format --dry-run --Werror`
- `python3 tools/gen_docs.py --check`
- `python3 tools/gen_web_models.py --check`
- Python bytecode compile and `git diff --check`