### PR TITLE
perf: trim ODE callback and Jacobian overhead

### DIFF
--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -391,6 +391,27 @@ the top of the page, not replacements for the current corpus rows:
   results were bitwise identical for all 63/63 checked scalars across three
   points. This targeted A/B attributes the direct-seeding change; the current
   corpus rows above and in the table below are the later end-to-end refresh.
+- **Direct ODE Jacobian-row harvest plus scalar RHS cleanup.** Stan Math's ODE
+  outputs are already precomputed-gradient nodes directly connected to active
+  inputs, so the kernel now chains the selected output instead of running a
+  nested reverse sweep across every sibling output for each Jacobian row, and
+  clears only that output and its inputs between rows. A conservative
+  load-time pass also removes overwritten scalar initializer
+  constants and aliases stable single-definition copies; any range-reading,
+  dynamic, density, or kernel instruction leaves the RHS program unchanged. A
+  targeted 2026-08-25 three-binary A/B (seven rotating matched-batch medians)
+  measured:
+
+  | model | parent | direct node only | full change | improvement |
+  | --- | ---: | ---: | ---: | ---: |
+  | `lotka_volterra` | 78.5160 us | 70.3923 us | 60.8881 us | 1.28951x |
+  | `soil_incubation` | 101.3979 us | 88.5437 us | 82.0553 us | 1.23573x |
+  | `one_comp_mm_elim_abs` | 663.9302 us | 665.3790 us | 629.7752 us | 1.05423x |
+
+  The full change improves the geometric mean by 1.18876x. Fresh parent and
+  patched checkers were byte-identical for all 63/63 LP-and-gradient scalars
+  over three evaluation points. These targeted medians isolate the mechanism;
+  they do not refresh the full-corpus table or its retained CmdStan columns.
 - **Packed row-wise reductions** (the LDA inner loop): targeted medians fall
   from 154 to 94 us for `ldaK2` and 6.82 to 3.70 ms for `ldaK5`, while their
   graphs collapse from 15,854 to 22 and 434,126 to 156 ops. The full

--- a/runtime/kernels/ode.cpp
+++ b/runtime/kernels/ode.cpp
@@ -17,11 +17,11 @@
 // has no sensitivities and takes the plain double solve.
 //
 // Reading them out is cheap. stan-math integrates the coupled system on
-// doubles and only builds precomputed-gradient varis for the solution
-// itself, so the nested tape left standing after a solve holds the inputs
-// and the outputs and nothing else; one reverse sweep per output element
-// walks a few dozen varis, against several hundred right-hand-side
-// evaluations for a solve.
+// doubles and builds each solution element as one precomputed-gradient vari
+// directly connected to the active inputs. Chaining that selected output node
+// yields one Jacobian row without walking its sibling output nodes. After one
+// initial tape reset, only that output and those inputs need clearing between
+// rows; the graph backward later applies the rows in Stan's reverse order.
 #include <stanli/graph.hpp>
 #include <stanli/packet.hpp>
 #include <stanli/mir_interp.hpp>
@@ -212,21 +212,31 @@ void ode_fwd_typed(KernelCtx& ctx, const OdeSpec& s) {
         ctx.out.data[(int64_t)n * S + k] = solv[n][k].val();
 
     // d(solution)/d(z_init, theta), row per flattened solution element.
-    // Sweep last-to-first to retain the accumulation order ode_bwd and the
-    // former all-var solve used. Only the scalar types changed.
+    // Harvest last-to-first to retain the row order ode_bwd and the former
+    // all-var solve used. Each solution is a precomputed-gradient node whose
+    // one chain call writes this raw row directly to the active inputs.
+    stan::math::set_zero_all_adjoints_nested();
     for (int64_t o = ctx.out.len; o-- > 0;) {
-      stan::math::set_zero_all_adjoints_nested();
-      stan::math::grad(solv[(size_t)(o / S)][(size_t)(o % S)].vi_);
+      auto* output = solv[(size_t)(o / S)][(size_t)(o % S)].vi_;
+      output->adj_ = 1.0;
+      output->chain();
       if constexpr (YAutodiff) {
-        for (int64_t i = 0; i < S; ++i) J[o * W + i] = z0[(size_t)i].adj();
+        for (int64_t i = 0; i < S; ++i) {
+          J[o * W + i] = z0[(size_t)i].adj();
+          z0[(size_t)i].vi_->adj_ = 0.0;
+        }
       } else {
         for (int64_t i = 0; i < S; ++i) J[o * W + i] = 0.0;
       }
       if constexpr (ThetaAutodiff) {
-        for (int64_t i = 0; i < P; ++i) J[o * W + S + i] = th[(size_t)i].adj();
+        for (int64_t i = 0; i < P; ++i) {
+          J[o * W + S + i] = th[(size_t)i].adj();
+          th[(size_t)i].vi_->adj_ = 0.0;
+        }
       } else {
         for (int64_t i = 0; i < P; ++i) J[o * W + S + i] = 0.0;
       }
+      output->adj_ = 0.0;
     }
   }
 }

