### PR TITLE
perf: compile scalar binomial RNGs

### DIFF
--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -193,12 +193,13 @@ the top of the page, not replacements for the current corpus rows:
   which await the next corpus refresh.
 - **Compiled scalar generated-quantities RNGs** keep caller-owned chain state
   on the forward-only write-array graph for scalar `poisson_log`, `uniform`,
-  `bernoulli`, `normal`, and `lognormal` draws. Unsupported/container RNGs and
-  draws used as dynamic control, indices, or geometry still fail closed to the
-  whole-section interpreter. In an exact census of the 24 previously
-  interpreted corpus models, eight moved to the graph and the other 16 kept
-  the interpreter; all 24 still produced complete rows. A targeted 2026-08-24
-  C-ABI A/B (point 0, two warmups, seven matched batch medians) measured:
+  `bernoulli`, `normal`, `lognormal`, and `binomial` draws.
+  Unsupported/container RNGs and draws used as dynamic control, indices, or
+  geometry still fail closed to the whole-section interpreter. In an exact
+  census of the 24 previously interpreted corpus models, 12 moved to the graph
+  and the other 12 kept the interpreter; all 24 still produced complete rows.
+  A targeted 2026-08-24 C-ABI A/B (point 0, two warmups, seven matched batch
+  medians) measured:
 
   | model | interpreted row | compiled row | improvement |
   | --- | ---: | ---: | ---: |
@@ -210,11 +211,20 @@ the top of the page, not replacements for the current corpus rows:
   | `hierarchical_gp` | 2.291 ms | 46.301 us | 49.47x |
   | `lotka_volterra` | 1.797 ms | 31.434 us | 57.16x |
   | `one_comp_mm_elim_abs` | 5.123 ms | 139.431 us | 36.74x |
+  | `M0_model` | 15.378 us | 0.119 us | 129.55x |
+  | `Mb_model` | 2.020 ms | 26.703 us | 75.65x |
+  | `Rate_4_model` | 4.007 us | 0.126 us | 31.93x |
+  | `Rate_5_model` | 4.311 us | 0.124 us | 34.82x |
 
   The largest setup tradeoff is the two Covid graphs: C-API model
   construction rises from about 0.239 s to 2.20-2.21 s, but the 154 ms saved
