### PR TITLE
perf: single-tape density partials, packet log, deferred-work doc

### DIFF
--- a/runtime/kernels/constrain.cpp
+++ b/runtime/kernels/constrain.cpp
@@ -396,9 +396,10 @@ void offset_mult_bwd(KernelCtx& ctx) {
       // lp term (sum(log(sigma))) before the value (fma), so the reverse
       // sweep contracts fma's contribution into sigma.adj first and the
       // jacobian's second -- and a += b += c does not round like a += (b + c).
-      for (int64_t i = 0; i < n; ++i) ctx.in_adj[2].data[i] += dout[i] * x[i];
-      for (int64_t i = 0; i < n; ++i)
+      for (int64_t i = 0; i < n; ++i) {
+        ctx.in_adj[2].data[i] += dout[i] * x[i];
         ctx.in_adj[2].data[i] += ctx.out2_adj / sg[i];
+      }
     } else {
       double s = 0.0;
       for (int64_t i = 0; i < n; ++i) s += dout[i] * x[i];

--- a/runtime/kernels/densities_impl.hpp
+++ b/runtime/kernels/densities_impl.hpp
@@ -277,10 +277,10 @@ void density_bwd(KernelCtx& ctx) {
   if (ctx.scratch[n_partials] == 0.0) return;
   int64_t off = 0;
   for (int k = 0; k < NArgs; ++k) {
-    if (((mask >> k) & 1u) != 0 && ctx.in_adj[k].data != nullptr) {
-      for (int64_t i = 0; i < ctx.in[k].len; ++i)
-        ctx.in_adj[k].data[i] += ctx.out_adj * ctx.scratch[off + i];
-    }
+    if (((mask >> k) & 1u) != 0 && ctx.in_adj[k].data != nullptr)
+      Eigen::Map<Eigen::ArrayXd>(ctx.in_adj[k].data, ctx.in[k].len) +=
+          ctx.out_adj *
+          Eigen::Map<const Eigen::ArrayXd>(ctx.scratch + off, ctx.in[k].len);
     off += ctx.in[k].len;
   }
 }

--- a/runtime/kernels/eltwise_expr.cpp
+++ b/runtime/kernels/eltwise_expr.cpp
@@ -330,10 +330,9 @@ void cumsum_bwd(KernelCtx& ctx) {
   ctx.in_adj[0].data[0] += radj[0];
 }
 
-void logv_fwd(KernelCtx& ctx) {
-  for (int64_t i = 0; i < ctx.out.len; ++i)
-    ctx.out.data[i] = std::log(ctx.in[0].data[i]);
-}
+// Eigen's packet log, a ulp off libm on some arguments. The matching packet
+// exp is NOT taken: it puts kronecker_gp over its reference gate.
+void logv_fwd(KernelCtx& ctx) { out_a(ctx) = in_a(ctx, 0).log(); }
 void logv_bwd(KernelCtx& ctx) {
   if (!ctx.in_adj[0].data) return;
   if (ctx.out.len == 1)

--- a/runtime/kernels/legacy_fns.cpp
+++ b/runtime/kernels/legacy_fns.cpp
@@ -3,6 +3,7 @@
 #include <stanli/graph.hpp>
 #include <stanli/legacy.hpp>
 #include <stanli/optable.hpp>
+#include <stanli/packet.hpp>
 
 namespace stanli {
 namespace {
@@ -24,7 +25,6 @@ void softmax_bwd(KernelCtx& ctx) {
 // legacy propto op must bind each argument var-or-double per the activity
 // mask, exactly like the native kernels do; promoting an inactive argument
 // to var silently keeps terms CmdStan drops.
-template <bool Grad>
 double dirichlet_eval(KernelCtx& ctx) {
   stan::math::nested_rev_autodiff nested;
   using stan::math::var;
@@ -74,17 +74,15 @@ double dirichlet_eval(KernelCtx& ctx) {
       else
         lpv = stan::math::dirichlet_lpdf<false>(thd, alpha_d);
     }
-    if constexpr (Grad) {
-      var j = lpv * ctx.out_adj;
-      stan::math::grad(j.vi_);
-      if (a0 && ctx.in_adj[0].data)
-        for (int64_t r = 0; r < reps; ++r)
-          for (int64_t i = 0; i < K; ++i)
-            ctx.in_adj[0].data[r * K + i] += th[r](i).adj();
-      if (a1 && ctx.in_adj[1].data)
-        for (int64_t i = 0; i < K; ++i) ctx.in_adj[1].data[i] += alpha(i).adj();
+    const double vv = lpv.val();
+    if (!values_only()) {
+      stan::math::grad(lpv.vi_);
+      double* s = ctx.scratch;
+      for (int64_t r = 0; r < reps; ++r)
+        for (int64_t i = 0; i < K; ++i) *s++ = th[r](i).adj();
+      for (int64_t i = 0; i < K; ++i) *s++ = alpha(i).adj();
     }
-    return lpv.val();
+    return vv;
   }
   if (propto) {
     if (a0 && a1)
@@ -105,22 +103,29 @@ double dirichlet_eval(KernelCtx& ctx) {
     else
       lp = stan::math::dirichlet_lpdf<false>(theta_d, alpha_d);
   }
-  if constexpr (Grad) {
-    var j = lp * ctx.out_adj;
-    stan::math::grad(j.vi_);
-    if (ctx.in_adj[0].data)
-      for (int64_t i = 0; i < ctx.in[0].len; ++i)
-        ctx.in_adj[0].data[i] += theta(i).adj();
-    if (ctx.in_adj[1].data)
-      for (int64_t i = 0; i < ctx.in[1].len; ++i)
-        ctx.in_adj[1].data[i] += alpha(i).adj();
+  const double value = lp.val();
+  if (!values_only()) {
+    stan::math::grad(lp.vi_);
+    double* s = ctx.scratch;
+    for (int64_t i = 0; i < ctx.in[0].len; ++i) *s++ = theta(i).adj();
+    for (int64_t i = 0; i < ctx.in[1].len; ++i) *s++ = alpha(i).adj();
   }
-  return lp.val();
+  return value;
 }
-void dirichlet_fwd(KernelCtx& ctx) {
-  ctx.out.data[0] = dirichlet_eval<false>(ctx);
+void dirichlet_fwd(KernelCtx& ctx) { ctx.out.data[0] = dirichlet_eval(ctx); }
+
+// One tape per gradient, not two: the forward grads it with a seed of 1 and
+// stashes, the backward scales. dirichlet_lpdf reduces through a partials
+// propagator, so the two seedings round identically.
+void dirichlet_bwd(KernelCtx& ctx) {
+  const double* s = ctx.scratch;
+  for (int k = 0; k < 2; ++k) {
+    if (ctx.in_adj[k].data)
+      Eigen::Map<Eigen::ArrayXd>(ctx.in_adj[k].data, ctx.in[k].len) +=
+          ctx.out_adj * Eigen::Map<const Eigen::ArrayXd>(s, ctx.in[k].len);
+    s += ctx.in[k].len;
+  }
 }
-void dirichlet_bwd(KernelCtx& ctx) { dirichlet_eval<true>(ctx); }
 
 void log_softmax_fwd(KernelCtx& ctx) {
   Eigen::Map<const Eigen::VectorXd> x(ctx.in[0].data, ctx.in[0].len);
@@ -139,7 +144,7 @@ void register_legacy_kernels() {
                   Kernel{log_softmax_fwd, log_softmax_bwd, nullptr});
   register_kernel(OP_SOFTMAX, Kernel{softmax_fwd, softmax_bwd, nullptr});
   register_kernel(OP_DIRICHLET_LPDF,
-                  Kernel{dirichlet_fwd, dirichlet_bwd, nullptr});
+                  Kernel{dirichlet_fwd, dirichlet_bwd, sum_in_lens});
 }
 
 }  // namespace stanli

--- a/runtime/kernels/matrix_fns.cpp
+++ b/runtime/kernels/matrix_fns.cpp
@@ -181,6 +181,65 @@ template <bool Grad, typename... Args>
   return value;
 }
 
+double* tail_stash(double* s, const VarM& M) {
+  for (int64_t i = 0; i < M.size(); ++i) *s++ = M.data()[i].adj();
+  return s;
+}
+double* tail_stash(double* s, const VarV& v) {
+  for (int64_t i = 0; i < v.size(); ++i) *s++ = v(i).adj();
+  return s;
+}
+double* tail_stash(double* s, const stan::math::var& x) {
+  *s++ = x.adj();
+  return s;
+}
+double* tail_stash(double* s, const std::vector<VarV>& xs) {
+  for (const auto& x : xs) s = tail_stash(s, x);
+  return s;
+}
+
+// finish_tail_density split across the sweeps: one tape per gradient, gradded
+// in the FORWARD with a seed of 1, contracted in the backward. That is only
+// bitwise for a density whose reverse sweep multiplies the output adjoint in
+// once per operand -- the partials_propagator family. Densities that reduce
+// through var arithmetic (wishart, lkj, wiener, multi_normal_prec) round the
+// two orders differently and stay on the two-tape form above.
+template <typename... Args>
+[[gnu::always_inline]] inline double tail_density_fwd(
+    KernelCtx& ctx, const stan::math::var& density, const Args&... args) {
+  const double value = density.val();
+  if (!values_only()) {
+    stan::math::grad(density.vi_);
+    double* s = ctx.scratch;
+    ((s = tail_stash(s, args)), ...);
+  }
+  return value;
+}
+
+// Mirror of tail_density_fwd's layout: one partial per element of the first
+// NArgs inputs, in slot order.
+template <int NArgs>
+void tail_density_bwd(KernelCtx& ctx) {
+  const double* s = ctx.scratch;
+  const double w = ctx.out_adj;
+  for (int k = 0; k < NArgs; ++k) {
+    if (ctx.in_adj[k].data)
+      Eigen::Map<Eigen::ArrayXd>(ctx.in_adj[k].data, ctx.in[k].len) +=
+          w * Eigen::Map<const Eigen::ArrayXd>(s, ctx.in[k].len);
+    s += ctx.in[k].len;
+  }
+}
+
+template <int NArgs>
+int64_t tail_density_scratch(const Op& op, const Slot* slots) {
+  int64_t t = 0;
+  for (int k = 0; k < NArgs && k < op.n_in; ++k) {
+    if (op.in[k] < 0) return 0;
+    t += slots[op.in[k]].len;
+  }
+  return t;
+}
+
 // ---- multi_normal_lpdf(y | mu, Sigma) -------------------------------------
 // in = {y, mu, Sigma}; idata = {n}. Propto and per-argument activity follow
 // the density convention: stan-math drops terms by argument type, so inactive
@@ -239,19 +298,23 @@ double mn_eval(KernelCtx& ctx) {
     else
       v_out = aS ? (am ? call(ysd, mu, S) : call(ysd, mud, S))
                  : (am ? call(ysd, mu, Sd) : call(ysd, mud, Sd));
-    const double vv = v_out.val();
-    if constexpr (Grad) {
-      var jj = v_out * ctx.out_adj;
-      stan::math::grad(jj.vi_);
-      // y stays hand-written here: it is a std::vector<VarV>, not a VarV.
-      if (ay && ctx.in_adj[0].data)
-        for (int64_t k = 0; k < m; ++k)
-          for (int64_t i = 0; i < n; ++i)
-            ctx.in_adj[0].data[k * n + i] += ys[k](i).adj();
-      if (am) tail_scatter(ctx, 1, mu);
-      if (aS) tail_scatter(ctx, 2, S);
+    if constexpr (Kind == kMnPrec) {
+      const double vv = v_out.val();
+      if constexpr (Grad) {
+        var jj = v_out * ctx.out_adj;
+        stan::math::grad(jj.vi_);
+        // y stays hand-written here: it is a std::vector<VarV>, not a VarV.
+        if (ay && ctx.in_adj[0].data)
+          for (int64_t k = 0; k < m; ++k)
+            for (int64_t i = 0; i < n; ++i)
+              ctx.in_adj[0].data[k * n + i] += ys[k](i).adj();
+        if (am) tail_scatter(ctx, 1, mu);
+        if (aS) tail_scatter(ctx, 2, S);
+      }
+      return vv;
+    } else {
+      return tail_density_fwd(ctx, v_out, ys, mu, S);
     }
-    return vv;
   }
   if (ay && am && aS)
     out = call(y, mu, S);
@@ -270,18 +333,22 @@ double mn_eval(KernelCtx& ctx) {
   else
     return call(yd, mud, Sd);
 
-  const double v = out.val();
-  if constexpr (Grad) {
-    var j = out * ctx.out_adj;
-    stan::math::grad(j.vi_);
-    if (ay) tail_scatter(ctx, 0, y);
-    if (am) tail_scatter(ctx, 1, mu);
-    if (aS) tail_scatter(ctx, 2, S);
+  if constexpr (Kind == kMnPrec) {
+    const double v = out.val();
+    if constexpr (Grad) {
+      var j = out * ctx.out_adj;
+      stan::math::grad(j.vi_);
+      if (ay) tail_scatter(ctx, 0, y);
+      if (am) tail_scatter(ctx, 1, mu);
+      if (aS) tail_scatter(ctx, 2, S);
+    }
+    return v;
+  } else {
+    return tail_density_fwd(ctx, out, y, mu, S);
   }
-  return v;
 }
 void mn_fwd(KernelCtx& ctx) { ctx.out.data[0] = mn_eval<false>(ctx); }
-void mn_bwd(KernelCtx& ctx) { mn_eval<true>(ctx); }
+void mn_bwd(KernelCtx& ctx) { tail_density_bwd<3>(ctx); }
 void mnprec_fwd(KernelCtx& ctx) {
   ctx.out.data[0] = mn_eval<false, kMnPrec>(ctx);
 }
@@ -343,11 +410,8 @@ double mnc_native_fwd(KernelCtx& ctx) {
 
   double logp(0.0);
   logp += stan::math::sum(stan::math::log(inv_L.diagonal()));
-  if (!values_only()) {
-    MapM partials(ctx.scratch, n, n);
-    partials.setZero();
-    partials += scaled_diff * half - inv_L.transpose();
-  }
+  if (!values_only())
+    MapM(ctx.scratch, n, n) = scaled_diff * half - inv_L.transpose();
   logp -= 0.5 * stan::math::sum(stan::math::dot_self(half));
   return logp;
 }
@@ -358,7 +422,7 @@ void mnc_fwd(KernelCtx& ctx) {
 }
 void mnc_bwd(KernelCtx& ctx) {
   if (!mnc_native_shape(ctx)) {
-    mn_eval<true, kMnChol>(ctx);
+    tail_density_bwd<3>(ctx);
     return;
   }
   if (!ctx.in_adj[2].data) return;
@@ -367,15 +431,18 @@ void mnc_bwd(KernelCtx& ctx) {
     ctx.in_adj[2].data[i] += ctx.out_adj * ctx.scratch[i];
 }
 
+// Everything that misses the native gate replays through mn_eval, which
+// stashes one partial per input element instead of the pullback's n*n.
 int64_t mnc_scratch(const Op& op, const Slot* slots) {
-  if (!mnc_native_variant(op.variant, op.idata, op.n_idata) || op.n_in != 3 ||
-      op.out < 0 || slots == nullptr)
+  if (op.n_in != 3 || op.out < 0 || slots == nullptr || op.in[0] < 0 ||
+      op.in[1] < 0 || op.in[2] < 0)
     return 0;
+  if (!mnc_native_variant(op.variant, op.idata, op.n_idata))
+    return tail_density_scratch<3>(op, slots);
   const int64_t n = op.idata[0];
-  if (op.in[0] < 0 || op.in[1] < 0 || op.in[2] < 0 ||
-      slots[op.in[0]].len != n || slots[op.in[1]].len != n ||
+  if (slots[op.in[0]].len != n || slots[op.in[1]].len != n ||
       slots[op.in[2]].len != n * n || slots[op.out].len != 1)
-    return 0;
+    return tail_density_scratch<3>(op, slots);
   return n * n;
 }
 
@@ -931,7 +998,7 @@ double lkjcov_eval(KernelCtx& ctx) {
 // coefficient matrix, a second int group), so they take the var tape.
 // idata = [outcome..., rows, cols] and, for binomial, the trial counts.
 enum GlmKind { kBinomLogitGlm, kCatLogitGlm, kOrdLogisticGlm };
-template <bool Grad, GlmKind Kind>
+template <GlmKind Kind>
 double tglm_eval(KernelCtx& ctx) {
   const int64_t rows = ctx.idata[ctx.n_idata - 2];
   const int64_t cols = ctx.idata[ctx.n_idata - 1];
@@ -950,7 +1017,7 @@ double tglm_eval(KernelCtx& ctx) {
                                                              beta)
                  : stan::math::binomial_logit_glm_lpmf<false>(nn, NN, X, alpha,
                                                               beta);
-    return finish_tail_density<Grad>(ctx, out, X, alpha, beta);
+    return tail_density_fwd(ctx, out, X, alpha, beta);
   } else {
     std::vector<int> y(ctx.idata, ctx.idata + rows);
     if constexpr (Kind == kCatLogitGlm) {
@@ -960,7 +1027,7 @@ double tglm_eval(KernelCtx& ctx) {
                                                                   beta)
                    : stan::math::categorical_logit_glm_lpmf<false>(y, X, alpha,
                                                                    beta);
-      return finish_tail_density<Grad>(ctx, out, X, alpha, beta);
+      return tail_density_fwd(ctx, out, X, alpha, beta);
     } else {
       // in = {X, beta, cutpoints}; alpha above is beta for this one.
       VarV beta = tail_v(ctx, 1, cols);
@@ -969,7 +1036,7 @@ double tglm_eval(KernelCtx& ctx) {
           propto
               ? stan::math::ordered_logistic_glm_lpmf<true>(y, X, beta, cuts)
               : stan::math::ordered_logistic_glm_lpmf<false>(y, X, beta, cuts);
-      return finish_tail_density<Grad>(ctx, out, X, beta, cuts);
+      return tail_density_fwd(ctx, out, X, beta, cuts);
     }
   }
 }
@@ -977,17 +1044,14 @@ double tglm_eval(KernelCtx& ctx) {
 void lkjcov_fwd(KernelCtx& ctx) { ctx.out.data[0] = lkjcov_eval<false>(ctx); }
 void lkjcov_bwd(KernelCtx& ctx) { lkjcov_eval<true>(ctx); }
 void blglm_fwd(KernelCtx& ctx) {
-  ctx.out.data[0] = tglm_eval<false, kBinomLogitGlm>(ctx);
+  ctx.out.data[0] = tglm_eval<kBinomLogitGlm>(ctx);
 }
-void blglm_bwd(KernelCtx& ctx) { tglm_eval<true, kBinomLogitGlm>(ctx); }
 void clglm_fwd(KernelCtx& ctx) {
-  ctx.out.data[0] = tglm_eval<false, kCatLogitGlm>(ctx);
+  ctx.out.data[0] = tglm_eval<kCatLogitGlm>(ctx);
 }
-void clglm_bwd(KernelCtx& ctx) { tglm_eval<true, kCatLogitGlm>(ctx); }
 void olglm_fwd(KernelCtx& ctx) {
-  ctx.out.data[0] = tglm_eval<false, kOrdLogisticGlm>(ctx);
+  ctx.out.data[0] = tglm_eval<kOrdLogisticGlm>(ctx);
 }
-void olglm_bwd(KernelCtx& ctx) { tglm_eval<true, kOrdLogisticGlm>(ctx); }
 
 // ---- the cdfs the recorder cannot take ---------------------------------
 // Same reason ordered_probit and wiener are here, one step further out:
@@ -1090,17 +1154,21 @@ void register_matrix_kernels() {
   STANLI_TAIL_INT_CDF_LIST(STANLI_REGISTER_TAIL_CDF)
 #undef STANLI_REGISTER_TAIL_CDF
   register_kernel(OP_LKJ_COV_LPDF, Kernel{lkjcov_fwd, lkjcov_bwd, nullptr});
-  register_kernel(OP_BINOMIAL_LOGIT_GLM_LPMF,
-                  Kernel{blglm_fwd, blglm_bwd, nullptr});
-  register_kernel(OP_CATEGORICAL_LOGIT_GLM_LPMF,
-                  Kernel{clglm_fwd, clglm_bwd, nullptr});
-  register_kernel(OP_ORDERED_LOGISTIC_GLM_LPMF,
-                  Kernel{olglm_fwd, olglm_bwd, nullptr});
+  register_kernel(
+      OP_BINOMIAL_LOGIT_GLM_LPMF,
+      Kernel{blglm_fwd, tail_density_bwd<3>, tail_density_scratch<3>});
+  register_kernel(
+      OP_CATEGORICAL_LOGIT_GLM_LPMF,
+      Kernel{clglm_fwd, tail_density_bwd<3>, tail_density_scratch<3>});
+  register_kernel(
+      OP_ORDERED_LOGISTIC_GLM_LPMF,
+      Kernel{olglm_fwd, tail_density_bwd<3>, tail_density_scratch<3>});
   register_kernel(OP_DIAG_MATRIX, Kernel{diag_fwd, diag_bwd, nullptr});
   register_kernel(OP_CHOLESKY, Kernel{chol_fwd, chol_bwd, nullptr});
   register_kernel(OP_MULTI_NORMAL_CHOL_LPDF,
                   Kernel{mnc_fwd, mnc_bwd, mnc_scratch});
-  register_kernel(OP_MULTI_NORMAL_LPDF, Kernel{mn_fwd, mn_bwd, nullptr});
+  register_kernel(OP_MULTI_NORMAL_LPDF,
+                  Kernel{mn_fwd, mn_bwd, tail_density_scratch<3>});
   register_kernel(OP_MULTI_NORMAL_PREC_LPDF,
                   Kernel{mnprec_fwd, mnprec_bwd, nullptr});
   register_kernel(OP_GEMM, Kernel{gemm_fwd, gemm_bwd, nullptr});

--- a/runtime/kernels/mixture.cpp
+++ b/runtime/kernels/mixture.cpp
@@ -41,8 +41,8 @@ void lse_fwd(KernelCtx& ctx) {
 void lse_bwd(KernelCtx& ctx) {
   if (!ctx.in_adj[0].data) return;
   const int64_t n = ctx.in[0].len;
-  for (int64_t i = 0; i < n; ++i)
-    ctx.in_adj[0].data[i] += ctx.out_adj * ctx.scratch[i];
+  Eigen::Map<Eigen::ArrayXd>(ctx.in_adj[0].data, n) +=
+      ctx.out_adj * Eigen::Map<const Eigen::ArrayXd>(ctx.scratch, n);
 }
 
 // ---- log_sum_exp over packed rows -----------------------------------------
@@ -69,8 +69,8 @@ void lse_rows_bwd(KernelCtx& ctx) {
   for (int64_t r = 0; r < ctx.out.len; ++r) {
     const int64_t off = r * K;
     const double scale = ctx.out_adj_vec.data[r];
-    for (int64_t k = 0; k < K; ++k)
-      ctx.in_adj[0].data[off + k] += scale * ctx.scratch[off + k];
+    Eigen::Map<Eigen::ArrayXd>(ctx.in_adj[0].data + off, K) +=
+        scale * Eigen::Map<const Eigen::ArrayXd>(ctx.scratch + off, K);
   }
 }
 

--- a/runtime/src/OPTIMIZATIONS.md
+++ b/runtime/src/OPTIMIZATIONS.md
@@ -738,6 +738,53 @@ comparison). After these changes per-op cost is dominated by loading
 the context, not the dispatch, so the remaining lever is fewer ops,
 which is what the passes above are.
 
+## Deferred: reduction reassociation (surveyed 2026-08-25)
+
+The candidates below change summation order rather than any elementwise
+result. Each was measured or profiled during the 2026-08-25 precision survey
+and deferred as a policy choice: the corpus reference gate passes either way,
+but models listed as bitwise against CmdStan in
+[`docs/corpus-status.md`](../../docs/corpus-status.md) would move into the
+small-ULP bands. Re-profile before implementing any of them, since profile
+share is a ceiling on the win and the `pow` entry below shows how a large
+share can still yield nothing.
+
+Softmax backward as a packet dot product (`adjoint.cpp`). The fold is written
+by hand because Stan Math reduces var expressions, which have no packet
+access. `Map(p).dot(Map(oa))` measured 5.86x on the reduction alone.
+`OP_SOFTMAX` is 37% of `gpcm_latent_reg_irt`'s gradient and most of that is
+backward. Drift is reorder-class, about 1e-15 relative on realistic lengths.
+
+Matvec through Eigen gemv (`elementwise.cpp`, `lower.cpp`). The scalar loop
+preserves Stan Math's multiply order at a cost the file comment puts at 82% of
+`prophet`'s gradient. Every matrix model pays something. Drift is 1-2 ULP per
+element against the current form.
+
+Gather backward via segmented reduction (`elementwise.cpp`). The ascending
+scatter-add matches var edge order; a rowwise sum over a presorted index
+(indices are lowering-time constants) was 37% of
+`radon_county_intercept`'s backward.
+
+Per-lane scalar density binding (`densities_impl.hpp`). N scalar recorder
+calls with a `sink_scope` each, where one vectorized call would do. Density
+share is 40-86% of most profiles but the math is libm-bound either way; the
+recoverable part is recorder overhead plus reduction reorder and was not
+measured separately.
+
+Broadcast adjoint accumulation (`eltwise_expr.cpp`, `mixture.cpp` `mix_bwd`,
+`densities_impl.hpp` column sums). Descending or in-memory accumulation orders
+that mirror the unrolled reverse sweep. Packet sums are 4-6x on the reduction;
+the whole-model effect is small per site but the pattern is wide.
+
+Three measured dead ends, recorded so they are not retried. `-ffp-contract=fast`
+is a 1.7% geomean slowdown on this corpus (`arK` 0.85, reproducible) and
+perturbs 101 of 120 models at reduction-class magnitudes, so the `off` in
+`CMakeLists.txt` stays. The `STANLI_PACKET_MATH` fast forms (constrain,
+`inv_logit`, `seq_sum`) measure 0.995 geomean: neutral, correctly left off.
+And Eigen's vectorized `pow` is 5x slower than scalar `std::pow` on Apple
+libm, with the `exp(k log x)` form costing 8 ULP, so the `POW` share of the
+`dogs` models stays where it is.
+
 ## How we check all of this
 
 Every pass changes the graph, and a wrong graph produces wrong numbers

--- a/runtime/src/adjoint.cpp
+++ b/runtime/src/adjoint.cpp
@@ -337,6 +337,13 @@ bool gen_adjoint(IslandProg& p) {
   return true;
 }
 
+// Ranged arms below map their operand and output ranges. The validator in
+// gen_adjoint admits only disjoint ranges or exactly coincident ones, and the
+// coincident case keeps the scalar loop: reading before clearing is what an
+// in-place `x = exp(x)` needs.
+using AdjA = Eigen::Map<Eigen::ArrayXd>;
+using CAdjA = Eigen::Map<const Eigen::ArrayXd>;
+
 void run_adjoint(const Program& fwd, const AdjProgram& ap, const double* val,
                  double* adj) {
   for (const AdjInstr& I : ap.code) {
@@ -382,18 +389,23 @@ void run_adjoint(const Program& fwd, const AdjProgram& ap, const double* val,
         adj[I.dst] = 0.0;
         break;
       case Program::CONSTR:
-        for (int32_t k = 0; k < I.len; ++k) adj[I.dst + k] = 0.0;
+        AdjA(adj + I.dst, I.len).setZero();
         break;
       case Program::MOV:
         adj[I.dst] = 0.0;
         adj[I.a] += t;
         break;
       case Program::MOVR:
-        for (int32_t k = 0; k < I.len; ++k) {
-          const double u = adj[I.dst + k];
-          adj[I.dst + k] = 0.0;
-          adj[I.a + k] += u;
+        if (I.a == I.dst) {
+          for (int32_t k = 0; k < I.len; ++k) {
+            const double u = adj[I.dst + k];
+            adj[I.dst + k] = 0.0;
+            adj[I.a + k] += u;
+          }
+          break;
         }
+        AdjA(adj + I.a, I.len) += AdjA(adj + I.dst, I.len);
+        AdjA(adj + I.dst, I.len).setZero();
         break;
       case Program::ADD:
         adj[I.dst] = 0.0;
@@ -516,18 +528,30 @@ void run_adjoint(const Program& fwd, const AdjProgram& ap, const double* val,
         adj[I.dst] = 0.0;
         break;
       case Program::LOG_RANGE:
-        for (int32_t k = 0; k < I.len; ++k) {
-          const double u = adj[I.dst + k];
-          adj[I.dst + k] = 0.0;
-          adj[I.a + k] += u / val[I.va + k];
+        if (I.a == I.dst) {
+          for (int32_t k = 0; k < I.len; ++k) {
+            const double u = adj[I.dst + k];
+            adj[I.dst + k] = 0.0;
+            adj[I.a + k] += u / val[I.va + k];
+          }
+          break;
         }
+        AdjA(adj + I.a, I.len) +=
+            AdjA(adj + I.dst, I.len) / CAdjA(val + I.va, I.len);
+        AdjA(adj + I.dst, I.len).setZero();
         break;
       case Program::EXP_RANGE:
-        for (int32_t k = 0; k < I.len; ++k) {
-          const double u = adj[I.dst + k];
-          adj[I.dst + k] = 0.0;
-          adj[I.a + k] += u * val[I.vd + k];
+        if (I.a == I.dst) {
+          for (int32_t k = 0; k < I.len; ++k) {
+            const double u = adj[I.dst + k];
+            adj[I.dst + k] = 0.0;
+            adj[I.a + k] += u * val[I.vd + k];
+          }
+          break;
         }
+        AdjA(adj + I.a, I.len) +=
+            AdjA(adj + I.dst, I.len) * CAdjA(val + I.vd, I.len);
+        AdjA(adj + I.dst, I.len).setZero();
         break;
       case Program::DOT:
         adj[I.dst] = 0.0;

--- a/tests/test_eltwise.cpp
+++ b/tests/test_eltwise.cpp
@@ -3,6 +3,7 @@
 #include "graph_helpers.hpp"
 
 #include <stan/math.hpp>
+#include <cmath>
 #include <cstdio>
 #include <string>
 #include <vector>
@@ -28,10 +29,22 @@ static VecV mkv(const std::vector<double>& v) {
   return x;
 }
 
+// OP_LOGV takes Eigen's packet log, a ulp off libm on some arguments. The
+// gradients are 1/x and stay bitwise; only lp carries the difference, and a
+// sum that cancels reports it as several ulps of the result.
+static void expect_near_ulp(const std::string& what, double got, double want,
+                            int budget) {
+  if (got == want) return;
+  const double u = std::nextafter(std::abs(want), 1e308) - std::abs(want);
+  if (std::abs(got - want) <= budget * u) return;
+  ++failures;
+  std::printf("FAIL %-24s got %.17g want %.17g\n", what.c_str(), got, want);
+}
+
 template <typename F>
 static void check_case(const std::string& tag, uint16_t opcode, int64_t out_len,
-                       const std::vector<std::vector<double>>& vals,
-                       F&& ref_fn) {
+                       const std::vector<std::vector<double>>& vals, F&& ref_fn,
+                       int lp_ulp = 0) {
   auto r = stanli::testutil::run_op_sum(opcode, out_len, vals,
                                         std::vector<bool>(vals.size(), true));
   // Reference: promote all inputs to var, apply ref_fn, sum, grad.
@@ -39,7 +52,7 @@ static void check_case(const std::string& tag, uint16_t opcode, int64_t out_len,
   for (const auto& v : vals) vs.push_back(mkv(v));
   var lp = ref_fn(vs);
   lp.grad();
-  expect_eq(tag + " lp", r.value, lp.val());
+  expect_near_ulp(tag + " lp", r.value, lp.val(), lp_ulp);
   size_t gi = 0;
   for (auto& v : vs)
     for (int i = 0; i < v.size(); ++i)
@@ -145,8 +158,9 @@ int main() {
              [](auto& v) { return stan::math::sum(stan::math::exp(v[0])); });
   check_case("exp s", OP_EXPV, 1, {{S}},
              [](auto& v) { return stan::math::exp(v[0](0)); });
-  check_case("log v", OP_LOGV, N, {{1.5, 0.7, 0.4, 2.2}},
-             [](auto& v) { return stan::math::sum(stan::math::log(v[0])); });
+  check_case(
+      "log v", OP_LOGV, N, {{1.5, 0.7, 0.4, 2.2}},
+      [](auto& v) { return stan::math::sum(stan::math::log(v[0])); }, 16);
   check_case("inv_logit v", OP_INV_LOGIT, N, {A}, [](auto& v) {
     return stan::math::sum(stan::math::inv_logit(v[0]));
   });

--- a/tests/test_glm.cpp
+++ b/tests/test_glm.cpp
@@ -79,6 +79,125 @@ static void check_empty_glm(uint16_t opcode, const std::string& name) {
   stan::math::recover_memory();
 }
 
+// The three GLMs that take the var tape rather than the recorder, each with
+// a non-unit output adjoint: their kernels seed the tape with 1.0 in the
+// forward and scale in the backward.
+static void check_tail_glm(const std::string& tag, uint16_t opcode, bool propto,
+                           const std::vector<int>& idata, int rows, int cols,
+                           int alpha_len, int beta_len) {
+  using namespace stanli;
+  using stan::math::var;
+  const double seed = -0.73;
+  std::vector<double> X((size_t)rows * cols), a((size_t)alpha_len),
+      b((size_t)beta_len);
+  for (int j = 0; j < cols; ++j)
+    for (int i = 0; i < rows; ++i)
+      X[(size_t)j * rows + i] = std::sin(0.31 * i + 0.7 * j);
+  for (int i = 0; i < alpha_len; ++i) a[(size_t)i] = 0.15 - 0.08 * i;
+  for (int i = 0; i < beta_len; ++i) b[(size_t)i] = 0.2 + 0.11 * i;
+
+  Graph g;
+  const int Xs = g.add_slot(rows * cols, true);
+  const int as = g.add_slot(alpha_len, true);
+  const int bs = g.add_slot(beta_len, true);
+  const int lp = g.add_slot(1, false);
+  const int ss = g.add_slot(1, false);
+  const int total = g.add_slot(1, false);
+  const int op = g.add_op(opcode, {Xs, as, bs}, lp, idata);
+  g.ops[(size_t)op].variant = propto ? 0x80u : 0x00u;
+  g.add_op(OP_MUL, {lp, ss}, total);
+  g.result_slot = total;
+
+  Executor ex(std::move(g));
+  std::copy(X.begin(), X.end(), ex.param_ptr(Xs));
+  std::copy(a.begin(), a.end(), ex.param_ptr(as));
+  std::copy(b.begin(), b.end(), ex.param_ptr(bs));
+  ex.value_ptr(ss)[0] = seed;
+  std::vector<double> grad(X.size() + a.size() + b.size(), 0.0);
+  const double got = ex.gradient(grad.data());
+
+  stan::math::nested_rev_autodiff nested;
+  Eigen::Matrix<var, -1, -1> Xv(rows, cols);
+  for (size_t i = 0; i < X.size(); ++i) Xv.data()[i] = X[i];
+  Eigen::Matrix<var, -1, 1> av(alpha_len), bv(beta_len);
+  for (int i = 0; i < alpha_len; ++i) av(i) = a[(size_t)i];
+  for (int i = 0; i < beta_len; ++i) bv(i) = b[(size_t)i];
+  var ref;
+  if (opcode == OP_BINOMIAL_LOGIT_GLM_LPMF) {
+    std::vector<int> nn(idata.begin(), idata.begin() + rows);
+    std::vector<int> NN(idata.begin() + rows, idata.begin() + 2 * rows);
+    ref =
+        propto
+            ? stan::math::binomial_logit_glm_lpmf<true>(nn, NN, Xv, av(0), bv)
+            : stan::math::binomial_logit_glm_lpmf<false>(nn, NN, Xv, av(0), bv);
+  } else if (opcode == OP_CATEGORICAL_LOGIT_GLM_LPMF) {
+    std::vector<int> yy(idata.begin(), idata.begin() + rows);
+    Eigen::Matrix<var, -1, -1> bm(cols, beta_len / cols);
+    for (int i = 0; i < beta_len; ++i) bm.data()[i] = bv(i);
+    ref = propto
+              ? stan::math::categorical_logit_glm_lpmf<true>(yy, Xv, av, bm)
+              : stan::math::categorical_logit_glm_lpmf<false>(yy, Xv, av, bm);
+    var scaled_cat = ref * seed;
+    stan::math::grad(scaled_cat.vi_);
+    expect_eq(tag + " total", got, scaled_cat.val());
+    size_t at = 0;
+    for (size_t i = 0; i < X.size(); ++i)
+      expect_eq(tag + " dX" + std::to_string(i), grad[at++],
+                Xv.data()[i].adj());
+    for (int i = 0; i < alpha_len; ++i)
+      expect_eq(tag + " da" + std::to_string(i), grad[at++], av(i).adj());
+    for (int i = 0; i < beta_len; ++i)
+      expect_eq(tag + " db" + std::to_string(i), grad[at++],
+                bm.data()[i].adj());
+    return;
+  } else {
+    std::vector<int> yy(idata.begin(), idata.begin() + rows);
+    ref = propto ? stan::math::ordered_logistic_glm_lpmf<true>(yy, Xv, av, bv)
+                 : stan::math::ordered_logistic_glm_lpmf<false>(yy, Xv, av, bv);
+  }
+  var scaled = ref * seed;
+  stan::math::grad(scaled.vi_);
+  expect_eq(tag + " total", got, scaled.val());
+  size_t at = 0;
+  for (size_t i = 0; i < X.size(); ++i)
+    expect_eq(tag + " dX" + std::to_string(i), grad[at++], Xv.data()[i].adj());
+  for (int i = 0; i < alpha_len; ++i)
+    expect_eq(tag + " da" + std::to_string(i), grad[at++], av(i).adj());
+  for (int i = 0; i < beta_len; ++i)
+    expect_eq(tag + " db" + std::to_string(i), grad[at++], bv(i).adj());
+}
+
+static void check_tail_glms() {
+  using namespace stanli;
+  const int rows = 5, cols = 3;
+  std::vector<int> bin;
+  for (int i = 0; i < rows; ++i) bin.push_back(1 + (i % 4));
+  for (int i = 0; i < rows; ++i) bin.push_back(5 + i);
+  bin.push_back(rows);
+  bin.push_back(cols);
+  check_tail_glm("binom glm", OP_BINOMIAL_LOGIT_GLM_LPMF, false, bin, rows,
+                 cols, 1, cols);
+  check_tail_glm("binom glm propto", OP_BINOMIAL_LOGIT_GLM_LPMF, true, bin,
+                 rows, cols, 1, cols);
+
+  const int cats = 3;
+  std::vector<int> cat;
+  for (int i = 0; i < rows; ++i) cat.push_back(1 + (i % cats));
+  cat.push_back(rows);
+  cat.push_back(cols);
+  check_tail_glm("cat glm", OP_CATEGORICAL_LOGIT_GLM_LPMF, false, cat, rows,
+                 cols, cats, cols * cats);
+  check_tail_glm("cat glm propto", OP_CATEGORICAL_LOGIT_GLM_LPMF, true, cat,
+                 rows, cols, cats, cols * cats);
+
+  // in = {X, beta, cutpoints}: the cutpoints ride the `alpha` slot here and
+  // must stay ordered.
+  check_tail_glm("ord glm", OP_ORDERED_LOGISTIC_GLM_LPMF, false, cat, rows,
+                 cols, cols, cats - 1);
+  check_tail_glm("ord glm propto", OP_ORDERED_LOGISTIC_GLM_LPMF, true, cat,
+                 rows, cols, cols, cats - 1);
+}
+
 static void reference(const double* q, double* lp_out, double* grad_out) {
   using stan::math::var;
   using stanli::testmodels::LogisticGlm;
@@ -133,6 +252,8 @@ int main() {
     for (int i = 0; i < NP; ++i)
       expect_eq(tag + " g" + std::to_string(i), grad[i], grad_ref[i]);
   }
+
+  check_tail_glms();
 
   check_empty_glm(OP_BERNOULLI_LOGIT_GLM_LPMF, "bernoulli_logit_glm");
   check_empty_glm(OP_POISSON_LOG_GLM_LPMF, "poisson_log_glm");

--- a/tests/test_legacy.cpp
+++ b/tests/test_legacy.cpp
@@ -9,6 +9,7 @@
 #include <cstdio>
 #include <limits>
 #include <string>
+#include <vector>
 
 static int failures = 0;
 static void expect_eq(const std::string& what, double got, double want) {
@@ -27,6 +28,80 @@ static void expect_ulp(const std::string& what, double got, double want) {
     ++failures;
     std::printf("FAIL %-16s got %.17g want %.17g\n", what.c_str(), got, want);
   }
+}
+
+// dirichlet through the graph, with a non-unit output adjoint: the kernel
+// grads its nested tape once in the forward with a seed of 1 and scales in
+// the backward, so a unit seed would not exercise the scaling at all.
+static void check_dirichlet(const std::string& tag, int reps, bool propto,
+                            bool alpha_var) {
+  using namespace stanli;
+  using stan::math::var;
+  const int K = 4;
+  const double seed = -0.73;
+  const double simplex[4] = {0.1, 0.2, 0.3, 0.4};
+  std::vector<double> th((size_t)K * reps), al(K);
+  for (int r = 0; r < reps; ++r)
+    for (int i = 0; i < K; ++i) th[(size_t)r * K + i] = simplex[(i + r) % K];
+  for (int i = 0; i < K; ++i) al[(size_t)i] = 1.3 + 0.6 * i;
+
+  Graph g;
+  const int t_slot = g.add_slot((int64_t)K * reps, true);
+  const int a_slot = g.add_slot(K, alpha_var);
+  const int s_slot = g.add_slot(1, false);
+  const int lp = g.add_slot(1, false);
+  const int total = g.add_slot(1, false);
+  g.add_op(OP_DIRICHLET_LPDF, {t_slot, a_slot}, lp);
+  g.ops.back().variant =
+      (propto ? 0x80u : 0x00u) | 0x1u | (alpha_var ? 0x2u : 0x0u);
+  g.add_op(OP_MUL, {lp, s_slot}, total);
+  g.result_slot = total;
+
+  Executor ex(std::move(g));
+  for (int i = 0; i < K * reps; ++i) ex.param_ptr(t_slot)[i] = th[(size_t)i];
+  double* ap = alpha_var ? ex.param_ptr(a_slot) : ex.value_ptr(a_slot);
+  for (int i = 0; i < K; ++i) ap[i] = al[(size_t)i];
+  ex.value_ptr(s_slot)[0] = seed;
+  std::vector<double> grad((size_t)K * reps + (alpha_var ? K : 0), 0.0);
+  const double val = ex.gradient(grad.data());
+
+  stan::math::nested_rev_autodiff nested;
+  std::vector<Eigen::Matrix<var, -1, 1>> tv((size_t)reps,
+                                            Eigen::Matrix<var, -1, 1>(K));
+  for (int r = 0; r < reps; ++r)
+    for (int i = 0; i < K; ++i) {
+      tv[(size_t)r](i) = th[(size_t)r * K + i];
+    }
+  Eigen::Matrix<var, -1, 1> av(K);
+  for (int i = 0; i < K; ++i) av(i) = al[(size_t)i];
+  Eigen::Map<const Eigen::VectorXd> ad(al.data(), K);
+  var ref;
+  if (reps > 1) {
+    if (alpha_var)
+      ref = propto ? stan::math::dirichlet_lpdf<true>(tv, av)
+                   : stan::math::dirichlet_lpdf<false>(tv, av);
+    else
+      ref = propto ? stan::math::dirichlet_lpdf<true>(tv, ad)
+                   : stan::math::dirichlet_lpdf<false>(tv, ad);
+  } else {
+    if (alpha_var)
+      ref = propto ? stan::math::dirichlet_lpdf<true>(tv[0], av)
+                   : stan::math::dirichlet_lpdf<false>(tv[0], av);
+    else
+      ref = propto ? stan::math::dirichlet_lpdf<true>(tv[0], ad)
+                   : stan::math::dirichlet_lpdf<false>(tv[0], ad);
+  }
+  var scaled = ref * seed;
+  stan::math::grad(scaled.vi_);
+  expect_eq(tag + " value", val, scaled.val());
+  for (int r = 0; r < reps; ++r)
+    for (int i = 0; i < K; ++i)
+      expect_eq(tag + " dtheta" + std::to_string(r * K + i),
+                grad[(size_t)r * K + i], tv[(size_t)r](i).adj());
+  if (alpha_var)
+    for (int i = 0; i < K; ++i)
+      expect_eq(tag + " dalpha" + std::to_string(i), grad[(size_t)K * reps + i],
+                av(i).adj());
 }
 
 int main() {
@@ -89,6 +164,12 @@ int main() {
       expect_eq("softmax d" + std::to_string(i), grad[i], xv(i).adj());
     stan::math::recover_memory();
   }
+
+  check_dirichlet("single propto", 1, true, true);
+  check_dirichlet("single full", 1, false, true);
+  check_dirichlet("single alpha data", 1, false, false);
+  check_dirichlet("vectorized propto", 3, true, true);
+  check_dirichlet("vectorized alpha data", 3, false, false);
 
   if (failures == 0) std::printf("test_legacy OK\n");
   return failures == 0 ? 0 : 1;

--- a/tests/test_mnc.cpp
+++ b/tests/test_mnc.cpp
@@ -174,8 +174,10 @@ Result run_direct(const Inputs& x, uint8_t variant, double seed,
   if (!kernel) throw std::runtime_error("MNC kernel missing");
   int dims[2] = {x.n, x.m};
   double density = std::numeric_limits<double>::quiet_NaN();
+  // The generic fallback stashes one partial per input element, which is
+  // more than the native pullback's n*n.
   std::vector<double> scratch(
-      std::max<size_t>(1, static_cast<size_t>(x.n) * x.n),
+      std::max<size_t>(1, x.y.size() + x.mu.size() + x.L.size()),
       std::numeric_limits<double>::quiet_NaN());
   Result r;
   r.dy = dy0;
@@ -331,6 +333,90 @@ std::string reference_error(const Inputs& x) {
   return thrown([&] { (void)reference_l_only<true>(x, 0.7); });
 }
 
+// OP_MULTI_NORMAL_LPDF is the only shape that reaches mn_eval's covariance
+// overload. Non-unit output adjoint: the kernel seeds its nested tape with
+// 1.0 and scales in the backward.
+void check_multi_normal(const std::string& tag, int n, int m, uint8_t variant,
+                        double seed) {
+  using namespace stanli;
+  const Inputs x = inputs(n, m, 0.21);
+  Eigen::Map<const MatD> Lm(x.L.data(), n, n);
+  const MatD Sm = Lm * Lm.transpose();
+  const unsigned mask = variant == 0 ? 0x7u : (variant & 0x3fu);
+  const bool ay = mask & 1u, am = mask & 2u, aS = mask & 4u;
+  const bool propto = (variant & 0x80u) != 0;
+
+  Graph g;
+  const int y = g.add_slot(n * m, ay);
+  const int mu = g.add_slot(n, am);
+  const int S = g.add_slot(n * n, aS);
+  const int density = g.add_slot(1, false);
+  const int seed_slot = g.add_slot(1, false);
+  const int total = g.add_slot(1, false);
+  const int op = g.add_op(OP_MULTI_NORMAL_LPDF, {y, mu, S}, density, {n, m});
+  g.ops[(size_t)op].variant = variant;
+  g.add_op(OP_MUL, {density, seed_slot}, total);
+  g.result_slot = total;
+
+  Executor ex(std::move(g));
+  auto fill = [&](int slot, bool param, const double* src, int len) {
+    double* p = param ? ex.param_ptr(slot) : ex.value_ptr(slot);
+    std::copy(src, src + len, p);
+  };
+  fill(y, ay, x.y.data(), n * m);
+  fill(mu, am, x.mu.data(), n);
+  fill(S, aS, Sm.data(), n * n);
+  ex.value_ptr(seed_slot)[0] = seed;
+  std::vector<double> grad(
+      (size_t)(ay ? n * m : 0) + (am ? n : 0) + (aS ? n * n : 0), 0.0);
+  const double got = ex.gradient(grad.data());
+
+  stan::math::nested_rev_autodiff nested;
+  std::vector<VarV> yv((size_t)m, VarV(n));
+  std::vector<VecD> yd((size_t)m, VecD(n));
+  for (int k = 0; k < m; ++k)
+    for (int i = 0; i < n; ++i) {
+      yv[(size_t)k](i) = x.y[(size_t)k * n + i];
+      yd[(size_t)k](i) = x.y[(size_t)k * n + i];
+    }
+  VarV muv(n);
+  VarM Sv(n, n);
+  for (int i = 0; i < n; ++i) muv(i) = x.mu[(size_t)i];
+  for (int i = 0; i < n * n; ++i) Sv.data()[i] = Sm.data()[i];
+  Eigen::Map<const VecD> mud(x.mu.data(), n);
+  Eigen::Map<const MatD> Sd(Sm.data(), n, n);
+  auto call = [&](auto&& a, auto&& b, auto&& c) {
+    return propto ? stan::math::multi_normal_lpdf<true>(a, b, c)
+                  : stan::math::multi_normal_lpdf<false>(a, b, c);
+  };
+  auto dispatch = [&](auto&& yy) {
+    return aS ? (am ? call(yy, muv, Sv) : call(yy, mud, Sv))
+              : (am ? call(yy, muv, Sd) : call(yy, mud, Sd));
+  };
+  stan::math::var ref;
+  if (m > 1)
+    ref = ay ? dispatch(yv) : dispatch(yd);
+  else
+    ref = ay ? dispatch(yv[0]) : dispatch(yd[0]);
+  stan::math::var scaled = ref * seed;
+  stan::math::grad(scaled.vi_);
+
+  expect_bits(tag + " total", got, scaled.val());
+  size_t at = 0;
+  if (ay)
+    for (int k = 0; k < m; ++k)
+      for (int i = 0; i < n; ++i)
+        expect_bits(tag + " dy" + std::to_string(k * n + i), grad[at++],
+                    yv[(size_t)k](i).adj());
+  if (am)
+    for (int i = 0; i < n; ++i)
+      expect_bits(tag + " dmu" + std::to_string(i), grad[at++], muv(i).adj());
+  if (aS)
+    for (int i = 0; i < n * n; ++i)
+      expect_bits(tag + " dS" + std::to_string(i), grad[at++],
+                  Sv.data()[i].adj());
+}
+
 }  // namespace
 
 int main() {
@@ -372,25 +458,27 @@ int main() {
   compare_runner("reuse gradient a again", runner.gradient(eleven_a, seed),
                  ref_a, true);
 
-  // Exact scratch sizing is the fast-path sentinel. These near misses are
-  // real supported contracts and must continue through mn_eval: non-propto,
-  // another active argument, vectorized y, legacy activity, the hier_2pl
-  // all-active variant, a missing repetition immediate, or malformed slots.
+  // Exact scratch sizing is the fast-path sentinel: the native gate asks for
+  // the pullback's n*n, every near miss asks for the fallback's one partial
+  // per input element. These near misses are real supported contracts and
+  // must continue through mn_eval: non-propto, another active argument,
+  // vectorized y, legacy activity, the hier_2pl all-active variant, a missing
+  // repetition immediate, or malformed slots.
   check(scratch_for(0x84u, 11, 1, 11, 11, 121) == 121,
         "native gate gets n*n scratch");
-  check(scratch_for(0x04u, 11, 1, 11, 11, 121) == 0,
+  check(scratch_for(0x04u, 11, 1, 11, 11, 121) == 143,
         "non-propto refuses native path");
-  check(scratch_for(0x85u, 11, 1, 11, 11, 121) == 0,
+  check(scratch_for(0x85u, 11, 1, 11, 11, 121) == 143,
         "active y refuses native path");
-  check(scratch_for(0x84u, 11, 2, 22, 11, 121) == 0,
+  check(scratch_for(0x84u, 11, 2, 22, 11, 121) == 154,
         "vectorized y refuses native path");
-  check(scratch_for(0x00u, 11, 1, 11, 11, 121) == 0,
+  check(scratch_for(0x00u, 11, 1, 11, 11, 121) == 143,
         "legacy variant refuses native path");
-  check(scratch_for(0x07u, 11, 1, 11, 11, 121) == 0,
+  check(scratch_for(0x07u, 11, 1, 11, 11, 121) == 143,
         "hier_2pl variant refuses native path");
-  check(scratch_for(0x84u, 11, 1, 11, 11, 121, 1) == 0,
+  check(scratch_for(0x84u, 11, 1, 11, 11, 121, 1) == 143,
         "missing repetition immediate refuses native path");
-  check(scratch_for(0x84u, 11, 1, 11, 10, 121) == 0,
+  check(scratch_for(0x84u, 11, 1, 11, 10, 121) == 142,
         "malformed mu refuses native path");
 
   // Functional fallback oracles accompany the sizing sentinels: one changed
@@ -421,6 +509,11 @@ int main() {
   const std::string reference_y = reference_error(bad_y);
   check(!native_y.empty(), "native rejects NaN y");
   check(native_y == reference_y, "NaN y error matches fallback");
+
+  check_multi_normal("mn all active", 3, 1, 0x07u, seed);
+  check_multi_normal("mn sigma only propto", 3, 1, 0x84u, seed);
+  check_multi_normal("mn legacy activity", 3, 1, 0x00u, seed);
+  check_multi_normal("mn vectorized", 3, 2, 0x87u, seed);
 
   if (failures == 0) std::printf("test_mnc OK\n");
   return failures == 0 ? 0 : 1;


### PR DESCRIPTION
Wave 3 of the perf work. Dirichlet, multi_normal (cov/chol), and the tail GLMs stop building the nested tape twice per gradient (probe-verified bitwise under seed-then-scale; the var-arithmetic densities that drift keep two tapes). Packet log forward (1 ULP; packet exp tried and reverted, it broke kronecker_gp's allowance). multi_occupancy 1.28x, hier_2pl/gpcm/ldaK2 3-4%. Also documents the deferred reduction-reassociation candidates and measured dead ends in OPTIMIZATIONS.md. ctest 60/60, corpus 129/129 with the worst line unmoved.