### PR TITLE
perf: specialize Bernoulli density forwards

### DIFF
--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -18,15 +18,18 @@ The harness now records file read, parse, compile, construction, and binding
 only; that column should be refreshed as a unit rather than mixing definitions.
 Targeted preparation measurements later on this page use the new mode.
 
-Two targeted 2026-08-23 remeasurements are newer than the full snapshot below.
+Three targeted 2026-08-23 remeasurements are newer than the full snapshot below.
 Packed row-wise `log_sum_exp` reduces `ldaK2` from 15,854 ops to 22 and
 154 to 94 us/gradient (1.11x CmdStan), and `ldaK5` from 434,126 ops to 156
 and 6.82 to 3.70 ms/gradient (1.51x CmdStan). `ldaK5` file-to-bound-model
 preparation also falls from about 0.59 s to 0.27 s. In-place slice stores move
 `Mtbh_model` from 106.5 to 47.4 us/gradient (0.43x to 0.95x CmdStan): its 146
 strided stores still dispatch once each, but update four cells instead of
-copying all 730. The committed full-corpus tables retain one measurement
-definition and will be refreshed as a unit.
+copying all 730. Native Bernoulli forwards then move `Mt_model` from 30.6 to
+19.2 us (0.62x to 0.99x CmdStan), `Mth_model` from 113.2 to 57.3 us (0.90x to
+1.77x), and the stacked `Mtbh_model` result from 47.4 to 26.8 us (0.95x to
+1.68x). The committed full-corpus tables retain one measurement definition
+and will be refreshed as a unit.
 
 ## Per-gradient latency
 
@@ -161,6 +164,15 @@ headline measurements:
   values rather than copying a 730-value matrix. Median gradient latency
   falls 106.5 -> 47.4 us (2.24x); direct replay remains within 3.61e-15 of
   the CmdStan references across 465 values.
+- **Native Bernoulli forwards** (recorder-bound scalar and short-vector
+  calls): both Bernoulli parameterizations have one real argument and one
+  analytic partial, so they write that column directly into the density
+  scratch instead of constructing the generic recorder edge. Summed vector
+  logits preserve Eigen's packet `exp`, select, and reduction order while
+  reusing the partial column as their `ntheta` workspace. `Mt_model` falls
+  30.6 -> 19.2 us, `Mth_model` 113.2 -> 57.3 us, and `Mtbh_model` 47.4 ->
+  26.8 us after the slice fix. The combined `Mtbh_model` improvement is
+  106.5 -> 26.8 us (3.98x), ending at 1.68x CmdStan.
 - **Elementwise-lp fusion** (the mixture idiom): `low_dim_gauss_mix`
   7,208 ops -> 16, crossing parity (0.78x -> 1.07x); `normal_mixture`
   13 ops, 1.09x.

--- a/docs/superpowers/plans/2026-08-08-cmdstan-parity-roadmap.md
+++ b/docs/superpowers/plans/2026-08-08-cmdstan-parity-roadmap.md
@@ -160,9 +160,10 @@ Alongside it, the tail fixes the profile already names:
 - **Row-wise `log_sum_exp`** closes `ldaK2`/`ldaK5` (0.71x). The K=2
   case is already closed by the elementwise-lp fusion.
 - **Kernel-bound stragglers**, in the shape of the `diamonds` and
-  `prophet` fixes: `Mt_model` (62% in a scalar `bernoulli_lpmf`),
-  `gp_regr` (55% in `multi_normal_cholesky_lpdf`), `kronecker_gp` (38%
-  in an eigendecomposition).
+  `prophet` fixes. `Mt_model` is now closed: direct Bernoulli partials move it
+  from 30.6 to 19.2 us/gradient, or 0.99x CmdStan. Remaining examples include
+  `gp_regr` (55% in `multi_normal_cholesky_lpdf`) and `kronecker_gp` (38% in
+  an eigendecomposition).
 - **Two loose threads.** `lotka_volterra` is 0.61x per gradient yet blows
   the 900 s sampling cap CmdStan clears in 6.2 s — untraced, and
   `tools/sampler_trace.py` is the tool. `sir`'s benchmark probe point

