### PR TITLE
feat: bundle the runtime into wasm builds of the R package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## Unreleased
+
+### Wasm builds of the R package bundle their runtime
+
+`stanli_install()` cannot run in a browser: github.com serves release
+assets without CORS headers, so webR users had to fetch the runtime by
+hand (#163). A configure script now detects an Emscripten cross-build
+and bundles the matching runtime into the package, where
+`stanli_runtime_path()` finds it before looking at the cache.
+`stanli_install()` reports the bundle instead of downloading. Native
+builds are unchanged; the script exits before doing anything on a
+non-wasm compiler. Suggested by @StaffanBetner.
+
 ## 0.8.4
 
 ### Three kernels stop replaying stan-math

--- a/r/R/install.R
+++ b/r/R/install.R
@@ -48,14 +48,17 @@ runtime_asset <- function() {
 #' Where the stanli runtime lives
 #'
 #' The path is taken from `STANLI_RUNTIME` when that is set (which is how
-#' a development build is used), and from the user cache directory
-#' otherwise.
+#' a development build is used), then from a runtime bundled into the
+#' package (wasm builds bundle one at build time, since a browser cannot
+#' download it), and from the user cache directory otherwise.
 #'
 #' @return A file path, which may not exist yet.
 #' @export
 stanli_runtime_path <- function() {
   from_env <- Sys.getenv("STANLI_RUNTIME", "")
   if (nzchar(from_env)) return(from_env)
+  bundled <- system.file("runtime", runtime_filename(), package = "stanli")
+  if (nzchar(bundled)) return(bundled)
   file.path(tools::R_user_dir("stanli", "cache"), runtime_filename())
 }
 
@@ -81,6 +84,11 @@ stanli_available <- function() {
 #' @export
 stanli_install <- function(version = stanli_runtime_release, quiet = FALSE,
                            overwrite = FALSE) {
+  bundled <- system.file("runtime", runtime_filename(), package = "stanli")
+  if (nzchar(bundled)) {
+    if (!quiet) message("this build bundles its runtime at ", bundled)
+    return(invisible(bundled))
+  }
   dest_dir <- tools::R_user_dir("stanli", "cache")
   dir.create(dest_dir, recursive = TRUE, showWarnings = FALSE)
   dest <- file.path(dest_dir, runtime_filename())

--- a/r/configure
+++ b/r/configure
@@ -1,0 +1,18 @@
+#!/bin/sh
+# Wasm cross-builds (r-universe building for webR) bundle the runtime
+# here, at package build time: the browser cannot download it later,
+# because github.com serves release assets without CORS headers.
+CC=`"${R_HOME}/bin/R" CMD config CC`
+case `$CC -dumpmachine 2>/dev/null` in
+  *emscripten*) ;;
+  *) exit 0 ;;
+esac
+release=`sed -n 's/^stanli_runtime_release <- "\(.*\)"$/\1/p' R/install.R`
+url="https://github.com/seantalts/stanli/releases/download/$release/stanli-runtime-emscripten-wasm32.tar.gz"
+mkdir -p inst/runtime
+if curl -fsSL "$url" | tar xz -C inst/runtime libstanli.so; then
+  echo "bundled the $release wasm runtime"
+else
+  echo "could not fetch $url; supply the runtime via STANLI_RUNTIME" >&2
+fi
+exit 0

--- a/r/man/stanli_runtime_path.Rd
+++ b/r/man/stanli_runtime_path.Rd
@@ -11,6 +11,7 @@ A file path, which may not exist yet.
 }
 \description{
 The path is taken from `STANLI_RUNTIME` when that is set (which is how
-a development build is used), and from the user cache directory
-otherwise.
+a development build is used), then from a runtime bundled into the
+package (wasm builds bundle one at build time, since a browser cannot
+download it), and from the user cache directory otherwise.
 }


### PR DESCRIPTION
Implements @StaffanBetner's suggestion in #163: `stanli_install()` cannot run in a browser, since github.com serves release assets without CORS headers, so the wasm build of the package should carry its runtime instead of downloading one.

A configure script detects an Emscripten cross-build (`$CC -dumpmachine`) and downloads the release-pinned wasm runtime into inst/runtime at package build time, where the build machine has ordinary network access. Resolution order becomes STANLI_RUNTIME, then the bundle, then the user cache. `stanli_install()` reports the bundle instead of downloading. A fetch failure degrades to the previous behavior with a message, and native builds run none of this.

Verified on webR 0.6.0 in Node with the release-built v0.8.4 side module at the bundle path and the new install.R patched over the r-universe package: the bundled path resolves, `stanli_install()` short-circuits, and a model compiles and evaluates with no STANLI_RUNTIME and no network. The configure fetch was exercised against the real v0.8.4 asset. R CMD check on the native path is Status: OK.

One dependency to confirm on r-universe's side: the wasm build container needs network access during configure. If it does not have it, the script's fallback leaves the package exactly as it is today.
