### PR TITLE
feat: build and publish the runtime for emscripten-wasm32

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -744,6 +744,57 @@ jobs:
             build-wasm/stanli.js
             build-wasm/stanli.wasm
 
+  # The webR runtime: libstanli.so as an Emscripten side module, the
+  # artifact stanli_install() downloads on emscripten-wasm32 (webR under
+  # r-universe). The emsdk here is pinned to the version the CURRENT webR
+  # release builds with, NOT the browser build's pin: side modules are
+  # not binary compatible across webR's Emscripten bumps, so when webR
+  # updates Emscripten this pin must follow and a release must be cut, or
+  # users on the new webR load an incompatible artifact and dyn.load
+  # fails. webR 0.6.0 = Emscripten 4.0.8; the npm webr pinned below is
+  # the same release, so the load test answers the exact ABI question.
+  wasm-webr:
+    name: webR runtime
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: mymindstorm/setup-emsdk@v14
+        with:
+          version: 4.0.8
+      - name: Restore the compiler cache
+        uses: actions/cache@v4
+        with:
+          path: .ccache
+          key: ccache-wasm-webr-${{ github.sha }}
+          restore-keys: ccache-wasm-webr-
+      - name: Fetch pinned dependencies
+        run: ./deps/fetch.sh
+      - name: Build the side module
+        run: |
+          which ccache || sudo apt-get install -y ccache
+          export CCACHE_DIR="$PWD/.ccache" CCACHE_COMPRESS=1 CCACHE_MAXSIZE=600M
+          emcmake cmake -B build-wasm-side -DCMAKE_BUILD_TYPE=Release \
+            -DSTANLI_WASM_SIDE=ON -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
+            -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+          cmake --build build-wasm-side -j4 --target stanli_webr
+          ccache -s
+      - name: Load it into webR
+        run: |
+          npm install webr@0.6.0
+          node tests/test_webr.mjs build-wasm-side/libstanli.so
+      - name: Runtime tarball
+        run: |
+          mkdir -p runtime-dist
+          tar czf runtime-dist/stanli-runtime-emscripten-wasm32.tar.gz \
+            -C build-wasm-side libstanli.so
+          tar tzf runtime-dist/stanli-runtime-emscripten-wasm32.tar.gz
+      - uses: actions/upload-artifact@v4
+        with:
+          name: runtime-emscripten-wasm32
+          path: runtime-dist/*.tar.gz
+
   # The public demo: web/ plus the two build artifacts, deployed to
   # GitHub Pages on every main push. stancjs is stanc3's own js_of_ocaml
   # target, cached like the embedded object (a miss costs the opam path
@@ -940,7 +991,7 @@ jobs:
   # web form, and this is where that file comes from.
   runtime-release:
     if: startsWith(github.ref, 'refs/tags/v')
-    needs: [build, windows]
+    needs: [build, windows, wasm-webr]
     runs-on: ubuntu-latest
     permissions:
       contents: write  # create the release and attach assets to it
@@ -976,12 +1027,12 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           ls -la runtime/
-          # Five platforms, one asset each. A partial upload is worse
-          # than none: releases/latest/download resolves for four
-          # platforms and 404s for the fifth, and nothing says which.
+          # Six platforms, one asset each. A partial upload is worse
+          # than none: releases/latest/download resolves for five
+          # platforms and 404s for the sixth, and nothing says which.
           n=$(ls runtime/*.tar.gz | wc -l)
           echo "$n runtime assets"
-          [ "$n" -eq 5 ]
+          [ "$n" -eq 6 ]
           # Immutable releases freeze their assets the moment they are
           # published, so everything must attach while the release is a
           # draft and publishing is the last step. Publishing first and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## Unreleased
+
+### A runtime for webR
+
+`stanli_install()` on webR resolves the asset name
+stanli-runtime-emscripten-wasm32.tar.gz, which no release published, so
+the R package installed from r-universe could never find its runtime
+(#163). The release pipeline now builds libstanli.so as an Emscripten
+side module and attaches it to every release beside the five native
+runtimes. The build is pinned to the Emscripten version the current
+webR release uses (webR 0.6.0, Emscripten 4.0.8) because side modules
+are not binary compatible across webR's Emscripten bumps; CI loads the
+artifact into webR itself and resolves the bridge's symbols. The full
+flow -- the r-universe package, log_prob_grad, NUTS -- was verified
+against webR 0.6.0 by hand. Compiling Stan source inside webR still
+needs a compiler: the V8 package is not available there, so pass
+precompiled MIR via stanli_model(mir = ...) for now.
+
 ## 0.8.3
 
 Five wrong-number fixes, every one found by testing machinery that did

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -403,6 +403,22 @@ endif()
 # entry point (no embedded stanc; stanc.js supplies the MIR in JS). One
 # .js + .wasm pair, MODULARIZE'd so web pages and Node both load it.
 if(EMSCRIPTEN)
+  # The C API surface the wasm artifacts export: without an explicit list
+  # wasm-ld garbage-collects the capi functions, which nothing inside the
+  # module references (SIDE_MODULE=1 does not root them either). The list
+  # is read out of capi.h so a new entry point exports without anyone
+  # remembering this file; the R bridge resolves whatever subset it needs
+  # (stanli_abi_version among it, which the hand-kept browser list missed).
+  file(READ runtime/include/stanli/capi.h _capi_h)
+  string(REGEX MATCHALL "(stanli|bs)_[a-zA-Z0-9_]+[ \t]*\\(" _capi_decls
+         "${_capi_h}")
+  set(_capi_names "")
+  foreach(_d ${_capi_decls})
+    string(REGEX REPLACE "[ \t]*\\($" "" _d "${_d}")
+    list(APPEND _capi_names "_${_d}")
+  endforeach()
+  list(REMOVE_DUPLICATES _capi_names)
+  list(JOIN _capi_names "," STANLI_CAPI_EXPORTS)
   add_executable(stanli_wasm runtime/src/capi.cpp tests/tbb_stub.cpp)
   target_compile_definitions(stanli_wasm
                              PRIVATE STANLI_BUILD_ID="${STANLI_BUILD_ID}")
@@ -416,9 +432,38 @@ if(EMSCRIPTEN)
     "SHELL:-s MAXIMUM_MEMORY=4GB"
     "SHELL:-s STACK_SIZE=8MB"
     "SHELL:-s ENVIRONMENT=web,worker,node"
-    "SHELL:-s EXPORTED_FUNCTIONS=_stanli_model_new,_stanli_model_new_from_stan,_stanli_has_embedded_stanc,_stanli_exact_lp,_stanli_model_free,_stanli_n_unconstrained,_stanli_grad,_stanli_sample,_stanli_n_constrained,_stanli_constrained_name,_stanli_constrain,_stanli_wa_n_columns,_stanli_wa_column_name,_stanli_wa_seed,_stanli_wa_row,_stanli_sample_stream,_stanli_sample_walnuts_stream,_stanli_run_pathfinder,_malloc,_free"
+    "SHELL:-s EXPORTED_FUNCTIONS=${STANLI_CAPI_EXPORTS},_malloc,_free"
     "SHELL:-s EXPORTED_RUNTIME_METHODS=cwrap,UTF8ToString,stringToNewUTF8,HEAPF64,addFunction,removeFunction"
     "SHELL:-s ALLOW_TABLE_GROWTH=1")
+
+# The webR runtime: the same capi surface as a relocatable SIDE_MODULE
+# that webR's main module dlopens, which is how the R package loads
+# libstanli.so on every platform. Memory, stack, and environment belong
+# to the main module, so none of stanli_wasm's -s settings apply; the
+# whole tree must be compiled -fPIC, which is why this is its own build
+# configuration (-DSTANLI_WASM_SIDE=ON) rather than a second target in
+# the browser build. The emsdk version must match the webR release the
+# artifact is for -- side modules are not binary compatible across
+# webR's Emscripten bumps.
+option(STANLI_WASM_SIDE
+  "Build libstanli.so as an Emscripten side module for webR" OFF)
+if(STANLI_WASM_SIDE)
+  # add_executable, not add_library: Emscripten's CMake platform archives
+  # a SHARED library instead of linking it, so the side module is spelled
+  # as an "executable" whose output name and SIDE_MODULE flag make emcc
+  # emit a relocatable wasm dylib.
+  add_executable(stanli_webr runtime/src/capi.cpp tests/tbb_stub.cpp)
+  target_compile_definitions(stanli_webr
+                             PRIVATE STANLI_BUILD_ID="${STANLI_BUILD_ID}")
+  target_link_libraries(stanli_webr PRIVATE stanli)
+  set_target_properties(stanli_webr PROPERTIES
+    OUTPUT_NAME libstanli
+    SUFFIX ".so")
+  target_link_options(stanli_webr PRIVATE
+    -fwasm-exceptions
+    "SHELL:-s SIDE_MODULE=2"
+    "SHELL:-s EXPORTED_FUNCTIONS=${STANLI_CAPI_EXPORTS}")
+endif()
 endif()
 
 if(NOT EMSCRIPTEN)

--- a/tests/test_webr.mjs
+++ b/tests/test_webr.mjs
@@ -1,0 +1,46 @@
+// The webR runtime artifact loads into webR and resolves the C API.
+//
+// This is the ABI question the emsdk pin exists to answer: a side module
+// built against the wrong Emscripten fails right here, in dyn.load. The
+// full R-package flow (r-universe bridge, log_prob_grad, sampling) was
+// verified by hand against webR 0.6.0 when this landed; this test keeps
+// the load-and-resolve half, which needs nothing beyond the npm webr
+// package.
+//
+// Usage: node tests/test_webr.mjs build-wasm-side/libstanli.so
+import { WebR } from 'webr';
+import fs from 'node:fs';
+
+const soPath = process.argv[2];
+if (!soPath) {
+  console.error('usage: node tests/test_webr.mjs <libstanli.so>');
+  process.exit(2);
+}
+
+const webR = new WebR();
+await webR.init();
+const arch = (await (await webR.evalR('R.version$arch')).toJs()).values[0];
+if (arch !== 'wasm32') {
+  console.error(`FAIL unexpected webR arch ${arch}`);
+  process.exit(1);
+}
+
+await webR.FS.writeFile('/tmp/libstanli.so',
+                        new Uint8Array(fs.readFileSync(soPath)));
+
+// The symbols the R bridge dlsyms, stanli_abi_version first: it is the
+// handshake, and the one a hand-kept export list forgot once already.
+const res = await webR.evalR(`
+  dyn.load('/tmp/libstanli.so')
+  syms <- c('stanli_abi_version', 'stanli_model_new', 'stanli_exact_lp',
+            'stanli_grad', 'stanli_sample_multi', 'stanli_optimize',
+            'stanli_diagnose_text', 'stanli_wa_row')
+  syms[!vapply(syms, is.loaded, logical(1))]
+`);
+const missing = (await res.toJs()).values;
+if (missing.length > 0) {
+  console.error('FAIL symbols missing from the side module:', missing.join(' '));
+  process.exit(1);
+}
+console.log('webr load OK: side module loads and the bridge symbols resolve');
+process.exit(0);


### PR DESCRIPTION
Fixes #163.

`stanli_install()` on webR resolves `stanli-runtime-emscripten-wasm32.tar.gz`, which no release published, so the R package installed from r-universe could never find its runtime.

**What this adds**: `libstanli.so` built as an Emscripten side module (`-DSTANLI_WASM_SIDE=ON`) and attached to every release beside the five native runtimes. Implementation notes:

- The target is an `add_executable`-shaped link because Emscripten's CMake platform archives a SHARED library instead of linking it; `SIDE_MODULE=2` plus an export list emits a relocatable wasm dylib.
- The export list is generated from `capi.h` at configure time and shared with the browser build. It has to be explicit twice over: wasm-ld garbage-collects the capi functions nothing inside the module references, and `SIDE_MODULE=1` neither roots them nor accepts a list. Generating it from the header is what keeps `stanli_abi_version` in it, the R bridge's handshake symbol that the hand-kept browser list had already missed.
- The new `wasm-webr` CI job pins the Emscripten version the current webR release uses (webR 0.6.0 = Emscripten 4.0.8), deliberately distinct from the browser build's pin: side modules are not binary compatible across webR's Emscripten bumps, so when webR updates, this pin follows and a release gets cut. The job loads the built artifact into webR (npm `webr`, pinned to the same release) and resolves the bridge's symbols, which is exactly the failure mode the pin guards against. The runtime-release asset gate moves from five to six.

**Verified by hand end to end against webR 0.6.0 in Node**: the reporter's r-universe stanli package plus this artifact through `STANLI_RUNTIME` passes the bridge's ABI handshake, `stanli_available()` is true, `log_prob_grad` is exact (the gradient matches the closed form), and a NUTS run recovers the right posterior mean. The browser build was rebuilt and smoke-tested on the refactored export list (`tests/test_wasm.cjs` passes).

**Known limitation, out of scope**: compiling Stan source inside webR still needs a compiler. The V8 package is not available on webR, so `stanli_model(code = ...)` fails with the existing instructive error; `stanli_model(mir = ...)` works today. The asset first appears on the next tagged release; v0.8.3's assets are frozen, so the reporter's pinned install keeps failing until a release ships.