--- a/runtime/kernels/densities_lpmf.cpp
+++ b/runtime/kernels/densities_lpmf.cpp
@@ -10,11 +10,214 @@ namespace stanli {
 namespace dens {
 
 STANLI_LPMF_FWD(poisson_log_fwd, poisson_log_lpmf, 1)
-STANLI_LPMF_FWD(bernoulli_logit_fwd, bernoulli_logit_lpmf, 1)
-STANLI_LPMF_FWD(bernoulli_fwd, bernoulli_lpmf, 1)
+STANLI_LPMF_FWD(bernoulli_logit_recorded_fwd, bernoulli_logit_lpmf, 1)
 STANLI_LPMF_FWD(poisson_fwd, poisson_lpmf, 1)
 STANLI_LPMF_FWD(neg_binomial_2_fwd, neg_binomial_2_lpmf, 2)
 #undef STANLI_LPMF_FWD
+
+namespace {
+
+// The generic density recorder is valuable for distributions with several
+// arguments and complicated partials. Bernoulli's only real argument has a
+// closed-form partial, though, and these kernels commonly appear hundreds of
+// times in a graph. Keep Stan Math responsible for Bernoulli values and all
+// scalar calls; the hot vector-logit branch below mirrors its body and packet
+// reduction exactly. Both write the one partial column directly into
+// density_bwd<1>'s existing scratch layout.
+inline bool bernoulli_arg_active(const KernelCtx& ctx) {
+  return ctx.variant == 0 || (ctx.variant & 0x01u) != 0;
+}
+
+inline bool bernoulli_drop_propto(const KernelCtx& ctx) {
+  constexpr bool has_propto = (density_tier(3) & STANLI_DENSITY_PROPTO) != 0;
+  return has_propto && (ctx.variant & 0x80u) != 0 && !bernoulli_arg_active(ctx);
+}
+
+template <bool Logit>
+double bernoulli_value(int y, double theta, bool drop) {
+  if constexpr (Logit) {
+    return drop ? stan::math::bernoulli_logit_lpmf<true>(y, theta)
+                : stan::math::bernoulli_logit_lpmf<false>(y, theta);
+  } else {
+    return drop ? stan::math::bernoulli_lpmf<true>(y, theta)
+                : stan::math::bernoulli_lpmf<false>(y, theta);
+  }
+}
+
+template <bool Logit>
+double bernoulli_value(const Eigen::Map<const Eigen::VectorXi>& y,
+                       const Desc& theta, bool drop) {
+  if (theta.len == 1) {
+    if constexpr (Logit) {
+      return drop ? stan::math::bernoulli_logit_lpmf<true>(y, theta.data[0])
+                  : stan::math::bernoulli_logit_lpmf<false>(y, theta.data[0]);
+    } else {
+      return drop ? stan::math::bernoulli_lpmf<true>(y, theta.data[0])
+                  : stan::math::bernoulli_lpmf<false>(y, theta.data[0]);
+    }
+  }
+  const Eigen::Map<const Eigen::VectorXd> theta_vec(theta.data, theta.len);
+  if constexpr (Logit) {
+    return drop ? stan::math::bernoulli_logit_lpmf<true>(y, theta_vec)
+                : stan::math::bernoulli_logit_lpmf<false>(y, theta_vec);
+  } else {
+    return drop ? stan::math::bernoulli_lpmf<true>(y, theta_vec)
+                : stan::math::bernoulli_lpmf<false>(y, theta_vec);
+  }
+}
+
+inline double bernoulli_partial(int y, double theta) {
+  return y == 1 ? stan::math::inv(theta) : stan::math::inv(theta - 1.0);
+}
+
+// This deliberately mirrors the strict inequalities and even the high-tail
+// partial in the pinned Stan Math implementation. In particular, infinities
+// are accepted (only NaN is rejected), and z == +/-20 takes the middle arm.
+inline double bernoulli_logit_partial(int y, double theta) {
+  const double sign = 2.0 * y - 1.0;
+  const double z = sign * theta;
+  const double exp_m_z = std::exp(-z);
+  if (z > 20.0) return -exp_m_z;
+  if (z >= -20.0) return sign * exp_m_z / (exp_m_z + 1.0);
+  return sign;
+}
+
+// The hot summed/vector shape needs Eigen's packet exp and reduction order to
+// stay bitwise with Stan Math. Its one partial column is also exactly the size
+// of ntheta, so use that existing scratch as the temporary and then overwrite
+// it with the finished partials. Compared with the recorder path this removes
+// both the ntheta allocation and the recorder edge/partial allocation.
+void bernoulli_logit_vector_fwd(KernelCtx& ctx) {
+  static constexpr const char* function = "bernoulli_logit_lpmf";
+  static constexpr double cutoff = 20.0;
+  const Desc& theta = ctx.in[0];
+  const Eigen::Map<const Eigen::VectorXi> y(
+      ctx.idata, static_cast<Eigen::Index>(ctx.n_idata));
+  const Eigen::Map<const Eigen::VectorXd> theta_vec(theta.data, theta.len);
+
+  stan::math::check_consistent_sizes(function, "Random variable", y,
+                                     "Probability parameter", theta_vec);
+  std::fill_n(ctx.scratch, static_cast<size_t>(theta.len + 1), 0.0);
+  if (stan::math::size_zero(y, theta_vec)) {
+    ctx.out.data[0] = 0.0;
+    return;
+  }
+  stan::math::check_bounded(function, "n", y, 0, 1);
+  decltype(auto) theta_val = stan::math::to_ref(
+      stan::math::as_value_column_array_or_scalar(theta_vec));
+  stan::math::check_not_nan(function, "Logit transformed probability parameter",
+                            theta_val);
+  if (bernoulli_drop_propto(ctx)) {
+    ctx.out.data[0] = 0.0;
+    return;
+  }
+
+  const auto& n_col = stan::math::as_column_vector_or_scalar(y);
+  const auto& n_double = stan::math::value_of_rec(n_col);
+  const auto signs = 2 * stan::math::as_array_or_scalar(n_double) - 1;
+  Eigen::Map<Eigen::ArrayXd> ntheta(ctx.scratch, theta.len);
+  ntheta = signs * theta_val;
+  Eigen::ArrayXd exp_m_ntheta = stan::math::exp(-ntheta);
+  ctx.out.data[0] = stan::math::sum(
+      (ntheta > cutoff)
+          .select(-exp_m_ntheta,
+                  (ntheta < -cutoff)
+                      .select(ntheta, -stan::math::log1p(exp_m_ntheta))));
+
+  if (!bernoulli_arg_active(ctx)) {
+    ntheta.setZero();
+    return;
+  }
+  ntheta =
+      (ntheta > cutoff)
+          .select(-exp_m_ntheta,
+                  (ntheta >= -cutoff)
+                      .select(stan::math::promote_scalar<double>(
+                                  signs * exp_m_ntheta / (exp_m_ntheta + 1)),
+                              stan::math::promote_scalar<double>(signs)));
+  ctx.scratch[theta.len] = 1.0;
+}
+
+template <bool Logit>
+void bernoulli_native_fwd(KernelCtx& ctx) {
+  const bool active = bernoulli_arg_active(ctx);
+  const bool drop = bernoulli_drop_propto(ctx);
+  const Desc& theta = ctx.in[0];
+
+  if ((ctx.variant & 0x40u) != 0) {
+    const int64_t n = ctx.out.len;
+    std::fill_n(ctx.scratch, static_cast<size_t>(2 * n), 0.0);
+    for (int64_t i = 0; i < n; ++i) {
+      const double theta_i = theta.data[theta.len == 1 ? 0 : i];
+      ctx.out.data[i] = bernoulli_value<Logit>(ctx.idata[i], theta_i, drop);
+      if (active) {
+        ctx.scratch[i] = Logit ? bernoulli_logit_partial(ctx.idata[i], theta_i)
+                               : bernoulli_partial(ctx.idata[i], theta_i);
+        ctx.scratch[n + i] = 1.0;
+      }
+    }
+    return;
+  }
+
+  const Eigen::Map<const Eigen::VectorXi> y(
+      ctx.idata, static_cast<Eigen::Index>(ctx.n_idata));
+  ctx.out.data[0] = bernoulli_value<Logit>(y, theta, drop);
+  std::fill_n(ctx.scratch, static_cast<size_t>(theta.len + 1), 0.0);
+
+  // Both functions return a literal zero before constructing their partials
+  // edge for an empty input. Preserve that disconnected topology: multiplying
+  // an empty density by an infinite downstream adjoint must not form inf * 0.
+  if (!active || drop || ctx.n_idata == 0 || theta.len == 0) return;
+  ctx.scratch[theta.len] = 1.0;
+
+  if (theta.len == 1) {
+    if constexpr (Logit) {
+      double partial = 0.0;
+      for (int64_t i = 0; i < ctx.n_idata; ++i)
+        partial += bernoulli_logit_partial(ctx.idata[i], theta.data[0]);
+      ctx.scratch[0] = partial;
+    } else {
+      int64_t successes = 0;
+      for (int64_t i = 0; i < ctx.n_idata; ++i) successes += ctx.idata[i];
+      if (successes == ctx.n_idata) {
+        ctx.scratch[0] = static_cast<double>(ctx.n_idata) / theta.data[0];
+      } else if (successes == 0) {
+        ctx.scratch[0] =
+            static_cast<double>(ctx.n_idata) / (theta.data[0] - 1.0);
+      } else {
+        ctx.scratch[0] =
+            static_cast<double>(successes) * stan::math::inv(theta.data[0]);
+        ctx.scratch[0] += static_cast<double>(ctx.n_idata - successes) *
+                          stan::math::inv(theta.data[0] - 1.0);
+      }
+    }
+    return;
+  }
+
+  for (int64_t i = 0; i < theta.len; ++i)
+    ctx.scratch[i] = Logit
+                         ? bernoulli_logit_partial(ctx.idata[i], theta.data[i])
+                         : bernoulli_partial(ctx.idata[i], theta.data[i]);
+}
+
+}  // namespace
+
+void bernoulli_fwd(KernelCtx& ctx) { bernoulli_native_fwd<false>(ctx); }
+void bernoulli_logit_fwd(KernelCtx& ctx) {
+  // A scalar theta against vector y contracts its lane partials with Eigen's
+  // reduction order. Keep the recorder for that uncommon shape; the native
+  // path covers scalar/scalar, vector/vector, and every rerolled elementwise
+  // call without changing the contraction by a few ULPs.
+  if ((ctx.variant & 0x40u) == 0 && ctx.in[0].len == 1 && ctx.n_idata > 1) {
+    bernoulli_logit_recorded_fwd(ctx);
+    return;
+  }
+  if ((ctx.variant & 0x40u) == 0 && ctx.in[0].len > 1) {
+    bernoulli_logit_vector_fwd(ctx);
+    return;
+  }
+  bernoulli_native_fwd<true>(ctx);
+}
 
 // The same shape, one line per distribution (STANLI_INT_DENSITY_LIST).
 #define STANLI_DEFINE_INT_DENSITY(code, fn, nreal, tier) \

--- a/tests/test_densities.cpp
+++ b/tests/test_densities.cpp
@@ -9,6 +9,7 @@
 #include <cmath>
 #include <cstdio>
 #include <cstdint>
+#include <cstring>
 #include <limits>
 #include <functional>
 #include <string>
@@ -169,6 +170,369 @@ static void check_elt(
     expect_eq(tag + " out" + std::to_string(i), f.out[i], l.out[i]);
   for (size_t i = 0; i < f.grad.size(); ++i)
     expect_eq(tag + " g" + std::to_string(i), f.grad[i], l.grad[i]);
+}
+
+// Bernoulli's native forwards deliberately replace the generic rvar
+// recorder, so pin their complete contract directly to this checkout's Stan
+// Math. Equality below is bit equality (including signed zero), rather than
+// the numerical equality used by the older density coverage above.
+static void expect_bits(const std::string& what, double got, double want) {
+  if (std::memcmp(&got, &want, sizeof(double)) != 0) {
+    ++failures;
+    std::printf("FAIL %-32s got %.17g want %.17g (bit mismatch)\n",
+                what.c_str(), got, want);
+  }
+}
+
+static void expect_true(const std::string& what, bool got) {
+  if (!got) {
+    ++failures;
+    std::printf("FAIL %-32s false\n", what.c_str());
+  }
+}
+
+static stanli::testutil::RunResult run_bernoulli_variant(
+    uint16_t opcode, uint8_t variant, const std::vector<int>& y,
+    const std::vector<double>& theta) {
+  using namespace stanli;
+  Graph g;
+  const int theta_slot = g.add_slot((int64_t)theta.size(), true);
+  const int lp = g.add_slot(1, false);
+  Op op;
+  op.opcode = opcode;
+  op.variant = variant;
+  op.out = lp;
+  op.in[op.n_in++] = theta_slot;
+  if (!y.empty()) {
+    g.idata_pool.push_back(y);
+    op.idata = g.idata_pool.back().data();
+    op.n_idata = (int64_t)y.size();
+  }
+  g.ops.push_back(op);
+  g.result_slot = lp;
+
+  Executor ex(std::move(g));
+  for (size_t i = 0; i < theta.size(); ++i) ex.params_data()[i] = theta[i];
+  stanli::testutil::RunResult r;
+  r.grad.assign(theta.size(), 0.0);
+  r.value = ex.gradient(r.grad.data());
+  return r;
+}
+
+static stanli::testutil::RunResult run_bernoulli_scaled(
+    uint16_t opcode, uint8_t variant, const std::vector<int>& y, double theta,
+    double scale) {
+  using namespace stanli;
+  Graph g;
+  const int theta_slot = g.add_slot(1, true);
+  const int scale_slot = g.add_slot(1, false);
+  const int lp = g.add_slot(1, false);
+  const int result = g.add_slot(1, false);
+  Op op;
+  op.opcode = opcode;
+  op.variant = variant;
+  op.out = lp;
+  op.in[op.n_in++] = theta_slot;
+  if (!y.empty()) {
+    g.idata_pool.push_back(y);
+    op.idata = g.idata_pool.back().data();
+    op.n_idata = (int64_t)y.size();
+  }
+  g.ops.push_back(op);
+  g.add_op(OP_MUL, {lp, scale_slot}, result);
+  g.result_slot = result;
+
+  Executor ex(std::move(g));
+  ex.params_data()[0] = theta;
+  ex.value_ptr(scale_slot)[0] = scale;
+  stanli::testutil::RunResult r;
+  r.grad.assign(1, 0.0);
+  r.value = ex.gradient(r.grad.data());
+  return r;
+}
+
+struct BernoulliRef {
+  double value = 0.0;
+  std::vector<double> grad;
+};
+
+template <bool Logit, bool Propto, typename Y, typename Theta>
+static auto bernoulli_math(const Y& y, const Theta& theta) {
+  if constexpr (Logit)
+    return stan::math::bernoulli_logit_lpmf<Propto>(y, theta);
+  else
+    return stan::math::bernoulli_lpmf<Propto>(y, theta);
+}
+
+static Eigen::VectorXi as_int_vector(const std::vector<int>& x) {
+  Eigen::VectorXi out((Eigen::Index)x.size());
+  for (size_t i = 0; i < x.size(); ++i) out((Eigen::Index)i) = x[i];
+  return out;
+}
+
+template <bool Logit, bool Propto>
+static BernoulliRef run_bernoulli_reference(const std::vector<int>& y,
+                                            const std::vector<double>& theta,
+                                            bool scalar_outcome, bool active) {
+  using stan::math::var;
+  BernoulliRef r;
+  r.grad.assign(theta.size(), 0.0);
+  const Eigen::VectorXi y_vec = as_int_vector(y);
+
+  if (!active) {
+    if (theta.size() == 1) {
+      r.value = scalar_outcome ? bernoulli_math<Logit, Propto>(y[0], theta[0])
+                               : bernoulli_math<Logit, Propto>(y_vec, theta[0]);
+    } else {
+      const Eigen::Map<const Eigen::VectorXd> theta_vec(theta.data(),
+                                                        theta.size());
+      r.value = scalar_outcome
+                    ? bernoulli_math<Logit, Propto>(y[0], theta_vec)
+                    : bernoulli_math<Logit, Propto>(y_vec, theta_vec);
+    }
+    return r;
+  }
+
+  if (theta.size() == 1) {
+    var theta_var = theta[0];
+    var lp;
+    if (scalar_outcome)
+      lp = bernoulli_math<Logit, Propto>(y[0], theta_var);
+    else
+      lp = bernoulli_math<Logit, Propto>(y_vec, theta_var);
+    lp.grad();
+    r.value = lp.val();
+    r.grad[0] = theta_var.adj();
+  } else {
+    Eigen::Matrix<var, -1, 1> theta_var((Eigen::Index)theta.size());
+    for (size_t i = 0; i < theta.size(); ++i)
+      theta_var((Eigen::Index)i) = theta[i];
+    var lp;
+    if (scalar_outcome)
+      lp = bernoulli_math<Logit, Propto>(y[0], theta_var);
+    else
+      lp = bernoulli_math<Logit, Propto>(y_vec, theta_var);
+    lp.grad();
+    r.value = lp.val();
+    for (size_t i = 0; i < theta.size(); ++i)
+      r.grad[i] = theta_var((Eigen::Index)i).adj();
+  }
+  stan::math::recover_memory();
+  return r;
+}
+
+static BernoulliRef run_bernoulli_reference(uint16_t opcode, uint8_t variant,
+                                            const std::vector<int>& y,
+                                            const std::vector<double>& theta,
+                                            bool scalar_outcome) {
+  const bool logit = opcode == stanli::OP_BERNOULLI_LOGIT_LPMF;
+  const bool propto = (variant & 0x80u) != 0;
+  const bool active = variant == 0 || (variant & 0x01u) != 0;
+  if (logit) {
+    if (propto)
+      return run_bernoulli_reference<true, true>(y, theta, scalar_outcome,
+                                                 active);
+    return run_bernoulli_reference<true, false>(y, theta, scalar_outcome,
+                                                active);
+  }
+  if (propto)
+    return run_bernoulli_reference<false, true>(y, theta, scalar_outcome,
+                                                active);
+  return run_bernoulli_reference<false, false>(y, theta, scalar_outcome,
+                                               active);
+}
+
+static void check_bernoulli_run(const std::string& tag, uint16_t opcode,
+                                uint8_t variant, const std::vector<int>& y,
+                                const std::vector<double>& theta,
+                                bool scalar_outcome) {
+  const auto got = run_bernoulli_variant(opcode, variant, y, theta);
+  const auto want =
+      run_bernoulli_reference(opcode, variant, y, theta, scalar_outcome);
+  expect_bits(tag + " value", got.value, want.value);
+  expect_true(tag + " grad size", got.grad.size() == want.grad.size());
+  const size_t n = std::min(got.grad.size(), want.grad.size());
+  for (size_t i = 0; i < n; ++i)
+    expect_bits(tag + " grad" + std::to_string(i), got.grad[i], want.grad[i]);
+}
+
+template <bool Logit, bool Propto>
+static EltRun run_bernoulli_elt_reference(uint8_t variant,
+                                          const std::vector<int>& y,
+                                          const std::vector<double>& theta) {
+  using stan::math::var;
+  EltRun r;
+  r.out.reserve(y.size());
+  r.grad.assign(theta.size(), 0.0);
+  // Bit 6 makes an otherwise-zero variant explicit, so elementwise activity
+  // always comes from bit 0 rather than the variant == 0 default.
+  const bool active = (variant & 0x01u) != 0;
+  if (!active) {
+    for (size_t i = 0; i < y.size(); ++i) {
+      const double theta_i = theta[theta.size() == 1 ? 0 : i];
+      r.out.push_back(bernoulli_math<Logit, Propto>(y[i], theta_i));
+    }
+    r.value = 0.0;
+    for (double x : r.out) r.value += x;
+    return r;
+  }
+
+  var total = 0.0;
+  if (theta.size() == 1) {
+    var theta_var = theta[0];
+    for (size_t i = 0; i < y.size(); ++i) {
+      var lane = bernoulli_math<Logit, Propto>(y[i], theta_var);
+      r.out.push_back(lane.val());
+      total += lane;
+    }
+    total.grad();
+    r.value = total.val();
+    r.grad[0] = theta_var.adj();
+  } else {
+    Eigen::Matrix<var, -1, 1> theta_var((Eigen::Index)theta.size());
+    for (size_t i = 0; i < theta.size(); ++i)
+      theta_var((Eigen::Index)i) = theta[i];
+    for (size_t i = 0; i < y.size(); ++i) {
+      var lane =
+          bernoulli_math<Logit, Propto>(y[i], theta_var((Eigen::Index)i));
+      r.out.push_back(lane.val());
+      total += lane;
+    }
+    total.grad();
+    r.value = total.val();
+    for (size_t i = 0; i < theta.size(); ++i)
+      r.grad[i] = theta_var((Eigen::Index)i).adj();
+  }
+  stan::math::recover_memory();
+  return r;
+}
+
+static EltRun run_bernoulli_elt_reference(uint16_t opcode, uint8_t variant,
+                                          const std::vector<int>& y,
+                                          const std::vector<double>& theta) {
+  const bool logit = opcode == stanli::OP_BERNOULLI_LOGIT_LPMF;
+  const bool propto = (variant & 0x80u) != 0;
+  if (logit) {
+    if (propto)
+      return run_bernoulli_elt_reference<true, true>(variant, y, theta);
+    return run_bernoulli_elt_reference<true, false>(variant, y, theta);
+  }
+  if (propto)
+    return run_bernoulli_elt_reference<false, true>(variant, y, theta);
+  return run_bernoulli_elt_reference<false, false>(variant, y, theta);
+}
+
+static void check_bernoulli_elt(const std::string& tag, uint16_t opcode,
+                                uint8_t variant, const std::vector<int>& y,
+                                const std::vector<double>& theta) {
+  const EltRun got =
+      run_elt_fused(opcode, variant, (int64_t)y.size(), {theta}, {true}, y);
+  const EltRun want = run_bernoulli_elt_reference(opcode, variant, y, theta);
+  expect_bits(tag + " value", got.value, want.value);
+  expect_true(tag + " out size", got.out.size() == want.out.size());
+  const size_t n_out = std::min(got.out.size(), want.out.size());
+  for (size_t i = 0; i < n_out; ++i)
+    expect_bits(tag + " out" + std::to_string(i), got.out[i], want.out[i]);
+  expect_true(tag + " grad size", got.grad.size() == want.grad.size());
+  const size_t n_grad = std::min(got.grad.size(), want.grad.size());
+  for (size_t i = 0; i < n_grad; ++i)
+    expect_bits(tag + " grad" + std::to_string(i), got.grad[i], want.grad[i]);
+}
+
+struct CapturedException {
+  bool thrown = false;
+  std::string kind;
+  std::string message;
+};
+
+template <typename F>
+static CapturedException capture_exception(F&& f) {
+  try {
+    f();
+    return {};
+  } catch (const std::domain_error& e) {
+    return {true, "domain_error", e.what()};
+  } catch (const std::invalid_argument& e) {
+    return {true, "invalid_argument", e.what()};
+  } catch (const std::runtime_error& e) {
+    return {true, "runtime_error", e.what()};
+  } catch (const std::exception& e) {
+    return {true, "exception", e.what()};
+  }
+}
+
+static void expect_exception_parity(const std::string& tag,
+                                    const CapturedException& got,
+                                    const CapturedException& want) {
+  if (got.thrown != want.thrown || got.kind != want.kind ||
+      got.message != want.message) {
+    ++failures;
+    std::printf("FAIL %-32s got %s '%s' want %s '%s'\n", tag.c_str(),
+                got.kind.c_str(), got.message.c_str(), want.kind.c_str(),
+                want.message.c_str());
+  }
+}
+
+// Exercise one forward context repeatedly. Executor-bound variants and idata
+// are immutable, so a direct registered-kernel call is the only focused way
+// to prove that a valid call cannot leave partials/connectivity behind for a
+// subsequent empty or inactive call using the same scratch bytes.
+static void check_bernoulli_scratch_reset(const std::string& tag,
+                                          uint16_t opcode) {
+  using namespace stanli;
+  const Kernel* k = find_kernel(opcode);
+  expect_true(tag + " registered",
+              k != nullptr && k->forward != nullptr && k->backward != nullptr);
+  if (k == nullptr || k->forward == nullptr || k->backward == nullptr) return;
+
+  int y = 1;
+  double theta = opcode == OP_BERNOULLI_LPMF ? 0.4 : 0.3;
+  double out = 0.0;
+  double scratch[2] = {-77.0, -88.0};
+  KernelCtx ctx;
+  ctx.in[0] = Desc{&theta, 1};
+  ctx.n_in = 1;
+  ctx.out = Desc{&out, 1};
+  ctx.scratch = scratch;
+  ctx.idata = &y;
+  ctx.n_idata = 1;
+
+  ctx.variant = 0;
+  k->forward(ctx);
+  expect_bits(tag + " valid connected", scratch[1], 1.0);
+
+  ctx.variant = 0x02u;  // explicit inactive, full density
+  k->forward(ctx);
+  expect_bits(tag + " inactive partial", scratch[0], 0.0);
+  expect_bits(tag + " inactive connected", scratch[1], 0.0);
+  double adj = 0.0;
+  ctx.in_adj[0] = Desc{&adj, 1};
+  ctx.out_adj = std::numeric_limits<double>::infinity();
+  k->backward(ctx);
+  expect_bits(tag + " inactive pullback", adj, 0.0);
+
+  ctx.variant = 0;
+  k->forward(ctx);
+  expect_bits(tag + " refill connected", scratch[1], 1.0);
+  ctx.n_idata = 0;
+  k->forward(ctx);
+  expect_bits(tag + " empty value", out, 0.0);
+  expect_bits(tag + " empty partial", scratch[0], 0.0);
+  expect_bits(tag + " empty connected", scratch[1], 0.0);
+  adj = 0.0;
+  k->backward(ctx);
+  expect_bits(tag + " empty pullback", adj, 0.0);
+
+  ctx.idata = &y;
+  ctx.n_idata = 1;
+  ctx.variant = 0x81u;  // active propto
+  k->forward(ctx);
+  expect_bits(tag + " propto connected", scratch[1], 1.0);
+  ctx.variant = 0x80u;  // inactive propto drops the only summand
+  k->forward(ctx);
+  expect_bits(tag + " dropped value", out, 0.0);
+  expect_bits(tag + " dropped partial", scratch[0], 0.0);
+  expect_bits(tag + " dropped connected", scratch[1], 0.0);
 }
 
 int main() {
@@ -530,6 +894,218 @@ int main() {
                 va(i).adj());
     stan::math::recover_memory();
   }
+
+  // ---- native Bernoulli forwards vs the pinned Stan Math checkout --------
+  // Default means variant == 0 (all arguments active). Once any variant bit
+  // is present, bit 0 explicitly selects activity; bit 7 selects propto.
+  // These are all five representable full/propto x default/active/inactive
+  // cases for a one-real-argument density.
+  {
+    struct Dist {
+      uint16_t opcode;
+      const char* tag;
+      std::vector<double> vector_theta;
+      double scalar_theta;
+    };
+    const Dist dists[] = {
+        {OP_BERNOULLI_LPMF, "bernoulli native", {0.2, 0.7, 0.4, 0.9}, 0.4},
+        {OP_BERNOULLI_LOGIT_LPMF,
+         "bernoulli_logit native",
+         {-2.0, 0.3, 1.4, -0.7},
+         0.3}};
+    const std::vector<int> y{1, 0, 1, 0};
+    struct VariantCase {
+      uint8_t variant;
+      const char* tag;
+    };
+    const VariantCase variants[] = {{0x00u, "default full"},
+                                    {0x01u, "active full"},
+                                    {0x02u, "inactive full"},
+                                    {0x81u, "active propto"},
+                                    {0x80u, "inactive propto"}};
+
+    for (const Dist& d : dists) {
+      check_bernoulli_run(std::string(d.tag) + " scalar/scalar", d.opcode, 0,
+                          {1}, {d.scalar_theta}, true);
+      check_bernoulli_run(std::string(d.tag) + " vector/vector", d.opcode, 0, y,
+                          d.vector_theta, false);
+      check_bernoulli_run(std::string(d.tag) + " vector/broadcast", d.opcode, 0,
+                          y, {d.scalar_theta}, false);
+      for (const VariantCase& c : variants)
+        check_bernoulli_run(std::string(d.tag) + " " + c.tag, d.opcode,
+                            c.variant, y, d.vector_theta, false);
+
+      // Reroll emits both vector and broadcast elementwise forms. Exercise
+      // explicit active and inactive masks under both template flags.
+      check_bernoulli_elt(std::string(d.tag) + " elt vector full", d.opcode,
+                          0x01u, y, d.vector_theta);
+      check_bernoulli_elt(std::string(d.tag) + " elt broadcast full", d.opcode,
+                          0x01u, y, {d.scalar_theta});
+      check_bernoulli_elt(std::string(d.tag) + " elt vector propto", d.opcode,
+                          0x81u, y, d.vector_theta);
+      check_bernoulli_elt(std::string(d.tag) + " elt broadcast propto",
+                          d.opcode, 0x81u, y, {d.scalar_theta});
+      check_bernoulli_elt(std::string(d.tag) + " elt inactive full", d.opcode,
+                          0x02u, y, d.vector_theta);
+      check_bernoulli_elt(std::string(d.tag) + " elt inactive propto", d.opcode,
+                          0x80u, y, {d.scalar_theta});
+    }
+  }
+
+  // Bernoulli probability endpoints are valid inputs. Pin the exact values
+  // and partials on both outcomes at the endpoint, its adjacent representable
+  // interior value, and one ordinary interior point.
+  {
+    const double p[] = {0.0, std::nextafter(0.0, 1.0), 0.4,
+                        std::nextafter(1.0, 0.0), 1.0};
+    for (int y = 0; y <= 1; ++y)
+      for (size_t i = 0; i < sizeof(p) / sizeof(p[0]); ++i)
+        check_bernoulli_run(
+            "bernoulli p-grid y" + std::to_string(y) + " p" + std::to_string(i),
+            OP_BERNOULLI_LPMF, 0, {y}, {p[i]}, true);
+  }
+
+  // Stan Math's logit implementation has deliberately asymmetric strict
+  // cutoff comparisons: value uses z > 20 and z < -20, while the partial's
+  // middle arm includes z == -20. Test both sides, both exact cutoffs, both
+  // outcomes, and accepted infinities.
+  {
+    const double inf = std::numeric_limits<double>::infinity();
+    const double z[] = {
+        -inf, std::nextafter(-20.0, -inf), -20.0, std::nextafter(-20.0, inf),
+        0.0,  std::nextafter(20.0, -inf),  20.0,  std::nextafter(20.0, inf),
+        inf};
+    for (int y = 0; y <= 1; ++y) {
+      const double sign = 2.0 * y - 1.0;
+      for (size_t i = 0; i < sizeof(z) / sizeof(z[0]); ++i)
+        check_bernoulli_run("bernoulli_logit z-grid y" + std::to_string(y) +
+                                " z" + std::to_string(i),
+                            OP_BERNOULLI_LOGIT_LPMF, 0, {y}, {sign * z[i]},
+                            true);
+    }
+
+    // One summed vector call reaches Eigen's packet exp, reduction, and
+    // vector partial assignment. Alternate outcomes while preserving z so
+    // every strict cutoff/tail arm appears in that one call.
+    std::vector<int> grid_y;
+    std::vector<double> grid_theta;
+    for (size_t i = 0; i < sizeof(z) / sizeof(z[0]); ++i) {
+      const int y = (int)(i & 1u);
+      grid_y.push_back(y);
+      grid_theta.push_back((2.0 * y - 1.0) * z[i]);
+    }
+    check_bernoulli_run("bernoulli_logit vector cutoff grid",
+                        OP_BERNOULLI_LOGIT_LPMF, 0, grid_y, grid_theta, false);
+
+    // Odd length forces a packet remainder; irregular magnitudes make a
+    // scalar-loop implementation diverge bitwise if it does not mirror the
+    // pinned vector expression's exp and reduction paths.
+    check_bernoulli_run("bernoulli_logit vector irregular",
+                        OP_BERNOULLI_LOGIT_LPMF, 0,
+                        {1, 0, 1, 1, 0, 0, 1, 0, 1, 0, 1},
+                        {-37.25, 0.03125, 19.75, -0.875, 20.125, -19.875, 7.3,
+                         -2.6, 0.0, 41.0, -13.125},
+                        false);
+
+    // A longer deterministic spread catches packet/scalar exp differences
+    // away from the named cutoffs as well as reduction-order differences.
+    std::vector<int> random_y;
+    std::vector<double> random_theta;
+    uint64_t state = 0x243f6a8885a308d3ULL;
+    for (int i = 0; i < 257; ++i) {
+      state = state * 6364136223846793005ULL + 1442695040888963407ULL;
+      random_y.push_back((int)(state & 1u));
+      const double unit = static_cast<double>(state >> 11) * 0x1.0p-53;
+      random_theta.push_back(80.0 * unit - 40.0);
+    }
+    check_bernoulli_run("bernoulli_logit vector deterministic spread",
+                        OP_BERNOULLI_LOGIT_LPMF, 0, random_y, random_theta,
+                        false);
+  }
+
+  // Invalid inputs must throw the same exception category and diagnostic as
+  // Stan Math, including validation order. The summed kernel binds outcomes
+  // as a vector, so the reference does too even for a single invalid lane.
+  {
+    auto check_bernoulli_exception =
+        [&](const std::string& tag, uint16_t opcode, const std::vector<int>& y,
+            double theta) {
+          const CapturedException got = capture_exception(
+              [&] { (void)run_bernoulli_variant(opcode, 0, y, {theta}); });
+          const CapturedException want = capture_exception([&] {
+            const Eigen::VectorXi y_ref = as_int_vector(y);
+            if (opcode == OP_BERNOULLI_LPMF)
+              (void)stan::math::bernoulli_lpmf<false>(y_ref, theta);
+            else
+              (void)stan::math::bernoulli_logit_lpmf<false>(y_ref, theta);
+          });
+          expect_exception_parity(tag, got, want);
+        };
+    check_bernoulli_exception("bernoulli invalid y", OP_BERNOULLI_LPMF,
+                              {1, 2, 0}, 0.4);
+    check_bernoulli_exception("bernoulli probability low", OP_BERNOULLI_LPMF,
+                              {1, 0}, -0.1);
+    check_bernoulli_exception("bernoulli probability high", OP_BERNOULLI_LPMF,
+                              {1, 0}, 1.1);
+    check_bernoulli_exception("bernoulli probability nan", OP_BERNOULLI_LPMF,
+                              {1, 0}, std::numeric_limits<double>::quiet_NaN());
+    check_bernoulli_exception("bernoulli_logit invalid y",
+                              OP_BERNOULLI_LOGIT_LPMF, {1, -1, 0}, 0.3);
+    check_bernoulli_exception("bernoulli_logit nan", OP_BERNOULLI_LOGIT_LPMF,
+                              {1, 0}, std::numeric_limits<double>::quiet_NaN());
+
+    // Empty Bernoulli validates theta before its size-zero return; logit does
+    // the size-zero return first. Both orderings are observable and pinned.
+    check_bernoulli_exception("bernoulli empty nan", OP_BERNOULLI_LPMF, {},
+                              std::numeric_limits<double>::quiet_NaN());
+    check_bernoulli_exception("bernoulli_logit empty nan",
+                              OP_BERNOULLI_LOGIT_LPMF, {},
+                              std::numeric_limits<double>::quiet_NaN());
+  }
+
+  // Empty calls return a literal constant, so an infinite downstream
+  // adjoint must leave theta at +0 rather than form infinity * 0. Conversely,
+  // a valid logit call at +infinity has a connected edge whose local partial
+  // is -0, and therefore must produce NaN under the same upstream adjoint.
+  {
+    const double inf = std::numeric_limits<double>::infinity();
+    for (uint16_t opcode : {OP_BERNOULLI_LPMF, OP_BERNOULLI_LOGIT_LPMF}) {
+      const auto got = run_bernoulli_scaled(opcode, 0, {}, 0.4, inf);
+      Eigen::VectorXi y_ref(0);
+      var theta_ref = 0.4;
+      var lp_ref =
+          opcode == OP_BERNOULLI_LPMF
+              ? stan::math::bernoulli_lpmf<false>(y_ref, theta_ref)
+              : stan::math::bernoulli_logit_lpmf<false>(y_ref, theta_ref);
+      var result_ref = lp_ref * inf;
+      result_ref.grad();
+      expect_nan(std::string(opcode == OP_BERNOULLI_LPMF ? "bernoulli"
+                                                         : "bernoulli_logit") +
+                     " empty scaled value",
+                 got.value, result_ref.val());
+      expect_bits(std::string(opcode == OP_BERNOULLI_LPMF ? "bernoulli"
+                                                          : "bernoulli_logit") +
+                      " empty scaled grad",
+                  got.grad[0], theta_ref.adj());
+      stan::math::recover_memory();
+    }
+
+    const auto got =
+        run_bernoulli_scaled(OP_BERNOULLI_LOGIT_LPMF, 0, {1}, inf, inf);
+    Eigen::VectorXi y_ref(1);
+    y_ref[0] = 1;
+    var theta_ref = inf;
+    var lp_ref = stan::math::bernoulli_logit_lpmf<false>(y_ref, theta_ref);
+    var result_ref = lp_ref * inf;
+    result_ref.grad();
+    expect_nan("bernoulli_logit connected value", got.value, result_ref.val());
+    expect_nan("bernoulli_logit connected grad", got.grad[0], theta_ref.adj());
+    stan::math::recover_memory();
+  }
+
+  check_bernoulli_scratch_reset("bernoulli scratch", OP_BERNOULLI_LPMF);
+  check_bernoulli_scratch_reset("bernoulli_logit scratch",
+                                OP_BERNOULLI_LOGIT_LPMF);
 
   // ---- elementwise variant (bit 6) vs the scalar lanes it replaces --------
   {


### PR DESCRIPTION
## Summary

- specialize `bernoulli_lpmf` and `bernoulli_logit_lpmf` forwards for their single real argument instead of constructing the generic recorder edge on every call
- write analytic partials directly into the existing density scratch layout; reuse the vector-logit partial column as `ntheta` workspace while preserving Eigen packet `exp`, select, and reduction order
- retain the recorder for scalar-theta/vector-outcome logit calls, whose broadcast partial uses Eigen's scalar contraction order
- add bitwise Stan Math oracles for shapes, masks/propto, endpoints and cutoffs, vector packet paths, exception order, disconnected topology, and scratch reuse

This is stacked on #158 and should be reviewed/merged after it.

## Performance

Median of seven interleaved 50,000-gradient processes on Apple arm64, with matched CmdStan binaries:

| model | before | after | change | CmdStan | CmdStan / stanli |
| --- | ---: | ---: | ---: | ---: | ---: |
| `Mt_model` | 30.595 us | 19.181 us | 1.60x | 18.969 us | 0.99x |
| `Mth_model` | 113.190 us | 57.289 us | 1.98x | 101.372 us | 1.77x |
| `Mtbh_model` | 47.450 us | 26.786 us | 1.77x | 44.905 us | 1.68x |

The `Mtbh_model` baseline above already contains #158. Relative to the pre-slice 106.5 us baseline, the stacked result is 3.98x faster.

Profiled Bernoulli-logit forward time fell 2.92x in both `Mth_model` and `Mtbh_model`.

## Validation

- fresh clean Release build: pass (291/291 actions)
- CTest: 55/55 pass
- full reference replay: 129/129 models at all 3 points; 800,674 values; worst relative deviation 1.79e-11
- `tools/format.sh --check`
- `python3 tools/gen_docs.py --check`
- `python3 tools/gen_web_models.py --check`
- `git diff --check`

The vector exactness test includes a 257-lane deterministic spread. A scalar-`std::exp` implementation failed 20 bitwise gradients in that oracle; the committed packet path passes it exactly.
