### PR TITLE
perf: compact island adjoint storage

### DIFF
--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -259,21 +259,38 @@ because the registers also make its vector copies disappear.
 
 The estimate changed with it. It weighed the register file 4x because the
 file was built as vars, and that term is what refused thirteen of the
-fourteen regions it could compile. A register is a memory cost again
-(written by the forward, read by the backward, plus one zeroing of the
-adjoint file: `kRegWeight = 3`), and what an island buys is now mostly
-the per-op tax the graph pays -- a dispatch, a context load and a
-scratch-partials backward, ~5 ns against ~1 ns for an island instruction,
-which the estimate had no term for at all (`kOpCost = 5`). Without it a
-region like `garch11`, whose 1,797 scalar ops barely move more elements
-than there are ops, read as a wash; it measures 1.27x. Against the table
-it carves all eight regions that clear parity by more than run-to-run
-noise, and refuses `bones_model` -- 36 ops behind a 4,024-register file,
-still exactly the shape islands are wrong for -- and the
-`covid19imperial` pair. The seven left sit between 0.97x and 1.00x, which
-is inside the noise; it carves five of them and leaves two.
-`STANLI_ISLAND_ALWAYS=1` skips the estimate, which is how to ask why a
-region was left alone.
+fourteen regions it could compile. A value register is a memory cost again:
+one forward write and one backward read. The adjoint file is a separate
+cost, however. Checkpoints hold values only, and registers made equivalent
+by a copy already share an adjoint cell to reproduce stan-math's tape order.
+Those equivalence classes are now packed densely, so the runtime zeroes one
+cell per distinct class rather than one per value or checkpoint register.
+The estimate mirrors the storage exactly: two passes over value and
+checkpoint registers other than CALL scratch, one pass over the compact
+adjoint file, both instruction streams, and the existing neutral charge for
+CALLs.
+
+What an island buys is still mostly the per-op tax the graph pays -- a
+dispatch, a context load and a scratch-partials backward, ~5 ns against
+~1 ns for an island instruction (`kOpCost = 5`). Without it a region like
+`garch11`, whose scalar ops barely move more elements than there are ops,
+reads as a wash. The 2026-08-24 structural census reran default, disabled,
+and forced islands on all 21 corpus models with compilable regions. Compact
+accounting changed exactly one decision, `iohmm_reg`, and preserved every
+previous selection and refusal, including the measured loss guards
+`bones_model`, `dugongs_model`, `Survey_model`, and both `covid19imperial`
+models. `STANLI_ISLAND_ALWAYS=1` skips the estimate, which is how to ask why
+a region was left alone.
+
+In the targeted Release A/B from that census, `iohmm_reg`'s 95,424 forward
+register ids reduce to 39,000 distinct adjoint cells; 4,488 additional
+checkpoint registers remain value-only. Its estimated island cost falls
+from 389,640 to 328,728 against the graph's 361,045, so the default path now
+collapses 53,456 ops to 27. Seven clean, interleaved runs moved the median
+from 498.612 to 241.453 us/gradient (2.065x internally), within 0.3% of the
+forced-island path and 1.33x faster than the retained 320.335 us CmdStan
+reference. This is a targeted A/B; the warmed corpus table above remains the
+last full-corpus run until the next benchmark refresh.
 
 `STANLI_NO_NATIVE_ADJ=1` restores the replay. It changes nothing else --
 the adjoint is still generated, the estimate still assumes it, and the

--- a/runtime/include/stanli/adjoint.hpp
+++ b/runtime/include/stanli/adjoint.hpp
@@ -59,6 +59,11 @@ struct AdjProgram {
   // copy's contributions separately and transferring them in one lump would
   // regroup the sum and cost the last few bits.
   std::vector<int32_t> adj_reg;
+  // Number of cells in the adjoint file. `adj_reg` is indexed by forward
+  // register, but its entries are compact: registers made equivalent by a
+  // copy share one cell, and the remaining equivalence classes are packed
+  // densely. Checkpoint registers hold values only and are absent entirely.
+  int n_regs = 0;
   bool empty() const { return adj_reg.empty(); }
 };
 

