### PR TITLE
perf: remove ODE RHS input staging

### DIFF
--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -113,11 +113,12 @@ by the model's *shape*, not its size.
 
 **Slower (a shrinking tail, mostly 0.5-0.9x):**
 
-- **ODE models**: `lotka_volterra`, `soil_incubation`, and
-  `one_comp_mm_elim_abs` are 0.53x, 0.59x, and 0.75x. The remaining gap is our
-  per-call dispatch of the compiled right-hand side against CmdStan's fully
-  inlined one inside the same CVODES solver. (They were 0.015-0.025x before
-  the right-hand side compiled; see below.)
+- **ODE models (retained full-corpus snapshot)**: `lotka_volterra`,
+  `soil_incubation`, and `one_comp_mm_elim_abs` are 0.53x, 0.59x, and 0.75x.
+  The remaining gap is our per-call dispatch of the compiled right-hand side
+  against CmdStan's native C++ right-hand side inside the same underlying Stan
+  Math integrator. (They were 0.015-0.025x before the right-hand side compiled;
+  see below.)
 - **Large scalar residue, occupancy, and latent-regression IRT shapes**:
   `iohmm_reg` is 0.65x, `gpcm_latent_reg_irt` and `grsm_latent_reg_irt` are
   0.74x and 0.79x, and `multi_occupancy` is 0.79x. These are all the non-ODE
@@ -214,6 +215,23 @@ the top of the page, not replacements for the current corpus rows:
   construction rises from about 0.239 s to 2.20-2.21 s, but the 154 ms saved
   per row repays it after roughly 13 draws. These are targeted write-array
   medians, not replacements for the sampling columns in the full corpus table.
+- **Allocation-free ODE right-hand-side input seeding** removes the promoted
+  `y` and `theta` staging vectors built on every solver callback and seeds the
+  reusable register file directly. A targeted 2026-08-24 Release A/B (seven
+  alternating matched-batch medians) measured:
+
+  | model | staged inputs | direct register seeding | improvement |
+  | --- | ---: | ---: | ---: |
+  | `lotka_volterra` | 78.6216 us | 68.6068 us | 1.14597x |
+  | `soil_incubation` | 102.1527 us | 89.5593 us | 1.14062x |
+  | `one_comp_mm_elim_abs` | 643.1571 us | 578.8621 us | 1.11107x |
+
+  The geometric-mean improvement is 1.13245x, and the known callback counts
+  put the saving at a consistent 38.5-39.3 ns/callback. LP and gradient
+  results were bitwise identical for all 63/63 checked scalars across three
+  points. This targeted A/B attributes the direct-seeding change; it does not
+  replace the retained full-corpus warmed means or CmdStan ratios above and in
+  the table below, which await the next corpus refresh.
 - **Packed row-wise reductions** (the LDA inner loop): targeted medians fall
   from 154 to 94 us for `ldaK2` and 6.82 to 3.70 ms for `ldaK5`, while their
   graphs collapse from 15,854 to 22 and 434,126 to 156 ops. The full
@@ -389,9 +407,10 @@ input promoted both to reverse mode and integrated sensitivities for both.
 On `one_comp_mm_elim_abs` the initial state is data, so the sensitivity width
 falls from four to three and median latency from 699 to 639 us/gradient. The
 fully active `lotka_volterra` and `soil_incubation` shapes take the same path
-as before and remain flat within measurement noise. The current warmed means
-are 629 us for `one_comp_mm_elim_abs`, 78 us for `lotka_volterra`, and 103 us
-for `soil_incubation`, or 0.75x, 0.53x, and 0.59x CmdStan.
+as before and remain flat within measurement noise. The retained pre-patch
+full-corpus warmed means are 629 us for `one_comp_mm_elim_abs`, 78 us for
+`lotka_volterra`, and 103 us for `soil_incubation`, or 0.75x, 0.53x, and
+0.59x CmdStan.
 
 Preparation scales too: the largest corpus model (`nn_rbm1bJ100`, MNIST,
 60,000 rows, 79,411 parameters) lowers to a 132,024-op graph. Its old 23.80 s