--- a/runtime/src/OPTIMIZATIONS.md
+++ b/runtime/src/OPTIMIZATIONS.md
@@ -711,6 +711,40 @@ means and CmdStan ratios remain the absolute source of truth in
 The original RHS compiler, solve reuse, and mixed-activity work made the ODE
 models 29-39x faster; direct input seeding compounds that historical gain.
 
+The remaining Jacobian extraction also used more reverse-mode machinery than
+the ODE result contains. Stan Math returns each solution scalar as one
+`precomputed_gradients_vari` directly connected to the active inputs. Calling
+`grad` once per output therefore walked every sibling output node merely to
+chain the selected node. The kernel now zeros the nested adjoints and chains
+that selected result node directly. Between rows it clears only that output
+and the active inputs it touched; the graph backward still consumes rows
+last-to-first and accumulates inputs in their original order.
+
+A narrow load-time cleanup complements that change inside the callback. MIR
+spells initialized scalar locals as a default constant followed by the real
+assignment and copies values through return temporaries. For an RHS containing
+only scalar, effect-free instructions, the compiler removes an initializer
+overwritten before any read/control-flow edge and aliases a `MOV` only when
+both registers have stable single definitions. It remaps jump targets after
+compaction. Any dynamic indexing, range read or transform, density, kernel
+call, or other unfamiliar instruction retains the original program unchanged.
+
+A targeted 2026-08-25 Release A/B used three isolated binaries from the same
+parent, seven rotating matched batches per model, a 200 ms warmup, and roughly
+one measured second per batch:
+
+| model | parent | direct Jacobian node only | node + RHS cleanup | total improvement |
+| --- | ---: | ---: | ---: | ---: |
+| `lotka_volterra` | 78.5160 us | 70.3923 us | 60.8881 us | 1.28951x |
+| `soil_incubation` | 101.3979 us | 88.5437 us | 82.0553 us | 1.23573x |
+| `one_comp_mm_elim_abs` | 663.9302 us | 665.3790 us | 629.7752 us | 1.05423x |
+
+The full change improves the geometric mean by 1.18876x. The same fresh
+parent and patched checkers produced byte-identical LP and gradient output at
+three evaluation points for all three models (63/63 scalars). This is a
+targeted mechanism A/B; it does not replace the full-corpus warmed means or
+CmdStan columns in `docs/corpus-bench.tsv`.
+
 ## Executor details (`executor.cpp`)
 
 - Each op's context (the pointers telling the kernel where its inputs,

