### PR TITLE
release: 0.8.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,20 @@
 # Changelog
 
-## Unreleased
+## 0.8.4
+
+### Three kernels stop replaying stan-math
+
+Performance work from three directions, each replacing a nested
+autodiff replay with the pinned pullback formulas over doubles, with
+bitwise value and gradient coverage against the replay it replaces
+(#160, #161, #162). Symmetric eigendecompositions computed in the
+forward sweep are reused in the backward one: kronecker_gp goes from
+289.0 to 185.7 us per gradient, 0.75x to 1.17x against CmdStan. ODE
+solves keep the initial-state and parameter activity types the
+lowering already knew instead of promoting both when either is active:
+one_comp_mm_elim_abs gains 1.09x. And the single-observation
+multi_normal_cholesky shape gp_regr uses gets a native pullback:
+6.05 to 4.20 us per gradient, 0.77x to 1.12x against CmdStan.
 
 ### A runtime for webR
 

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@seantalts/stanli",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "description": "Full Stan in the browser: stanc3 compiles the model in JS, a WASM runtime lowers it to an op graph and runs NUTS. No server, no C++ toolchain.",
   "type": "module",
   "main": "index.mjs",

--- a/python/stanli/__init__.py
+++ b/python/stanli/__init__.py
@@ -21,7 +21,7 @@ __all__ = ["Model", "Fit", "Summary", "OptimizeResult",
            "SAMPLER_COLUMNS", "__version__"]
 # The one place the version lives. setup.py and the release workflow both
 # read it from here.
-__version__ = "0.8.3"
+__version__ = "0.8.4"
 
 _BIN = pathlib.Path(__file__).parent / "_bin"
 

--- a/r/DESCRIPTION
+++ b/r/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: stanli
 Type: Package
 Title: The Stan Language Interpreter
-Version: 0.8.3
+Version: 0.8.4
 Authors@R: person("Sean", "Talts", email = "xitrium@gmail.com",
                   role = c("aut", "cre"))
 Description: Compile and sample Stan models without a C++ toolchain. Stan

--- a/r/R/install.R
+++ b/r/R/install.R
@@ -17,7 +17,7 @@
 # pinned binding with a runtime that has moved. The release workflow
 # asserts this equals the tag being cut, so bumping one without the
 # other fails there rather than at a user's install.
-stanli_runtime_release <- "v0.8.3"
+stanli_runtime_release <- "v0.8.4"
 
 runtime_filename <- function() {
   switch(Sys.info()[["sysname"]],


### PR DESCRIPTION
Version bump for 0.8.4: the webR runtime asset and in-webR Stan compilation (#163, #164, #165), plus changelog entries for the three kernel perf PRs (#160, #161, #162) that merged without them. Tag v0.8.4 follows once this merges.