--- a/runtime/kernels/island.cpp
+++ b/runtime/kernels/island.cpp
@@ -66,8 +66,8 @@ void island_fwd(KernelCtx& ctx) {
 // The generated backward: seed the live-outs, sweep, harvest the live-ins.
 void island_bwd_native(const IslandProg& p, KernelCtx& ctx) {
   static thread_local std::vector<double> adj;
-  if ((int64_t)adj.size() < p.n_regs) adj.resize((size_t)p.n_regs);
-  std::fill(adj.begin(), adj.begin() + p.n_regs, 0.0);
+  if ((int64_t)adj.size() < p.adj.n_regs) adj.resize((size_t)p.adj.n_regs);
+  std::fill(adj.begin(), adj.begin() + p.adj.n_regs, 0.0);
   // Through the sharing map, since a live-out register need not own its
   // adjoint cell. Descending, because two live-out slots can share a
   // register range (the carver aliases a dead copy-then-modify chain onto

--- a/runtime/src/OPTIMIZATIONS.md
+++ b/runtime/src/OPTIMIZATIONS.md
@@ -285,12 +285,26 @@ the register file makes free, which is why it was the one winner before
 The pass still estimates both sides before committing, because one shape
 is still wrong for it: a region carrying far more state than it
 computes, where the register file costs more to write and read back than
-the ops ever moved. The estimate weighs what the ops move and what they
-pay per dispatch against the register file and the two instruction
-lists, and it keeps every region that measured clearly above parity
-while dropping that shape and two more that were slower compiled.
-`STANLI_ISLAND_ALWAYS=1` skips it, which is how to ask why a region was
-left alone.
+the ops ever moved. Value and adjoint storage are accounted separately.
+Every value or checkpoint register other than CALL scratch is charged for
+its forward write and backward read. Checkpoints have no adjoint cell, and
+copies that share a stan-math vari share an adjoint equivalence class; those
+classes are packed densely and charged once for the runtime's zeroing pass.
+The estimate then adds both instruction lists, the graph's per-op dispatch
+cost, and a cost-neutral correction for calls to graph kernels. This is the
+same layout the native island backward allocates and clears, rather than a
+fixed weight per forward register.
+
+On `iohmm_reg`, 95,424 forward register ids contain only 39,000 distinct
+adjoint classes, while 4,488 checkpoint registers are value-only. Correct
+accounting moves the estimate from 389,640 to 328,728 against a graph cost of
+361,045, so the default path now takes the same 27-op island as
+`STANLI_ISLAND_ALWAYS=1`. A targeted seven-run Release A/B measured
+498.612 -> 241.453 us/gradient (2.065x). A default/disabled/forced census of
+all 21 corpus models with compilable regions changed only this decision and
+preserved every known refusal, including `bones_model`, `dugongs_model`,
+`Survey_model`, and both `covid19imperial` models. The environment switch
+still skips the estimate, which is how to ask why a region was left alone.
 
 Vocabulary is no longer a refusal for scalar work. The machine has its
 own instructions for the arithmetic a recurrence is made of, and

--- a/runtime/src/adjoint.cpp
+++ b/runtime/src/adjoint.cpp
@@ -149,20 +149,6 @@ bool gen_adjoint(IslandProg& p) {
   ap.code.reserve(orig.size());
   ap.adj_reg.resize((size_t)n0);
   for (int r = 0; r < n0; ++r) ap.adj_reg[(size_t)r] = r;
-  int n_regs = n0;
-
-  auto checkpoint = [&](int r, int len, bool needed) {
-    if (!needed) return r;
-    const int ck = n_regs;
-    n_regs += len;
-    Program::Instr save;
-    save.code = len == 1 ? Program::MOV : Program::MOVR;
-    save.dst = ck;
-    save.a = r;
-    save.len = len;
-    ncode.push_back(save);
-    return ck;
-  };
 
   // A copy the forward never rewrites shares its source's adjoint cell.
   // This is the replay's vari sharing, written down: `reg[d] = reg[a]` on
@@ -191,6 +177,54 @@ bool gen_adjoint(IslandProg& p) {
     return true;
   };
 
+  // Discover every shared cell before emitting the adjoint instructions.
+  // Besides making their indices final for map1/mapn below, this lets the
+  // file store one double per equivalence class rather than retaining holes
+  // at the copied registers' original ids. Representatives are packed in
+  // numeric order: if an old mapped range was base+k, every integer in that
+  // interval is present, so rank compression preserves base'+k. That is the
+  // contiguity contract the ranged rules and CALL backwards rely on.
+  for (int i = 0; i < (int)orig.size(); ++i) {
+    const Program::Instr& I = orig[(size_t)i];
+    if (!aliasable(I, i)) continue;
+    const int len = I.code == Program::MOV ? 1 : I.len;
+    for (int k = 0; k < len; ++k)
+      ap.adj_reg[(size_t)(I.dst + k)] = ap.adj_reg[(size_t)(I.a + k)];
+  }
+  std::vector<char> used_adj((size_t)n0, 0);
+  for (int32_t r : ap.adj_reg) {
+    if (r < 0 || r >= n0) return false;
+    used_adj[(size_t)r] = 1;
+  }
+  std::vector<int32_t> compact_adj((size_t)n0, -1);
+  for (int r = 0; r < n0; ++r)
+    if (used_adj[(size_t)r]) compact_adj[(size_t)r] = ap.n_regs++;
+  for (int32_t& r : ap.adj_reg) r = compact_adj[(size_t)r];
+
+  bool mapped_ranges_ok = true;
+  auto map1 = [&](int32_t r) { return ap.adj_reg[(size_t)r]; };
+  auto mapn = [&](int32_t r, int len) {
+    if (len == 0) return int32_t{0};
+    const int32_t base = ap.adj_reg[(size_t)r];
+    for (int k = 1; k < len; ++k)
+      if (ap.adj_reg[(size_t)(r + k)] != base + k) mapped_ranges_ok = false;
+    return base;
+  };
+
+  int n_regs = n0;
+  auto checkpoint = [&](int r, int len, bool needed) {
+    if (!needed) return r;
+    const int ck = n_regs;
+    n_regs += len;
+    Program::Instr save;
+    save.code = len == 1 ? Program::MOV : Program::MOVR;
+    save.dst = ck;
+    save.a = r;
+    save.len = len;
+    ncode.push_back(save);
+    return ck;
+  };
+
   // A range needs a checkpoint when any element is overwritten strictly
   // after i; the copy is one MOVR and the backward reads it instead.
   auto save_range = [&](int r, int len, int i) {
@@ -208,8 +242,12 @@ bool gen_adjoint(IslandProg& p) {
       // guarantee), and some read their output values too -- so both are
       // checkpointed whenever a later instruction overwrites them.
       Program::Call& call = fwd.calls[(size_t)I.a];
-      for (int j = 0; j < call.n_in; ++j)
+      for (int j = 0; j < call.n_in; ++j) {
+        (void)mapn(call.in[j], call.in_len[j]);
         call.bwd_in[j] = save_range(call.in[j], call.in_len[j], i);
+      }
+      (void)mapn(call.out, call.out_len);
+      if (!mapped_ranges_ok) return false;
       ncode.push_back(I);
       call.bwd_out = save_range(call.out, call.out_len, i);
       AdjInstr A;
@@ -219,9 +257,6 @@ bool gen_adjoint(IslandProg& p) {
       continue;
     }
     if (aliasable(I, i)) {
-      const int len = I.code == Program::MOV ? 1 : I.len;
-      for (int k = 0; k < len; ++k)
-        ap.adj_reg[(size_t)(I.dst + k)] = ap.adj_reg[(size_t)(I.a + k)];
       ncode.push_back(I);
       continue;  // no adjoint instruction: the cells are already shared
     }
@@ -276,14 +311,6 @@ bool gen_adjoint(IslandProg& p) {
     // A range has to map to a range: aliasing builds contiguous maps from
     // contiguous copies, so this holds, and refusing is cheaper than
     // scattering the interpreter's loops.
-    bool ok = true;
-    auto map1 = [&](int32_t r) { return ap.adj_reg[(size_t)r]; };
-    auto mapn = [&](int32_t r, int len) {
-      const int32_t base = ap.adj_reg[(size_t)r];
-      for (int k = 1; k < len; ++k)
-        if (ap.adj_reg[(size_t)(r + k)] != base + k) ok = false;
-      return base;
-    };
     A.dst = wl > 1 ? mapn(I.dst, wl) : map1(I.dst);
     if (I.code == Program::DENSITY) {
       const int ar = program_density_arity(I.len);
@@ -299,7 +326,7 @@ bool gen_adjoint(IslandProg& p) {
       A.b = spec.has(kProgramRangeB) ? mapn(I.b, I.len) : map1(I.b);
       A.c = map1(I.c);
     }
-    if (!ok) return false;
+    if (!mapped_ranges_ok) return false;
     ap.code.push_back(A);
   }
 
@@ -316,29 +343,31 @@ void run_adjoint(const Program& fwd, const AdjProgram& ap, const double* val,
     if (I.code == Program::CALL) {
       // The kernel's own backward is the rule: values from the (possibly
       // checkpointed) forward registers, partials from the scratch the
-      // forward stashed inside the file, adjoints accumulated straight
-      // into the adjoint file at the same ranges the values occupy --
-      // every CALL range is excluded from cell sharing, so range index
-      // and cell index agree. Then the output's cells are cleared, the
-      // same consume-and-clear every other rule performs.
+      // forward stashed inside the file, adjoints accumulated into the
+      // compact ranges named by adj_reg -- every CALL range is excluded
+      // from cell sharing, and numeric-order compaction preserves its
+      // contiguity. Then the output's cells are cleared, the same
+      // consume-and-clear every other rule performs.
       const Program::Call& call = fwd.calls[(size_t)I.a];
       KernelCtx ctx;
       ctx.n_in = call.n_in;
       for (int k = 0; k < call.n_in; ++k) {
         ctx.in[k] =
             Desc{const_cast<double*>(val) + call.bwd_in[k], call.in_len[k]};
-        ctx.in_adj[k] = Desc{adj + call.in[k], call.in_len[k]};
+        const int in_adj = call.in_len[k] ? ap.adj_reg[(size_t)call.in[k]] : 0;
+        ctx.in_adj[k] = Desc{adj + in_adj, call.in_len[k]};
       }
       ctx.out = Desc{const_cast<double*>(val) + call.bwd_out, call.out_len};
-      ctx.out_adj_vec = Desc{adj + call.out, call.out_len};
-      if (call.out_len == 1) ctx.out_adj = adj[call.out];
+      const int out_adj = ap.adj_reg[(size_t)call.out];
+      ctx.out_adj_vec = Desc{adj + out_adj, call.out_len};
+      if (call.out_len == 1) ctx.out_adj = adj[out_adj];
       ctx.variant = call.variant;
       ctx.scratch = const_cast<double*>(val) + call.scratch;
       ctx.idata = call.idata.data();
       ctx.n_idata = (int64_t)call.idata.size();
       const Kernel* k = find_kernel(call.opcode);
       k->backward(ctx);
-      for (int j = 0; j < call.out_len; ++j) adj[call.out + j] = 0.0;
+      for (int j = 0; j < call.out_len; ++j) adj[out_adj + j] = 0.0;
       continue;
     }
     // Every instruction consumes its output's adjoint and clears it: the

--- a/runtime/src/island.cpp
+++ b/runtime/src/island.cpp
@@ -37,17 +37,17 @@ namespace {
 
 constexpr int64_t kMinIslandOps = 32;
 constexpr int kMaxLiveIns = 6;
-// What one register costs against one element of graph traffic. The file is
-// written by the forward and read by the backward, and the backward's
-// adjoint file is zeroed once per call besides -- so three passes over a
-// register against one element moved.
+// What one value register costs against one element of graph traffic. The
+// value file is written by the forward and read by the backward. The compact
+// adjoint file is charged separately below: copied registers share a cell,
+// and checkpoint registers have no adjoint cell at all.
 //
 // It was 4 while the backward replayed the program under var, where a
 // register meant an allocated vari and a virtual chain() call. That term
 // dominated the estimate and is what refused thirteen of the fourteen
 // regions the carver could compile; the generated adjoint (adjoint.hpp)
 // is what makes it a memory cost again.
-constexpr int kRegWeight = 3;
+constexpr int kValueRegWeight = 2;
 // And what one graph op costs against one element. An op that writes a
 // scalar still pays a dispatch, a context load and a scratch-partials
 // backward; measured at ~5 ns against ~1 ns for an island instruction
@@ -165,8 +165,9 @@ struct Compiler {
   std::vector<int> live_in_slots;
   size_t op_index = 0;  // graph index of the op being compiled
   // Scratch registers CALLs allocated: working memory the graph op also
-  // had, free in the estimate's eyes, so the estimate counts these at
-  // weight 1 rather than kRegWeight.
+  // had, free in the estimate's eyes. They are subtracted from the two
+  // value-file passes and retain only their identity cell in the compact
+  // adjoint count below: effective weight 1.
   int64_t n_call_scratch = 0;
   bool ok = true;
 
@@ -538,16 +539,22 @@ int carve_islands(Graph& g,
       // kernel with the graph's own per-call overhead (context assembly,
       // indirect call, twice per gradient), so absorbing one buys
       // continuity, never speed. Two corrections make that true in the
-      // arithmetic: its scratch counts at weight 1 rather than
-      // kRegWeight (working memory the graph op also had, free in this
-      // accounting), and each CALL pays the same kOpCost the graph side
-      // is charged -- without which a region of nothing but CALLs reads
-      // as a win and measures a loss (dugongs_model, 0.63x, the first
-      // sweep after the vocabulary widened).
+      // arithmetic: its scratch is subtracted from the two value-file passes
+      // (working memory the graph op also had) but retains its identity cell
+      // in the compact adjoint count, for effective weight 1; and each CALL
+      // pays the same kOpCost the graph side is charged -- without which a
+      // region of nothing but CALLs reads as a win and measures a loss
+      // (dugongs_model, 0.63x, the first sweep after the vocabulary widened).
       const int64_t n_calls = (int64_t)cc.prog.calls.size();
+      // A rare program the generator refuses keeps the replay. Preserve its
+      // old one-cell-per-value charge rather than treating an absent compact
+      // adjoint program as a zero-sized file.
+      const int64_t adj_regs = cc.prog.adj.empty()
+                                   ? (int64_t)cc.prog.n_regs
+                                   : (int64_t)cc.prog.adj.n_regs;
       const int64_t island_cost =
-          kRegWeight * ((int64_t)cc.prog.n_regs - cc.n_call_scratch) +
-          cc.n_call_scratch + (int64_t)cc.prog.code.size() +
+          kValueRegWeight * ((int64_t)cc.prog.n_regs - cc.n_call_scratch) +
+          adj_regs + (int64_t)cc.prog.code.size() +
           (int64_t)cc.prog.adj.code.size() + (kOpCost - 1) * 2 * n_calls;
       if (std::getenv("STANLI_DEBUG_ISLAND"))
         std::fprintf(stderr, "island? ops=%zu graph=%lld island=%lld\n", j - i,
@@ -630,9 +637,9 @@ int carve_islands(Graph& g,
           const IslandProg& p = *static_cast<const IslandProg*>(is.udata);
           std::fprintf(stderr,
                        "island: ops=%zu instr=%zu regs=%d ins=%zu outs=%zu "
-                       "adj=%zu\n",
+                       "adj=%zu adj_regs=%d\n",
                        j - i, p.code.size(), p.n_regs, p.ins.size(),
-                       p.out_regs.size(), p.adj.code.size());
+                       p.out_regs.size(), p.adj.code.size(), p.adj.n_regs);
           // Which instructions the region is made of, so a disagreement
           // with the replay can be attributed to an opcode rather than
           // guessed at.

--- a/tests/test_adjoint.cpp
+++ b/tests/test_adjoint.cpp
@@ -91,7 +91,7 @@ static std::vector<double> native_adjoints(const IslandProg& p,
   for (size_t m = 0; m < p.out_regs.size(); ++m)
     out_vals->push_back(val[(size_t)p.out_regs[m]]);
 
-  std::vector<double> adj((size_t)p.n_regs, 0.0);
+  std::vector<double> adj((size_t)p.adj.n_regs, 0.0);
   const auto& map = p.adj.adj_reg;
   for (size_t m = p.out_regs.size(); m-- > 0;)
     adj[(size_t)map[(size_t)p.out_regs[m]]] += seed[m];
@@ -377,6 +377,32 @@ static void test_copy_then_modify_chain() {
     st = d;
   }
   check("copy then modify chain", b.done({acc}, {1.0}));
+}
+
+// Copy sharing is storage sharing, not only an arithmetic shortcut. The
+// value file keeps its original register ids, while adjoint equivalence
+// classes are packed densely. Removing the copied range's old ids must also
+// preserve the contiguity the following ranged EXP rule requires.
+static void test_compact_adjoint_ranges() {
+  Build b({0.31, 0.72, -0.45, 1.1}, 4);
+  const int copy = b.alloc(4);
+  b.emit_to(Program::MOVR, copy, 0, 0, 0, 4);
+  const int out = b.emit(Program::EXP_RANGE, copy, 0, 0, 4, 4);
+  Case c = b.done({out, out + 1, out + 2, out + 3}, {0.2, 0.4, 0.6, 0.8});
+  Case parity = c;
+  expect("compact ranges generated", gen_adjoint(c.p));
+  expect("compact ranges forward ids", c.p.adj.adj_reg.size() == 12);
+  expect("compact ranges cells", c.p.adj.n_regs == 8);
+  const std::vector<int32_t> want_map{0, 1, 2, 3, 0, 1, 2, 3, 4, 5, 6, 7};
+  expect("compact ranges map", c.p.adj.adj_reg == want_map);
+  expect("compact ranges instruction count", c.p.adj.code.size() == 1);
+  if (c.p.adj.code.size() == 1) {
+    const AdjInstr& A = c.p.adj.code[0];
+    expect("compact ranges opcode", A.code == Program::EXP_RANGE);
+    expect("compact ranges contiguous output", A.dst == 4);
+    expect("compact ranges contiguous input", A.a == 0);
+  }
+  check("compact ranges parity", std::move(parity));
 }
 
 static void test_accumulate_into_one_register() {
@@ -827,6 +853,7 @@ int main() {
   test_self_write();
   test_live_copy_both_read();
   test_copy_then_modify_chain();
+  test_compact_adjoint_ranges();
   test_accumulate_into_one_register();
   test_ranged();
   test_in_place_ranges();

--- a/tests/test_island.cpp
+++ b/tests/test_island.cpp
@@ -41,6 +41,25 @@ static std::vector<double> run_grad(Graph g, const Fills& fills) {
   return testutil::run_grad(std::move(g), fills, fill_at);
 }
 
+// The island kernel reuses its thread-local compact adjoint file. Running the
+// same executor twice catches a stale cell beyond the shortened zeroed range.
+static std::vector<double> run_grad_twice(Graph g, const Fills& fills) {
+  Executor ex(std::move(g));
+  for (const auto& f : fills) {
+    double* p = ex.value_ptr(f.first);
+    for (size_t j = 0; j < f.second.size(); ++j) p[j] = f.second[j];
+  }
+  for (int64_t i = 0; i < ex.n_params(); ++i) ex.params_data()[i] = fill_at(i);
+  std::vector<double> first(1 + (size_t)ex.n_params());
+  std::vector<double> second(1 + (size_t)ex.n_params());
+  first[0] = ex.gradient(first.data() + 1);
+  second[0] = ex.gradient(second.data() + 1);
+  expect("repeat sizes", first.size() == second.size());
+  for (size_t i = 0; i < first.size(); ++i)
+    expect_close("repeat v" + std::to_string(i), second[i], first[i]);
+  return second;
+}
+
 static std::string slurp(const std::string& path) {
   std::ifstream f(path);
   std::ostringstream ss;
@@ -270,10 +289,68 @@ static void test_vector_copies_carved() {
   const int carved = carve_islands(isl.g, isl.fills, isl.terms, {});
   expect("copies carved==1", carved == 1);
   expect("copies ops==4", isl.g.ops.size() == 4);
-  const std::vector<double> got = run_grad(std::move(isl.g), isl.fills);
+  const std::vector<double> got = run_grad_twice(std::move(isl.g), isl.fills);
   expect("copies sizes", got.size() == want.size());
   for (size_t i = 0; i < want.size() && i < got.size(); ++i)
     expect_close("copies v" + std::to_string(i), got[i], want[i]);
+}
+
+// A measured-cost boundary made from the same two facts as iohmm_reg:
+// INDEX copies share their source's adjoint cell, while ADD_N expands to a
+// short instruction chain. Charging one adjoint cell per forward register
+// refuses this region; charging the compact file carves it. Constants keep
+// the boundary honest by adding real value/adjoint work without a graph op.
+static HmmGraph build_compact_cost_boundary() {
+  HmmGraph h;
+  Graph& g = h.g;
+  constexpr int W = 4;
+  const int x = g.add_slot(W, true);
+  int last = -1;
+  for (int t = 0; t < 8; ++t) {
+    int e[W];
+    for (int k = 0; k < W; ++k) {
+      e[k] = g.add_slot(1, false);
+      g.add_op(OP_INDEX, {x}, e[k], {k});
+    }
+    const int c = g.add_slot(1, false);
+    h.fills.emplace_back(c, std::vector<double>{0.1 * (t + 1)});
+    last = g.add_slot(1, false);
+    g.add_op(OP_ADD_N, {e[0], e[1], e[2], e[3], c}, last);
+  }
+  h.body_ops = g.ops.size();  // 40 scalar ops, all one maximal run
+  const int lp = g.add_slot(1, false);
+  g.add_op(OP_ADD, {last, last}, lp);  // target term ends the run
+  h.terms.push_back(lp);
+  g.result_slot = lp;
+  return h;
+}
+
+static void test_compact_adjoint_cost_boundary() {
+  HmmGraph forced = build_compact_cost_boundary();
+  const int64_t graph_cost = 6 * (int64_t)forced.body_ops;
+  test_setenv("STANLI_ISLAND_ALWAYS", "1", 1);
+  expect("compact boundary forced carve",
+         carve_islands(forced.g, forced.fills, forced.terms, {}) == 1);
+  test_unsetenv("STANLI_ISLAND_ALWAYS");
+  const IslandProg* p = nullptr;
+  for (const Op& op : forced.g.ops)
+    if (op.opcode == OP_ISLAND) p = static_cast<const IslandProg*>(op.udata);
+  expect("compact boundary has island", p != nullptr);
+  if (p) {
+    const int64_t streams =
+        (int64_t)p->code.size() + (int64_t)p->adj.code.size();
+    const int64_t old_sparse_cost = 3 * (int64_t)p->n_regs + streams;
+    const int64_t compact_cost =
+        2 * (int64_t)p->n_regs + p->adj.n_regs + streams;
+    expect("compact boundary new wins", compact_cost < graph_cost);
+    expect("compact boundary old loses", graph_cost < old_sparse_cost);
+    expect("compact boundary actually smaller",
+           p->adj.n_regs < (int)p->adj.adj_reg.size());
+  }
+
+  HmmGraph normal = build_compact_cost_boundary();
+  expect("compact boundary default carve",
+         carve_islands(normal.g, normal.fills, normal.terms, {}) == 1);
 }
 
 // The same recurrence on a two-element state: nothing is copied, so the
@@ -309,12 +386,18 @@ static void test_kernel_call_ops_carved() {
   Fills fills;
   const int p0 = g.add_slot(1, true);
   const int p1 = g.add_slot(1, true);
+  const int seed_vec = g.add_slot(2, true);
+  const int seed = g.add_slot(1, false);
+  g.add_op(OP_INDEX, {seed_vec}, seed, {0});
   auto cslot = [&](double v) {
     const int s = g.add_slot(1, false);
     fills.emplace_back(s, std::vector<double>{v});
     return s;
   };
-  int acc = p0;
+  // INDEX compiles to an aliasable MOV before the first CALL. Compacting
+  // that shared cell shifts the CALL's later ranges, so the assertions
+  // below exercise mapped addressing rather than identity by accident.
+  int acc = seed;
   for (int t = 0; t < 12; ++t) {
     // inv_logit keeps the recurrence in (0, 1): pow of a negative base at
     // a non-integer exponent is NaN, and tanh below goes negative.
@@ -358,7 +441,27 @@ static void test_kernel_call_ops_carved() {
   const std::vector<double> want = run_grad(std::move(ref), fills);
   const int carved = carve_islands(g, fills, terms, {});
   expect("callops carved==1", carved == 1);
-  const std::vector<double> got = run_grad(std::move(g), fills);
+  bool shifted_call_range = false;
+  for (const Op& op : g.ops) {
+    if (op.opcode != OP_ISLAND) continue;
+    const auto& p = *static_cast<const IslandProg*>(op.udata);
+    for (const Program::Call& call : p.calls) {
+      auto check_range = [&](int reg, int len) {
+        if (len == 0) return;
+        const int base = p.adj.adj_reg[(size_t)reg];
+        expect("call compact base", base >= 0 && base + len <= p.adj.n_regs);
+        for (int k = 1; k < len; ++k)
+          expect("call compact contiguous",
+                 p.adj.adj_reg[(size_t)(reg + k)] == base + k);
+        if (base != reg) shifted_call_range = true;
+      };
+      for (int k = 0; k < call.n_in; ++k)
+        check_range(call.in[k], call.in_len[k]);
+      check_range(call.out, call.out_len);
+    }
+  }
+  expect("call range actually compacted", shifted_call_range);
+  const std::vector<double> got = run_grad_twice(std::move(g), fills);
   expect("callops sizes", got.size() == want.size());
   for (size_t i = 0; i < want.size() && i < got.size(); ++i)
     expect_close("callops v" + std::to_string(i), got[i], want[i]);
@@ -545,6 +648,7 @@ int main() {
   test_unsetenv("STANLI_ISLAND_ALWAYS");
   test_wide_state_refused();
   test_vector_copies_carved();
+  test_compact_adjoint_cost_boundary();
   test_scalar_chain_carved();
   test_inplace_slice_cost_refuses_wide_state();
   if (failures) {


### PR DESCRIPTION
## Summary

- pack copy-equivalent island adjoints into a dense file while keeping checkpoints value-only
- use compact adjoint ranges for native backward and CALL kernels
- make the island estimator charge the exact value and adjoint storage it executes
- add range, CALL, repeat-evaluation, and cost-boundary regressions

## Performance

On `iohmm_reg`, the compact file has 39,000 adjoint cells for 95,424 forward register IDs, with 4,488 value-only checkpoints. The default estimator now chooses the island:

- graph: 53,456 -> 27 ops
- gradient: 498.612 -> 241.453 us, 2.065x faster
- retained CmdStan comparison: 1.33x

A default/disabled/forced census of all 21 island-capable corpus models changed only the IOHMM decision. Known losing shapes including bones, dugongs, Survey, and both Covid models remain refused.

## Validation

- fresh Release build: 297/297 targets
- CTest: 59/59 passed
- corpus references: 129/129 models at all 3 points, 800,674 values
- format, generated docs, web catalog, and diff checks passed