### PR TITLE
perf: make rerolled slice stores in place

### DIFF
--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -18,12 +18,15 @@ The harness now records file read, parse, compile, construction, and binding
 only; that column should be refreshed as a unit rather than mixing definitions.
 Targeted preparation measurements later on this page use the new mode.
 
-One targeted 2026-08-23 remeasurement is newer than the full snapshot below.
+Two targeted 2026-08-23 remeasurements are newer than the full snapshot below.
 Packed row-wise `log_sum_exp` reduces `ldaK2` from 15,854 ops to 22 and
 154 to 94 us/gradient (1.11x CmdStan), and `ldaK5` from 434,126 ops to 156
 and 6.82 to 3.70 ms/gradient (1.51x CmdStan). `ldaK5` file-to-bound-model
-preparation also falls from about 0.59 s to 0.27 s. The committed full-corpus
-tables retain one measurement definition and will be refreshed as a unit.
+preparation also falls from about 0.59 s to 0.27 s. In-place slice stores move
+`Mtbh_model` from 106.5 to 47.4 us/gradient (0.43x to 0.95x CmdStan): its 146
+strided stores still dispatch once each, but update four cells instead of
+copying all 730. The committed full-corpus tables retain one measurement
+definition and will be refreshed as a unit.
 
 ## Per-gradient latency
 
@@ -106,6 +109,10 @@ by the model's *shape*, not its size.
   rather than higher is per-op dispatch against CmdStan's inlined
   scalar code, one interpreted instruction at a time in each
   direction (the island section below has the per-region numbers).
+- **Matrix-filling updates.** `Mtbh_model` re-rolls 584 element writes into
+  146 strided stores. A second in-place pass now keeps one initial copy and
+  makes all 146 stores destructive, reducing their profile share from 42.4%
+  to 5.5% and moving the model from 0.43x to 0.95x CmdStan.
 
 **Slower (a shrinking tail, mostly 0.5-0.9x):**
 
@@ -113,10 +120,6 @@ by the model's *shape*, not its size.
   right-hand side against CmdStan's fully inlined one inside the same
   CVODES solver. (They were 0.015x before the right-hand side compiled;
   see below.)
-- **`Mtbh_model` (0.45x)**, the slowest model, spends 36% in
-  `OP_SET_SLICE_STRIDED`. The in-place rule rewrites element writes but
-  not slice writes, so a model that fills a matrix column by column
-  still copies the whole matrix per column. Open.
 
 A profile of every sub-parity model (`STANLI_PROFILE=1`) says the
 remaining tail is mostly not a graph problem: in seven of those models
@@ -153,6 +156,11 @@ headline measurements:
   integer-outcome fusion closed the `dogs` family (0.65x -> 2.8x).
   57 of the 120 corpus models change under the passes, against 28
   before write-side fusion.
+- **Post-reroll in-place slices** (chained partial matrix fills):
+  `Mtbh_model` keeps the same 1,585-op graph, but 146 stores now move four
+  values rather than copying a 730-value matrix. Median gradient latency
+  falls 106.5 -> 47.4 us (2.24x); direct replay remains within 3.61e-15 of
+  the CmdStan references across 465 values.
 - **Elementwise-lp fusion** (the mixture idiom): `low_dim_gauss_mix`
   7,208 ops -> 16, crossing parity (0.78x -> 1.07x); `normal_mixture`
   13 ops, 1.09x.

--- a/docs/hacking.md
+++ b/docs/hacking.md
@@ -339,14 +339,14 @@ compare the sampler diagnostic columns distributionally.
 The bugs worth recording share a shape: the graph looked right, the op
 count did not change, and the numbers were silently wrong.
 
-- **A destructive write ahead of a backward that re-reads its
-  inputs.** The in-place pass turns "copy the vector, then modify one
-  element" into "modify the element in place", which destroys the old
-  value. The reverse sweep runs after all forward writes, so this is
-  safe only if no earlier op's `backward` needs the destroyed value.
-  The allowlist `backward_ignores_input_values` names the ops whose
-  backward only routes adjoints and never re-reads its inputs; only
-  those may sit in front of an in-place write, and
+- **A destructive write whose producer or an earlier reader re-reads
+  values in backward.** The in-place pass turns "copy the vector, then
+  modify it" into "modify it in place", which destroys the old value.
+  The reverse sweep runs after all forward writes, so this is safe only
+  if neither the op that produced the current version nor any earlier
+  reader needs the destroyed input or output values. The allowlist
+  `backward_ignores_values` names the ops whose backward only routes
+  adjoints or reads scratch; both sides of that proof must be on it, and
   [`test_pass_safety.cpp`](../tests/test_pass_safety.cpp) pins the
   property for each one. Before this rule existed, eight corpus models
   were wrong by up to 1.7e+05 relative, with their op counts

--- a/runtime/include/stanli/inplace.hpp
+++ b/runtime/include/stanli/inplace.hpp
@@ -1,8 +1,7 @@
-// Destructive functional updates. `v[n] = ...` under an unrolled loop
-// lowers to a chain of OP_SET_INDEX ops, each of which copies the whole
-// vector into a fresh slot: N writes cost O(N^2) time and arena. When a
-// write is the last use of the vector it overwrites, it can mutate that
-// vector in place instead, making the chain O(N).
+// Destructive functional updates. `v[n] = ...` under an unrolled loop and
+// re-rolled slice stores both copy the whole base into a fresh slot. When a
+// write is the last use of the base it overwrites, it can mutate that buffer
+// in place instead.
 #ifndef STANLI_INPLACE_HPP
 #define STANLI_INPLACE_HPP
 