--- a/docs/superpowers/plans/2026-08-08-cmdstan-parity-roadmap.md
+++ b/docs/superpowers/plans/2026-08-08-cmdstan-parity-roadmap.md
@@ -178,14 +178,17 @@ warmed arithmetic means.
 - **Native `multi_normal_cholesky` partials — LANDED.** Retaining the exact
   active-Cholesky partial matrix moved `gp_regr` from 6.05 to 4.20 us/gradient
   in the targeted A/B. Its current full-corpus ratio is 1.11x CmdStan.
-- **Mixed ODE activity types — LANDED.** Removing the inactive initial-state
-  sensitivity moved `one_comp_mm_elim_abs` from 699 to 639 us/gradient in the
-  targeted A/B; its current full-corpus ratio is 0.75x CmdStan. The fully
-  active `lotka_volterra` and `soil_incubation` shapes do not benefit from this
-  specialization and currently sit at 0.53x and 0.59x.
-- **The remaining tail.** `lotka_volterra` now completes sampling in 10.00 s
-  versus CmdStan's 6.24 s; the earlier timeout claim is no longer reproducible,
-  although its 0.53x gradient ratio still points to solver/RHS dispatch.
+- **Mixed ODE activity and allocation-free RHS seeding — LANDED.** Removing
+  the inactive initial-state sensitivity first moved `one_comp_mm_elim_abs`
+  from 699 to 639 us/gradient. The later targeted 2026-08-24 A/B removed
+  per-callback `y`/`theta` staging and improved all three ODEs by
+  1.11107-1.14597x (1.13245x geometric mean; 63/63 bitwise LP/gradient
+  checks). The retained full-corpus ratios remain 0.53x, 0.59x, and 0.75x
+  until the next refresh.
+- **The remaining tail.** In the retained pre-patch full-corpus run,
+  `lotka_volterra` completed sampling in 10.00 s versus CmdStan's 6.24 s; the
+  earlier timeout claim is no longer reproducible, although its 0.53x gradient
+  ratio still points to solver/RHS dispatch.
   `iohmm_reg` is 0.65x CmdStan in the current full warmed-mean run. Its 4.74x
   generated-adjoint result was a targeted comparison against islands disabled,
   not a CmdStan speedup; stored loop bodies do not remove per-executed-

--- a/runtime/include/stanli/ode_prog.hpp
+++ b/runtime/include/stanli/ode_prog.hpp
@@ -69,18 +69,36 @@ RhsProgram compile_rhs(const mir::FunDef& f,
                        int n_y, int n_theta, int n_x_r,
                        const std::vector<int>& x_i);
 
-// Evaluate. The register file is reused between calls (one per scalar type),
-// which is what makes a call allocation-free; the compiler guarantees every
-// register is written before it is read, so leftovers are never observed.
+// Evaluate. The register file is reused between calls (one per result scalar
+// type), which keeps the register-machine body allocation-free after first
+// use; the compiler guarantees every register is written before it is read,
+// so leftovers are never observed. y and theta may have different scalar
+// types: seed them straight into the result-typed registers instead of
+// allocating promoted vectors for every integrator callback.
+//
+// Promotions deliberately retain the old order: y, every source theta
+// (including an unused lowering placeholder), t, then x_r. Besides keeping
+// values identical, this preserves stan-math's var/nochain node creation order
+// from when y and theta were staged in vectors before the call.
 // Not reentrant, which is fine: an ODE right-hand side cannot solve an ODE.
 template <typename T>
