### PR TITLE
perf: reuse symmetric eigendecompositions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -482,7 +482,7 @@ install(DIRECTORY runtime/include/stanli
         DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 
 set(STANLI_TESTS
-  test_smoke test_executor test_recorder test_densities test_matvec
+  test_smoke test_executor test_recorder test_densities test_matvec test_eigen
   test_legacy test_eight_schools test_glm test_nuts test_walnuts test_sexp
   test_mir test_transforms test_eltwise test_scalar_binary test_lower
   test_lower_views

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -18,7 +18,7 @@ The harness now records file read, parse, compile, construction, and binding
 only; that column should be refreshed as a unit rather than mixing definitions.
 Targeted preparation measurements later on this page use the new mode.
 
-Three targeted 2026-08-23 remeasurements are newer than the full snapshot below.
+Four targeted 2026-08-23 remeasurements are newer than the full snapshot below.
 Packed row-wise `log_sum_exp` reduces `ldaK2` from 15,854 ops to 22 and
 154 to 94 us/gradient (1.11x CmdStan), and `ldaK5` from 434,126 ops to 156
 and 6.82 to 3.70 ms/gradient (1.51x CmdStan). `ldaK5` file-to-bound-model
@@ -28,7 +28,9 @@ strided stores still dispatch once each, but update four cells instead of
 copying all 730. Native Bernoulli forwards then move `Mt_model` from 30.6 to
 19.2 us (0.62x to 0.99x CmdStan), `Mth_model` from 113.2 to 57.3 us (0.90x to
 1.77x), and the stacked `Mtbh_model` result from 47.4 to 26.8 us (0.95x to
-1.68x). The committed full-corpus tables retain one measurement definition
+1.68x). Native symmetric-eigen pullbacks remove the reverse-time eigensolves
+in `kronecker_gp`, moving it from 289.0 to 185.7 us/gradient (0.75x to 1.17x
+CmdStan). The committed full-corpus tables retain one measurement definition
 and will be refreshed as a unit.
 
 ## Per-gradient latency

--- a/docs/superpowers/plans/2026-08-08-cmdstan-parity-roadmap.md
+++ b/docs/superpowers/plans/2026-08-08-cmdstan-parity-roadmap.md
@@ -161,9 +161,10 @@ Alongside it, the tail fixes the profile already names:
   case is already closed by the elementwise-lp fusion.
 - **Kernel-bound stragglers**, in the shape of the `diamonds` and
   `prophet` fixes. `Mt_model` is now closed: direct Bernoulli partials move it
-  from 30.6 to 19.2 us/gradient, or 0.99x CmdStan. Remaining examples include
-  `gp_regr` (55% in `multi_normal_cholesky_lpdf`) and `kronecker_gp` (38% in
-  an eigendecomposition).
+  from 30.6 to 19.2 us/gradient, or 0.99x CmdStan. `kronecker_gp` is closed as
+  well: retaining each symmetric eigendecomposition for its native pullback
+  moves it from 289.0 to 185.7 us/gradient, or 1.17x CmdStan. `gp_regr` remains
+  (55% in `multi_normal_cholesky_lpdf`).
 - **Two loose threads.** `lotka_volterra` is 0.61x per gradient yet blows
   the 900 s sampling cap CmdStan clears in 6.2 s — untraced, and
   `tools/sampler_trace.py` is the tool. `sir`'s benchmark probe point

--- a/runtime/kernels/matrix_fns.cpp
+++ b/runtime/kernels/matrix_fns.cpp
@@ -9,6 +9,7 @@
 #include <stanli/graph.hpp>
 #include <stanli/legacy.hpp>
 #include <stanli/optable.hpp>
+#include <stanli/packet.hpp>
 
 #include <stan/math.hpp>
 
@@ -543,32 +544,66 @@ void transpose_bwd(KernelCtx& ctx) {
 // SelfAdjointEigenSolver, which is what stan-math uses.
 void eigvals_fwd(KernelCtx& ctx) {
   const int64_t n = ctx.idata[0];
+  if (n == 0) return;
   MatD a = CMapM(ctx.in[0].data, n, n);
-  Eigen::Map<VecD>(ctx.out.data, n) = stan::math::eigenvalues_sym(a);
+  if (values_only()) {
+    Eigen::Map<VecD>(ctx.out.data, n) = stan::math::eigenvalues_sym(a);
+    return;
+  }
+  // Keep the decomposition that stan-math's reverse callback would retain.
+  // The old backward rebuilt a nested var matrix and decomposed it again;
+  // retaining the vectors makes the pullback the same two GEMMs with no
+  // second eigensolve or tape.  Use stan-math's exact check spelling before
+  // dropping to the Eigen solver its prim implementation wraps.
+  stan::math::check_symmetric("eigenvalues_sym", "m", a);
+  Eigen::SelfAdjointEigenSolver<MatD> solver(a);
+  Eigen::Map<VecD>(ctx.out.data, n) = solver.eigenvalues();
+  MapM(ctx.scratch, n, n) = solver.eigenvectors();
 }
 void eigvals_bwd(KernelCtx& ctx) {
+  if (!ctx.in_adj[0].data) return;
   const int64_t n = ctx.idata[0];
-  nary_bwd(ctx, [&](std::vector<VarV>& xs) {
-    VarM a(n, n);
-    for (int64_t j = 0; j < n; ++j)
-      for (int64_t i = 0; i < n; ++i) a(i, j) = xs[0](j * n + i);
-    return stan::math::eigenvalues_sym(a);
-  });
+  if (n == 0) return;
+  CMapM eigenvecs(ctx.scratch, n, n);
+  CMapV eigenvals_adj(ctx.out_adj_vec.data, n);
+  // stan/math/rev/fun/eigenvalues_sym.hpp, in the same association order.
+  MapM(ctx.in_adj[0].data, n, n) +=
+      eigenvecs * eigenvals_adj.asDiagonal() * eigenvecs.transpose();
 }
 void eigvecs_fwd(KernelCtx& ctx) {
   const int64_t n = ctx.idata[0];
+  if (n == 0) return;
   MatD a = CMapM(ctx.in[0].data, n, n);
-  MapM(ctx.out.data, n, n) = stan::math::eigenvectors_sym(a);
+  // eigenvectors_sym's prim check deliberately names eigenvalues_sym; retain
+  // that observable spelling together with its underlying full solver.
+  stan::math::check_symmetric("eigenvalues_sym", "m", a);
+  Eigen::SelfAdjointEigenSolver<MatD> solver(a);
+  MapM(ctx.out.data, n, n) = solver.eigenvectors();
+  if (!values_only()) Eigen::Map<VecD>(ctx.scratch, n) = solver.eigenvalues();
 }
 void eigvecs_bwd(KernelCtx& ctx) {
+  if (!ctx.in_adj[0].data) return;
   const int64_t n = ctx.idata[0];
-  nary_bwd(ctx, [&](std::vector<VarV>& xs) {
-    VarM a(n, n);
-    for (int64_t j = 0; j < n; ++j)
-      for (int64_t i = 0; i < n; ++i) a(i, j) = xs[0](j * n + i);
-    return stan::math::eigenvectors_sym(a);
-  });
+  if (n == 0) return;
+  CMapM eigenvecs(ctx.out.data, n, n);
+  CMapV eigenvals(ctx.scratch, n);
+  CMapM eigenvecs_adj(ctx.out_adj_vec.data, n, n);
+  // stan/math/rev/fun/eigenvectors_sym.hpp, expression for expression.
+  Eigen::MatrixXd f = (1 / (eigenvals.rowwise().replicate(n).transpose() -
+                            eigenvals.rowwise().replicate(n))
+                               .array());
+  f.diagonal().setZero();
+  MapM(ctx.in_adj[0].data, n, n) +=
+      eigenvecs * f.cwiseProduct(eigenvecs.transpose() * eigenvecs_adj) *
+      eigenvecs.transpose();
 }
+
+int64_t eigvals_scratch(const Op& op, const Slot*) {
+  const int64_t n = op.idata[0];
+  return n * n;
+}
+
+int64_t eigvecs_scratch(const Op& op, const Slot*) { return op.idata[0]; }
 
 // ---- tail densities: one nested var tape, no hand-written derivative ----
 // Everything below binds EVERY argument as var, calls the unmodified
@@ -982,9 +1017,9 @@ void register_matrix_kernels() {
   register_kernel(OP_MDIVIDE_RIGHT,
                   Kernel{solve_fwd<false>, solve_bwd<false>, nullptr});
   register_kernel(OP_EIGENVALUES_SYM,
-                  Kernel{eigvals_fwd, eigvals_bwd, nullptr});
+                  Kernel{eigvals_fwd, eigvals_bwd, eigvals_scratch});
   register_kernel(OP_EIGENVECTORS_SYM,
-                  Kernel{eigvecs_fwd, eigvecs_bwd, nullptr});
+                  Kernel{eigvecs_fwd, eigvecs_bwd, eigvecs_scratch});
   register_kernel(OP_TRANSPOSE, Kernel{transpose_fwd, transpose_bwd, nullptr});
   register_kernel(OP_LKJ_CORR_CHOL_LPDF, Kernel{lkj_fwd, lkj_bwd, nullptr});
   register_kernel(OP_LKJ_CORR_LPDF, Kernel{lkjc_fwd, lkjc_bwd, nullptr});

--- a/runtime/src/OPTIMIZATIONS.md
+++ b/runtime/src/OPTIMIZATIONS.md
@@ -314,6 +314,29 @@ directions read one instruction at a time and decide what to do with it,
 where CmdStan's compiler has inlined the equivalent straight into the
 model's machine code.
 
+## Native symmetric eigendecomposition pullbacks (`matrix_fns.cpp`)
+
+Stan Math's reverse overloads for `eigenvalues_sym` and `eigenvectors_sym`
+retain a full symmetric eigendecomposition on their autodiff tape. The old
+kernels ran the primitive double operation in the forward sweep, discarded
+that decomposition, then rebuilt the input on a nested tape and solved it
+again during the backward sweep.
+
+The forward kernels now retain exactly the missing half of the solver result
+in scratch: eigenvectors beside an eigenvalue output, and eigenvalues beside
+an eigenvector output. Their backwards transcribe Stan Math's matrix
+pullbacks expression for expression, using the retained decomposition and
+plain doubles. `forward_value_only()` keeps the original eigenvalues-only
+solver and writes no backward scratch, so initialization does not pay for
+work it will not use; a later gradient always refreshes the scratch with a
+normal forward first.
+
+On `kronecker_gp`, two matrices each feed both symmetric-eigen operations.
+This removes four reverse-time eigensolves per gradient and moves median
+latency from 289.0 to 185.7 us (1.56x internally, 1.17x CmdStan). The two
+forward operations on each matrix remain separate; sharing them would need a
+paired graph operation and is deliberately outside this kernel-only change.
+
 ## Compiled ODE right-hand sides (`ode_prog.cpp`, report fallbacks: `STANLI_DEBUG_ODE=1`)
 
 An ODE model passes a user function (the right-hand side) to a solver

--- a/tests/test_eigen.cpp
+++ b/tests/test_eigen.cpp
@@ -1,0 +1,273 @@
+// Symmetric eigendecomposition kernels retain the decomposition their
+// pullbacks need.  Pin the forward values and native pullbacks against the
+// exact stan-math calls, including reuse of one Executor: stale eigenvectors
+// or eigenvalues in scratch produce a plausible but wrong second gradient.
+#include <stanli/graph.hpp>
+#include <stanli/optable.hpp>
+
+#include <stan/math.hpp>
+
+#include <cmath>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <limits>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace {
+
+using MatD = Eigen::MatrixXd;
+using VecD = Eigen::VectorXd;
+using VarM = Eigen::Matrix<stan::math::var, -1, -1>;
+
+int failures = 0;
+
+int64_t ulp_key(double d) {
+  int64_t i;
+  std::memcpy(&i, &d, sizeof(i));
+  return i < 0 ? std::numeric_limits<int64_t>::min() - i : i;
+}
+
+void check(bool ok, const std::string& what) {
+  if (!ok) {
+    ++failures;
+    std::printf("FAIL %s\n", what.c_str());
+  }
+}
+
+void expect_eq(const std::string& what, double got, double want) {
+  if (got != want) {
+    ++failures;
+    std::printf("FAIL %-32s got %.17g want %.17g (%lld ulp)\n", what.c_str(),
+                got, want, (long long)std::llabs(ulp_key(got) - ulp_key(want)));
+  }
+}
+
+MatD first_matrix() {
+  MatD a(3, 3);
+  a << 4.0, 0.7, -0.2, 0.7, 2.5, 0.4, -0.2, 0.4, 1.2;
+  return a;
+}
+
+MatD second_matrix() {
+  MatD a(3, 3);
+  a << 1.8, -0.3, 0.6, -0.3, 3.7, -0.5, 0.6, -0.5, 2.4;
+  return a;
+}
+
+std::vector<double> weights(int n) {
+  std::vector<double> w((size_t)n);
+  for (int i = 0; i < n; ++i) w[(size_t)i] = 0.17 * (i + 1) - 0.23 * (i % 3);
+  return w;
+}
+
+struct Result {
+  std::vector<double> value;
+  std::vector<double> grad;
+};
+
+stanli::Graph one_eigen_graph(uint16_t opcode, int n) {
+  using namespace stanli;
+  const int out_len = opcode == OP_EIGENVALUES_SYM ? n : n * n;
+  Graph g;
+  const int a = g.add_slot(n * n, true);
+  const int w = g.add_slot(out_len, false);
+  const int out = g.add_slot(out_len, false);
+  const int lp = g.add_slot(1, false);
+  g.add_op(opcode, {a}, out, {n});
+  g.add_op(OP_DOT, {out, w}, lp);
+  g.result_slot = lp;
+  return g;
+}
+
+// The slot numbering in one_eigen_graph is deliberate and fixed here: input,
+// weights, eigendecomposition output, scalar result.
+class Runner {
+ public:
+  Runner(uint16_t opcode, int n)
+      : opcode_(opcode), n_(n), ex_(one_eigen_graph(opcode, n)) {}
+
+  Result run(const MatD& a, const std::vector<double>& w) {
+    fill(a, w);
+    Result r;
+    r.grad.resize((size_t)n_ * n_);
+    (void)ex_.gradient(r.grad.data());
+    read_value(r);
+    return r;
+  }
+
+  Result run_value_only(const MatD& a, const std::vector<double>& w) {
+    fill(a, w);
+    Result r;
+    (void)ex_.forward_value_only();
+    read_value(r);
+    return r;
+  }
+
+ private:
+  void fill(const MatD& a, const std::vector<double>& w) {
+    for (int i = 0; i < n_ * n_; ++i) ex_.params_data()[i] = a.data()[i];
+    for (size_t i = 0; i < w.size(); ++i) ex_.value_ptr(1)[i] = w[i];
+  }
+
+  void read_value(Result& r) {
+    const int out_len = opcode_ == stanli::OP_EIGENVALUES_SYM ? n_ : n_ * n_;
+    r.value.assign(ex_.value_ptr(2), ex_.value_ptr(2) + out_len);
+  }
+
+  uint16_t opcode_;
+  int n_;
+  stanli::Executor ex_;
+};
+
+std::vector<double> reference_grad(uint16_t opcode, const MatD& a,
+                                   const std::vector<double>& w) {
+  stan::math::nested_rev_autodiff nested;
+  const int n = (int)a.rows();
+  VarM av(n, n);
+  for (int i = 0; i < n * n; ++i) av.data()[i] = a.data()[i];
+  auto pullback = [&](const auto& out) {
+    MatD seed(out.rows(), out.cols());
+    for (int i = 0; i < seed.size(); ++i) seed.data()[i] = w[(size_t)i];
+    stan::math::var lp = stan::math::sum(stan::math::elt_multiply(out, seed));
+    stan::math::grad(lp.vi_);
+    std::vector<double> grad((size_t)n * n);
+    for (int i = 0; i < n * n; ++i) grad[(size_t)i] = av.data()[i].adj();
+    return grad;
+  };
+  if (opcode == stanli::OP_EIGENVALUES_SYM)
+    return pullback(stan::math::eigenvalues_sym(av));
+  return pullback(stan::math::eigenvectors_sym(av));
+}
+
+std::vector<double> reference_value(uint16_t opcode, const MatD& a) {
+  if (opcode == stanli::OP_EIGENVALUES_SYM) {
+    VecD out = stan::math::eigenvalues_sym(a);
+    return std::vector<double>(out.data(), out.data() + out.size());
+  }
+  MatD out = stan::math::eigenvectors_sym(a);
+  return std::vector<double>(out.data(), out.data() + out.size());
+}
+
+void compare(uint16_t opcode, const std::string& name, Runner& runner,
+             const MatD& a) {
+  const int out_len =
+      opcode == stanli::OP_EIGENVALUES_SYM ? (int)a.rows() : (int)a.size();
+  const std::vector<double> w = weights(out_len);
+  const Result got = runner.run(a, w);
+  const std::vector<double> want_value = reference_value(opcode, a);
+  const std::vector<double> want_grad = reference_grad(opcode, a, w);
+  for (size_t i = 0; i < got.value.size(); ++i)
+    expect_eq(name + " value[" + std::to_string(i) + "]", got.value[i],
+              want_value[i]);
+  for (size_t i = 0; i < got.grad.size(); ++i)
+    expect_eq(name + " grad[" + std::to_string(i) + "]", got.grad[i],
+              want_grad[i]);
+}
+
+void compare_value_only(uint16_t opcode, const std::string& name,
+                        Runner& runner, const MatD& a) {
+  const int out_len =
+      opcode == stanli::OP_EIGENVALUES_SYM ? (int)a.rows() : (int)a.size();
+  const Result got = runner.run_value_only(a, weights(out_len));
+  const std::vector<double> want = reference_value(opcode, a);
+  for (size_t i = 0; i < got.value.size(); ++i)
+    expect_eq(name + " value-only[" + std::to_string(i) + "]", got.value[i],
+              want[i]);
+}
+
+void check_full_solver_value_parity(const MatD& a, const std::string& name) {
+  Eigen::SelfAdjointEigenSolver<MatD> solver(a);
+  const VecD values_only = stan::math::eigenvalues_sym(a);
+  const MatD vectors_prim = stan::math::eigenvectors_sym(a);
+  for (int i = 0; i < a.rows(); ++i)
+    expect_eq(name + " full/value-only eigenvalue " + std::to_string(i),
+              solver.eigenvalues()(i), values_only(i));
+  for (int i = 0; i < a.size(); ++i)
+    expect_eq(name + " full/prim eigenvector " + std::to_string(i),
+              solver.eigenvectors().data()[i], vectors_prim.data()[i]);
+}
+
+void check_scratch_sizes() {
+  using namespace stanli;
+  int n_data[] = {3};
+  Slot slots[] = {{0, 9, true}, {0, 3, false}, {0, 9, false}};
+  Op vals;
+  vals.opcode = OP_EIGENVALUES_SYM;
+  vals.in[0] = 0;
+  vals.n_in = 1;
+  vals.out = 1;
+  vals.idata = n_data;
+  vals.n_idata = 1;
+  Op vecs = vals;
+  vecs.opcode = OP_EIGENVECTORS_SYM;
+  vecs.out = 2;
+  const Kernel* kv = find_kernel(OP_EIGENVALUES_SYM);
+  const Kernel* kV = find_kernel(OP_EIGENVECTORS_SYM);
+  check(kv && kv->scratch_size, "eigenvalues scratch callback");
+  check(kV && kV->scratch_size, "eigenvectors scratch callback");
+  if (kv && kv->scratch_size)
+    check(kv->scratch_size(vals, slots) == 9,
+          "eigenvalues retain n*n eigenvectors");
+  if (kV && kV->scratch_size)
+    check(kV->scratch_size(vecs, slots) == 3,
+          "eigenvectors retain n eigenvalues");
+  n_data[0] = 0;
+  if (kv && kv->scratch_size)
+    check(kv->scratch_size(vals, slots) == 0, "zero eigenvalues scratch");
+  if (kV && kV->scratch_size)
+    check(kV->scratch_size(vecs, slots) == 0, "zero eigenvectors scratch");
+}
+
+}  // namespace
+
+int main() {
+  using namespace stanli;
+  const MatD a = first_matrix();
+  const MatD b = second_matrix();
+
+  // Eigen's full and EigenvaluesOnly paths must agree bitwise before the
+  // eigenvalues kernel may retain vectors from the full decomposition.
+  check_full_solver_value_parity(a, "3x3 a");
+  check_full_solver_value_parity(b, "3x3 b");
+  MatD r(30, 30);
+  for (int j = 0; j < r.cols(); ++j)
+    for (int i = 0; i < r.rows(); ++i)
+      r(i, j) = std::sin(0.13 * (i + 1) * (j + 2)) + 0.01 * (i - j);
+  MatD big = r * r.transpose();
+  big.diagonal().array() += 0.5;
+  check_full_solver_value_parity(big, "30x30");
+
+  Runner vals(OP_EIGENVALUES_SYM, 3);
+  Runner vecs(OP_EIGENVECTORS_SYM, 3);
+  compare_value_only(OP_EIGENVALUES_SYM, "eigenvalues", vals, a);
+  compare_value_only(OP_EIGENVECTORS_SYM, "eigenvectors", vecs, a);
+  compare(OP_EIGENVALUES_SYM, "eigenvalues first", vals, a);
+  compare(OP_EIGENVECTORS_SYM, "eigenvectors first", vecs, a);
+  // Reuse the same Executors in both directions.  This catches scratch that
+  // is only initialized once as well as a partial overwrite on a later run.
+  compare(OP_EIGENVALUES_SYM, "eigenvalues second", vals, b);
+  compare(OP_EIGENVECTORS_SYM, "eigenvectors second", vecs, b);
+  compare(OP_EIGENVALUES_SYM, "eigenvalues repeat", vals, a);
+  compare(OP_EIGENVECTORS_SYM, "eigenvectors repeat", vecs, a);
+
+  MatD scalar(1, 1);
+  scalar(0, 0) = 2.75;
+  Runner scalar_vals(OP_EIGENVALUES_SYM, 1);
+  Runner scalar_vecs(OP_EIGENVECTORS_SYM, 1);
+  compare(OP_EIGENVALUES_SYM, "eigenvalues 1x1", scalar_vals, scalar);
+  compare(OP_EIGENVECTORS_SYM, "eigenvectors 1x1", scalar_vecs, scalar);
+
+  // Real kronecker_gp shape: this exercises Eigen's blocked products over
+  // CMap operands in both native pullbacks, not just scalar-size kernels.
+  Runner big_vals(OP_EIGENVALUES_SYM, 30);
+  Runner big_vecs(OP_EIGENVECTORS_SYM, 30);
+  compare(OP_EIGENVALUES_SYM, "eigenvalues 30x30", big_vals, big);
+  compare(OP_EIGENVECTORS_SYM, "eigenvectors 30x30", big_vecs, big);
+  check_scratch_sizes();
+
+  if (failures == 0) std::printf("test_eigen OK\n");
+  return failures == 0 ? 0 : 1;
+}


