### PR TITLE
perf: specialize scalar categorical probability

### DIFF
--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -175,6 +175,21 @@ the top of the page, not replacements for the current corpus rows:
   26.8 us after the slice fix. The combined `Mtbh_model` improvement is
   106.5 -> 26.8 us (3.98x). In the full warmed-mean snapshot the three models
   are 19.0, 57.1, and 27.0 us/gradient, or 1.05x, 1.65x, and 1.59x CmdStan.
+- **Native scalar probability categorical** removes the nested autodiff replay
+  only when one categorical outcome selects from an active probability vector.
+  Stan Math's double overload still computes the value and performs every
+  check; reverse adds the incoming seed divided by the selected probability to
+  that probability's adjoint. Array outcomes retain replay to preserve their
+  repeated-selection accumulation topology, and categorical-logit calls retain
+  replay for their dense pullback. The graph is unchanged. In a targeted
+  2026-08-24 Release A/B (seven matched-run medians),
+  `gpcm_latent_reg_irt` moved 1.741465 -> 0.955609 ms/gradient (1.8224x
+  internally, now 1.3998x CmdStan), and `grsm_latent_reg_irt` moved
+  0.9705208 -> 0.4953192 ms/gradient (1.9594x internally, now 1.5387x
+  CmdStan). Their categorical opcode time fell 4.45x and 5.00x respectively;
+  the categorical-logit RBM controls were unchanged. These targeted medians
+  are not replacements for the full-corpus warmed means in the table below,
+  which await the next corpus refresh.
 - **Packed row-wise reductions** (the LDA inner loop): targeted medians fall
   from 154 to 94 us for `ldaK2` and 6.82 to 3.70 ms for `ldaK5`, while their
   graphs collapse from 15,854 to 22 and 434,126 to 156 ops. The full

--- a/runtime/kernels/message.cpp
+++ b/runtime/kernels/message.cpp
@@ -297,10 +297,39 @@ Eigen::Matrix<stan::math::var, -1, 1> categorical_vars(const Desc& input) {
   return arg;
 }
 
