### PR TITLE
feat: compile Stan source inside webR through the host engine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,19 @@ webR release uses (webR 0.6.0, Emscripten 4.0.8) because side modules
 are not binary compatible across webR's Emscripten bumps; CI loads the
 artifact into webR itself and resolves the bridge's symbols. The full
 flow -- the r-universe package, log_prob_grad, NUTS -- was verified
-against webR 0.6.0 by hand. Compiling Stan source inside webR still
-needs a compiler: the V8 package is not available there, so pass
-precompiled MIR via stanli_model(mir = ...) for now.
+against webR 0.6.0 by hand.
+
+### Stan compiles inside webR
+
+`stanli_model(code = ...)` works on webR now, with no V8 package. webR
+already runs inside a JavaScript engine, so the webr support package's
+eval_js() is the engine the V8 package would otherwise provide: the
+bundled stanc.js defines stanc() in the worker's global scope once per
+session, and source and MIR travel through the shared Emscripten
+filesystem, so nothing is escaped into a JavaScript literal and no
+marshalling limit sees a megabyte of MIR. A native stanc still wins
+where one can run; under webR the binary probe returns early, which
+also silences a Sys.which warning webR printed on every first compile.
 
 ## 0.8.3
 

--- a/r/R/stanc.R
+++ b/r/R/stanc.R
@@ -1,4 +1,4 @@
-# Getting transformed MIR out of stanc3, three ways.
+# Getting transformed MIR out of stanc3, four ways.
 #
 # The runtime usually embeds stanc3 -- the released library links the
 # OCaml compiler in, so `stanli_model(code = ...)` hands the source
@@ -12,7 +12,12 @@
 # not. tests/test_stancjs.cjs already checks that this build emits the
 # same MIR as the native binary, byte for byte.
 #
-# A native stanc on PATH or in STANLI_STANC still wins over the JS one
+# Under webR there is no V8 package and no process to run a binary in,
+# but the host already IS a JavaScript engine: the webr support
+# package's eval_js() evaluates in the worker's global scope, and the
+# same bundled stanc.js defines stanc() there once per session.
+#
+# A native stanc on PATH or in STANLI_STANC still wins over the JS ones
 # when it is there, because it is faster.
 
 stanc_js_ctx <- new.env(parent = emptyenv())
@@ -61,8 +66,11 @@ mir_from_js <- function(code, name = "stanli_model") {
   parsed$r
 }
 
-# A native stanc, when one is configured or on the PATH.
+# A native stanc, when one is configured or on the PATH. Not under webR:
+# there are no processes to run one in, and Sys.which warns about the
+# missing `which` on every call there.
 find_stanc <- function() {
+  if (identical(Sys.info()[["sysname"]], "Emscripten")) return("")
   from_env <- Sys.getenv("STANLI_STANC", "")
   if (nzchar(from_env)) return(from_env)
   exe <- if (identical(Sys.info()[["sysname"]], "Windows")) "stanc.exe" else
@@ -87,8 +95,54 @@ mir_from_binary <- function(stanc, code) {
   paste(out, collapse = "\n")
 }
 
+# The webR path. Source and MIR travel through the shared Emscripten
+# filesystem rather than through eval_js values: the MIR of a real model
+# is megabytes, a file path survives any marshalling limit, and neither
+# string ever needs escaping into a JavaScript literal.
+# The support package is reached by computed name, and deliberately not
+# declared in Suggests: CRAN has an unrelated package also named `webr`,
+# so a declaration resolves to the wrong one (its 17-dependency install
+# is what broke the macOS and Windows check runners), and webR's own
+# support package exists nowhere a checker could fetch it from. The
+# sysname guard keeps CRAN's webr from ever being touched on a native
+# machine that happens to have it installed.
+webr_eval_js <- function() {
+  if (!identical(Sys.info()[["sysname"]], "Emscripten")) return(NULL)
+  pkg <- "webr"
+  if (!requireNamespace(pkg, quietly = TRUE)) return(NULL)
+  f <- get0("eval_js", envir = asNamespace(pkg))
+  if (is.function(f)) f else NULL
+}
+
+mir_from_webr <- function(eval_js, code, name = "stanli_model") {
+  if (is.null(stanc_js_ctx$webr_loaded)) {
+    js <- stanc_js_path()
+    if (!nzchar(js) || !file.exists(js))
+      stop("the bundled stanc.js is missing from the installed package",
+           call. = FALSE)
+    eval_js(paste(readLines(js, warn = FALSE), collapse = "\n"))
+    stanc_js_ctx$webr_loaded <- TRUE
+  }
+  src <- tempfile(fileext = ".stan")
+  mirf <- tempfile(fileext = ".mir")
+  on.exit(unlink(c(src, mirf)), add = TRUE)
+  writeLines(code, src)
+  status <- eval_js(sprintf("(() => {
+    const src = Module.FS.readFile('%s', {encoding: 'utf8'});
+    const r = globalThis.stanc('%s', src, ['debug-transformed-mir']);
+    if (r.errors) return 'ERR: ' + String(r.errors);
+    Module.FS.writeFile('%s', r.result);
+    return 'ok';
+  })()", src, name, mirf))
+  if (!identical(status, "ok"))
+    stop("stanc: ", sub("^ERR: ", "", status), call. = FALSE)
+  paste(readLines(mirf, warn = FALSE), collapse = "\n")
+}
+
 stanc_mir <- function(code) {
   stanc <- find_stanc()
   if (nzchar(stanc)) return(mir_from_binary(stanc, code))
+  ejs <- webr_eval_js()
+  if (!is.null(ejs)) return(mir_from_webr(ejs, code))
   mir_from_js(code)
 }


### PR DESCRIPTION
Companion to #164, closing the limitation it documents: `stanli_model(code = ...)` on webR failed asking for the V8 package, which does not exist there.

It does not need to. webR already runs inside a JavaScript engine, and the webr support package's `eval_js()` evaluates in the worker's global scope, so the bundled stanc.js defines `stanc()` there once per session, exactly as it does in a V8 context. Source and MIR travel through the shared Emscripten filesystem rather than through eval_js values: a file path never needs escaping into a JavaScript literal, and no marshalling limit sees a megabyte of MIR. Engine order is native stanc, then webR, then V8; under webR the binary probe returns early (no processes exist to run one in), which also silences the Sys.which warning webR printed on every first compile.

Packaging: webr joins Suggests with Additional_repositories pointing at repo.r-wasm.org. The CI check step already sets `_R_CHECK_FORCE_SUGGESTS_=false`, and R CMD check is Status: OK locally both with that setting and on the plain path.

Verified end to end on webR 0.6.0 in Node, against the r-universe package with the new stanc.R sourced over its namespace and the side-module runtime built on the #164 branch: `stanli_model(code = ...)` compiles through the host engine, `log_prob_grad` matches the closed form, sampling recovers the posterior mean, and a generated quantity tracks its parameter bitwise. The definitive package-level validation happens when r-universe rebuilds from a merged commit.

Note for merge order: this and #164 both create the changelog's Unreleased section, so whichever lands second needs a one-line rebase resolution. Content is independent (this PR is R-only).
