### PR TITLE
release: 0.8.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.8.5
 
 ### Wasm builds of the R package bundle their runtime
 
@@ -12,6 +12,23 @@ and bundles the matching runtime into the package, where
 `stanli_install()` reports the bundle instead of downloading. Native
 builds are unchanged; the script exits before doing anything on a
 non-wasm compiler. Suggested by @StaffanBetner.
+
+### Generated quantities compile instead of interpreting
+
+Five more shapes move from the per-draw interpreter onto the
+forward-only write_array graph: scalar RNGs (normal, lognormal,
+uniform, bernoulli, poisson_log, binomial, categorical), vector
+reductions, and min/max (#170, #172, #173, #174, #175). Models whose
+GQ blocks were interpreter-bound speed up accordingly: Mh_model rows
+went from 869 to 12.5 us, another from 330 to 3.4 us.
+
+### Gradient-path work
+
+Island adjoints pack into a dense file (#168), scalar categorical
+probability gets the selected-probability pullback instead of a
+nested tape (#169), and compiled ODE callbacks seed mixed scalar
+inputs directly into the register file instead of staging copies of
+y and theta (#171).
 
 ## 0.8.4
 

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@seantalts/stanli",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "description": "Full Stan in the browser: stanc3 compiles the model in JS, a WASM runtime lowers it to an op graph and runs NUTS. No server, no C++ toolchain.",
   "type": "module",
   "main": "index.mjs",

--- a/python/stanli/__init__.py
+++ b/python/stanli/__init__.py
@@ -21,7 +21,7 @@ __all__ = ["Model", "Fit", "Summary", "OptimizeResult",
            "SAMPLER_COLUMNS", "__version__"]
 # The one place the version lives. setup.py and the release workflow both
 # read it from here.
-__version__ = "0.8.4"
+__version__ = "0.8.5"
 
 _BIN = pathlib.Path(__file__).parent / "_bin"
 

--- a/r/DESCRIPTION
+++ b/r/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: stanli
 Type: Package
 Title: The Stan Language Interpreter
-Version: 0.8.4
+Version: 0.8.5
 Authors@R: person("Sean", "Talts", email = "xitrium@gmail.com",
                   role = c("aut", "cre"))
 Description: Compile and sample Stan models without a C++ toolchain. Stan

--- a/r/R/install.R
+++ b/r/R/install.R
@@ -17,7 +17,7 @@
 # pinned binding with a runtime that has moved. The release workflow
 # asserts this equals the tag being cut, so bumping one without the
 # other fails there rather than at a user's install.
-stanli_runtime_release <- "v0.8.4"
+stanli_runtime_release <- "v0.8.5"
 
 runtime_filename <- function() {
   switch(Sys.info()[["sysname"]],


### PR DESCRIPTION
Version bump for 0.8.5: the bundled wasm runtime for webR (#176, from #163), plus changelog entries for the eight perf PRs (#168 through #175) that merged without them. Tag v0.8.5 follows once this merges.