### PR TITLE
perf: analytic mixture partials, CSE, POW rerolling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -280,6 +280,7 @@ set(STANLI_RUNTIME_SOURCES
   runtime/src/reroll.cpp
   runtime/src/inplace.cpp
   runtime/src/constfold.cpp
+  runtime/src/cse.cpp
   runtime/src/data.cpp
   runtime/src/data_var_context.cpp)
 
@@ -536,7 +537,7 @@ set(STANLI_TESTS
   test_lower_view_contract test_lower_array_contract test_data test_e2e
   test_reroll test_profile test_inplace test_pass_safety test_sampling
   test_ode_prog test_mir_program_conformance test_mir_checks
-  test_structured_checks test_mir_unary_fallback test_constfold
+  test_structured_checks test_mir_unary_fallback test_constfold test_cse
   test_solve test_cross_path
   test_write_array test_pool test_bridgestan test_mixture test_island
   test_adjoint test_diagnose test_multichain test_newtrans test_rejectprint

--- a/runtime/include/stanli/cse.hpp
+++ b/runtime/include/stanli/cse.hpp
@@ -1,0 +1,34 @@
+// Common-subexpression elimination over the op graph. Unrolled models emit
+// the same computation many times (685 bit-identical BERNOULLI_LPMF ops in
+// Mh_model); the second and later copies become references to the first.
+#ifndef STANLI_CSE_HPP
+#define STANLI_CSE_HPP
+
+#include <stanli/graph.hpp>
+
+#include <utility>
+#include <vector>
+
+namespace stanli {
+
+struct CseStats {
+  int ops_removed = 0;
+};
+
+// In place. `target_terms` entries naming a removed op's output are rewritten
+// to the surviving output; duplicates in that list are fine, since the term
+// reduction sums the same slot twice for the two terms it stands for.
+//
+// `extra_roots` must list every slot something outside the op graph reads
+// (jacobian terms, constrained-parameter views), as reroll's must: those are
+// never renamed away. `fills` is read to keep bind-time-filled slots alive,
+// since their buffers are sized from the slot length.
+// STANLI_NO_CSE=1 disables the pass.
+CseStats cse(Graph& g,
+             const std::vector<std::pair<int, std::vector<double>>>& fills,
+             std::vector<int>& target_terms,
+             const std::vector<int>& extra_roots);
+
+}  // namespace stanli
+
+#endif

--- a/runtime/include/stanli/optable.hpp
+++ b/runtime/include/stanli/optable.hpp
@@ -731,6 +731,7 @@ constexpr uint8_t op_traits(uint16_t opcode) {
     case OP_SUB:
     case OP_MUL:
     case OP_DIV:
+    case OP_POW:
     case OP_FMA:
     case OP_NEG:
     case OP_EXPV:

--- a/runtime/kernels/mixture.cpp
+++ b/runtime/kernels/mixture.cpp
@@ -1,31 +1,20 @@
 // log_sum_exp / log_mix.
 //
-// These were legacy ops whose backward replayed on `Matrix<var>`: N varis
-// reached through N pointers, built and torn down per op per gradient.
-// That is the AoS var tape stanli exists to avoid, sitting in the hot loop
-// of every mixture and HMM model (40,636 ops across 9 corpus models).
-//
-// stan-math still computes every derivative here -- nothing is
-// hand-differentiated. Two things changed:
-//
-//   * the operand is `var_value<VectorXd>` (varmat, SoA) rather than
-//     `Matrix<var>`, which is what `stanc --O1` reaches for and roughly
-//     twice as fast: 3.39 vs 6.68 ns/element on Apple M-series, and
-//   * the replay runs in the FORWARD sweep and stashes the partials, so
-//     the backward is a scale of what stan-math already returned.
-//
-// The second point is not just bookkeeping: a backward that reads only
+// The forward computes the value and stashes every partial; the backward is
+// a scale of what the forward left in scratch. A backward that reads only
 // scratch cannot be broken by a destructive write to its input, which is
 // what gives these ops the value-free trait in optable.hpp and lets the HMM
 // forward algorithm -- fill `acc` element by element, read it whole --
 // take the in-place path.
+//
+// The partial forms are stan-math's own reverse-mode chains, written out.
 #include <stanli/graph.hpp>
 #include <stanli/optable.hpp>
 
 #include <stan/math.hpp>
 
-#include <array>
 #include <cassert>
+#include <cmath>
 
 namespace stanli {
 namespace {
@@ -35,14 +24,12 @@ int64_t lse_scratch(const Op& op, const Slot* slots) {
   return slots[op.in[0]].len;
 }
 
+// Scalar libm, not Eigen packet math: a vectorized exp rounds a last bit
+// away from the var reference, whose value extraction blocks vectorization.
 double lse_fwd_partials(const double* data, int64_t len, double* partials) {
-  stan::math::nested_rev_autodiff nested;
-  stan::math::var_value<Eigen::VectorXd> x(
-      Eigen::Map<const Eigen::VectorXd>(data, len));
-  stan::math::var out = stan::math::log_sum_exp(x);
-  const double value = out.val();
-  stan::math::grad(out.vi_);
-  Eigen::Map<Eigen::VectorXd>(partials, len) = x.adj();
+  const double value =
+      stan::math::log_sum_exp(Eigen::Map<const Eigen::VectorXd>(data, len));
+  for (int64_t i = 0; i < len; ++i) partials[i] = std::exp(data[i] - value);
   return value;
 }
 
@@ -91,11 +78,10 @@ void lse_rows_bwd(KernelCtx& ctx) {
 // Shape dispatch matches the elementwise binaries: each argument is len 1
 // (broadcast) or len N, out is len N, out[n] applies the scalar stan-math
 // function to element n. N == 1 is exactly the old scalar kernel; the len-N
-// form is the re-rolled body of a per-observation mixture loop. Each element
-// replays on its own nested tape, so element n's value and partials are
-// bit-identical to a lone scalar op over the same inputs.
+// form is the re-rolled body of a per-observation mixture loop.
 //
-// Scratch is NArgs partials per element, [n * NArgs + k].
+// Scratch is NArgs partials per element, [n * NArgs + k]. `f` writes that
+// element's partials and returns its value.
 template <int NArgs>
 int64_t mix_scratch(const Op& op, const Slot* slots) {
   return NArgs * slots[op.out].len;
@@ -105,14 +91,10 @@ template <int NArgs, typename F>
 void mix_fwd(KernelCtx& ctx, F&& f) {
   const int64_t n = ctx.out.len;
   for (int64_t i = 0; i < n; ++i) {
-    stan::math::nested_rev_autodiff nested;
-    std::array<stan::math::var, NArgs> a;
+    double a[NArgs];
     for (int k = 0; k < NArgs; ++k)
       a[k] = ctx.in[k].data[ctx.in[k].len == 1 ? 0 : i];
-    stan::math::var j = f(a);
-    ctx.out.data[i] = j.val();
-    stan::math::grad(j.vi_);
-    for (int k = 0; k < NArgs; ++k) ctx.scratch[i * NArgs + k] = a[k].adj();
+    ctx.out.data[i] = f(a, ctx.scratch + i * NArgs);
   }
 }
 
@@ -139,21 +121,48 @@ void mix_bwd(KernelCtx& ctx) {
 }
 
 void lse2_fwd(KernelCtx& ctx) {
-  mix_fwd<2>(ctx,
-             [](const auto& a) { return stan::math::log_sum_exp(a[0], a[1]); });
+  mix_fwd<2>(ctx, [](const double* a, double* p) {
+    p[0] = stan::math::inv_logit(a[0] - a[1]);
+    p[1] = stan::math::inv_logit(a[1] - a[0]);
+    return stan::math::log_sum_exp(a[0], a[1]);
+  });
 }
 
 // log_diff_exp(a, b) = log(exp(a) - exp(b)). Truncation is what wants
 // it: stanc3 lowers `y ~ foo(...) T[l, u]` into the density minus
 // log_diff_exp(foo_lcdf(u|...), foo_lcdf(l|...)).
 void log_diff_exp_fwd(KernelCtx& ctx) {
-  mix_fwd<2>(
-      ctx, [](const auto& a) { return stan::math::log_diff_exp(a[0], a[1]); });
+  mix_fwd<2>(ctx, [](const double* a, double* p) {
+    p[0] = -1.0 / stan::math::expm1(a[1] - a[0]);
+    p[1] = -1.0 / stan::math::expm1(a[0] - a[1]);
+    return stan::math::log_diff_exp(a[0], a[1]);
+  });
 }
 
 void log_mix_fwd(KernelCtx& ctx) {
-  mix_fwd<3>(
-      ctx, [](const auto& a) { return stan::math::log_mix(a[0], a[1], a[2]); });
+  mix_fwd<3>(ctx, [](const double* a, double* p) {
+    const double value = stan::math::log_mix(a[0], a[1], a[2]);
+    double theta = a[0];
+    double one_m_exp_lam2_m_lam1 = 0.0;
+    double one_m_t_prod_exp_lam2_m_lam1 = 0.0;
+    double one_d = 0.0;
+    if (a[1] > a[2]) {
+      stan::math::log_mix_partial_helper(theta, a[1], a[2],
+                                         one_m_exp_lam2_m_lam1,
+                                         one_m_t_prod_exp_lam2_m_lam1, one_d);
+    } else {
+      stan::math::log_mix_partial_helper(1.0 - theta, a[2], a[1],
+                                         one_m_exp_lam2_m_lam1,
+                                         one_m_t_prod_exp_lam2_m_lam1, one_d);
+      one_m_exp_lam2_m_lam1 = -one_m_exp_lam2_m_lam1;
+      theta = one_m_t_prod_exp_lam2_m_lam1;
+      one_m_t_prod_exp_lam2_m_lam1 = 1.0 - a[0];
+    }
+    p[0] = one_m_exp_lam2_m_lam1 * one_d;
+    p[1] = theta * one_d;
+    p[2] = one_m_t_prod_exp_lam2_m_lam1 * one_d;
+    return value;
+  });
 }
 
 }  // namespace

--- a/runtime/kernels/mixture.cpp
+++ b/runtime/kernels/mixture.cpp
@@ -24,12 +24,12 @@ int64_t lse_scratch(const Op& op, const Slot* slots) {
   return slots[op.in[0]].len;
 }
 
-// Scalar libm, not Eigen packet math: a vectorized exp rounds a last bit
-// away from the var reference, whose value extraction blocks vectorization.
+// Packet exp rounds up to a last bit away from the scalar-libm var reference.
 double lse_fwd_partials(const double* data, int64_t len, double* partials) {
   const double value =
       stan::math::log_sum_exp(Eigen::Map<const Eigen::VectorXd>(data, len));
-  for (int64_t i = 0; i < len; ++i) partials[i] = std::exp(data[i] - value);
+  Eigen::Map<Eigen::ArrayXd>(partials, len) =
+      (Eigen::Map<const Eigen::ArrayXd>(data, len) - value).exp();
   return value;
 }
 

--- a/runtime/src/cse.cpp
+++ b/runtime/src/cse.cpp
@@ -1,0 +1,142 @@
+// Common-subexpression elimination.
+//
+// The unrolled M*_model family evaluates one Bernoulli term per capture
+// occasion per individual, and for most of them the arguments are the same
+// slot: Mh_model emits 685 bit-identical BERNOULLI_LPMF ops, Mb_model 786,
+// and each one is a full kernel call plus a tape entry on every leapfrog
+// step. Reroll leaves them alone (they are target terms with no op consumer),
+// so nothing upstream removes the recomputation.
+//
+// This is textbook local value numbering, made safe for a graph whose slots
+// are mutable buffers rather than SSA values:
+//
+//   - every write bumps a per-slot version, and the key carries the version
+//     of each input, so two ops separated by a store to something they read
+//     are different computations,
+//   - only an op whose output slot is written exactly once in the whole graph
+//     can be the survivor, which is what excludes the destructive update
+//     chains: a slot a later SET_*_INPLACE mutates has two writers,
+//   - effectful and stateful opcodes never merge, and neither does anything
+//     carrying an opaque payload the key cannot compare.
+//
+// Renaming is lazy: ops are in evaluation order, so resolving each op's
+// inputs through the map as the single forward pass reaches it is enough,
+// and chains collapse in that same pass. Rescanning the tail after each
+// merge would be quadratic in the op count.
+#include <stanli/cse.hpp>
+#include <stanli/optable.hpp>
+
+#include <cstdlib>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+namespace stanli {
+namespace {
+
+// Effects are graph semantics: a merged print prints once, a merged check
+// throws once, a merged draw returns the same number twice. The set is the
+// union of constfold.cpp's and reroll's ops_match, plus the two opcodes
+// holding structure this pass cannot compare.
+bool never_merge(uint16_t oc) {
+  return oc == OP_CHECK_STRUCTURED || oc == OP_CHECK_MATCHING_DIMS ||
+         oc == OP_CHECK_LOWER || oc == OP_CHECK_UPPER || oc == OP_CATEGORICAL ||
+         oc == OP_RNG || oc == OP_PRINT || oc == OP_REJECT ||
+         oc == OP_PROD_VEC || oc == OP_EXTREMA_VEC || oc == OP_ISLAND ||
+         oc == OP_ODE;
+}
+
+struct Key {
+  std::vector<int64_t> w;
+  bool operator==(const Key& o) const { return w == o.w; }
+};
+
+struct KeyHash {
+  size_t operator()(const Key& k) const {
+    size_t h = 1469598103934665603ull;
+    for (int64_t v : k.w) {
+      h ^= static_cast<size_t>(v);
+      h *= 1099511628211ull;
+    }
+    return h;
+  }
+};
+
+}  // namespace
+
+CseStats cse(Graph& g,
+             const std::vector<std::pair<int, std::vector<double>>>& fills,
+             std::vector<int>& target_terms,
+             const std::vector<int>& extra_roots) {
+  CseStats st;
+  if (std::getenv("STANLI_NO_CSE")) return st;
+
+  const size_t n_slots = g.slots.size();
+  std::vector<int> writes(n_slots, 0);
+  for (const Op& op : g.ops) {
+    if (op.out >= 0) ++writes[(size_t)op.out];
+    if (op.out2 >= 0) ++writes[(size_t)op.out2];
+  }
+
+  std::unordered_set<int> keep(extra_roots.begin(), extra_roots.end());
+  if (g.result_slot >= 0) keep.insert(g.result_slot);
+  // A fill writes its slot at bind time from a buffer sized by the slot
+  // length, so a filled slot must keep that length even once dead.
+  for (const auto& f : fills) keep.insert(f.first);
+
+  std::vector<int64_t> version(n_slots, 0);
+  std::unordered_map<Key, int, KeyHash> table;
+  std::unordered_map<int, int> rename;  // removed output -> surviving output
+  const auto resolve = [&](int s) {
+    auto it = rename.find(s);
+    return it == rename.end() ? s : it->second;
+  };
+
+  std::vector<char> drop(g.ops.size(), 0);
+  Key key;
+  for (size_t i = 0; i < g.ops.size(); ++i) {
+    Op& op = g.ops[i];
+    for (int j = 0; j < op.n_in; ++j) op.in[j] = resolve(op.in[j]);
+
+    bool candidate = op.out >= 0 && op.out2 < 0 && op.udata == nullptr &&
+                     !never_merge(op.opcode) && writes[(size_t)op.out] == 1 &&
+                     !keep.count(op.out) && !g.slots[(size_t)op.out].is_param;
+    for (int j = 0; candidate && j < op.n_in; ++j)
+      candidate = op.in[j] != op.out;
+
+    if (candidate) {
+      key.w.clear();
+      key.w.push_back(op.opcode);
+      key.w.push_back(op.variant);
+      key.w.push_back(g.slots[(size_t)op.out].len);
+      key.w.push_back(op.n_in);
+      for (int j = 0; j < op.n_in; ++j) {
+        key.w.push_back(op.in[j]);
+        key.w.push_back(op.in[j] >= 0 ? version[(size_t)op.in[j]] : 0);
+      }
+      key.w.push_back(op.n_idata);
+      for (int64_t k = 0; k < op.n_idata; ++k) key.w.push_back(op.idata[k]);
+      auto ins = table.emplace(key, op.out);
+      if (!ins.second) {
+        rename.emplace(op.out, ins.first->second);
+        g.slots[(size_t)op.out].len = 0;
+        drop[i] = 1;
+        ++st.ops_removed;
+        continue;
+      }
+    }
+    if (op.out >= 0) ++version[(size_t)op.out];
+    if (op.out2 >= 0) ++version[(size_t)op.out2];
+  }
+
+  if (st.ops_removed == 0) return st;
+  for (int& t : target_terms) t = resolve(t);
+  std::vector<Op> kept;
+  kept.reserve(g.ops.size() - (size_t)st.ops_removed);
+  for (size_t i = 0; i < g.ops.size(); ++i)
+    if (!drop[i]) kept.push_back(g.ops[i]);
+  g.ops = std::move(kept);
+  return st;
+}
+
+}  // namespace stanli

--- a/runtime/src/lower.cpp
+++ b/runtime/src/lower.cpp
@@ -1,5 +1,6 @@
 #include <stanli/compile.hpp>
 #include <stanli/constfold.hpp>
+#include <stanli/cse.hpp>
 #include <stanli/inplace.hpp>
 #include <stanli/mir_prog.hpp>
 #include <stanli/mir.hpp>
@@ -4936,6 +4937,13 @@ struct Lowering {
     prep.graph(prep_graph, "post_reroll_inplace", post_reroll_inplace_time, g,
                out.fills, target_terms.size(), out.views.size(),
                PrepTrace::Extra::Rewrites, post_reroll_inplace);
+    // After reroll, whose lane matching needs the repeated ops it hoists to
+    // still be there, and before islands, so they compile the smaller
+    // residue.
+    const auto cse_time = prep.start();
+    const CseStats cse_st = cse(g, out.fills, target_terms, roots);
+    prep.graph(prep_graph, "cse", cse_time, g, out.fills, target_terms.size(),
+               out.views.size(), PrepTrace::Extra::Removed, cse_st.ops_removed);
     // LAST, after every other pass has had first crack: compile whatever
     // scalar residue survives (recurrences the re-roll can never widen)
     // into island ops. Off under STANLI_NO_ISLAND.

--- a/tests/test_cse.cpp
+++ b/tests/test_cse.cpp
@@ -1,0 +1,239 @@
+// Common-subexpression elimination: identical pure ops collapse to one, and
+// the values the graph computes do not move.
+#include "env_helpers.hpp"
+#include "graph_helpers.hpp"
+#include <stanli/cse.hpp>
+#include <stanli/graph.hpp>
+#include <stanli/optable.hpp>
+
+#include <cmath>
+#include <cstdio>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+static int failures = 0;
+static void expect(const char* what, bool ok) {
+  if (!ok) {
+    ++failures;
+    std::printf("FAIL %s\n", what);
+  }
+}
+
+using namespace stanli;
+using stanli::testutil::Fills;
+
+static double fill_at(int64_t i) { return 0.3 + 0.2 * (i % 2); }
+static std::vector<double> run_grad(Graph g, const Fills& fills) {
+  return testutil::run_grad(std::move(g), fills, fill_at);
+}
+
+static void expect_same_values(const char* what, const std::vector<double>& got,
+                               const std::vector<double>& want) {
+  bool ok = got.size() == want.size();
+  for (size_t i = 0; ok && i < got.size(); ++i)
+    ok = std::abs(got[i] - want[i]) <= 1e-13 * std::max(1.0, std::abs(want[i]));
+  if (!ok) {
+    ++failures;
+    std::printf("FAIL %s\n", what);
+    for (size_t i = 0; i < want.size(); ++i)
+      std::printf("  [%zu] got %.17g want %.17g\n", i,
+                  i < got.size() ? got[i] : 0.0, want[i]);
+  }
+}
+
+static int count_opcode(const Graph& g, uint16_t oc) {
+  int n = 0;
+  for (const Op& op : g.ops) n += op.opcode == oc;
+  return n;
+}
+
+// exp(p) computed twice, both results consumed.
+static void test_merges_identical_ops() {
+  Graph g;
+  Fills fills;
+  const int p = g.add_slot(1, true);
+  const int e1 = g.add_slot(1, false), e2 = g.add_slot(1, false);
+  g.add_op(OP_EXP, {p}, e1);
+  g.add_op(OP_EXP, {p}, e2);
+  const int s = g.add_slot(1, false);
+  g.add_op(OP_ADD, {e1, e2}, s);
+  g.result_slot = s;
+
+  Graph ref = g;
+  const std::vector<double> want = run_grad(std::move(ref), fills);
+
+  std::vector<int> terms;
+  const CseStats st = cse(g, fills, terms, {});
+  expect("one op removed", st.ops_removed == 1);
+  expect("one EXP left", count_opcode(g, OP_EXP) == 1);
+  expect("the use is rewritten", g.ops[1].in[0] == e1 && g.ops[1].in[1] == e1);
+  expect_same_values("value and gradient unchanged",
+                     run_grad(std::move(g), fills), want);
+}
+
+// Target terms are the whole win on the M*_model family: the duplicated ops
+// there have no op consumer at all.
+static void test_rewrites_target_terms() {
+  Graph g;
+  Fills fills;
+  const int p = g.add_slot(1, true);
+  const int t1 = g.add_slot(1, false), t2 = g.add_slot(1, false);
+  g.add_op(OP_EXP, {p}, t1);
+  g.add_op(OP_EXP, {p}, t2);
+  std::vector<int> terms{t1, t2};
+  const CseStats st = cse(g, fills, terms, {});
+  expect("duplicate term op removed", st.ops_removed == 1);
+  expect("both terms name the survivor",
+         terms.size() == 2 && terms[0] == t1 && terms[1] == t1);
+}
+
+// Effects are graph semantics: two prints print twice.
+static void test_keeps_effectful_ops() {
+  const uint16_t effectful[] = {OP_PRINT,
+                                OP_REJECT,
+                                OP_RNG,
+                                OP_CHECK_STRUCTURED,
+                                OP_CHECK_MATCHING_DIMS,
+                                OP_CHECK_LOWER,
+                                OP_CHECK_UPPER};
+  for (uint16_t oc : effectful) {
+    Graph g;
+    Fills fills;
+    const int p = g.add_slot(1, true);
+    const int a = g.add_slot(1, false), b = g.add_slot(1, false);
+    g.add_op(oc, {p}, a);
+    g.add_op(oc, {p}, b);
+    std::vector<int> terms;
+    const CseStats st = cse(g, fills, terms, {});
+    std::string what = std::string(opcode_name(oc)) + " never merges";
+    expect(what.c_str(), st.ops_removed == 0 && g.ops.size() == 2);
+  }
+}
+
+// Same opcode, same inputs, different immediates: different elements.
+static void test_idata_distinguishes() {
+  Graph g;
+  Fills fills;
+  const int v = g.add_slot(3, true);
+  const int a = g.add_slot(1, false), b = g.add_slot(1, false);
+  g.add_op(OP_INDEX, {v}, a, {0});
+  g.add_op(OP_INDEX, {v}, b, {1});
+  const int s = g.add_slot(1, false);
+  g.add_op(OP_ADD, {a, b}, s);
+  g.result_slot = s;
+
+  std::vector<int> terms;
+  const CseStats st = cse(g, fills, terms, {});
+  expect("differing idata does not merge", st.ops_removed == 0);
+  expect("both reads survive", count_opcode(g, OP_INDEX) == 2);
+}
+
+// A destructive store rewrites the vector between the two reads, so the
+// producer of the pre-store version may not stand in for the post-store one.
+static void test_refuses_mutated_slot() {
+  Graph g;
+  Fills fills;
+  const int p = g.add_slot(1, true);
+  const int base = g.add_slot(2, false);
+  fills.emplace_back(base, std::vector<double>{0.0, 0.0});
+  const int vec = g.add_slot(2, false);
+  g.add_op(OP_ADD, {base, base}, vec);  // a fresh, op-written buffer
+  const int r1 = g.add_slot(1, false);
+  g.add_op(OP_INDEX, {vec}, r1, {0});
+  g.add_op(OP_SET_INDEX_INPLACE, {vec, p}, vec, {0});
+  const int r2 = g.add_slot(1, false);
+  g.add_op(OP_INDEX, {vec}, r2, {0});
+  const int s = g.add_slot(1, false);
+  g.add_op(OP_ADD, {r1, r2}, s);
+  g.result_slot = s;
+
+  Graph ref = g;
+  const std::vector<double> want = run_grad(std::move(ref), fills);
+
+  std::vector<int> terms;
+  const CseStats st = cse(g, fills, terms, {});
+  expect("read across a mutation does not merge", st.ops_removed == 0);
+  expect_same_values("mutation case unchanged", run_grad(std::move(g), fills),
+                     want);
+}
+
+// (a + b) twice, then (a + b) * c twice: both levels collapse in one pass.
+static void test_chain_dedup() {
+  Graph g;
+  Fills fills;
+  const int a = g.add_slot(1, true), b = g.add_slot(1, true);
+  const int c = g.add_slot(1, true);
+  const int s1 = g.add_slot(1, false), s2 = g.add_slot(1, false);
+  g.add_op(OP_ADD, {a, b}, s1);
+  g.add_op(OP_ADD, {a, b}, s2);
+  const int m1 = g.add_slot(1, false), m2 = g.add_slot(1, false);
+  g.add_op(OP_MUL, {s1, c}, m1);
+  g.add_op(OP_MUL, {s2, c}, m2);
+  const int r = g.add_slot(1, false);
+  g.add_op(OP_ADD, {m1, m2}, r);
+  g.result_slot = r;
+
+  Graph ref = g;
+  const std::vector<double> want = run_grad(std::move(ref), fills);
+
+  std::vector<int> terms;
+  const CseStats st = cse(g, fills, terms, {});
+  expect("both levels collapse", st.ops_removed == 2);
+  expect("three ops left", g.ops.size() == 3);
+  expect_same_values("chain case unchanged", run_grad(std::move(g), fills),
+                     want);
+}
+
+// A slot the executor reads straight out of the arena keeps its writer.
+static void test_keeps_roots() {
+  Graph g;
+  Fills fills;
+  const int p = g.add_slot(1, true);
+  const int e1 = g.add_slot(1, false), e2 = g.add_slot(1, false);
+  g.add_op(OP_EXP, {p}, e1);
+  g.add_op(OP_EXP, {p}, e2);
+  g.result_slot = e1;
+  std::vector<int> terms;
+  const CseStats st = cse(g, fills, terms, {e2});
+  expect("root output is not merged away", st.ops_removed == 0);
+}
+
+static void test_env_disable() {
+  test_setenv("STANLI_NO_CSE", "1", 1);
+  Graph g;
+  Fills fills;
+  const int p = g.add_slot(1, true);
+  const int e1 = g.add_slot(1, false), e2 = g.add_slot(1, false);
+  g.add_op(OP_EXP, {p}, e1);
+  g.add_op(OP_EXP, {p}, e2);
+  const int s = g.add_slot(1, false);
+  g.add_op(OP_ADD, {e1, e2}, s);
+  g.result_slot = s;
+  std::vector<int> terms;
+  const CseStats st = cse(g, fills, terms, {});
+  test_unsetenv("STANLI_NO_CSE");
+  expect("disabled by env", st.ops_removed == 0 && g.ops.size() == 3);
+}
+
+int main() {
+  {  // kernels register through the first Executor
+    Graph g;
+    const int a = g.add_slot(1, true), o = g.add_slot(1, false);
+    g.add_op(OP_EXP, {a}, o);
+    g.result_slot = o;
+    Executor warm(std::move(g));
+    (void)warm.n_params();
+  }
+  test_merges_identical_ops();
+  test_rewrites_target_terms();
+  test_keeps_effectful_ops();
+  test_idata_distinguishes();
+  test_refuses_mutated_slot();
+  test_chain_dedup();
+  test_keeps_roots();
+  test_env_disable();
+  if (failures == 0) std::printf("test_cse OK\n");
+  return failures == 0 ? 0 : 1;
+}

--- a/tests/test_legacy.cpp
+++ b/tests/test_legacy.cpp
@@ -5,12 +5,25 @@
 #include <stanli/optable.hpp>
 
 #include <stan/math.hpp>
+#include <cmath>
 #include <cstdio>
+#include <limits>
 #include <string>
 
 static int failures = 0;
 static void expect_eq(const std::string& what, double got, double want) {
   if (got != want) {
+    ++failures;
+    std::printf("FAIL %-16s got %.17g want %.17g\n", what.c_str(), got, want);
+  }
+}
+
+// The log_sum_exp partials come off Eigen's packet exp, which rounds a last
+// bit away from the var reference's scalar libm.
+static void expect_ulp(const std::string& what, double got, double want) {
+  if (got == want) return;
+  const double ulp = std::nextafter(std::abs(want), 1e308) - std::abs(want);
+  if (!(std::abs(got - want) <= ulp)) {
     ++failures;
     std::printf("FAIL %-16s got %.17g want %.17g\n", what.c_str(), got, want);
   }
@@ -40,7 +53,7 @@ int main() {
     vlp.grad();
     expect_eq("lse value", val, vlp.val());
     for (int i = 0; i < N; ++i)
-      expect_eq("lse d" + std::to_string(i), grad[i], xv(i).adj());
+      expect_ulp("lse d" + std::to_string(i), grad[i], xv(i).adj());
     stan::math::recover_memory();
   }
 

--- a/tests/test_mixture.cpp
+++ b/tests/test_mixture.cpp
@@ -289,7 +289,8 @@ static void check_row_edge(const std::string& tag,
   expect_eq(tag + " value", got.value, want.val());
   expect_eq(tag + " row value", got.out[0], want.val());
   for (int i = 0; i < (int)x.size(); ++i)
-    expect_eq(tag + " g" + std::to_string(i), got.grad[(size_t)i], xv(i).adj());
+    expect_ulp(tag + " g" + std::to_string(i), got.grad[(size_t)i], xv(i).adj(),
+               1);
   stan::math::recover_memory();
 }
 
@@ -336,7 +337,8 @@ static void check_rows() {
     expect_eq("rows out" + std::to_string(r), got.out[(size_t)r],
               row_lp[(size_t)r].val());
   for (int i = 0; i < (int)x.size(); ++i)
-    expect_eq("rows g" + std::to_string(i), got.grad[(size_t)i], xv(i).adj());
+    expect_ulp("rows g" + std::to_string(i), got.grad[(size_t)i], xv(i).adj(),
+               1);
   stan::math::recover_memory();
 
   // A nonuniform consumer verifies that backward uses each row's own output
@@ -353,8 +355,8 @@ static void check_rows() {
   }
   weighted_lp.grad();
   for (int i = 0; i < (int)x.size(); ++i)
-    expect_eq("weighted rows g" + std::to_string(i), weighted.grad[(size_t)i],
-              wx(i).adj());
+    expect_ulp("weighted rows g" + std::to_string(i), weighted.grad[(size_t)i],
+               wx(i).adj(), 1);
   stan::math::recover_memory();
 
   Graph shape;
@@ -404,7 +406,8 @@ static void check_rows() {
       expect_eq("rows9 out" + std::to_string(r), g9.out[(size_t)r],
                 rows9[(size_t)r].val());
     for (int i = 0; i < (int)many.size(); ++i)
-      expect_eq("rows9 g" + std::to_string(i), g9.grad[(size_t)i], xv(i).adj());
+      expect_ulp("rows9 g" + std::to_string(i), g9.grad[(size_t)i], xv(i).adj(),
+                 1);
     stan::math::recover_memory();
   }
 

--- a/tests/test_mixture.cpp
+++ b/tests/test_mixture.cpp
@@ -10,6 +10,7 @@
 
 #include <stan/math.hpp>
 
+#include <algorithm>
 #include <cmath>
 #include <cstdio>
 #include <limits>
@@ -32,12 +33,31 @@ static void expect_eq(const std::string& what, double got, double want) {
   }
 }
 
+static void expect_ulp(const std::string& what, double got, double want,
+                       int max_ulp) {
+  if (got == want || (std::isnan(got) && std::isnan(want))) return;
+  double ulps = std::numeric_limits<double>::infinity();
+  if (std::isfinite(got) && std::isfinite(want))
+    ulps = std::abs(got - want) /
+           std::max(std::nextafter(std::abs(want), 1e308) - std::abs(want),
+                    std::numeric_limits<double>::denorm_min());
+  if (ulps > (double)max_ulp) {
+    ++failures;
+    std::printf("FAIL %-28s got %.17g want %.17g (%.1f ulp)\n", what.c_str(),
+                got, want, ulps);
+  }
+}
+
 using stan::math::var;
 
 static const std::vector<double> TH{0.35, 0.62, 0.18, 0.91};
 static const std::vector<double> A{-1.3, 0.4, 2.1, -0.7};
 static const std::vector<double> B{0.9, -2.2, 1.5, 0.1};
 static const double S = 0.55, U = -0.8, W = 1.2;
+// log_diff_exp(a, b) is real only for a > b.
+static const std::vector<double> HI{3.2, 1.7, 4.5, 0.6};
+static const std::vector<double> LO{-0.4, 1.1, 2.0, -3.3};
+static const double SHI = 5.0;
 
 // ---- 1. Against the var reference -----------------------------------------
 // vals[k] is len 1 or len N; ref applies the scalar stan-math function per
@@ -61,6 +81,68 @@ static void check_ref(const std::string& tag, uint16_t opcode, int64_t out_len,
   for (auto& v : vs)
     for (auto& x : v)
       expect_eq(tag + " g" + std::to_string(gi), r.grad[gi], x.adj()), ++gi;
+  stan::math::recover_memory();
+}
+
+// ---- 1b. Per-element partials ----------------------------------------------
+// A distinct output adjoint per element (OP_DOT against a weight vector)
+// separates the elements: grad at a non-broadcast argument element n is
+// w[n] * partial(n), so equal gradients are equal partials one by one.
+static std::vector<double> run_weighted(
+    uint16_t opcode, int64_t out_len,
+    const std::vector<std::vector<double>>& vals,
+    const std::vector<double>& w) {
+  stanli::Graph g;
+  std::vector<int> slots;
+  int64_t n_par = 0;
+  for (const auto& v : vals) {
+    slots.push_back(g.add_slot((int64_t)v.size(), true));
+    n_par += (int64_t)v.size();
+  }
+  const int out = g.add_slot(out_len, false);
+  const int ws = g.add_slot(out_len, false);
+  const int lp = g.add_slot(1, false);
+  stanli::Op op;
+  op.opcode = opcode;
+  op.out = out;
+  for (int s : slots) op.in[op.n_in++] = s;
+  g.ops.push_back(op);
+  g.add_op(OP_DOT, {out, ws}, lp);
+  g.result_slot = lp;
+
+  stanli::Executor ex(std::move(g));
+  for (size_t i = 0; i < vals.size(); ++i)
+    for (size_t j = 0; j < vals[i].size(); ++j)
+      ex.param_ptr(slots[i])[j] = vals[i][j];
+  for (int64_t i = 0; i < out_len; ++i) ex.value_ptr(ws)[i] = w[(size_t)i];
+  std::vector<double> grad((size_t)n_par, 0.0);
+  ex.gradient(grad.data());
+  return grad;
+}
+
+template <typename F>
+static void check_partials(const std::string& tag, uint16_t opcode,
+                           int64_t out_len,
+                           const std::vector<std::vector<double>>& vals, F&& f,
+                           int max_ulp = 0) {
+  std::vector<double> w((size_t)out_len);
+  for (int64_t i = 0; i < out_len; ++i) w[(size_t)i] = 0.75 - 0.5 * (double)i;
+  const std::vector<double> got = run_weighted(opcode, out_len, vals, w);
+
+  std::vector<std::vector<var>> vs;
+  for (const auto& v : vals) vs.emplace_back(v.begin(), v.end());
+  var lp = 0.0;
+  for (int64_t n = 0; n < out_len; ++n) {
+    std::vector<var> a;
+    for (auto& v : vs) a.push_back(v[v.size() == 1 ? 0 : n]);
+    lp += w[(size_t)n] * f(a);
+  }
+  lp.grad();
+  size_t gi = 0;
+  for (auto& v : vs)
+    for (auto& x : v)
+      expect_ulp(tag + " p" + std::to_string(gi), got[gi], x.adj(), max_ulp),
+          ++gi;
   stan::math::recover_memory();
 }
 
@@ -293,6 +375,39 @@ static void check_rows() {
   expect("rows opcode name", std::string(opcode_name(OP_LOG_SUM_EXP_ROWS)) ==
                                  "OP_LOG_SUM_EXP_ROWS");
 
+  // Widths past Eigen's packet boundary, and one that is not a multiple of
+  // it.
+  std::vector<double> wide(16), odd(7);
+  for (size_t i = 0; i < wide.size(); ++i)
+    wide[i] = 0.37 * (double)i - 2.1 + 0.05 * (double)(i % 3);
+  for (size_t i = 0; i < odd.size(); ++i) odd[i] = 1.9 - 0.61 * (double)i;
+  check_row_edge("rows K=16", wide);
+  check_row_edge("rows K=7", odd);
+  {
+    std::vector<double> many;
+    for (int r = 0; r < 5; ++r)
+      many.insert(many.end(), wide.begin(), wide.begin() + 9);
+    for (size_t i = 0; i < many.size(); ++i) many[i] += 0.011 * (double)i;
+    const RowsRun g9 = run_rows(many, 9);
+    Eigen::Matrix<var, -1, 1> xv((int)many.size());
+    for (int i = 0; i < (int)many.size(); ++i) xv(i) = many[(size_t)i];
+    var lp9 = 0.0;
+    std::vector<var> rows9;
+    for (int r = 0; r < 5; ++r) {
+      Eigen::Matrix<var, -1, 1> row(9);
+      for (int k = 0; k < 9; ++k) row(k) = xv(r * 9 + k);
+      rows9.push_back(stan::math::log_sum_exp(row));
+      lp9 += rows9.back();
+    }
+    lp9.grad();
+    for (int r = 0; r < 5; ++r)
+      expect_eq("rows9 out" + std::to_string(r), g9.out[(size_t)r],
+                rows9[(size_t)r].val());
+    for (int i = 0; i < (int)many.size(); ++i)
+      expect_eq("rows9 g" + std::to_string(i), g9.grad[(size_t)i], xv(i).adj());
+    stan::math::recover_memory();
+  }
+
   const double inf = std::numeric_limits<double>::infinity();
   const double nan = std::numeric_limits<double>::quiet_NaN();
   check_row_edge("rows K=1", {-3.25});
@@ -320,6 +435,45 @@ int main() {
   check_ref("log_mix svv", OP_LOG_MIX, N, {{S}, A, B}, lmix);
   check_ref("log_mix vss", OP_LOG_MIX, N, {TH, {U}, {W}}, lmix);
   check_ref("log_mix sss", OP_LOG_MIX, 1, {{S}, {U}, {W}}, lmix);
+
+  auto ldiff = [](const std::vector<var>& a) {
+    return stan::math::log_diff_exp(a[0], a[1]);
+  };
+  check_ref("log_diff_exp vv", OP_LOG_DIFF_EXP, N, {HI, LO}, ldiff);
+  check_ref("log_diff_exp vs", OP_LOG_DIFF_EXP, N, {HI, {U}}, ldiff);
+  check_ref("log_diff_exp sv", OP_LOG_DIFF_EXP, N, {{SHI}, LO}, ldiff);
+  check_ref("log_diff_exp ss", OP_LOG_DIFF_EXP, 1, {{SHI}, {U}}, ldiff);
+
+  // -- every partial, element by element --
+  check_partials("lse2 vv", OP_LSE2, N, {A, B}, lse2);
+  check_partials("lse2 vs", OP_LSE2, N, {A, {S}}, lse2);
+  check_partials("lse2 sv", OP_LSE2, N, {{S}, B}, lse2);
+  check_partials("lse2 ss", OP_LSE2, 1, {{S}, {U}}, lse2);
+  check_partials("lse2 wide", OP_LSE2, N, {{1000.0, 999.0, -1e3, 0.1}, B},
+                 lse2);
+  check_partials("lse2 tie", OP_LSE2, N, {A, A}, lse2);
+
+  check_partials("log_mix vvv", OP_LOG_MIX, N, {TH, A, B}, lmix);
+  check_partials("log_mix svv", OP_LOG_MIX, N, {{S}, A, B}, lmix);
+  check_partials("log_mix vsv", OP_LOG_MIX, N, {TH, {U}, B}, lmix);
+  check_partials("log_mix vvs", OP_LOG_MIX, N, {TH, A, {W}}, lmix);
+  check_partials("log_mix vss", OP_LOG_MIX, N, {TH, {U}, {W}}, lmix);
+  check_partials("log_mix ssv", OP_LOG_MIX, N, {{S}, {U}, B}, lmix);
+  check_partials("log_mix svs", OP_LOG_MIX, N, {{S}, A, {W}}, lmix);
+  check_partials("log_mix sss", OP_LOG_MIX, 1, {{S}, {U}, {W}}, lmix);
+  // theta at the ends of its bound, and lambda1 <= lambda2 (the other arm of
+  // stan-math's partial helper).
+  check_partials("log_mix edge", OP_LOG_MIX, N,
+                 {{0.0, 1.0, 1e-12, 1.0 - 1e-12}, A, B}, lmix);
+  check_partials("log_mix ordered", OP_LOG_MIX, N, {TH, B, A}, lmix);
+  check_partials("log_mix tie", OP_LOG_MIX, N, {TH, A, A}, lmix);
+
+  // stan-math's log_diff_exp chain divides the output adjoint rather than
+  // scaling a partial, so a non-unit adjoint rounds one step differently.
+  check_partials("log_diff_exp vv", OP_LOG_DIFF_EXP, N, {HI, LO}, ldiff, 1);
+  check_partials("log_diff_exp vs", OP_LOG_DIFF_EXP, N, {HI, {U}}, ldiff, 1);
+  check_partials("log_diff_exp sv", OP_LOG_DIFF_EXP, N, {{SHI}, LO}, ldiff, 1);
+  check_partials("log_diff_exp ss", OP_LOG_DIFF_EXP, 1, {{SHI}, {U}}, ldiff, 1);
 
   // -- bit-identical to the unrolled loop it replaces --
   check_bitwise("unroll lse2 vv", OP_LSE2, N, {A, B});

--- a/tests/test_reroll.cpp
+++ b/tests/test_reroll.cpp
@@ -1314,6 +1314,59 @@ static void test_write_fusion_scalar_chain() {
                  want[i]);
 }
 
+// The dogs shape: per lane, two data exponents index a data vector and raise
+// a scalar parameter, and the product is the lane's target term. POW is
+// widened with a broadcast base and a per-lane exponent.
+static void test_pow_widens() {
+  const int L = 8;
+  Graph g;
+  Fills fills;
+  const int a = g.add_slot(1, true), b = g.add_slot(1, true);
+  const int shock = g.add_slot(L, false), avoid = g.add_slot(L, false);
+  std::vector<double> sv((size_t)L), av((size_t)L);
+  for (int l = 0; l < L; ++l) {
+    sv[(size_t)l] = (double)(l % 4);
+    av[(size_t)l] = (double)(l / 2);
+  }
+  fills.emplace_back(shock, sv);
+  fills.emplace_back(avoid, av);
+  std::vector<int> terms;
+  for (int l = 0; l < L; ++l) {
+    const int s = g.add_slot(1, false);
+    g.add_op(OP_INDEX, {shock}, s, {l});
+    const int v = g.add_slot(1, false);
+    g.add_op(OP_INDEX, {avoid}, v, {l});
+    const int pa = g.add_slot(1, false);
+    g.add_op(OP_POW, {a, s}, pa);
+    const int pb = g.add_slot(1, false);
+    g.add_op(OP_POW, {b, v}, pb);
+    const int t = g.add_slot(1, false);
+    g.add_op(OP_MUL, {pa, pb}, t);
+    terms.push_back(t);
+  }
+  Graph ref = g;
+  reduce_into_result(ref, terms);
+  const std::vector<double> want = run_grad(std::move(ref), fills);
+
+  std::vector<int> tt = terms;
+  Fills f2 = fills;
+  RerollStats st = reroll(g, f2, tt, {});
+  expect("pow regions==1", st.regions == 1);
+  // The indexed constants become the lanes' exponent vectors, so the INDEX
+  // ops elide: 2 POW + MUL + SUM_VEC.
+  expect("pow ops==4", g.ops.size() == 4);
+  expect("pow one term", tt.size() == 1);
+  int widened = 0;
+  for (const Op& op : g.ops)
+    if (op.opcode == OP_POW) widened += g.slots[(size_t)op.out].len == L;
+  expect("both pows widened", widened == 2);
+  g.result_slot = tt[0];
+  const std::vector<double> got = run_grad(std::move(g), f2);
+  expect("pow sizes", got.size() == want.size());
+  for (size_t i = 0; i < want.size() && i < got.size(); ++i)
+    expect_close(("pow v" + std::to_string(i)).c_str(), got[i], want[i]);
+}
+
 // ---- end to end through compile_model ------------------------------------
 
 static std::string slurp(const char* p) {
@@ -1511,6 +1564,7 @@ int main() {
   test_write_fusion_bails();
   test_post_reroll_slice_inplace();
   test_write_fusion_scalar_chain();
+  test_pow_widens();
   test_e2e_fixtures();
   if (failures) {
     std::printf("%d failures\n", failures);


### PR DESCRIPTION
First wave of the data-advantage perf work. Three independent items:

- mixture.cpp kernels compute closed-form partials instead of a nested autodiff tape per element: normal_mixture and the low_dim_gauss_mix pair -45-47%, ldaK2 -46%, ldaK5 -26%. LSE family stays bitwise; two pre-existing 1-ULP log_diff_exp cases pinned.
- CSE pass after inplace: Mt_model 16.1x (1,062 ops to 70), Mh 1.39x, gpcm graph 61,612 to 34,634. Forward bitwise; STANLI_NO_CSE kill switch.
- OP_POW joins reroll's widenable set: dogs_hierarchical -69%, dogs_nonhierarchical -56%.

ctest 60/60, corpus 129/129 with the worst line identical to baseline.