--- a/runtime/src/ode_prog.cpp
+++ b/runtime/src/ode_prog.cpp
@@ -15,6 +15,210 @@ namespace stanli {
 
 namespace {
 
+// The MIR spells an initialized local as its language-level default fill
+// followed by a copy of the initializer, and copies values again through
+// return temporaries. Native C++ optimization removes that bookkeeping. An
+// ODE right-hand side otherwise pays it on every solver callback, including
+// under var where a dead constant also allocates a disconnected tape node.
+//
+// Keep this deliberately narrower than a general Program optimizer. ODE
+// scalar arithmetic has no effects, range reads, densities, or kernel calls;
+// an unfamiliar instruction leaves the program unchanged. Dead constants
+// may disappear only before the next control-flow edge, and a MOV aliases its
+// source only when both registers have stable single definitions. Branch
+// joins therefore retain their initialized value.
+bool scalar_rhs_instruction(Program::Code code) {
+  switch (code) {
+    case Program::CONST:
+    case Program::CONSTR:
+    case Program::MOV:
+    case Program::ADD:
+    case Program::SUB:
+    case Program::MUL:
+    case Program::DIV:
+    case Program::POW:
+    case Program::FMAX:
+    case Program::FMIN:
+    case Program::NEG:
+    case Program::EXP:
+    case Program::LOG:
+    case Program::SQRT:
+    case Program::SQUARE:
+    case Program::INV:
+    case Program::FABS:
+    case Program::INV_LOGIT:
+    case Program::LOG1M:
+    case Program::TANH:
+    case Program::GT:
+    case Program::GE:
+    case Program::LT:
+    case Program::LE:
+    case Program::EQ:
+    case Program::NE:
+    case Program::JZ:
+    case Program::JMP:
+    case Program::LSE2:
+    case Program::LOG_MIX:
+    case Program::FMA:
+      return true;
+    default:
+      return false;
+  }
+}
+
+bool binary_rhs_instruction(Program::Code code) {
+  switch (code) {
+    case Program::ADD:
+    case Program::SUB:
+    case Program::MUL:
+    case Program::DIV:
+    case Program::POW:
+    case Program::FMAX:
+    case Program::FMIN:
+    case Program::GT:
+    case Program::GE:
+    case Program::LT:
+    case Program::LE:
+    case Program::EQ:
+    case Program::NE:
+    case Program::LSE2:
+      return true;
+    default:
+      return false;
+  }
+}
+
+bool unary_rhs_instruction(Program::Code code) {
+  switch (code) {
+    case Program::MOV:
+    case Program::NEG:
+    case Program::EXP:
+    case Program::LOG:
+    case Program::SQRT:
+    case Program::SQUARE:
+    case Program::INV:
+    case Program::FABS:
+    case Program::INV_LOGIT:
+    case Program::LOG1M:
+    case Program::TANH:
+    case Program::JZ:
+      return true;
+    default:
+      return false;
+  }
+}
+
+bool reads_rhs_register(const Program::Instr& instr, int reg) {
+  if (unary_rhs_instruction(instr.code)) return instr.a == reg;
+  if (binary_rhs_instruction(instr.code))
+    return instr.a == reg || instr.b == reg;
+  if (instr.code == Program::LOG_MIX || instr.code == Program::FMA)
+    return instr.a == reg || instr.b == reg || instr.c == reg;
+  return false;
+}
+
+bool writes_rhs_register(const Program::Instr& instr, int reg) {
+  if (instr.code == Program::JZ || instr.code == Program::JMP) return false;
+  if (instr.code == Program::CONSTR)
+    return reg >= instr.dst && reg < instr.dst + instr.len;
+  return instr.dst == reg;
+}
+
+void rewrite_rhs_reads(Program::Instr& instr, const std::vector<int>& alias) {
+  if (unary_rhs_instruction(instr.code)) {
+    instr.a = alias[(size_t)instr.a];
+    return;
+  }
+  if (binary_rhs_instruction(instr.code)) {
+    instr.a = alias[(size_t)instr.a];
+    instr.b = alias[(size_t)instr.b];
+    return;
+  }
+  if (instr.code == Program::LOG_MIX || instr.code == Program::FMA) {
+    instr.a = alias[(size_t)instr.a];
+    instr.b = alias[(size_t)instr.b];
+    instr.c = alias[(size_t)instr.c];
+  }
+}
+
+void optimize_scalar_rhs(RhsProgram& p) {
+  if (!std::all_of(p.code.begin(), p.code.end(), [](const auto& instr) {
+        return scalar_rhs_instruction(instr.code);
+      }))
+    return;
+
+  const size_t n = p.code.size();
+  std::vector<bool> remove(n, false);
+
+  // A scalar declaration fill overwritten before any read or branch is
+  // disconnected bookkeeping. Stop at a jump even when a later assignment
+  // looks unconditional in the linear instruction array.
+  for (size_t i = 0; i < n; ++i) {
+    const Program::Instr& init = p.code[i];
+    if (init.code != Program::CONST) continue;
+    for (size_t j = i + 1; j < n; ++j) {
+      const Program::Instr& next = p.code[j];
+      if (next.code == Program::JZ || next.code == Program::JMP) break;
+      if (reads_rhs_register(next, init.dst)) break;
+      if (writes_rhs_register(next, init.dst)) {
+        remove[i] = true;
+        break;
+      }
+    }
+  }
+
+  std::vector<int> writers((size_t)p.n_regs, 0);
+  std::vector<int> writer_pc((size_t)p.n_regs, -1);
+  for (size_t pc = 0; pc < n; ++pc) {
+    if (remove[pc]) continue;
+    const Program::Instr& instr = p.code[pc];
+    if (instr.code == Program::JZ || instr.code == Program::JMP) continue;
+    const int len = instr.code == Program::CONSTR ? instr.len : 1;
+    for (int k = 0; k < len; ++k) {
+      const size_t reg = (size_t)(instr.dst + k);
+      ++writers[reg];
+      writer_pc[reg] = (int)pc;
+    }
+  }
+
+  std::vector<int> alias((size_t)p.n_regs);
+  for (int reg = 0; reg < p.n_regs; ++reg) alias[(size_t)reg] = reg;
+  for (size_t pc = 0; pc < n; ++pc) {
+    if (remove[pc]) continue;
+    Program::Instr& instr = p.code[pc];
+    rewrite_rhs_reads(instr, alias);
+    if (instr.code == Program::MOV && writers[(size_t)instr.dst] == 1 &&
+        writers[(size_t)instr.a] <= 1 && writer_pc[(size_t)instr.a] < (int)pc) {
+      alias[(size_t)instr.dst] = instr.a;
+      remove[pc] = true;
+      continue;
+    }
+    if (instr.code == Program::JZ || instr.code == Program::JMP) continue;
+    const int len = instr.code == Program::CONSTR ? instr.len : 1;
+    for (int k = 0; k < len; ++k)
+      alias[(size_t)(instr.dst + k)] = instr.dst + k;
+  }
+  for (int& reg : p.out_regs) reg = alias[(size_t)reg];
+
+  std::vector<int> new_pc(n + 1, 0);
+  int at = 0;
+  for (size_t pc = 0; pc < n; ++pc) {
+    new_pc[pc] = at;
+    if (!remove[pc]) ++at;
+  }
+  new_pc[n] = at;
+  std::vector<Program::Instr> compact;
+  compact.reserve((size_t)at);
+  for (size_t pc = 0; pc < n; ++pc) {
+    if (remove[pc]) continue;
+    Program::Instr instr = p.code[pc];
+    if (instr.code == Program::JZ || instr.code == Program::JMP)
+      instr.dst = new_pc[(size_t)instr.dst];
+    compact.push_back(instr);
+  }
+  p.code = std::move(compact);
+}
+
 bool supported_rhs_view(const mir::UnsizedView& view) {
   if (view.depth > 1) return false;
   if (view.depth == 1)
@@ -111,6 +315,7 @@ RhsProgram compile_rhs_args(
              " values for " + std::to_string(n_y) + " states");
     for (int k = 0; k < out.len; ++k) p.out_regs.push_back(out.reg + k);
     c.finish();
+    optimize_scalar_rhs(p);
     p.ok = true;
   } catch (Bail& b) {
     p.ok = false;

--- a/tests/test_ode_prog.cpp
+++ b/tests/test_ode_prog.cpp
@@ -17,6 +17,7 @@
 
 #include <stan/math.hpp>
 
+#include <algorithm>
 #include <cmath>
 #include <cstdint>
 #include <cstdio>
@@ -252,6 +253,18 @@ int main() {
     const RhsProgram p = compile_rhs(*it->second, funs, 2, 4, 2, x_i);
     expect("mixed seed fixture compiles", p.ok);
     if (p.ok) {
+      const bool compact =
+          p.code.size() == 7 &&
+          std::none_of(p.code.begin(), p.code.end(), [](const auto& i) {
+            return i.code == Program::CONST || i.code == Program::MOV;
+          });
+      if (!compact) {
+        std::printf("optimized f_lin has %zu instructions:", p.code.size());
+        for (const auto& i : p.code)
+          std::printf(" %s", program_code_spec(i.code).name);
+        std::printf("\n");
+      }
+      expect("straight-line RHS drops initializer/copy bookkeeping", compact);
       check_mixed_seed<true, false>(p, "var/double");
       check_mixed_seed<false, true>(p, "double/var");
       check_mixed_seed<true, true>(p, "var/var");

--- a/tests/test_odevariadic.cpp
+++ b/tests/test_odevariadic.cpp
@@ -213,6 +213,39 @@ void check_activity_case(const stanli::OdeSpec& spec, const char* label) {
   }
 }
 
+static void check_precomputed_jacobian_harvest() {
+  stan::math::nested_rev_autodiff nested;
+  std::vector<stan::math::var> inputs{0.2, -0.35, 1.1, 0.7};
+  const std::vector<std::vector<double>> jacobian{
+      {0.25, -0.5, 0.75, -1.0}, {-1.25, 1.5, -1.75, 2.0},
+      {2.25, -2.5, 2.75, -3.0}, {-3.25, 3.5, -3.75, 4.0},
+      {4.25, -4.5, 4.75, -5.0}, {-5.25, 5.5, -5.75, 6.0},
+  };
+  std::vector<stan::math::var> outputs;
+  for (size_t o = 0; o < jacobian.size(); ++o)
+    outputs.push_back(stan::math::precomputed_gradients(10.0 + (double)o,
+                                                        inputs, jacobian[o]));
+
+  std::vector<std::vector<double>> full(outputs.size());
+  for (size_t o = outputs.size(); o-- > 0;) {
+    stan::math::set_zero_all_adjoints_nested();
+    stan::math::grad(outputs[o].vi_);
+    for (const auto& input : inputs) full[o].push_back(input.adj());
+  }
+
+  stan::math::set_zero_all_adjoints_nested();
+  for (size_t o = outputs.size(); o-- > 0;) {
+    outputs[o].vi_->adj_ = 1.0;
+    outputs[o].vi_->chain();
+    for (size_t i = 0; i < inputs.size(); ++i) {
+      expect("direct precomputed-gradient harvest matches full reverse sweep",
+             inputs[i].adj() == full[o][i]);
+      inputs[i].vi_->adj_ = 0.0;
+    }
+    outputs[o].vi_->adj_ = 0.0;
+  }
+}
+
 static const stanli::OdeSpec* fixture_rk45_spec(const stanli::Graph& graph) {
   using namespace stanli;
   for (const Op& op : graph.ops)
@@ -256,6 +289,8 @@ int main() {
         write_has_dd = write_has_dd || op.variant == 0x4u;
       }
   expect("write_array contains a double/double ODE", write_has_dd);
+
+  check_precomputed_jacobian_harvest();
 
   if (rk45_spec) {
     check_activity_case<true, false>(*rk45_spec, "active y/data theta");


### PR DESCRIPTION
## Summary

- harvest each Stan Math ODE Jacobian row by chaining its precomputed-gradient output node directly, with one initial tape reset and explicit clearing of only the touched output/inputs
- compact effect-free scalar RHS bytecode at load time by removing overwritten initializer constants and stable single-definition copies; unfamiliar/ranged/effectful programs remain unchanged
- pin the exact precomputed-gradient sequence, scalar RHS compaction, branch behavior, mixed activity masks, and document the targeted three-binary A/B

## Performance

Seven rotating matched Release medians (parent / direct-node-only / full change):

| model | parent | direct node only | full change | total |
| --- | ---: | ---: | ---: | ---: |
| `lotka_volterra` | 78.5160 us | 70.3923 us | 60.8881 us | 1.28951x |
| `soil_incubation` | 101.3979 us | 88.5437 us | 82.0553 us | 1.23573x |
| `one_comp_mm_elim_abs` | 663.9302 us | 665.3790 us | 629.7752 us | 1.05423x |

Geometric-mean improvement: **1.18876x**. The full-corpus table is deliberately unchanged; these are mechanism-isolating targeted medians.

## Validation

- Release all-target build and CTest: **59/59**
- CmdStan reference replay: **129/129 models**, 800,674 values at three points
- ODE interface sweep: **11/11** modern/legacy solver and argument shapes
- parent vs patch: **63/63 LP + gradient scalars byte-identical** across the three ODE models and three points
- format, generated docs, web-model notes, and diff checks pass