-void run_rhs(const RhsProgram& p, const T& t, const T* y, const T* th,
-             const double* xr, std::vector<T>& out) {
+std::vector<T>& rhs_regs() {
   static thread_local std::vector<T> reg;
+  return reg;
+}
+
+template <typename T, typename T_time, typename T_y, typename T_theta>
+void run_rhs(const RhsProgram& p, const T_time& t, const T_y* y,
+             const T_theta* th, size_t n_th_source, const double* xr,
+             std::vector<T>& out) {
+  std::vector<T>& reg = rhs_regs<T>();
   if ((int)reg.size() < p.n_regs) reg.resize((size_t)p.n_regs);
-  reg[(size_t)p.t_reg] = t;
-  for (int i = 0; i < p.n_y; ++i) reg[(size_t)(p.y0 + i)] = y[i];
-  for (int i = 0; i < p.n_th; ++i) reg[(size_t)(p.th0 + i)] = th[i];
+  for (int i = 0; i < p.n_y; ++i) reg[(size_t)(p.y0 + i)] = T(y[i]);
+  for (int i = 0; i < p.n_th; ++i) reg[(size_t)(p.th0 + i)] = T(th[i]);
+  for (size_t i = (size_t)p.n_th; i < n_th_source; ++i) {
+    [[maybe_unused]] const T promoted(th[i]);
+  }
+  reg[(size_t)p.t_reg] = T(t);
   for (int i = 0; i < p.n_xr; ++i) reg[(size_t)(p.xr0 + i)] = T(xr[i]);
 
   run_program(p, reg);
@@ -88,6 +106,15 @@ void run_rhs(const RhsProgram& p, const T& t, const T* y, const T* th,
   out.resize(p.out_regs.size());
   for (size_t i = 0; i < p.out_regs.size(); ++i)
     out[i] = reg[(size_t)p.out_regs[i]];
+}
+
+// Compatibility entry for the register program's existing callers. A normal
+// RHS has exactly p.n_th source values; the ODE adapter above uses the sized
+// overload when lowering supplied an extra, deliberately unread placeholder.
+template <typename T, typename T_time, typename T_y, typename T_theta>
+void run_rhs(const RhsProgram& p, const T_time& t, const T_y* y,
+             const T_theta* th, const double* xr, std::vector<T>& out) {
+  run_rhs<T>(p, t, y, th, (size_t)p.n_th, xr, out);
 }
 
 }  // namespace stanli

--- a/runtime/kernels/ode.cpp
+++ b/runtime/kernels/ode.cpp
@@ -1,7 +1,8 @@
 // ODE integrator ops. stan-math does the solving and the sensitivities; the
 // right-hand side is the model's own user-defined function, evaluated at
-// runtime by the MIR interpreter (see mir_interp.hpp) because the integrator
-// picks the times, so the body cannot be inlined at compile time.
+// runtime by a compiled register program (with the MIR interpreter as its
+// fallback) because the integrator picks the times, so the body cannot be
+// inlined at compile time.
 //
 // One solve per gradient, in the forward sweep, with the solution's jacobian
 // stashed for the backward one.
@@ -44,20 +45,35 @@ struct MirRhs {
   const OdeSpec* spec;
 
   template <typename T_y, typename T_param>
+  std::vector<stan::return_type_t<T_y, T_param>> eval(
+      const double& t, const T_y* y, size_t n_y,
+      const std::vector<T_param>& theta, const std::vector<double>& x_r,
+      const std::vector<int>& x_i, std::ostream* msgs = nullptr) const {
+    using T = stan::return_type_t<T_y, T_param>;
+    if (spec->prog.ok) {
+      // Seed mixed scalar inputs directly into the result-typed register file.
+      // theta.size(), rather than prog.n_th, retains promotion of lowering's
+      // unread no-parameter placeholder in the old tape position.
+      std::vector<T> out;
+      run_rhs<T>(spec->prog, t, y, theta.data(), theta.size(), x_r.data(), out);
+      return out;
+    }
+    // Preserve the interpreter adapter exactly. The modern caller used to
+    // make this state vector before entering MirRhs; doing it here keeps the
+    // fallback's ownership and evaluation path unchanged.
+    std::vector<T_y> state;
+    if (n_y != 0) state.assign(y, y + n_y);
+    return (*this)(t, state, theta, x_r, x_i, msgs);
+  }
+
+  template <typename T_y, typename T_param>
   std::vector<stan::return_type_t<T_y, T_param>> operator()(
       const double& t, const std::vector<T_y>& y,
       const std::vector<T_param>& theta, const std::vector<double>& x_r,
-      const std::vector<int>& x_i, std::ostream* = nullptr) const {
+      const std::vector<int>& x_i, std::ostream* msgs = nullptr) const {
     using T = stan::return_type_t<T_y, T_param>;
-    if (spec->prog.ok) {
-      // y and theta arrive as T_y / T_param, which are T or double; the
-      // register file is T, so promote through a small staging buffer only
-      // when they differ.
-      std::vector<T> out, ys(y.begin(), y.end()),
-          ths(theta.begin(), theta.end());
-      run_rhs<T>(spec->prog, T(t), ys.data(), ths.data(), x_r.data(), out);
-      return out;
-    }
+    if (spec->prog.ok)
+      return eval(t, y.data(), y.size(), theta, x_r, x_i, msgs);
     // Rebuild the formal argument list the right-hand side declares.
     // MirInterp::call binds positionally by declared type, so the real
     // arguments have to arrive already split out of the packed theta and
@@ -101,8 +117,8 @@ struct VarRhs {
              const std::vector<double>& x_r,
              const std::vector<int>& x_i) const {
     using T = stan::return_type_t<T_y, T_param>;
-    const std::vector<T_y> yv(y.data(), y.data() + y.size());
-    const std::vector<T> dy = MirRhs{spec}(t, yv, theta, x_r, x_i);
+    const std::vector<T> dy =
+        MirRhs{spec}.eval(t, y.data(), (size_t)y.size(), theta, x_r, x_i);
     Eigen::Matrix<T, Eigen::Dynamic, 1> out(dy.size());
     for (size_t i = 0; i < dy.size(); ++i) out(i) = dy[i];
     return out;

--- a/runtime/src/OPTIMIZATIONS.md
+++ b/runtime/src/OPTIMIZATIONS.md
@@ -455,7 +455,28 @@ scratch layout and gating inactive columns in the backward sweep. On
 sensitivity width from four to three and median latency from 699 to 639 us
 per gradient (1.09x); fully active ODE models are unchanged.
 
-Together these made the ODE models 29-39x faster.
+The compiled right-hand side also used to allocate promoted `y` and `theta`
+staging vectors on every callback. It now seeds those inputs directly into the
+reusable result-scalar register file in the original promotion order, including
+unused parameter source slots, before executing the unchanged instruction
+list. Solver math, output ownership, and the interpreter fallback are
+unchanged. A targeted 2026-08-24 Release A/B (seven alternating matched-batch
+medians) measured:
+
+| model | staged inputs | direct register seeding | improvement |
+| --- | ---: | ---: | ---: |
+| `lotka_volterra` | 78.6216 us | 68.6068 us | 1.14597x |
+| `soil_incubation` | 102.1527 us | 89.5593 us | 1.14062x |
+| `one_comp_mm_elim_abs` | 643.1571 us | 578.8621 us | 1.11107x |
+
+The geometric-mean improvement is 1.13245x, or 38.5-39.3 ns saved per callback
+at the known callback counts. Three evaluation points produced bitwise-
+identical LP and gradient values for all 63/63 checked scalars. This dated
+targeted A/B isolates the direct-seeding change; it does not replace the
+retained full-corpus warmed means and CmdStan ratios in `docs/benchmarks.md`.
+
+The original RHS compiler, solve reuse, and mixed-activity work made the ODE
+models 29-39x faster; direct input seeding compounds that historical gain.
 
 ## Executor details (`executor.cpp`)
 

--- a/tests/test_ode_prog.cpp
+++ b/tests/test_ode_prog.cpp
@@ -15,17 +15,35 @@
 #include <stanli/ode_prog.hpp>
 #include <stanli/sexp.hpp>
 
+#include <stan/math.hpp>
+
 #include <cmath>
+#include <cstdint>
 #include <cstdio>
+#include <cstring>
 #include <fstream>
 #include <map>
 #include <sstream>
 #include <string>
+#include <type_traits>
 #include <vector>
 
 namespace {
 
 int failures = 0;
+
+void expect(const std::string& what, bool ok) {
+  if (!ok) {
+    ++failures;
+    std::printf("FAIL %s\n", what.c_str());
+  }
+}
+
+uint64_t bits(double x) {
+  uint64_t out;
+  std::memcpy(&out, &x, sizeof(out));
+  return out;
+}
 
 std::string slurp(const std::string& path) {
   std::ifstream f(path);
@@ -87,6 +105,111 @@ void check(const std::string& name, const stanli::mir::FunDef& f,
   }
 }
 
+// Capture the observable result and the exact scalar tape written by one RHS
+// replay. The staged case spells the old MirRhs path: promote all y/theta
+// values first, then t, before entering the register machine. The direct case
+// is the allocation-free path. Tape values as well as counts make moving one
+// of those promotions across t visible even when the gradient is unchanged.
+struct MixedRun {
+  std::vector<uint64_t> values;
+  std::vector<uint64_t> y_grads;
+  std::vector<uint64_t> theta_grads;
+  std::vector<uint64_t> chain_tape;
+  std::vector<uint64_t> nochain_tape;
+};
+
+std::vector<uint64_t> tape_bits(const std::vector<stan::math::vari_base*>& tape,
+                                size_t first) {
+  std::vector<uint64_t> out;
+  out.reserve(tape.size() - first);
+  for (size_t i = first; i < tape.size(); ++i) {
+    const auto* scalar = dynamic_cast<const stan::math::vari*>(tape[i]);
+    if (!scalar) {
+      ++failures;
+      std::printf("FAIL mixed seed produced a non-scalar tape node\n");
+      return {};
+    }
+    out.push_back(bits(scalar->val_));
+  }
+  return out;
+}
+
+template <bool YAutodiff, bool ThetaAutodiff, bool Staged>
+MixedRun mixed_run(const stanli::RhsProgram& p, double t,
+                   const std::vector<double>& y_values,
+                   const std::vector<double>& theta_values,
+                   const std::vector<double>& x_r) {
+  using T_y = std::conditional_t<YAutodiff, stan::math::var, double>;
+  using T_theta = std::conditional_t<ThetaAutodiff, stan::math::var, double>;
+  using T = stan::return_type_t<T_y, T_theta>;
+
+  stan::math::nested_rev_autodiff nested;
+  std::vector<T_y> y(y_values.begin(), y_values.end());
+  std::vector<T_theta> theta(theta_values.begin(), theta_values.end());
+  auto* stack = stan::math::ChainableStack::instance_;
+  const size_t chain_first = stack->var_stack_.size();
+  const size_t nochain_first = stack->var_nochain_stack_.size();
+
+  std::vector<T> out;
+  if constexpr (Staged) {
+    std::vector<T> staged_y(y.begin(), y.end());
+    std::vector<T> staged_theta(theta.begin(), theta.end());
+    const T staged_t(t);
+    stanli::run_rhs<T>(p, staged_t, staged_y.data(), staged_theta.data(),
+                       staged_theta.size(), x_r.data(), out);
+  } else {
+    stanli::run_rhs<T>(p, t, y.data(), theta.data(), theta.size(), x_r.data(),
+                       out);
+  }
+
+  MixedRun run;
+  for (const T& value : out)
+    run.values.push_back(bits(stan::math::value_of(value)));
+  run.chain_tape = tape_bits(stack->var_stack_, chain_first);
+  run.nochain_tape = tape_bits(stack->var_nochain_stack_, nochain_first);
+
+  if constexpr (std::is_same_v<T, stan::math::var>) {
+    const stan::math::var root = out.at(0) * 0.37 + out.at(1) * -0.29;
+    stan::math::grad(root.vi_);
+  }
+  run.y_grads.reserve(y.size());
+  for (size_t i = 0; i < y.size(); ++i) {
+    if constexpr (YAutodiff)
+      run.y_grads.push_back(bits(y[i].adj()));
+    else
+      run.y_grads.push_back(bits(0.0));
+  }
+  run.theta_grads.reserve(theta.size());
+  for (size_t i = 0; i < theta.size(); ++i) {
+    if constexpr (ThetaAutodiff)
+      run.theta_grads.push_back(bits(theta[i].adj()));
+    else
+      run.theta_grads.push_back(bits(0.0));
+  }
+  return run;
+}
+
+template <bool YAutodiff, bool ThetaAutodiff>
+void check_mixed_seed(const stanli::RhsProgram& p, const char* label) {
+  const std::vector<double> y{1.1, 0.7};
+  // The fifth value models lower_ode_variadic's unread scalar placeholder.
+  // The program consumes four, but the old staging vector promoted all five.
+  const std::vector<double> theta{0.2, 0.35, 0.17, 0.41, 19.25};
+  const std::vector<double> x_r{2.5, 1.25};
+  const MixedRun staged =
+      mixed_run<YAutodiff, ThetaAutodiff, true>(p, 0.73, y, theta, x_r);
+  const MixedRun direct =
+      mixed_run<YAutodiff, ThetaAutodiff, false>(p, 0.73, y, theta, x_r);
+  const std::string prefix = std::string("mixed seed ") + label + ": ";
+  expect(prefix + "output bits", direct.values == staged.values);
+  expect(prefix + "y gradient bits", direct.y_grads == staged.y_grads);
+  expect(prefix + "theta gradient bits",
+         direct.theta_grads == staged.theta_grads);
+  expect(prefix + "chain tape order", direct.chain_tape == staged.chain_tape);
+  expect(prefix + "nochain tape order",
+         direct.nochain_tape == staged.nochain_tape);
+}
+
 }  // namespace
 
 int main() {
@@ -119,6 +242,21 @@ int main() {
       continue;
     }
     check(c.name, *it->second, funs, c.n_y, c.n_th, x_r, x_i, c.want_ok);
+  }
+
+  // stan-math instantiates a var state whenever either side is active. The
+  // data-y/active-theta case is included too: run_rhs is a generic boundary,
+  // and this is the combination most likely to expose a changed y promotion.
+  {
+    const auto it = funs.find("f_lin");
+    const RhsProgram p = compile_rhs(*it->second, funs, 2, 4, 2, x_i);
+    expect("mixed seed fixture compiles", p.ok);
+    if (p.ok) {
+      check_mixed_seed<true, false>(p, "var/double");
+      check_mixed_seed<false, true>(p, "double/var");
+      check_mixed_seed<true, true>(p, "var/var");
+      check_mixed_seed<false, false>(p, "double/double");
+    }
   }
 
   // A right-hand side whose arity is not the integrate_ode_* one is refused


### PR DESCRIPTION
## What

Compiled ODE callbacks previously copied and promoted `y` and `theta` into fresh vectors before every register-program evaluation. This change seeds mixed scalar inputs directly into the reusable result-typed register file.

- preserves the exact `y` -> all source `theta` -> time -> `x_r` promotion order
- preserves unused lowering placeholders and Stan Math tape topology
- keeps one thread-local register file per result scalar type
- retains existing `run_rhs` call forms
- leaves solver math, output ownership, and MIR interpreter fallback unchanged

## Measured first

Targeted Release A/B on the same M3 Ultra, seven alternating matched batches:

| model | baseline | patched | speedup |
| --- | ---: | ---: | ---: |
| `lotka_volterra` | 78.6216 us | 68.6068 us | 1.14597x |
| `soil_incubation` | 102.1527 us | 89.5593 us | 1.14062x |
| `one_comp_mm_elim_abs` | 643.1571 us | 578.8621 us | 1.11107x |

Geometric mean: 1.13245x. The absolute savings normalize to 38.52, 38.63, and 39.25 ns per RHS callback. Prep is unchanged within noise. The corpus TSV is intentionally unchanged because these are targeted medians, not a full warmed-mean refresh.

## Exactness

- direct versus staged tests cover DD, VD, DV, and VV inputs
- output, gradient, chain tape, and nochain tape value order are pinned bitwise
- 63/63 LP and gradient scalars matched bitwise across three points for all three corpus ODEs
- authoritative corpus replay: 129/129 models at all three points, 800,674 values
- ODE differential sweep: 11/11 interfaces, including RK45, BDF, Adams, CKRK, tolerance forms, vector parameters, mixed arguments, and legacy `integrate_ode`

## Validation

- fresh isolated Release all-target build
- 59/59 CTests
- format check
- generated docs check
- 117-model website-note check
- `git diff --check`

The final implementation received an independent strict review with no blockers.