### PR DESCRIPTION
## Summary

- retain the eigenvectors/eigenvalues that Stan Math's symmetric eigensolvers already compute in the forward sweep
- replace nested-autodiff replay and reverse-time eigensolves with the pinned Stan Math pullback formulas over doubles
- preserve the original `EigenvaluesOnly` path during `forward_value_only()`
- add bitwise value/gradient coverage at 1x1, 3x3, and the real 30x30 Kronecker shape, including scratch reuse

## Performance

On the same cached `kronecker_gp` MIR/data and five 2,000-gradient runs:

| | before | after |
| --- | ---: | ---: |
| median gradient | 289.0 us | 185.7 us |
| vs CmdStan (218.0 us) | 0.75x | 1.17x |

This is a 1.56x internal speedup. Profiled symmetric-eigen backward work falls from 127.9 us to 13.4 us per gradient. The two forward decompositions of each matrix remain separate; sharing them is deliberately left to a later graph-level change.

## Validation

- clean isolated Release build
- 56/56 CTest tests passed
- 129/129 corpus models within their CmdStan reference gates at all three points (800,674 values)
- focused `kronecker_gp` replay passed at all three points (1,317 values)
- format, generated docs, generated web models, and diff checks passed

## Stack

Stacked on #159 (`perf/native-bernoulli`); this PR contains only the symmetric-eigen commit.
