### PR TITLE
perf: compile generated-quantities reductions

### DIFF
--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -196,8 +196,8 @@ the top of the page, not replacements for the current corpus rows:
   `bernoulli`, `normal`, `lognormal`, and `binomial` draws.
   Unsupported/container RNGs and draws used as dynamic control, indices, or
   geometry still fail closed to the whole-section interpreter. In an exact
-  census of the 24 previously interpreted corpus models, 12 moved to the graph
-  and the other 12 kept the interpreter; all 24 still produced complete rows.
+  census of the 24 previously interpreted corpus models, this RNG tranche
+  moved 12 to the graph; all 24 still produced complete rows.
   A targeted 2026-08-24 C-ABI A/B (point 0, two warmups, seven matched batch
   medians) measured:
 
@@ -225,6 +225,38 @@ the top of the page, not replacements for the current corpus rows:
   were bitwise identical for all 28,926 compared values. These are targeted
   write-array medians, not replacements for the sampling columns in the full
   corpus table.
+- **Compiled generated-quantities reductions** add an exact forward-only
+  product for the vector/row-vector surfaces used by the capture-recapture
+  models, plus integer sum only when a one-dimensional runtime array is proved
+  fully initialized, integral, and safe from 32-bit overflow. Product grouping
+  follows Stan Math's expression provenance: materialized vectors use its
+  address-independent packet grouping, while strided matrix-row expressions
+  retain ascending scalar grouping. Shifted views, arbitrary expressions,
+  reverse-mode products, and unproved integer arrays still fail closed to the
+  interpreter. This moved `Mh_model`, `Mt_model`, `Mtbh_model`, and `Mth_model`
+  to the graph, taking the current 24-model census from 12 graph / 12
+  interpreter to 16 / 8, with all 119 compiling corpus models still producing
+  complete rows. A targeted 2026-08-24 C-ABI A/B (point 0, two warmups, seven
+  matched batch medians) measured:
+
+  | model | interpreted row | compiled row | improvement |
+  | --- | ---: | ---: | ---: |
+  | `Mh_model` | 869.179 us | 12.494 us | 69.57x |
+  | `Mt_model` | 20.867 us | 0.127 us | 164.83x |
+  | `Mtbh_model` | 1.046 ms | 9.856 us | 106.18x |
+  | `Mth_model` | 1.099 ms | 18.205 us | 60.36x |
+
+  Across 1,000 rows of each model, aggregate row time fell from 3.035338 s to
+  0.040682 s (74.61x). Including one construction of each model, it fell from
+  3.056579 s to 0.075491 s (40.49x); the equal-mix aggregate setup cost breaks
+  even after five rows per model. Within a 146,196-value comparison, every
+  product-fed draw and final integer sum matched the frozen interpreter
+  bitwise, including a fourth-row stream-continuation check. `Mtbh_model` and
+  `Mth_model` also expose the pre-existing graph/interpreter boundary in
+  deterministic transformed parameters: their `p` columns differ by at most
+  two ULP, while the graph is closer to live CmdStan at the shared point. These
+  are targeted write-array medians; the full-corpus sampling table awaits the
+  next refresh.
 - **Allocation-free ODE right-hand-side input seeding** removes the promoted
   `y` and `theta` staging vectors built on every solver callback and seeds the
   reusable register file directly. A targeted 2026-08-24 Release A/B (seven

--- a/runtime/include/stanli/mir.hpp
+++ b/runtime/include/stanli/mir.hpp
@@ -57,6 +57,73 @@ struct Expr {
   std::string raw;         // Unsupported diagnostics
 };
 
+// A matrix row is a non-contiguous Eigen block.  Transposing it changes the
+// logical orientation but not the stride, so an outer elementwise expression
+// containing it has no packet access and Stan Math's product reduces in
+// ascending scalar order.  Both write_array engines consult this syntactic
+// fact before materializing the expression, when the stride is still visible.
+inline bool is_matrix_row_value(const Expr& value) {
+  const Expr* indexed = &value;
+  if (value.kind == Expr::FunApp && value.fn_lib == Expr::Lib::StanLib &&
+      (value.name == "Transpose__" || value.name == "transpose") &&
+      value.args.size() == 1)
+    indexed = &value.args[0];
+  if (indexed->kind != Expr::Indexed ||
+      indexed->unsized.leaf != UnsizedLeaf::RowVector ||
+      indexed->args.empty() || indexed->args[0].kind != Expr::Var ||
+      indexed->args[0].unsized.depth != 0 ||
+      indexed->args[0].unsized.leaf != UnsizedLeaf::Matrix)
+    return false;
+  const bool implicit_all =
+      indexed->args.size() == 2 && indexed->args[1].name == "IndexSingle";
+  const bool explicit_all = indexed->args.size() == 3 &&
+                            indexed->args[1].name == "IndexSingle" &&
+                            indexed->args[2].name == "IndexAll";
+  return implicit_all || explicit_all;
+}
+
+enum class ProdGrouping : uint8_t { Legacy, Packet, Scalar };
+
+// Classify only the syntax whose Eigen evaluator provenance has been audited.
+// Legacy means "retain MirInterp's old scalar fold / refuse native lowering",
+// not a guess about an arbitrary expression's Eigen flags.
+inline ProdGrouping prod_grouping(const Expr& product_arg) {
+  if (is_matrix_row_value(product_arg)) return ProdGrouping::Scalar;
+  if (product_arg.kind == Expr::Var) return ProdGrouping::Packet;
+  if (product_arg.kind == Expr::FunApp &&
+      product_arg.fn_lib == Expr::Lib::StanLib &&
+      (product_arg.name == "Transpose__" || product_arg.name == "transpose") &&
+      product_arg.args.size() == 1 && product_arg.args[0].kind == Expr::Var)
+    return ProdGrouping::Packet;
+  if (product_arg.kind != Expr::FunApp ||
+      product_arg.fn_lib != Expr::Lib::StanLib ||
+      product_arg.name != "Minus__" || product_arg.args.size() != 2)
+    return ProdGrouping::Legacy;
+
+  bool scalar = false;
+  for (const Expr& operand : product_arg.args) {
+    if (is_matrix_row_value(operand)) {
+      scalar = true;
+      continue;
+    }
+    if (operand.unsized.depth == 0 &&
+        (operand.kind == Expr::LitInt || operand.kind == Expr::LitReal))
+      continue;
+    if (operand.kind == Expr::Var) continue;
+    if (operand.kind == Expr::FunApp && operand.fn_lib == Expr::Lib::StanLib &&
+        (operand.name == "Transpose__" || operand.name == "transpose") &&
+        operand.args.size() == 1 && operand.args[0].kind == Expr::Var)
+      continue;
+    if (operand.kind == Expr::FunApp && operand.fn_lib == Expr::Lib::StanLib &&
+        operand.name == "rep_vector" && operand.args.size() == 2 &&
+        (operand.args[0].kind == Expr::LitInt ||
+         operand.args[0].kind == Expr::LitReal))
+      continue;
+    return ProdGrouping::Legacy;
+  }
+  return scalar ? ProdGrouping::Scalar : ProdGrouping::Packet;
+}
+
 struct Transform {
   // The names are stanc3's own MIR tags, so a new transform in the
   // compiler is greppable here.

--- a/runtime/include/stanli/mir_interp.hpp
+++ b/runtime/include/stanli/mir_interp.hpp
@@ -118,7 +118,13 @@ class MirInterp {
   std::vector<T> call(const mir::FunDef& f,
                       const std::vector<std::vector<T>>& args,
                       const std::vector<std::vector<int>>& int_args) {
+    if (udf_depth_ > 64) fail("UDF recursion too deep");
     MirInterp sub(funs_, where_, hooks_);
+    // Positional calls are used by the ODE/RHS fallback, but their formals
+    // have the same unknown Eigen-view provenance as an ordinary UDF's.
+    // Keeping them below top-level depth prevents product lowering from
+    // assuming a formal is an owning, address-zero vector.
+    sub.udf_depth_ = udf_depth_ + 1;
     sub.propto_ctx_ = propto_ctx_;
     size_t ai = 0, ii = 0;
     for (size_t k = 0; k < f.arg_names.size(); ++k) {
@@ -244,17 +250,20 @@ class MirInterp {
           // uninitialized value: hmm_drive writes best_logp[1, K] where it
           // means best_logp[1, k], and its Viterbi only matches CmdStan's
           // because the never-written element loses every comparison.
-          if (e.is_int) e.i = {0};
-          e.r = {e.is_int ? T(0.0)
-                          : T(std::numeric_limits<double>::quiet_NaN())};
+          if (e.is_int) e.i = {std::numeric_limits<int>::min()};
+          e.r = {e.is_int
+                     ? T(static_cast<double>(std::numeric_limits<int>::min()))
+                     : T(std::numeric_limits<double>::quiet_NaN())};
         } else if (!st.decl_type.base.empty()) {
           // Bare sized decl: allocate so element writes work; real elements
           // are NaN until written (see the scalar case above).
           int64_t n = 1;
           for (int64_t d : declared_dims) n *= d;
-          e.r.assign(n, e.is_int ? T(0.0)
-                                 : T(std::numeric_limits<double>::quiet_NaN()));
-          if (e.is_int) e.i.assign(n, 0);
+          e.r.assign(
+              n, e.is_int
+                     ? T(static_cast<double>(std::numeric_limits<int>::min()))
+                     : T(std::numeric_limits<double>::quiet_NaN()));
+          if (e.is_int) e.i.assign(n, std::numeric_limits<int>::min());
           e.dims = declared_dims;
         }
         env_[st.decl_id] = std::move(e);
@@ -310,6 +319,27 @@ class MirInterp {
           }
           return;
         }
+        // Contiguous subrange write into a 1-D value: x[a:b] = rhs.
+        if (st.lhs_idx.size() == 1 && st.lhs_idx[0].name == "IndexBetween" &&
+            en->dims.size() == 1) {
+          const long a = as_int(st.lhs_idx[0].args[0]);
+          const long b = as_int(st.lhs_idx[0].args[1]);
+          const int64_t n = b >= a ? b - a + 1 : 0;
+          if (n > 0 && (a < 1 || b > en->dims[0] || b > (long)en->r.size()))
+            fail("range assignment index out of bounds", st.raw);
+          if ((int64_t)v.r.size() != n)
+            fail("range assignment size mismatch", st.raw);
+          for (int64_t k = 0; k < n; ++k) {
+            const size_t dst = static_cast<size_t>(a - 1 + k);
+            en->r.at(dst) = v.r.at(static_cast<size_t>(k));
+            if (en->is_int)
+              en->i.at(dst) =
+                  v.is_int && static_cast<size_t>(k) < v.i.size()
+                      ? v.i[static_cast<size_t>(k)]
+                      : static_cast<int>(val(v.r.at(static_cast<size_t>(k))));
+          }
+          return;
+        }
         // General all-Single N-D element write.
         if (st.lhs_idx.size() == en->dims.size()) {
           bool all_single = true;
@@ -343,8 +373,20 @@ class MirInterp {
           const long b = as_int(st.lhs_idx[0].args[1]);
           const long j = as_int(st.lhs_idx[1].args[0]);
           const int64_t R = en->dims[0];
-          for (long k = a; k <= b; ++k)
-            en->r.at((j - 1) * R + (k - 1)) = v.r.at((size_t)(k - a));
+          const int64_t n = b >= a ? b - a + 1 : 0;
+          if (j < 1 || j > en->dims[1] || (n > 0 && (a < 1 || b > R)))
+            fail("matrix range assignment index out of bounds", st.raw);
+          if ((int64_t)v.r.size() != n)
+            fail("matrix range assignment size mismatch", st.raw);
+          for (int64_t k = 0; k < n; ++k) {
+            const size_t dst = static_cast<size_t>((j - 1) * R + (a - 1) + k);
+            en->r.at(dst) = v.r.at(static_cast<size_t>(k));
+            if (en->is_int)
+              en->i.at(dst) =
+                  v.is_int && static_cast<size_t>(k) < v.i.size()
+                      ? v.i[static_cast<size_t>(k)]
+                      : static_cast<int>(val(v.r.at(static_cast<size_t>(k))));
+          }
           return;
         }
         {
@@ -1504,9 +1546,37 @@ class MirInterp {
     }
     if (e.name == "prod") {
       Value a = eval(e.args[0]);
-      T m = T(1.0);
-      for (const T& v : a.r) m *= v;
-      r.r = {m};
+      if (a.r.empty()) {
+        r.r = {T(1.0)};
+        return r;
+      }
+      const bool eigen_container =
+          e.args[0].unsized.depth == 0 &&
+          (e.args[0].unsized.leaf == mir::UnsizedLeaf::Vector ||
+           e.args[0].unsized.leaf == mir::UnsizedLeaf::RowVector);
+      const mir::ProdGrouping grouping = udf_depth_ == 0
+                                             ? mir::prod_grouping(e.args[0])
+                                             : mir::ProdGrouping::Legacy;
+      if (!eigen_container || grouping == mir::ProdGrouping::Legacy) {
+        T product = T(1.0);
+        for (const T& value : a.r) product *= value;
+        r.r = {product};
+        return r;
+      }
+      if (grouping == mir::ProdGrouping::Scalar) {
+        T product = a.r[0];
+        for (size_t i = 1; i < a.r.size(); ++i) product *= a.r[i];
+        r.r = {product};
+        return r;
+      }
+      // Match the address-independent packet grouping used by the compiled
+      // generated-quantities kernel.  A direct Map (including the Map used
+      // by stan::math::prod(std::vector)) can pick a different alignedStart
+      // when this vector's allocation is shifted under AVX.
+      using Vec = Eigen::Matrix<T, Eigen::Dynamic, 1>;
+      const Eigen::Map<const Vec> input(a.r.data(), a.r.size());
+      r.r = {stan::math::prod(
+          input.unaryExpr(Eigen::internal::core_cast_op<T, T>()))};
       return r;
     }
     // Two arguments is the elementwise form, which Stan vectorizes over

--- a/runtime/include/stanli/optable.hpp
+++ b/runtime/include/stanli/optable.hpp
@@ -148,7 +148,8 @@ namespace stanli {
   X(OP_CATEGORICAL)                 \
   X(OP_REJECT)                      \
   X(OP_PRINT)                       \
-  X(OP_DIRICHLET_LPDF)
+  X(OP_DIRICHLET_LPDF)              \
+  X(OP_PROD_VEC)
 
 // Scalar densities, one line each: this list generates the opcode, the
 // name, the kernel, its registration, and the lowering table entry

--- a/runtime/kernels/elementwise.cpp
+++ b/runtime/kernels/elementwise.cpp
@@ -2,6 +2,8 @@
 #include <stanli/graph.hpp>
 #include <stanli/optable.hpp>
 
+#include <stan/math/prim/fun/prod.hpp>
+
 #include <cassert>
 #include <cmath>
 
@@ -142,6 +144,31 @@ void sum_vec_bwd(KernelCtx& ctx) {
   if (ctx.in_adj[0].data)
     for (int64_t i = 0; i < ctx.in[0].len; ++i)
       ctx.in_adj[0].data[i] += ctx.out_adj;
+}
+
+// OP_PROD_VEC: generated-quantities-only product of a vector/row-vector.
+// Variant 1 preserves the ascending scalar reduction selected by Eigen when
+// the source expression contains a strided matrix row.  The lowering records
+// that fact before the expression is materialized into a contiguous slot.
+// Eigen's redux normally chooses its packet boundary from the input address.
+// Graph slots share one arena, so that would make the arithmetic grouping
+// depend on every slot laid out before this one.  The explicit same-type
+// CwiseUnary expression has no DirectAccessBit but retains packet access:
+// first_default_aligned is consequently lane zero, matching the Eigen value
+// CmdStan passes to stan::math::prod without allocating a copy here.
+void prod_vec_fwd(KernelCtx& ctx) {
+  assert(ctx.in[0].len > 0);
+  if (ctx.variant == 1) {
+    double product = ctx.in[0].data[0];
+    for (int64_t i = 1; i < ctx.in[0].len; ++i) product *= ctx.in[0].data[i];
+    ctx.out.data[0] = product;
+    return;
+  }
+  assert(ctx.variant == 0);
+  using Vec = Eigen::Matrix<double, Eigen::Dynamic, 1>;
+  const Eigen::Map<const Vec> input(ctx.in[0].data, ctx.in[0].len);
+  ctx.out.data[0] = stan::math::prod(
+      input.unaryExpr(Eigen::internal::core_cast_op<double, double>()));
 }
 
 // OP_INDEX: scalar out = in[flat], idata = {flat}. Backward scatters.
@@ -353,6 +380,7 @@ void register_elementwise_kernels() {
   register_kernel(OP_BCAST_FMA, Kernel{fma_fwd, fma_bwd, nullptr});
   register_kernel(OP_MATVEC, Kernel{matvec_fwd, matvec_bwd, nullptr});
   register_kernel(OP_SUM_VEC, Kernel{sum_vec_fwd, sum_vec_bwd, nullptr});
+  register_kernel(OP_PROD_VEC, Kernel{prod_vec_fwd, nullptr, nullptr});
   register_kernel(OP_INDEX, Kernel{index_fwd, index_bwd, nullptr});
   register_kernel(OP_SET_INDEX, Kernel{set_index_fwd, set_index_bwd, nullptr});
   register_kernel(OP_SET_INDEX_INPLACE, Kernel{set_index_inplace_fwd,

--- a/runtime/src/OPTIMIZATIONS.md
+++ b/runtime/src/OPTIMIZATIONS.md
@@ -263,7 +263,7 @@ live exactly in one double slot only while used by ordinary graph arithmetic;
 integer division and other dynamic-integer operations still refuse lowering.
 
 An exact census of the 24 corpus models that previously used `WaInterp` moved
-12 to the graph: `GLMM1_model`, both `covid19imperial` models, both `dogs`
+12 to the graph in this tranche: `GLMM1_model`, both `covid19imperial` models, both `dogs`
 models, `hierarchical_gp`, `lotka_volterra`, `one_comp_mm_elim_abs`, `M0_model`,
 `Mb_model`, `Rate_4_model`, and `Rate_5_model`. The other 12 remained
 interpreted and all 24 retained complete rows. In targeted seven-batch C-ABI
@@ -280,6 +280,54 @@ Across 1,000 rows of each model, their aggregate time falls from 2.0438003 s to
 0.0270713 s (75.50x). Construction also improves in all four, so the change
 breaks even immediately. Graph and frozen-interpreter output was bitwise exact
 for all 28,926 compared values across six seeds and three sequential rows.
+
+## Compiled generated-quantities reductions (`elementwise.cpp`, `lower.cpp`)
+
+Four remaining capture-recapture models stopped at `prod` over a vector or
+row-vector and/or `sum` over an integer array assembled from scalar RNG draws.
+`OP_PROD_VEC` is a forward-only write-array opcode: it uses Stan Math's Eigen
+product grouping while hiding the graph arena's input alignment for
+materialized vectors, so an odd slot offset cannot change their packet
+boundary. A strided matrix-row operand instead records and preserves Stan
+Math's ascending scalar grouping before the expression is materialized.
+Lowering admits only a bare materialized vector/row-vector and the exact
+outer-subtraction surfaces used by these models. Shifted views, arbitrary
+nested expressions, UDF formals, empty containers, and any product that needs
+reverse mode remain on the existing fallback. The opcode is explicitly
+excluded from reroll matching and island CALLs because it deliberately has no
+backward kernel.
+
+Runtime integer `sum` reuses `OP_SUM_VEC` only after lowering proves that the
+one-dimensional array is completely initialized in ascending contiguous
+writes, every element is an exactly represented integer in a known interval,
+and every possible partial sum stays in 32-bit range. Under that proof, the
+ascending double additions are exact and equal Stan's integer accumulation.
+Uninitialized slots carry CmdStan's `INT_MIN` sentinel on both the graph and
+interpreter paths; gaps, strides, unknown RNG ranges, possible overflow, and
+using the result as dynamic control or geometry all fail closed.
+
+This completed `Mh_model`, `Mt_model`, `Mtbh_model`, and `Mth_model`, moving the
+current 24-model write-array census from 12 graph / 12 interpreter to 16 / 8;
+all 119 compiling corpus models still produce complete rows. Targeted
+2026-08-24 C-ABI A/B medians (point 0, two warmups, seven matched batches) were:
+
+| model | interpreted us/row | compiled us/row | speedup |
+| --- | ---: | ---: | ---: |
+| `Mh_model` | 869.1794 | 12.4941 | 69.57x |
+| `Mt_model` | 20.8673 | 0.1266 | 164.83x |
+| `Mtbh_model` | 1046.4414 | 9.8556 | 106.18x |
+| `Mth_model` | 1098.8496 | 18.2054 | 60.36x |
+
+Across 1,000 rows of each model, aggregate row time fell from 3.035338 s to
+0.040682 s (74.61x). Including one construction per model, it fell from
+3.056579 s to 0.075491 s (40.49x); the aggregate setup delta amortizes after
+five rows per model. Within a 146,196-value comparison, all product-fed RNG
+outputs and final sums were bitwise identical to the frozen interpreter,
+including a fourth-row stream-continuation check. The two larger models expose a
+pre-existing write-array mode-boundary difference in deterministic transformed
+parameters: `Mtbh_model` is within two ULP and `Mth_model` within one, while the
+compiled graph is closer to live CmdStan at the shared point. These are
+targeted medians; the committed full-corpus timing table remains unchanged.
 
 ## Control flow that depends on a parameter (`lower.cpp`, `mir_prog.hpp`)
 

--- a/runtime/src/island.cpp
+++ b/runtime/src/island.cpp
@@ -103,6 +103,7 @@ bool callable(const Graph& g, const Op& op) {
     case OP_ISLAND:
     case OP_ODE:
     case OP_RNG:
+    case OP_PROD_VEC:
     case OP_PRINT:
     case OP_REJECT:
       return false;

--- a/runtime/src/lower.cpp
+++ b/runtime/src/lower.cpp
@@ -212,6 +212,15 @@ struct SlotInfo {
 };
 static_assert(sizeof(SlotInfo) == 24);
 
+// A proof that every definitely initialized value in a graph slot is an
+// integral double in this closed interval.  Coverage is tracked separately;
+// this is deliberately outside SlotInfo because logical shape and parameter
+// provenance survive much more broadly than the narrow write_array grammar.
+struct IntRange {
+  int32_t lo = 0;
+  int32_t hi = 0;
+};
+
 bool is_matrix(const SlotInfo& si) { return si.kind == ViewKind::Matrix; }
 bool is_vector(const SlotInfo& si) { return si.kind == ViewKind::Vector; }
 bool is_row_vector(const SlotInfo& si) {
@@ -350,6 +359,10 @@ struct Lowering {
   CompiledModel out;
   std::map<std::string, Val> scope;     // var -> value and logical view
   std::map<std::string, long> int_env;  // data int scalars
+  std::map<int, IntRange> int_ranges;   // runtime integral slot provenance
+  // Definite initialization proof for the target construction grammar.
+  // Writes must extend one contiguous prefix; gaps/strides fail closed.
+  std::map<int, int64_t> int_initialized_prefix;
   std::map<double, int> const_cache;
   struct ObservationKey {
     int slot;
@@ -483,6 +496,78 @@ struct Lowering {
     en.r = {v};
     observe(out, std::move(en));
     return out;
+  }
+
+  void set_int_range(const Val& v, int64_t lo, int64_t hi) {
+    int_initialized_prefix[v.slot] = g.slots[v.slot].len;
+    if (lo < std::numeric_limits<int32_t>::min() ||
+        hi > std::numeric_limits<int32_t>::max() || lo > hi) {
+      int_ranges.erase(v.slot);
+      return;
+    }
+    int_ranges[v.slot] =
+        IntRange{static_cast<int32_t>(lo), static_cast<int32_t>(hi)};
+  }
+
+  void set_int_initialized(const Val& v) {
+    int_initialized_prefix[v.slot] = g.slots[v.slot].len;
+    int_ranges.erase(v.slot);
+  }
+
+  void set_uninitialized_int_array(const Val& v) {
+    int_ranges.erase(v.slot);
+    int_initialized_prefix[v.slot] = 0;
+  }
+
+  // Target models build int arrays in ascending contiguous writes.  Track the
+  // initialized prefix in O(1) per immutable slot: overwrites inside it are
+  // safe, an adjacent write extends it, and any gap/stride fails closed.  The
+  // interval hull may retain overwritten values, conservatively widening the
+  // later overflow proof.
+  void propagate_int_update(const Val& out_v, const Val& base, const Val& rhs,
+                            int64_t start, int64_t stride) {
+    const auto base_prefix = int_initialized_prefix.find(base.slot);
+    const auto rhs_prefix = int_initialized_prefix.find(rhs.slot);
+    const int64_t rhs_len = g.slots[rhs.slot].len;
+    if (rhs_len == 0 && base_prefix != int_initialized_prefix.end() &&
+        g.slots[out_v.slot].len == g.slots[base.slot].len) {
+      int_initialized_prefix[out_v.slot] = base_prefix->second;
+      const auto base_range = int_ranges.find(base.slot);
+      if (base_range == int_ranges.end())
+        int_ranges.erase(out_v.slot);
+      else
+        int_ranges[out_v.slot] = base_range->second;
+      return;
+    }
+    if (base_prefix == int_initialized_prefix.end() ||
+        rhs_prefix == int_initialized_prefix.end() ||
+        rhs_prefix->second != rhs_len || stride != 1 || start < 0 ||
+        start > base_prefix->second || rhs_len < 0 ||
+        start > g.slots[out_v.slot].len - rhs_len ||
+        g.slots[out_v.slot].len != g.slots[base.slot].len) {
+      int_ranges.erase(out_v.slot);
+      int_initialized_prefix.erase(out_v.slot);
+      return;
+    }
+    int_initialized_prefix[out_v.slot] =
+        std::max(base_prefix->second, start + rhs_len);
+
+    const auto rhs_range = int_ranges.find(rhs.slot);
+    if (rhs_range == int_ranges.end()) {
+      int_ranges.erase(out_v.slot);
+      return;
+    }
+    IntRange range = rhs_range->second;
+    if (base_prefix->second > 0) {
+      const auto base_range = int_ranges.find(base.slot);
+      if (base_range == int_ranges.end()) {
+        int_ranges.erase(out_v.slot);
+        return;
+      }
+      range.lo = std::min(range.lo, base_range->second.lo);
+      range.hi = std::max(range.hi, base_range->second.hi);
+    }
+    int_ranges[out_v.slot] = range;
   }
 
   long eval_int(const mir::Expr& e) {
@@ -1406,8 +1491,11 @@ struct Lowering {
         }
         return emit_value(OP_INDEX, {base}, 1, view_of(e.type_), {(int)flat});
       }
-      case mir::Expr::LitInt:
-        return constant(static_cast<double>(e.lit_i));
+      case mir::Expr::LitInt: {
+        Val v = constant(static_cast<double>(e.lit_i));
+        set_int_range(v, e.lit_i, e.lit_i);
+        return v;
+      }
       case mir::Expr::LitReal:
         return constant(e.lit);
       case mir::Expr::FunApp:
@@ -2204,7 +2292,131 @@ struct Lowering {
     // mistaking a draw for data.
     draw.si.param_free = false;
     draw.autodiff = false;
+    if (scalar_rng_is_int(family)) set_int_initialized(draw);
+    if (family == ScalarRng::Bernoulli) set_int_range(draw, 0, 1);
     return draw;
+  }
+
+  static bool is_int_sum_surface(const mir::Expr& e) {
+    return e.kind == mir::Expr::FunApp && e.fn_lib == mir::Expr::Lib::StanLib &&
+           e.name == "sum" && e.args.size() == 1 && e.type_ == "UInt" &&
+           e.unsized.leaf == mir::UnsizedLeaf::Int && e.unsized.depth == 0 &&
+           e.args[0].unsized.leaf == mir::UnsizedLeaf::Int &&
+           e.args[0].unsized.depth == 1;
+  }
+
+  // Scalar int declarations normally stay in int_env.  A sum over an array
+  // assembled from runtime RNG draws must instead bind to a graph slot.  The
+  // named-value probe is intentionally non-lowering so ordinary compile-time
+  // sums retain the interpreter path they already had.  Range validity is
+  // checked by the guarded lowering, so an unknown runtime source fails
+  // closed instead of falling back through the legacy real-valued reduction.
+  bool runtime_int_sum_candidate(const mir::Expr& e) const {
+    if (!is_int_sum_surface(e) || e.args[0].kind != mir::Expr::Var)
+      return false;
+    const auto value = scope.find(e.args[0].name);
+    return value != scope.end() && !value->second.si.param_free;
+  }
+
+  bool runtime_int_binding(const mir::Expr& e) {
+    return expr_effectful(e) || runtime_int_sum_candidate(e);
+  }
+
+  static bool prod_transpose_of(const mir::Expr& e, mir::Expr::Kind kind) {
+    return e.kind == mir::Expr::FunApp && e.fn_lib == mir::Expr::Lib::StanLib &&
+           e.args.size() == 1 &&
+           (e.name == "Transpose__" || e.name == "transpose") &&
+           e.args[0].kind == kind;
+  }
+
+  bool prod_literal_length(const mir::Expr& e) const {
+    if (e.kind == mir::Expr::LitInt) return true;
+    return e.kind == mir::Expr::Var && int_env.count(e.name) != 0;
+  }
+
+  bool prod_minus_operand(const mir::Expr& e) const {
+    // Promotion is transparent in the reader, so a promoted scalar literal
+    // still has its LitInt/LitReal kind here.
+    if (e.unsized.depth == 0 &&
+        (e.kind == mir::Expr::LitInt || e.kind == mir::Expr::LitReal))
+      return true;
+    if (e.kind == mir::Expr::FunApp && e.fn_lib == mir::Expr::Lib::StanLib &&
+        e.name == "rep_vector" && e.args.size() == 2 &&
+        (e.args[0].kind == mir::Expr::LitInt ||
+         e.args[0].kind == mir::Expr::LitReal) &&
+        prod_literal_length(e.args[1]))
+      return true;
+    const bool vector_leaf =
+        e.unsized.depth == 0 && (e.unsized.leaf == mir::UnsizedLeaf::Vector ||
+                                 e.unsized.leaf == mir::UnsizedLeaf::RowVector);
+    if (!vector_leaf) return false;
+    if (e.kind == mir::Expr::Var) return true;
+    if (e.kind == mir::Expr::Indexed) return mir::is_matrix_row_value(e);
+    if (prod_transpose_of(e, mir::Expr::Var)) return true;
+    return mir::is_matrix_row_value(e);
+  }
+
+  bool prod_native_surface(const mir::Expr& e) const {
+    if (e.kind == mir::Expr::Var || prod_transpose_of(e, mir::Expr::Var))
+      return true;
+    if (e.kind != mir::Expr::FunApp || e.fn_lib != mir::Expr::Lib::StanLib ||
+        e.args.size() != 2 || e.name != "Minus__")
+      return false;
+    return prod_minus_operand(e.args[0]) && prod_minus_operand(e.args[1]);
+  }
+
+  Val lower_runtime_int_sum(const mir::Expr& e) {
+    if (!in_write_array)
+      fail("runtime integer sum is supported only in generated quantities",
+           e.raw);
+    if (!is_int_sum_surface(e))
+      fail(
+          "runtime integer sum needs one one-dimensional int-array argument "
+          "and a scalar int result",
+          e.raw);
+
+    Val a = lower_expr(e.args[0]);
+    if (!is_array(a.si))
+      fail("runtime integer sum argument is not an array", e.raw);
+    const ArrayShape& shape = array_shape(a.si);
+    const int64_t len = g.slots[a.slot].len;
+    if (shape.leaf != ViewKind::Flat || shape.dims.size() != 1)
+      fail("runtime integer sum needs a one-dimensional int array", e.raw);
+    if (len <= 0) fail("runtime integer sum needs a nonempty int array", e.raw);
+    if (a.si.param_free)
+      fail("runtime integer sum needs a runtime-produced int array", e.raw);
+
+    const auto initialized = int_initialized_prefix.find(a.slot);
+    if (initialized == int_initialized_prefix.end() ||
+        initialized->second != len)
+      fail("runtime integer sum array is not definitely initialized", e.raw);
+    const auto known = int_ranges.find(a.slot);
+    if (known == int_ranges.end())
+      fail("runtime integer sum has unproved integral slot values", e.raw);
+    const IntRange range = known->second;
+    const uint64_t n = static_cast<uint64_t>(len);
+    if (range.lo < 0) {
+      const uint64_t magnitude =
+          static_cast<uint64_t>(-static_cast<int64_t>(range.lo));
+      const uint64_t capacity = static_cast<uint64_t>(
+          -static_cast<int64_t>(std::numeric_limits<int32_t>::min()));
+      if (n > capacity / magnitude)
+        fail("runtime integer sum may overflow int32 in a partial sum", e.raw);
+    }
+    if (range.hi > 0 &&
+        n > static_cast<uint64_t>(std::numeric_limits<int32_t>::max()) /
+                static_cast<uint64_t>(range.hi))
+      fail("runtime integer sum may overflow int32 in a partial sum", e.raw);
+
+    Val result = emit_value(OP_SUM_VEC, {a}, 1, view_of("UInt"));
+    result.autodiff = false;
+    // A range is only a static proof; the source itself was required to be
+    // runtime-produced.  Keeping this result non-constant prevents later
+    // compile-time geometry/control from consuming it through Val metadata.
+    result.si.param_free = false;
+    set_int_range(result, static_cast<int64_t>(range.lo) * len,
+                  static_cast<int64_t>(range.hi) * len);
+    return result;
   }
 
   Val lower_funapp(const mir::Expr& e) {
@@ -2994,6 +3206,36 @@ struct Lowering {
       Val a = lower_expr(e.args[0]);
       return emit_value(OP_MEAN, {a}, 1);
     }
+    if (e.name == "prod" && in_write_array) {
+      // Preserve the pre-existing construction-time behavior for data-only
+      // products.  OP_PROD_VEC is only the dynamic write_array tranche.
+      if (auto v = fold_const(e)) return *v;
+      if (e.args.size() != 1 || e.type_ != "UReal" ||
+          e.unsized.leaf != mir::UnsizedLeaf::Real || e.unsized.depth != 0)
+        fail("prod needs exactly one scalar-real result", e.raw);
+      const mir::Expr& arg = e.args[0];
+      const bool vector_arg = arg.type_ == "UVector" &&
+                              arg.unsized.leaf == mir::UnsizedLeaf::Vector &&
+                              arg.unsized.depth == 0;
+      const bool row_vector_arg =
+          arg.type_ == "URowVector" &&
+          arg.unsized.leaf == mir::UnsizedLeaf::RowVector &&
+          arg.unsized.depth == 0;
+      if (!vector_arg && !row_vector_arg)
+        fail("prod needs one vector or row-vector argument", e.raw);
+      if (udf_depth != 0 || !prod_native_surface(arg))
+        fail("prod expression surface stays on WaInterp", e.raw);
+      Val a = lower_expr(arg);
+      if ((!is_vector(a.si) && !is_row_vector(a.si)) ||
+          g.slots[a.slot].len <= 0)
+        fail("prod needs a nonempty vector or row-vector argument", e.raw);
+      const mir::ProdGrouping grouping = mir::prod_grouping(arg);
+      if (grouping == mir::ProdGrouping::Legacy)
+        fail("prod expression grouping is not native", e.raw);
+      Val result = emit_value(OP_PROD_VEC, {a}, 1);
+      g.ops.back().variant = grouping == mir::ProdGrouping::Scalar ? 1u : 0u;
+      return result;
+    }
     if (e.name == "rep_vector") {
       Val a = lower_expr(e.args[0]);
       const long n = eval_int(e.args[1]);
@@ -3003,6 +3245,24 @@ struct Lowering {
       // One argument is the reduction; two is the elementwise form below.
       if (e.name == "log_sum_exp" && e.args.size() == 2)
         return lower_binary_mix(OP_LSE2, e);
+      const bool int_surface =
+          e.name == "sum" &&
+          (e.type_ == "UInt" || e.unsized.leaf == mir::UnsizedLeaf::Int ||
+           (!e.args.empty() &&
+            e.args[0].unsized.leaf == mir::UnsizedLeaf::Int));
+      if (int_surface && in_write_array) {
+        if (runtime_int_sum_candidate(e)) return lower_runtime_int_sum(e);
+        if (!is_int_sum_surface(e))
+          fail(
+              "runtime integer sum needs one one-dimensional int-array "
+              "argument and a scalar int result",
+              e.raw);
+        if (e.args[0].kind != mir::Expr::Var || expr_effectful(e))
+          fail("direct runtime integer sum stays on WaInterp", e.raw);
+        // A param-free named array retains the legacy OP_SUM_VEC/fold path.
+      }
+      if (e.args.size() != 1)
+        fail(e.name + ": reduction needs exactly one argument", e.raw);
       Val a = lower_expr(e.args[0]);
       return emit_value(e.name == "sum" ? OP_SUM_VEC : OP_LOG_SUM_EXP, {a}, 1);
     }
@@ -3751,6 +4011,7 @@ struct Lowering {
     int64_t len = 0;
     bool autodiff = false;
     SlotInfo si;
+    bool int_array = false;
   };
   // The only name-keyed declaration protocol. Runtime values carry the same
   // static scalar type and SlotInfo in `scope`; this registry is needed only
@@ -3763,7 +4024,7 @@ struct Lowering {
         if (s.read_transform) {
           lower_read_param(s);
         } else if (s.decl_type.base == "SInt") {
-          if (in_write_array && s.has_init && expr_effectful(s.init)) {
+          if (in_write_array && s.has_init && runtime_int_binding(s.init)) {
             Val v = lower_expr(s.init);
             SlotInfo expected = view_of(s.decl_type);
             require_binding(v, 1, expected, s.decl_id, s.raw);
@@ -3777,6 +4038,16 @@ struct Lowering {
             td.env().erase(s.decl_id);
             return;
           }
+          // A fresh scalar-int declaration shadows every representation of
+          // an earlier declaration with the same optimized MIR id.  In
+          // particular, a preceding runtime sum may have installed a graph
+          // value in scope/decls; leaving it there would make a later Var
+          // read win over the compile-time literal installed below.
+          scope.erase(s.decl_id);
+          decls.erase(s.decl_id);
+          td.env().erase(s.decl_id);
+          int_env.erase(s.decl_id);
+          int_locals.erase(s.decl_id);
           // Int locals are always data-only in Stan; keep them in int_env
           // so size expressions and indices resolve at compile time.
           int_locals.insert(s.decl_id);
@@ -3794,6 +4065,12 @@ struct Lowering {
           sh.len = sized_len(s.decl_type);
           sh.autodiff = !s.decl_data_only && scalar_autodiff();
           sh.si = view_of(s.decl_type);
+          // CmdStan fills every uninitialized integer container with the
+          // INT_MIN sentinel.  Runtime-sum provenance remains deliberately
+          // one-dimensional, but the value-level initialization contract is
+          // independent of rank.
+          sh.int_array =
+              s.decl_type.base == "SArray" && s.decl_type.elem_base == "SInt";
           if (s.has_init) {
             Val v = lower_expr(s.init);
             SlotInfo expected = view_of(s.decl_type, v.si.param_free);
@@ -3811,7 +4088,7 @@ struct Lowering {
         return;
       case mir::Stmt::Assignment: {
         if (s.lhs_idx.empty() && int_locals.count(s.lhs)) {
-          if (in_write_array && expr_effectful(s.rhs)) {
+          if (in_write_array && runtime_int_binding(s.rhs)) {
             Val rhs = lower_expr(s.rhs);
             SlotInfo expected = view_of("UInt");
             require_binding(rhs, 1, expected, s.lhs, s.raw);
@@ -3842,8 +4119,13 @@ struct Lowering {
             si.param_free = true;
             prev_v =
                 Val{add_slot(dl->second.len, false), dl->second.autodiff, si};
-            out.fills.emplace_back(prev_v.slot,
-                                   std::vector<double>(dl->second.len, 0.0));
+            const double initial =
+                dl->second.int_array
+                    ? static_cast<double>(std::numeric_limits<int>::min())
+                    : 0.0;
+            out.fills.emplace_back(
+                prev_v.slot, std::vector<double>(dl->second.len, initial));
+            if (dl->second.int_array) set_uninitialized_int_array(prev_v);
           }
           const int prev = prev_v.slot;
           bool all_single = true;
@@ -3866,18 +4148,32 @@ struct Lowering {
             Val nv = emit_value(OP_SET_SLICE_STRIDED, {prev_v, rhs_v},
                                 g.slots[prev].len, out_si,
                                 {(int)i, (int)prev_v.si.rows});
+            propagate_int_update(nv, prev_v, rhs_v, i, prev_v.si.rows);
             scope[s.lhs] = nv;
             td.env().erase(s.lhs);
             return;
           }
           // Between write w[a:b] = rhs (contiguous on 1-D values).
           if (s.lhs_idx.size() == 1 && s.lhs_idx[0].name == "IndexBetween") {
+            const bool flat_1d_array =
+                is_array(prev_v.si) &&
+                array_shape(prev_v.si).dims.size() == 1 &&
+                array_shape(prev_v.si).leaf == ViewKind::Flat;
+            if (!is_vector(prev_v.si) && !is_row_vector(prev_v.si) &&
+                !flat_1d_array)
+              fail("range assignment needs a one-dimensional flat value for " +
+                       s.lhs,
+                   s.raw);
             const int64_t lo = eval_int(s.lhs_idx[0].args[0]);
             const int64_t hi = eval_int(s.lhs_idx[0].args[1]);
-            if (g.slots[rhs].len != hi - lo + 1)
+            const int64_t len = hi >= lo ? hi - lo + 1 : 0;
+            check_range(lo, hi, g.slots[prev].len, "range assignment", s.raw);
+            if (g.slots[rhs].len != len)
               fail("range assignment size mismatch for " + s.lhs);
+            const int64_t start = len == 0 ? 0 : lo - 1;
             Val nv = emit_value(OP_SET_SLICE, {prev_v, rhs_v},
-                                g.slots[prev].len, out_si, {(int)(lo - 1)});
+                                g.slots[prev].len, out_si, {(int)start});
+            propagate_int_update(nv, prev_v, rhs_v, start, 1);
             scope[s.lhs] = nv;
             td.env().erase(s.lhs);
             return;
@@ -3893,6 +4189,7 @@ struct Lowering {
             Val nv =
                 emit_value(OP_SET_SLICE, {prev_v, rhs_v}, g.slots[prev].len,
                            out_si, {(int)(j * prev_v.si.rows)});
+            propagate_int_update(nv, prev_v, rhs_v, j * prev_v.si.rows, 1);
             scope[s.lhs] = nv;
             td.env().erase(s.lhs);
             return;
@@ -3904,11 +4201,16 @@ struct Lowering {
             const int64_t lo = eval_int(s.lhs_idx[0].args[0]);
             const int64_t hi = eval_int(s.lhs_idx[0].args[1]);
             const int64_t j = eval_int(s.lhs_idx[1].args[0]) - 1;
-            if (g.slots[rhs].len != hi - lo + 1)
+            if (j < 0 || j >= prev_v.si.cols)
+              fail("column assignment index out of bounds for " + s.lhs);
+            const int64_t len = hi >= lo ? hi - lo + 1 : 0;
+            check_range(lo, hi, prev_v.si.rows, "row-range assignment", s.raw);
+            if (g.slots[rhs].len != len)
               fail("range assignment size mismatch for " + s.lhs);
-            Val nv =
-                emit_value(OP_SET_SLICE, {prev_v, rhs_v}, g.slots[prev].len,
-                           out_si, {(int)(j * prev_v.si.rows + lo - 1)});
+            const int64_t start = len == 0 ? 0 : j * prev_v.si.rows + lo - 1;
+            Val nv = emit_value(OP_SET_SLICE, {prev_v, rhs_v},
+                                g.slots[prev].len, out_si, {(int)start});
+            propagate_int_update(nv, prev_v, rhs_v, start, 1);
             scope[s.lhs] = nv;
             td.env().erase(s.lhs);
             return;
@@ -3935,6 +4237,7 @@ struct Lowering {
                            : emit_value(OP_SET_SLICE, {prev_v, rhs_v},
                                         g.slots[prev].len, out_si,
                                         {(int)a.off}));
+            propagate_int_update(nv, prev_v, rhs_v, a.off, a.stride);
             scope[s.lhs] = nv;
             td.env().erase(s.lhs);
             return;
@@ -3954,6 +4257,7 @@ struct Lowering {
           }
           Val nv = emit_value(OP_SET_INDEX, {prev_v, rhs_v}, g.slots[prev].len,
                               out_si, {(int)flat});
+          propagate_int_update(nv, prev_v, rhs_v, flat, 1);
           scope[s.lhs] = nv;
           td.env().erase(s.lhs);
           return;

--- a/runtime/src/reroll.cpp
+++ b/runtime/src/reroll.cpp
@@ -90,7 +90,7 @@ bool ops_match(const Graph& g, const Op& a, const Op& b) {
       a.out2 >= 0 || b.out2 >= 0 || a.opcode == OP_CHECK_STRUCTURED ||
       a.opcode == OP_CHECK_MATCHING_DIMS || a.opcode == OP_CHECK_LOWER ||
       a.opcode == OP_CHECK_UPPER || a.opcode == OP_CATEGORICAL ||
-      a.opcode == OP_RNG)
+      a.opcode == OP_RNG || a.opcode == OP_PROD_VEC)
     return false;
   for (int j = 0; j < a.n_in; ++j)
     if (g.slots[a.in[j]].len != g.slots[b.in[j]].len) return false;

--- a/tests/fixtures/gq_prod_udf.stan
+++ b/tests/fixtures/gq_prod_udf.stan
@@ -1,0 +1,20 @@
+functions {
+  real vector_product(vector x) {
+    // Keep this call visible in optimized MIR: a UDF formal can bind a
+    // shifted Eigen Block even when the source-level caller passes a vector.
+    array[2] matrix[2, 2] uninlined_shape_guard;
+    return prod(x);
+  }
+}
+parameters {
+  vector[5] x;
+  matrix[2, 5] p;
+}
+model {
+  x ~ normal(0, 1);
+}
+generated quantities {
+  real pr = vector_product(x);
+  real transposed_surface = prod(1.0 - x');
+  real target_surface = prod(rep_vector(1.0, 5) - p[2]');
+}

--- a/tests/fixtures/gq_prod_udf.tmir.sexp
+++ b/tests/fixtures/gq_prod_udf.tmir.sexp
@@ -1,0 +1,607 @@
+((functions_block
+  (((fdrt (ReturnType UReal)) (fdname vector_product) (fdsuffix FnPlain)
+    (fdargs ((AutoDiffable x UVector)))
+    (fdbody
+     (((pattern
+        (Block
+         (((pattern
+            (Decl (decl_adtype AutoDiffable) (decl_id uninlined_shape_guard)
+             (decl_type
+              (Sized
+               (SArray
+                (SMatrix AoS
+                 ((pattern (Lit Int 2))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                 ((pattern (Lit Int 2))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                ((pattern (Lit Int 2))
+                 (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+             (initialize Default)))
+           (meta <opaque>))
+          ((pattern
+            (Return
+             (((pattern
+                (FunApp (StanLib prod FnPlain AoS)
+                 (((pattern (Var x))
+                   (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
+           (meta <opaque>)))))
+       (meta <opaque>))))
+    (fdloc <opaque>))))
+ (input_vars ()) (prepare_data ())
+ (log_prob
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id x)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Lit Int 5)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity)
+             (dims
+              (((pattern (Lit Int 5))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id p)
+      (decl_type
+       (Sized
+        (SMatrix AoS
+         ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+         ((pattern (Lit Int 5)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity)
+             (dims
+              (((pattern (Lit Int 2))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+               ((pattern (Lit Int 5))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib normal_lpdf (FnLpdf true) AoS)
+             (((pattern (Var x))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))
+              ((pattern
+                (Promotion
+                 ((pattern (Lit Int 0))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                 UReal DataOnly))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+              ((pattern
+                (Promotion
+                 ((pattern (Lit Int 1))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                 UReal DataOnly))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>)))))
+    (meta <opaque>))))
+ (reverse_mode_log_prob
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id x)
+      (decl_type
+       (Sized
+        (SVector SoA
+         ((pattern (Lit Int 5)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity)
+             (dims
+              (((pattern (Lit Int 5))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern SoA)))
+           ()))
+         (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id p)
+      (decl_type
+       (Sized
+        (SMatrix SoA
+         ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+         ((pattern (Lit Int 5)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity)
+             (dims
+              (((pattern (Lit Int 2))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+               ((pattern (Lit Int 5))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern SoA)))
+           ()))
+         (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib normal_lpdf (FnLpdf true) SoA)
+             (((pattern (Var x))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))
+              ((pattern
+                (Promotion
+                 ((pattern (Lit Int 0))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                 UReal DataOnly))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+              ((pattern
+                (Promotion
+                 ((pattern (Lit Int 1))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                 UReal DataOnly))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>)))))
+    (meta <opaque>))))
+ (generate_quantities
+  (((pattern
+     (Decl (decl_adtype DataOnly) (decl_id x)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Lit Int 5)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity)
+             (dims
+              (((pattern (Lit Int 5))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id p)
+      (decl_type
+       (Sized
+        (SMatrix AoS
+         ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+         ((pattern (Lit Int 5)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity)
+             (dims
+              (((pattern (Lit Int 2))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+               ((pattern (Lit Int 5))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt ())
+        (var
+         ((pattern (Var x)) (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt ())
+        (var
+         ((pattern (Var p)) (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (IfElse
+      ((pattern
+        (FunApp (StanLib PNot__ FnPlain AoS)
+         (((pattern
+            (EOr
+             ((pattern (Var emit_transformed_parameters__))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+             ((pattern (Var emit_generated_quantities__))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+      ((pattern (Block (((pattern (Return ())) (meta <opaque>))))) (meta <opaque>)) ()))
+    (meta <opaque>))
+   ((pattern
+     (IfElse
+      ((pattern
+        (FunApp (StanLib PNot__ FnPlain AoS)
+         (((pattern (Var emit_generated_quantities__))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+      ((pattern (Block (((pattern (Return ())) (meta <opaque>))))) (meta <opaque>)) ()))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id pr) (decl_type (Sized SReal))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id inline_vector_product_return_sym1__)
+      (decl_type (Sized SReal)) (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable)
+          (decl_id inline_vector_product_uninlined_shape_guard_sym2__)
+          (decl_type
+           (Sized
+            (SArray
+             (SMatrix AoS
+              ((pattern (Lit Int 2))
+               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+              ((pattern (Lit Int 2))
+               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+             ((pattern (Lit Int 2))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+          (initialize Default)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable inline_vector_product_return_sym1__) ()) UReal
+          ((pattern
+            (FunApp (StanLib prod FnPlain AoS)
+             (((pattern (Var x))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>)))))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable pr) ()) UReal
+      ((pattern (Var inline_vector_product_return_sym1__))
+       (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id transposed_surface) (decl_type (Sized SReal))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable transposed_surface) ()) UReal
+      ((pattern
+        (FunApp (StanLib prod FnPlain AoS)
+         (((pattern
+            (FunApp (StanLib Minus__ FnPlain AoS)
+             (((pattern (Lit Real 1.0))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+              ((pattern
+                (FunApp (StanLib Transpose__ FnPlain AoS)
+                 (((pattern (Var x))
+                   (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+               (meta ((type_ URowVector) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ URowVector) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id target_surface) (decl_type (Sized SReal))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable target_surface) ()) UReal
+      ((pattern
+        (FunApp (StanLib prod FnPlain AoS)
+         (((pattern
+            (FunApp (StanLib Minus__ FnPlain AoS)
+             (((pattern
+                (FunApp (StanLib rep_vector FnPlain AoS)
+                 (((pattern (Lit Real 1.0))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+                  ((pattern (Lit Int 5))
+                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly))))
+              ((pattern
+                (FunApp (StanLib Transpose__ FnPlain AoS)
+                 (((pattern
+                    (Indexed
+                     ((pattern (Var p))
+                      (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly))))
+                     ((Single
+                       ((pattern (Lit Int 2))
+                        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                   (meta ((type_ URowVector) (loc <opaque>) (adlevel DataOnly)))))))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt ())
+        (var
+         ((pattern (Var pr)) (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt ())
+        (var
+         ((pattern (Var transposed_surface))
+          (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt ())
+        (var
+         ((pattern (Var target_surface))
+          (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))))
+ (transform_inits
+  (((pattern
+     (Decl (decl_adtype DataOnly) (decl_id pos__) (decl_type (Sized SInt))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id x)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Lit Int 5)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id x_flat__)
+          (decl_type (Unsized (UArray UReal))) (initialize Uninit)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable x_flat__) ()) (UArray UReal)
+          ((pattern
+            (FunApp (CompilerInternal FnReadData)
+             (((pattern (Lit Str x))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable pos__) ()) UInt
+          ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar sym1__)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Lit Int 5))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (Assignment
+                  ((LVariable x)
+                   ((Single
+                     ((pattern (Var sym1__))
+                      (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                  UVector
+                  ((pattern
+                    (Indexed
+                     ((pattern (Var x_flat__))
+                      (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))
+                     ((Single
+                       ((pattern (Var pos__))
+                        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+                (meta <opaque>))
+               ((pattern
+                 (Assignment ((LVariable pos__) ()) UInt
+                  ((pattern
+                    (FunApp (StanLib Plus__ FnPlain AoS)
+                     (((pattern (Var pos__))
+                       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                      ((pattern (Lit Int 1))
+                       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var x)) (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id p)
+      (decl_type
+       (Sized
+        (SMatrix AoS
+         ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+         ((pattern (Lit Int 5)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id p_flat__)
+          (decl_type (Unsized (UArray UReal))) (initialize Uninit)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable p_flat__) ()) (UArray UReal)
+          ((pattern
+            (FunApp (CompilerInternal FnReadData)
+             (((pattern (Lit Str p))
+               (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable pos__) ()) UInt
+          ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar sym1__)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Lit Int 5))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (For (loopvar sym2__)
+                  (lower
+                   ((pattern (Lit Int 1))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (upper
+                   ((pattern (Lit Int 2))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (body
+                   ((pattern
+                     (Block
+                      (((pattern
+                         (Assignment
+                          ((LVariable p)
+                           ((Single
+                             ((pattern (Var sym2__))
+                              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                            (Single
+                             ((pattern (Var sym1__))
+                              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                          UMatrix
+                          ((pattern
+                            (Indexed
+                             ((pattern (Var p_flat__))
+                              (meta
+                               ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))
+                             ((Single
+                               ((pattern (Var pos__))
+                                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                           (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+                        (meta <opaque>))
+                       ((pattern
+                         (Assignment ((LVariable pos__) ()) UInt
+                          ((pattern
+                            (FunApp (StanLib Plus__ FnPlain AoS)
+                             (((pattern (Var pos__))
+                               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                              ((pattern (Lit Int 1))
+                               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                        (meta <opaque>)))))
+                    (meta <opaque>)))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var p)) (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))))
+ (unconstrain_array
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id x)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Lit Int 5)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable x) ()) UVector
+      ((pattern
+        (FunApp (CompilerInternal FnReadDeserializer)
+         (((pattern (Lit Int 5)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var x)) (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id p)
+      (decl_type
+       (Sized
+        (SMatrix AoS
+         ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+         ((pattern (Lit Int 5)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable p) ()) UMatrix
+      ((pattern
+        (FunApp (CompilerInternal FnReadDeserializer)
+         (((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+          ((pattern (Lit Int 5)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var p)) (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))))
+ (output_vars
+  ((x <opaque>
+    ((out_unconstrained_st
+      (SVector AoS
+       ((pattern (Lit Int 5)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+     (out_constrained_st
+      (SVector AoS
+       ((pattern (Lit Int 5)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+     (out_block Parameters) (out_trans Identity)))
+   (p <opaque>
+    ((out_unconstrained_st
+      (SMatrix AoS
+       ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+       ((pattern (Lit Int 5)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+     (out_constrained_st
+      (SMatrix AoS
+       ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+       ((pattern (Lit Int 5)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+     (out_block Parameters) (out_trans Identity)))
+   (pr <opaque>
+    ((out_unconstrained_st SReal) (out_constrained_st SReal)
+     (out_block GeneratedQuantities) (out_trans Identity)))
+   (transposed_surface <opaque>
+    ((out_unconstrained_st SReal) (out_constrained_st SReal)
+     (out_block GeneratedQuantities) (out_trans Identity)))
+   (target_surface <opaque>
+    ((out_unconstrained_st SReal) (out_constrained_st SReal)
+     (out_block GeneratedQuantities) (out_trans Identity)))))
+ (prog_name gq_prod_udf_model) (prog_path tests/fixtures/gq_prod_udf.stan))

--- a/tests/fixtures/gq_reductions.stan
+++ b/tests/fixtures/gq_reductions.stan
@@ -1,0 +1,29 @@
+data {
+  vector[3] d;
+  array[3] int counts;
+}
+parameters {
+  real pad;
+  vector[5] x;
+}
+model {
+  target += prod(d);
+  target += sum(counts);
+  pad ~ normal(0, 1);
+  x ~ normal(0, 1);
+}
+generated quantities {
+  real pr = prod(x);
+  array[5] int z;
+  array[2] int tail;
+  array[2, 2] int partial_matrix;
+  partial_matrix[1, 1] = 7;
+  z[1] = 1;
+  z[2] = bernoulli_rng(pr);
+  z[3] = 0;
+  tail[1] = 0;
+  tail[2] = bernoulli_rng(0.7);
+  z[10 : 0] = tail[2 : 1];
+  z[4 : 5] = tail;
+  int total = sum(z);
+}

--- a/tests/fixtures/gq_reductions.tmir.sexp
+++ b/tests/fixtures/gq_reductions.tmir.sexp
@@ -1,0 +1,758 @@
+((functions_block ())
+ (input_vars
+  ((d <opaque>
+    (SVector AoS
+     ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+   (counts <opaque>
+    (SArray SInt
+     ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+ (prepare_data
+  (((pattern
+     (Decl (decl_adtype DataOnly) (decl_id pos__) (decl_type (Sized SInt))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable pos__) ()) UInt
+      ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id d)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id d_flat__)
+          (decl_type (Unsized (UArray UReal))) (initialize Uninit)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable d_flat__) ()) (UArray UReal)
+          ((pattern
+            (FunApp (CompilerInternal FnReadData)
+             (((pattern (Lit Str d))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable pos__) ()) UInt
+          ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar sym1__)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Lit Int 3))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (Assignment
+                  ((LVariable d)
+                   ((Single
+                     ((pattern (Var sym1__))
+                      (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                  UVector
+                  ((pattern
+                    (Indexed
+                     ((pattern (Var d_flat__))
+                      (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))
+                     ((Single
+                       ((pattern (Var pos__))
+                        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+                (meta <opaque>))
+               ((pattern
+                 (Assignment ((LVariable pos__) ()) UInt
+                  ((pattern
+                    (FunApp (StanLib Plus__ FnPlain AoS)
+                     (((pattern (Var pos__))
+                       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                      ((pattern (Lit Int 1))
+                       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id counts)
+      (decl_type
+       (Sized
+        (SArray SInt
+         ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable counts) ()) (UArray UInt)
+      ((pattern
+        (FunApp (CompilerInternal FnReadData)
+         (((pattern (Lit Str counts))
+           (meta ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))))
+ (log_prob
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id pad) (decl_type (Sized SReal))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity) (dims ()) (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id x)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Lit Int 5)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity)
+             (dims
+              (((pattern (Lit Int 5))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib prod FnPlain AoS)
+             (((pattern (Var d))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib sum FnPlain AoS)
+             (((pattern (Var counts))
+               (meta ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib normal_lpdf (FnLpdf true) AoS)
+             (((pattern (Var pad))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+              ((pattern
+                (Promotion
+                 ((pattern (Lit Int 0))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                 UReal DataOnly))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+              ((pattern
+                (Promotion
+                 ((pattern (Lit Int 1))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                 UReal DataOnly))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>))
+       ((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib normal_lpdf (FnLpdf true) AoS)
+             (((pattern (Var x))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))
+              ((pattern
+                (Promotion
+                 ((pattern (Lit Int 0))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                 UReal DataOnly))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+              ((pattern
+                (Promotion
+                 ((pattern (Lit Int 1))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                 UReal DataOnly))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>)))))
+    (meta <opaque>))))
+ (reverse_mode_log_prob
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id pad) (decl_type (Sized SReal))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity) (dims ()) (mem_pattern SoA)))
+           ()))
+         (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id x)
+      (decl_type
+       (Sized
+        (SVector SoA
+         ((pattern (Lit Int 5)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity)
+             (dims
+              (((pattern (Lit Int 5))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern SoA)))
+           ()))
+         (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib prod FnPlain AoS)
+             (((pattern (Var d))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib sum FnPlain SoA)
+             (((pattern (Var counts))
+               (meta ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib normal_lpdf (FnLpdf true) SoA)
+             (((pattern (Var pad))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+              ((pattern
+                (Promotion
+                 ((pattern (Lit Int 0))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                 UReal DataOnly))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+              ((pattern
+                (Promotion
+                 ((pattern (Lit Int 1))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                 UReal DataOnly))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>))
+       ((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib normal_lpdf (FnLpdf true) SoA)
+             (((pattern (Var x))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))
+              ((pattern
+                (Promotion
+                 ((pattern (Lit Int 0))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                 UReal DataOnly))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+              ((pattern
+                (Promotion
+                 ((pattern (Lit Int 1))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                 UReal DataOnly))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>)))))
+    (meta <opaque>))))
+ (generate_quantities
+  (((pattern
+     (Decl (decl_adtype DataOnly) (decl_id pad) (decl_type (Sized SReal))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity) (dims ()) (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id x)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Lit Int 5)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity)
+             (dims
+              (((pattern (Lit Int 5))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt ())
+        (var
+         ((pattern (Var pad)) (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt ())
+        (var
+         ((pattern (Var x)) (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (IfElse
+      ((pattern
+        (FunApp (StanLib PNot__ FnPlain AoS)
+         (((pattern
+            (EOr
+             ((pattern (Var emit_transformed_parameters__))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+             ((pattern (Var emit_generated_quantities__))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+      ((pattern (Block (((pattern (Return ())) (meta <opaque>))))) (meta <opaque>)) ()))
+    (meta <opaque>))
+   ((pattern
+     (IfElse
+      ((pattern
+        (FunApp (StanLib PNot__ FnPlain AoS)
+         (((pattern (Var emit_generated_quantities__))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+      ((pattern (Block (((pattern (Return ())) (meta <opaque>))))) (meta <opaque>)) ()))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id pr) (decl_type (Sized SReal))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable pr) ()) UReal
+      ((pattern
+        (FunApp (StanLib prod FnPlain AoS)
+         (((pattern (Var x)) (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id z)
+      (decl_type
+       (Sized
+        (SArray SInt
+         ((pattern (Lit Int 5)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id tail)
+      (decl_type
+       (Sized
+        (SArray SInt
+         ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id partial_matrix)
+      (decl_type
+       (Sized
+        (SArray
+         (SArray SInt
+          ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+         ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment
+      ((LVariable partial_matrix)
+       ((Single
+         ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+        (Single
+         ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (UArray (UArray UInt))
+      ((pattern (Lit Int 7)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (Assignment
+      ((LVariable z)
+       ((Single
+         ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (UArray UInt)
+      ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (Assignment
+      ((LVariable z)
+       ((Single
+         ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (UArray UInt)
+      ((pattern
+        (FunApp (StanLib bernoulli_rng FnRng AoS)
+         (((pattern (Var pr)) (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (Assignment
+      ((LVariable z)
+       ((Single
+         ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (UArray UInt)
+      ((pattern (Lit Int 0)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (Assignment
+      ((LVariable tail)
+       ((Single
+         ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (UArray UInt)
+      ((pattern (Lit Int 0)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (Assignment
+      ((LVariable tail)
+       ((Single
+         ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (UArray UInt)
+      ((pattern
+        (FunApp (StanLib bernoulli_rng FnRng AoS)
+         (((pattern (Lit Real 0.7))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (Assignment
+      ((LVariable z)
+       ((Between
+         ((pattern (Lit Int 10)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+         ((pattern (Lit Int 0)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (UArray UInt)
+      ((pattern
+        (Indexed
+         ((pattern (Var tail))
+          (meta ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly))))
+         ((Between
+           ((pattern (Lit Int 2))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+       (meta ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (Assignment
+      ((LVariable z)
+       ((Between
+         ((pattern (Lit Int 4)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+         ((pattern (Lit Int 5)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (UArray UInt)
+      ((pattern (Var tail))
+       (meta ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id total) (decl_type (Sized SInt))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable total) ()) UInt
+      ((pattern
+        (FunApp (StanLib sum FnPlain AoS)
+         (((pattern (Var z))
+           (meta ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt ())
+        (var
+         ((pattern (Var pr)) (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt ())
+        (var
+         ((pattern (Var z))
+          (meta ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt ())
+        (var
+         ((pattern (Var tail))
+          (meta ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (For (loopvar sym1__)
+      (lower
+       ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+      (upper
+       ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+      (body
+       ((pattern
+         (Block
+          (((pattern
+             (For (loopvar sym2__)
+              (lower
+               ((pattern (Lit Int 1))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+              (upper
+               ((pattern (Lit Int 2))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+              (body
+               ((pattern
+                 (Block
+                  (((pattern
+                     (NRFunApp
+                      (CompilerInternal
+                       (FnWriteParam (unconstrain_opt ())
+                        (var
+                         ((pattern
+                           (Indexed
+                            ((pattern (Var partial_matrix))
+                             (meta
+                              ((type_ (UArray (UArray UInt))) (loc <opaque>)
+                               (adlevel DataOnly))))
+                            ((Single
+                              ((pattern (Var sym2__))
+                               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                             (Single
+                              ((pattern (Var sym1__))
+                               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                      ()))
+                    (meta <opaque>)))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt ())
+        (var
+         ((pattern (Var total)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))))
+ (transform_inits
+  (((pattern
+     (Decl (decl_adtype DataOnly) (decl_id pos__) (decl_type (Sized SInt))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable pos__) ()) UInt
+      ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id pad) (decl_type (Sized SReal))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable pad) ()) UReal
+      ((pattern
+        (Indexed
+         ((pattern
+           (FunApp (CompilerInternal FnReadData)
+            (((pattern (Lit Str pad))
+              (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+          (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))
+         ((Single
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+       (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var pad)) (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id x)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Lit Int 5)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id x_flat__)
+          (decl_type (Unsized (UArray UReal))) (initialize Uninit)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable x_flat__) ()) (UArray UReal)
+          ((pattern
+            (FunApp (CompilerInternal FnReadData)
+             (((pattern (Lit Str x))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable pos__) ()) UInt
+          ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar sym1__)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Lit Int 5))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (Assignment
+                  ((LVariable x)
+                   ((Single
+                     ((pattern (Var sym1__))
+                      (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                  UVector
+                  ((pattern
+                    (Indexed
+                     ((pattern (Var x_flat__))
+                      (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))
+                     ((Single
+                       ((pattern (Var pos__))
+                        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+                (meta <opaque>))
+               ((pattern
+                 (Assignment ((LVariable pos__) ()) UInt
+                  ((pattern
+                    (FunApp (StanLib Plus__ FnPlain AoS)
+                     (((pattern (Var pos__))
+                       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                      ((pattern (Lit Int 1))
+                       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var x)) (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))))
+ (unconstrain_array
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id pad) (decl_type (Sized SReal))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable pad) ()) UReal
+      ((pattern (FunApp (CompilerInternal FnReadDeserializer) ()))
+       (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var pad)) (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id x)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Lit Int 5)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable x) ()) UVector
+      ((pattern
+        (FunApp (CompilerInternal FnReadDeserializer)
+         (((pattern (Lit Int 5)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var x)) (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))))
+ (output_vars
+  ((pad <opaque>
+    ((out_unconstrained_st SReal) (out_constrained_st SReal) (out_block Parameters)
+     (out_trans Identity)))
+   (x <opaque>
+    ((out_unconstrained_st
+      (SVector AoS
+       ((pattern (Lit Int 5)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+     (out_constrained_st
+      (SVector AoS
+       ((pattern (Lit Int 5)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+     (out_block Parameters) (out_trans Identity)))
+   (pr <opaque>
+    ((out_unconstrained_st SReal) (out_constrained_st SReal)
+     (out_block GeneratedQuantities) (out_trans Identity)))
+   (z <opaque>
+    ((out_unconstrained_st
+      (SArray SInt
+       ((pattern (Lit Int 5)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+     (out_constrained_st
+      (SArray SInt
+       ((pattern (Lit Int 5)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+     (out_block GeneratedQuantities) (out_trans Identity)))
+   (tail <opaque>
+    ((out_unconstrained_st
+      (SArray SInt
+       ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+     (out_constrained_st
+      (SArray SInt
+       ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+     (out_block GeneratedQuantities) (out_trans Identity)))
+   (partial_matrix <opaque>
+    ((out_unconstrained_st
+      (SArray
+       (SArray SInt
+        ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+       ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+     (out_constrained_st
+      (SArray
+       (SArray SInt
+        ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+       ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+     (out_block GeneratedQuantities) (out_trans Identity)))
+   (total <opaque>
+    ((out_unconstrained_st SInt) (out_constrained_st SInt)
+     (out_block GeneratedQuantities) (out_trans Identity)))))
+ (prog_name gq_reductions_model) (prog_path tests/fixtures/gq_reductions.stan))

--- a/tests/test_mir.cpp
+++ b/tests/test_mir.cpp
@@ -411,6 +411,39 @@ int main(int argc, char** argv) {
     check(scaled == std::vector<double>({6.0, 8.0}),
           "ODE call scalar formal broadcasts over vector");
 
+    // The same positional entry point can evaluate a fallback RHS/UDF with a
+    // product over a vector formal.  A formal can be bound to a shifted Eigen
+    // view, so it must retain MirInterp's legacy ascending fold rather than
+    // being classified as an owning top-level packet vector.  These factors
+    // distinguish the two groupings: ascending gives 3, while packet pairing
+    // forms inf*0 and produces NaN.
+    mir::FunDef reduce;
+    reduce.name = "reduce";
+    reduce.arg_names = {"x"};
+    reduce.arg_views = {{0, mir::UnsizedLeaf::Vector}};
+    reduce.arg_types = {"UVector"};
+    mir::Expr formal;
+    formal.kind = mir::Expr::Var;
+    formal.name = "x";
+    formal.type_ = "UVector";
+    formal.unsized.leaf = mir::UnsizedLeaf::Vector;
+    formal.data_only = true;
+    mir::Stmt reduced_return;
+    reduced_return.kind = mir::Stmt::Return;
+    reduced_return.has_init = true;
+    reduced_return.rhs.kind = mir::Expr::FunApp;
+    reduced_return.rhs.fn_lib = mir::Expr::Lib::StanLib;
+    reduced_return.rhs.name = "prod";
+    reduced_return.rhs.type_ = "UReal";
+    reduced_return.rhs.unsized.leaf = mir::UnsizedLeaf::Real;
+    reduced_return.rhs.data_only = true;
+    reduced_return.rhs.args = {formal};
+    reduce.body = {reduced_return};
+    const std::vector<double> reduced =
+        interp.call(reduce, {{1e200, 1e-200, 1e200, 1e-200, 3.0}}, {});
+    check(reduced == std::vector<double>{3.0},
+          "ODE call vector formal retains scalar product grouping");
+
     // stanc may reconstruct a scalar data declaration through a flat
     // FnReadData assignment. The declaration still owns scalar geometry;
     // treating its one value as vector[1] breaks later scalar broadcasts.

--- a/tests/test_pass_safety.cpp
+++ b/tests/test_pass_safety.cpp
@@ -371,10 +371,67 @@ static void test_rng_is_an_effect_barrier() {
   expect("RNG effect count/order preserved", rng_ops == 40);
 }
 
+static void test_product_is_forward_only_pass_barrier() {
+  Graph g;
+  Fills fills;
+  const int input = g.add_slot(5, true);
+  constexpr int kLanes = 20;
+  const int result = g.add_slot(kLanes, false);
+  fills.emplace_back(result, std::vector<double>(kLanes, 0.0));
+  // Each period contains a candidate element store, so reroll reaches
+  // ops_match and must reject PROD explicitly.  Without that vocabulary
+  // barrier the invariant product is eligible to hoist across all lanes.
+  for (int lane = 0; lane < kLanes; ++lane) {
+    const int output = g.add_slot(1, false);
+    g.add_op(OP_PROD_VEC, {input}, output);
+    g.add_op(OP_SET_INDEX_INPLACE, {result, output}, result, {lane});
+  }
+  const int final = g.add_slot(1, false);
+  g.add_op(OP_SUM_VEC, {result}, final);
+  g.result_slot = final;
+  std::vector<int> roots{final};
+  std::vector<int> terms;
+
+  const ConstFoldStats folded = const_fold(g, fills, roots);
+  const RerollStats rerolled = reroll(g, fills, terms, roots);
+  const int islands = carve_islands(g, fills, terms, roots);
+  int products = 0, stores = 0, island_ops = 0;
+  for (const Op& op : g.ops) {
+    products += op.opcode == OP_PROD_VEC;
+    stores += op.opcode == OP_SET_INDEX_INPLACE;
+    island_ops += op.opcode == OP_ISLAND;
+  }
+  expect("product has no backward kernel",
+         find_kernel(OP_PROD_VEC) != nullptr &&
+             kernel(OP_PROD_VEC).backward == nullptr);
+  expect("product is absent from value-free backward traits",
+         !backward_ignores_values(OP_PROD_VEC));
+  expect("product survives constfold with parameter input",
+         folded.ops_removed == 0);
+  expect("product is absent from reroll vocabulary", rerolled.regions == 0);
+  expect("product is absent from island CALL vocabulary", islands == 0);
+  expect("product remains a standalone forward op",
+         products == kLanes && stores == kLanes && island_ops == 0);
+
+  Executor ex(std::move(g));
+  const double values[] = {1e200, 1e200, 1e-200, 1e-200, 3.0};
+  for (int i = 0; i < 5; ++i) ex.params_data()[i] = values[i];
+  ex.run_forward_only();
+  Eigen::VectorXd pinned(5);
+  for (int i = 0; i < 5; ++i) pinned[i] = values[i];
+  const double want = stan::math::prod(pinned);
+  bool exact = true;
+  for (int lane = 0; lane < kLanes; ++lane)
+    exact &= ex.value_ptr(result)[lane] == want;
+  exact &= ex.value_ptr(final)[0] == static_cast<double>(kLanes) * want;
+  expect("standalone products keep pinned Stan Math grouping", exact);
+}
+
 int main() {
   test_setenv("STANLI_ISLAND_ALWAYS", "1", 1);  // see the fuzz loop
   test_whitelist_backwards_ignore_values();
   test_rng_is_an_effect_barrier();
+  test_product_is_forward_only_pass_barrier();
   test_random_graphs_preserve_gradients();
   if (failures) {
     std::printf("%d failures\n", failures);

--- a/tests/test_write_array.cpp
+++ b/tests/test_write_array.cpp
@@ -863,6 +863,16 @@ static uint64_t reduction_bits(double x) {
   return out;
 }
 
+static bool same_reduction_value(double got, double want) {
+  // Eigen deliberately leaves the sign and payload of a propagated NaN
+  // unspecified.  Sanitizer instrumentation can therefore change those bits
+  // without changing the reduction's value contract.  Everything else --
+  // including signed zero and infinity -- remains a bitwise comparison.
+  if (std::isnan(got) || std::isnan(want))
+    return std::isnan(got) && std::isnan(want);
+  return reduction_bits(got) == reduction_bits(want);
+}
+
 static stanli::DataMap reduction_data() {
   stanli::DataMap data;
   data.set_real_array("d", {0.5, -2.0, 4.0});
@@ -967,18 +977,18 @@ void test_product_exact_grouping() {
     const std::vector<double>& values = cases[c];
     Eigen::VectorXd pinned(static_cast<Eigen::Index>(values.size()));
     for (size_t i = 0; i < values.size(); ++i) pinned[i] = values[i];
-    const uint64_t want = reduction_bits(stan::math::prod(pinned));
+    const double want = stan::math::prod(pinned);
 
     DataMap::Entry entry;
     entry.r = values;
     entry.dims = {static_cast<int64_t>(values.size())};
     interp.env()["x"] = std::move(entry);
-    const uint64_t interpreted = reduction_bits(interp.eval(call).r.at(0));
-    if (interpreted != want) {
+    const double interpreted = interp.eval(call).r.at(0);
+    if (!same_reduction_value(interpreted, want)) {
       ++failures;
       std::printf("FAIL product interpreter case %zu: got %llx want %llx\n", c,
-                  static_cast<unsigned long long>(interpreted),
-                  static_cast<unsigned long long>(want));
+                  static_cast<unsigned long long>(reduction_bits(interpreted)),
+                  static_cast<unsigned long long>(reduction_bits(want)));
     }
 
     // Pin the address-independence seam at every packet-relevant shift.  A
@@ -995,13 +1005,13 @@ void test_product_exact_grouping() {
           Desc{storage.data() + offset, static_cast<int64_t>(values.size())};
       ctx.out = Desc{&got, 1};
       product.forward(ctx);
-      if (reduction_bits(got) != want) {
+      if (!same_reduction_value(got, want)) {
         ++failures;
         std::printf(
             "FAIL product kernel case %zu offset %d: got %llx want "
             "%llx\n",
             c, offset, static_cast<unsigned long long>(reduction_bits(got)),
-            static_cast<unsigned long long>(want));
+            static_cast<unsigned long long>(reduction_bits(want)));
       }
     }
   }

--- a/tests/test_write_array.cpp
+++ b/tests/test_write_array.cpp
@@ -18,8 +18,12 @@
 
 #include <stan/math.hpp>
 
+#include <algorithm>
+#include <array>
 #include <cmath>
+#include <cstdint>
 #include <cstdio>
+#include <cstring>
 #include <fstream>
 #include <limits>
 #include <map>
@@ -853,6 +857,1191 @@ void test_compiled_scalar_rng() {
   }
 }
 
+static uint64_t reduction_bits(double x) {
+  uint64_t out = 0;
+  std::memcpy(&out, &x, sizeof(out));
+  return out;
+}
+
+static stanli::DataMap reduction_data() {
+  stanli::DataMap data;
+  data.set_real_array("d", {0.5, -2.0, 4.0});
+  data.set_int_array("counts", {1, 2, 3});
+  return data;
+}
+
+static std::map<std::string, stanli::DataMap::Entry> reduction_base(
+    const stanli::DataMap& data) {
+  std::map<std::string, stanli::DataMap::Entry> base;
+  base["d"] = data.at("d");
+  base["counts"] = data.at("counts");
+  for (const char* flag :
+       {"emit_transformed_parameters__", "emit_generated_quantities__"}) {
+    stanli::DataMap::Entry one;
+    one.is_int = true;
+    one.i = {1};
+    one.r = {1.0};
+    base[flag] = one;
+  }
+  return base;
+}
+
+void test_product_exact_grouping() {
+  using namespace stanli;
+  // Direct kernel calls need the one-time registration normally performed by
+  // Executor construction.
+  {
+    Graph graph;
+    const int in = graph.add_slot(1, true);
+    const int out = graph.add_slot(1, false);
+    graph.add_op(OP_EXP, {in}, out);
+    graph.result_slot = out;
+    Executor warm(std::move(graph));
+  }
+
+  const Kernel& product = kernel(OP_PROD_VEC);
+  if (product.backward != nullptr) {
+    ++failures;
+    std::printf("FAIL product kernel has a backward implementation\n");
+  }
+
+  const double denorm = std::numeric_limits<double>::denorm_min();
+  const double inf = std::numeric_limits<double>::infinity();
+  const double nan = std::numeric_limits<double>::quiet_NaN();
+  std::vector<std::vector<double>> cases = {
+      {0.5},
+      {-0.0},
+      {denorm},
+      {inf},
+      {nan},
+      {0.5, 0.5, 0.5},
+      {0.0, inf, 2.0},
+      {-0.0, inf, 2.0},
+      {inf, 0.0, -2.0},
+      {nan, 0.0, inf},
+      {1.0 + 0x1p-52, 1.0 - 0x1p-52, 1.0 + 0x1p-51},
+      {0.5, 0.5, 0.5, 0.5, 0.5},
+      {1e200, 1e200, 1e-200, 1e-200, 3.0},
+      {1e200, 1e-200, 1e200, 1e-200, 3.0},
+      {denorm, 2.0, 2.0, 2.0, 2.0},
+      {-0.0, -1.0, -1.0, 1.0, 1.0},
+      {inf, -0.0, nan, -inf, 1.0},
+  };
+
+  // Exercise every packet boundary on the build host.  Fixed lengths 1/3/5
+  // above pin the public contract; these sizes keep the same test meaningful
+  // when Eigen is compiled for SSE, AVX2, or AVX-512.
+  const int packet_width = std::max(
+      1, static_cast<int>(Eigen::internal::packet_traits<double>::size));
+  const int packet_lengths[] = {packet_width - 1, packet_width,
+                                packet_width + 1, 2 * packet_width + 1};
+  const int exponents[] = {500, -500, 400, -400, 300, -300, 0, 0};
+  for (int n : packet_lengths) {
+    if (n <= 0) continue;  // Scalar-only Eigen has packet width one.
+    std::vector<double> values(static_cast<size_t>(n));
+    for (int i = 0; i < n; ++i) {
+      const double mantissa =
+          1.0 + static_cast<double>((i * 5 + 1) % 7) * 0x1p-52;
+      values[static_cast<size_t>(i)] =
+          std::ldexp((i % 3 == 0) ? -mantissa : mantissa, exponents[i % 8]);
+    }
+    cases.push_back(std::move(values));
+  }
+
+  std::map<std::string, const mir::FunDef*> funs;
+  MirInterp<double> interp(funs, "product grouping test");
+  mir::Expr variable;
+  variable.kind = mir::Expr::Var;
+  variable.name = "x";
+  variable.type_ = "UVector";
+  variable.unsized.leaf = mir::UnsizedLeaf::Vector;
+  mir::Expr call;
+  call.kind = mir::Expr::FunApp;
+  call.name = "prod";
+  call.fn_lib = mir::Expr::Lib::StanLib;
+  call.type_ = "UReal";
+  call.unsized.leaf = mir::UnsizedLeaf::Real;
+  call.args = {variable};
+
+  for (size_t c = 0; c < cases.size(); ++c) {
+    const std::vector<double>& values = cases[c];
+    Eigen::VectorXd pinned(static_cast<Eigen::Index>(values.size()));
+    for (size_t i = 0; i < values.size(); ++i) pinned[i] = values[i];
+    const uint64_t want = reduction_bits(stan::math::prod(pinned));
+
+    DataMap::Entry entry;
+    entry.r = values;
+    entry.dims = {static_cast<int64_t>(values.size())};
+    interp.env()["x"] = std::move(entry);
+    const uint64_t interpreted = reduction_bits(interp.eval(call).r.at(0));
+    if (interpreted != want) {
+      ++failures;
+      std::printf("FAIL product interpreter case %zu: got %llx want %llx\n", c,
+                  static_cast<unsigned long long>(interpreted),
+                  static_cast<unsigned long long>(want));
+    }
+
+    // Pin the address-independence seam at every packet-relevant shift.  A
+    // direct Eigen::Map differs at odd shifts; OP_PROD_VEC must not.
+    for (int offset = 0; offset < packet_width; ++offset) {
+      Eigen::VectorXd storage(static_cast<Eigen::Index>(
+          values.size() + static_cast<size_t>(packet_width)));
+      storage.setZero();
+      std::copy(values.begin(), values.end(), storage.data() + offset);
+      double got = 0.0;
+      KernelCtx ctx;
+      ctx.n_in = 1;
+      ctx.in[0] =
+          Desc{storage.data() + offset, static_cast<int64_t>(values.size())};
+      ctx.out = Desc{&got, 1};
+      product.forward(ctx);
+      if (reduction_bits(got) != want) {
+        ++failures;
+        std::printf(
+            "FAIL product kernel case %zu offset %d: got %llx want "
+            "%llx\n",
+            c, offset, static_cast<unsigned long long>(reduction_bits(got)),
+            static_cast<unsigned long long>(want));
+      }
+    }
+  }
+
+  // This tranche changes only Eigen vector/row-vector products.  Stan arrays
+  // retain MirInterp's existing ascending scalar fold.
+  mir::Expr array_variable = variable;
+  array_variable.name = "a";
+  array_variable.type_ = "(UArray UReal)";
+  array_variable.unsized.leaf = mir::UnsizedLeaf::Real;
+  array_variable.unsized.depth = 1;
+  mir::Expr array_call = call;
+  array_call.args = {array_variable};
+  const std::vector<double> array_values = {1e200, 1e200, 1e-200, 1e-200, 3.0};
+  DataMap::Entry array_entry;
+  array_entry.r = array_values;
+  array_entry.dims = {static_cast<int64_t>(array_values.size())};
+  interp.env()["a"] = std::move(array_entry);
+  double array_want = 1.0;
+  for (double value : array_values) array_want *= value;
+  const double array_got = interp.eval(array_call).r.at(0);
+  if (reduction_bits(array_got) != reduction_bits(array_want)) {
+    ++failures;
+    std::printf("FAIL array product changed its scalar left fold\n");
+  }
+
+  // Pin the actual expression surfaces admitted by lower.cpp.  CmdStan
+  // gives Eigen the unevaluated CwiseBinary expression; stanli materializes
+  // subtraction into a graph slot before OP_PROD_VEC.  Basic subtraction is
+  // lane-bit-transparent, so the two product groupings must still agree.
+  const auto check_minus_surface = [&](int n, const char* label) {
+    std::vector<Eigen::VectorXd> indexed(2, Eigen::VectorXd(n));
+    const double xs[] = {0.5,  -0.25, 2.0, -1.0, std::nextafter(1.0, 0.0),
+                         -0.5, 0.25,  1.5};
+    for (int i = 0; i < n; ++i)
+      indexed[1][i] = xs[i % static_cast<int>(sizeof(xs) / sizeof(xs[0]))];
+
+    const uint64_t direct =
+        reduction_bits(stan::math::prod(Eigen::VectorXd::Ones(n) - indexed[1]));
+    const uint64_t indexed_transpose = reduction_bits(
+        stan::math::prod(Eigen::RowVectorXd::Ones(n) - indexed[1].transpose()));
+    if (direct != indexed_transpose) {
+      ++failures;
+      std::printf(
+          "FAIL %s pinned outer-minus surfaces disagree: %llx vs "
+          "%llx\n",
+          label, static_cast<unsigned long long>(direct),
+          static_cast<unsigned long long>(indexed_transpose));
+    }
+
+    std::vector<double> materialized(static_cast<size_t>(n));
+    for (int i = 0; i < n; ++i)
+      materialized[static_cast<size_t>(i)] = 1.0 - indexed[1][i];
+    for (int offset = 0; offset < packet_width; ++offset) {
+      Eigen::VectorXd storage(n + packet_width);
+      storage.setZero();
+      std::copy(materialized.begin(), materialized.end(),
+                storage.data() + offset);
+      double got = 0.0;
+      KernelCtx ctx;
+      ctx.n_in = 1;
+      ctx.in[0] = Desc{storage.data() + offset, n};
+      ctx.out = Desc{&got, 1};
+      product.forward(ctx);
+      const uint64_t bits = reduction_bits(got);
+      if (bits != direct || bits != indexed_transpose) {
+        ++failures;
+        std::printf("FAIL %s offset %d: got %llx want %llx\n", label, offset,
+                    static_cast<unsigned long long>(bits),
+                    static_cast<unsigned long long>(direct));
+      }
+    }
+  };
+  check_minus_surface(5, "len5 outer-minus product");
+  check_minus_surface(2 * packet_width + 1,
+                      "packet-boundary outer-minus product");
+
+  // The corpus surface indexes a row of a column-major matrix and transposes
+  // it.  That Eigen block remains strided, disables packet access on the
+  // outer subtraction, and makes prod reduce from coefficient zero in
+  // ascending scalar order.  Search deterministic valid probabilities for a
+  // case that distinguishes that order from the packet variant, then pin the
+  // raw-expression oracle and the materialized graph kernel to the scalar
+  // result.  Scalar-only Eigen builds have no distinct packet order.
+  const int matrix_n = 2 * packet_width + 1;
+  Eigen::MatrixXd matrix(2, matrix_n);
+  std::vector<double> factors(static_cast<size_t>(matrix_n));
+  bool distinguished = packet_width == 1;
+  uint64_t state = 0x4d4154524958524fULL;
+  for (int trial = 0; trial < 4096 && !distinguished; ++trial) {
+    for (int i = 0; i < matrix_n; ++i) {
+      state = state * 6364136223846793005ULL + 1442695040888963407ULL;
+      const double p = 0.01 + 0.98 * static_cast<double>(state >> 11) /
+                                  static_cast<double>(uint64_t{1} << 53);
+      matrix(0, i) = 0.25;
+      matrix(1, i) = p;
+      factors[static_cast<size_t>(i)] = 1.0 - p;
+    }
+    double scalar = factors[0];
+    for (int i = 1; i < matrix_n; ++i)
+      scalar *= factors[static_cast<size_t>(i)];
+
+    double packet = 0.0;
+    KernelCtx packet_ctx;
+    packet_ctx.n_in = 1;
+    packet_ctx.in[0] = Desc{factors.data(), matrix_n};
+    packet_ctx.out = Desc{&packet, 1};
+    packet_ctx.variant = 0;
+    product.forward(packet_ctx);
+    if (reduction_bits(packet) == reduction_bits(scalar)) continue;
+
+    const double direct = stan::math::prod(Eigen::VectorXd::Ones(matrix_n) -
+                                           matrix.row(1).transpose());
+    double got = 0.0;
+    KernelCtx scalar_ctx = packet_ctx;
+    scalar_ctx.out = Desc{&got, 1};
+    scalar_ctx.variant = 1;
+    product.forward(scalar_ctx);
+    if (reduction_bits(direct) != reduction_bits(scalar) ||
+        reduction_bits(got) != reduction_bits(scalar)) {
+      ++failures;
+      std::printf("FAIL matrix-row product did not use scalar grouping\n");
+    }
+    distinguished = true;
+  }
+  if (!distinguished) {
+    ++failures;
+    std::printf("FAIL matrix-row oracle did not distinguish packet order\n");
+  }
+}
+
+void test_compiled_gq_reductions() {
+  using namespace stanli;
+  const std::string text = slurp("tests/fixtures/gq_reductions.tmir.sexp");
+  const DataMap data = reduction_data();
+  CompiledModel cm = compile_model(text, data);
+  if (!cm.write_array || cm.write_array->interp ||
+      !cm.write_array->truncated.empty()) {
+    ++failures;
+    std::printf(
+        "FAIL reductions fixture did not compile completely: %s\n",
+        cm.write_array ? cm.write_array->truncated.c_str() : "no write_array");
+    return;
+  }
+
+  // The same fixture pins both legacy seams in log_prob: data-only prod is
+  // folded rather than becoming the forward-only opcode, and pure-data int
+  // sum still compiles/evaluates outside the runtime GQ specialization.
+  int log_products = 0;
+  for (const Op& op : cm.graph.ops)
+    if (op.opcode == OP_PROD_VEC) ++log_products;
+  if (log_products != 0) {
+    ++failures;
+    std::printf("FAIL data-only log_prob prod used OP_PROD_VEC\n");
+  }
+  Executor log_ex(std::move(cm.graph));
+  cm.bind(log_ex);
+  log_ex.params_data()[0] = 0.25;
+  for (int i = 0; i < 5; ++i) log_ex.params_data()[1 + i] = 0.5;
+  if (!std::isfinite(log_ex.forward())) {
+    ++failures;
+    std::printf("FAIL legacy data prod/int sum log_prob evaluation\n");
+  }
+
+  int product_ops = 0, rng_ops = 0, sum_ops = 0;
+  for (const Op& op : cm.write_array->graph.ops) {
+    product_ops += op.opcode == OP_PROD_VEC;
+    rng_ops += op.opcode == OP_RNG;
+    sum_ops += op.opcode == OP_SUM_VEC;
+  }
+  if (product_ops != 1 || rng_ops != 2 || sum_ops != 1) {
+    ++failures;
+    std::printf("FAIL reductions op census: prod=%d rng=%d sum=%d\n",
+                product_ops, rng_ops, sum_ops);
+  }
+
+  Executor graph(std::move(cm.write_array->graph));
+  cm.write_array->bind(graph);
+  const Op* product_op = nullptr;
+  for (const Op& op : graph.graph().ops)
+    if (op.opcode == OP_PROD_VEC) product_op = &op;
+  if (!product_op || graph.graph().slots[product_op->in[0]].offset != 1) {
+    ++failures;
+    std::printf("FAIL reductions product input is not the pinned odd offset\n");
+  }
+  graph.params_data()[0] = 0.25;
+  for (int i = 0; i < 5; ++i) graph.params_data()[1 + i] = 0.5;
+  const auto graph_row = [&](WaRng& rng) {
+    graph.run_forward_only(EvalState{&rng});
+    std::vector<double> row;
+    for (const auto& column : cm.write_array->columns) {
+      const double* values = graph.value_ptr(column.slot);
+      for (int64_t i = 0; i < column.len; ++i)
+        row.push_back(values[column.storage_index(i)]);
+    }
+    return row;
+  };
+
+  auto program =
+      std::make_shared<mir::Program>(mir::read_program(sexp::parse(text)));
+  WaInterp interpreted(program, reduction_base(data));
+  std::map<std::string, DataMap::Entry> params;
+  params["pad"].r = {0.25};
+  params["x"].r = std::vector<double>(5, 0.5);
+  params["x"].dims = {5};
+
+  WaRng graph_rng(2026), interp_rng(2026);
+  const std::vector<double> got = graph_row(graph_rng);
+  const std::vector<double> want = interpreted.eval(params, interp_rng);
+  const auto graph_next = graph_rng.gen()();
+  const auto interp_next = interp_rng.gen()();
+  if (got != want || graph_next != interp_next) {
+    ++failures;
+    std::printf("FAIL reductions graph/interpreter row or next RNG state\n");
+  }
+  const std::vector<std::string> names =
+      CompiledModel::csv_names(cm.write_array->columns);
+  for (size_t i = 0; i < names.size(); ++i) {
+    if (names[i] == "pr" && reduction_bits(got[i]) != reduction_bits(0.03125)) {
+      ++failures;
+      std::printf("FAIL reductions product output\n");
+    }
+    if (names[i] == "total" && (got[i] < 1.0 || got[i] > 3.0)) {
+      ++failures;
+      std::printf("FAIL reductions integer sum output %.17g\n", got[i]);
+    }
+    if (names[i].rfind("partial_matrix.", 0) == 0) {
+      const double want =
+          names[i] == "partial_matrix.1.1"
+              ? 7.0
+              : static_cast<double>(std::numeric_limits<int>::min());
+      if (got[i] != want) {
+        ++failures;
+        std::printf("FAIL nested int-array sentinel for %s\n",
+                    names[i].c_str());
+      }
+    }
+  }
+
+  // Consecutive rows consume exactly the same stream on both paths too.
+  WaRng graph_stream(91), interp_stream(91);
+  const std::vector<double> g1 = graph_row(graph_stream);
+  const std::vector<double> i1 = interpreted.eval(params, interp_stream);
+  const std::vector<double> g2 = graph_row(graph_stream);
+  const std::vector<double> i2 = interpreted.eval(params, interp_stream);
+  if (g1 != i1 || g2 != i2) {
+    ++failures;
+    std::printf("FAIL reductions consecutive RNG stream rows\n");
+  }
+}
+
+static bool replace_reduction_after(std::string& text, size_t after,
+                                    const std::string& from,
+                                    const std::string& to, const char* what) {
+  const size_t at = text.find(from, after);
+  if (at == std::string::npos) {
+    ++failures;
+    std::printf("FAIL reduction mutation cannot find %s\n", what);
+    return false;
+  }
+  text.replace(at, from.size(), to);
+  return true;
+}
+
+static void expect_reduction_interp(const std::string& text,
+                                    const std::string& reason, const char* what,
+                                    bool sum_prefix = false) {
+  using namespace stanli;
+  CompiledModel cm;
+  try {
+    cm = compile_model(text, reduction_data());
+  } catch (const std::exception& e) {
+    ++failures;
+    std::printf("FAIL %s: mutation did not parse/compile: %s\n", what,
+                e.what());
+    return;
+  }
+  const bool fallback = cm.write_array && cm.write_array->interp &&
+                        (reason.empty() || cm.write_array->truncated.find(
+                                               reason) != std::string::npos);
+  if (!fallback) {
+    ++failures;
+    std::printf(
+        "FAIL %s: got %s\n", what,
+        cm.write_array ? cm.write_array->truncated.c_str() : "no write_array");
+    return;
+  }
+  if (sum_prefix) {
+    int sums = 0;
+    for (const Op& op : cm.write_array->graph.ops)
+      if (op.opcode == OP_SUM_VEC) ++sums;
+    if (sums != 1) {
+      ++failures;
+      std::printf("FAIL %s: runtime sum was not retained in graph prefix\n",
+                  what);
+    }
+  }
+}
+
+static std::vector<double> eval_reduction_interp(
+    const std::string& text, std::vector<std::string>* names) {
+  using namespace stanli;
+  const DataMap data = reduction_data();
+  auto program =
+      std::make_shared<mir::Program>(mir::read_program(sexp::parse(text)));
+  WaInterp interp(program, reduction_base(data));
+  std::map<std::string, DataMap::Entry> params;
+  params["pad"].r = {0.25};
+  params["x"].r = std::vector<double>(5, 0.5);
+  params["x"].dims = {5};
+  WaRng rng(44);
+  std::vector<double> row = interp.eval(params, rng);
+  *names = CompiledModel::csv_names(interp.columns());
+  return row;
+}
+
+void test_gq_reduction_lowering_guards() {
+  using namespace stanli;
+  const std::string base = slurp("tests/fixtures/gq_reductions.tmir.sexp");
+
+  // Generated optimized MIR for the exact corpus surface:
+  // prod(rep_vector(1,T) - Transpose__(Indexed(Var p,i))).  Its matrix-row
+  // operand deliberately selects the scalar product variant.
+  const std::string udf_fixture = slurp("tests/fixtures/gq_prod_udf.tmir.sexp");
+  {
+    DataMap no_data;
+    CompiledModel surface = compile_model(udf_fixture, no_data);
+    int products = 0, packet_products = 0, scalar_products = 0;
+    if (surface.write_array)
+      for (const Op& op : surface.write_array->graph.ops) {
+        if (op.opcode != OP_PROD_VEC) continue;
+        ++products;
+        packet_products += op.variant == 0;
+        scalar_products += op.variant == 1;
+      }
+    if (!surface.write_array || surface.write_array->interp || products != 3 ||
+        packet_products != 2 || scalar_products != 1) {
+      ++failures;
+      std::printf(
+          "FAIL exact product surfaces did not select packet/scalar "
+          "variants\n");
+    } else {
+      // Execute all three admitted syntactic surfaces through both engines.
+      // In particular, `prod(1 - x')` must be classified Packet rather than
+      // silently emitted as variant 0 from a Legacy classifier result.
+      Executor graph(std::move(surface.write_array->graph));
+      surface.write_array->bind(graph);
+      const std::vector<double> x = {0.5, -0.25, 2.0, -1.0,
+                                     std::nextafter(1.0, 0.0)};
+      const std::vector<double> p = {0.25, 0.11, 0.25, 0.37, 0.25,
+                                     0.43, 0.25, 0.59, 0.25, 0.73};
+      std::copy(x.begin(), x.end(), graph.params_data());
+      std::copy(p.begin(), p.end(), graph.params_data() + x.size());
+      graph.run_forward_only();
+      std::vector<double> graph_row;
+      for (const auto& column : surface.write_array->columns) {
+        const double* values = graph.value_ptr(column.slot);
+        for (int64_t i = 0; i < column.len; ++i)
+          graph_row.push_back(values[column.storage_index(i)]);
+      }
+
+      auto program = std::make_shared<mir::Program>(
+          mir::read_program(sexp::parse(udf_fixture)));
+      std::map<std::string, DataMap::Entry> base_env;
+      for (const char* flag :
+           {"emit_transformed_parameters__", "emit_generated_quantities__"}) {
+        DataMap::Entry one;
+        one.is_int = true;
+        one.i = {1};
+        one.r = {1.0};
+        base_env[flag] = one;
+      }
+      WaInterp interp(program, std::move(base_env));
+      std::map<std::string, DataMap::Entry> params;
+      params["x"].r = x;
+      params["x"].dims = {5};
+      params["p"].r = p;
+      params["p"].dims = {2, 5};
+      WaRng rng(1234);
+      const std::vector<double> interp_row = interp.eval(params, rng);
+      if (graph_row.size() != interp_row.size()) {
+        ++failures;
+        std::printf("FAIL exact product surface row widths differ\n");
+      } else {
+        for (size_t i = 0; i < graph_row.size(); ++i)
+          if (reduction_bits(graph_row[i]) != reduction_bits(interp_row[i])) {
+            ++failures;
+            std::printf(
+                "FAIL exact product surface graph/interpreter bits at %zu\n",
+                i);
+            break;
+          }
+      }
+    }
+  }
+
+  // A row of a matrix-valued expression need not have the matrix variable's
+  // col-major stride (transpose(M) is the simplest counterexample).  Only an
+  // Indexed bare matrix variable belongs to the audited scalar surface.
+  std::string matrix_expression = udf_fixture;
+  const size_t matrix_wa =
+      matrix_expression.find("(Assignment ((LVariable target_surface)");
+  const std::string matrix_var = "(pattern (Var p))";
+  const std::string transposed_matrix =
+      "(pattern\n"
+      "                       (FunApp (StanLib Transpose__ FnPlain AoS)\n"
+      "                        (((pattern (Var p))\n"
+      "                          (meta ((type_ UMatrix) (loc <opaque>) "
+      "(adlevel DataOnly)))))))";
+  if (matrix_wa == std::string::npos ||
+      !replace_reduction_after(matrix_expression, matrix_wa, matrix_var,
+                               transposed_matrix,
+                               "matrix-expression product base")) {
+    ++failures;
+    std::printf("FAIL product fixture has no indexed matrix variable\n");
+  } else {
+    DataMap no_data;
+    CompiledModel cm = compile_model(matrix_expression, no_data);
+    if (!cm.write_array || !cm.write_array->interp ||
+        cm.write_array->truncated.find("expression surface") ==
+            std::string::npos) {
+      ++failures;
+      std::printf("FAIL matrix-expression product base did not fall back\n");
+    }
+  }
+
+  // O1 normally inlines generated-quantities UDF calls.  Restore the call
+  // at its retained function definition to pin the lower_call_udf guard: a
+  // formal vector may be bound to a shifted Eigen Block, so dynamic prod in
+  // a UDF must remain on WaInterp even when the caller's syntax is a Var.
+  std::string dynamic_udf = udf_fixture;
+  const size_t udf_wa = dynamic_udf.find("(generate_quantities");
+  const std::string stan_prod = "(FunApp (StanLib prod FnPlain AoS)";
+  const size_t inlined_prod = dynamic_udf.find(stan_prod, udf_wa);
+  if (udf_wa == std::string::npos || inlined_prod == std::string::npos) {
+    ++failures;
+    std::printf("FAIL generated UDF product fixture has no inlined call\n");
+  } else {
+    dynamic_udf.replace(inlined_prod, stan_prod.size(),
+                        "(FunApp (UserDefined vector_product FnPlain)");
+    expect_reduction_interp(dynamic_udf, "expression surface",
+                            "dynamic UDF product stays interpreted");
+  }
+
+  const size_t assignment = base.find("(Assignment ((LVariable pr)");
+  const size_t prod_call = base.find("(FunApp (StanLib prod", assignment);
+  const std::string vector_node =
+      "((pattern (Var x)) (meta ((type_ UVector) (loc <opaque>) (adlevel "
+      "DataOnly))))";
+  const std::string vector_meta =
+      "(meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))";
+  if (assignment == std::string::npos || prod_call == std::string::npos ||
+      base.find(vector_node, prod_call) == std::string::npos) {
+    ++failures;
+    std::printf("FAIL reductions guard fixture has no dynamic product\n");
+    return;
+  }
+
+  struct BadInput {
+    const char* type;
+    const char* label;
+  };
+  const BadInput bad_inputs[] = {
+      {"UReal", "scalar"},
+      {"UMatrix", "matrix"},
+      {"(UArray UReal)", "array"},
+      {"(UArray (UArray UReal))", "nested array"},
+  };
+  for (const BadInput& bad : bad_inputs) {
+    std::string mutated = base;
+    const std::string replacement = std::string("(meta ((type_ ") + bad.type +
+                                    ") (loc <opaque>) (adlevel DataOnly)))";
+    if (!replace_reduction_after(mutated, prod_call, vector_meta, replacement,
+                                 bad.label))
+      continue;
+    const std::string label =
+        std::string("product ") + bad.label + " input stays interpreted";
+    expect_reduction_interp(mutated, "vector or row-vector", label.c_str());
+  }
+
+  std::string container_result = base;
+  const std::string real_result =
+      "(meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))";
+  const std::string vector_result =
+      "(meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))";
+  if (replace_reduction_after(container_result, prod_call, real_result,
+                              vector_result, "container product result"))
+    expect_reduction_interp(container_result, "scalar-real result",
+                            "product container result stays interpreted");
+
+  std::string two_args = base;
+  const size_t one_arg = two_args.find(vector_node, prod_call);
+  if (one_arg == std::string::npos) {
+    ++failures;
+    std::printf("FAIL reduction mutation cannot find product arity\n");
+  } else {
+    two_args.insert(one_arg + vector_node.size(), " " + vector_node);
+    expect_reduction_interp(two_args, "scalar-real result",
+                            "two-argument product stays interpreted");
+  }
+
+  const std::string empty_vector =
+      "((pattern\n"
+      "            (FunApp (StanLib rep_vector FnPlain AoS)\n"
+      "             (((pattern (Var pad))\n"
+      "               (meta ((type_ UReal) (loc <opaque>) (adlevel "
+      "DataOnly))))\n"
+      "              ((pattern (Lit Int 0))\n"
+      "               (meta ((type_ UInt) (loc <opaque>) (adlevel "
+      "DataOnly)))))))\n"
+      "           (meta ((type_ UVector) (loc <opaque>) (adlevel "
+      "DataOnly))))";
+  std::string empty = base;
+  if (replace_reduction_after(empty, prod_call, vector_node, empty_vector,
+                              "empty product"))
+    expect_reduction_interp(empty, "expression surface",
+                            "empty dynamic product stays interpreted");
+
+  const std::string segment =
+      "((pattern\n"
+      "            (FunApp (StanLib segment FnPlain AoS)\n"
+      "             (((pattern (Var x))\n"
+      "               (meta ((type_ UVector) (loc <opaque>) (adlevel "
+      "DataOnly))))\n"
+      "              ((pattern (Lit Int 2))\n"
+      "               (meta ((type_ UInt) (loc <opaque>) (adlevel "
+      "DataOnly))))\n"
+      "              ((pattern (Lit Int 3))\n"
+      "               (meta ((type_ UInt) (loc <opaque>) (adlevel "
+      "DataOnly)))))))\n"
+      "           (meta ((type_ UVector) (loc <opaque>) (adlevel "
+      "DataOnly))))";
+  std::string direct_view = base;
+  if (replace_reduction_after(direct_view, prod_call, vector_node, segment,
+                              "segment product"))
+    expect_reduction_interp(direct_view, "expression surface",
+                            "segment product stays interpreted");
+
+  const std::string transposed_segment =
+      "((pattern\n"
+      "            (FunApp (StanLib Transpose__ FnPlain AoS)\n"
+      "             (" +
+      segment +
+      ")))\n"
+      "           (meta ((type_ URowVector) (loc <opaque>) (adlevel "
+      "DataOnly))))";
+  std::string wrapped_view = base;
+  if (replace_reduction_after(wrapped_view, prod_call, vector_node,
+                              transposed_segment, "transposed segment product"))
+    expect_reduction_interp(wrapped_view, "expression surface",
+                            "transposed segment product stays interpreted");
+
+  // A transpose of a bare vector is an address-zero row-vector view in
+  // CmdStan and remains in scope for the native path.
+  const std::string transposed_bare =
+      "((pattern\n"
+      "            (FunApp (StanLib Transpose__ FnPlain AoS)\n"
+      "             (" +
+      vector_node +
+      ")))\n"
+      "           (meta ((type_ URowVector) (loc <opaque>) (adlevel "
+      "DataOnly))))";
+  std::string row_vector = base;
+  if (replace_reduction_after(row_vector, prod_call, vector_node,
+                              transposed_bare, "row-vector product")) {
+    CompiledModel cm = compile_model(row_vector, reduction_data());
+    int products = 0;
+    if (cm.write_array)
+      for (const Op& op : cm.write_array->graph.ops)
+        products += op.opcode == OP_PROD_VEC;
+    if (!cm.write_array || cm.write_array->interp || products != 1) {
+      ++failures;
+      std::printf("FAIL bare row-vector product did not compile\n");
+    }
+  }
+
+  const std::string exp_vector =
+      "((pattern\n"
+      "            (FunApp (StanLib exp FnPlain AoS)\n"
+      "             (" +
+      vector_node +
+      ")))\n"
+      "           (meta ((type_ UVector) (loc <opaque>) (adlevel "
+      "DataOnly))))";
+  std::string exp_product = base;
+  if (replace_reduction_after(exp_product, prod_call, vector_node, exp_vector,
+                              "exp product"))
+    expect_reduction_interp(exp_product, "expression surface",
+                            "prod(exp(x)) stays interpreted");
+
+  const std::string scalar_one =
+      "((pattern (Lit Real 1.0))\n"
+      "              (meta ((type_ UReal) (loc <opaque>) (adlevel "
+      "DataOnly))))";
+  const std::string safe_minus =
+      "((pattern\n"
+      "            (FunApp (StanLib Minus__ FnPlain AoS)\n"
+      "             (" +
+      scalar_one + " " + vector_node +
+      ")))\n"
+      "           (meta ((type_ UVector) (loc <opaque>) (adlevel "
+      "DataOnly))))";
+  std::string minus_product = base;
+  if (replace_reduction_after(minus_product, prod_call, vector_node, safe_minus,
+                              "audited subtraction product")) {
+    CompiledModel cm = compile_model(minus_product, reduction_data());
+    int products = 0;
+    if (cm.write_array)
+      for (const Op& op : cm.write_array->graph.ops)
+        products += op.opcode == OP_PROD_VEC;
+    if (!cm.write_array || cm.write_array->interp || products != 1) {
+      ++failures;
+      std::printf("FAIL audited outer-subtraction product did not compile\n");
+    }
+  }
+
+  // The same outer subtraction with a transpose-of-bare-vector operand is
+  // also packet-grouped.  This exact form previously passed the lowering
+  // whitelist while the shared classifier returned Legacy.
+  const std::string safe_transposed_minus =
+      "((pattern\n"
+      "            (FunApp (StanLib Minus__ FnPlain AoS)\n"
+      "             (" +
+      scalar_one + " " + transposed_bare +
+      ")))\n"
+      "           (meta ((type_ URowVector) (loc <opaque>) (adlevel "
+      "DataOnly))))";
+  std::string transposed_minus_product = base;
+  if (replace_reduction_after(transposed_minus_product, prod_call, vector_node,
+                              safe_transposed_minus,
+                              "transposed subtraction product")) {
+    CompiledModel cm =
+        compile_model(transposed_minus_product, reduction_data());
+    int products = 0, packet_products = 0;
+    if (cm.write_array)
+      for (const Op& op : cm.write_array->graph.ops) {
+        if (op.opcode != OP_PROD_VEC) continue;
+        ++products;
+        packet_products += op.variant == 0;
+      }
+    if (!cm.write_array || cm.write_array->interp || products != 1 ||
+        packet_products != 1) {
+      ++failures;
+      std::printf(
+          "FAIL transposed outer-subtraction product did not compile as "
+          "packet\n");
+    }
+  }
+
+  // Eigen's IndexedView for a gather also clears PacketAccess.  It is outside
+  // this tranche's exact native grammar, so an outer subtraction containing
+  // one must stay on the interpreter rather than materialize then packetize.
+  const std::string gather_vector =
+      "((pattern\n"
+      "            (Indexed\n"
+      "             (" +
+      vector_node +
+      "\n"
+      "              (MultiIndex\n"
+      "               ((pattern (Var counts))\n"
+      "                (meta ((type_ (UArray UInt)) (loc <opaque>) "
+      "(adlevel DataOnly))))))))\n"
+      "           (meta ((type_ UVector) (loc <opaque>) (adlevel "
+      "DataOnly))))";
+  const std::string gather_minus =
+      "((pattern\n"
+      "            (FunApp (StanLib Minus__ FnPlain AoS)\n"
+      "             (" +
+      scalar_one + " " + gather_vector +
+      ")))\n"
+      "           (meta ((type_ UVector) (loc <opaque>) (adlevel "
+      "DataOnly))))";
+  std::string gathered_product = base;
+  if (replace_reduction_after(gathered_product, prod_call, vector_node,
+                              gather_minus, "gather product"))
+    expect_reduction_interp(gathered_product, "expression surface",
+                            "prod(1-x[idx]) stays interpreted");
+
+  const std::string unsafe_minus =
+      "((pattern\n"
+      "            (FunApp (StanLib Minus__ FnPlain AoS)\n"
+      "             (" +
+      scalar_one + " " + exp_vector +
+      ")))\n"
+      "           (meta ((type_ UVector) (loc <opaque>) (adlevel "
+      "DataOnly))))";
+  std::string nested_math = base;
+  if (replace_reduction_after(nested_math, prod_call, vector_node, unsafe_minus,
+                              "nested vector math product"))
+    expect_reduction_interp(nested_math, "expression surface",
+                            "prod(1-exp(x)) stays interpreted");
+
+  // A dynamic product in log_prob must retain the old unsupported/fallback
+  // behavior; the forward-only opcode is never admitted to reverse mode.
+  std::string reverse = base;
+  const size_t log_prod = reverse.find("(FunApp (StanLib prod");
+  const std::string data_node =
+      "((pattern (Var d))\n"
+      "               (meta ((type_ UVector) (loc <opaque>) (adlevel "
+      "DataOnly))))";
+  const std::string active_node =
+      "((pattern (Var x))\n"
+      "               (meta ((type_ UVector) (loc <opaque>) (adlevel "
+      "AutoDiffable))))";
+  if (replace_reduction_after(reverse, log_prod, data_node, active_node,
+                              "reverse-mode product")) {
+    bool refused = false;
+    try {
+      (void)compile_model(reverse, reduction_data());
+    } catch (const CompileError& e) {
+      refused = std::string(e.what()).find("unsupported function prod") !=
+                std::string::npos;
+    }
+    if (!refused) {
+      ++failures;
+      std::printf("FAIL dynamic log_prob product was not refused\n");
+    }
+  }
+
+  const size_t sum_call = base.find("(FunApp (StanLib sum", prod_call);
+  const std::string sum_arg =
+      "((pattern (Var z))\n"
+      "           (meta ((type_ (UArray UInt)) (loc <opaque>) (adlevel "
+      "DataOnly))))";
+  if (sum_call == std::string::npos ||
+      base.find(sum_arg, sum_call) == std::string::npos) {
+    ++failures;
+    std::printf("FAIL reductions guard fixture has no runtime int sum\n");
+    return;
+  }
+
+  std::string nested_sum = base;
+  const std::string nested_arg =
+      "((pattern (Var z))\n"
+      "           (meta ((type_ (UArray (UArray UInt))) (loc <opaque>) "
+      "(adlevel DataOnly))))";
+  if (replace_reduction_after(nested_sum, sum_call, sum_arg, nested_arg,
+                              "nested int sum"))
+    expect_reduction_interp(nested_sum, "", "nested int sum fallback");
+
+  std::string unproved = base;
+  const size_t first_runtime_rng =
+      unproved.find("(FunApp (StanLib bernoulli_rng", prod_call);
+  if (first_runtime_rng == std::string::npos) {
+    ++failures;
+    std::printf("FAIL reductions guard fixture has no Bernoulli source\n");
+  } else {
+    unproved.replace(first_runtime_rng,
+                     std::string("(FunApp (StanLib bernoulli_rng").size(),
+                     "(FunApp (StanLib poisson_log_rng");
+    expect_reduction_interp(unproved, "unproved integral slot values",
+                            "unproved runtime int sum fallback");
+  }
+
+  std::string overflow = base;
+  const size_t first_z = overflow.find("((LVariable z)", prod_call);
+  const size_t index_one = overflow.find("(Lit Int 1)", first_z);
+  const size_t value_one = overflow.find("(Lit Int 1)", index_one + 1);
+  if (value_one == std::string::npos) {
+    ++failures;
+    std::printf("FAIL reductions guard cannot find overflow literal\n");
+  } else {
+    overflow.replace(value_one, std::string("(Lit Int 1)").size(),
+                     "(Lit Int 2147483647)");
+    expect_reduction_interp(overflow, "overflow int32",
+                            "overflowing runtime int sum fallback");
+  }
+
+  // Default local ints are INT_MIN sentinels, not zero.  Re-target the z[3]
+  // write to z[2], leaving one element definitely uninitialized: a range hull
+  // over the written values alone must not authorize the sum.
+  std::string partial = base;
+  size_t z_assignment = partial.find("((LVariable z)", prod_call);
+  for (int occurrence = 1; occurrence < 3 && z_assignment != std::string::npos;
+       ++occurrence)
+    z_assignment = partial.find("((LVariable z)", z_assignment + 1);
+  const size_t index_three = partial.find("(Lit Int 3)", z_assignment);
+  if (z_assignment == std::string::npos || index_three == std::string::npos) {
+    ++failures;
+    std::printf("FAIL reductions guard cannot find z[3] write\n");
+  } else {
+    partial.replace(index_three, std::string("(Lit Int 3)").size(),
+                    "(Lit Int 2)");
+    expect_reduction_interp(partial, "not definitely initialized",
+                            "partially initialized runtime int sum fallback");
+    std::vector<std::string> names;
+    const std::vector<double> row = eval_reduction_interp(partial, &names);
+    double z_sum = 0.0, total = 0.0;
+    bool found_uninitialized = false, found_total = false;
+    for (size_t i = 0; i < row.size(); ++i) {
+      if (names[i].rfind("z.", 0) == 0) z_sum += row[i];
+      if (names[i] == "z.3")
+        found_uninitialized =
+            row[i] == static_cast<double>(std::numeric_limits<int>::min());
+      if (names[i] == "total") {
+        found_total = true;
+        total = row[i];
+      }
+    }
+    if (!found_uninitialized || !found_total || total != z_sum) {
+      ++failures;
+      std::printf(
+          "FAIL partially initialized interpreter did not preserve the "
+          "INT_MIN sentinel\n");
+    }
+  }
+
+  const std::string empty_slice =
+      "((pattern\n"
+      "            (Indexed\n"
+      "             ((pattern (Var z))\n"
+      "              (meta ((type_ (UArray UInt)) (loc <opaque>) (adlevel "
+      "DataOnly))))\n"
+      "             ((Between\n"
+      "               ((pattern (Lit Int 1))\n"
+      "                (meta ((type_ UInt) (loc <opaque>) (adlevel "
+      "DataOnly))))\n"
+      "               ((pattern (Lit Int 0))\n"
+      "                (meta ((type_ UInt) (loc <opaque>) (adlevel "
+      "DataOnly))))))))\n"
+      "           (meta ((type_ (UArray UInt)) (loc <opaque>) (adlevel "
+      "DataOnly))))";
+  std::string empty_sum = base;
+  if (replace_reduction_after(empty_sum, sum_call, sum_arg, empty_slice,
+                              "empty int sum"))
+    expect_reduction_interp(empty_sum, "", "empty direct int sum fallback");
+
+  // The generated fixture's reversed 10:0 write proves that arbitrary
+  // reversed ranges are harmless empty updates.  Mutate its later 4:5 write
+  // to pin both sides of the bounds check and a width mismatch; every case
+  // must fail closed to WaInterp, which then reports the same invalid write.
+  const size_t tail_range = base.rfind("((Between");
+  const size_t tail_lo = base.find("(Lit Int 4)", tail_range);
+  const size_t tail_hi = base.find("(Lit Int 5)", tail_lo);
+  if (tail_range == std::string::npos || tail_lo == std::string::npos ||
+      tail_hi == std::string::npos) {
+    ++failures;
+    std::printf("FAIL reductions guard cannot find the 4:5 range write\n");
+  } else {
+    const auto expect_invalid_range = [&](long lo, long hi, const char* reason,
+                                          const char* what) {
+      std::string mutated = base;
+      mutated.replace(tail_hi, std::string("(Lit Int 5)").size(),
+                      "(Lit Int " + std::to_string(hi) + ")");
+      mutated.replace(tail_lo, std::string("(Lit Int 4)").size(),
+                      "(Lit Int " + std::to_string(lo) + ")");
+      expect_reduction_interp(mutated, reason, what);
+      try {
+        std::vector<std::string> names;
+        (void)eval_reduction_interp(mutated, &names);
+        ++failures;
+        std::printf("FAIL %s: interpreter accepted invalid range\n", what);
+      } catch (const std::exception&) {
+      }
+    };
+    expect_invalid_range(0, 1, "out of bounds", "low OOB range assignment");
+    expect_invalid_range(5, 6, "out of bounds", "high OOB range assignment");
+    expect_invalid_range(4, 4, "size mismatch",
+                         "range assignment RHS width mismatch");
+
+    // A single range index on a matrix denotes rows, not a contiguous flat
+    // slice.  This first tranche has no strided multi-row write opcode.
+    std::string matrix_rows = base;
+    const size_t lhs_z = matrix_rows.rfind("(LVariable z)", tail_range);
+    if (lhs_z == std::string::npos) {
+      ++failures;
+      std::printf("FAIL reductions guard cannot find range target\n");
+    } else {
+      matrix_rows.replace(lhs_z, std::string("(LVariable z)").size(),
+                          "(LVariable partial_matrix)");
+      expect_reduction_interp(matrix_rows, "one-dimensional flat value",
+                              "matrix row-range assignment stays interpreted");
+    }
+  }
+}
+
+void test_runtime_int_sum_is_not_compile_time() {
+  const std::string base = slurp("tests/fixtures/gq_reductions.tmir.sexp");
+  const size_t sum_call = base.find(
+      "(FunApp (StanLib sum", base.find("(Assignment ((LVariable total)"));
+  const size_t insertion = base.find("((pattern\n     (NRFunApp", sum_call);
+  if (sum_call == std::string::npos || insertion == std::string::npos) {
+    ++failures;
+    std::printf("FAIL reductions fixture has no post-sum insertion point\n");
+    return;
+  }
+
+  const std::string runtime_index =
+      "((pattern\n"
+      "     (Assignment ((LVariable pr) ()) UReal\n"
+      "      ((pattern\n"
+      "        (Indexed\n"
+      "         ((pattern (Var x))\n"
+      "          (meta ((type_ UVector) (loc <opaque>) (adlevel "
+      "DataOnly))))\n"
+      "         ((Single\n"
+      "           ((pattern (Var total))\n"
+      "            (meta ((type_ UInt) (loc <opaque>) (adlevel "
+      "DataOnly))))))))\n"
+      "       (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))\n"
+      "    (meta <opaque>))\n   ";
+  std::string index = base;
+  index.insert(insertion, runtime_index);
+  expect_reduction_interp(index, "unknown int total",
+                          "runtime sum cannot provide an index", true);
+
+  const std::string runtime_shape =
+      "((pattern\n"
+      "     (Decl (decl_adtype DataOnly) (decl_id shaped)\n"
+      "      (decl_type\n"
+      "       (Sized\n"
+      "        (SVector AoS\n"
+      "         ((pattern (Var total))\n"
+      "          (meta ((type_ UInt) (loc <opaque>) (adlevel "
+      "DataOnly)))))))\n"
+      "      (initialize Default)))\n"
+      "    (meta <opaque>))\n   ";
+  std::string shape = base;
+  shape.insert(insertion, runtime_shape);
+  expect_reduction_interp(shape, "unknown int total",
+                          "runtime sum cannot provide a shape", true);
+
+  const std::string runtime_loop =
+      "((pattern\n"
+      "     (For (loopvar i)\n"
+      "      (lower\n"
+      "       ((pattern (Lit Int 1))\n"
+      "        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))\n"
+      "      (upper\n"
+      "       ((pattern (Var total))\n"
+      "        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))\n"
+      "      (body\n"
+      "       ((pattern (Block (((pattern Skip) (meta <opaque>)))))\n"
+      "        (meta <opaque>)))))\n"
+      "    (meta <opaque>))\n   ";
+  std::string loop = base;
+  loop.insert(insertion, runtime_loop);
+  expect_reduction_interp(loop, "unknown int total",
+                          "runtime sum cannot provide a loop bound", true);
+
+  const std::string runtime_condition =
+      "((pattern\n"
+      "     (IfElse\n"
+      "      ((pattern (Var total))\n"
+      "       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))\n"
+      "      ((pattern (Block (((pattern Skip) (meta <opaque>)))))\n"
+      "       (meta <opaque>))\n"
+      "      ()))\n"
+      "    (meta <opaque>))\n   ";
+  std::string condition = base;
+  condition.insert(insertion, runtime_condition);
+  expect_reduction_interp(condition, "data-only condition is unavailable",
+                          "runtime sum cannot provide a condition", true);
+}
+
+void test_runtime_int_sum_redeclaration_shadowing() {
+  using namespace stanli;
+  const std::string base = slurp("tests/fixtures/gq_reductions.tmir.sexp");
+  const size_t sum = base.find("(FunApp (StanLib sum",
+                               base.find("(Assignment ((LVariable total)"));
+  const size_t insertion = base.find("((pattern\n     (NRFunApp", sum);
+  if (sum == std::string::npos || insertion == std::string::npos) {
+    ++failures;
+    std::printf(
+        "FAIL reductions fixture has no post-sum redeclaration "
+        "point\n");
+    return;
+  }
+
+  const std::string literal_decl =
+      "((pattern\n"
+      "     (Decl (decl_adtype DataOnly) (decl_id total)\n"
+      "      (decl_type (Sized SInt))\n"
+      "      (initialize\n"
+      "       (Assign\n"
+      "        ((pattern (Lit Int 2))\n"
+      "         (meta ((type_ UInt) (loc <opaque>) (adlevel "
+      "DataOnly))))))))\n"
+      "    (meta <opaque>))\n   ";
+  std::string literal = base;
+  literal.insert(insertion, literal_decl);
+  CompiledModel cm = compile_model(literal, reduction_data());
+  if (!cm.write_array || cm.write_array->interp) {
+    ++failures;
+    std::printf(
+        "FAIL same-id literal int redeclaration did not compile: %s\n",
+        cm.write_array ? cm.write_array->truncated.c_str() : "no write_array");
+  } else {
+    Executor graph(std::move(cm.write_array->graph));
+    cm.write_array->bind(graph);
+    graph.params_data()[0] = 0.25;
+    for (int i = 0; i < 5; ++i) graph.params_data()[1 + i] = 0.5;
+    WaRng rng(44);
+    graph.run_forward_only(EvalState{&rng});
+    const std::vector<std::string> names =
+        CompiledModel::csv_names(cm.write_array->columns);
+    bool found = false;
+    size_t at = 0;
+    for (const auto& column : cm.write_array->columns) {
+      const double* values = graph.value_ptr(column.slot);
+      for (int64_t i = 0; i < column.len; ++i, ++at) {
+        if (names[at] != "total") continue;
+        found = true;
+        if (reduction_bits(values[column.storage_index(i)]) !=
+            reduction_bits(2.0)) {
+          ++failures;
+          std::printf("FAIL stale runtime sum shadowed later literal int\n");
+        }
+      }
+    }
+    if (!found) {
+      ++failures;
+      std::printf("FAIL same-id literal test has no total column\n");
+    }
+  }
+
+  const std::string uninitialized_decl =
+      "((pattern\n"
+      "     (Decl (decl_adtype DataOnly) (decl_id total)\n"
+      "      (decl_type (Sized SInt)) (initialize Uninit)))\n"
+      "    (meta <opaque>))\n   ";
+  std::string uninitialized = base;
+  uninitialized.insert(insertion, uninitialized_decl);
+  expect_reduction_interp(uninitialized, "unknown variable total",
+                          "same-id uninitialized int fails closed", true);
+  std::vector<std::string> names;
+  const std::vector<double> row = eval_reduction_interp(uninitialized, &names);
+  bool found_sentinel = false;
+  for (size_t i = 0; i < row.size(); ++i)
+    if (names[i] == "total" &&
+        row[i] == static_cast<double>(std::numeric_limits<int>::min()))
+      found_sentinel = true;
+  if (!found_sentinel) {
+    ++failures;
+    std::printf(
+        "FAIL uninitialized scalar interpreter did not preserve the "
+        "INT_MIN sentinel\n");
+  }
+}
+
 int main() {
   test_naming_rules();
   test_wanames_pipeline();
@@ -863,6 +2052,11 @@ int main() {
   test_binomial_rng_helper_contract();
   test_binomial_rng_lowering_guards();
   test_compiled_scalar_rng();
+  test_product_exact_grouping();
+  test_compiled_gq_reductions();
+  test_gq_reduction_lowering_guards();
+  test_runtime_int_sum_is_not_compile_time();
+  test_runtime_int_sum_redeclaration_shadowing();
   test_caller_owned_rng();
   test_transformed_parameter_checks();
   if (failures == 0) std::printf("test_write_array OK\n");


### PR DESCRIPTION
## Summary

- add a forward-only `OP_PROD_VEC` for audited generated-quantities vector and row-vector surfaces
- preserve Stan Math packet grouping for materialized vectors and ascending scalar grouping for strided matrix rows
- compile one-dimensional runtime integer `sum` only with complete initialization, integral-range, and int32 overflow proofs
- keep shifted views, arbitrary expressions, UDF formals, dynamic geometry/control, reverse-mode products, and unproved sums on `WaInterp`
- harden integer sentinels and range assignments while adding exact pass, fallback, stream, and grouping tests

This moves `Mh_model`, `Mt_model`, `Mtbh_model`, and `Mth_model` from whole-section interpretation to graph execution. The 24-model write-array census moves from 12 compiled / 12 interpreted to 16 / 8, while all 119 compilable corpus models still emit complete rows.

## Measured first

Targeted C-ABI A/B at point 0, two warmups, seven matched batch medians:

| Model | Interpreted | Compiled | Speedup |
| --- | ---: | ---: | ---: |
| `Mh_model` | 869.1794 us | 12.4941 us | 69.57x |
| `Mt_model` | 20.8673 us | 0.1266 us | 164.83x |
| `Mtbh_model` | 1046.4414 us | 9.8556 us | 106.18x |
| `Mth_model` | 1098.8496 us | 18.2054 us | 60.36x |

Across 1,000 rows of each model, row time falls from 3.035338 s to 0.040682 s, or 74.61x. Including one construction per model, total time falls from 3.056579 s to 0.075491 s, or 40.49x; equal-mix setup breaks even after five rows per model.

## Exactness

- all product-fed RNG outputs, final integer sums, and fourth-row stream-continuation sentinels match both current and frozen interpreters bit-for-bit across six seeds
- current and frozen interpreters match all 146,196 compared values
- the only graph/interpreter differences are the documented pre-existing 1-2 ULP `p` transformed-parameter boundary in `Mtbh_model` and `Mth_model`; the graph is closer to live CmdStan at the shared point
- product grouping tests cover packet widths and offsets, signed zero, NaN/Inf, UDF and shifted-view refusal, transpose-of-vector, and actual strided matrix rows

## Validation

- fresh Release all-target build
- CTest: 59/59
- reference corpus: 129/129 models at three points, 800,674 values
- `tools/format.sh --check`
- `python3 tools/gen_docs.py --check`
- `python3 tools/gen_web_models.py --check`
- `git diff --check`