+// The scalar-outcome probability form is just log(theta[n - 1]), with one
+// selected reciprocal in reverse.  Its generic implementation used to build
+// and tear down a nested var tape in both sweeps.  Keep Stan Math's double
+// overload responsible for the value and every check, then write the exact
+// scalar rev rule directly below.  Array outcomes deliberately stay on the
+// replay: repeated selections share log nodes, and replacing that tape with
+// counts would regroup low bits (pinned in test_lower.cpp).
+bool native_scalar_probability(const CategoricalSpec& spec) {
+  return !spec.logit && spec.scalar_outcome && spec.arg_autodiff;
+}
+
+int categorical_scalar_outcome(const KernelCtx& ctx) {
+  if (ctx.in[0].len != 1)
+    throw std::logic_error("categorical scalar outcome has wrong width");
+  return categorical_outcome(ctx.in[0].data[0]);
+}
+
 void categorical_fwd(KernelCtx& ctx) {
   if (ctx.n_in != 2 || ctx.out.len != 1 || ctx.udata == nullptr)
     throw std::logic_error("malformed categorical op");
   const auto& spec = *static_cast<const CategoricalSpec*>(ctx.udata);
+  // forward_value_only intentionally instantiates the expression on doubles:
+  // a propto call whose source type was var therefore returns its dropped
+  // zero in that mode.  Preserve that existing contract and use the native
+  // active-type path only for a normal forward/gradient evaluation.
+  if (native_scalar_probability(spec) && !values_only()) {
+    const int outcome = categorical_scalar_outcome(ctx);
+    const Eigen::Map<const Eigen::VectorXd> arg(ctx.in[1].data, ctx.in[1].len);
+    // With an active argument, both <true> and <false> retain this summand;
+    // the double <false> body is the same value/check order without a tape.
+    ctx.out.data[0] = stan::math::categorical_lpmf<false>(outcome, arg);
+    return;
+  }
   const std::vector<int> outcomes = categorical_outcomes(ctx, spec);
   if (spec.arg_autodiff && !values_only()) {
     stan::math::nested_rev_autodiff nested;
@@ -317,6 +346,12 @@ void categorical_bwd(KernelCtx& ctx) {
   if (!spec.arg_autodiff || ctx.in_adj[1].data == nullptr ||
       (!spec.scalar_outcome && ctx.in[0].len == 0))
     return;
+  if (native_scalar_probability(spec)) {
+    const int outcome = categorical_scalar_outcome(ctx);
+    ctx.in_adj[1].data[outcome - 1] +=
+        ctx.out_adj / ctx.in[1].data[outcome - 1];
+    return;
+  }
   stan::math::nested_rev_autodiff nested;
   auto arg = categorical_vars(ctx.in[1]);
   for (int64_t k = 0; k < ctx.in[1].len; ++k)

--- a/runtime/src/OPTIMIZATIONS.md
+++ b/runtime/src/OPTIMIZATIONS.md
@@ -215,6 +215,30 @@ candidate-free million-op LDA shape from 1.16 s to about 3.4 ms. The exact
 candidate-index, packed-row, and use-list work counters live in `RerollStats`
 and have deterministic scaling tests.
 
+## Native scalar probability categorical (`message.cpp`)
+
+The active scalar-outcome probability form of `categorical_lpmf` has a narrow
+derivative: only the selected probability receives the incoming seed divided
+by that probability. Its kernel therefore asks Stan Math's double overload to
+compute the value and perform every domain and bounds check, then applies that
+single pullback directly. This removes the nested reverse-mode tape from both
+sweeps without changing the graph or its operation count.
+
+The contract is intentionally no wider: the outcome must be scalar, the
+probability vector must be active, and the call must use probabilities rather
+than logits. Array outcomes retain the existing replay so repeated selections
+keep the exact log-node and accumulation topology, while categorical-logit
+retains replay for its dense softmax pullback. The categorical-logit RBM models
+are therefore unchanged controls.
+
+In a targeted 2026-08-24 Release A/B using seven matched-run medians,
+`gpcm_latent_reg_irt` moved 1.741465 -> 0.955609 ms/gradient (1.8224x
+internally and 1.3998x CmdStan), while `grsm_latent_reg_irt` moved 0.9705208 ->
+0.4953192 ms/gradient (1.9594x internally and 1.5387x CmdStan). Time in their
+categorical opcode fell 4.45x and 5.00x respectively. These are targeted
+medians, not the full-corpus warmed means; `docs/corpus-bench.tsv` and the
+generated corpus table remain unchanged until the next refresh.
+
 ## Control flow that depends on a parameter (`lower.cpp`, `mir_prog.hpp`)
 
 `if (theta > 0) ...` cannot become ops: the op list is fixed at load

--- a/tests/test_lower.cpp
+++ b/tests/test_lower.cpp
@@ -1175,6 +1175,121 @@ int main() {
     stan::math::recover_memory();
   }
 
+  // The native scalar probability rule has one selected reciprocal. Pin its
+  // non-unit upstream seed, += into an adjoint a later consumer already
+  // wrote, propto/type behavior, and value-only -> gradient reuse against the
+  // exact Stan tape it replaces.
+  {
+    Graph g;
+    const int theta = g.add_slot(3, true);
+    const int outcome = g.add_slot(1, false);
+    const int cat = g.add_slot(1, false);
+    const int cat_op = g.add_op(OP_CATEGORICAL, {outcome, theta}, cat);
+    auto spec = std::make_shared<CategoricalSpec>();
+    spec->logit = false;
+    spec->scalar_outcome = true;
+    spec->arg_autodiff = true;
+    spec->propto = true;
+    g.ops[(size_t)cat_op].udata = spec.get();
+    g.udata_pool.push_back(std::move(spec));
+    const int cat_scale = g.add_slot(1, false);
+    const int scaled_cat = g.add_slot(1, false);
+    g.add_op(OP_MUL, {cat, cat_scale}, scaled_cat);
+    const int selected = g.add_slot(1, false);
+    g.add_op(OP_INDEX, {theta}, selected, {1});
+    const int linear_scale = g.add_slot(1, false);
+    const int linear = g.add_slot(1, false);
+    g.add_op(OP_MUL, {selected, linear_scale}, linear);
+    const int total = g.add_slot(1, false);
+    g.add_op(OP_ADD, {scaled_cat, linear}, total);
+    g.result_slot = total;
+
+    Executor ex(std::move(g));
+    const double point[3] = {0.2, 0.7, 0.1};
+    std::copy(std::begin(point), std::end(point), ex.params_data());
+    ex.value_ptr(outcome)[0] = 2.0;
+    ex.value_ptr(cat_scale)[0] = 0.3;
+    ex.value_ptr(linear_scale)[0] = -0.2;
+    expect_eq("categorical native value-only propto", ex.forward_value_only(),
+              point[1] * -0.2);
+    double got_grad[3];
+    const double got = ex.gradient(got_grad);
+
+    Eigen::Matrix<stan::math::var, -1, 1> ref_theta(3);
+    ref_theta << point[0], point[1], point[2];
+    stan::math::var ref =
+        stan::math::categorical_lpmf<true>(2, ref_theta) * 0.3 +
+        ref_theta(1) * -0.2;
+    ref.grad();
+    expect_eq("categorical native scalar value", got, ref.val());
+    for (int i = 0; i < 3; ++i)
+      expect_eq("categorical native scalar g" + std::to_string(i), got_grad[i],
+                ref_theta(i).adj());
+    stan::math::recover_memory();
+  }
+
+  // Direct kernel edges for the same rule. A scalar categorical log only
+  // connects the selected probability: an infinite seed must leave an
+  // unselected signed zero untouched, while a zero seed over a selected zero
+  // still follows the connected log edge and forms 0 / 0. Reusing the context
+  // also pins that the native path carries no hidden scratch state.
+  {
+    const Kernel* kernel = find_kernel(OP_CATEGORICAL);
+    check(kernel != nullptr, "categorical native kernel registered");
+    check(kernel && kernel->scratch_size == nullptr,
+          "categorical native kernel scratchless");
+    if (kernel) {
+      CategoricalSpec spec;
+      spec.logit = false;
+      spec.scalar_outcome = true;
+      spec.arg_autodiff = true;
+      spec.propto = true;
+      double outcome = 1.0;
+      double theta[2] = {1.0, 0.0};
+      double theta_adj[2] = {0.0, -0.0};
+      double out = 0.0;
+      KernelCtx ctx{};
+      ctx.n_in = 2;
+      ctx.in[0] = Desc{&outcome, 1};
+      ctx.in[1] = Desc{theta, 2};
+      ctx.in_adj[0] = Desc{nullptr, 1};
+      ctx.in_adj[1] = Desc{theta_adj, 2};
+      ctx.out = Desc{&out, 1};
+      ctx.udata = &spec;
+
+      kernel->forward(ctx);
+      ctx.out_adj = std::numeric_limits<double>::infinity();
+      kernel->backward(ctx);
+      check(std::isinf(theta_adj[0]) && theta_adj[0] > 0.0,
+            "categorical native infinite selected adjoint");
+      check(theta_adj[1] == 0.0 && std::signbit(theta_adj[1]),
+            "categorical native unselected signed zero");
+
+      theta[0] = 0.0;
+      theta[1] = 1.0;
+      theta_adj[0] = 0.0;
+      theta_adj[1] = -0.0;
+      kernel->forward(ctx);
+      check(std::isinf(out) && out < 0.0,
+            "categorical native selected zero value");
+      ctx.out_adj = 0.0;
+      kernel->backward(ctx);
+      check(std::isnan(theta_adj[0]),
+            "categorical native selected zero topology");
+      check(theta_adj[1] == 0.0 && std::signbit(theta_adj[1]),
+            "categorical native repeated unselected zero");
+
+      outcome = 2.0;
+      theta[0] = 0.2;
+      theta[1] = 0.8;
+      ctx.in_adj[1] = Desc{nullptr, 2};
+      kernel->forward(ctx);
+      expect_eq("categorical native null-adjoint value", out, std::log(0.8));
+      ctx.out_adj = 1.0;
+      kernel->backward(ctx);  // active source type, but no graph adjoint edge
+    }
+  }
+
   // Array outcomes add one callback contribution per observation. Preserve
   // that exact accumulation order under a non-unit upstream adjoint; replacing
   // it with count * adjoint changes the selected gradient's low bit. The zero


### PR DESCRIPTION
## Summary

- replace nested reverse-mode tape construction for active scalar-outcome `categorical_lpmf` probability calls with the exact selected-probability pullback
- keep Stan Math responsible for value computation, validation, exception ordering, and propto semantics
- retain the existing replay for array outcomes and categorical-logit calls, where topology and dense accumulation matter
- add exact seed, prefilled-adjoint, signed-zero, zero-probability, null-adjoint, reuse, and value-only coverage

This is stacked on #168. The PR diff itself is four files and does not change graph structure or corpus benchmark rows.

## Performance

Targeted 2026-08-24 Release A/B, seven matched-run medians:

| model | before | after | internal | vs CmdStan |
|---|---:|---:|---:|---:|
| `gpcm_latent_reg_irt` | 1.741465 ms | 0.955609 ms | 1.8224x | 1.3998x |
| `grsm_latent_reg_irt` | 0.9705208 ms | 0.4953192 ms | 1.9594x | 1.5387x |

Categorical opcode time fell 4.45x and 5.00x. The `nn_rbm1bJ10` and `nn_rbm1bJ100` categorical-logit controls were unchanged within run noise.

## Validation

- fresh Release build: 297/297 steps
- CTest: 59/59 passed
- reference oracle: 129/129 models at all three evaluation points, 800,674 values
- `tools/format.sh --check`
- `python3 tools/gen_docs.py --check`
- `python3 tools/gen_web_models.py --check`
- `git diff --check`

Strict semantic review found no blocker. The new path preserves the exact `out_adj / theta[y - 1]` arithmetic and selected-only log topology.