### PR TITLE
perf: compile covariance multivariate-normal RNG

### DIFF
--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -194,9 +194,10 @@ the top of the page, not replacements for the current corpus rows:
 - **Compiled scalar generated-quantities RNGs** keep caller-owned chain state
   on the forward-only write-array graph for scalar `poisson_log`, `uniform`,
   `bernoulli`, `normal`, `lognormal`, and `binomial` draws.
-  RNGs outside that scalar tranche, container-valued results, and draws used
-  as dynamic control, indices, or geometry still fail closed to the
-  whole-section interpreter. In an exact census of the 24 previously
+  Apart from the audited categorical and multivariate-normal extensions below,
+  other RNGs, container-valued results, and draws used as dynamic control,
+  indices, or geometry still fail closed to the whole-section interpreter. In
+  an exact census of the 24 previously
   interpreted corpus models, this RNG tranche moved 12 to the graph; all 24
   still produced complete rows.
   A targeted 2026-08-24 C-ABI A/B (point 0, two warmups, seven matched batch
@@ -237,9 +238,10 @@ the top of the page, not replacements for the current corpus rows:
   interpreter. This moved `Mh_model`, `Mt_model`, `Mtbh_model`, and `Mth_model`
   to the graph, taking the then-current 24-model census from 12 graph / 12
   interpreter to 16 / 8. The categorical tranche below subsequently advances
-  that census to 17 / 7, and the extrema tranche after it advances the current
-  census to 18 / 6. All 119 compiling corpus models still produce complete
-  rows. A targeted 2026-08-24 C-ABI A/B (point 0, two warmups, seven matched
+  that census to 17 / 7, the extrema tranche advances it to 18 / 6, and the
+  multivariate-normal tranche advances the current census to 19 / 5. All 119
+  compiling corpus models still produce complete rows. A targeted 2026-08-24
+  C-ABI A/B (point 0, two warmups, seven matched
   batch medians) measured:
 
   | model | interpreted row | compiled row | improvement |
@@ -300,10 +302,11 @@ the top of the page, not replacements for the current corpus rows:
   islands because it has no reverse kernel.
 
   `losscurve_sislob` was the only model to change in the exact 24-model
-  census, moving graph/interpreter coverage from 17 / 7 to the current 18 / 6;
-  all 24 census models and all 119 compiling corpus models retained complete
-  rows. Its 1,218-op graph contains exactly one length-10 min opcode and one
-  length-10 max opcode, and writes 384 columns. Graph and `WaInterp` matched
+  census, moving graph/interpreter coverage from 17 / 7 to the then-current
+  18 / 6; the multivariate-normal tranche below advances the current census to
+  19 / 5. All 24 census models and all 119 compiling corpus models retained
+  complete rows. Its 1,218-op graph contains exactly one length-10 min opcode
+  and one length-10 max opcode, and writes 384 columns. Graph and `WaInterp` matched
   bitwise for all 1,536/1,536 compared values; the same-input pinned Stan Math
   check matched 8/8 cases.
   Against 1,200 stored CmdStan values, the worst difference was 4.44e-16, or
@@ -314,6 +317,28 @@ the top of the page, not replacements for the current corpus rows:
   moved from 4107.375 to 5291.959 us, a 1184.584 us setup increase that
   amortizes after 3.627 rows, or four whole rows. These targeted results do not
   refresh `docs/corpus-bench.tsv` or the generated full-corpus table below.
+- **Compiled covariance-form multivariate-normal RNGs** extend `OP_RNG` to
+  the audited `multi_normal_rng(vector, matrix) -> vector` write-array surface.
+  The mean length and square covariance shape are fixed by lowering, and both
+  the graph and `WaInterp` copy their column-major inputs into the same owning
+  Eigen values before calling pinned Stan Math. This preserves its finite,
+  symmetry, and positive-definiteness validation order and its exact normal
+  draw schedule. Array overloads, non-square or mismatched shapes, and
+  `multi_normal_cholesky_rng` remain on the whole-section interpreter.
+
+  `multi_occupancy` was the only model to change in the exact 24-model census,
+  moving graph/interpreter coverage from 18 / 6 to the current 19 / 5. All 24
+  census models and all 119 compiling corpus models retained complete rows;
+  overall corpus coverage is now 114 graph and five interpreted models. Its
+  graph and forced-interpreter rows were bitwise identical for all 5,616
+  values from six seeds continued for three sequential rows.
+
+  In a targeted 2026-08-25 matched C-ABI A/B (point 0, two warmups, seven
+  batch medians), `multi_occupancy` moved from 298.9260 to 5.4898 us/row
+  (54.4512x), saving 0.2934362 s per 1,000 rows. Construction also improved,
+  from 5864.792 to 5368.583 us, so there is no setup break-even penalty. These
+  targeted results do not refresh `docs/corpus-bench.tsv` or the generated
+  full-corpus table below.
 - **Allocation-free ODE right-hand-side input seeding** removes the promoted
   `y` and `theta` staging vectors built on every solver callback and seeds the
   reusable register file directly. A targeted 2026-08-24 Release A/B (seven

--- a/runtime/include/stanli/wa_interp.hpp
+++ b/runtime/include/stanli/wa_interp.hpp
@@ -67,12 +67,17 @@ enum class ScalarRng : uint8_t {
 // one logical argument containing an arbitrary number of probabilities.
 inline constexpr uint8_t kCategoricalRngVariant =
     static_cast<uint8_t>(ScalarRng::Binomial) + 1;
+inline constexpr uint8_t kMultiNormalRngVariant = kCategoricalRngVariant + 1;
 
 size_t scalar_rng_arity(ScalarRng family);
 bool scalar_rng_is_int(ScalarRng family);
 double scalar_rng_draw(ScalarRng family, const double* args, size_t nargs,
                        WaRng& rng);
 int categorical_rng_draw(const double* probabilities, size_t size, WaRng& rng);
+void multi_normal_rng_draw(const double* location, size_t location_size,
+                           const double* covariance, size_t covariance_size,
+                           size_t covariance_rows, size_t covariance_cols,
+                           double* output, size_t output_size, WaRng& rng);
 
 // The columns only exist after one evaluation, so every driver that wants
 // them at construction time has to probe. These two are that probe, shared

--- a/runtime/kernels/rng.cpp
+++ b/runtime/kernels/rng.cpp
@@ -1,11 +1,11 @@
 // Scalar generated-quantities draws on the compiled write_array graph.
 //
 // OP_RNG is deliberately one effectful opcode. Its variant names the family;
-// variants 0..5 take scalar-double arguments, while categorical takes one
-// probability-vector slot. Every result is scalar (Stan int draws are
-// represented exactly in graph doubles too). The stream is evaluation state,
-// not graph/model state, so callers can interleave independent chains through
-// one compiled model without sharing or resetting a stream.
+// variants 0..5 take scalar-double arguments, categorical takes one
+// probability-vector slot, and multi-normal takes a mean vector plus a square
+// covariance and produces a vector. The stream is evaluation state, not
+// graph/model state, so callers can interleave independent chains through one
+// compiled model without sharing or resetting a stream.
 #include <stanli/graph.hpp>
 #include <stanli/optable.hpp>
 #include <stanli/wa_interp.hpp>
@@ -17,12 +17,12 @@ namespace stanli {
 namespace {
 
 void rng_fwd(KernelCtx& ctx) {
-  if (ctx.out.len != 1 ||
-      (ctx.variant > static_cast<uint8_t>(ScalarRng::Binomial) &&
-       ctx.variant != kCategoricalRngVariant))
+  if (ctx.variant > static_cast<uint8_t>(ScalarRng::Binomial) &&
+      ctx.variant != kCategoricalRngVariant &&
+      ctx.variant != kMultiNormalRngVariant)
     throw std::logic_error("malformed RNG op");
   if (ctx.variant == kCategoricalRngVariant) {
-    if (ctx.n_in != 1 || ctx.in[0].len < 0)
+    if (ctx.out.len != 1 || ctx.n_in != 1 || ctx.in[0].len < 0)
       throw std::logic_error("malformed categorical RNG op");
     if (ctx.eval_state == nullptr || ctx.eval_state->wa_rng == nullptr)
       throw std::logic_error(
@@ -32,6 +32,24 @@ void rng_fwd(KernelCtx& ctx) {
                              *ctx.eval_state->wa_rng));
     return;
   }
+  if (ctx.variant == kMultiNormalRngVariant) {
+    if (ctx.n_in != 2 || ctx.n_idata != 1 || ctx.idata == nullptr ||
+        ctx.idata[0] < 0)
+      throw std::logic_error("malformed multi-normal RNG op");
+    const int64_t k = ctx.idata[0];
+    if (ctx.in[0].len != k || ctx.in[1].len != k * k || ctx.out.len != k)
+      throw std::logic_error("malformed multi-normal RNG op");
+    if (ctx.eval_state == nullptr || ctx.eval_state->wa_rng == nullptr)
+      throw std::logic_error(
+          "OP_RNG requires caller-owned evaluation RNG state");
+    multi_normal_rng_draw(ctx.in[0].data, static_cast<size_t>(ctx.in[0].len),
+                          ctx.in[1].data, static_cast<size_t>(ctx.in[1].len),
+                          static_cast<size_t>(k), static_cast<size_t>(k),
+                          ctx.out.data, static_cast<size_t>(ctx.out.len),
+                          *ctx.eval_state->wa_rng);
+    return;
+  }
+  if (ctx.out.len != 1) throw std::logic_error("malformed scalar RNG op");
   const ScalarRng family = static_cast<ScalarRng>(ctx.variant);
   const size_t nargs = scalar_rng_arity(family);
   if (ctx.n_in != static_cast<int>(nargs))

--- a/runtime/src/OPTIMIZATIONS.md
+++ b/runtime/src/OPTIMIZATIONS.md
@@ -256,13 +256,13 @@ caller's stream. The graph passes treat every RNG op as an ordered effect, so
 they cannot fold, reroll, carve, delete, or duplicate a draw whose result is
 otherwise unused.
 
-The boundary is deliberately fail-closed. Container-valued results or
-unsupported RNGs, and integer draws needed as a loop bound, index, shape, or
-branch condition, still select the whole-section interpreter. Scalar integer
-results live exactly in one double slot only while used by ordinary graph
-arithmetic; integer division and other dynamic-integer operations still refuse
-lowering. A later tranche adds the one audited vector-argument exception,
-`categorical_rng(vector)`, without admitting container-valued results.
+The boundary is deliberately fail-closed. Apart from the audited categorical
+and covariance-form multivariate-normal extensions below, container-valued
+results or unsupported RNGs, and integer draws needed as a loop bound, index,
+shape, or branch condition, still select the whole-section interpreter. Scalar
+integer results live exactly in one double slot only while used by ordinary
+graph arithmetic; integer division and other dynamic-integer operations still
+refuse lowering.
 
 An exact census of the 24 corpus models that previously used `WaInterp` moved
 12 to the graph in this tranche: `GLMM1_model`, both `covid19imperial` models, both `dogs`
@@ -311,8 +311,9 @@ using the result as dynamic control or geometry all fail closed.
 This completed `Mh_model`, `Mt_model`, `Mtbh_model`, and `Mth_model`, moving the
 then-current 24-model write-array census from 12 graph / 12 interpreter to
 16 / 8. The categorical tranche below subsequently advances that census to
-17 / 7, and the extrema tranche after it advances the current census to 18 / 6.
-All 119 compiling corpus models still produce complete rows. Targeted
+17 / 7, the extrema tranche advances it to 18 / 6, and the covariance-form
+multivariate-normal tranche advances the current census to 19 / 5. All 119
+compiling corpus models still produce complete rows. Targeted
 2026-08-24 C-ABI A/B medians (point 0, two warmups, seven matched batches) were:
 
 | model | interpreted us/row | compiled us/row | speedup |
@@ -390,12 +391,13 @@ lowering gate forward-only rather than allowing a graph transformation to
 place it in a reverse sweep.
 
 `losscurve_sislob` was the only model to change in the exact 24-model census,
-moving coverage from 17 graph / 7 interpreter to the current 18 / 6. All 24
-census models and all 119 compiling corpus models retained complete rows. Its
-1,218-op graph contains exactly one length-10 min opcode and one length-10 max
-opcode, and writes 384 columns. Graph and `WaInterp` output was bitwise exact
-for all 1,536/1,536 compared values, and the same-input pinned Stan Math oracle
-matched 8/8 cases.
+moving coverage from 17 graph / 7 interpreter to the then-current 18 / 6. The
+covariance-form multivariate-normal tranche below advances the current census
+to 19 / 5. All 24 census models and all 119 compiling corpus models retained
+complete rows. Its 1,218-op graph contains exactly one length-10 min opcode and
+one length-10 max opcode, and writes 384 columns. Graph and `WaInterp` output
+was bitwise exact for all 1,536/1,536 compared values, and the same-input pinned
+Stan Math oracle matched 8/8 cases.
 Against 1,200 stored CmdStan values, the worst difference was 4.44e-16, or
 eight ULP.
 
@@ -405,6 +407,40 @@ from 4107.375 to 5291.959 us, a 1184.584 us setup increase that amortizes after
 3.627 rows, or four whole rows. These targeted results do not refresh
 `docs/corpus-bench.tsv` or the generated full-corpus table in
 `docs/benchmarks.md`.
+
+## Compiled covariance-form multivariate-normal RNG (`rng.cpp`, `wa_interp.cpp`)
+
+The vector-result `multi_normal_rng(vector, matrix)` write-array surface reuses
+`OP_RNG` rather than adding a second effect vocabulary. Its variant reads a
+length-`K` mean and a column-major `K` by `K` covariance, and writes a
+length-`K` vector. Lowering admits only an exact non-array `UVector` result,
+one non-array `UVector` mean, and one square `UMatrix` covariance whose known
+dimensions match. Row-vector/array overloads, mismatched or unknown shapes,
+and `multi_normal_cholesky_rng` still select `WaInterp`.
+
+The graph and interpreter call one helper. It reconstructs the same owning
+Eigen vector and column-major matrix accepted by pinned Stan Math, invokes
+`multi_normal_rng` once, and copies the resulting vector out. Stan Math remains
+the single definition of finite-mean, NaN, symmetry, and positive-definiteness
+validation order, exception behavior, covariance factorization, output
+arithmetic, and engine consumption. Invalid calls therefore consume no draws,
+while valid graph and interpreter calls advance the caller-owned stream
+identically. The existing opcode-wide effect barriers keep the vector draw out
+of constant folding, rerolling, and islands without another pass-specific
+exception.
+
+`multi_occupancy` was the only model to change in the exact 24-model census,
+moving coverage from 18 graph / 6 interpreter to the current 19 / 5. All 24
+census models and all 119 compiling corpus models retained complete rows;
+overall corpus coverage is 114 graph and five interpreted models. Graph and
+forced-interpreter output was bitwise exact for all 5,616 values across seeds
+0, 1, 2, 7, 1234, and `UINT32_MAX`, each continued for three sequential rows.
+
+In a targeted 2026-08-25 matched C-ABI A/B (point 0, two warmups, seven batch
+medians), `multi_occupancy` moved from 298.9260 to 5.4898 us/row (54.4512x),
+saving 0.2934362 s per 1,000 rows. Construction also improved from 5864.792 to
+5368.583 us, so there is no setup break-even penalty. These targeted results
+do not refresh `docs/corpus-bench.tsv` or the generated full-corpus table.
 
 ## Control flow that depends on a parameter (`lower.cpp`, `mir_prog.hpp`)
 

--- a/runtime/src/lower.cpp
+++ b/runtime/src/lower.cpp
@@ -2243,6 +2243,44 @@ struct Lowering {
     return ret;
   }
 
+  std::optional<Val> lower_multi_normal_rng(const mir::Expr& e) {
+    if (e.name != "multi_normal_rng") return std::nullopt;
+    if (!in_write_array)
+      fail("multi_normal_rng is supported only in generated quantities", e.raw);
+    if (e.args.size() != 2 || e.type_ != "UVector" ||
+        e.unsized.leaf != mir::UnsizedLeaf::Vector || e.unsized.depth != 0)
+      fail("multi_normal_rng: expected one vector result", e.raw);
+    const mir::Expr& location_expr = e.args[0];
+    const mir::Expr& covariance_expr = e.args[1];
+    if (location_expr.type_ != "UVector" ||
+        location_expr.unsized.leaf != mir::UnsizedLeaf::Vector ||
+        location_expr.unsized.depth != 0)
+      fail("multi_normal_rng: expected one vector location", e.raw);
+    if (covariance_expr.type_ != "UMatrix" ||
+        covariance_expr.unsized.leaf != mir::UnsizedLeaf::Matrix ||
+        covariance_expr.unsized.depth != 0)
+      fail("multi_normal_rng: expected one covariance matrix", e.raw);
+
+    Val location = lower_expr(location_expr);
+    Val covariance = lower_expr(covariance_expr);
+    if (!is_vector(location.si))
+      fail("multi_normal_rng: location is not a logical vector", e.raw);
+    if (!is_matrix(covariance.si))
+      fail("multi_normal_rng: covariance has no known matrix shape", e.raw);
+    const int64_t k = g.slots[location.slot].len;
+    if (k > std::numeric_limits<int>::max() || covariance.si.rows != k ||
+        covariance.si.cols != k ||
+        g.slots[covariance.slot].len != checked_product({k, k}, "covariance"))
+      fail("multi_normal_rng: covariance shape must match the location", e.raw);
+
+    Val draw = emit_value(OP_RNG, {location, covariance}, k, view_of(e.type_),
+                          {static_cast<int>(k)});
+    g.ops.back().variant = kMultiNormalRngVariant;
+    draw.si.param_free = false;
+    draw.autodiff = false;
+    return draw;
+  }
+
   std::optional<Val> lower_categorical_rng(const mir::Expr& e) {
     if (e.name != "categorical_rng") return std::nullopt;
     if (!in_write_array)
@@ -2542,6 +2580,7 @@ struct Lowering {
     }
     // The stan-library names split into disjoint groups; each helper owns
     // one and declines the rest.
+    if (auto v = lower_multi_normal_rng(e)) return *v;
     if (auto v = lower_categorical_rng(e)) return *v;
     if (auto v = lower_scalar_rng(e)) return *v;
     if (auto v = lower_density_fn(e)) return *v;

--- a/runtime/src/wa_interp.cpp
+++ b/runtime/src/wa_interp.cpp
@@ -5,6 +5,7 @@
 #include <Eigen/Dense>
 
 #include <algorithm>
+#include <limits>
 #include <utility>
 
 namespace stanli {
@@ -58,6 +59,35 @@ int categorical_rng_draw(const double* probabilities, size_t size, WaRng& rng) {
   for (size_t i = 0; i < size; ++i)
     theta[static_cast<Eigen::Index>(i)] = probabilities[i];
   return stan::math::categorical_rng(theta, rng.gen());
+}
+
+void multi_normal_rng_draw(const double* location, size_t location_size,
+                           const double* covariance, size_t covariance_size,
+                           size_t covariance_rows, size_t covariance_cols,
+                           double* output, size_t output_size, WaRng& rng) {
+  if ((location_size != 0 && location == nullptr) ||
+      (covariance_size != 0 && covariance == nullptr) ||
+      (output_size != 0 && output == nullptr) || output_size != location_size ||
+      (covariance_rows != 0 &&
+       covariance_cols >
+           std::numeric_limits<size_t>::max() / covariance_rows) ||
+      covariance_rows * covariance_cols != covariance_size)
+    throw std::logic_error("malformed multi-normal RNG arguments");
+
+  Eigen::VectorXd mu(static_cast<Eigen::Index>(location_size));
+  for (size_t i = 0; i < location_size; ++i)
+    mu[static_cast<Eigen::Index>(i)] = location[i];
+  Eigen::MatrixXd sigma(static_cast<Eigen::Index>(covariance_rows),
+                        static_cast<Eigen::Index>(covariance_cols));
+  for (size_t j = 0; j < covariance_cols; ++j)
+    for (size_t i = 0; i < covariance_rows; ++i)
+      sigma(static_cast<Eigen::Index>(i), static_cast<Eigen::Index>(j)) =
+          covariance[j * covariance_rows + i];
+
+  const Eigen::VectorXd draw =
+      stan::math::multi_normal_rng(mu, sigma, rng.gen());
+  for (size_t i = 0; i < output_size; ++i)
+    output[i] = draw[static_cast<Eigen::Index>(i)];
 }
 
 double wa_probe_point(int64_t i, int variant) {
@@ -292,22 +322,31 @@ bool WaInterp::rng_fun(MirInterp<double>& in, const mir::Expr& e,
   };
 
   // Vector-valued draw from a mean vector and covariance (or Cholesky
-  // factor) matrix.
+  // factor) matrix. The covariance form shares its owning-Eigen helper with
+  // OP_RNG so validation and engine schedules cannot drift between modes.
   if (base == "multi_normal" || base == "multi_normal_cholesky") {
     const auto& mu = av.at(0);
     const auto& S = av.at(1);
     const int64_t K = (int64_t)mu.r.size();
-    Eigen::VectorXd m(K);
-    for (int64_t i = 0; i < K; ++i) m[i] = mu.r[(size_t)i];
-    Eigen::MatrixXd sig(K, K);
-    for (int64_t j = 0; j < K; ++j)
-      for (int64_t i = 0; i < K; ++i) sig(i, j) = S.r.at((size_t)(j * K + i));
-    const Eigen::VectorXd draw =
-        base == "multi_normal"
-            ? stan::math::multi_normal_rng(m, sig, g)
-            : stan::math::multi_normal_cholesky_rng(m, sig, g);
     out->dims = {K};
-    for (int64_t i = 0; i < K; ++i) out->r.push_back(draw[i]);
+    out->r.resize(static_cast<size_t>(K));
+    if (base == "multi_normal") {
+      if (S.dims.size() != 2)
+        throw std::logic_error("malformed multi-normal covariance shape");
+      multi_normal_rng_draw(mu.r.data(), mu.r.size(), S.r.data(), S.r.size(),
+                            static_cast<size_t>(S.dims[0]),
+                            static_cast<size_t>(S.dims[1]), out->r.data(),
+                            out->r.size(), rng);
+    } else {
+      Eigen::VectorXd m(K);
+      for (int64_t i = 0; i < K; ++i) m[i] = mu.r[(size_t)i];
+      Eigen::MatrixXd sig(K, K);
+      for (int64_t j = 0; j < K; ++j)
+        for (int64_t i = 0; i < K; ++i) sig(i, j) = S.r.at((size_t)(j * K + i));
+      const Eigen::VectorXd draw =
+          stan::math::multi_normal_cholesky_rng(m, sig, g);
+      for (int64_t i = 0; i < K; ++i) out->r[static_cast<size_t>(i)] = draw[i];
+    }
     return true;
   }
 

--- a/tests/fixtures/gq_multi_normal_rng.stan
+++ b/tests/fixtures/gq_multi_normal_rng.stan
@@ -1,0 +1,25 @@
+functions {
+  matrix cov_matrix_2d(vector sigma, real rho) {
+    matrix[2, 2] covariance;
+    covariance[1, 1] = square(sigma[1]);
+    covariance[1, 2] = sigma[1] * sigma[2] * rho;
+    covariance[2, 1] = covariance[1, 2];
+    covariance[2, 2] = square(sigma[2]);
+    return covariance;
+  }
+}
+parameters {
+  vector[2] mu;
+  vector<lower=0>[2] sigma;
+  real<lower=-1, upper=1> rho;
+}
+model {
+  mu ~ normal(0, 1);
+  sigma ~ lognormal(0, 1);
+  rho ~ uniform(-1, 1);
+}
+generated quantities {
+  vector[2] draw = multi_normal_rng(mu, cov_matrix_2d(sigma, rho));
+  real shifted = draw[1] - draw[2];
+  real tail = uniform_rng(0, 1);
+}

--- a/tests/fixtures/gq_multi_normal_rng.tmir.sexp
+++ b/tests/fixtures/gq_multi_normal_rng.tmir.sexp
@@ -1,0 +1,1010 @@
+((functions_block
+  (((fdrt (ReturnType UMatrix)) (fdname cov_matrix_2d) (fdsuffix FnPlain)
+    (fdargs ((AutoDiffable sigma UVector) (AutoDiffable rho UReal)))
+    (fdbody
+     (((pattern
+        (Block
+         (((pattern
+            (Decl (decl_adtype AutoDiffable) (decl_id covariance)
+             (decl_type
+              (Sized
+               (SMatrix AoS
+                ((pattern (Lit Int 2))
+                 (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                ((pattern (Lit Int 2))
+                 (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+             (initialize Default)))
+           (meta <opaque>))
+          ((pattern
+            (Assignment
+             ((LVariable covariance)
+              ((Single
+                ((pattern (Lit Int 1))
+                 (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+               (Single
+                ((pattern (Lit Int 1))
+                 (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+             UMatrix
+             ((pattern
+               (FunApp (StanLib square FnPlain AoS)
+                (((pattern
+                   (Indexed
+                    ((pattern (Var sigma))
+                     (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))
+                    ((Single
+                      ((pattern (Lit Int 1))
+                       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                  (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
+              (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+           (meta <opaque>))
+          ((pattern
+            (Assignment
+             ((LVariable covariance)
+              ((Single
+                ((pattern (Lit Int 1))
+                 (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+               (Single
+                ((pattern (Lit Int 2))
+                 (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+             UMatrix
+             ((pattern
+               (FunApp (StanLib Times__ FnPlain AoS)
+                (((pattern
+                   (FunApp (StanLib Times__ FnPlain AoS)
+                    (((pattern
+                       (Indexed
+                        ((pattern (Var sigma))
+                         (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))
+                        ((Single
+                          ((pattern (Lit Int 1))
+                           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                      (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+                     ((pattern
+                       (Indexed
+                        ((pattern (Var sigma))
+                         (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))
+                        ((Single
+                          ((pattern (Lit Int 2))
+                           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                      (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
+                  (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+                 ((pattern (Var rho))
+                  (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
+              (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+           (meta <opaque>))
+          ((pattern
+            (Assignment
+             ((LVariable covariance)
+              ((Single
+                ((pattern (Lit Int 2))
+                 (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+               (Single
+                ((pattern (Lit Int 1))
+                 (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+             UMatrix
+             ((pattern
+               (Indexed
+                ((pattern (Var covariance))
+                 (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))
+                ((Single
+                  ((pattern (Lit Int 1))
+                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                 (Single
+                  ((pattern (Lit Int 2))
+                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+              (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+           (meta <opaque>))
+          ((pattern
+            (Assignment
+             ((LVariable covariance)
+              ((Single
+                ((pattern (Lit Int 2))
+                 (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+               (Single
+                ((pattern (Lit Int 2))
+                 (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+             UMatrix
+             ((pattern
+               (FunApp (StanLib square FnPlain AoS)
+                (((pattern
+                   (Indexed
+                    ((pattern (Var sigma))
+                     (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))
+                    ((Single
+                      ((pattern (Lit Int 2))
+                       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                  (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
+              (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+           (meta <opaque>))
+          ((pattern
+            (Return
+             (((pattern (Var covariance))
+               (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable)))))))
+           (meta <opaque>)))))
+       (meta <opaque>))))
+    (fdloc <opaque>))))
+ (input_vars ()) (prepare_data ())
+ (log_prob
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id mu)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity)
+             (dims
+              (((pattern (Lit Int 2))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id sigma)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam
+             (constrain
+              (Lower
+               ((pattern (Lit Int 0))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (dims
+              (((pattern (Lit Int 2))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id rho) (decl_type (Sized SReal))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam
+             (constrain
+              (LowerUpper
+               ((pattern
+                 (FunApp (StanLib PMinus__ FnPlain AoS)
+                  (((pattern (Lit Int 1))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+               ((pattern (Lit Int 1))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (dims ()) (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib normal_lpdf (FnLpdf true) AoS)
+             (((pattern (Var mu))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))
+              ((pattern
+                (Promotion
+                 ((pattern (Lit Int 0))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                 UReal DataOnly))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+              ((pattern
+                (Promotion
+                 ((pattern (Lit Int 1))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                 UReal DataOnly))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>))
+       ((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib lognormal_lpdf (FnLpdf true) AoS)
+             (((pattern (Var sigma))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))
+              ((pattern
+                (Promotion
+                 ((pattern (Lit Int 0))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                 UReal DataOnly))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+              ((pattern
+                (Promotion
+                 ((pattern (Lit Int 1))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                 UReal DataOnly))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>))
+       ((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib uniform_lpdf (FnLpdf true) AoS)
+             (((pattern (Var rho))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+              ((pattern
+                (Promotion
+                 ((pattern (Lit Int -1))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                 UReal DataOnly))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+              ((pattern
+                (Promotion
+                 ((pattern (Lit Int 1))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                 UReal DataOnly))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>)))))
+    (meta <opaque>))))
+ (reverse_mode_log_prob
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id mu)
+      (decl_type
+       (Sized
+        (SVector SoA
+         ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity)
+             (dims
+              (((pattern (Lit Int 2))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern SoA)))
+           ()))
+         (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id sigma)
+      (decl_type
+       (Sized
+        (SVector SoA
+         ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam
+             (constrain
+              (Lower
+               ((pattern (Lit Int 0))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (dims
+              (((pattern (Lit Int 2))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern SoA)))
+           ()))
+         (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id rho) (decl_type (Sized SReal))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam
+             (constrain
+              (LowerUpper
+               ((pattern
+                 (FunApp (StanLib PMinus__ FnPlain SoA)
+                  (((pattern (Lit Int 1))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+               ((pattern (Lit Int 1))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (dims ()) (mem_pattern SoA)))
+           ()))
+         (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib normal_lpdf (FnLpdf true) SoA)
+             (((pattern (Var mu))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))
+              ((pattern
+                (Promotion
+                 ((pattern (Lit Int 0))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                 UReal DataOnly))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+              ((pattern
+                (Promotion
+                 ((pattern (Lit Int 1))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                 UReal DataOnly))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>))
+       ((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib lognormal_lpdf (FnLpdf true) SoA)
+             (((pattern (Var sigma))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))
+              ((pattern
+                (Promotion
+                 ((pattern (Lit Int 0))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                 UReal DataOnly))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+              ((pattern
+                (Promotion
+                 ((pattern (Lit Int 1))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                 UReal DataOnly))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>))
+       ((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib uniform_lpdf (FnLpdf true) SoA)
+             (((pattern (Var rho))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+              ((pattern
+                (Promotion
+                 ((pattern (Lit Int -1))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                 UReal DataOnly))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+              ((pattern
+                (Promotion
+                 ((pattern (Lit Int 1))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                 UReal DataOnly))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>)))))
+    (meta <opaque>))))
+ (generate_quantities
+  (((pattern
+     (Decl (decl_adtype DataOnly) (decl_id mu)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity)
+             (dims
+              (((pattern (Lit Int 2))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id sigma)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam
+             (constrain
+              (Lower
+               ((pattern (Lit Int 0))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (dims
+              (((pattern (Lit Int 2))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id rho) (decl_type (Sized SReal))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam
+             (constrain
+              (LowerUpper
+               ((pattern
+                 (FunApp (StanLib PMinus__ FnPlain AoS)
+                  (((pattern (Lit Int 1))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+               ((pattern (Lit Int 1))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (dims ()) (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt ())
+        (var
+         ((pattern (Var mu)) (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt ())
+        (var
+         ((pattern (Var sigma))
+          (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt ())
+        (var
+         ((pattern (Var rho)) (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (IfElse
+      ((pattern
+        (FunApp (StanLib PNot__ FnPlain AoS)
+         (((pattern
+            (EOr
+             ((pattern (Var emit_transformed_parameters__))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+             ((pattern (Var emit_generated_quantities__))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+      ((pattern (Block (((pattern (Return ())) (meta <opaque>))))) (meta <opaque>)) ()))
+    (meta <opaque>))
+   ((pattern
+     (IfElse
+      ((pattern
+        (FunApp (StanLib PNot__ FnPlain AoS)
+         (((pattern (Var emit_generated_quantities__))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+      ((pattern (Block (((pattern (Return ())) (meta <opaque>))))) (meta <opaque>)) ()))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id draw)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id inline_cov_matrix_2d_return_sym1__)
+      (decl_type
+       (Sized
+        (SMatrix AoS
+         ((pattern (Lit Int 0)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+         ((pattern (Lit Int 0)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable)
+          (decl_id inline_cov_matrix_2d_covariance_sym2__)
+          (decl_type
+           (Sized
+            (SMatrix AoS
+             ((pattern (Lit Int 2))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+             ((pattern (Lit Int 2))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+          (initialize Default)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment
+          ((LVariable inline_cov_matrix_2d_covariance_sym2__)
+           ((Single
+             ((pattern (Lit Int 1))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+            (Single
+             ((pattern (Lit Int 1))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+          UMatrix
+          ((pattern
+            (FunApp (StanLib square FnPlain AoS)
+             (((pattern
+                (Indexed
+                 ((pattern (Var sigma))
+                  (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly))))
+                 ((Single
+                   ((pattern (Lit Int 1))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>))
+       ((pattern
+         (Assignment
+          ((LVariable inline_cov_matrix_2d_covariance_sym2__)
+           ((Single
+             ((pattern (Lit Int 1))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+            (Single
+             ((pattern (Lit Int 2))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+          UMatrix
+          ((pattern
+            (FunApp (StanLib Times__ FnPlain AoS)
+             (((pattern
+                (FunApp (StanLib Times__ FnPlain AoS)
+                 (((pattern
+                    (Indexed
+                     ((pattern (Var sigma))
+                      (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly))))
+                     ((Single
+                       ((pattern (Lit Int 1))
+                        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+                  ((pattern
+                    (Indexed
+                     ((pattern (Var sigma))
+                      (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly))))
+                     ((Single
+                       ((pattern (Lit Int 2))
+                        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+              ((pattern (Var rho))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>))
+       ((pattern
+         (Assignment
+          ((LVariable inline_cov_matrix_2d_covariance_sym2__)
+           ((Single
+             ((pattern (Lit Int 2))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+            (Single
+             ((pattern (Lit Int 1))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+          UMatrix
+          ((pattern
+            (Indexed
+             ((pattern (Var inline_cov_matrix_2d_covariance_sym2__))
+              (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))
+             ((Single
+               ((pattern (Lit Int 1))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+              (Single
+               ((pattern (Lit Int 2))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>))
+       ((pattern
+         (Assignment
+          ((LVariable inline_cov_matrix_2d_covariance_sym2__)
+           ((Single
+             ((pattern (Lit Int 2))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+            (Single
+             ((pattern (Lit Int 2))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+          UMatrix
+          ((pattern
+            (FunApp (StanLib square FnPlain AoS)
+             (((pattern
+                (Indexed
+                 ((pattern (Var sigma))
+                  (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly))))
+                 ((Single
+                   ((pattern (Lit Int 2))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable inline_cov_matrix_2d_return_sym1__) ()) UMatrix
+          ((pattern (Var inline_cov_matrix_2d_covariance_sym2__))
+           (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>)))))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable draw) ()) UVector
+      ((pattern
+        (FunApp (StanLib multi_normal_rng FnRng AoS)
+         (((pattern (Var mu)) (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly))))
+          ((pattern (Var inline_cov_matrix_2d_return_sym1__))
+           (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id shifted) (decl_type (Sized SReal))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable shifted) ()) UReal
+      ((pattern
+        (FunApp (StanLib Minus__ FnPlain AoS)
+         (((pattern
+            (Indexed
+             ((pattern (Var draw))
+              (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly))))
+             ((Single
+               ((pattern (Lit Int 1))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+          ((pattern
+            (Indexed
+             ((pattern (Var draw))
+              (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly))))
+             ((Single
+               ((pattern (Lit Int 2))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id tail) (decl_type (Sized SReal))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable tail) ()) UReal
+      ((pattern
+        (FunApp (StanLib uniform_rng FnRng AoS)
+         (((pattern (Lit Int 0)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+          ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt ())
+        (var
+         ((pattern (Var draw))
+          (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt ())
+        (var
+         ((pattern (Var shifted))
+          (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt ())
+        (var
+         ((pattern (Var tail)) (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))))
+ (transform_inits
+  (((pattern
+     (Decl (decl_adtype DataOnly) (decl_id pos__) (decl_type (Sized SInt))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id mu)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id mu_flat__)
+          (decl_type (Unsized (UArray UReal))) (initialize Uninit)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable mu_flat__) ()) (UArray UReal)
+          ((pattern
+            (FunApp (CompilerInternal FnReadData)
+             (((pattern (Lit Str mu))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable pos__) ()) UInt
+          ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar sym1__)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Lit Int 2))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (Assignment
+                  ((LVariable mu)
+                   ((Single
+                     ((pattern (Var sym1__))
+                      (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                  UVector
+                  ((pattern
+                    (Indexed
+                     ((pattern (Var mu_flat__))
+                      (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))
+                     ((Single
+                       ((pattern (Var pos__))
+                        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+                (meta <opaque>))
+               ((pattern
+                 (Assignment ((LVariable pos__) ()) UInt
+                  ((pattern
+                    (FunApp (StanLib Plus__ FnPlain AoS)
+                     (((pattern (Var pos__))
+                       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                      ((pattern (Lit Int 1))
+                       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var mu)) (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id sigma)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id sigma_flat__)
+          (decl_type (Unsized (UArray UReal))) (initialize Uninit)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable sigma_flat__) ()) (UArray UReal)
+          ((pattern
+            (FunApp (CompilerInternal FnReadData)
+             (((pattern (Lit Str sigma))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable pos__) ()) UInt
+          ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar sym1__)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Lit Int 2))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (Assignment
+                  ((LVariable sigma)
+                   ((Single
+                     ((pattern (Var sym1__))
+                      (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                  UVector
+                  ((pattern
+                    (Indexed
+                     ((pattern (Var sigma_flat__))
+                      (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))
+                     ((Single
+                       ((pattern (Var pos__))
+                        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+                (meta <opaque>))
+               ((pattern
+                 (Assignment ((LVariable pos__) ()) UInt
+                  ((pattern
+                    (FunApp (StanLib Plus__ FnPlain AoS)
+                     (((pattern (Var pos__))
+                       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                      ((pattern (Lit Int 1))
+                       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam
+        (unconstrain_opt
+         ((Lower
+           ((pattern (Lit Int 0))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+        (var
+         ((pattern (Var sigma))
+          (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id rho) (decl_type (Sized SReal))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable rho) ()) UReal
+      ((pattern
+        (Indexed
+         ((pattern
+           (FunApp (CompilerInternal FnReadData)
+            (((pattern (Lit Str rho))
+              (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+          (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))
+         ((Single
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+       (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam
+        (unconstrain_opt
+         ((LowerUpper
+           ((pattern (Lit Int -1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+        (var
+         ((pattern (Var rho)) (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))))
+ (unconstrain_array
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id mu)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable mu) ()) UVector
+      ((pattern
+        (FunApp (CompilerInternal FnReadDeserializer)
+         (((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var mu)) (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id sigma)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable sigma) ()) UVector
+      ((pattern
+        (FunApp (CompilerInternal FnReadDeserializer)
+         (((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam
+        (unconstrain_opt
+         ((Lower
+           ((pattern (Lit Int 0))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+        (var
+         ((pattern (Var sigma))
+          (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id rho) (decl_type (Sized SReal))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable rho) ()) UReal
+      ((pattern (FunApp (CompilerInternal FnReadDeserializer) ()))
+       (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam
+        (unconstrain_opt
+         ((LowerUpper
+           ((pattern (Lit Int -1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+        (var
+         ((pattern (Var rho)) (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))))
+ (output_vars
+  ((mu <opaque>
+    ((out_unconstrained_st
+      (SVector AoS
+       ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+     (out_constrained_st
+      (SVector AoS
+       ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+     (out_block Parameters) (out_trans Identity)))
+   (sigma <opaque>
+    ((out_unconstrained_st
+      (SVector AoS
+       ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+     (out_constrained_st
+      (SVector AoS
+       ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+     (out_block Parameters)
+     (out_trans
+      (Lower
+       ((pattern (Lit Int 0)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+   (rho <opaque>
+    ((out_unconstrained_st SReal) (out_constrained_st SReal) (out_block Parameters)
+     (out_trans
+      (LowerUpper
+       ((pattern (Lit Int -1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+       ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+   (draw <opaque>
+    ((out_unconstrained_st
+      (SVector AoS
+       ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+     (out_constrained_st
+      (SVector AoS
+       ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+     (out_block GeneratedQuantities) (out_trans Identity)))
+   (shifted <opaque>
+    ((out_unconstrained_st SReal) (out_constrained_st SReal)
+     (out_block GeneratedQuantities) (out_trans Identity)))
+   (tail <opaque>
+    ((out_unconstrained_st SReal) (out_constrained_st SReal)
+     (out_block GeneratedQuantities) (out_trans Identity)))))
+ (prog_name gq_multi_normal_rng_model)
+ (prog_path tests/fixtures/gq_multi_normal_rng.stan))

--- a/tests/test_pass_safety.cpp
+++ b/tests/test_pass_safety.cpp
@@ -355,11 +355,21 @@ static void test_rng_is_an_effect_barrier() {
   const int probabilities = g.add_slot(4, false);
   fills.emplace_back(probabilities,
                      std::vector<double>{0.125, 0.25, 0.375, 0.25});
+  const int location = g.add_slot(2, false);
+  const int covariance = g.add_slot(4, false);
+  fills.emplace_back(location, std::vector<double>{0.5, -1.25});
+  fills.emplace_back(covariance, std::vector<double>{1.69, 0.364, 0.364, 0.64});
   std::vector<int> roots;
   for (int i = 0; i < 40; ++i) {
-    const int out = g.add_slot(1, false);
-    g.add_op(OP_RNG, {probabilities}, out);
-    g.ops.back().variant = kCategoricalRngVariant;
+    const bool vector_draw = i == 39;
+    const int out = g.add_slot(vector_draw ? 2 : 1, false);
+    if (vector_draw) {
+      g.add_op(OP_RNG, {location, covariance}, out, {2});
+      g.ops.back().variant = kMultiNormalRngVariant;
+    } else {
+      g.add_op(OP_RNG, {probabilities}, out);
+      g.ops.back().variant = kCategoricalRngVariant;
+    }
     if (i == 39) roots.push_back(out);
   }
   g.result_slot = roots.back();
@@ -387,12 +397,18 @@ static void test_rng_is_an_effect_barrier() {
   theta << 0.125, 0.25, 0.375, 0.25;
   WaRng got_rng(20260824), want_rng(20260824);
   ex.run_forward_only(EvalState{&got_rng});
-  int want = 0;
-  for (int i = 0; i < 40; ++i)
-    want = stan::math::categorical_rng(theta, want_rng.gen());
-  expect("categorical RNG effect order preserved",
-         ex.value_ptr(roots.back())[0] == static_cast<double>(want));
-  expect("categorical RNG next state preserved",
+  for (int i = 0; i < 39; ++i)
+    (void)stan::math::categorical_rng(theta, want_rng.gen());
+  Eigen::VectorXd mu(2);
+  mu << 0.5, -1.25;
+  Eigen::MatrixXd sigma(2, 2);
+  sigma << 1.69, 0.364, 0.364, 0.64;
+  const Eigen::VectorXd want =
+      stan::math::multi_normal_rng(mu, sigma, want_rng.gen());
+  expect("vector RNG effect order preserved",
+         ex.value_ptr(roots.back())[0] == want[0] &&
+             ex.value_ptr(roots.back())[1] == want[1]);
+  expect("vector RNG next state preserved",
          got_rng.gen()() == want_rng.gen()());
 }
 

--- a/tests/test_write_array.cpp
+++ b/tests/test_write_array.cpp
@@ -673,6 +673,40 @@ static Eigen::VectorXd categorical_theta(const std::vector<double>& p) {
   return theta;
 }
 
+static Eigen::VectorXd multi_normal_location(const std::vector<double>& x) {
+  Eigen::VectorXd out(static_cast<Eigen::Index>(x.size()));
+  for (size_t i = 0; i < x.size(); ++i)
+    out[static_cast<Eigen::Index>(i)] = x[i];
+  return out;
+}
+
+static Eigen::MatrixXd multi_normal_covariance(const std::vector<double>& x,
+                                               size_t rows, size_t cols) {
+  Eigen::MatrixXd out(static_cast<Eigen::Index>(rows),
+                      static_cast<Eigen::Index>(cols));
+  for (size_t j = 0; j < cols; ++j)
+    for (size_t i = 0; i < rows; ++i)
+      out(static_cast<Eigen::Index>(i), static_cast<Eigen::Index>(j)) =
+          x.at(j * rows + i);
+  return out;
+}
+
+static std::vector<double> direct_multi_normal_rng(
+    const std::vector<double>& mu, const std::vector<double>& covariance,
+    size_t rows, size_t cols, stanli::WaRng& rng) {
+  const Eigen::VectorXd draw = stan::math::multi_normal_rng(
+      multi_normal_location(mu),
+      multi_normal_covariance(covariance, rows, cols), rng.gen());
+  return std::vector<double>(draw.data(), draw.data() + draw.size());
+}
+
+static bool same_double_bytes(const std::vector<double>& a,
+                              const std::vector<double>& b) {
+  return a.size() == b.size() &&
+         (a.empty() ||
+          std::memcmp(a.data(), b.data(), a.size() * sizeof(double)) == 0);
+}
+
 // categorical_rng is unusual in this opcode family: one logical argument is
 // a variable-length vector, while the result is still one Stan int. Keep the
 // shared helper byte-for-byte on Stan Math's validation and engine schedule.
@@ -745,6 +779,117 @@ void test_categorical_rng_helper_contract() {
   if (null_input.kind != 3 || malformed.gen()() != untouched.gen()()) {
     ++failures;
     std::printf("FAIL categorical helper malformed pointer contract\n");
+  }
+}
+
+void test_multi_normal_rng_helper_contract() {
+  using namespace stanli;
+  struct Valid {
+    std::vector<double> mu;
+    std::vector<double> covariance;
+  };
+  const Valid valid[] = {
+      {{-0.25}, {1.75}},
+      {{0.5, -1.25}, {1.69, 0.364, 0.364, 0.64}},
+      {{0.25, -0.5, 1.75}, {2.0, 0.25, -0.4, 0.25, 1.5, 0.3, -0.4, 0.3, 1.25}},
+  };
+  for (size_t c = 0; c < sizeof(valid) / sizeof(valid[0]); ++c) {
+    for (unsigned seed : {1u, 29u, 2026u}) {
+      const size_t k = valid[c].mu.size();
+      std::vector<double> got(k);
+      WaRng got_rng(seed + static_cast<unsigned>(c));
+      WaRng want_rng(seed + static_cast<unsigned>(c));
+      multi_normal_rng_draw(valid[c].mu.data(), k, valid[c].covariance.data(),
+                            valid[c].covariance.size(), k, k, got.data(),
+                            got.size(), got_rng);
+      const std::vector<double> want = direct_multi_normal_rng(
+          valid[c].mu, valid[c].covariance, k, k, want_rng);
+      if (!same_double_bytes(got, want) ||
+          got_rng.gen()() != want_rng.gen()()) {
+        ++failures;
+        std::printf("FAIL multi-normal helper valid case %zu seed %u\n", c,
+                    seed);
+      }
+    }
+  }
+
+  const double nan = std::numeric_limits<double>::quiet_NaN();
+  const double inf = std::numeric_limits<double>::infinity();
+  struct Invalid {
+    std::vector<double> mu;
+    std::vector<double> covariance;
+    size_t rows;
+    size_t cols;
+    const char* label;
+  };
+  // The asymmetric case uses four distinct column-major positions. Its Stan
+  // message names both off-diagonal values, catching a transposed rebuild.
+  const Invalid invalid[] = {
+      {{nan, 0.0}, {1.0, 0.0, 0.0, 1.0}, 2, 2, "NaN mean"},
+      {{inf, 0.0}, {1.0, 0.0, 0.0, 1.0}, 2, 2, "infinite mean"},
+      {{0.0, 0.0}, {1.0, 0.0, nan, 1.0}, 2, 2, "NaN covariance"},
+      {{0.0, 0.0}, {1.25, 0.75, 0.125, 0.8}, 2, 2, "asymmetric covariance"},
+      {{0.0, 0.0}, {1.0, 2.0, 2.0, 1.0}, 2, 2, "non-PD covariance"},
+      {{0.0, 0.0}, {1.0, 0.0, 0.0, 1.0}, 1, 4, "dimension mismatch"},
+      {{}, {}, 0, 0, "empty covariance"},
+  };
+  for (size_t c = 0; c < sizeof(invalid) / sizeof(invalid[0]); ++c) {
+    std::vector<double> got(invalid[c].mu.size());
+    WaRng got_rng(static_cast<unsigned>(501 + c));
+    WaRng want_rng(static_cast<unsigned>(501 + c));
+    const RngException got_error = capture_rng_exception([&] {
+      multi_normal_rng_draw(invalid[c].mu.data(), invalid[c].mu.size(),
+                            invalid[c].covariance.data(),
+                            invalid[c].covariance.size(), invalid[c].rows,
+                            invalid[c].cols, got.data(), got.size(), got_rng);
+    });
+    const RngException want_error = capture_rng_exception([&] {
+      (void)direct_multi_normal_rng(invalid[c].mu, invalid[c].covariance,
+                                    invalid[c].rows, invalid[c].cols, want_rng);
+    });
+    if (got_error.kind == 0 || got_error.kind != want_error.kind ||
+        got_error.message != want_error.message ||
+        got_rng.gen()() != want_rng.gen()()) {
+      ++failures;
+      std::printf("FAIL multi-normal helper %s contract\n", invalid[c].label);
+    }
+  }
+
+  const std::vector<double> mu{0.5, -1.25};
+  const std::vector<double> covariance{1.69, 0.364, 0.364, 0.64};
+  std::vector<double> output(2);
+  WaRng malformed(991), untouched(991);
+  const RngException mismatch = capture_rng_exception([&] {
+    multi_normal_rng_draw(mu.data(), mu.size(), covariance.data(),
+                          covariance.size(), 1, 3, output.data(), output.size(),
+                          malformed);
+  });
+  const RngException null_location = capture_rng_exception([&] {
+    multi_normal_rng_draw(nullptr, mu.size(), covariance.data(),
+                          covariance.size(), 2, 2, output.data(), output.size(),
+                          malformed);
+  });
+  if (mismatch.kind != 3 || null_location.kind != 3 ||
+      malformed.gen()() != untouched.gen()()) {
+    ++failures;
+    std::printf("FAIL multi-normal malformed helper contract\n");
+  }
+
+  // A rejected helper call is reusable at the exact untouched draw.
+  WaRng recovered(811), direct(811);
+  std::vector<double> recovered_draw(2);
+  (void)capture_rng_exception([&] {
+    const std::vector<double> bad{1.0, 2.0, 2.0, 1.0};
+    multi_normal_rng_draw(mu.data(), 2, bad.data(), 4, 2, 2,
+                          recovered_draw.data(), 2, recovered);
+  });
+  multi_normal_rng_draw(mu.data(), 2, covariance.data(), 4, 2, 2,
+                        recovered_draw.data(), 2, recovered);
+  const std::vector<double> direct_draw =
+      direct_multi_normal_rng(mu, covariance, 2, 2, direct);
+  if (recovered_draw != direct_draw || recovered.gen()() != direct.gen()()) {
+    ++failures;
+    std::printf("FAIL multi-normal helper rejected-call reuse\n");
   }
 }
 
@@ -1109,6 +1254,419 @@ void test_categorical_rng_dynamic_index_fallback() {
   if (got != want || interp_next != direct_next) {
     ++failures;
     std::printf("FAIL categorical dynamic interpreter row/stream\n");
+  }
+}
+
+static std::map<std::string, stanli::DataMap::Entry> multi_normal_base() {
+  std::map<std::string, stanli::DataMap::Entry> base;
+  for (const char* flag :
+       {"emit_transformed_parameters__", "emit_generated_quantities__"}) {
+    stanli::DataMap::Entry one;
+    one.is_int = true;
+    one.i = {1};
+    one.r = {1.0};
+    base[flag] = one;
+  }
+  return base;
+}
+
+static stanli::DataMap::Entry real_entry(double value) {
+  stanli::DataMap::Entry out;
+  out.r = {value};
+  return out;
+}
+
+static stanli::DataMap::Entry vector_entry(std::vector<double> values) {
+  stanli::DataMap::Entry out;
+  out.dims = {static_cast<int64_t>(values.size())};
+  out.r = std::move(values);
+  return out;
+}
+
+static std::vector<double> multi_normal_direct_row(
+    const std::vector<double>& mu, const std::vector<double>& sigma, double rho,
+    stanli::WaRng& rng) {
+  const double cross = sigma[0] * sigma[1] * rho;
+  const std::vector<double> covariance = {sigma[0] * sigma[0], cross, cross,
+                                          sigma[1] * sigma[1]};
+  const std::vector<double> draw =
+      direct_multi_normal_rng(mu, covariance, 2, 2, rng);
+  return {mu[0],
+          mu[1],
+          sigma[0],
+          sigma[1],
+          rho,
+          draw[0],
+          draw[1],
+          draw[0] - draw[1],
+          stan::math::uniform_rng(0.0, 1.0, rng.gen())};
+}
+
+void test_multi_normal_rng_kernel_contract() {
+  using namespace stanli;
+  const Kernel* kernel = find_kernel(OP_RNG);
+  if (kernel == nullptr || kernel->forward == nullptr) {
+    ++failures;
+    std::printf("FAIL multi-normal RNG kernel is not registered\n");
+    return;
+  }
+  double mu[] = {0.5, -1.25};
+  double covariance[] = {1.69, 0.364, 0.364, 0.64};
+  double output[] = {-99.0, -99.0};
+  int k = 2;
+  WaRng rng(123), direct_rng(123);
+  EvalState state{&rng};
+  KernelCtx valid;
+  valid.variant = kMultiNormalRngVariant;
+  valid.n_in = 2;
+  valid.in[0] = Desc{mu, 2};
+  valid.in[1] = Desc{covariance, 4};
+  valid.out = Desc{output, 2};
+  valid.idata = &k;
+  valid.n_idata = 1;
+  valid.eval_state = &state;
+  kernel->forward(valid);
+  const std::vector<double> want = direct_multi_normal_rng(
+      {mu[0], mu[1]}, {1.69, 0.364, 0.364, 0.64}, 2, 2, direct_rng);
+  if (std::vector<double>(output, output + 2) != want ||
+      rng.gen()() != direct_rng.gen()()) {
+    ++failures;
+    std::printf("FAIL multi-normal RNG valid kernel contract\n");
+  }
+
+  struct Mutation {
+    const char* label;
+    void (*apply)(KernelCtx&);
+  };
+  const Mutation malformed[] = {
+      {"unknown variant", [](KernelCtx& c) { c.variant = 255; }},
+      {"arity", [](KernelCtx& c) { c.n_in = 1; }},
+      {"missing idata", [](KernelCtx& c) { c.n_idata = 0; }},
+      {"null idata", [](KernelCtx& c) { c.idata = nullptr; }},
+      {"mean length", [](KernelCtx& c) { c.in[0].len = 1; }},
+      {"covariance length", [](KernelCtx& c) { c.in[1].len = 3; }},
+      {"output length", [](KernelCtx& c) { c.out.len = 1; }},
+      {"missing evaluation state",
+       [](KernelCtx& c) { c.eval_state = nullptr; }},
+  };
+  for (size_t i = 0; i < sizeof(malformed) / sizeof(malformed[0]); ++i) {
+    WaRng got(static_cast<unsigned>(900 + i));
+    WaRng untouched(static_cast<unsigned>(900 + i));
+    EvalState got_state{&got};
+    KernelCtx ctx = valid;
+    ctx.eval_state = &got_state;
+    output[0] = output[1] = -99.0;
+    malformed[i].apply(ctx);
+    const RngException error =
+        capture_rng_exception([&] { kernel->forward(ctx); });
+    if (error.kind != 3 || got.gen()() != untouched.gen()() ||
+        output[0] != -99.0 || output[1] != -99.0) {
+      ++failures;
+      std::printf("FAIL multi-normal malformed kernel %s\n",
+                  malformed[i].label);
+    }
+  }
+}
+
+void test_multi_normal_rng_lowering_guards() {
+  using namespace stanli;
+  const std::string base =
+      slurp("tests/fixtures/gq_multi_normal_rng.tmir.sexp");
+  const size_t call = base.find("(FunApp (StanLib multi_normal_rng");
+  const std::string mean_arg =
+      "((pattern (Var mu)) (meta ((type_ UVector) (loc <opaque>) (adlevel "
+      "DataOnly))))";
+  const std::string covariance_arg =
+      "((pattern (Var inline_cov_matrix_2d_return_sym1__))\n"
+      "           (meta ((type_ UMatrix) (loc <opaque>) (adlevel "
+      "DataOnly))))";
+  const size_t mean = base.find(mean_arg, call);
+  const size_t covariance = base.find(covariance_arg, call);
+  if (call == std::string::npos || mean == std::string::npos ||
+      covariance == std::string::npos) {
+    ++failures;
+    std::printf("FAIL multi-normal lowering guard fixture has no call\n");
+    return;
+  }
+
+  const auto expect_interp = [](const std::string& mir,
+                                const std::string& reason, const char* label) {
+    try {
+      CompiledModel cm = compile_model(mir, DataMap{});
+      if (!cm.write_array || !cm.write_array->interp ||
+          (!reason.empty() &&
+           cm.write_array->truncated.find(reason) == std::string::npos)) {
+        ++failures;
+        std::printf("FAIL %s: got %s\n", label,
+                    cm.write_array ? cm.write_array->truncated.c_str()
+                                   : "no write_array");
+      }
+    } catch (const std::exception& e) {
+      ++failures;
+      std::printf("FAIL %s: mutation did not parse/compile: %s\n", label,
+                  e.what());
+    }
+  };
+
+  const auto replace_once = [](std::string text, size_t at, size_t count,
+                               const std::string& replacement) {
+    text.replace(at, count, replacement);
+    return text;
+  };
+  for (const auto& bad : std::vector<std::pair<std::string, const char*>>{
+           {"UReal", "scalar"},
+           {"URowVector", "row-vector"},
+           {"(UArray UVector)", "array-vector"}}) {
+    const std::string replacement = "((pattern (Var mu)) (meta ((type_ " +
+                                    bad.first +
+                                    ") (loc <opaque>) (adlevel DataOnly))))";
+    expect_interp(
+        replace_once(base, mean, mean_arg.size(), replacement),
+        "expected one vector location",
+        (std::string("multi-normal ") + bad.second + " mean stays interpreted")
+            .c_str());
+  }
+  for (const auto& bad : std::vector<std::pair<std::string, const char*>>{
+           {"UVector", "vector"}, {"(UArray UMatrix)", "array-matrix"}}) {
+    std::string replacement = covariance_arg;
+    const size_t type = replacement.find("UMatrix");
+    replacement.replace(type, std::string("UMatrix").size(), bad.first);
+    expect_interp(
+        replace_once(base, covariance, covariance_arg.size(), replacement),
+        "expected one covariance matrix",
+        (std::string("multi-normal ") + bad.second +
+         " covariance stays interpreted")
+            .c_str());
+  }
+
+  std::string one_arg = base;
+  one_arg.erase(covariance, covariance_arg.size());
+  expect_interp(one_arg, "expected one vector result",
+                "one-argument multi-normal stays interpreted");
+  std::string zero_args = base;
+  zero_args.erase(covariance, covariance_arg.size());
+  zero_args.erase(mean, mean_arg.size());
+  expect_interp(zero_args, "expected one vector result",
+                "zero-argument multi-normal stays interpreted");
+  std::string three_args = base;
+  three_args.insert(covariance + covariance_arg.size(), " " + mean_arg);
+  expect_interp(three_args, "expected one vector result",
+                "three-argument multi-normal stays interpreted");
+
+  const size_t mean_type = base.find("(type_ UVector)", call);
+  const size_t result_type = base.find("(type_ UVector)", mean_type + 1);
+  if (result_type == std::string::npos) {
+    ++failures;
+    std::printf("FAIL multi-normal lowering guard cannot find result type\n");
+  } else {
+    std::string row_result = base;
+    row_result.replace(result_type, std::string("(type_ UVector)").size(),
+                       "(type_ URowVector)");
+    expect_interp(row_result, "expected one vector result",
+                  "multi-normal row-vector result stays interpreted");
+    std::string array_result = base;
+    array_result.replace(result_type, std::string("(type_ UVector)").size(),
+                         "(type_ (UArray UVector))");
+    expect_interp(array_result, "expected one vector result",
+                  "multi-normal array result stays interpreted");
+  }
+
+  std::string unknown_covariance = base;
+  const size_t covariance_var =
+      unknown_covariance.find("(Var inline_cov_matrix_2d_return_sym1__)", call);
+  unknown_covariance.replace(
+      covariance_var,
+      std::string("(Var inline_cov_matrix_2d_return_sym1__)").size(),
+      "(Var mu)");
+  expect_interp(unknown_covariance, "covariance has no known matrix shape",
+                "multi-normal unknown covariance shape stays interpreted");
+
+  std::string mismatched_covariance = base;
+  const size_t matrix_decl = mismatched_covariance.find(
+      "(decl_id inline_cov_matrix_2d_covariance_sym2__)");
+  size_t first_extent =
+      mismatched_covariance.find("((pattern (Lit Int 2))", matrix_decl);
+  size_t second_extent =
+      mismatched_covariance.find("((pattern (Lit Int 2))", first_extent + 1);
+  if (matrix_decl == std::string::npos || first_extent == std::string::npos ||
+      second_extent == std::string::npos) {
+    ++failures;
+    std::printf("FAIL multi-normal cannot locate covariance extents\n");
+  } else {
+    first_extent = mismatched_covariance.find("Int 2", first_extent) + 4;
+    second_extent = mismatched_covariance.find("Int 2", second_extent) + 4;
+    mismatched_covariance[first_extent] = '3';
+    mismatched_covariance[second_extent] = '3';
+    expect_interp(mismatched_covariance,
+                  "covariance shape must match the location",
+                  "multi-normal known dimension mismatch stays interpreted");
+  }
+
+  std::string mismatched_result = base;
+  const size_t draw_decl = mismatched_result.find("(decl_id draw)");
+  size_t draw_extent =
+      mismatched_result.find("((pattern (Lit Int 2))", draw_decl);
+  if (draw_decl == std::string::npos || draw_extent == std::string::npos) {
+    ++failures;
+    std::printf("FAIL multi-normal cannot locate result extent\n");
+  } else {
+    draw_extent = mismatched_result.find("Int 2", draw_extent) + 4;
+    mismatched_result[draw_extent] = '3';
+    expect_interp(mismatched_result, "",
+                  "multi-normal result dimension mismatch stays interpreted");
+  }
+
+  std::string cholesky = base;
+  cholesky.replace(call + std::string("(FunApp (StanLib ").size(),
+                   std::string("multi_normal_rng").size(),
+                   "multi_normal_cholesky_rng");
+  expect_interp(cholesky, "unsupported function multi_normal_cholesky_rng",
+                "multi-normal Cholesky stays interpreted");
+}
+
+void test_compiled_multi_normal_rng() {
+  using namespace stanli;
+  const std::string text =
+      slurp("tests/fixtures/gq_multi_normal_rng.tmir.sexp");
+  CompiledModel cm = compile_model(text, DataMap{});
+  if (!cm.write_array || cm.write_array->interp ||
+      !cm.write_array->truncated.empty()) {
+    ++failures;
+    std::printf(
+        "FAIL multi-normal RNG did not compile completely: %s\n",
+        cm.write_array ? cm.write_array->truncated.c_str() : "no write_array");
+    return;
+  }
+  int multi_ops = 0, uniform_ops = 0, other_rng_ops = 0;
+  for (const Op& op : cm.write_array->graph.ops) {
+    if (op.opcode != OP_RNG) continue;
+    if (op.variant == kMultiNormalRngVariant) {
+      ++multi_ops;
+      if (op.n_in != 2 || op.n_idata != 1 || op.idata == nullptr ||
+          op.idata[0] != 2 || cm.write_array->graph.slots[op.in[0]].len != 2 ||
+          cm.write_array->graph.slots[op.in[1]].len != 4 ||
+          cm.write_array->graph.slots[op.out].len != 2) {
+        ++failures;
+        std::printf("FAIL multi-normal RNG malformed graph descriptor\n");
+      }
+    } else if (op.variant == static_cast<uint8_t>(ScalarRng::Uniform)) {
+      ++uniform_ops;
+    } else {
+      ++other_rng_ops;
+    }
+  }
+  if (multi_ops != 1 || uniform_ops != 1 || other_rng_ops != 0) {
+    ++failures;
+    std::printf(
+        "FAIL multi-normal RNG op census: multi=%d uniform=%d other=%d\n",
+        multi_ops, uniform_ops, other_rng_ops);
+  }
+  expect_eq("multi-normal RNG columns", joined(cm.write_array->columns),
+            "mu.1,mu.2,sigma.1,sigma.2,rho,draw.1,draw.2,shifted,tail");
+
+  Executor graph(std::move(cm.write_array->graph));
+  cm.write_array->bind(graph);
+  const std::vector<double> unconstrained = {0.5, -1.25, std::log(1.3),
+                                             std::log(0.8), 0.73};
+  std::copy(unconstrained.begin(), unconstrained.end(), graph.params_data());
+  const auto graph_row = [&](WaRng& rng) {
+    graph.run_forward_only(EvalState{&rng});
+    std::vector<double> row;
+    for (const auto& column : cm.write_array->columns) {
+      const double* values = graph.value_ptr(column.slot);
+      for (int64_t i = 0; i < column.len; ++i)
+        row.push_back(values[column.storage_index(i)]);
+    }
+    return row;
+  };
+
+  // Obtain the exact constrained parameter bits produced by the graph; those
+  // are the write_array interpreter's public input contract.
+  WaRng probe_rng(999);
+  const std::vector<double> probe = graph_row(probe_rng);
+  const std::vector<double> mu{probe[0], probe[1]};
+  const std::vector<double> sigma{probe[2], probe[3]};
+  const double rho = probe[4];
+  std::map<std::string, DataMap::Entry> params;
+  params["mu"] = vector_entry(mu);
+  params["sigma"] = vector_entry(sigma);
+  params["rho"] = real_entry(rho);
+  auto program =
+      std::make_shared<mir::Program>(mir::read_program(sexp::parse(text)));
+  WaInterp interpreted(program, multi_normal_base());
+
+  WaRng graph_rng(42), interp_rng(42), direct_rng(42);
+  const std::vector<double> graph_first = graph_row(graph_rng);
+  const std::vector<double> interp_first = interpreted.eval(params, interp_rng);
+  const std::vector<double> direct_first =
+      multi_normal_direct_row(mu, sigma, rho, direct_rng);
+  const std::vector<double> graph_second = graph_row(graph_rng);
+  const std::vector<double> interp_second =
+      interpreted.eval(params, interp_rng);
+  const std::vector<double> direct_second =
+      multi_normal_direct_row(mu, sigma, rho, direct_rng);
+  const auto graph_next = graph_rng.gen()();
+  const auto interp_next = interp_rng.gen()();
+  const auto direct_next = direct_rng.gen()();
+  if (!same_double_bytes(graph_first, interp_first) ||
+      !same_double_bytes(graph_first, direct_first) ||
+      !same_double_bytes(graph_second, interp_second) ||
+      !same_double_bytes(graph_second, direct_second) ||
+      graph_next != interp_next || graph_next != direct_next) {
+    ++failures;
+    std::printf("FAIL multi-normal sequential row/stream parity\n");
+  }
+  graph_rng.seed(42);
+  if (graph_row(graph_rng) != graph_first) {
+    ++failures;
+    std::printf("FAIL multi-normal reseed did not reproduce first row\n");
+  }
+
+  std::vector<double> invalid_q = unconstrained;
+  invalid_q[0] = std::numeric_limits<double>::infinity();
+  std::copy(invalid_q.begin(), invalid_q.end(), graph.params_data());
+  params["mu"] = vector_entry({std::numeric_limits<double>::infinity(), mu[1]});
+  WaRng graph_failing(211), interp_failing(211), direct_failing(211);
+  const RngException graph_error =
+      capture_rng_exception([&] { (void)graph_row(graph_failing); });
+  const RngException interp_error = capture_rng_exception(
+      [&] { (void)interpreted.eval(params, interp_failing); });
+  const RngException direct_error = capture_rng_exception([&] {
+    const std::vector<double> covariance = {
+        sigma[0] * sigma[0], sigma[0] * sigma[1] * rho,
+        sigma[0] * sigma[1] * rho, sigma[1] * sigma[1]};
+    (void)direct_multi_normal_rng(
+        {std::numeric_limits<double>::infinity(), mu[1]}, covariance, 2, 2,
+        direct_failing);
+  });
+  if (graph_error.kind == 0 || graph_error.kind != interp_error.kind ||
+      graph_error.kind != direct_error.kind ||
+      graph_error.message != interp_error.message ||
+      graph_error.message != direct_error.message) {
+    ++failures;
+    std::printf("FAIL multi-normal invalid exception parity\n");
+  }
+
+  std::copy(unconstrained.begin(), unconstrained.end(), graph.params_data());
+  params["mu"] = vector_entry(mu);
+  const RngException missing_state =
+      capture_rng_exception([&] { graph.run_forward_only(); });
+  const std::vector<double> graph_recovered = graph_row(graph_failing);
+  const std::vector<double> interp_recovered =
+      interpreted.eval(params, interp_failing);
+  const std::vector<double> direct_recovered =
+      multi_normal_direct_row(mu, sigma, rho, direct_failing);
+  const auto graph_recovered_next = graph_failing.gen()();
+  const auto interp_recovered_next = interp_failing.gen()();
+  const auto direct_recovered_next = direct_failing.gen()();
+  if (missing_state.kind != 3 ||
+      missing_state.message.find("caller-owned") == std::string::npos ||
+      !same_double_bytes(graph_recovered, interp_recovered) ||
+      !same_double_bytes(graph_recovered, direct_recovered) ||
+      graph_recovered_next != interp_recovered_next ||
+      graph_recovered_next != direct_recovered_next) {
+    ++failures;
+    std::printf("FAIL multi-normal exception/reuse contract\n");
   }
 }
 
@@ -2913,10 +3471,14 @@ int main() {
   test_constant_folded_gq_column();
   test_binomial_rng_helper_contract();
   test_categorical_rng_helper_contract();
+  test_multi_normal_rng_helper_contract();
   test_categorical_rng_lowering_guards();
   test_compiled_categorical_rng();
   test_categorical_rng_empty_vector();
   test_categorical_rng_dynamic_index_fallback();
+  test_multi_normal_rng_kernel_contract();
+  test_multi_normal_rng_lowering_guards();
+  test_compiled_multi_normal_rng();
   test_binomial_rng_lowering_guards();
   test_compiled_scalar_rng();
   test_product_exact_grouping();


### PR DESCRIPTION
## Summary

- extend the effectful generated-quantities `OP_RNG` path with the audited covariance-form `multi_normal_rng(vector, matrix) -> vector` surface
- share one owning-Eigen Stan Math adapter between the compiled graph and `WaInterp`, preserving validation, exception, output, and caller-owned stream semantics
- keep row-vector/array overloads, mismatched compile-time shapes, and `multi_normal_cholesky_rng` fail-closed on the whole-section interpreter
- add helper, descriptor, lowering, stream/reuse, malformed-input, and pass-safety coverage

## Corpus result

`multi_occupancy` is the only model that changes mode. The tracked 24-model census moves from 18 graph / 6 interpreted to 19 / 5; all 119 compiling corpus models still produce complete rows. Graph and forced-interpreter output is bitwise identical for 5,616 values across six seeds and three sequential rows.

Targeted matched C-ABI medians:

- generated-quantities row: 298.9260 -> 5.4898 us (54.4512x)
- 1,000-row saving: 0.2934362 s
- construction: 5864.792 -> 5368.583 us

The generated full-corpus benchmark table is intentionally unchanged.

## Validation

- fresh Release all-target build
- CTest: 59/59
- CmdStan reference replay: 129/129 models at all three points, 800,674 values
- write-array coverage: 119/119 complete, 114 graph / 5 interpreted overall
- format, generated docs, generated web models, and `git diff --check`