@@ -12,19 +11,20 @@
 
 namespace stanli {
 
-// Rewrites eligible OP_SET_INDEX ops to OP_SET_INDEX_INPLACE (whose out
-// slot IS its first input) and renames later references to the dead
-// output slot. `roots` are slots read from outside the op graph (jacobian
-// terms, constrained-parameter views, the result): they are never
-// overwritten and never renamed. Returns the number of writes rewritten.
-// STANLI_NO_INPLACE=1 disables the pass.
-// True for ops whose backward only routes adjoints and never reads the
-// values of its inputs. The destructive rewrite below is sound only for
-// vectors whose earlier readers all satisfy this: a backward pass runs
-// after every write has landed, and kernels like log_sum_exp rebuild
-// their var tape from the input buffer at that point. Exposed so
-// tests/test_pass_safety.cpp can check every opcode claimed here really
-// has the property, by poisoning inputs between the sweeps.
+// Rewrites eligible OP_SET_INDEX / OP_SET_SLICE / OP_SET_SLICE_STRIDED ops
+// to their INPLACE forms (whose out slot IS their first input) and renames
+// later references to the dead output slot. `roots` are slots read from
+// outside the op graph (jacobian terms, constrained-parameter views, the
+// result): they are never overwritten and never renamed. Returns the number
+// of writes rewritten. STANLI_NO_INPLACE=1 disables the pass.
+// True for ops whose backward only routes adjoints or reads scratch, never
+// input OR output value buffers. The destructive rewrite is sound only when
+// both earlier readers and the producer of the current buffer version satisfy
+// this strong property. Exposed so tests/test_pass_safety.cpp can verify every
+// claimed opcode by poisoning all values between the sweeps.
+bool backward_ignores_values(uint16_t opcode);
+// Compatibility spelling retained for callers of the original input-only
+// description. The actual contract is now deliberately stronger.
 bool backward_ignores_input_values(uint16_t opcode);
 
 int make_inplace_updates(Graph& g, const std::vector<int>& roots);

--- a/runtime/include/stanli/legacy.hpp
+++ b/runtime/include/stanli/legacy.hpp
@@ -53,7 +53,7 @@ void legacy_bwd_vec_in(KernelCtx& ctx, F&& f) {
 // output adjoint later is equivalent to replaying with the real seed --
 // and it leaves the backward reading only scratch, never the input
 // values. That is what lets these ops opt into the destructive-update
-// trait in optable.hpp (see backward_ignores_input_values).
+// trait in optable.hpp (see backward_ignores_values).
 template <typename F>
 double legacy_fwd_partials_vec(KernelCtx& ctx, F&& f) {
   stan::math::nested_rev_autodiff nested;

--- a/runtime/include/stanli/optable.hpp
+++ b/runtime/include/stanli/optable.hpp
@@ -34,7 +34,9 @@ namespace stanli {
   X(OP_SET_INDEX_INPLACE)           \
   X(OP_SLICE)                       \
   X(OP_SET_SLICE)                   \
+  X(OP_SET_SLICE_INPLACE)           \
   X(OP_SET_SLICE_STRIDED)           \
+  X(OP_SET_SLICE_STRIDED_INPLACE)   \
   X(OP_SLICE_STRIDED)               \
   X(OP_GATHER)                      \
   X(OP_CONCAT2)                     \
@@ -679,6 +681,7 @@ constexpr uint8_t kRerollDensity = 1 << 0;
 constexpr uint8_t kRerollIdataDensity = 1 << 1;
 constexpr uint8_t kRerollAnyDensity = kRerollDensity | kRerollIdataDensity;
 constexpr uint8_t kRerollWidenable = 1 << 2;
+// Backward reads adjoints/scratch only, never input or output value buffers.
 constexpr uint8_t kBackwardValueFree = 1 << 3;
 }  // namespace op_trait
 
@@ -737,14 +740,19 @@ constexpr uint8_t op_traits(uint16_t opcode) {
     case OP_LOG1M_INV_LOGIT:
       return op_trait::kRerollWidenable;
 
-    // Backward routes adjoints without rereading input values. This permits
-    // a later destructive update to reuse the input buffer safely.
+    // Backward routes adjoints without rereading input OR output values. This
+    // permits a later destructive update to reuse an input buffer, and a
+    // store-produced output to become the next update's base.
     case OP_INDEX:
     case OP_SLICE:
     case OP_SLICE_STRIDED:
     case OP_GATHER:
     case OP_SET_INDEX:
     case OP_SET_INDEX_INPLACE:
+    case OP_SET_SLICE:
+    case OP_SET_SLICE_INPLACE:
+    case OP_SET_SLICE_STRIDED:
+    case OP_SET_SLICE_STRIDED_INPLACE:
     case OP_LOG_SUM_EXP:
     case OP_LOG_SUM_EXP_ROWS:
       return op_trait::kBackwardValueFree;

--- a/runtime/include/stanli/program.hpp
+++ b/runtime/include/stanli/program.hpp
@@ -140,7 +140,7 @@ struct Program {
   // way every value is. `bwd_in`/`bwd_out` are where the VALUES live at
   // backward time -- the same registers, unless the adjoint generator
   // had to checkpoint them (some kernel backwards re-read their inputs;
-  // backward_ignores_input_values is a whitelist, not a guarantee).
+  // backward_ignores_values is a whitelist, not a guarantee).
   struct Call {
     uint16_t opcode = 0;
     uint8_t variant = 0;

--- a/runtime/kernels/elementwise.cpp
+++ b/runtime/kernels/elementwise.cpp
@@ -278,6 +278,22 @@ void set_slice_bwd(KernelCtx& ctx) {
       ctx.in_adj[1].data[i] += ctx.out_adj_vec.data[start + i];
 }
 
+// OP_SET_SLICE_INPLACE: out IS in[0]. Untouched adjoints already pass
+// through because those two adjoint buffers alias. Overwritten cells belong
+// to the RHS instead, so route them there and clear them from the base.
+void set_slice_inplace_fwd(KernelCtx& ctx) {
+  const int64_t start = ctx.idata[0];
+  for (int64_t i = 0; i < ctx.in[1].len; ++i)
+    ctx.out.data[start + i] = ctx.in[1].data[i];
+}
+void set_slice_inplace_bwd(KernelCtx& ctx) {
+  const int64_t start = ctx.idata[0], len = ctx.in[1].len;
+  if (ctx.in_adj[1].data)
+    for (int64_t i = 0; i < len; ++i)
+      ctx.in_adj[1].data[i] += ctx.out_adj_vec.data[start + i];
+  for (int64_t i = 0; i < len; ++i) ctx.out_adj_vec.data[start + i] = 0.0;
+}
+
 // OP_SET_SLICE_STRIDED: out = copy(in[0]) with
 // out[start + i*stride] = in[1][i], idata = {start, stride}. The write-side
 // mirror of OP_SLICE_STRIDED: a loop filling a column-major matrix row by
@@ -310,6 +326,23 @@ void set_slice_strided_bwd(KernelCtx& ctx) {
   }
 }
 
+// OP_SET_SLICE_STRIDED_INPLACE: the comb-shaped counterpart above, with
+// out and in[0] sharing both value and adjoint storage.
+void set_slice_strided_inplace_fwd(KernelCtx& ctx) {
+  const int64_t start = ctx.idata[0], stride = ctx.idata[1];
+  for (int64_t i = 0; i < ctx.in[1].len; ++i)
+    ctx.out.data[start + i * stride] = ctx.in[1].data[i];
+}
+void set_slice_strided_inplace_bwd(KernelCtx& ctx) {
+  const int64_t start = ctx.idata[0], stride = ctx.idata[1],
+                len = ctx.in[1].len;
+  if (ctx.in_adj[1].data)
+    for (int64_t i = 0; i < len; ++i)
+      ctx.in_adj[1].data[i] += ctx.out_adj_vec.data[start + i * stride];
+  for (int64_t i = 0; i < len; ++i)
+    ctx.out_adj_vec.data[start + i * stride] = 0.0;
+}
+
 }  // namespace
 
 // Called from Executor's constructor path; a static registrar object in a
@@ -326,8 +359,13 @@ void register_elementwise_kernels() {
                                                set_index_inplace_bwd, nullptr});
   register_kernel(OP_SLICE, Kernel{slice_fwd, slice_bwd, nullptr});
   register_kernel(OP_SET_SLICE, Kernel{set_slice_fwd, set_slice_bwd, nullptr});
+  register_kernel(OP_SET_SLICE_INPLACE, Kernel{set_slice_inplace_fwd,
+                                               set_slice_inplace_bwd, nullptr});
   register_kernel(OP_SET_SLICE_STRIDED, Kernel{set_slice_strided_fwd,
                                                set_slice_strided_bwd, nullptr});
+  register_kernel(OP_SET_SLICE_STRIDED_INPLACE,
+                  Kernel{set_slice_strided_inplace_fwd,
+                         set_slice_strided_inplace_bwd, nullptr});
   register_kernel(OP_SLICE_STRIDED,
                   Kernel{slice_strided_fwd, slice_strided_bwd, nullptr});
   register_kernel(OP_GATHER, Kernel{gather_fwd, gather_bwd, nullptr});

--- a/runtime/src/OPTIMIZATIONS.md
+++ b/runtime/src/OPTIMIZATIONS.md
@@ -57,7 +57,8 @@ order, from `lower.cpp`:
 2. store-to-load forwarding (`inplace.cpp`)
 3. constant folding (`constfold.cpp`)
 4. loop re-rolling (`reroll.cpp`)
-5. tape islands (`island.cpp`)
+5. in-place updates again, for slice stores created by re-rolling
+6. tape islands (`island.cpp`)
 
 ## In-place updates (`inplace.cpp`, disable: `STANLI_NO_INPLACE=1`)
 
@@ -68,23 +69,39 @@ N*N/2 numbers. One real model (radon_county_intercept, N = 12,573)
 spent 90 ms per gradient and 2.6 GB of memory this way.
 
 The fix: if nothing ever looks at the old version of the vector again,
-change the element directly in the existing buffer. "Nothing looks at
-it again" has two parts:
+change the element directly in the existing buffer. Re-rolling can create
+contiguous or strided slice stores only after the first in-place pass, so the
+same proof runs again after re-rolling. "Nothing looks at it again" has two
+parts:
 
 - No later op reads the old version; the write is the last use of that
   buffer.
 - No earlier op needs the old values during the gradient step. Some
   ops recompute their derivative from their input buffer when the
   gradient runs, which happens after all the writes. Only ops whose
-  gradient step just moves numbers around, without re-reading input
+  gradient step just moves numbers around, without re-reading input or output
   values, may sit before an in-place write. There is an explicit list
-  of those ops (`backward_ignores_input_values`) and a test that checks
+  of those ops (`backward_ignores_values`) and a test that checks
   each one really has that property.
 
 The second condition was learned the hard way: without it, eight models
 were silently wrong by large amounts with nothing visibly different
 about their graphs. The full-corpus comparison at the end of this file
 is what caught it.
+
+Every chain keeps one copying write when its base is a declaration fill rather
+than an op result. That copy restores the full buffer on every evaluation;
+later element or slice writes can share its fresh output. In reverse, untouched
+slice cells pass through the aliased base/output adjoint buffer automatically.
+Overwritten cells are routed to the slice RHS and then cleared from that shared
+buffer, so an earlier write cannot count them again. Direct base/RHS aliases,
+malformed ranges, roots, parameters, and bases without a value-free producer
+before the write all remain copying.
+
+On `Mtbh_model`, re-rolling creates 146 strided stores of four values into a
+730-cell matrix. Re-running this pass leaves the initial full copy and turns
+all 146 stores into four-cell updates, reducing median gradient latency from
+106.5 to 47.4 us (2.24x).
 
 ## Store-to-load forwarding (`inplace.cpp`, same switch)
 

--- a/runtime/src/adjoint.cpp
+++ b/runtime/src/adjoint.cpp
@@ -204,7 +204,7 @@ bool gen_adjoint(IslandProg& p) {
     const Program::Instr& I = orig[i];
     if (I.code == Program::CALL) {
       // The kernel's backward may read its input VALUES, not just its
-      // scratch (backward_ignores_input_values is a whitelist, not a
+      // scratch (backward_ignores_values is a whitelist, not a
       // guarantee), and some read their output values too -- so both are
       // checkpointed whenever a later instruction overwrites them.
       Program::Call& call = fwd.calls[(size_t)I.a];

--- a/runtime/src/inplace.cpp
+++ b/runtime/src/inplace.cpp
@@ -3,8 +3,11 @@
 // `mu[n] = ...` inside a data-bound loop unrolls into a chain of
 // OP_SET_INDEX ops. Each one copies its whole input vector into a fresh
 // slot and then pokes one element, so N writes cost O(N^2) time and O(N^2)
-// arena. Measured on radon_county_intercept (N=12,573): 90.5 ms per
-// gradient and 2.58 GB peak RSS, against CmdStan's 438 us.
+// arena. Re-rolling can turn a run into one OP_SET_SLICE(_STRIDED), but a
+// chain of those still makes one whole-base copy per slice. Measured on
+// radon_county_intercept (N=12,573): 90.5 ms per gradient and 2.58 GB peak
+// RSS, against CmdStan's 438 us; Mtbh_model's strided matrix fills are the
+// corresponding slice shape.
 //
 // A write can mutate its input vector directly when nothing later observes
 // that vector's pre-write contents. The condition is LAST USE, not single
@@ -20,14 +23,16 @@
 //   - this op is the last op reading that slot,
 //   - neither the input nor the output is a root (read straight from the
 //     arena, invisible in the use map) or a parameter, and
+//   - the op that produced this version does not reread its output values in
+//     reverse (exp does, while a preceding copying store does not), and
 //   - no EARLIER reader of that vector needs its values during the reverse
 //     sweep. Forward order makes the values those readers see correct, but
 //     a backward pass runs after every write has landed: `legacy_bwd_vec_in`
 //     (log_sum_exp, softmax, ...) rebuilds its var tape from
 //     `ctx.in[0].data` at reverse time, so a destroyed buffer feeds it the
 //     wrong numbers. Only ops whose backward moves adjoints and never reads
-//     input values may precede a destructive write. Found by the corpus
-//     A/B: without this, 8 HMM/LDA/mixture models were wrong by up to
+//     input or output values may precede a destructive write. Found by the
+//     corpus A/B: without this, 8 HMM/LDA/mixture models were wrong by up to
 //     1.7e+05 relative while every op count looked untouched.
 //
 // The rewrite makes the op's output slot BE its input slot, so `bind_()`
@@ -44,22 +49,89 @@
 
 namespace stanli {
 
-bool backward_ignores_input_values(uint16_t opcode) {
+namespace {
+
+uint16_t inplace_form(uint16_t opcode) {
+  switch (opcode) {
+    case OP_SET_INDEX:
+      return OP_SET_INDEX_INPLACE;
+    case OP_SET_SLICE:
+      return OP_SET_SLICE_INPLACE;
+    case OP_SET_SLICE_STRIDED:
+      return OP_SET_SLICE_STRIDED_INPLACE;
+    default:
+      return 0;
+  }
+}
+
+bool is_inplace_store(uint16_t opcode) {
+  return opcode == OP_SET_INDEX_INPLACE || opcode == OP_SET_SLICE_INPLACE ||
+         opcode == OP_SET_SLICE_STRIDED_INPLACE;
+}
+
+// In-place kernels deliberately omit the base copy, so accept only the exact
+// contracts the copying kernels implement. Besides making the rewrite fail
+// closed on hand-built graphs, the division-form strided bound avoids an
+// overflow in start + (len - 1) * stride.
+bool valid_store_contract(const Graph& g, const Op& op) {
+  if (op.n_in != 2 || op.out2 >= 0 || op.variant != 0 || op.udata != nullptr)
+    return false;
+  if (op.in[0] < 0 || op.in[1] < 0 || op.out < 0 ||
+      op.in[0] >= static_cast<int>(g.slots.size()) ||
+      op.in[1] >= static_cast<int>(g.slots.size()) ||
+      op.out >= static_cast<int>(g.slots.size()))
+    return false;
+  const bool inplace = is_inplace_store(op.opcode);
+  if (inplace) {
+    if (op.out != op.in[0] || op.in[1] == op.in[0] || g.slots[op.out].is_param)
+      return false;
+  } else if (op.out == op.in[0] || op.out == op.in[1] ||
+             g.slots[op.out].is_param ||
+             g.slots[op.out].len != g.slots[op.in[0]].len) {
+    return false;
+  }
+
+  const int64_t base_len = g.slots[op.in[0]].len;
+  const int64_t rhs_len = g.slots[op.in[1]].len;
+  if (base_len < 0 || rhs_len < 0 || op.idata == nullptr) return false;
+  if (op.opcode == OP_SET_INDEX || op.opcode == OP_SET_INDEX_INPLACE) {
+    return op.n_idata == 1 && rhs_len == 1 && op.idata[0] >= 0 &&
+           static_cast<int64_t>(op.idata[0]) < base_len;
+  }
+  if (op.opcode == OP_SET_SLICE || op.opcode == OP_SET_SLICE_INPLACE) {
+    if (op.n_idata != 1 || op.idata[0] < 0) return false;
+    const int64_t start = op.idata[0];
+    return start <= base_len && rhs_len <= base_len - start;
+  }
+  if (op.opcode == OP_SET_SLICE_STRIDED ||
+      op.opcode == OP_SET_SLICE_STRIDED_INPLACE) {
+    if (op.n_idata != 2 || op.idata[0] < 0 || op.idata[1] <= 0) return false;
+    const int64_t start = op.idata[0], stride = op.idata[1];
+    if (rhs_len == 0) return start <= base_len;
+    return start < base_len && rhs_len - 1 <= (base_len - 1 - start) / stride;
+  }
+  return false;
+}
+
+}  // namespace
+
+bool backward_ignores_values(uint16_t opcode) {
   return has_op_trait(opcode, op_trait::kBackwardValueFree);
+}
+
+bool backward_ignores_input_values(uint16_t opcode) {
+  return backward_ignores_values(opcode);
 }
 
 int make_inplace_updates(Graph& g, const std::vector<int>& roots) {
   if (std::getenv("STANLI_NO_INPLACE")) return 0;
 
   const int n_slots = static_cast<int>(g.slots.size());
-  // Last op index that reads each slot, and whether an op writes it.
+  // Last op index that reads each slot.
   std::vector<int> last_use(n_slots, -1);
-  std::vector<char> written(n_slots, 0);
   for (size_t i = 0; i < g.ops.size(); ++i) {
     for (int j = 0; j < g.ops[i].n_in; ++j)
       last_use[g.ops[i].in[j]] = static_cast<int>(i);
-    written[g.ops[i].out] = 1;
-    if (g.ops[i].out2 >= 0) written[g.ops[i].out2] = 1;
   }
   std::unordered_set<int> root_set(roots.begin(), roots.end());
   if (g.result_slot >= 0) root_set.insert(g.result_slot);
@@ -73,38 +145,82 @@ int make_inplace_updates(Graph& g, const std::vector<int>& roots) {
   // Set once some op that will re-read a slot's values during the reverse
   // sweep has consumed it; from then on that slot may not be destroyed.
   std::vector<char> value_reader(n_slots, 0);
+  // A later or pre-existing in-place writer must not make a fill-backed slot
+  // look safe on this second, post-reroll pass. Requiring the fresh producer's
+  // backward to ignore its output also protects producers such as exp, whose
+  // derivative rereads the value a destructive store would replace.
+  std::vector<char> output_safe_producer(n_slots, 0);
 
   int n_rewritten = 0;
   for (size_t i = 0; i < g.ops.size(); ++i) {
     Op& op = g.ops[i];
+    // A rewrite earlier in this same scan may have renamed the slot shared by
+    // an already-destructive store. Preserve its defining out==in[0]
+    // invariant: resolving only the input would leave out naming the dead,
+    // zero-length slot. Verify the original alias before canonicalizing so a
+    // malformed hand-built op cannot acquire legitimacy from the pass.
+    const bool existing_inplace = is_inplace_store(op.opcode);
+    const int original_in0 = op.n_in > 0 ? op.in[0] : -1;
+    const bool original_inplace_alias =
+        existing_inplace && op.out >= 0 && op.out == original_in0;
     for (int j = 0; j < op.n_in; ++j) op.in[j] = resolve(op.in[j]);
-    const bool routes_only = backward_ignores_input_values(op.opcode);
+    if (original_inplace_alias) op.out = op.in[0];
+    const bool valid_existing_inplace =
+        !existing_inplace ||
+        (original_inplace_alias && valid_store_contract(g, op));
+    const auto mark_fresh_output = [&](int out) {
+      if (out < 0) return;
+      for (int j = 0; j < op.n_in; ++j) {
+        if (op.in[j] != out) continue;
+        // A known destructive store preserves the safety (or unsafety) of
+        // the version it mutates. Any other aliased producer replaces the
+        // version with one its own backward may reread, so fail closed.
+        const bool known_destructive_store =
+            existing_inplace && valid_existing_inplace;
+        if (!known_destructive_store) output_safe_producer[out] = 0;
+        return;
+      }
+      output_safe_producer[out] =
+          valid_existing_inplace && backward_ignores_values(op.opcode);
+    };
+    const bool routes_only =
+        backward_ignores_values(op.opcode) && valid_existing_inplace;
 
-    if (op.opcode != OP_SET_INDEX) {
+    const uint16_t inplace_opcode = inplace_form(op.opcode);
+    if (inplace_opcode == 0) {
       if (!routes_only)
         for (int j = 0; j < op.n_in; ++j) value_reader[op.in[j]] = 1;
+      mark_fresh_output(op.out);
+      if (op.out2 >= 0) output_safe_producer[op.out2] = 0;
       continue;
     }
 
     const int vec = op.in[0];
+    // The in-place forward overwrites the base before it could finish reading
+    // an aliased RHS; reverse would also route into and clear one buffer.
+    const bool eligible = valid_store_contract(g, op) && op.in[1] != vec &&
+                          output_safe_producer[vec] && !g.slots[vec].is_param &&
+                          !root_set.count(vec) && !root_set.count(op.out) &&
+                          last_use[vec] == static_cast<int>(i) &&
+                          !value_reader[vec];
+    if (!eligible) {
+      mark_fresh_output(op.out);
+      if (op.out2 >= 0) output_safe_producer[op.out2] = 0;
+      continue;
+    }
     // The renamed slot inherits the original's last use: a read of any
     // link in the chain is a read of the one buffer they now share.
-    if (!written[vec] || g.slots[vec].is_param) continue;
-    if (root_set.count(vec) || root_set.count(op.out)) continue;
-    if (last_use[vec] != static_cast<int>(i)) continue;
-    if (value_reader[vec]) continue;
-
     rename[op.out] = vec;
     // A later read of the old output is a read of the shared buffer, so
     // the surviving slot inherits it: the next write in the chain must not
     // treat itself as the last use while that read is still pending.
     last_use[vec] = std::max(last_use[vec], last_use[op.out]);
     // The old output slot is now unreachable: no op writes or reads it,
-    // and it was neither a root nor fill-backed (checked above), so it
+    // and it was neither a root nor a parameter (checked above), so it
     // needs no arena. Without this the chain still costs O(N^2) memory --
     // bind_() sizes the arenas from slot lengths, not from op references.
     g.slots[op.out].len = 0;
-    op.opcode = OP_SET_INDEX_INPLACE;
+    op.opcode = inplace_opcode;
     op.out = vec;  // out and in[0] are now one slot: one buffer, one adjoint
     ++n_rewritten;
   }
@@ -140,6 +256,16 @@ int forward_stores_to_loads(Graph& g, const std::vector<int>& roots) {
       // The written vector is op.out (both forms), and the element written
       // is idata[0]. A later write to the same vector supersedes this one.
       last_store[op.out] = Store{i, op.idata[0], op.in[1]};
+      continue;
+    }
+    if (op.opcode == OP_SET_SLICE || op.opcode == OP_SET_SLICE_INPLACE ||
+        op.opcode == OP_SET_SLICE_STRIDED ||
+        op.opcode == OP_SET_SLICE_STRIDED_INPLACE) {
+      // A destructive slice may cover the cached element. Copying forms
+      // have a distinct output and therefore erase nothing in ordinary SSA
+      // graphs, but spelling all four contracts keeps this correct for a
+      // hand-built graph too.
+      last_store.erase(op.out);
       continue;
     }
     if (op.opcode == OP_INDEX && op.n_idata == 1) {

--- a/runtime/src/island.cpp
+++ b/runtime/src/island.cpp
@@ -134,6 +134,7 @@ bool in_vocab(const Graph& g, const Op& op) {
     case OP_SET_INDEX_INPLACE:
     case OP_SLICE:
     case OP_SET_SLICE:
+    case OP_SET_SLICE_INPLACE:
       return op.n_idata == 1;
     case OP_DOT:
       return op.n_in == 2 && g.slots[op.in[0]].len == g.slots[op.in[1]].len;
@@ -367,10 +368,14 @@ struct Compiler {
         emit(Program::MOV, d + idx, val);
         return ok;
       }
-      case OP_SET_SLICE: {
+      case OP_SET_SLICE:
+      case OP_SET_SLICE_INPLACE: {
         const int start = op.idata[0];
         const int64_t vlen = g.slots[op.in[1]].len;
         if (op.n_in != 2 || start < 0 || start + vlen > out_len) return false;
+        if (op.opcode == OP_SET_SLICE_INPLACE &&
+            (op.out != op.in[0] || op.in[0] == op.in[1]))
+          return false;
         const int base = read_reg(op.in[0]);
         const int val = read_reg(op.in[1]);
         if (base_dead_here(op.in[0])) reg_of[op.out] = base;
@@ -519,10 +524,15 @@ int carve_islands(Graph& g,
     // and for asking why a region was left alone.)
     if (compiled && !std::getenv("STANLI_ISLAND_ALWAYS")) {
       int64_t graph_elems = 0;
-      for (size_t u = i; u < j; ++u)
-        graph_elems += g.ops[u].opcode == OP_SET_INDEX_INPLACE
-                           ? 1
-                           : g.slots[g.ops[u].out].len;
+      for (size_t u = i; u < j; ++u) {
+        const Op& op = g.ops[u];
+        if (op.opcode == OP_SET_INDEX_INPLACE)
+          graph_elems += 1;
+        else if (op.opcode == OP_SET_SLICE_INPLACE)
+          graph_elems += g.slots[op.in[1]].len;
+        else
+          graph_elems += g.slots[op.out].len;
+      }
       const int64_t graph_cost = graph_elems + kOpCost * (int64_t)(j - i);
       // A CALL should read as cost-NEUTRAL: it runs the graph's own
       // kernel with the graph's own per-call overhead (context assembly,

--- a/runtime/src/lower.cpp
+++ b/runtime/src/lower.cpp
@@ -197,7 +197,7 @@ struct PrepTrace {
   }
 
   Row& next() {
-    // There are currently 18 rows with a write_array graph. Keep this a fixed
+    // There are currently 20 rows with a write_array graph. Keep this a fixed
     // buffer so the profiler itself cannot show up as allocator work.
     if (size_ >= rows_.size()) std::abort();
     return rows_[size_++];
@@ -4237,6 +4237,14 @@ struct Lowering {
                target_terms.size(), out.views.size(), PrepTrace::Extra::Reroll,
                rerolled.regions, rerolled.list_steps, false, 0,
                rerolled.candidate_steps, rerolled.row_steps);
+    // Re-roll can replace many element writes with copying slice stores.
+    // Give those new ops the same last-use proof as the scalar stores.
+    const auto post_reroll_inplace_time = prep.start();
+    const int post_reroll_inplace =
+        rerolled.regions ? make_inplace_updates(g, roots) : 0;
+    prep.graph(prep_graph, "post_reroll_inplace", post_reroll_inplace_time, g,
+               out.fills, target_terms.size(), out.views.size(),
+               PrepTrace::Extra::Rewrites, post_reroll_inplace);
     const auto finalize_time = prep.start();
     // Nothing reads a result here, but forward() asserts a scalar result
     // slot, so point it at one.
@@ -4308,6 +4316,17 @@ struct Lowering {
                target_terms.size(), out.views.size(), PrepTrace::Extra::Reroll,
                rerolled.regions, rerolled.list_steps, false, 0,
                rerolled.candidate_steps, rerolled.row_steps);
+    // Target terms may have been replaced by vector reductions, so rebuild
+    // the implicit-root set before considering the slice stores reroll made.
+    std::vector<int> post_reroll_roots = roots;
+    post_reroll_roots.insert(post_reroll_roots.end(), target_terms.begin(),
+                             target_terms.end());
+    const auto post_reroll_inplace_time = prep.start();
+    const int post_reroll_inplace =
+        rerolled.regions ? make_inplace_updates(g, post_reroll_roots) : 0;
+    prep.graph(prep_graph, "post_reroll_inplace", post_reroll_inplace_time, g,
+               out.fills, target_terms.size(), out.views.size(),
+               PrepTrace::Extra::Rewrites, post_reroll_inplace);
     // LAST, after every other pass has had first crack: compile whatever
     // scalar residue survives (recurrences the re-roll can never widen)
     // into island ops. Off under STANLI_NO_ISLAND.

--- a/tests/test_inplace.cpp
+++ b/tests/test_inplace.cpp
@@ -9,6 +9,7 @@
 
 #include <cmath>
 #include <cstdio>
+#include <limits>
 #include <string>
 #include <utility>
 #include <vector>
@@ -89,6 +90,270 @@ static Graph build_chain(int L, Fills& fills, std::vector<int>& terms,
     prev = nxt;
   }
   return g;
+}
+
+// Two copying slices over a fill-backed vector. The first must keep its copy
+// so every evaluation starts from the fill; the second can reuse that fresh
+// output. The windows overlap deliberately: reverse must clear the later
+// write's cells before the earlier write routes them to its RHS.
+static Graph build_slice_chain(bool strided, Fills& fills,
+                               std::vector<int>& first_pos,
+                               std::vector<int>& second_pos) {
+  const int N = 10, K = 4;
+  Graph g;
+  const int a = g.add_slot(K, true);
+  const int b = g.add_slot(K, true);
+  const int base = g.add_slot(N, false);
+  std::vector<double> base_values(N);
+  for (int i = 0; i < N; ++i) base_values[(size_t)i] = -0.4 + 0.1 * i;
+  fills.emplace_back(base, base_values);
+
+  const int first = g.add_slot(N, false);
+  const int second = g.add_slot(N, false);
+  if (strided) {
+    g.add_op(OP_SET_SLICE_STRIDED, {base, a}, first, {0, 2});
+    g.add_op(OP_SET_SLICE_STRIDED, {first, b}, second, {2, 2});
+    first_pos = {0, 2, 4, 6};
+    second_pos = {2, 4, 6, 8};
+  } else {
+    g.add_op(OP_SET_SLICE, {base, a}, first, {1});
+    g.add_op(OP_SET_SLICE, {first, b}, second, {3});
+    first_pos = {1, 2, 3, 4};
+    second_pos = {3, 4, 5, 6};
+  }
+  const int weights = g.add_slot(N, false);
+  std::vector<double> w(N);
+  for (int i = 0; i < N; ++i) w[(size_t)i] = 0.5 + 0.25 * i;
+  fills.emplace_back(weights, w);
+  const int result = g.add_slot(1, false);
+  g.add_op(OP_DOT, {second, weights}, result);
+  g.result_slot = result;
+  return g;
+}
+
+static void test_slice_chain(bool strided) {
+  const std::string tag = strided ? "strided slice" : "contiguous slice";
+  Fills fills;
+  std::vector<int> first_pos, second_pos;
+  Graph g = build_slice_chain(strided, fills, first_pos, second_pos);
+  Graph ref = g;
+  const std::vector<double> want = run_grad(std::move(ref), fills);
+
+  expect((tag + " one later rewrite").c_str(),
+         make_inplace_updates(g, {}) == 1);
+  int copying = 0, inplace = 0;
+  for (const Op& op : g.ops) {
+    if (strided) {
+      copying += op.opcode == OP_SET_SLICE_STRIDED;
+      inplace += op.opcode == OP_SET_SLICE_STRIDED_INPLACE;
+    } else {
+      copying += op.opcode == OP_SET_SLICE;
+      inplace += op.opcode == OP_SET_SLICE_INPLACE;
+    }
+  }
+  expect((tag + " keeps fill copy").c_str(), copying == 1);
+  expect((tag + " uses one shared buffer").c_str(), inplace == 1);
+
+  const std::vector<double> got = run_grad_twice(std::move(g), fills);
+  expect((tag + " gradient sizes").c_str(), got.size() == want.size());
+  for (size_t i = 0; i < want.size() && i < got.size(); ++i)
+    expect_close((tag + " v" + std::to_string(i)).c_str(), got[i], want[i]);
+
+  // Parameter slots a then b occupy the eight returned gradient cells.
+  for (size_t k = 0; k < first_pos.size(); ++k) {
+    bool overwritten = false;
+    for (int p : second_pos) overwritten = overwritten || p == first_pos[k];
+    const double expected = overwritten ? 0.0 : 0.5 + 0.25 * first_pos[k];
+    expect_close((tag + " first rhs " + std::to_string(k)).c_str(), got[1 + k],
+                 expected);
+    expect_close((tag + " second rhs " + std::to_string(k)).c_str(),
+                 got[1 + first_pos.size() + k], 0.5 + 0.25 * second_pos[k]);
+  }
+}
+
+static void test_slice_rewrite_bails() {
+  {  // A base read outside the graph is never overwritten.
+    Fills fills;
+    std::vector<int> first_pos, second_pos;
+    Graph g = build_slice_chain(true, fills, first_pos, second_pos);
+    const int second_base = g.ops[1].in[0];
+    expect("slice root blocks rewrite",
+           make_inplace_updates(g, {second_base}) == 0);
+  }
+  {  // Direct base/RHS aliasing is unsafe in both sweeps.
+    Graph g;
+    const int rhs = g.add_slot(4, true);
+    const int fill = g.add_slot(4, false);
+    const int fresh = g.add_slot(4, false);
+    g.add_op(OP_SET_SLICE, {fill, rhs}, fresh, {0});
+    const int out = g.add_slot(4, false);
+    g.add_op(OP_SET_SLICE, {fresh, fresh}, out, {0});
+    expect("slice base-rhs alias refused", make_inplace_updates(g, {}) == 0);
+  }
+  {  // A malformed comb fails closed without overflowing its bound check.
+    Graph g;
+    const int rhs = g.add_slot(4, true);
+    const int fill = g.add_slot(8, false);
+    const int fresh = g.add_slot(8, false);
+    g.add_op(OP_SET_SLICE, {fill, rhs}, fresh, {0});
+    const int out = g.add_slot(8, false);
+    g.add_op(OP_SET_SLICE_STRIDED, {fresh, rhs}, out,
+             {7, std::numeric_limits<int>::max()});
+    expect("slice malformed range refused", make_inplace_updates(g, {}) == 0);
+  }
+  {  // Pre-existing destructive writers do not make a fill a fresh value.
+    Graph g;
+    const int rhs = g.add_slot(2, true);
+    const int fill = g.add_slot(6, false);
+    const int scalar = g.add_slot(1, true);
+    g.add_op(OP_SET_INDEX_INPLACE, {fill, scalar}, fill, {0});
+    const int out = g.add_slot(6, false);
+    g.add_op(OP_SET_SLICE, {fill, rhs}, out, {1});
+    expect("prior inplace writer is not a producer",
+           make_inplace_updates(g, {}) == 0);
+  }
+  {  // An output-reading aliased op invalidates an earlier safe producer.
+    Graph g;
+    const int rhs = g.add_slot(2, true);
+    const int fill = g.add_slot(4, false);
+    const int fresh = g.add_slot(4, false);
+    g.add_op(OP_SET_SLICE, {fill, rhs}, fresh, {0});
+    g.add_op(OP_EXPV, {fresh}, fresh);
+    const int out = g.add_slot(4, false);
+    g.add_op(OP_SET_SLICE, {fresh, rhs}, out, {2});
+    expect("aliased exp clears producer safety",
+           make_inplace_updates(g, {}) == 0);
+  }
+  {  // A malformed destructive opcode must not certify a fresh output.
+    Graph g;
+    const int rhs = g.add_slot(2, true);
+    const int fill = g.add_slot(4, false);
+    const int fresh = g.add_slot(4, false);
+    g.add_op(OP_SET_SLICE, {fill, rhs}, fresh, {0});
+    const int malformed = g.add_slot(4, false);
+    g.add_op(OP_SET_SLICE_INPLACE, {fresh, rhs}, malformed, {0});
+    const int out = g.add_slot(4, false);
+    g.add_op(OP_SET_SLICE, {malformed, rhs}, out, {2});
+    expect("malformed inplace is not a safe producer",
+           make_inplace_updates(g, {}) == 0);
+  }
+}
+
+// Last-use and earlier-reader proofs are not enough: the op that produced the
+// base can need its own output value during reverse. EXPV does. Its first
+// update must therefore copy, while that copying store safely produces the
+// version a second update may reuse.
+static void test_output_reading_producer_keeps_copy() {
+  Graph g;
+  const int p = g.add_slot(4, true);
+  const int first_rhs = g.add_slot(2, true);
+  const int second_rhs = g.add_slot(2, true);
+  const int exp_p = g.add_slot(4, false);
+  g.add_op(OP_EXPV, {p}, exp_p);
+  const int old = g.add_slot(1, false);
+  g.add_op(OP_INDEX, {exp_p}, old, {0});
+  const int first = g.add_slot(4, false);
+  g.add_op(OP_SET_SLICE, {exp_p, first_rhs}, first, {0});
+  const int second = g.add_slot(4, false);
+  g.add_op(OP_SET_SLICE, {first, second_rhs}, second, {2});
+  const int sum = g.add_slot(1, false);
+  g.add_op(OP_SUM_VEC, {second}, sum);
+  const int result = g.add_slot(1, false);
+  g.add_op(OP_ADD, {old, sum}, result);
+  g.result_slot = result;
+
+  Graph ref = g;
+  const std::vector<double> want = run_grad(std::move(ref), {});
+  expect("exp producer keeps first slice copy",
+         make_inplace_updates(g, {}) == 1);
+  int copying = 0, inplace = 0;
+  for (const Op& op : g.ops) {
+    copying += op.opcode == OP_SET_SLICE;
+    inplace += op.opcode == OP_SET_SLICE_INPLACE;
+  }
+  expect("exp producer one copying slice", copying == 1);
+  expect("exp producer later slice inplace", inplace == 1);
+  const std::vector<double> got = run_grad_twice(std::move(g), {});
+  for (size_t i = 0; i < want.size() && i < got.size(); ++i)
+    expect_close(("exp producer v" + std::to_string(i)).c_str(), got[i],
+                 want[i]);
+}
+
+// Reroll can leave scalar destructive stores after the slice stores it
+// creates. If an earlier slice is then aliased back to its base, both sides
+// of every already-in-place op must follow that rename. Resolving only in[0]
+// leaves out pointing at the tombstoned slot (the five-model corpus failure
+// this regression was distilled from).
+static void test_slice_rename_rebinds_existing_inplace_output() {
+  Graph g;
+  const int a = g.add_slot(2, true);
+  const int b = g.add_slot(2, true);
+  const int scalar = g.add_slot(1, true);
+  const int base = g.add_slot(6, false);
+  const int first = g.add_slot(6, false);
+  g.add_op(OP_SET_SLICE, {base, a}, first, {0});
+  const int second = g.add_slot(6, false);
+  g.add_op(OP_SET_SLICE, {first, b}, second, {2});
+  g.add_op(OP_SET_INDEX_INPLACE, {second, scalar}, second, {5});
+  const int weights = g.add_slot(6, false);
+  const int result = g.add_slot(1, false);
+  g.add_op(OP_DOT, {second, weights}, result);
+  g.result_slot = result;
+  Fills fills{{base, {0.1, 0.2, 0.3, 0.4, 0.5, 0.6}},
+              {weights, {0.5, 0.75, 1.0, 1.25, 1.5, 1.75}}};
+
+  Graph ref = g;
+  const std::vector<double> want = run_grad(std::move(ref), fills);
+  expect("slice rename rewrites later copy", make_inplace_updates(g, {}) == 1);
+  expect("slice rename tombstones old output", g.slots[second].len == 0);
+  const Op& terminal = g.ops[2];
+  expect("existing inplace output follows input rename",
+         terminal.opcode == OP_SET_INDEX_INPLACE && terminal.in[0] == first &&
+             terminal.out == first);
+  const std::vector<double> got = run_grad_twice(std::move(g), fills);
+  for (size_t i = 0; i < want.size() && i < got.size(); ++i)
+    expect_close(("slice rebind v" + std::to_string(i)).c_str(), got[i],
+                 want[i]);
+}
+
+// Store-to-load forwarding caches the last scalar element write. An
+// intervening in-place slice invalidates that cache: the later read must see
+// the slice RHS, not the stale scalar value.
+static void test_slice_invalidates_store_forwarding(bool strided) {
+  const std::string tag =
+      strided ? "strided slice invalidates" : "slice invalidates";
+  Graph g;
+  const int scalar = g.add_slot(1, true);
+  const int rhs = g.add_slot(2, true);
+  const int template_vec = g.add_slot(4, false);
+  const int base = g.add_slot(4, false);
+  // This first functional store keeps its fill copy and is an explicitly
+  // value-free producer. Store forwarding will cache its element.
+  g.add_op(OP_SET_INDEX, {template_vec, scalar}, base, {1});
+  const int updated = g.add_slot(4, false);
+  if (strided)
+    g.add_op(OP_SET_SLICE_STRIDED, {base, rhs}, updated, {1, 2});
+  else
+    g.add_op(OP_SET_SLICE, {base, rhs}, updated, {1});
+  const int read = g.add_slot(1, false);
+  g.add_op(OP_INDEX, {updated}, read, {1});
+  // Keep the INDEX itself out of the root set so forwarding would really
+  // drop it if the intervening slice failed to invalidate the cache.
+  const int result = g.add_slot(1, false);
+  g.add_op(OP_EXP, {read}, result);
+  g.result_slot = result;
+
+  Graph ref = g;
+  const std::vector<double> want = run_grad(std::move(ref), {});
+  expect((tag + " rewrites").c_str(), make_inplace_updates(g, {}) == 1);
+  expect((tag + " keeps later read").c_str(),
+         forward_stores_to_loads(g, {}) == 0);
+  int reads = 0;
+  for (const Op& op : g.ops) reads += op.opcode == OP_INDEX;
+  expect((tag + " index survives").c_str(), reads == 1);
+  const std::vector<double> got = run_grad_twice(std::move(g), {});
+  for (size_t i = 0; i < want.size() && i < got.size(); ++i)
+    expect_close((tag + " v" + std::to_string(i)).c_str(), got[i], want[i]);
 }
 
 static void test_chain_collapses() {
@@ -393,6 +658,13 @@ static void test_env_disable() {
 
 int main() {
   test_chain_collapses();
+  test_slice_chain(false);
+  test_slice_chain(true);
+  test_slice_rewrite_bails();
+  test_output_reading_producer_keeps_copy();
+  test_slice_rename_rebinds_existing_inplace_output();
+  test_slice_invalidates_store_forwarding(false);
+  test_slice_invalidates_store_forwarding(true);
   test_env_disable();
   test_native_lse_allows_destructive();
   test_store_to_load_forwarding();

--- a/tests/test_island.cpp
+++ b/tests/test_island.cpp
@@ -479,6 +479,52 @@ static void test_live_in_and_out_slot() {
     expect_close("liveinout v" + std::to_string(i), got[i], want[i]);
 }
 
+static Graph build_slice_island(int n_updates, int width,
+                                std::vector<int>& terms) {
+  Graph g;
+  const int seed = g.add_slot(1, true);
+  const int rhs = g.add_slot(2, true);
+  const int vec = g.add_slot(width, false);
+  g.add_op(OP_REP_VEC, {seed}, vec);  // vector-out barrier before the region
+  for (int k = 0; k < n_updates; ++k)
+    // Repeated overlapping windows exercise last-write-wins in the generated
+    // adjoint: each later MOVR must consume the cells before an earlier one.
+    g.add_op(OP_SET_SLICE_INPLACE, {vec, rhs}, vec, {k % 5});
+  const int lp = g.add_slot(1, false);
+  g.add_op(OP_LOG_SUM_EXP, {vec}, lp);
+  g.result_slot = lp;
+  terms.push_back(lp);
+  return g;
+}
+
+static void test_inplace_slices_carved() {
+  std::vector<int> ref_terms;
+  Graph ref = build_slice_island(36, 40, ref_terms);
+  const std::vector<double> want = run_grad(std::move(ref), {});
+
+  std::vector<int> terms;
+  Graph g = build_slice_island(36, 40, terms);
+  Fills fills;
+  expect("slice inplace island carved",
+         carve_islands(g, fills, terms, {}) == 1);
+  const std::vector<double> got = run_grad(std::move(g), {});
+  for (size_t i = 0; i < want.size() && i < got.size(); ++i)
+    expect_close("slice island v" + std::to_string(i), got[i], want[i]);
+}
+
+// In-place slice cost is the RHS window, not the wide aliased output. If it
+// were charged as a full-vector copy, this register-heavy region would look
+// profitable and the carver would build a 4K-register island for tiny writes.
+static void test_inplace_slice_cost_refuses_wide_state() {
+  std::vector<int> terms;
+  Graph g = build_slice_island(36, 4096, terms);
+  Fills fills;
+  const size_t before = g.ops.size();
+  expect("wide inplace slices not carved",
+         carve_islands(g, fills, terms, {}) == 0);
+  expect("wide inplace slice graph unchanged", g.ops.size() == before);
+}
+
 int main() {
   // What the compiler does with a region, on graphs small enough to
   // reason about. The cost estimate would refuse most of them -- it is
@@ -488,6 +534,7 @@ int main() {
   test_hmm_parity();
   test_env_disable();
   test_live_in_and_out_slot();
+  test_inplace_slices_carved();
   test_short_run_untouched();
   test_propto_density_refused();
   test_unsupported_op_splits();
@@ -499,6 +546,7 @@ int main() {
   test_wide_state_refused();
   test_vector_copies_carved();
   test_scalar_chain_carved();
+  test_inplace_slice_cost_refuses_wide_state();
   if (failures) {
     std::printf("%d failures\n", failures);
     return 1;

--- a/tests/test_pass_safety.cpp
+++ b/tests/test_pass_safety.cpp
@@ -1,13 +1,13 @@
 // Safety properties the graph passes depend on, tested directly rather
 // than through the models that happen to exercise them.
 //
-// 1. The whitelist is real. `backward_ignores_input_values(op)` is what
+// 1. The whitelist is real. `backward_ignores_values(op)` is what
 //    lets a destructive write happen before an op's backward runs. Every
-//    opcode it claims is checked by poisoning the input buffers with NaN
-//    between the forward and backward sweeps: a kernel that reads values
-//    there produces NaN adjoints and fails. This is the check that would
-//    have caught the log_sum_exp bug immediately -- it was found instead
-//    by the corpus A/B, after 8 models had been silently wrong.
+//    opcode it claims is checked by poisoning every input and output value
+//    buffer with NaN between the forward and backward sweeps: a kernel that
+//    reads values there produces NaN adjoints and fails. This is the check
+//    that would have caught the log_sum_exp bug immediately -- it was found
+//    instead by the corpus A/B, after 8 models had been silently wrong.
 //
 // 2. The passes are gradient-preserving on randomly generated graphs
 //    built from the shapes real models produce (write chains, read-backs,
@@ -43,12 +43,12 @@ using stanli::testutil::reduce_into_result;
 
 // ---- 1. the whitelist ------------------------------------------------------
 
-// Runs one opcode's forward, optionally poisons every input value, then
-// runs its backward and returns the resulting input adjoints.
+// Runs one opcode's forward, optionally poisons all input and output values,
+// then runs its backward and returns the resulting input adjoints.
 static std::vector<double> route_adjoints(uint16_t oc, bool poison) {
   const int64_t N = 6;
-  std::vector<double> vec(N), out(N, 0.0), scalar{0.75};
-  std::vector<double> vec_adj(N, 0.0), out_adj(N, 0.0), scalar_adj{0.0};
+  std::vector<double> vec(N), out(N, 0.0), rhs{0.75, -0.3, 1.1};
+  std::vector<double> vec_adj(N, 0.0), out_adj(N, 0.0), rhs_adj(3, 0.0);
   // Extra operands for the multi-argument mixture ops, and the scratch the
   // native ones stash partials in (a separate arena a destructive write
   // never touches -- which is exactly why their backward is value-free).
@@ -84,8 +84,24 @@ static std::vector<double> route_adjoints(uint16_t oc, bool poison) {
       idata = {2};
       out_len = N;
       ctx.n_in = 2;
-      ctx.in[1] = Desc{scalar.data(), 1};
-      ctx.in_adj[1] = Desc{scalar_adj.data(), 1};
+      ctx.in[1] = Desc{rhs.data(), 1};
+      ctx.in_adj[1] = Desc{rhs_adj.data(), 1};
+      break;
+    case OP_SET_SLICE:
+    case OP_SET_SLICE_INPLACE:
+      idata = {2};
+      out_len = N;
+      ctx.n_in = 2;
+      ctx.in[1] = Desc{rhs.data(), 3};
+      ctx.in_adj[1] = Desc{rhs_adj.data(), 3};
+      break;
+    case OP_SET_SLICE_STRIDED:
+    case OP_SET_SLICE_STRIDED_INPLACE:
+      idata = {0, 2};
+      out_len = N;
+      ctx.n_in = 2;
+      ctx.in[1] = Desc{rhs.data(), 3};
+      ctx.in_adj[1] = Desc{rhs_adj.data(), 3};
       break;
     case OP_LOG_SUM_EXP:
       out_len = 1;
@@ -119,7 +135,9 @@ static std::vector<double> route_adjoints(uint16_t oc, bool poison) {
       return {};
   }
   // The in-place form writes through its first input: one buffer.
-  const bool aliased = oc == OP_SET_INDEX_INPLACE;
+  const bool aliased = oc == OP_SET_INDEX_INPLACE ||
+                       oc == OP_SET_SLICE_INPLACE ||
+                       oc == OP_SET_SLICE_STRIDED_INPLACE;
   ctx.out = Desc{aliased ? vec.data() : out.data(), out_len};
   ctx.idata = idata.data();
   ctx.n_idata = (int64_t)idata.size();
@@ -129,22 +147,23 @@ static std::vector<double> route_adjoints(uint16_t oc, bool poison) {
 
   // Seed adjoints, then destroy the values the way a later destructive
   // write would. Adjoint buffers are deliberately left alone.
-  for (int64_t i = 0; i < out_len; ++i) out_adj[i] = 1.0 + 0.5 * i;
-  ctx.out_adj = out_adj[0];
-  ctx.out_adj_vec = Desc{out_adj.data(), out_len};
+  double* seeded_adj = aliased ? vec_adj.data() : out_adj.data();
+  for (int64_t i = 0; i < out_len; ++i) seeded_adj[i] = 1.0 + 0.5 * i;
+  ctx.out_adj = seeded_adj[0];
+  ctx.out_adj_vec = Desc{seeded_adj, out_len};
   if (poison) {
     const double nan = std::nan("");
     for (int64_t i = 0; i < N; ++i) vec[i] = nan;
-    scalar[0] = nan;
+    for (double& x : rhs) x = nan;
     b_in[0] = nan;
     c_in[0] = nan;
-    if (!aliased)
-      for (int64_t i = 0; i < out_len; ++i) out[i] = nan;
+    double* output_values = aliased ? vec.data() : out.data();
+    for (int64_t i = 0; i < out_len; ++i) output_values[i] = nan;
   }
   k.backward(ctx);
 
   std::vector<double> got = vec_adj;
-  got.push_back(scalar_adj[0]);
+  got.insert(got.end(), rhs_adj.begin(), rhs_adj.end());
   got.push_back(b_adj[0]);
   got.push_back(c_adj[0]);
   return got;
@@ -164,7 +183,7 @@ static void test_whitelist_backwards_ignore_values() {
   }
   int checked = 0;
   for (uint16_t oc = 1; oc < OP_COUNT_; ++oc) {
-    if (!backward_ignores_input_values(oc)) continue;
+    if (!backward_ignores_values(oc)) continue;
     const std::string name = opcode_name(oc);
     const std::vector<double> clean = route_adjoints(oc, /*poison=*/false);
     if (clean.empty()) {
@@ -179,7 +198,7 @@ static void test_whitelist_backwards_ignore_values() {
     for (size_t i = 0; i < clean.size(); ++i) {
       if (clean[i] != poisoned[i] || !std::isfinite(poisoned[i])) {
         ++failures;
-        std::printf("FAIL %s backward reads input values (adj[%zu] %g -> %g)\n",
+        std::printf("FAIL %s backward reads values (adj[%zu] %g -> %g)\n",
                     name.c_str(), i, clean[i], poisoned[i]);
         break;
       }
@@ -293,6 +312,7 @@ static void test_random_graphs_preserve_gradients() {
     make_inplace_updates(g, {});
     forward_stores_to_loads(g, {});
     reroll(g, f2, tt, {});
+    make_inplace_updates(g, tt);  // slice stores reroll just created
     // The whole pipeline, in order. Islands are forced on: these graphs
     // are small, so the pass's cost estimate would decline nearly all of
     // them, and it is the compiler that this test is for.

--- a/tests/test_reroll.cpp
+++ b/tests/test_reroll.cpp
@@ -4,6 +4,7 @@
 #include "graph_helpers.hpp"
 #include <stanli/compile.hpp>
 #include <stanli/graph.hpp>
+#include <stanli/inplace.hpp>
 #include <stanli/optable.hpp>
 #include <stanli/reroll.hpp>
 
@@ -1197,6 +1198,72 @@ static void test_write_fusion_bails() {
   }
 }
 
+// Reroll creates slice stores after the compiler's first in-place pass has
+// already run. Two disjoint comb runs model Mtbh's column fills: the first
+// store must copy its fill-backed base, while the second can reuse that fresh
+// result when the pass runs again.
+static void test_post_reroll_slice_inplace() {
+  Graph g;
+  Fills fills;
+  const int a = g.add_slot(8, true), sigma = g.add_slot(1, true);
+  const int yh = g.add_slot(8, false);
+  fills.emplace_back(yh, std::vector<double>(8, -0.25));
+  const int yd = g.add_slot(8, false);
+  fills.emplace_back(yd, std::vector<double>(8, 0.75));
+
+  for (int l = 0; l < 4; ++l) {
+    const int v = g.add_slot(1, false);
+    g.add_op(OP_INDEX, {a}, v, {l});
+    g.add_op(OP_SET_INDEX_INPLACE, {yh, v}, yh, {2 * l});
+  }
+  // A non-lane scalar op separates the two affine store regions.
+  const int sep = g.add_slot(1, false);
+  g.add_op(OP_SUM_VEC, {a}, sep);
+  for (int l = 0; l < 4; ++l) {
+    const int v = g.add_slot(1, false);
+    g.add_op(OP_INDEX, {a}, v, {4 + l});
+    g.add_op(OP_SET_INDEX_INPLACE, {yh, v}, yh, {1 + 2 * l});
+  }
+  const int lp = g.add_slot(1, false);
+  const int id = g.add_op(OP_NORMAL_LPDF, {yd, yh, sigma}, lp);
+  g.ops[(size_t)id].variant = 0x06;
+  std::vector<int> terms{sep, lp};
+
+  Graph ref = g;
+  std::vector<int> ref_terms = terms;
+  reduce_into_result(ref, ref_terms);
+  const std::vector<double> want = run_grad(std::move(ref), fills);
+
+  Fills optimized_fills = fills;
+  std::vector<int> optimized_terms = terms;
+  reroll(g, optimized_fills, optimized_terms, {});
+  expect("reroll made two strided stores",
+         writefuse::count(g, OP_SET_SLICE_STRIDED) == 2);
+  std::vector<int> roots = optimized_terms;
+  expect("post-reroll rewrites later slice",
+         make_inplace_updates(g, roots) == 1);
+  expect("post-reroll preserves first copy",
+         writefuse::count(g, OP_SET_SLICE_STRIDED) == 1 &&
+             writefuse::count(g, OP_SET_SLICE_STRIDED_INPLACE) == 1);
+  reduce_into_result(g, optimized_terms);
+
+  Executor ex(std::move(g));
+  for (const auto& f : optimized_fills) {
+    double* p = ex.value_ptr(f.first);
+    for (size_t j = 0; j < f.second.size(); ++j) p[j] = f.second[j];
+  }
+  for (int64_t i = 0; i < ex.n_params(); ++i) ex.params_data()[i] = fill_at(i);
+  std::vector<double> first(1 + ex.n_params()), second(1 + ex.n_params());
+  first[0] = ex.gradient(first.data() + 1);
+  second[0] = ex.gradient(second.data() + 1);
+  for (size_t i = 0; i < want.size() && i < first.size(); ++i) {
+    expect_close(("post-reroll v" + std::to_string(i)).c_str(), first[i],
+                 want[i]);
+    expect_close(("post-reroll repeat v" + std::to_string(i)).c_str(),
+                 second[i], first[i]);
+  }
+}
+
 // (k) The losscurve shape: a run whose value chain is scalar end to end,
 // because its lane-varying inputs all come from HOISTED producers. Widening
 // such an op hands the kernels scalar inputs with a vector output, and their
@@ -1407,6 +1474,7 @@ int main() {
   test_sparse_candidate_cost();
   test_write_fusion();
   test_write_fusion_bails();
+  test_post_reroll_slice_inplace();
   test_write_fusion_scalar_chain();
   test_e2e_fixtures();
   if (failures) {


### PR DESCRIPTION
Depends on #157 and is intentionally based on `perf/prep-adjoints-row-lse`.

## Summary

- add destructive contiguous and strided slice-store kernels
- extend the last-use/value-safety proof from element stores to slice stores
- rerun that proof after reroll creates slice stores, while skipping the scan when reroll changed no regions
- preserve pre-existing destructive-store aliases through slot renames
- teach contiguous islands and the cost model about in-place slices
- invalidate scalar store forwarding across slice writes

## Result

`Mtbh_model` rerolls 584 scalar writes into 146 strided stores. Previously each store copied all 730 matrix cells; now one initial copy remains and each store updates its four cells.

| measurement | before | after |
|---|---:|---:|
| gradient latency | 106.5 us | 47.4 us |
| relative to CmdStan | 0.43x | 0.95x |
| slice-store profile share | 42.4% | 5.5% |
| log-prob slot elements | 115,923 | 9,343 |

The gradient path is 2.24x faster, with the same 1,585-op graph. Direct replay of `Mtbh_model` remains within 3.61e-15 of the CmdStan references.

## Safety

The destructive rewrite now requires both the earlier readers and the producer of the current buffer version to have a value-free backward. The poison harness destroys every claimed opcode input and output before reverse mode. Focused tests cover overlapping contiguous/strided writes, repeated evaluation, producer-output dependencies, roots and aliases, malformed contracts, store-forward invalidation, post-reroll roots, existing in-place stores after renamed slices, and island adjoints/costing.

## Validation

- clean Release build: 291/291 targets
- CTest: 55/55 passed
- CmdStan oracle: 129/129 models at all 3 points, 800,674 values; worst relative deviation 1.79e-11
- format, generated docs, generated web-model catalog, and `git diff --check`: passed
