### PR TITLE
perf: compile generated-quantities extrema

### DIFF
--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -237,7 +237,8 @@ the top of the page, not replacements for the current corpus rows:
   interpreter. This moved `Mh_model`, `Mt_model`, `Mtbh_model`, and `Mth_model`
   to the graph, taking the then-current 24-model census from 12 graph / 12
   interpreter to 16 / 8. The categorical tranche below subsequently advances
-  that census to 17 / 7. All 119 compiling corpus models still produce complete
+  that census to 17 / 7, and the extrema tranche after it advances the current
+  census to 18 / 6. All 119 compiling corpus models still produce complete
   rows. A targeted 2026-08-24 C-ABI A/B (point 0, two warmups, seven matched
   batch medians) measured:
 
@@ -287,6 +288,32 @@ the top of the page, not replacements for the current corpus rows:
   direct pinned Stan Math call, then comparing the next engine state. These
   targeted results do not refresh `docs/corpus-bench.tsv` or the generated
   full-corpus table below.
+- **Compiled generated-quantities extrema** add the forward-only
+  `OP_EXTREMA_VEC` min/max variants. Lowering admits only a top-level
+  write-array call on a direct `UVector` or `URowVector` `Var` and evaluates
+  it with the same address-independent grouping that pinned Stan Math uses for
+  an owning Eigen value. Empty-real results are preserved: `min` is positive
+  infinity and `max` is negative infinity. Arrays, matrices, indexed views,
+  expressions, and UDF calls still select `WaInterp`; reverse-mode uses remain
+  refused.
+  The opcode is explicitly excluded from reroll matching and interpreter
+  islands because it has no reverse kernel.
+
+  `losscurve_sislob` was the only model to change in the exact 24-model
+  census, moving graph/interpreter coverage from 17 / 7 to the current 18 / 6;
+  all 24 census models and all 119 compiling corpus models retained complete
+  rows. Its 1,218-op graph contains exactly one length-10 min opcode and one
+  length-10 max opcode, and writes 384 columns. Graph and `WaInterp` matched
+  bitwise for all 1,536/1,536 compared values; the same-input pinned Stan Math
+  check matched 8/8 cases.
+  Against 1,200 stored CmdStan values, the worst difference was 4.44e-16, or
+  eight ULP.
+
+  In a targeted matched C-ABI A/B, `losscurve_sislob` moved from 329.9520 to
+  3.3704 us/row (97.8970x), saving 0.3265816 s per 1,000 rows. Construction
+  moved from 4107.375 to 5291.959 us, a 1184.584 us setup increase that
+  amortizes after 3.627 rows, or four whole rows. These targeted results do not
+  refresh `docs/corpus-bench.tsv` or the generated full-corpus table below.
 - **Allocation-free ODE right-hand-side input seeding** removes the promoted
   `y` and `theta` staging vectors built on every solver callback and seeds the
   reusable register file directly. A targeted 2026-08-24 Release A/B (seven

--- a/runtime/include/stanli/mir.hpp
+++ b/runtime/include/stanli/mir.hpp
@@ -124,6 +124,32 @@ inline ProdGrouping prod_grouping(const Expr& product_arg) {
   return scalar ? ProdGrouping::Scalar : ProdGrouping::Packet;
 }
 
+// One-argument min/max is overloaded across scalars, arrays, matrices, and
+// Eigen expressions.  Only a named Eigen vector has the owning-storage
+// evaluator provenance audited by the generated-quantities extrema opcode.
+// Keeping the function kind in the classifier makes every excluded or
+// malformed call an explicit Legacy result instead of inferring semantics
+// from a loosely typed argument.
+enum class ExtremaKind : uint8_t { Legacy, Min, Max };
+
+inline ExtremaKind extrema_kind(const Expr& call) {
+  if (call.kind != Expr::FunApp || call.fn_lib != Expr::Lib::StanLib ||
+      call.args.size() != 1 || call.type_ != "UReal" ||
+      call.unsized.leaf != UnsizedLeaf::Real || call.unsized.depth != 0)
+    return ExtremaKind::Legacy;
+  const Expr& arg = call.args[0];
+  const bool vector_arg = arg.kind == Expr::Var && arg.type_ == "UVector" &&
+                          arg.unsized.leaf == UnsizedLeaf::Vector &&
+                          arg.unsized.depth == 0;
+  const bool row_vector_arg =
+      arg.kind == Expr::Var && arg.type_ == "URowVector" &&
+      arg.unsized.leaf == UnsizedLeaf::RowVector && arg.unsized.depth == 0;
+  if (!vector_arg && !row_vector_arg) return ExtremaKind::Legacy;
+  if (call.name == "min") return ExtremaKind::Min;
+  if (call.name == "max") return ExtremaKind::Max;
+  return ExtremaKind::Legacy;
+}
+
 struct Transform {
   // The names are stanc3's own MIR tags, so a new transform in the
   // compiler is greppable here.

--- a/runtime/include/stanli/mir_interp.hpp
+++ b/runtime/include/stanli/mir_interp.hpp
@@ -1643,6 +1643,32 @@ class MirInterp {
     if (e.name == "PNot__")
       return un([](const T& x) { return T(val(x) == 0.0 ? 1.0 : 0.0); });
     if (e.name == "max" || e.name == "min") {
+      const bool owning_vector_context =
+          where_ == "write_array" || where_ == "prepare_data";
+      const mir::ExtremaKind native_kind =
+          owning_vector_context && udf_depth_ == 0 ? mir::extrema_kind(e)
+                                                   : mir::ExtremaKind::Legacy;
+      if (native_kind != mir::ExtremaKind::Legacy) {
+        Value a = eval(e.args[0]);
+        if (a.r.empty()) {
+          r.r = {native_kind == mir::ExtremaKind::Min
+                     ? T(std::numeric_limits<double>::infinity())
+                     : T(-std::numeric_limits<double>::infinity())};
+          return r;
+        }
+        // The std::vector backing an interpreted value has no aligned-owning
+        // address contract.  Clear DirectAccessBit but retain packet access,
+        // making lane zero Eigen's packet start just as for CmdStan's owning
+        // vector and the graph kernel.
+        using Vec = Eigen::Matrix<T, Eigen::Dynamic, 1>;
+        const Eigen::Map<const Vec> input(a.r.data(), a.r.size());
+        const auto owning_grouping =
+            input.unaryExpr(Eigen::internal::core_cast_op<T, T>());
+        r.r = {native_kind == mir::ExtremaKind::Min
+                   ? stan::math::min(owning_grouping)
+                   : stan::math::max(owning_grouping)};
+        return r;
+      }
       // std::max/min semantics on values, not fmax/fmin: NaN handling and
       // tie selection must not change under the template.
       const auto vmax = [](const T& x, const T& y) {
@@ -1659,6 +1685,19 @@ class MirInterp {
         r.is_int = a.is_int && b.is_int;
         if (r.is_int) r.i = {(int)val(m)};
         r.r = {m};
+        return r;
+      }
+      if (a.r.empty()) {
+        if (a.is_int) {
+          // Preserve Stan Math's exception class and diagnostic for the
+          // excluded integer-container overload.
+          if (e.name == "min")
+            (void)stan::math::min(a.i);
+          else
+            (void)stan::math::max(a.i);
+        }
+        r.r = {e.name == "min" ? T(std::numeric_limits<double>::infinity())
+                               : T(-std::numeric_limits<double>::infinity())};
         return r;
       }
       T m = a.r.at(0);

--- a/runtime/include/stanli/optable.hpp
+++ b/runtime/include/stanli/optable.hpp
@@ -149,7 +149,8 @@ namespace stanli {
   X(OP_REJECT)                      \
   X(OP_PRINT)                       \
   X(OP_DIRICHLET_LPDF)              \
-  X(OP_PROD_VEC)
+  X(OP_PROD_VEC)                    \
+  X(OP_EXTREMA_VEC)
 
 // Scalar densities, one line each: this list generates the opcode, the
 // name, the kernel, its registration, and the lowering table entry

--- a/runtime/kernels/elementwise.cpp
+++ b/runtime/kernels/elementwise.cpp
@@ -3,9 +3,12 @@
 #include <stanli/optable.hpp>
 
 #include <stan/math/prim/fun/prod.hpp>
+#include <stan/math/prim/fun/max.hpp>
+#include <stan/math/prim/fun/min.hpp>
 
 #include <cassert>
 #include <cmath>
+#include <limits>
 
 namespace stanli {
 namespace {
@@ -169,6 +172,29 @@ void prod_vec_fwd(KernelCtx& ctx) {
   const Eigen::Map<const Vec> input(ctx.in[0].data, ctx.in[0].len);
   ctx.out.data[0] = stan::math::prod(
       input.unaryExpr(Eigen::internal::core_cast_op<double, double>()));
+}
+
+// OP_EXTREMA_VEC: generated-quantities-only min/max of a direct named
+// vector/row-vector (variant 0/1).  Stan Math defines extrema of an empty real
+// Eigen container as +/- infinity.  For nonempty inputs, the same-type unary
+// expression deliberately clears DirectAccessBit while retaining packet
+// access, so Eigen begins its packet reduction at lane zero just as it does
+// for CmdStan's aligned owning VectorXd.  A direct Map would instead make
+// signed-zero/NaN tie grouping depend on this slot's arena address.
+void extrema_vec_fwd(KernelCtx& ctx) {
+  assert(ctx.variant <= 1);
+  if (ctx.in[0].len == 0) {
+    ctx.out.data[0] = ctx.variant == 0
+                          ? std::numeric_limits<double>::infinity()
+                          : -std::numeric_limits<double>::infinity();
+    return;
+  }
+  using Vec = Eigen::Matrix<double, Eigen::Dynamic, 1>;
+  const Eigen::Map<const Vec> input(ctx.in[0].data, ctx.in[0].len);
+  const auto owning_grouping =
+      input.unaryExpr(Eigen::internal::core_cast_op<double, double>());
+  ctx.out.data[0] = ctx.variant == 0 ? stan::math::min(owning_grouping)
+                                     : stan::math::max(owning_grouping);
 }
 
 // OP_INDEX: scalar out = in[flat], idata = {flat}. Backward scatters.
@@ -381,6 +407,7 @@ void register_elementwise_kernels() {
   register_kernel(OP_MATVEC, Kernel{matvec_fwd, matvec_bwd, nullptr});
   register_kernel(OP_SUM_VEC, Kernel{sum_vec_fwd, sum_vec_bwd, nullptr});
   register_kernel(OP_PROD_VEC, Kernel{prod_vec_fwd, nullptr, nullptr});
+  register_kernel(OP_EXTREMA_VEC, Kernel{extrema_vec_fwd, nullptr, nullptr});
   register_kernel(OP_INDEX, Kernel{index_fwd, index_bwd, nullptr});
   register_kernel(OP_SET_INDEX, Kernel{set_index_fwd, set_index_bwd, nullptr});
   register_kernel(OP_SET_INDEX_INPLACE, Kernel{set_index_inplace_fwd,

--- a/runtime/src/OPTIMIZATIONS.md
+++ b/runtime/src/OPTIMIZATIONS.md
@@ -311,7 +311,8 @@ using the result as dynamic control or geometry all fail closed.
 This completed `Mh_model`, `Mt_model`, `Mtbh_model`, and `Mth_model`, moving the
 then-current 24-model write-array census from 12 graph / 12 interpreter to
 16 / 8. The categorical tranche below subsequently advances that census to
-17 / 7. All 119 compiling corpus models still produce complete rows. Targeted
+17 / 7, and the extrema tranche after it advances the current census to 18 / 6.
+All 119 compiling corpus models still produce complete rows. Targeted
 2026-08-24 C-ABI A/B medians (point 0, two warmups, seven matched batches) were:
 
 | model | interpreted us/row | compiled us/row | speedup |
@@ -372,6 +373,38 @@ deterministic columns from the pre-existing graph/interpreter numerical
 boundary; those are not categorical or stream mismatches. These targeted
 results do not refresh `docs/corpus-bench.tsv` or the generated full-corpus
 table in `docs/benchmarks.md`.
+
+## Compiled generated-quantities extrema (`elementwise.cpp`, `lower.cpp`)
+
+`OP_EXTREMA_VEC` has forward-only variants for `min` and `max`. Its lowering
+gate is write-array only: a top-level call must consume a direct `UVector` or
+`URowVector` `Var`. The kernel uses the same address-independent grouping that
+the pinned Stan Math implementation applies to an owning Eigen value, while
+retaining its empty-real results: positive infinity for `min` and negative
+infinity for `max`. Arrays, matrices, indexed views, expressions, and UDF calls
+remain in `WaInterp`; reverse-mode uses remain refused.
+
+Because the opcode deliberately has no backward kernel, it is explicitly
+excluded from reroll matching and interpreter-island CALLs. This keeps the
+lowering gate forward-only rather than allowing a graph transformation to
+place it in a reverse sweep.
+
+`losscurve_sislob` was the only model to change in the exact 24-model census,
+moving coverage from 17 graph / 7 interpreter to the current 18 / 6. All 24
+census models and all 119 compiling corpus models retained complete rows. Its
+1,218-op graph contains exactly one length-10 min opcode and one length-10 max
+opcode, and writes 384 columns. Graph and `WaInterp` output was bitwise exact
+for all 1,536/1,536 compared values, and the same-input pinned Stan Math oracle
+matched 8/8 cases.
+Against 1,200 stored CmdStan values, the worst difference was 4.44e-16, or
+eight ULP.
+
+In a targeted matched C-ABI A/B, `losscurve_sislob` moved from 329.9520 to
+3.3704 us/row (97.8970x), saving 0.3265816 s per 1,000 rows. Construction moved
+from 4107.375 to 5291.959 us, a 1184.584 us setup increase that amortizes after
+3.627 rows, or four whole rows. These targeted results do not refresh
+`docs/corpus-bench.tsv` or the generated full-corpus table in
+`docs/benchmarks.md`.
 
 ## Control flow that depends on a parameter (`lower.cpp`, `mir_prog.hpp`)
 

--- a/runtime/src/island.cpp
+++ b/runtime/src/island.cpp
@@ -104,6 +104,7 @@ bool callable(const Graph& g, const Op& op) {
     case OP_ODE:
     case OP_RNG:
     case OP_PROD_VEC:
+    case OP_EXTREMA_VEC:
     case OP_PRINT:
     case OP_REJECT:
       return false;

--- a/runtime/src/lower.cpp
+++ b/runtime/src/lower.cpp
@@ -3229,6 +3229,23 @@ struct Lowering {
       Val a = lower_expr(e.args[0]);
       return emit_value(OP_LOGIT, {a}, g.slots[a.slot].len, a.si);
     }
+    if ((e.name == "min" || e.name == "max") && in_write_array) {
+      // Preserve the construction-time path for well-formed data-only
+      // extrema, including the scalar two-argument overload.  Dynamic
+      // lowering is deliberately much narrower.
+      if (e.args.size() == 1 || e.args.size() == 2)
+        if (auto v = fold_const(e)) return *v;
+      const mir::ExtremaKind kind = mir::extrema_kind(e);
+      if (udf_depth != 0 || kind == mir::ExtremaKind::Legacy)
+        fail("min/max expression surface stays on WaInterp", e.raw);
+      Val a = lower_expr(e.args[0]);
+      if ((!is_vector(a.si) && !is_row_vector(a.si)) || g.slots[a.slot].len < 0)
+        fail("min/max needs one vector or row-vector argument", e.raw);
+      Val result = emit_value(OP_EXTREMA_VEC, {a}, 1);
+      result.autodiff = false;
+      g.ops.back().variant = kind == mir::ExtremaKind::Max ? 1u : 0u;
+      return result;
+    }
     if (e.name == "mean") {
       Val a = lower_expr(e.args[0]);
       return emit_value(OP_MEAN, {a}, 1);

--- a/runtime/src/reroll.cpp
+++ b/runtime/src/reroll.cpp
@@ -90,7 +90,8 @@ bool ops_match(const Graph& g, const Op& a, const Op& b) {
       a.out2 >= 0 || b.out2 >= 0 || a.opcode == OP_CHECK_STRUCTURED ||
       a.opcode == OP_CHECK_MATCHING_DIMS || a.opcode == OP_CHECK_LOWER ||
       a.opcode == OP_CHECK_UPPER || a.opcode == OP_CATEGORICAL ||
-      a.opcode == OP_RNG || a.opcode == OP_PROD_VEC)
+      a.opcode == OP_RNG || a.opcode == OP_PROD_VEC ||
+      a.opcode == OP_EXTREMA_VEC)
     return false;
   for (int j = 0; j < a.n_in; ++j)
     if (g.slots[a.in[j]].len != g.slots[b.in[j]].len) return false;

--- a/tests/fixtures/gq_extrema.stan
+++ b/tests/fixtures/gq_extrema.stan
@@ -1,0 +1,20 @@
+data {
+  int<lower=0> N;
+  vector[N] d;
+}
+parameters {
+  vector[N] x;
+  row_vector[N] xr;
+}
+model {
+  x ~ normal(0, 1);
+  xr ~ normal(0, 1);
+}
+generated quantities {
+  real x_min = min(x);
+  real x_max = max(x);
+  real xr_min = min(xr);
+  real xr_max = max(xr);
+  real d_min = min(d);
+  real d_max = max(d);
+}

--- a/tests/fixtures/gq_extrema.tmir.sexp
+++ b/tests/fixtures/gq_extrema.tmir.sexp
@@ -1,0 +1,728 @@
+((functions_block ())
+ (input_vars
+  ((N <opaque> SInt)
+   (d <opaque>
+    (SVector AoS
+     ((pattern (Var N)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+ (prepare_data
+  (((pattern
+     (Decl (decl_adtype DataOnly) (decl_id pos__) (decl_type (Sized SInt))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable pos__) ()) UInt
+      ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id N) (decl_type (Sized SInt))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable N) ()) UInt
+      ((pattern
+        (Indexed
+         ((pattern
+           (FunApp (CompilerInternal FnReadData)
+            (((pattern (Lit Str N))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+          (meta ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly))))
+         ((Single
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnCheck
+        (trans
+         (Lower
+          ((pattern (Lit Int 0)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (var_name N)
+        (var ((pattern (Var N)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (((pattern (Lit Int 0)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp (CompilerInternal FnValidateSize)
+      (((pattern (Lit Str d)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+       ((pattern (Lit Str N)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+       ((pattern (Var N)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id d)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Var N)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id d_flat__)
+          (decl_type (Unsized (UArray UReal))) (initialize Uninit)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable d_flat__) ()) (UArray UReal)
+          ((pattern
+            (FunApp (CompilerInternal FnReadData)
+             (((pattern (Lit Str d))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable pos__) ()) UInt
+          ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar sym1__)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Var N)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (Assignment
+                  ((LVariable d)
+                   ((Single
+                     ((pattern (Var sym1__))
+                      (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                  UVector
+                  ((pattern
+                    (Indexed
+                     ((pattern (Var d_flat__))
+                      (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))
+                     ((Single
+                       ((pattern (Var pos__))
+                        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+                (meta <opaque>))
+               ((pattern
+                 (Assignment ((LVariable pos__) ()) UInt
+                  ((pattern
+                    (FunApp (StanLib Plus__ FnPlain AoS)
+                     (((pattern (Var pos__))
+                       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                      ((pattern (Lit Int 1))
+                       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp (CompilerInternal FnValidateSize)
+      (((pattern (Lit Str x)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+       ((pattern (Lit Str N)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+       ((pattern (Var N)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp (CompilerInternal FnValidateSize)
+      (((pattern (Lit Str xr)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+       ((pattern (Lit Str N)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+       ((pattern (Var N)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+    (meta <opaque>))))
+ (log_prob
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id x)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Var N)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity)
+             (dims
+              (((pattern (Var N))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id xr)
+      (decl_type
+       (Sized
+        (SRowVector AoS
+         ((pattern (Var N)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity)
+             (dims
+              (((pattern (Var N))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern AoS)))
+           ()))
+         (meta ((type_ URowVector) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib normal_lpdf (FnLpdf true) AoS)
+             (((pattern (Var x))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))
+              ((pattern
+                (Promotion
+                 ((pattern (Lit Int 0))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                 UReal DataOnly))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+              ((pattern
+                (Promotion
+                 ((pattern (Lit Int 1))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                 UReal DataOnly))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>))
+       ((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib normal_lpdf (FnLpdf true) AoS)
+             (((pattern (Var xr))
+               (meta ((type_ URowVector) (loc <opaque>) (adlevel AutoDiffable))))
+              ((pattern
+                (Promotion
+                 ((pattern (Lit Int 0))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                 UReal DataOnly))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+              ((pattern
+                (Promotion
+                 ((pattern (Lit Int 1))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                 UReal DataOnly))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>)))))
+    (meta <opaque>))))
+ (reverse_mode_log_prob
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id x)
+      (decl_type
+       (Sized
+        (SVector SoA
+         ((pattern (Var N)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity)
+             (dims
+              (((pattern (Var N))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern SoA)))
+           ()))
+         (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id xr)
+      (decl_type
+       (Sized
+        (SRowVector SoA
+         ((pattern (Var N)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity)
+             (dims
+              (((pattern (Var N))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern SoA)))
+           ()))
+         (meta ((type_ URowVector) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib normal_lpdf (FnLpdf true) SoA)
+             (((pattern (Var x))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))
+              ((pattern
+                (Promotion
+                 ((pattern (Lit Int 0))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                 UReal DataOnly))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+              ((pattern
+                (Promotion
+                 ((pattern (Lit Int 1))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                 UReal DataOnly))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>))
+       ((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib normal_lpdf (FnLpdf true) SoA)
+             (((pattern (Var xr))
+               (meta ((type_ URowVector) (loc <opaque>) (adlevel AutoDiffable))))
+              ((pattern
+                (Promotion
+                 ((pattern (Lit Int 0))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                 UReal DataOnly))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+              ((pattern
+                (Promotion
+                 ((pattern (Lit Int 1))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                 UReal DataOnly))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>)))))
+    (meta <opaque>))))
+ (generate_quantities
+  (((pattern
+     (Decl (decl_adtype DataOnly) (decl_id x)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Var N)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity)
+             (dims
+              (((pattern (Var N))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id xr)
+      (decl_type
+       (Sized
+        (SRowVector AoS
+         ((pattern (Var N)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity)
+             (dims
+              (((pattern (Var N))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern AoS)))
+           ()))
+         (meta ((type_ URowVector) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt ())
+        (var
+         ((pattern (Var x)) (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt ())
+        (var
+         ((pattern (Var xr))
+          (meta ((type_ URowVector) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (IfElse
+      ((pattern
+        (FunApp (StanLib PNot__ FnPlain AoS)
+         (((pattern
+            (EOr
+             ((pattern (Var emit_transformed_parameters__))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+             ((pattern (Var emit_generated_quantities__))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+      ((pattern (Block (((pattern (Return ())) (meta <opaque>))))) (meta <opaque>)) ()))
+    (meta <opaque>))
+   ((pattern
+     (IfElse
+      ((pattern
+        (FunApp (StanLib PNot__ FnPlain AoS)
+         (((pattern (Var emit_generated_quantities__))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+      ((pattern (Block (((pattern (Return ())) (meta <opaque>))))) (meta <opaque>)) ()))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id x_min) (decl_type (Sized SReal))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable x_min) ()) UReal
+      ((pattern
+        (FunApp (StanLib min FnPlain AoS)
+         (((pattern (Var x)) (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id x_max) (decl_type (Sized SReal))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable x_max) ()) UReal
+      ((pattern
+        (FunApp (StanLib max FnPlain AoS)
+         (((pattern (Var x)) (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id xr_min) (decl_type (Sized SReal))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable xr_min) ()) UReal
+      ((pattern
+        (FunApp (StanLib min FnPlain AoS)
+         (((pattern (Var xr))
+           (meta ((type_ URowVector) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id xr_max) (decl_type (Sized SReal))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable xr_max) ()) UReal
+      ((pattern
+        (FunApp (StanLib max FnPlain AoS)
+         (((pattern (Var xr))
+           (meta ((type_ URowVector) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id d_min) (decl_type (Sized SReal))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable d_min) ()) UReal
+      ((pattern
+        (FunApp (StanLib min FnPlain AoS)
+         (((pattern (Var d)) (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id d_max) (decl_type (Sized SReal))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable d_max) ()) UReal
+      ((pattern
+        (FunApp (StanLib max FnPlain AoS)
+         (((pattern (Var d)) (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt ())
+        (var
+         ((pattern (Var x_min)) (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt ())
+        (var
+         ((pattern (Var x_max)) (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt ())
+        (var
+         ((pattern (Var xr_min))
+          (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt ())
+        (var
+         ((pattern (Var xr_max))
+          (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt ())
+        (var
+         ((pattern (Var d_min)) (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt ())
+        (var
+         ((pattern (Var d_max)) (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))))
+ (transform_inits
+  (((pattern
+     (Decl (decl_adtype DataOnly) (decl_id pos__) (decl_type (Sized SInt))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable pos__) ()) UInt
+      ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id x)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Var N)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id x_flat__)
+          (decl_type (Unsized (UArray UReal))) (initialize Uninit)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable x_flat__) ()) (UArray UReal)
+          ((pattern
+            (FunApp (CompilerInternal FnReadData)
+             (((pattern (Lit Str x))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable pos__) ()) UInt
+          ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar sym1__)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Var N)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (Assignment
+                  ((LVariable x)
+                   ((Single
+                     ((pattern (Var sym1__))
+                      (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                  UVector
+                  ((pattern
+                    (Indexed
+                     ((pattern (Var x_flat__))
+                      (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))
+                     ((Single
+                       ((pattern (Var pos__))
+                        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+                (meta <opaque>))
+               ((pattern
+                 (Assignment ((LVariable pos__) ()) UInt
+                  ((pattern
+                    (FunApp (StanLib Plus__ FnPlain AoS)
+                     (((pattern (Var pos__))
+                       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                      ((pattern (Lit Int 1))
+                       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var x)) (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id xr)
+      (decl_type
+       (Sized
+        (SRowVector AoS
+         ((pattern (Var N)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id xr_flat__)
+          (decl_type (Unsized (UArray UReal))) (initialize Uninit)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable xr_flat__) ()) (UArray UReal)
+          ((pattern
+            (FunApp (CompilerInternal FnReadData)
+             (((pattern (Lit Str xr))
+               (meta ((type_ URowVector) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable pos__) ()) UInt
+          ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar sym1__)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Var N)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (Assignment
+                  ((LVariable xr)
+                   ((Single
+                     ((pattern (Var sym1__))
+                      (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                  URowVector
+                  ((pattern
+                    (Indexed
+                     ((pattern (Var xr_flat__))
+                      (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))
+                     ((Single
+                       ((pattern (Var pos__))
+                        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+                (meta <opaque>))
+               ((pattern
+                 (Assignment ((LVariable pos__) ()) UInt
+                  ((pattern
+                    (FunApp (StanLib Plus__ FnPlain AoS)
+                     (((pattern (Var pos__))
+                       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                      ((pattern (Lit Int 1))
+                       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var xr))
+          (meta ((type_ URowVector) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))))
+ (unconstrain_array
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id x)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Var N)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable x) ()) UVector
+      ((pattern
+        (FunApp (CompilerInternal FnReadDeserializer)
+         (((pattern (Var N)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var x)) (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id xr)
+      (decl_type
+       (Sized
+        (SRowVector AoS
+         ((pattern (Var N)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable xr) ()) URowVector
+      ((pattern
+        (FunApp (CompilerInternal FnReadDeserializer)
+         (((pattern (Var N)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ URowVector) (loc <opaque>) (adlevel AutoDiffable))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var xr))
+          (meta ((type_ URowVector) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))))
+ (output_vars
+  ((x <opaque>
+    ((out_unconstrained_st
+      (SVector AoS
+       ((pattern (Var N)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+     (out_constrained_st
+      (SVector AoS
+       ((pattern (Var N)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+     (out_block Parameters) (out_trans Identity)))
+   (xr <opaque>
+    ((out_unconstrained_st
+      (SRowVector AoS
+       ((pattern (Var N)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+     (out_constrained_st
+      (SRowVector AoS
+       ((pattern (Var N)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+     (out_block Parameters) (out_trans Identity)))
+   (x_min <opaque>
+    ((out_unconstrained_st SReal) (out_constrained_st SReal)
+     (out_block GeneratedQuantities) (out_trans Identity)))
+   (x_max <opaque>
+    ((out_unconstrained_st SReal) (out_constrained_st SReal)
+     (out_block GeneratedQuantities) (out_trans Identity)))
+   (xr_min <opaque>
+    ((out_unconstrained_st SReal) (out_constrained_st SReal)
+     (out_block GeneratedQuantities) (out_trans Identity)))
+   (xr_max <opaque>
+    ((out_unconstrained_st SReal) (out_constrained_st SReal)
+     (out_block GeneratedQuantities) (out_trans Identity)))
+   (d_min <opaque>
+    ((out_unconstrained_st SReal) (out_constrained_st SReal)
+     (out_block GeneratedQuantities) (out_trans Identity)))
+   (d_max <opaque>
+    ((out_unconstrained_st SReal) (out_constrained_st SReal)
+     (out_block GeneratedQuantities) (out_trans Identity)))))
+ (prog_name gq_extrema_model) (prog_path tests/fixtures/gq_extrema.stan))

--- a/tests/fixtures/gq_extrema_reverse.stan
+++ b/tests/fixtures/gq_extrema_reverse.stan
@@ -1,0 +1,6 @@
+parameters {
+  vector[2] x;
+}
+model {
+  target += min(x);
+}

--- a/tests/fixtures/gq_extrema_reverse.tmir.sexp
+++ b/tests/fixtures/gq_extrema_reverse.tmir.sexp
@@ -1,0 +1,227 @@
+((functions_block ()) (input_vars ()) (prepare_data ())
+ (log_prob
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id x)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity)
+             (dims
+              (((pattern (Lit Int 2))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib min FnPlain AoS)
+             (((pattern (Var x))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>)))))
+    (meta <opaque>))))
+ (reverse_mode_log_prob
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id x)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity)
+             (dims
+              (((pattern (Lit Int 2))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib min FnPlain AoS)
+             (((pattern (Var x))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>)))))
+    (meta <opaque>))))
+ (generate_quantities
+  (((pattern
+     (Decl (decl_adtype DataOnly) (decl_id x)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity)
+             (dims
+              (((pattern (Lit Int 2))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt ())
+        (var
+         ((pattern (Var x)) (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (IfElse
+      ((pattern
+        (FunApp (StanLib PNot__ FnPlain AoS)
+         (((pattern
+            (EOr
+             ((pattern (Var emit_transformed_parameters__))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+             ((pattern (Var emit_generated_quantities__))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+      ((pattern (Block (((pattern (Return ())) (meta <opaque>))))) (meta <opaque>)) ()))
+    (meta <opaque>))
+   ((pattern
+     (IfElse
+      ((pattern
+        (FunApp (StanLib PNot__ FnPlain AoS)
+         (((pattern (Var emit_generated_quantities__))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+      ((pattern (Block (((pattern (Return ())) (meta <opaque>))))) (meta <opaque>)) ()))
+    (meta <opaque>))))
+ (transform_inits
+  (((pattern
+     (Decl (decl_adtype DataOnly) (decl_id pos__) (decl_type (Sized SInt))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id x)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id x_flat__)
+          (decl_type (Unsized (UArray UReal))) (initialize Uninit)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable x_flat__) ()) (UArray UReal)
+          ((pattern
+            (FunApp (CompilerInternal FnReadData)
+             (((pattern (Lit Str x))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable pos__) ()) UInt
+          ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar sym1__)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Lit Int 2))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (Assignment
+                  ((LVariable x)
+                   ((Single
+                     ((pattern (Var sym1__))
+                      (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                  UVector
+                  ((pattern
+                    (Indexed
+                     ((pattern (Var x_flat__))
+                      (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))
+                     ((Single
+                       ((pattern (Var pos__))
+                        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+                (meta <opaque>))
+               ((pattern
+                 (Assignment ((LVariable pos__) ()) UInt
+                  ((pattern
+                    (FunApp (StanLib Plus__ FnPlain AoS)
+                     (((pattern (Var pos__))
+                       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                      ((pattern (Lit Int 1))
+                       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var x)) (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))))
+ (unconstrain_array
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id x)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable x) ()) UVector
+      ((pattern
+        (FunApp (CompilerInternal FnReadDeserializer)
+         (((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var x)) (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))))
+ (output_vars
+  ((x <opaque>
+    ((out_unconstrained_st
+      (SVector AoS
+       ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+     (out_constrained_st
+      (SVector AoS
+       ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+     (out_block Parameters) (out_trans Identity)))))
+ (prog_name gq_extrema_reverse_model) (prog_path tests/fixtures/gq_extrema_reverse.stan))

--- a/tests/fixtures/gq_extrema_udf.stan
+++ b/tests/fixtures/gq_extrema_udf.stan
@@ -1,0 +1,15 @@
+functions {
+  real vector_min(vector x) {
+    array[2] matrix[2, 2] uninlined_shape_guard;
+    return min(x);
+  }
+}
+parameters {
+  vector[5] x;
+}
+model {
+  x ~ normal(0, 1);
+}
+generated quantities {
+  real x_min = vector_min(x);
+}

--- a/tests/fixtures/gq_extrema_udf.tmir.sexp
+++ b/tests/fixtures/gq_extrema_udf.tmir.sexp
@@ -1,0 +1,331 @@
+((functions_block
+  (((fdrt (ReturnType UReal)) (fdname vector_min) (fdsuffix FnPlain)
+    (fdargs ((AutoDiffable x UVector)))
+    (fdbody
+     (((pattern
+        (Block
+         (((pattern
+            (Decl (decl_adtype AutoDiffable) (decl_id uninlined_shape_guard)
+             (decl_type
+              (Sized
+               (SArray
+                (SMatrix AoS
+                 ((pattern (Lit Int 2))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                 ((pattern (Lit Int 2))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                ((pattern (Lit Int 2))
+                 (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+             (initialize Default)))
+           (meta <opaque>))
+          ((pattern
+            (Return
+             (((pattern
+                (FunApp (StanLib min FnPlain AoS)
+                 (((pattern (Var x))
+                   (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
+           (meta <opaque>)))))
+       (meta <opaque>))))
+    (fdloc <opaque>))))
+ (input_vars ()) (prepare_data ())
+ (log_prob
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id x)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Lit Int 5)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity)
+             (dims
+              (((pattern (Lit Int 5))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib normal_lpdf (FnLpdf true) AoS)
+             (((pattern (Var x))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))
+              ((pattern
+                (Promotion
+                 ((pattern (Lit Int 0))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                 UReal DataOnly))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+              ((pattern
+                (Promotion
+                 ((pattern (Lit Int 1))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                 UReal DataOnly))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>)))))
+    (meta <opaque>))))
+ (reverse_mode_log_prob
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id x)
+      (decl_type
+       (Sized
+        (SVector SoA
+         ((pattern (Lit Int 5)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity)
+             (dims
+              (((pattern (Lit Int 5))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern SoA)))
+           ()))
+         (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib normal_lpdf (FnLpdf true) SoA)
+             (((pattern (Var x))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))
+              ((pattern
+                (Promotion
+                 ((pattern (Lit Int 0))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                 UReal DataOnly))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+              ((pattern
+                (Promotion
+                 ((pattern (Lit Int 1))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                 UReal DataOnly))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>)))))
+    (meta <opaque>))))
+ (generate_quantities
+  (((pattern
+     (Decl (decl_adtype DataOnly) (decl_id x)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Lit Int 5)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity)
+             (dims
+              (((pattern (Lit Int 5))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt ())
+        (var
+         ((pattern (Var x)) (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (IfElse
+      ((pattern
+        (FunApp (StanLib PNot__ FnPlain AoS)
+         (((pattern
+            (EOr
+             ((pattern (Var emit_transformed_parameters__))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+             ((pattern (Var emit_generated_quantities__))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+      ((pattern (Block (((pattern (Return ())) (meta <opaque>))))) (meta <opaque>)) ()))
+    (meta <opaque>))
+   ((pattern
+     (IfElse
+      ((pattern
+        (FunApp (StanLib PNot__ FnPlain AoS)
+         (((pattern (Var emit_generated_quantities__))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+      ((pattern (Block (((pattern (Return ())) (meta <opaque>))))) (meta <opaque>)) ()))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id x_min) (decl_type (Sized SReal))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id inline_vector_min_return_sym1__)
+      (decl_type (Sized SReal)) (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable)
+          (decl_id inline_vector_min_uninlined_shape_guard_sym2__)
+          (decl_type
+           (Sized
+            (SArray
+             (SMatrix AoS
+              ((pattern (Lit Int 2))
+               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+              ((pattern (Lit Int 2))
+               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+             ((pattern (Lit Int 2))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+          (initialize Default)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable inline_vector_min_return_sym1__) ()) UReal
+          ((pattern
+            (FunApp (StanLib min FnPlain AoS)
+             (((pattern (Var x))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>)))))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable x_min) ()) UReal
+      ((pattern (Var inline_vector_min_return_sym1__))
+       (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt ())
+        (var
+         ((pattern (Var x_min)) (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))))
+ (transform_inits
+  (((pattern
+     (Decl (decl_adtype DataOnly) (decl_id pos__) (decl_type (Sized SInt))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id x)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Lit Int 5)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id x_flat__)
+          (decl_type (Unsized (UArray UReal))) (initialize Uninit)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable x_flat__) ()) (UArray UReal)
+          ((pattern
+            (FunApp (CompilerInternal FnReadData)
+             (((pattern (Lit Str x))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable pos__) ()) UInt
+          ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar sym1__)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Lit Int 5))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (Assignment
+                  ((LVariable x)
+                   ((Single
+                     ((pattern (Var sym1__))
+                      (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                  UVector
+                  ((pattern
+                    (Indexed
+                     ((pattern (Var x_flat__))
+                      (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))
+                     ((Single
+                       ((pattern (Var pos__))
+                        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+                (meta <opaque>))
+               ((pattern
+                 (Assignment ((LVariable pos__) ()) UInt
+                  ((pattern
+                    (FunApp (StanLib Plus__ FnPlain AoS)
+                     (((pattern (Var pos__))
+                       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                      ((pattern (Lit Int 1))
+                       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var x)) (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))))
+ (unconstrain_array
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id x)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Lit Int 5)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable x) ()) UVector
+      ((pattern
+        (FunApp (CompilerInternal FnReadDeserializer)
+         (((pattern (Lit Int 5)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var x)) (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))))
+ (output_vars
+  ((x <opaque>
+    ((out_unconstrained_st
+      (SVector AoS
+       ((pattern (Lit Int 5)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+     (out_constrained_st
+      (SVector AoS
+       ((pattern (Lit Int 5)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+     (out_block Parameters) (out_trans Identity)))
+   (x_min <opaque>
+    ((out_unconstrained_st SReal) (out_constrained_st SReal)
+     (out_block GeneratedQuantities) (out_trans Identity)))))
+ (prog_name gq_extrema_udf_model) (prog_path tests/fixtures/gq_extrema_udf.stan))

--- a/tests/test_pass_safety.cpp
+++ b/tests/test_pass_safety.cpp
@@ -452,11 +452,109 @@ static void test_product_is_forward_only_pass_barrier() {
   expect("standalone products keep pinned Stan Math grouping", exact);
 }
 
+static void test_extrema_is_forward_only_pass_barrier() {
+  Graph g;
+  Fills fills;
+  const int input = g.add_slot(7, true);
+  constexpr int kLanes = 40;
+  const int result = g.add_slot(kLanes, false);
+  fills.emplace_back(result, std::vector<double>(kLanes, 0.0));
+  // This is intentionally a real reroll candidate: with EXTREMA removed from
+  // ops_match's explicit refusal, the two-lane min/max period plus advancing
+  // stores forms a region.  Root only the downstream sum; rooting the vector
+  // being filled would itself make the element-store candidate ineligible.
+  for (int lane = 0; lane < kLanes; ++lane) {
+    const int output = g.add_slot(1, false);
+    g.add_op(OP_EXTREMA_VEC, {input}, output);
+    g.ops.back().variant = static_cast<uint8_t>(lane & 1);
+    g.add_op(OP_SET_INDEX_INPLACE, {result, output}, result, {lane});
+  }
+  const int final = g.add_slot(1, false);
+  g.add_op(OP_SUM_VEC, {result}, final);
+  g.result_slot = final;
+  std::vector<int> roots{final};
+  std::vector<int> terms;
+
+  const ConstFoldStats folded = const_fold(g, fills, roots);
+  const RerollStats rerolled = reroll(g, fills, terms, roots);
+  const int store_islands = carve_islands(g, fills, terms, roots);
+  int extrema_ops = 0, stores = 0, island_ops = 0;
+  for (const Op& op : g.ops) {
+    extrema_ops += op.opcode == OP_EXTREMA_VEC;
+    stores += op.opcode == OP_SET_INDEX_INPLACE;
+    island_ops += op.opcode == OP_ISLAND;
+  }
+  const Kernel* extrema = find_kernel(OP_EXTREMA_VEC);
+  expect("extrema has a forward-only no-scratch kernel",
+         extrema != nullptr && extrema->backward == nullptr &&
+             extrema->scratch_size == nullptr);
+  expect("extrema is absent from value-free backward traits",
+         !backward_ignores_values(OP_EXTREMA_VEC));
+  expect("extrema survives constfold with parameter input",
+         folded.ops_removed == 0);
+  expect("extrema is absent from reroll vocabulary", rerolled.regions == 0);
+  expect("vector-store graph does not form an island", store_islands == 0);
+  expect("extrema remains a standalone forward op",
+         extrema_ops == kLanes && stores == kLanes && island_ops == 0);
+
+  Executor ex(std::move(g));
+  const double values[] = {0.0, -0.0, 7.0, -11.0, 7.0, -3.0, -11.0};
+  for (int i = 0; i < 7; ++i) ex.params_data()[i] = values[i];
+  ex.run_forward_only();
+  Eigen::VectorXd pinned(7);
+  for (int i = 0; i < 7; ++i) pinned[i] = values[i];
+  const double wants[] = {stan::math::min(pinned), stan::math::max(pinned)};
+  bool exact = true;
+  for (int lane = 0; lane < kLanes; ++lane)
+    exact &= ex.value_ptr(result)[lane] == wants[lane & 1];
+  exact &= ex.value_ptr(final)[0] == (kLanes / 2) * (wants[0] + wants[1]);
+  expect("standalone extrema keep pinned Stan Math values", exact);
+
+  // A distinct all-scalar graph makes the island guard diagnostic.  With
+  // EXTREMA explicitly refused, each ADD run has length one and is below the
+  // carving threshold.  Removing only that refusal admits the whole 80-op
+  // chain and produces an island.
+  Graph island_graph;
+  const int island_input = island_graph.add_slot(7, true);
+  int accumulator = island_graph.add_slot(1, true);
+  for (int lane = 0; lane < kLanes; ++lane) {
+    const int extreme = island_graph.add_slot(1, false);
+    island_graph.add_op(OP_EXTREMA_VEC, {island_input}, extreme);
+    island_graph.ops.back().variant = static_cast<uint8_t>(lane & 1);
+    const int next = island_graph.add_slot(1, false);
+    island_graph.add_op(OP_ADD, {accumulator, extreme}, next);
+    accumulator = next;
+  }
+  island_graph.result_slot = accumulator;
+  Fills island_fills;
+  std::vector<int> island_terms;
+  std::vector<int> island_roots{accumulator};
+  const int scalar_islands =
+      carve_islands(island_graph, island_fills, island_terms, island_roots);
+  int scalar_extrema = 0, scalar_adds = 0;
+  for (const Op& op : island_graph.ops) {
+    scalar_extrema += op.opcode == OP_EXTREMA_VEC;
+    scalar_adds += op.opcode == OP_ADD;
+  }
+  expect(
+      "extrema splits otherwise island-eligible scalar chain",
+      scalar_islands == 0 && scalar_extrema == kLanes && scalar_adds == kLanes);
+
+  Executor island_ex(std::move(island_graph));
+  for (int i = 0; i < 7; ++i) island_ex.params_data()[i] = values[i];
+  island_ex.params_data()[7] = 0.25;
+  island_ex.run_forward_only();
+  expect("split scalar chain preserves extrema values",
+         island_ex.value_ptr(accumulator)[0] ==
+             0.25 + (kLanes / 2) * (wants[0] + wants[1]));
+}
+
 int main() {
   test_setenv("STANLI_ISLAND_ALWAYS", "1", 1);  // see the fuzz loop
   test_whitelist_backwards_ignore_values();
   test_rng_is_an_effect_barrier();
   test_product_is_forward_only_pass_barrier();
+  test_extrema_is_forward_only_pass_barrier();
   test_random_graphs_preserve_gradients();
   if (failures) {
     std::printf("%d failures\n", failures);

--- a/tests/test_write_array.cpp
+++ b/tests/test_write_array.cpp
@@ -1610,6 +1610,391 @@ void test_product_exact_grouping() {
   }
 }
 
+void test_extrema_exact_grouping() {
+  using namespace stanli;
+  const Kernel& extrema = kernel(OP_EXTREMA_VEC);
+  if (extrema.backward != nullptr || extrema.scratch_size != nullptr) {
+    ++failures;
+    std::printf("FAIL extrema kernel is not forward-only/no-scratch\n");
+  }
+
+  const double inf = std::numeric_limits<double>::infinity();
+  const double nan = std::numeric_limits<double>::quiet_NaN();
+  std::vector<std::vector<double>> cases = {
+      {},
+      {1.0},
+      {0.0, -0.0},
+      {-0.0, 0.0},
+      {inf, -inf, 3.0},
+      {-inf, inf, -3.0},
+      {2.0, 2.0, -4.0, -4.0, 2.0},
+      {nan, 1.0, -2.0},
+      {1.0, nan, -2.0},
+      {1.0, -2.0, nan},
+      {nan, nan, 0.0, -0.0},
+  };
+  const int packet_width = std::max(
+      1, static_cast<int>(Eigen::internal::packet_traits<double>::size));
+  for (int n : {packet_width - 1, packet_width, packet_width + 1,
+                2 * packet_width - 1, 2 * packet_width, 2 * packet_width + 1}) {
+    if (n < 0) continue;
+    std::vector<double> values(static_cast<size_t>(n));
+    for (int i = 0; i < n; ++i) {
+      const double magnitude =
+          std::ldexp(1.0 + static_cast<double>((i * 7 + 3) % 11) * 0x1p-52,
+                     (i % 7) * 137 - 411);
+      values[static_cast<size_t>(i)] = i % 2 == 0 ? magnitude : -magnitude;
+    }
+    if (n > 2) values[static_cast<size_t>(n - 1)] = values[1];
+    cases.push_back(std::move(values));
+  }
+
+  for (size_t c = 0; c < cases.size(); ++c) {
+    const std::vector<double>& values = cases[c];
+    Eigen::VectorXd pinned(static_cast<Eigen::Index>(values.size()));
+    std::copy(values.begin(), values.end(), pinned.data());
+    const double wants[] = {stan::math::min(pinned), stan::math::max(pinned)};
+    for (int variant = 0; variant < 2; ++variant) {
+      for (int offset = 0; offset < packet_width; ++offset) {
+        Eigen::VectorXd storage(static_cast<Eigen::Index>(
+            values.size() + static_cast<size_t>(packet_width)));
+        storage.setZero();
+        std::copy(values.begin(), values.end(), storage.data() + offset);
+        double got = 0.0;
+        KernelCtx ctx;
+        ctx.n_in = 1;
+        ctx.in[0] =
+            Desc{storage.data() + offset, static_cast<int64_t>(values.size())};
+        ctx.out = Desc{&got, 1};
+        ctx.variant = static_cast<uint8_t>(variant);
+        extrema.forward(ctx);
+        if (!same_reduction_value(got, wants[variant])) {
+          ++failures;
+          std::printf(
+              "FAIL extrema kernel case %zu variant %d offset %d: got %llx "
+              "want %llx\n",
+              c, variant, offset,
+              static_cast<unsigned long long>(reduction_bits(got)),
+              static_cast<unsigned long long>(reduction_bits(wants[variant])));
+        }
+      }
+    }
+  }
+
+  // The generic interpreter keeps scalar-fold behavior outside the audited
+  // direct write_array surface, except that Stan's defined empty-container
+  // results/errors must not become an out_of_range accident.
+  std::map<std::string, const mir::FunDef*> funs;
+  MirInterp<double> interp(funs, "empty extrema legacy test");
+  mir::Expr arg;
+  arg.kind = mir::Expr::Var;
+  arg.name = "a";
+  arg.type_ = "(UArray UReal)";
+  arg.unsized.leaf = mir::UnsizedLeaf::Real;
+  arg.unsized.depth = 1;
+  mir::Expr call;
+  call.kind = mir::Expr::FunApp;
+  call.name = "min";
+  call.fn_lib = mir::Expr::Lib::StanLib;
+  call.type_ = "UReal";
+  call.unsized.leaf = mir::UnsizedLeaf::Real;
+  call.args = {arg};
+  DataMap::Entry empty_real;
+  empty_real.dims = {0};
+  interp.env()["a"] = empty_real;
+  if (reduction_bits(interp.eval(call).r.at(0)) != reduction_bits(inf)) {
+    ++failures;
+    std::printf("FAIL empty real legacy min is not +infinity\n");
+  }
+  call.name = "max";
+  if (reduction_bits(interp.eval(call).r.at(0)) != reduction_bits(-inf)) {
+    ++failures;
+    std::printf("FAIL empty real legacy max is not -infinity\n");
+  }
+  arg.type_ = "(UArray UInt)";
+  arg.unsized.leaf = mir::UnsizedLeaf::Int;
+  call.args = {arg};
+  DataMap::Entry empty_int;
+  empty_int.is_int = true;
+  empty_int.dims = {0};
+  interp.env()["a"] = empty_int;
+  for (const char* name : {"min", "max"}) {
+    call.name = name;
+    bool invalid = false;
+    try {
+      (void)interp.eval(call);
+    } catch (const std::invalid_argument&) {
+      invalid = true;
+    }
+    if (!invalid) {
+      ++failures;
+      std::printf(
+          "FAIL empty int legacy %s did not preserve invalid_argument\n", name);
+    }
+  }
+}
+
+void test_compiled_gq_extrema() {
+  using namespace stanli;
+  const std::string text = slurp("tests/fixtures/gq_extrema.tmir.sexp");
+  const double nan = std::numeric_limits<double>::quiet_NaN();
+  const std::vector<std::vector<double>> cases = {
+      {},
+      {0.0},
+      {0.0, -0.0, 2.0, -3.0, 2.0},
+      {-0.0, 0.0, -4.0, 9.0, -4.0},
+      {nan, 1.0, -2.0, 8.0, -2.0},
+      {1.0, nan, -2.0, 8.0, -2.0},
+  };
+
+  for (size_t c = 0; c < cases.size(); ++c) {
+    const std::vector<double>& x = cases[c];
+    std::vector<double> xr(x.rbegin(), x.rend());
+    DataMap data;
+    data.set_int("N", static_cast<long>(x.size()));
+    data.set_real_array("d", x, {static_cast<int64_t>(x.size())});
+    CompiledModel cm = compile_model(text, data);
+    if (!cm.write_array || cm.write_array->interp ||
+        !cm.write_array->truncated.empty()) {
+      ++failures;
+      std::printf("FAIL extrema fixture case %zu did not compile: %s\n", c,
+                  cm.write_array ? cm.write_array->truncated.c_str()
+                                 : "no write_array");
+      continue;
+    }
+    int extrema_ops = 0, minima = 0, maxima = 0;
+    for (const Op& op : cm.write_array->graph.ops) {
+      if (op.opcode != OP_EXTREMA_VEC) continue;
+      ++extrema_ops;
+      minima += op.variant == 0;
+      maxima += op.variant == 1;
+    }
+    if (extrema_ops != 4 || minima != 2 || maxima != 2) {
+      ++failures;
+      std::printf(
+          "FAIL extrema fixture census case %zu: all=%d min=%d max=%d\n", c,
+          extrema_ops, minima, maxima);
+      continue;
+    }
+
+    Executor graph(std::move(cm.write_array->graph));
+    cm.write_array->bind(graph);
+    std::copy(x.begin(), x.end(), graph.params_data());
+    std::copy(xr.begin(), xr.end(), graph.params_data() + x.size());
+    graph.run_forward_only();
+    std::vector<double> graph_row;
+    for (const auto& column : cm.write_array->columns) {
+      const double* values = graph.value_ptr(column.slot);
+      for (int64_t i = 0; i < column.len; ++i)
+        graph_row.push_back(values[column.storage_index(i)]);
+    }
+
+    auto program =
+        std::make_shared<mir::Program>(mir::read_program(sexp::parse(text)));
+    std::map<std::string, DataMap::Entry> base;
+    base["N"] = data.at("N");
+    base["d"] = data.at("d");
+    for (const char* flag :
+         {"emit_transformed_parameters__", "emit_generated_quantities__"}) {
+      DataMap::Entry one;
+      one.is_int = true;
+      one.i = {1};
+      one.r = {1.0};
+      base[flag] = one;
+    }
+    WaInterp interp(program, std::move(base));
+    std::map<std::string, DataMap::Entry> params;
+    params["x"].r = x;
+    params["x"].dims = {static_cast<int64_t>(x.size())};
+    params["xr"].r = xr;
+    params["xr"].dims = {static_cast<int64_t>(xr.size())};
+    WaRng rng(1234);
+    const std::vector<double> interp_row = interp.eval(params, rng);
+    if (graph_row.size() != interp_row.size()) {
+      ++failures;
+      std::printf("FAIL extrema fixture row width case %zu\n", c);
+      continue;
+    }
+    for (size_t i = 0; i < graph_row.size(); ++i) {
+      if (same_reduction_value(graph_row[i], interp_row[i])) continue;
+      ++failures;
+      std::printf("FAIL extrema graph/interpreter case %zu column %zu\n", c, i);
+      break;
+    }
+
+    if (x.empty()) {
+      const std::vector<std::string> names =
+          CompiledModel::csv_names(cm.write_array->columns);
+      for (size_t i = 0; i < names.size(); ++i) {
+        if ((names[i] == "x_min" || names[i] == "xr_min" ||
+             names[i] == "d_min") &&
+            reduction_bits(graph_row[i]) !=
+                reduction_bits(std::numeric_limits<double>::infinity())) {
+          ++failures;
+          std::printf("FAIL empty %s is not +infinity\n", names[i].c_str());
+        }
+        if ((names[i] == "x_max" || names[i] == "xr_max" ||
+             names[i] == "d_max") &&
+            reduction_bits(graph_row[i]) !=
+                reduction_bits(-std::numeric_limits<double>::infinity())) {
+          ++failures;
+          std::printf("FAIL empty %s is not -infinity\n", names[i].c_str());
+        }
+      }
+    }
+  }
+}
+
+static stanli::DataMap extrema_guard_data() {
+  stanli::DataMap data;
+  data.set_int("N", 5);
+  data.set_real_array("d", {1.0, -2.0, 3.0, -4.0, 5.0}, {5});
+  return data;
+}
+
+static void expect_extrema_interp(const std::string& text, const char* what) {
+  using namespace stanli;
+  try {
+    CompiledModel cm = compile_model(text, extrema_guard_data());
+    if (cm.write_array && cm.write_array->interp &&
+        cm.write_array->truncated.find("expression surface") !=
+            std::string::npos)
+      return;
+    ++failures;
+    std::printf(
+        "FAIL %s: got %s\n", what,
+        cm.write_array ? cm.write_array->truncated.c_str() : "no write_array");
+  } catch (const std::exception& e) {
+    ++failures;
+    std::printf("FAIL %s: mutation did not parse/compile: %s\n", what,
+                e.what());
+  }
+}
+
+void test_gq_extrema_lowering_guards() {
+  using namespace stanli;
+  const std::string base = slurp("tests/fixtures/gq_extrema.tmir.sexp");
+  const size_t wa = base.find("(generate_quantities");
+  const size_t min_call = base.find("(FunApp (StanLib min", wa);
+  const std::string vector_node =
+      "((pattern (Var x)) (meta ((type_ UVector) (loc <opaque>) (adlevel "
+      "DataOnly))))";
+  const size_t arg_at = base.find(vector_node, min_call);
+  if (wa == std::string::npos || min_call == std::string::npos ||
+      arg_at == std::string::npos) {
+    ++failures;
+    std::printf("FAIL extrema guard fixture has no direct min call\n");
+    return;
+  }
+
+  struct BadType {
+    const char* type;
+    const char* label;
+  };
+  for (const BadType& bad :
+       {BadType{"UReal", "scalar"}, BadType{"UMatrix", "matrix"},
+        BadType{"(UArray UReal)", "array"}}) {
+    std::string mutated = base;
+    const std::string from = "type_ UVector";
+    const size_t at = mutated.find(from, arg_at);
+    if (at == std::string::npos) {
+      ++failures;
+      std::printf("FAIL extrema mutation cannot find %s type\n", bad.label);
+      continue;
+    }
+    mutated.replace(at, from.size(), std::string("type_ ") + bad.type);
+    expect_extrema_interp(mutated, (std::string("extrema ") + bad.label +
+                                    " argument stays interpreted")
+                                       .c_str());
+  }
+
+  const std::string exp_vector =
+      "((pattern\n"
+      "            (FunApp (StanLib exp FnPlain AoS)\n"
+      "             (" +
+      vector_node +
+      ")))\n"
+      "           (meta ((type_ UVector) (loc <opaque>) (adlevel "
+      "DataOnly))))";
+  std::string expression = base;
+  expression.replace(arg_at, vector_node.size(), exp_vector);
+  expect_extrema_interp(expression, "min(exp(x)) stays interpreted");
+
+  const std::string indexed =
+      "((pattern\n"
+      "            (Indexed\n"
+      "             (" +
+      vector_node +
+      "\n"
+      "              ((Between\n"
+      "                ((pattern (Lit Int 1))\n"
+      "                 (meta ((type_ UInt) (loc <opaque>) (adlevel "
+      "DataOnly))))\n"
+      "                ((pattern (Lit Int 3))\n"
+      "                 (meta ((type_ UInt) (loc <opaque>) (adlevel "
+      "DataOnly)))))))))\n"
+      "           (meta ((type_ UVector) (loc <opaque>) (adlevel "
+      "DataOnly))))";
+  std::string view = base;
+  view.replace(arg_at, vector_node.size(), indexed);
+  expect_extrema_interp(view, "min(x[1:3]) stays interpreted");
+
+  std::string zero_args = base;
+  zero_args.erase(arg_at, vector_node.size());
+  expect_extrema_interp(zero_args, "zero-argument min stays interpreted");
+
+  std::string two_args = base;
+  two_args.insert(arg_at + vector_node.size(), " " + vector_node);
+  expect_extrema_interp(two_args, "two-argument dynamic min stays interpreted");
+
+  std::string container_result = base;
+  const std::string scalar_result =
+      "(meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))";
+  const size_t result_at = container_result.find(scalar_result, arg_at);
+  if (result_at == std::string::npos) {
+    ++failures;
+    std::printf("FAIL extrema mutation cannot find result metadata\n");
+  } else {
+    container_result.replace(
+        result_at, scalar_result.size(),
+        "(meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))");
+    expect_extrema_interp(container_result,
+                          "container-result min stays interpreted");
+  }
+
+  // O1 normally inlines this UDF call.  Restore the retained call so the
+  // direct formal reaches lowering at udf_depth > 0 and cannot acquire an
+  // owning-vector provenance merely from its Var syntax.
+  std::string udf = slurp("tests/fixtures/gq_extrema_udf.tmir.sexp");
+  const size_t udf_wa = udf.find("(generate_quantities");
+  const std::string stan_min = "(FunApp (StanLib min FnPlain AoS)";
+  const size_t inlined = udf.find(stan_min, udf_wa);
+  if (udf_wa == std::string::npos || inlined == std::string::npos) {
+    ++failures;
+    std::printf("FAIL extrema UDF fixture has no inlined call\n");
+  } else {
+    udf.replace(inlined, stan_min.size(),
+                "(FunApp (UserDefined vector_min FnPlain)");
+    expect_extrema_interp(udf, "dynamic UDF extrema stays interpreted");
+  }
+
+  // The opcode is generated-quantities-only: an active log_prob reduction
+  // must still be refused rather than acquiring a forward-only reverse path.
+  bool reverse_refused = false;
+  try {
+    DataMap no_data;
+    (void)compile_model(slurp("tests/fixtures/gq_extrema_reverse.tmir.sexp"),
+                        no_data);
+  } catch (const CompileError& e) {
+    reverse_refused = std::string(e.what()).find("unsupported function min") !=
+                      std::string::npos;
+  }
+  if (!reverse_refused) {
+    ++failures;
+    std::printf("FAIL dynamic log_prob extrema was not refused\n");
+  }
+}
+
 void test_compiled_gq_reductions() {
   using namespace stanli;
   const std::string text = slurp("tests/fixtures/gq_reductions.tmir.sexp");
@@ -2535,6 +2920,9 @@ int main() {
   test_binomial_rng_lowering_guards();
   test_compiled_scalar_rng();
   test_product_exact_grouping();
+  test_extrema_exact_grouping();
+  test_compiled_gq_extrema();
+  test_gq_extrema_lowering_guards();
   test_compiled_gq_reductions();
   test_gq_reduction_lowering_guards();
   test_runtime_int_sum_is_not_compile_time();


### PR DESCRIPTION
## Summary

Compile top-level generated-quantities `min(vector)` and `max(vector)` calls onto the forward-only write-array graph.

This adds `OP_EXTREMA_VEC` variants for min/max. The kernel uses pinned Stan Math with the same address-independent packet grouping as an owning Eigen vector, so graph-arena alignment cannot change signed-zero, tie, or reduction grouping. Empty real inputs preserve Stan's defined results: `min([]) = +inf` and `max([]) = -inf`.

## Correctness and scope

The native lowering gate is deliberately narrow:

- write-array / generated quantities only
- exactly one direct top-level `UVector` or `URowVector` variable
- exactly one scalar `UReal` result

Arrays, matrices, indexed views, expressions, and UDF formals remain on `WaInterp`; reverse-mode uses remain refused. The forward-only opcode is explicitly excluded from reroll matching and island CALLs.

The interpreter uses owning-vector grouping only for the same audited top-level `prepare_data` and `write_array` surface. Every excluded expression retains its prior scalar-fold behavior. Empty integer containers continue to throw Stan Math's `invalid_argument`.

Tests cover packet-width-derived lengths and every arena offset, duplicate extrema, signed zero, infinities, NaNs, empty real and integer containers, direct vector/row-vector lowering, malformed calls, expression/view/UDF/reverse fallbacks, and diagnostic reroll/island barriers.

## Measurements

On `losscurve_sislob`, a targeted matched C-ABI A/B measured:

| | interpreted | compiled |
| --- | ---: | ---: |
| row time | 329.9520 us | 3.3704 us |
| seven-batch range | 329.7949–330.1263 us | 3.3595–3.3968 us |
| construction | 4107.375 us | 5291.959 us |

That is **97.8970x** faster, saving **0.3265816 s per 1,000 rows**. The 1184.584 us construction delta amortizes after 3.627 rows, or four whole rows.

The model's 1,218-op write-array graph contains exactly one length-10 min and one length-10 max and writes all 384 columns. Graph and `WaInterp` were bitwise identical for 1,536/1,536 values across four fixed points. The same-input pinned Stan Math boundary matched 8/8 extrema results. Stored CmdStan replay compared 1,200 values with a worst difference of 4.44e-16 / 8 ULP.

The tracked 24-model census moved from **17 graph / 7 interpreter** to **18 / 6**; `losscurve_sislob` was the only changed model. Full write-array coverage is now **119/119 complete**, with **113 graph / 6 interpreter** overall.

These targeted measurements do not refresh `docs/corpus-bench.tsv` or the generated full-corpus timing table.

## Validation

- Fresh Release all-target build
- CTest: 59/59
- CmdStan reference replay: 129/129 models, 800,674 values
- Write-array coverage: 119/119 complete
- Exact 24-model tracked census: 18 graph / 6 interpreter
- Three new MIR fixtures match pinned `stanc --O1 --debug-optimized-mir` output
- `tools/format.sh --check`
- `python3 tools/gen_docs.py --check`
- `python3 tools/gen_web_models.py --check`
- `git diff --check`
