### PR TITLE
perf: specialize Cholesky normal pullback

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -483,6 +483,7 @@ install(DIRECTORY runtime/include/stanli
 
 set(STANLI_TESTS
   test_smoke test_executor test_recorder test_densities test_matvec test_eigen
+  test_mnc
   test_legacy test_eight_schools test_glm test_nuts test_walnuts test_sexp
   test_mir test_transforms test_eltwise test_scalar_binary test_lower
   test_lower_views

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -18,7 +18,8 @@ The harness now records file read, parse, compile, construction, and binding
 only; that column should be refreshed as a unit rather than mixing definitions.
 Targeted preparation measurements later on this page use the new mode.
 
-Five targeted 2026-08-23 remeasurements are newer than the full snapshot below.
+Six targeted remeasurements from 2026-08-23 and 2026-08-24 are newer than the
+full snapshot below.
 Packed row-wise `log_sum_exp` reduces `ldaK2` from 15,854 ops to 22 and
 154 to 94 us/gradient (1.11x CmdStan), and `ldaK5` from 434,126 ops to 156
 and 6.82 to 3.70 ms/gradient (1.51x CmdStan). `ldaK5` file-to-bound-model
@@ -34,8 +35,11 @@ CmdStan). Preserving the separate initial-state and parameter scalar types in
 ODE solves removes one inactive sensitivity system from
 `one_comp_mm_elim_abs`, moving it from 699 to 639 us/gradient (1.09x
 internally, 0.67x to 0.74x CmdStan); ODE models whose two inputs are active are
-unchanged. The committed full-corpus tables retain one measurement definition
-and will be refreshed as a unit.
+unchanged. A native partial matrix for the exact single-observation,
+Cholesky-factor-active density in `gp_regr` moves it from 6.05 to 4.20
+us/gradient (1.44x internally, 0.77x to 1.12x CmdStan). The committed
+full-corpus tables retain one measurement definition and will be refreshed as
+a unit.
 
 ## Per-gradient latency
 

--- a/docs/superpowers/plans/2026-08-08-cmdstan-parity-roadmap.md
+++ b/docs/superpowers/plans/2026-08-08-cmdstan-parity-roadmap.md
@@ -163,8 +163,9 @@ Alongside it, the tail fixes the profile already names:
   `prophet` fixes. `Mt_model` is now closed: direct Bernoulli partials move it
   from 30.6 to 19.2 us/gradient, or 0.99x CmdStan. `kronecker_gp` is closed as
   well: retaining each symmetric eigendecomposition for its native pullback
-  moves it from 289.0 to 185.7 us/gradient, or 1.17x CmdStan. `gp_regr` remains
-  (55% in `multi_normal_cholesky_lpdf`). Preserving mixed ODE scalar types
+  moves it from 289.0 to 185.7 us/gradient, or 1.17x CmdStan. `gp_regr` is
+  closed too: retaining the exact active-Cholesky partial matrix moves it from
+  6.05 to 4.20 us/gradient, or 1.12x CmdStan. Preserving mixed ODE scalar types
   removes the inactive initial-state sensitivity from
   `one_comp_mm_elim_abs`, moving it from 699 to 639 us/gradient; the remaining
   ODE gap is inside the solver/RHS execution rather than graph dispatch.

--- a/runtime/kernels/matrix_fns.cpp
+++ b/runtime/kernels/matrix_fns.cpp
@@ -1,8 +1,9 @@
 // Matrix-valued legacy ops: GP covariance, cholesky_decompose, diag_matrix,
-// multi_normal(_cholesky). Forward runs the prim (double) implementation;
-// backward replays the same call on a nested var tape and seeds the output
-// adjoints with the dot trick. Correct by construction against the code
-// CmdStan runs, at the cost of a nested tape per gradient.
+// multi_normal(_cholesky). Most forwards run the prim (double)
+// implementation and backwards replay the same call on a nested var tape,
+// seeded with the dot trick. The profiled single-vector Cholesky density below
+// is the compact native exception: it retains Stan Math's closed-form matrix
+// partials from forward to backward.
 //
 // Matrices live in slots column-major, matching Eigen and the rest of the
 // pipeline, so a flat slot maps straight onto Map<MatrixXd>.
@@ -285,8 +286,98 @@ void mnprec_fwd(KernelCtx& ctx) {
   ctx.out.data[0] = mn_eval<false, kMnPrec>(ctx);
 }
 void mnprec_bwd(KernelCtx& ctx) { mn_eval<true, kMnPrec>(ctx); }
-void mnc_fwd(KernelCtx& ctx) { ctx.out.data[0] = mn_eval<false, kMnChol>(ctx); }
-void mnc_bwd(KernelCtx& ctx) { mn_eval<true, kMnChol>(ctx); }
+
+// gp_regr's single-observation Cholesky density has data y and mu, active L,
+// and propto=true. In that exact instantiation Stan Math's partials
+// propagator computes a closed-form L pullback in doubles, then builds a var
+// edge around it. Retain that matrix in scratch during the forward instead of
+// rebuilding an AoS var matrix and nested tape in both sweeps. The equality
+// checks here are deliberately strict: every other activity, propto, and
+// vectorized shape stays on mn_eval's generic replay.
+inline bool mnc_native_variant(uint8_t variant, const int* idata,
+                               int64_t n_idata) {
+  return variant == 0x84u && idata != nullptr && n_idata == 2 &&
+         idata[0] >= 0 && idata[1] == 1;
+}
+
+bool mnc_native_shape(const KernelCtx& ctx) {
+  if (!mnc_native_variant(ctx.variant, ctx.idata, ctx.n_idata) ||
+      ctx.n_in != 3 || ctx.out.len != 1)
+    return false;
+  const int64_t n = ctx.idata[0];
+  return ctx.in[0].len == n && ctx.in[1].len == n && ctx.in[2].len == n * n;
+}
+
+double mnc_native_fwd(KernelCtx& ctx) {
+  static constexpr const char* function = "multi_normal_cholesky_lpdf";
+  const int64_t n = ctx.idata[0];
+  CMapV y(ctx.in[0].data, n), mu(ctx.in[1].data, n);
+  CMapM L(ctx.in[2].data, n, n);
+
+  // Copy the pinned single-vector Stan Math overload's checks and
+  // arithmetic order. That overload intentionally does not call
+  // check_cholesky_factor; changing its observable domain here would make the
+  // native and fallback paths disagree.
+  stan::math::check_size_match(function, "Size of random variable", y.size(),
+                               "size of location parameter", mu.size());
+  stan::math::check_size_match(function, "Size of random variable", y.size(),
+                               "rows of covariance parameter", L.rows());
+  stan::math::check_size_match(function, "Size of random variable", y.size(),
+                               "columns of covariance parameter", L.cols());
+  stan::math::check_finite(function, "Location parameter", mu);
+  stan::math::check_not_nan(function, "Random variable", y);
+  if (n == 0) return 0.0;
+
+  VecD y_minus_mu = y - mu;
+  MatD inv_L = stan::math::mdivide_left_tri<Eigen::Lower>(L);
+  Eigen::RowVectorXd half;
+  half = (inv_L.template triangularView<Eigen::Lower>() *
+          y_minus_mu.template cast<double>())
+             .transpose();
+
+  VecD scaled_diff;
+  if (!values_only()) {
+    scaled_diff =
+        (half * inv_L.template triangularView<Eigen::Lower>()).transpose();
+  }
+
+  double logp(0.0);
+  logp += stan::math::sum(stan::math::log(inv_L.diagonal()));
+  if (!values_only()) {
+    MapM partials(ctx.scratch, n, n);
+    partials.setZero();
+    partials += scaled_diff * half - inv_L.transpose();
+  }
+  logp -= 0.5 * stan::math::sum(stan::math::dot_self(half));
+  return logp;
+}
+
+void mnc_fwd(KernelCtx& ctx) {
+  ctx.out.data[0] = mnc_native_shape(ctx) ? mnc_native_fwd(ctx)
+                                          : mn_eval<false, kMnChol>(ctx);
+}
+void mnc_bwd(KernelCtx& ctx) {
+  if (!mnc_native_shape(ctx)) {
+    mn_eval<true, kMnChol>(ctx);
+    return;
+  }
+  if (!ctx.in_adj[2].data) return;
+  const int64_t n = ctx.idata[0];
+  for (int64_t i = 0; i < n * n; ++i)
+    ctx.in_adj[2].data[i] += ctx.out_adj * ctx.scratch[i];
+}
+
+int64_t mnc_scratch(const Op& op, const Slot* slots) {
+  if (!mnc_native_variant(op.variant, op.idata, op.n_idata) || op.n_in != 3 ||
+      op.out < 0 || slots == nullptr)
+    return 0;
+  const int64_t n = op.idata[0];
+  if (op.in[0] < 0 || op.in[1] < 0 || op.in[2] < 0 ||
+      slots[op.in[0]].len != n || slots[op.in[1]].len != n ||
+      slots[op.in[2]].len != n * n || slots[op.out].len != 1)
+    return 0;
+  return n * n;
+}
 
 // ---- general matrix product: out = A * B ----------------------------------
 // idata = {rows_a, cols_a, cols_b}; either side may carry adjoints.
@@ -1007,7 +1098,8 @@ void register_matrix_kernels() {
                   Kernel{olglm_fwd, olglm_bwd, nullptr});
   register_kernel(OP_DIAG_MATRIX, Kernel{diag_fwd, diag_bwd, nullptr});
   register_kernel(OP_CHOLESKY, Kernel{chol_fwd, chol_bwd, nullptr});
-  register_kernel(OP_MULTI_NORMAL_CHOL_LPDF, Kernel{mnc_fwd, mnc_bwd, nullptr});
+  register_kernel(OP_MULTI_NORMAL_CHOL_LPDF,
+                  Kernel{mnc_fwd, mnc_bwd, mnc_scratch});
   register_kernel(OP_MULTI_NORMAL_LPDF, Kernel{mn_fwd, mn_bwd, nullptr});
   register_kernel(OP_MULTI_NORMAL_PREC_LPDF,
                   Kernel{mnprec_fwd, mnprec_bwd, nullptr});

--- a/runtime/src/OPTIMIZATIONS.md
+++ b/runtime/src/OPTIMIZATIONS.md
@@ -337,6 +337,21 @@ latency from 289.0 to 185.7 us (1.56x internally, 1.17x CmdStan). The two
 forward operations on each matrix remain separate; sharing them would need a
 paired graph operation and is deliberately outside this kernel-only change.
 
+## Native single-vector Cholesky normal (`matrix_fns.cpp`)
+
+The `gp_regr` likelihood is one `multi_normal_cholesky_lpdf` observation with
+data `y` and `mu`, an active Cholesky factor, and `propto=true`. Stan Math has
+an analytic matrix partial for that exact instantiation, but the generic
+kernel rebuilt an elementwise var matrix and nested tape in both sweeps.
+
+The exact `variant=0x84`, one-observation shape now evaluates Stan Math's
+triangular inverse, half-vector, value, and full factor-partial matrix in the
+same expression order during forward, retaining the partial matrix in
+scratch. Backward is only the seeded accumulation into the factor. All other
+activity masks, vectorized observations, and non-propto calls keep the generic
+Stan Math replay. On `gp_regr` the density falls from 2.48 to 0.70 us and the
+whole gradient from 6.05 to 4.20 us (1.44x internally, 1.12x CmdStan).
+
 ## Compiled ODE right-hand sides (`ode_prog.cpp`, report fallbacks: `STANLI_DEBUG_ODE=1`)
 
 An ODE model passes a user function (the right-hand side) to a solver

--- a/tests/test_mnc.cpp
+++ b/tests/test_mnc.cpp
@@ -1,0 +1,427 @@
+// The gp_regr multi_normal_cholesky fast path retains the pinned Stan Math
+// single-vector pullback in scratch. Pin its exact value and gradient, reuse
+// one Executor across value-only and gradient calls, and make every guard
+// mutation fall back to the generic nested-var implementation.
+#include <stanli/graph.hpp>
+#include <stanli/optable.hpp>
+
+#include <stan/math.hpp>
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <limits>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace {
+
+using MatD = Eigen::MatrixXd;
+using VecD = Eigen::VectorXd;
+using VarM = Eigen::Matrix<stan::math::var, -1, -1>;
+using VarV = Eigen::Matrix<stan::math::var, -1, 1>;
+
+int failures = 0;
+
+uint64_t bits(double x) {
+  uint64_t out;
+  std::memcpy(&out, &x, sizeof(out));
+  return out;
+}
+
+void check(bool ok, const std::string& what) {
+  if (!ok) {
+    ++failures;
+    std::printf("FAIL %s\n", what.c_str());
+  }
+}
+
+void expect_bits(const std::string& what, double got, double want) {
+  if (bits(got) != bits(want)) {
+    ++failures;
+    std::printf("FAIL %-42s got %.17g [%016llx] want %.17g [%016llx]\n",
+                what.c_str(), got, (unsigned long long)bits(got), want,
+                (unsigned long long)bits(want));
+  }
+}
+
+struct Inputs {
+  int n = 0;
+  int m = 1;
+  std::vector<double> y;
+  std::vector<double> mu;
+  std::vector<double> L;
+};
+
+Inputs inputs(int n, int m, double shift) {
+  Inputs x;
+  x.n = n;
+  x.m = m;
+  x.y.resize((size_t)n * m);
+  x.mu.resize((size_t)n);
+  x.L.assign((size_t)n * n, 0.0);
+  for (int k = 0; k < m; ++k)
+    for (int i = 0; i < n; ++i)
+      x.y[(size_t)k * n + i] =
+          std::sin(0.17 * (i + 1) * (k + 2) + shift) + 0.03 * i;
+  for (int i = 0; i < n; ++i)
+    x.mu[(size_t)i] = std::cos(0.11 * (i + 2) + shift) - 0.02 * i;
+  for (int j = 0; j < n; ++j)
+    for (int i = j; i < n; ++i)
+      x.L[(size_t)j * n + i] =
+          i == j ? 1.15 + 0.04 * i + 0.01 * shift
+                 : 0.025 * std::sin(0.19 * (i + 1) * (j + 2) + shift);
+  return x;
+}
+
+struct Result {
+  double density = 0.0;
+  double total = 0.0;
+  std::vector<double> dy;
+  std::vector<double> dmu;
+  std::vector<double> dL;
+};
+
+template <bool Propto>
+Result reference_l_only(const Inputs& x, double seed) {
+  stan::math::nested_rev_autodiff nested;
+  Eigen::Map<const VecD> y(x.y.data(), x.n);
+  Eigen::Map<const VecD> mu(x.mu.data(), x.n);
+  VarM L(x.n, x.n);
+  for (int i = 0; i < x.n * x.n; ++i) L.data()[i] = x.L[(size_t)i];
+  stan::math::var density =
+      stan::math::multi_normal_cholesky_lpdf<Propto>(y, mu, L);
+  stan::math::var total = density * seed;
+  stan::math::grad(total.vi_);
+  Result r;
+  r.density = density.val();
+  r.total = total.val();
+  r.dy.assign(x.y.size(), 0.0);
+  r.dmu.assign(x.mu.size(), 0.0);
+  r.dL.resize(x.L.size());
+  for (int i = 0; i < x.n * x.n; ++i) r.dL[(size_t)i] = L.data()[i].adj();
+  return r;
+}
+
+template <bool Propto>
+Result reference_all_active(const Inputs& x, double seed) {
+  stan::math::nested_rev_autodiff nested;
+  VarV y(x.n), mu(x.n);
+  VarM L(x.n, x.n);
+  for (int i = 0; i < x.n; ++i) {
+    y(i) = x.y[(size_t)i];
+    mu(i) = x.mu[(size_t)i];
+  }
+  for (int i = 0; i < x.n * x.n; ++i) L.data()[i] = x.L[(size_t)i];
+  stan::math::var density =
+      stan::math::multi_normal_cholesky_lpdf<Propto>(y, mu, L);
+  stan::math::var total = density * seed;
+  stan::math::grad(total.vi_);
+  Result r;
+  r.density = density.val();
+  r.total = total.val();
+  r.dy.resize(x.y.size());
+  r.dmu.resize(x.mu.size());
+  r.dL.resize(x.L.size());
+  for (int i = 0; i < x.n; ++i) {
+    r.dy[(size_t)i] = y(i).adj();
+    r.dmu[(size_t)i] = mu(i).adj();
+  }
+  for (int i = 0; i < x.n * x.n; ++i) r.dL[(size_t)i] = L.data()[i].adj();
+  return r;
+}
+
+template <bool Propto>
+Result reference_vectorized_l(const Inputs& x, double seed) {
+  stan::math::nested_rev_autodiff nested;
+  std::vector<VecD> y((size_t)x.m, VecD(x.n));
+  for (int k = 0; k < x.m; ++k)
+    for (int i = 0; i < x.n; ++i) y[(size_t)k](i) = x.y[(size_t)k * x.n + i];
+  Eigen::Map<const VecD> mu(x.mu.data(), x.n);
+  VarM L(x.n, x.n);
+  for (int i = 0; i < x.n * x.n; ++i) L.data()[i] = x.L[(size_t)i];
+  stan::math::var density =
+      stan::math::multi_normal_cholesky_lpdf<Propto>(y, mu, L);
+  stan::math::var total = density * seed;
+  stan::math::grad(total.vi_);
+  Result r;
+  r.density = density.val();
+  r.total = total.val();
+  r.dy.assign(x.y.size(), 0.0);
+  r.dmu.assign(x.mu.size(), 0.0);
+  r.dL.resize(x.L.size());
+  for (int i = 0; i < x.n * x.n; ++i) r.dL[(size_t)i] = L.data()[i].adj();
+  return r;
+}
+
+std::vector<double> sentinel(size_t n, double base) {
+  std::vector<double> out(n);
+  for (size_t i = 0; i < n; ++i)
+    out[i] = base + 0.03125 * static_cast<double>(i % 7);
+  return out;
+}
+
+Result run_direct(const Inputs& x, uint8_t variant, double seed,
+                  const std::vector<double>& dy0,
+                  const std::vector<double>& dmu0,
+                  const std::vector<double>& dL0, bool connect_L = true) {
+  using namespace stanli;
+  const Kernel* kernel = find_kernel(OP_MULTI_NORMAL_CHOL_LPDF);
+  if (!kernel) throw std::runtime_error("MNC kernel missing");
+  int dims[2] = {x.n, x.m};
+  double density = std::numeric_limits<double>::quiet_NaN();
+  std::vector<double> scratch(
+      std::max<size_t>(1, static_cast<size_t>(x.n) * x.n),
+      std::numeric_limits<double>::quiet_NaN());
+  Result r;
+  r.dy = dy0;
+  r.dmu = dmu0;
+  r.dL = dL0;
+  KernelCtx ctx;
+  ctx.n_in = 3;
+  ctx.in[0] = Desc{const_cast<double*>(x.y.data()), (int64_t)x.y.size()};
+  ctx.in[1] = Desc{const_cast<double*>(x.mu.data()), (int64_t)x.mu.size()};
+  ctx.in[2] = Desc{const_cast<double*>(x.L.data()), (int64_t)x.L.size()};
+  ctx.out = Desc{&density, 1};
+  ctx.variant = variant;
+  ctx.scratch = scratch.data();
+  ctx.idata = dims;
+  ctx.n_idata = 2;
+  ctx.in_adj[0] = Desc{r.dy.data(), (int64_t)r.dy.size()};
+  ctx.in_adj[1] = Desc{r.dmu.data(), (int64_t)r.dmu.size()};
+  ctx.in_adj[2] = Desc{connect_L ? r.dL.data() : nullptr, (int64_t)r.dL.size()};
+  ctx.out_adj = seed;
+  kernel->forward(ctx);
+  kernel->backward(ctx);
+  r.density = density;
+  r.total = density * seed;
+  return r;
+}
+
+void compare_direct(const std::string& tag, const Inputs& x, uint8_t variant,
+                    double seed, const Result& want, bool y_active,
+                    bool mu_active, bool L_active = true) {
+  const std::vector<double> dy0 = sentinel(x.y.size(), 7.25);
+  const std::vector<double> dmu0 = sentinel(x.mu.size(), -5.5);
+  const std::vector<double> dL0 = sentinel(x.L.size(), 0.375);
+  const Result got = run_direct(x, variant, seed, dy0, dmu0, dL0, L_active);
+  expect_bits(tag + " density", got.density, want.density);
+  expect_bits(tag + " total", got.total, want.total);
+  for (size_t i = 0; i < got.dy.size(); ++i) {
+    const double expected = y_active ? dy0[i] + want.dy[i] : dy0[i];
+    expect_bits(tag + " dy[" + std::to_string(i) + "]", got.dy[i], expected);
+  }
+  for (size_t i = 0; i < got.dmu.size(); ++i) {
+    const double expected = mu_active ? dmu0[i] + want.dmu[i] : dmu0[i];
+    expect_bits(tag + " dmu[" + std::to_string(i) + "]", got.dmu[i], expected);
+  }
+  for (size_t i = 0; i < got.dL.size(); ++i)
+    expect_bits(tag + " dL[" + std::to_string(i) + "]", got.dL[i],
+                L_active ? dL0[i] + want.dL[i] : dL0[i]);
+}
+
+stanli::Graph fast_graph(int n) {
+  using namespace stanli;
+  Graph g;
+  const int y = g.add_slot(n, false);
+  const int mu = g.add_slot(n, false);
+  const int L = g.add_slot(n * n, true);
+  const int density = g.add_slot(1, false);
+  const int seed = g.add_slot(1, false);
+  const int total = g.add_slot(1, false);
+  const int op =
+      g.add_op(OP_MULTI_NORMAL_CHOL_LPDF, {y, mu, L}, density, {n, 1});
+  g.ops[(size_t)op].variant = 0x84u;
+  g.add_op(OP_MUL, {density, seed}, total);
+  g.result_slot = total;
+  return g;
+}
+
+class Runner {
+ public:
+  explicit Runner(int n) : n_(n), ex_(fast_graph(n)) {}
+
+  Result gradient(const Inputs& x, double seed) {
+    fill(x, seed);
+    Result r;
+    r.dL.resize((size_t)n_ * n_);
+    r.total = ex_.gradient(r.dL.data());
+    r.density = ex_.value_ptr(3)[0];
+    return r;
+  }
+
+  Result value_only(const Inputs& x, double seed) {
+    fill(x, seed);
+    Result r;
+    r.total = ex_.forward_value_only();
+    r.density = ex_.value_ptr(3)[0];
+    return r;
+  }
+
+ private:
+  void fill(const Inputs& x, double seed) {
+    std::copy(x.y.begin(), x.y.end(), ex_.value_ptr(0));
+    std::copy(x.mu.begin(), x.mu.end(), ex_.value_ptr(1));
+    std::copy(x.L.begin(), x.L.end(), ex_.value_ptr(2));
+    ex_.value_ptr(4)[0] = seed;
+  }
+
+  int n_;
+  stanli::Executor ex_;
+};
+
+void compare_runner(const std::string& tag, const Result& got,
+                    const Result& want, bool gradient) {
+  expect_bits(tag + " density", got.density, want.density);
+  expect_bits(tag + " total", got.total, want.total);
+  if (gradient)
+    for (size_t i = 0; i < got.dL.size(); ++i)
+      expect_bits(tag + " dL[" + std::to_string(i) + "]", got.dL[i],
+                  want.dL[i]);
+}
+
+int64_t scratch_for(uint8_t variant, int n, int m, int64_t y_len,
+                    int64_t mu_len, int64_t L_len, int64_t n_idata = 2) {
+  using namespace stanli;
+  const Kernel* kernel = find_kernel(OP_MULTI_NORMAL_CHOL_LPDF);
+  if (!kernel || !kernel->scratch_size) return -1;
+  int dims[2] = {n, m};
+  Slot slots[4];
+  slots[0].len = y_len;
+  slots[1].len = mu_len;
+  slots[2].len = L_len;
+  slots[3].len = 1;
+  Op op;
+  op.opcode = OP_MULTI_NORMAL_CHOL_LPDF;
+  op.variant = variant;
+  op.in[0] = 0;
+  op.in[1] = 1;
+  op.in[2] = 2;
+  op.n_in = 3;
+  op.out = 3;
+  op.idata = dims;
+  op.n_idata = n_idata;
+  return kernel->scratch_size(op, slots);
+}
+
+template <typename F>
+std::string thrown(F&& f) {
+  try {
+    f();
+  } catch (const std::exception& e) {
+    return e.what();
+  }
+  return {};
+}
+
+std::string native_error(const Inputs& x) {
+  return thrown([&] {
+    const auto dy = sentinel(x.y.size(), 1.0);
+    const auto dm = sentinel(x.mu.size(), 2.0);
+    const auto dL = sentinel(x.L.size(), 3.0);
+    (void)run_direct(x, 0x84u, 0.7, dy, dm, dL);
+  });
+}
+
+std::string reference_error(const Inputs& x) {
+  return thrown([&] { (void)reference_l_only<true>(x, 0.7); });
+}
+
+}  // namespace
+
+int main() {
+  using namespace stanli;
+  const double seed = -0.73;
+
+  // Direct non-unit-seed calls pin every n*n partial (including the upper
+  // triangle), += into prefilled adjoints, and non-null inactive y/mu adjoint
+  // buffers. n=1 catches scalar-size Eigen branches; n=11 is gp_regr's
+  // corpus dimension and exercises blocked matrix products.
+  const Inputs one = inputs(1, 1, 0.2);
+  compare_direct("native n=1", one, 0x84u, seed,
+                 reference_l_only<true>(one, seed), false, false);
+  compare_direct("native null L adj", one, 0x84u, seed,
+                 reference_l_only<true>(one, seed), false, false, false);
+  const Inputs eleven_a = inputs(11, 1, -0.4);
+  const Inputs eleven_b = inputs(11, 1, 0.9);
+  compare_direct("native n=11", eleven_a, 0x84u, seed,
+                 reference_l_only<true>(eleven_a, seed), false, false);
+
+  // Empty inputs return a connected-type literal zero without touching any
+  // adjoint. Keep the native empty branch aligned with the same Stan Math
+  // instantiation.
+  const Inputs empty = inputs(0, 1, 0.0);
+  compare_direct("native empty", empty, 0x84u, seed,
+                 reference_l_only<true>(empty, seed), false, false);
+
+  // A value-only call may leave old partials in scratch, but the next
+  // gradient must run a complete forward and replace all of them.
+  Runner runner(11);
+  const Result ref_a = reference_l_only<true>(eleven_a, seed);
+  const Result ref_b = reference_l_only<true>(eleven_b, seed);
+  compare_runner("reuse gradient a", runner.gradient(eleven_a, seed), ref_a,
+                 true);
+  compare_runner("reuse value-only b", runner.value_only(eleven_b, seed), ref_b,
+                 false);
+  compare_runner("reuse gradient b", runner.gradient(eleven_b, seed), ref_b,
+                 true);
+  compare_runner("reuse gradient a again", runner.gradient(eleven_a, seed),
+                 ref_a, true);
+
+  // Exact scratch sizing is the fast-path sentinel. These near misses are
+  // real supported contracts and must continue through mn_eval: non-propto,
+  // another active argument, vectorized y, legacy activity, the hier_2pl
+  // all-active variant, a missing repetition immediate, or malformed slots.
+  check(scratch_for(0x84u, 11, 1, 11, 11, 121) == 121,
+        "native gate gets n*n scratch");
+  check(scratch_for(0x04u, 11, 1, 11, 11, 121) == 0,
+        "non-propto refuses native path");
+  check(scratch_for(0x85u, 11, 1, 11, 11, 121) == 0,
+        "active y refuses native path");
+  check(scratch_for(0x84u, 11, 2, 22, 11, 121) == 0,
+        "vectorized y refuses native path");
+  check(scratch_for(0x00u, 11, 1, 11, 11, 121) == 0,
+        "legacy variant refuses native path");
+  check(scratch_for(0x07u, 11, 1, 11, 11, 121) == 0,
+        "hier_2pl variant refuses native path");
+  check(scratch_for(0x84u, 11, 1, 11, 11, 121, 1) == 0,
+        "missing repetition immediate refuses native path");
+  check(scratch_for(0x84u, 11, 1, 11, 10, 121) == 0,
+        "malformed mu refuses native path");
+
+  // Functional fallback oracles accompany the sizing sentinels: one changed
+  // variant, the hier_2pl all-active contract (also legacy variant zero), and
+  // the vectorized-y overload.
+  const Inputs three = inputs(3, 1, 0.35);
+  compare_direct("fallback non-propto", three, 0x04u, seed,
+                 reference_l_only<false>(three, seed), false, false);
+  compare_direct("fallback hier activity", three, 0x07u, seed,
+                 reference_all_active<false>(three, seed), true, true);
+  compare_direct("fallback legacy activity", three, 0x00u, seed,
+                 reference_all_active<false>(three, seed), true, true);
+  const Inputs vectorized = inputs(3, 2, -0.15);
+  compare_direct("fallback vectorized", vectorized, 0x84u, seed,
+                 reference_vectorized_l<true>(vectorized, seed), false, false);
+
+  // Preserve the exact observable checks of the pinned single-vector
+  // overload on invalid data as well as its finite path.
+  Inputs bad_mu = inputs(3, 1, 0.1);
+  bad_mu.mu[1] = std::numeric_limits<double>::infinity();
+  const std::string native_mu = native_error(bad_mu);
+  const std::string reference_mu = reference_error(bad_mu);
+  check(!native_mu.empty(), "native rejects infinite mu");
+  check(native_mu == reference_mu, "infinite mu error matches fallback");
+  Inputs bad_y = inputs(3, 1, 0.1);
+  bad_y.y[2] = std::numeric_limits<double>::quiet_NaN();
+  const std::string native_y = native_error(bad_y);
+  const std::string reference_y = reference_error(bad_y);
+  check(!native_y.empty(), "native rejects NaN y");
+  check(native_y == reference_y, "NaN y error matches fallback");
+
+  if (failures == 0) std::printf("test_mnc OK\n");
+  return failures == 0 ? 0 : 1;
+}


### PR DESCRIPTION
## Summary

- Add a native pullback for the exact single-observation multi_normal_cholesky_lpdf shape used by gp_regr: propto, data y and mu, active Cholesky factor.
- Preserve the pinned Stan Math check order and matrix-expression order, retaining the full factor partial matrix in forward scratch.
- Reduce backward to seeded accumulation into L.
- Keep every other activity mask, vectorized shape, non-propto call, malformed shape, and legacy variant on the existing generic Stan Math replay.
- Add exact bit-pattern coverage for n=1 and the real n=11 shape, non-unit seeds, prefilled and null adjoints, value-only reuse, empty/errors, and fallback variants.

## Performance

Matched Apple arm64 Release measurements:

| metric | before | after | change |
| --- | ---: | ---: | ---: |
| gp_regr gradient | 6.048 us | 4.199 us | 1.44x |
| MNC kernel | 2.482 us | 0.699 us | 3.55x |
| gp_regr vs CmdStan | 0.77x | 1.12x | parity+ |

The only other corpus user, hier_2pl, has an all-active variant and remains on the generic path; its profile is flat.

## Validation

- Fresh isolated Release build
- 57/57 CTests
- 129/129 corpus models at all three reference points, 800,674 values
- gp_regr and hier_2pl targeted CmdStan references
- Exact focused native and fallback tests
- Format, generated docs, generated web models, and diff checks

Stacked on #161; this PR contains only commit dca41a8 relative to that branch.