-  per row repays it after roughly 13 draws. These are targeted write-array
-  medians, not replacements for the sampling columns in the full corpus table.
+  per row repays it after roughly 13 draws. For the four added scalar-binomial
+  models, across 1,000 rows of each model their aggregate time falls from
+  2.0438 s to 0.0271 s (75.50x), and construction also gets faster in every
+  case, so break-even is immediate. Their graph and frozen-interpreter rows
+  were bitwise identical for all 28,926 compared values. These are targeted
+  write-array medians, not replacements for the sampling columns in the full
+  corpus table.
 - **Allocation-free ODE right-hand-side input seeding** removes the promoted
   `y` and `theta` staging vectors built on every solver callback and seeds the
   reusable register file directly. A targeted 2026-08-24 Release A/B (seven

--- a/runtime/include/stanli/wa_interp.hpp
+++ b/runtime/include/stanli/wa_interp.hpp
@@ -57,6 +57,7 @@ enum class ScalarRng : uint8_t {
   Bernoulli,
   Normal,
   Lognormal,
+  Binomial,
 };
 
 size_t scalar_rng_arity(ScalarRng family);

--- a/runtime/kernels/rng.cpp
+++ b/runtime/kernels/rng.cpp
@@ -17,7 +17,7 @@ namespace {
 
 void rng_fwd(KernelCtx& ctx) {
   if (ctx.out.len != 1 ||
-      ctx.variant > static_cast<uint8_t>(ScalarRng::Lognormal))
+      ctx.variant > static_cast<uint8_t>(ScalarRng::Binomial))
     throw std::logic_error("malformed scalar RNG op");
   const ScalarRng family = static_cast<ScalarRng>(ctx.variant);
   const size_t nargs = scalar_rng_arity(family);

--- a/runtime/src/OPTIMIZATIONS.md
+++ b/runtime/src/OPTIMIZATIONS.md
@@ -247,13 +247,14 @@ draw; even a late scalar draw therefore reinterpreted constrained parameters,
 transformed parameters, and all earlier generated quantities.
 
 `OP_RNG` now covers scalar `poisson_log_rng`, `uniform_rng`, `bernoulli_rng`,
-`normal_rng`, and `lognormal_rng`. The graph and interpreter share one draw
-helper, so they call the same Stan Math function in the same order on the same
-caller-owned `WaRng`. An executor holds only a temporary pointer to that chain
-resource for one forward sweep; scoped restoration and copy rebinding prevent
-pooled or interleaved executors from retaining another caller's stream. The
-graph passes treat every RNG op as an ordered effect, so they cannot fold,
-reroll, carve, delete, or duplicate a draw whose result is otherwise unused.
+`normal_rng`, `lognormal_rng`, and `binomial_rng`. The graph and interpreter
+share one draw helper, so they call the same Stan Math function in the same
+order on the same caller-owned `WaRng`. An executor holds only a temporary
+pointer to that chain resource for one forward sweep; scoped restoration and
+copy rebinding prevent pooled or interleaved executors from retaining another
+caller's stream. The graph passes treat every RNG op as an ordered effect, so
+they cannot fold, reroll, carve, delete, or duplicate a draw whose result is
+otherwise unused.
 
 The boundary is deliberately fail-closed. Container-valued or unsupported
 RNGs, and integer draws needed as a loop bound, index, shape, or branch
@@ -262,14 +263,23 @@ live exactly in one double slot only while used by ordinary graph arithmetic;
 integer division and other dynamic-integer operations still refuse lowering.
 
 An exact census of the 24 corpus models that previously used `WaInterp` moved
-only eight to the graph: `GLMM1_model`, both `covid19imperial` models, both
-`dogs` models, `hierarchical_gp`, `lotka_volterra`, and
-`one_comp_mm_elim_abs`. The other 16 remained interpreted and all 24 retained
-complete rows. In targeted seven-batch C-ABI medians, those eight write-array
-rows became 34.72x to 80.02x faster. The two largest absolute wins were
-`covid19imperial_v2` (156.239 -> 2.089 ms) and v3 (157.176 -> 2.077 ms).
-Their C-API construction rises from about 0.239 s to 2.20-2.21 s because the
-full graphs are now built, a cost recovered after roughly 13 output rows.
+12 to the graph: `GLMM1_model`, both `covid19imperial` models, both `dogs`
+models, `hierarchical_gp`, `lotka_volterra`, `one_comp_mm_elim_abs`, `M0_model`,
+`Mb_model`, `Rate_4_model`, and `Rate_5_model`. The other 12 remained
+interpreted and all 24 retained complete rows. In targeted seven-batch C-ABI
+medians, the original eight write-array rows became 34.72x to 80.02x faster.
+The two largest absolute wins were `covid19imperial_v2` (156.239 -> 2.089 ms)
+and v3 (157.176 -> 2.077 ms). Their C-API construction rises from about 0.239 s
+to 2.20-2.21 s because the full graphs are now built, a cost recovered after
+roughly 13 output rows.
+
+The four scalar-binomial additions measured 31.93x to 129.55x faster per row:
+`M0_model` 15.3778 -> 0.1187 us, `Mb_model` 2020.1042 -> 26.7033 us,
+`Rate_4_model` 4.0072 -> 0.1255 us, and `Rate_5_model` 4.3111 -> 0.1238 us.
+Across 1,000 rows of each model, their aggregate time falls from 2.0438003 s to
+0.0270713 s (75.50x). Construction also improves in all four, so the change
+breaks even immediately. Graph and frozen-interpreter output was bitwise exact
+for all 28,926 compared values across six seeds and three sequential rows.
 
 ## Control flow that depends on a parameter (`lower.cpp`, `mir_prog.hpp`)
 

--- a/runtime/src/lower.cpp
+++ b/runtime/src/lower.cpp
@@ -2162,6 +2162,7 @@ struct Lowering {
         {"bernoulli_rng", ScalarRng::Bernoulli},
         {"normal_rng", ScalarRng::Normal},
         {"lognormal_rng", ScalarRng::Lognormal},
+        {"binomial_rng", ScalarRng::Binomial},
     };
     const auto found = kFamilies.find(e.name);
     if (found == kFamilies.end()) return std::nullopt;
@@ -2178,6 +2179,13 @@ struct Lowering {
                                              : mir::UnsizedLeaf::Real;
     if (e.unsized.leaf != result_leaf)
       fail(e.name + ": result type does not match RNG family", e.raw);
+    // Unlike the other scalar families, binomial's first argument is a
+    // population count. Valid stanc MIR always marks it UInt; fail closed on
+    // malformed hand-authored MIR rather than silently truncating a real in
+    // the runtime helper's graph-storage conversion.
+    if (family == ScalarRng::Binomial &&
+        e.args[0].unsized.leaf != mir::UnsizedLeaf::Int)
+      fail("binomial_rng: first argument must be int", e.raw);
     std::vector<Val> args;
     args.reserve(arity);
     for (const mir::Expr& arg : e.args) {

--- a/runtime/src/wa_interp.cpp
+++ b/runtime/src/wa_interp.cpp
@@ -17,13 +17,15 @@ size_t scalar_rng_arity(ScalarRng family) {
     case ScalarRng::Uniform:
     case ScalarRng::Normal:
     case ScalarRng::Lognormal:
+    case ScalarRng::Binomial:
       return 2;
   }
   throw std::logic_error("unknown scalar RNG family");
 }
 
 bool scalar_rng_is_int(ScalarRng family) {
-  return family == ScalarRng::PoissonLog || family == ScalarRng::Bernoulli;
+  return family == ScalarRng::PoissonLog || family == ScalarRng::Bernoulli ||
+         family == ScalarRng::Binomial;
 }
 
 double scalar_rng_draw(ScalarRng family, const double* args, size_t nargs,
@@ -42,6 +44,9 @@ double scalar_rng_draw(ScalarRng family, const double* args, size_t nargs,
       return stan::math::normal_rng(args[0], args[1], g);
     case ScalarRng::Lognormal:
       return stan::math::lognormal_rng(args[0], args[1], g);
+    case ScalarRng::Binomial:
+      return static_cast<double>(
+          stan::math::binomial_rng(static_cast<int>(args[0]), args[1], g));
   }
   throw std::logic_error("unknown scalar RNG family");
 }
@@ -359,7 +364,8 @@ bool WaInterp::rng_fun(MirInterp<double>& in, const mir::Expr& e,
       vi = stan::math::bernoulli_logit_rng(sc(0, i), g);
       iv = true;
     } else if (base == "binomial") {
-      vi = stan::math::binomial_rng((int)sc(0, i), sc(1, i), g);
+      const double args[] = {sc(0, i), sc(1, i)};
+      vi = static_cast<int>(scalar_rng_draw(ScalarRng::Binomial, args, 2, rng));
       iv = true;
     } else if (base == "poisson") {
       vi = stan::math::poisson_rng(sc(0, i), g);

--- a/tests/fixtures/gq_scalar_rng.stan
+++ b/tests/fixtures/gq_scalar_rng.stan
@@ -10,4 +10,5 @@ generated quantities {
   int b = bernoulli_rng(0.4);
   real n = normal_rng(x, 1.2);
   real l = lognormal_rng(0.2, 0.7);
+  int<lower=2, upper=7> k = 2 + binomial_rng(5, inv_logit(x));
 }

--- a/tests/fixtures/gq_scalar_rng.tmir.sexp
+++ b/tests/fixtures/gq_scalar_rng.tmir.sexp
@@ -177,6 +177,49 @@
        (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
     (meta <opaque>))
    ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id k) (decl_type (Sized SInt))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable k) ()) UInt
+      ((pattern
+        (FunApp (StanLib Plus__ FnPlain AoS)
+         (((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+          ((pattern
+            (FunApp (StanLib binomial_rng FnRng AoS)
+             (((pattern (Lit Int 5))
+               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+              ((pattern
+                (FunApp (StanLib inv_logit FnPlain AoS)
+                 (((pattern (Var x))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnCheck
+        (trans
+         (Lower
+          ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (var_name k)
+        (var ((pattern (Var k)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnCheck
+        (trans
+         (Upper
+          ((pattern (Lit Int 7)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (var_name k)
+        (var ((pattern (Var k)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (((pattern (Lit Int 7)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+    (meta <opaque>))
+   ((pattern
      (NRFunApp
       (CompilerInternal
        (FnWriteParam (unconstrain_opt ())
@@ -212,6 +255,13 @@
        (FnWriteParam (unconstrain_opt ())
         (var
          ((pattern (Var l)) (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt ())
+        (var ((pattern (Var k)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
       ()))
     (meta <opaque>))))
  (transform_inits
@@ -277,5 +327,12 @@
      (out_block GeneratedQuantities) (out_trans Identity)))
    (l <opaque>
     ((out_unconstrained_st SReal) (out_constrained_st SReal)
-     (out_block GeneratedQuantities) (out_trans Identity)))))
+     (out_block GeneratedQuantities) (out_trans Identity)))
+   (k <opaque>
+    ((out_unconstrained_st SInt) (out_constrained_st SInt)
+     (out_block GeneratedQuantities)
+     (out_trans
+      (LowerUpper
+       ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+       ((pattern (Lit Int 7)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))))
  (prog_name gq_scalar_rng_model) (prog_path tests/fixtures/gq_scalar_rng.stan))

--- a/tests/fixtures/gqrng.stan
+++ b/tests/fixtures/gqrng.stan
@@ -1,7 +1,7 @@
-// Generated quantities the graph cannot fully express: the unsupported
-// binomial RNG result feeds dynamic behavior, and prod is not yet lowered.
-// The interpreted write_array fallback runs the whole section, including the
-// otherwise graph-native normal draw.
+// Generated quantities the graph cannot fully express: the per-draw sigma
+// branch is data-only in write_array's double instantiation but unavailable
+// while lowering. The interpreted write_array fallback runs the whole section,
+// including both graph-native RNG draws.
 data {
   int<lower=1> N;
 }

--- a/tests/test_bridgestan.cpp
+++ b/tests/test_bridgestan.cpp
@@ -382,8 +382,8 @@ void test_constrain_graph() {
   bs_model_destruct(m);
 }
 
-// The interpreted write_array path: an unsupported int RNG and
-// draw-dependent behavior, with the stream owned by the caller's bs_rng.
+// The interpreted write_array path: per-draw control flow, with the stream
+// owned by the caller's bs_rng.
 void test_constrain_interp() {
   const std::string mir = slurp("tests/fixtures/gqrng.tmir.sexp");
   char* err = nullptr;
@@ -440,9 +440,9 @@ void test_constrain_interp() {
   bs_rng_destruct(b);
   bs_model_destruct(m);
 
-  // The unsupported binomial-RNG outcome forces the whole section through
-  // WaInterp; the categorical call before it must remain available through
-  // BridgeStan.
+  // A runtime RNG outcome cannot become categorical's compile-time integer
+  // payload, so the whole section uses WaInterp; the categorical call must
+  // remain available through BridgeStan.
   const std::string categorical = categorical_write_array_mir(
       slurp("tests/fixtures/cat.tmir.sexp"), "categorical_logit_lpmf", false,
       false, false, true);
@@ -486,9 +486,9 @@ void test_constrain_compiled_rng() {
     return;
   }
   expect_eq_str("compiled scalar RNG names", bs_param_names(m, true, true),
-                "x,p,u,b,n,l");
-  if (bs_param_num(m, true, true) != 6) {
-    fail("compiled scalar RNG column count is not six");
+                "x,p,u,b,n,l,k");
+  if (bs_param_num(m, true, true) != 7) {
+    fail("compiled scalar RNG column count is not seven");
     bs_model_destruct(m);
     return;
   }
@@ -502,7 +502,7 @@ void test_constrain_compiled_rng() {
     bs_model_destruct(m);
     return;
   }
-  std::vector<double> a1(6), b1(6), a2(6), b2(6);
+  std::vector<double> a1(7), b1(7), a2(7), b2(7);
   const int a1rc = bs_param_constrain(m, true, true, q, a1.data(), a, &err);
   const int b1rc = bs_param_constrain(m, true, true, q, b1.data(), b, &err);
   const int a2rc = bs_param_constrain(m, true, true, q, a2.data(), a, &err);

--- a/tests/test_capi.cpp
+++ b/tests/test_capi.cpp
@@ -337,9 +337,9 @@ void expect_compiled_scalar_rng() {
     return;
   }
   const int64_t n = stanli_wa_n_columns(model);
-  if (n != 6) {
+  if (n != 7) {
     ++failures;
-    std::printf("FAIL C API scalar RNG columns: got %lld want 6\n",
+    std::printf("FAIL C API scalar RNG columns: got %lld want 7\n",
                 static_cast<long long>(n));
     stanli_model_free(model);
     return;

--- a/tests/test_lower.cpp
+++ b/tests/test_lower.cpp
@@ -1638,9 +1638,9 @@ int main() {
     }
   }
 
-  // An unsupported binomial RNG selects the interpreted write_array for the
-  // whole section. Categorical calls before that fallback retain their
-  // scalar/array and normalized/propto semantics there too.
+  // A runtime RNG outcome cannot become categorical's compile-time integer
+  // payload, so it selects the interpreted write_array for the whole section.
+  // Scalar/array and normalized/propto semantics remain intact there.
   for (const std::string& fn : {"categorical_lpmf", "categorical_logit_lpmf"}) {
     for (bool propto : {false, true}) {
       for (int outcome_count : {1, 3}) {
@@ -1706,7 +1706,7 @@ int main() {
     }
   }
 
-  // Propto still validates on the interpreted route. A deterministic RNG
+  // Propto still validates on the interpreted route. A runtime RNG outcome
   // keeps the section in WaInterp while producing an out-of-range category.
   for (const std::string& fn : {"categorical_lpmf", "categorical_logit_lpmf"}) {
     std::string mir = categorical_write_array_mir(

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -57,9 +57,8 @@ def test_sample_returns_transformed_parameters():
 
 
 def test_sample_returns_generated_quantities():
-    # This model's unsupported binomial draw and dynamic behavior select the
-    # interpreted write_array; its columns and seeded RNG stream must both
-    # reach Python.
+    # This model's per-draw branch selects the interpreted write_array; its
+    # columns and seeded RNG stream must both reach Python.
     code = (FIXTURES / "gqrng.stan").read_text()
     m = stanli.Model(stan_code=code, data={"N": 5})
     d = m.sample(seed=7, warmup=200, samples=50)

--- a/tests/test_write_array.cpp
+++ b/tests/test_write_array.cpp
@@ -16,6 +16,8 @@
 #include <stanli/sexp.hpp>
 #include <stanli/wa_interp.hpp>
 
+#include <stan/math.hpp>
+
 #include <cmath>
 #include <cstdio>
 #include <fstream>
@@ -244,9 +246,9 @@ void test_wanames_interpreter_schema() {
   }
 }
 
-// Generated quantities the graph cannot express (an unsupported binomial
-// draw feeding dynamic behavior here) run through the interpreted fallback:
-// same columns contract, per-draw evaluation, seeded RNG stream.
+// Generated quantities the graph cannot express (per-draw control flow) run
+// through the interpreted fallback: same columns contract, per-draw
+// evaluation, seeded RNG stream.
 void test_interpreted_gq() {
   using namespace stanli;
   DataMap data;
@@ -572,6 +574,143 @@ void test_constant_folded_gq_column() {
   }
 }
 
+// Keep the shared helper a transparent call into Stan Math. In particular,
+// endpoint results must not become shortcuts: Stan Math owns validation and
+// however much of the engine it consumes, including at N=0 and p in {0,1}.
+void test_binomial_rng_helper_contract() {
+  using namespace stanli;
+  const auto helper_draw = [](int n, double p, WaRng& rng) {
+    const double args[] = {static_cast<double>(n), p};
+    return scalar_rng_draw(ScalarRng::Binomial, args, 2, rng);
+  };
+  const auto next = [](WaRng& rng) {
+    return stan::math::uniform_rng(0.0, 1.0, rng.gen());
+  };
+
+  struct ValidCase {
+    int n;
+    double p;
+  };
+  const ValidCase valid[] = {
+      {0, 0.0}, {0, 0.37}, {0, 1.0},  {9, -0.0},   {9, 0.0},
+      {9, 1.0}, {20, 0.5}, {21, 0.5}, {100, 0.49}, {100, 0.51},
+  };
+  for (size_t i = 0; i < sizeof(valid) / sizeof(valid[0]); ++i) {
+    WaRng got_rng(static_cast<unsigned>(101 + i));
+    WaRng want_rng(static_cast<unsigned>(101 + i));
+    const double got = helper_draw(valid[i].n, valid[i].p, got_rng);
+    const double want = static_cast<double>(
+        stan::math::binomial_rng(valid[i].n, valid[i].p, want_rng.gen()));
+    if (got != want || next(got_rng) != next(want_rng)) {
+      ++failures;
+      std::printf("FAIL binomial helper valid case %zu\n", i);
+    }
+  }
+
+  // Both-invalid cases pin Stan Math's validation priority. The remaining
+  // cases cover finite values just outside the interval, NaN, and infinities.
+  const ValidCase invalid[] = {
+      {-1, 0.4},
+      {-1, -0.2},
+      {4, -0.1},
+      {4, std::nextafter(1.0, std::numeric_limits<double>::infinity())},
+      {4, std::numeric_limits<double>::quiet_NaN()},
+      {4, std::numeric_limits<double>::infinity()},
+      {4, -std::numeric_limits<double>::infinity()},
+  };
+  for (size_t i = 0; i < sizeof(invalid) / sizeof(invalid[0]); ++i) {
+    WaRng got_rng(static_cast<unsigned>(211 + i));
+    WaRng want_rng(static_cast<unsigned>(211 + i));
+    std::string got_message, want_message;
+    try {
+      (void)helper_draw(invalid[i].n, invalid[i].p, got_rng);
+    } catch (const std::domain_error& e) {
+      got_message = e.what();
+    }
+    try {
+      (void)stan::math::binomial_rng(invalid[i].n, invalid[i].p,
+                                     want_rng.gen());
+    } catch (const std::domain_error& e) {
+      want_message = e.what();
+    }
+    if (got_message.empty() || got_message != want_message ||
+        next(got_rng) != next(want_rng)) {
+      ++failures;
+      std::printf("FAIL binomial helper invalid case %zu\n", i);
+    }
+  }
+}
+
+void test_binomial_rng_lowering_guards() {
+  using namespace stanli;
+  const std::string base = slurp("tests/fixtures/gq_scalar_rng.tmir.sexp");
+  const size_t call = base.find("(FunApp (StanLib binomial_rng");
+  if (call == std::string::npos) {
+    ++failures;
+    std::printf("FAIL binomial lowering guard fixture has no call\n");
+    return;
+  }
+
+  const auto expect_interp = [](const std::string& mir,
+                                const std::string& reason, const char* what) {
+    DataMap data;
+    CompiledModel cm = compile_model(mir, data);
+    if (!cm.write_array || !cm.write_array->interp ||
+        cm.write_array->truncated.find(reason) == std::string::npos) {
+      ++failures;
+      std::printf("FAIL %s: got %s\n", what,
+                  cm.write_array ? cm.write_array->truncated.c_str()
+                                 : "no write_array");
+    }
+  };
+
+  const std::string scalar_trials =
+      "((pattern (Lit Int 5))\n"
+      "               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))";
+  const size_t trials = base.find(scalar_trials, call);
+  if (trials == std::string::npos) {
+    ++failures;
+    std::printf("FAIL binomial lowering guard cannot find trials\n");
+    return;
+  }
+
+  std::string malformed = base;
+  malformed.replace(trials, scalar_trials.size(),
+                    "((pattern (Lit Real 5.0))\n"
+                    "               (meta ((type_ UReal) (loc <opaque>) "
+                    "(adlevel DataOnly))))");
+  expect_interp(malformed, "first argument must be int",
+                "binomial real trials stay interpreted");
+
+  std::string container_arg = base;
+  container_arg.replace(
+      trials, scalar_trials.size(),
+      "((pattern\n"
+      "                (FunApp (CompilerInternal FnMakeArray)\n"
+      "                 (((pattern (Lit Int 5))\n"
+      "                   (meta ((type_ UInt) (loc <opaque>) (adlevel "
+      "DataOnly)))))))\n"
+      "               (meta ((type_ (UArray UInt)) (loc <opaque>) (adlevel "
+      "DataOnly))))");
+  expect_interp(container_arg, "container arguments stay on WaInterp",
+                "binomial container argument stays interpreted");
+
+  std::string container_result = base;
+  const std::string result_meta =
+      "\n           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))";
+  const size_t result = container_result.find(result_meta, call);
+  if (result == std::string::npos) {
+    ++failures;
+    std::printf("FAIL binomial lowering guard cannot find result type\n");
+    return;
+  }
+  container_result.replace(result, result_meta.size(),
+                           "\n           (meta ((type_ (UArray UInt)) (loc "
+                           "<opaque>) (adlevel DataOnly)))");
+  expect_interp(container_result, "expected scalar result",
+                "binomial container result stays interpreted");
+}
+
 void test_compiled_scalar_rng() {
   using namespace stanli;
   const std::string path = "tests/fixtures/gq_scalar_rng.tmir.sexp";
@@ -587,12 +726,12 @@ void test_compiled_scalar_rng() {
   int rng_ops = 0;
   for (const Op& op : cm.write_array->graph.ops)
     if (op.opcode == OP_RNG) ++rng_ops;
-  if (rng_ops != 5) {
+  if (rng_ops != 6) {
     ++failures;
-    std::printf("FAIL scalar rng: got %d OP_RNG, want 5\n", rng_ops);
+    std::printf("FAIL scalar rng: got %d OP_RNG, want 6\n", rng_ops);
   }
   expect_eq("scalar rng columns", joined(cm.write_array->columns),
-            "x,p,u,b,n,l");
+            "x,p,u,b,n,l,k");
 
   Executor wex(std::move(cm.write_array->graph));
   cm.write_array->bind(wex);
@@ -721,6 +860,8 @@ int main() {
   test_array_of_matrix_columns();
   test_interpreted_gq();
   test_constant_folded_gq_column();
+  test_binomial_rng_helper_contract();
+  test_binomial_rng_lowering_guards();
   test_compiled_scalar_rng();
   test_caller_owned_rng();
   test_transformed_parameter_checks();


### PR DESCRIPTION
## Summary

- add scalar `binomial_rng` to the existing generated-quantities `OP_RNG` path
- share the exact pinned Stan Math draw helper between compiled and interpreted write-array execution
- preserve caller-owned RNG streams, validation order, exception text, endpoint advancement, and runtime integer checks
- keep container overloads and dynamic integer control/index/geometry fail-closed on `WaInterp`
- extend the compiled RNG fixture and C API/BridgeStan coverage from six to seven output columns

## Measured effect

Targeted C-ABI A/B on the same Apple M3 Ultra host, point 0, two warmups, fixed seeds 1–7, seven batches of at least 80 ms:

| model | interpreted row | compiled row | speedup |
| --- | ---: | ---: | ---: |
| `M0_model` | 15.3778 us | 0.1187 us | 129.55x |
| `Mb_model` | 2020.1042 us | 26.7033 us | 75.65x |
| `Rate_4_model` | 4.0072 us | 0.1255 us | 31.93x |
| `Rate_5_model` | 4.3111 us | 0.1238 us | 34.82x |

Across 1,000 rows of each model, aggregate steady-state time falls from 2.0438003 s to 0.0270713 s (75.50x). Construction also improves for all four models, so break-even is immediate. These targeted medians do not replace the retained full-corpus sampling table.

## Scope and exactness

- exact 24-model write-array census changes from 8 compiled / 16 interpreted to 12 / 12
- only `M0_model`, `Mb_model`, `Rate_4_model`, and `Rate_5_model` change route; all 24 retain complete rows and identical column/value counts
- compiled rows are bitwise identical to both the current forced interpreter and the frozen pre-change interpreter for 28,926 values across six seeds and three sequential rows
- direct helper tests compare valid endpoints, invalid inputs, exception messages, and subsequent engine state to pinned Stan Math
- scalar/result/container lowering mutations prove unsupported shapes stay interpreted
- the scalar RNG enum is appended, preserving existing variants and public ABI signatures

## Validation

- fresh isolated Release all-target build: 299 Ninja actions
- CTest: 59/59 passed
- focused C++ RNG/API suite: 5/5 passed
- Python suite: 21/21 passed
- stored CmdStan oracle: 129/129 models, all 3 points, 800,674 values; worst relative error 7.28e-12
- formatting, generated docs, web catalog, fixture regeneration, and `git diff --check`: passed
- independent strict semantic and final whole-diff reviews: GO
