### PR TITLE
perf: partition pass, slices 0 and 1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -281,6 +281,7 @@ set(STANLI_RUNTIME_SOURCES
   runtime/src/inplace.cpp
   runtime/src/constfold.cpp
   runtime/src/cse.cpp
+  runtime/src/partition.cpp
   runtime/src/data.cpp
   runtime/src/data_var_context.cpp)
 
@@ -538,6 +539,7 @@ set(STANLI_TESTS
   test_reroll test_profile test_inplace test_pass_safety test_sampling
   test_ode_prog test_mir_program_conformance test_mir_checks
   test_structured_checks test_mir_unary_fallback test_constfold test_cse
+  test_partition
   test_solve test_cross_path
   test_write_array test_pool test_bridgestan test_mixture test_island
   test_adjoint test_diagnose test_multichain test_newtrans test_rejectprint

--- a/runtime/include/stanli/optable.hpp
+++ b/runtime/include/stanli/optable.hpp
@@ -80,6 +80,7 @@ namespace stanli {
   X(OP_EIGENVECTORS_SYM)            \
   X(OP_LOG_SUM_EXP)                 \
   X(OP_LOG_SUM_EXP_ROWS)            \
+  X(OP_SUM_ROWS)                    \
   X(OP_LSE2)                        \
   X(OP_LOG_DIFF_EXP)                \
   X(OP_LOG_MIX)                     \
@@ -715,6 +716,12 @@ constexpr uint8_t op_traits(uint16_t opcode) {
     case OP_POISSON_LPMF:
     case OP_POISSON_LOG_LPMF:
     case OP_NEG_BINOMIAL_2_LPMF:
+    // Two integer groups rather than one, so their lanes concatenate group by
+    // group. Only partition.cpp does that; legacy re-roll's one-immediate
+    // path refuses them.
+    case OP_BINOMIAL_LPMF:
+    case OP_BINOMIAL_LOGIT_LPMF:
+    case OP_BETA_BINOMIAL_LPMF:
 #define STANLI_INT_DENSITY_TRAIT(code, fn, nreal, tier) case code:
       STANLI_INT_DENSITY_LIST(STANLI_INT_DENSITY_TRAIT)
 #undef STANLI_INT_DENSITY_TRAIT
@@ -760,6 +767,7 @@ constexpr uint8_t op_traits(uint16_t opcode) {
     case OP_SET_SLICE_STRIDED_INPLACE:
     case OP_LOG_SUM_EXP:
     case OP_LOG_SUM_EXP_ROWS:
+    case OP_SUM_ROWS:
       return op_trait::kBackwardValueFree;
     default:
       return 0;
@@ -768,6 +776,27 @@ constexpr uint8_t op_traits(uint16_t opcode) {
 
 constexpr bool has_op_trait(uint16_t opcode, uint8_t trait) {
   return (op_traits(opcode) & trait) != 0;
+}
+
+// Ops no rewrite may run a different number of times than the graph says.
+// Most are effects -- a merged print prints once, a hoisted draw returns the
+// same number twice, a folded check throws at compile time -- and
+// OP_CATEGORICAL rides along because its per-op spec payload is not
+// comparable, so two of them are never known to be the same computation.
+constexpr bool is_effectful_op(uint16_t opcode) {
+  switch (opcode) {
+    case OP_CHECK_STRUCTURED:
+    case OP_CHECK_MATCHING_DIMS:
+    case OP_CHECK_LOWER:
+    case OP_CHECK_UPPER:
+    case OP_CATEGORICAL:
+    case OP_RNG:
+    case OP_PRINT:
+    case OP_REJECT:
+      return true;
+    default:
+      return false;
+  }
 }
 
 // "OP_NORMAL_LPDF" for a known opcode, "OP_?" otherwise. Diagnostics and

--- a/runtime/include/stanli/partition.hpp
+++ b/runtime/include/stanli/partition.hpp
@@ -1,0 +1,46 @@
+// Lane bucketing: rewrites repeated per-observation work into vector ops
+// without requiring the repeats to be adjacent or periodic. Re-roll asks
+// "does a template repeat with period P"; this asks "where does a lane end",
+// segments on that, and groups the lanes by structure.
+#ifndef STANLI_PARTITION_HPP
+#define STANLI_PARTITION_HPP
+
+#include <stanli/graph.hpp>
+
+#include <cstdint>
+#include <utility>
+#include <vector>
+
+namespace stanli {
+
+struct PartitionStats {
+  int groups = 0;    // buckets rewritten
+  int lanes = 0;     // lanes absorbed
+  int declined = 0;  // buckets refused, by the cost model or a legality rule
+  // Deterministic work, asserted as a ratio between two problem sizes by
+  // tests/test_partition.cpp: a wall-clock reading says different things on
+  // a laptop and a shared CI runner, and these do not.
+  int64_t segment_steps = 0;      // ops visited while finding lane bounds
+  int64_t fingerprint_steps = 0;  // lane ops hashed and classified
+  int64_t list_steps = 0;         // per-slot use/writer entries read, probes
+                                  //   included: the term that once made
+                                  //   re-roll quadratic on ldaK5
+};
+
+// In place, after re-roll and its in-place re-run, before the island carver.
+// `fills` gains entries for materialized constant vectors. `target_terms`
+// entries produced by a fused lane are replaced by the single reduction's
+// output, at the first dead entry's position.
+//
+// `extra_roots` must list every slot something outside the op graph reads
+// (jacobian terms, constrained-parameter views), as re-roll's and CSE's must:
+// they have no consuming op, so a lane writing one cannot be proven dead.
+// Passing an incomplete list is a miscompile, so this is not defaulted.
+// STANLI_NO_PARTITION=1 disables the pass.
+PartitionStats partition_lanes(
+    Graph& g, std::vector<std::pair<int, std::vector<double>>>& fills,
+    std::vector<int>& target_terms, const std::vector<int>& extra_roots);
+
+}  // namespace stanli
+
+#endif

--- a/runtime/kernels/mixture.cpp
+++ b/runtime/kernels/mixture.cpp
@@ -74,6 +74,34 @@ void lse_rows_bwd(KernelCtx& ctx) {
   }
 }
 
+// ---- plain sum over packed rows -------------------------------------------
+// The same packing, without the exponential: idata[0] = row width K, one
+// output per row. Each row accumulates ascending, so a row is bit-identical
+// to the OP_SUM_VEC a fused lane replaces.
+void sum_rows_fwd(KernelCtx& ctx) {
+  assert(ctx.n_idata == 1);
+  const int64_t K = ctx.idata[0];
+  assert(K > 0 && ctx.in[0].len == ctx.out.len * K);
+  for (int64_t r = 0; r < ctx.out.len; ++r) {
+    const double* row = ctx.in[0].data + r * K;
+    double acc = 0;
+    for (int64_t k = 0; k < K; ++k) acc += row[k];
+    ctx.out.data[r] = acc;
+  }
+}
+
+void sum_rows_bwd(KernelCtx& ctx) {
+  if (!ctx.in_adj[0].data) return;
+  assert(ctx.n_idata == 1);
+  const int64_t K = ctx.idata[0];
+  assert(K > 0 && ctx.in[0].len == ctx.out.len * K);
+  for (int64_t r = 0; r < ctx.out.len; ++r) {
+    double* row = ctx.in_adj[0].data + r * K;
+    const double scale = ctx.out_adj_vec.data[r];
+    for (int64_t k = 0; k < K; ++k) row[k] += scale;
+  }
+}
+
 // ---- log_sum_exp(a, b) / log_mix(theta, a, b) -----------------------------
 // Shape dispatch matches the elementwise binaries: each argument is len 1
 // (broadcast) or len N, out is len N, out[n] applies the scalar stan-math
@@ -171,6 +199,7 @@ void register_mixture_kernels() {
   register_kernel(OP_LOG_SUM_EXP, Kernel{lse_fwd, lse_bwd, lse_scratch});
   register_kernel(OP_LOG_SUM_EXP_ROWS,
                   Kernel{lse_rows_fwd, lse_rows_bwd, lse_scratch});
+  register_kernel(OP_SUM_ROWS, Kernel{sum_rows_fwd, sum_rows_bwd, nullptr});
   register_kernel(OP_LSE2, Kernel{lse2_fwd, mix_bwd<2>, mix_scratch<2>});
   register_kernel(OP_LOG_DIFF_EXP,
                   Kernel{log_diff_exp_fwd, mix_bwd<2>, mix_scratch<2>});

--- a/runtime/src/constfold.cpp
+++ b/runtime/src/constfold.cpp
@@ -53,11 +53,7 @@ std::vector<char> mark_constant_ops(const Graph& g) {
       // Effects are graph semantics, even when all their values are data.
       // Executing them in this compile-time pass would erase them from every
       // subsequent evaluation (and print/reject while compiling instead).
-      bool c = op.n_in > 0 && op.opcode != OP_CHECK_STRUCTURED &&
-               op.opcode != OP_CHECK_MATCHING_DIMS &&
-               op.opcode != OP_CHECK_LOWER && op.opcode != OP_CHECK_UPPER &&
-               op.opcode != OP_CATEGORICAL && op.opcode != OP_RNG &&
-               op.opcode != OP_PRINT && op.opcode != OP_REJECT;
+      bool c = op.n_in > 0 && !is_effectful_op(op.opcode);
       for (int k = 0; k < op.n_in; ++k)
         if (op.in[k] >= 0 && live[(size_t)op.in[k]]) c = false;
       if (c && op.out >= 0 && no_fold[(size_t)op.out]) c = false;

--- a/runtime/src/cse.cpp
+++ b/runtime/src/cse.cpp
@@ -34,16 +34,12 @@
 namespace stanli {
 namespace {
 
-// Effects are graph semantics: a merged print prints once, a merged check
-// throws once, a merged draw returns the same number twice. The set is the
-// union of constfold.cpp's and reroll's ops_match, plus the two opcodes
-// holding structure this pass cannot compare.
+// The shared effect blocklist, plus the opcodes holding structure this pass
+// cannot compare: a reduction whose variant selects its arithmetic grouping,
+// a compiled region, a solver.
 bool never_merge(uint16_t oc) {
-  return oc == OP_CHECK_STRUCTURED || oc == OP_CHECK_MATCHING_DIMS ||
-         oc == OP_CHECK_LOWER || oc == OP_CHECK_UPPER || oc == OP_CATEGORICAL ||
-         oc == OP_RNG || oc == OP_PRINT || oc == OP_REJECT ||
-         oc == OP_PROD_VEC || oc == OP_EXTREMA_VEC || oc == OP_ISLAND ||
-         oc == OP_ODE;
+  return is_effectful_op(oc) || oc == OP_PROD_VEC || oc == OP_EXTREMA_VEC ||
+         oc == OP_ISLAND || oc == OP_ODE;
 }
 
 struct Key {

--- a/runtime/src/lower.cpp
+++ b/runtime/src/lower.cpp
@@ -8,6 +8,7 @@
 #include <stanli/ode.hpp>
 #include <stanli/optable.hpp>
 #include <stanli/island.hpp>
+#include <stanli/partition.hpp>
 #include <stanli/reroll.hpp>
 #include <stanli/sexp.hpp>
 #include <stanli/structured_check.hpp>
@@ -48,6 +49,7 @@ struct PrepTrace {
     Removed,
     ConstFold,
     Reroll,
+    Partition,
     Regions,
     Truncated,
     MirBytes,
@@ -161,6 +163,12 @@ struct PrepTrace {
           field("row_steps", r.d);
           field("list_steps", r.b);
           field("candidate_steps", r.c);
+          break;
+        case Extra::Partition:
+          field("groups", r.a);
+          field("lanes", r.b);
+          field("declined", r.c);
+          field("list_steps", r.d);
           break;
         case Extra::Regions:
           field("regions", r.a);
@@ -4957,6 +4965,28 @@ struct Lowering {
     prep.graph(prep_graph, "post_reroll_inplace", post_reroll_inplace_time, g,
                out.fills, target_terms.size(), out.views.size(),
                PrepTrace::Extra::Rewrites, post_reroll_inplace);
+    // After re-roll, which keeps first crack at the contiguous shapes it
+    // already handles, and before CSE, which would merge ops shared between
+    // lanes and leave the lanes no longer whole.
+    const auto partition_time = prep.start();
+    const PartitionStats parted =
+        partition_lanes(g, out.fills, target_terms, roots);
+    prep.graph(prep_graph, "partition", partition_time, g, out.fills,
+               target_terms.size(), out.views.size(),
+               PrepTrace::Extra::Partition, parted.groups, parted.lanes, false,
+               0, parted.declined, parted.list_steps);
+    // Same proof the slice stores re-roll makes get: rebuilt from the terms
+    // partition just replaced.
+    std::vector<int> post_partition_roots = roots;
+    post_partition_roots.insert(post_partition_roots.end(),
+                                target_terms.begin(), target_terms.end());
+    const auto post_partition_inplace_time = prep.start();
+    const int post_partition_inplace =
+        parted.groups ? make_inplace_updates(g, post_partition_roots) : 0;
+    prep.graph(prep_graph, "post_partition_inplace",
+               post_partition_inplace_time, g, out.fills, target_terms.size(),
+               out.views.size(), PrepTrace::Extra::Rewrites,
+               post_partition_inplace);
     // After reroll, whose lane matching needs the repeated ops it hoists to
     // still be there, and before islands, so they compile the smaller
     // residue.

--- a/runtime/src/partition.cpp
+++ b/runtime/src/partition.cpp
@@ -1,0 +1,605 @@
+// Lane bucketing.
+//
+// Re-roll asks "does this template repeat with period P". That question
+// cannot see a loop whose lanes are interleaved with anything else, and its
+// period scan can arrive at a run mis-phased and never find the alignment
+// (state_space_stochastic_level_stochastic_seasonal: one perfect four-op
+// random walk that re-roll leaves entirely scalar because the window-sum loop
+// before it left the scan off by two). This pass asks a different question:
+// where does a lane END?
+//
+// A lane ends at a target term or at an element store, and reaches back as
+// far as the ops whose values never leave it. Lane bounds are therefore
+// computed, not discovered, and lanes need not be adjacent: they are grouped
+// by a structural fingerprint (opcodes, shapes, dataflow edges, immediate
+// SHAPES -- never which slot a lane reads, which is what lets two branches of
+// a data condition share a bucket), and a bucket is rewritten in place of its
+// first lane.
+//
+// What a bucket's ops read is proven, not assumed: every slot the fused ops
+// read from outside must be finished before the first lane starts. That one
+// rule carries three of the soundness obligations at once -- no cross-lane
+// recurrence, no mid-bucket writer, and no destructive in-place store between
+// the lanes -- because all three appear as a writer at or after the first
+// lane's position. Ops only ever move EARLIER, so an in-place store proven
+// safe against a later reader stays safe.
+#include <stanli/optable.hpp>
+#include <stanli/partition.hpp>
+
+#include <algorithm>
+#include <cstdlib>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+namespace stanli {
+namespace {
+
+constexpr int64_t kMinLanes = 4;
+// island.cpp's currencies: ~5 ns per graph op against ~1 ns per element
+// moved. A bucket must beat its gathers by more than a rounding error, or it
+// churns the graph for nothing.
+constexpr int64_t kOpCost = 5;
+constexpr int64_t kPartitionMargin = 8 * kOpCost;
+
+using Fills = std::vector<std::pair<int, std::vector<double>>>;
+
+bool is_element_store(const Op& op) {
+  return (op.opcode == OP_SET_INDEX || op.opcode == OP_SET_INDEX_INPLACE) &&
+         op.n_in == 2 && op.n_idata == 1 && op.out == op.in[0];
+}
+
+bool is_blocked(const Op& op) {
+  return is_effectful_op(op.opcode) || op.opcode == OP_PROD_VEC ||
+         op.opcode == OP_EXTREMA_VEC || op.out2 >= 0 || op.udata != nullptr;
+}
+
+// Opcodes whose immediates are positions rather than values: two lanes
+// reading different elements are the same computation over different data,
+// which is exactly what a bucket resolves per input. Everything else keys on
+// the values, as ops_match does.
+bool idata_is_shape(uint16_t opcode) {
+  return opcode == OP_INDEX || opcode == OP_SET_INDEX ||
+         opcode == OP_SET_INDEX_INPLACE || opcode == OP_SLICE ||
+         opcode == OP_SLICE_STRIDED ||
+         has_op_trait(opcode, op_trait::kRerollIdataDensity);
+}
+
+struct Lane {
+  size_t begin = 0;
+  size_t end = 0;  // exclusive; end - 1 is the delimiter
+};
+
+enum class InKind { kInvariant, kConstLanes, kLaneLocal };
+
+struct PosIn {
+  InKind kind = InKind::kInvariant;
+  int producer = -1;           // kLaneLocal: position within the lane
+  std::vector<double> values;  // kConstLanes: one value per lane
+};
+
+enum class Emit {
+  kElide,        // reads the whole base in lane order: the base IS the value
+  kSlice,        // one contiguous window
+  kGather,       // arbitrary per-lane indices
+  kShared,       // same value in every lane: emit the op once
+  kRowSum,       // per-lane reduction of a width-W value
+  kWiden,        // elementwise, one output element per lane per width
+  kEltDensity,   // density consumed in-lane: variant bit 6, out[l] is lane l
+  kTermDensity,  // every lane's out is a term: one summed density
+  kTermWiden,    // every lane's out is a term: widen, then reduce
+};
+
+struct Pos {
+  Emit emit = Emit::kShared;
+  std::vector<PosIn> ins;
+  std::vector<int> idx;  // kSlice: {start}; kGather: L * width indices
+  int64_t width = 1;     // output elements per lane; ignored when kShared
+  bool shared = false;   // one value stands for every lane
+  int out = -1;          // filled during emission
+};
+
+struct Key {
+  std::vector<int64_t> w;
+  bool operator==(const Key& o) const { return w == o.w; }
+};
+
+struct KeyHash {
+  size_t operator()(const Key& k) const {
+    size_t h = 1469598103934665603ull;
+    for (int64_t v : k.w) {
+      h ^= static_cast<size_t>(v);
+      h *= 1099511628211ull;
+    }
+    return h;
+  }
+};
+
+}  // namespace
+
+PartitionStats partition_lanes(Graph& g, Fills& fills,
+                               std::vector<int>& target_terms,
+                               const std::vector<int>& extra_roots) {
+  PartitionStats st;
+  if (std::getenv("STANLI_NO_PARTITION")) return st;
+  const size_t n_ops = g.ops.size();
+  if (n_ops < 2 * (size_t)kMinLanes) return st;
+
+  std::unordered_set<int> term_set(target_terms.begin(), target_terms.end());
+  std::unordered_set<int> root_set(extra_roots.begin(), extra_roots.end());
+  if (g.result_slot >= 0) root_set.insert(g.result_slot);
+
+  // Most graphs have too few lane ends to hold a bucket at all. Answer that
+  // in one scan, before allocating anything per slot.
+  int64_t delimiters = 0;
+  for (const Op& op : g.ops) {
+    ++st.segment_steps;
+    if ((op.out >= 0 && term_set.count(op.out) != 0) || is_element_store(op))
+      ++delimiters;
+  }
+  if (delimiters < kMinLanes) return st;
+
+  const size_t n_slots = g.slots.size();
+  std::vector<std::vector<size_t>> uses(n_slots);
+  std::vector<std::vector<size_t>> writers(n_slots);
+  for (size_t u = 0; u < n_ops; ++u) {
+    const Op& op = g.ops[u];
+    for (int j = 0; j < op.n_in; ++j)
+      if (op.in[j] >= 0) uses[(size_t)op.in[j]].push_back(u);
+    if (op.out >= 0) writers[(size_t)op.out].push_back(u);
+    if (op.out2 >= 0) writers[(size_t)op.out2].push_back(u);
+  }
+
+  // Both lists are built by walking u upwards, so both are sorted and every
+  // question below is a range question. Answering those by scanning is what
+  // made re-roll quadratic in time on ldaK5; binary search reads only the
+  // entries that can matter, and every entry read is counted so the scaling
+  // test can assert on an exact integer.
+  const auto first_at_or_after = [&](const std::vector<size_t>& v, size_t x) {
+    size_t lo = 0, hi = v.size();
+    while (lo < hi) {
+      const size_t mid = lo + (hi - lo) / 2;
+      ++st.list_steps;
+      if (v[mid] < x)
+        lo = mid + 1;
+      else
+        hi = mid;
+    }
+    return v.begin() + (ptrdiff_t)lo;
+  };
+  const auto any_at_or_after = [&](const std::vector<size_t>& v, size_t x) {
+    return first_at_or_after(v, x) != v.end();
+  };
+
+  // ---- segmentation ---------------------------------------------------
+  std::vector<Lane> lanes;
+  size_t run_begin = 0;
+  for (size_t u = 0; u < n_ops; ++u) {
+    ++st.segment_steps;
+    const Op& op = g.ops[u];
+    // A slot the executor reads out of the arena, or a second output, ends
+    // the run without opening a lane: those values must still be written
+    // where they are.
+    if (op.out2 >= 0 || (op.out >= 0 && root_set.count(op.out) != 0)) {
+      run_begin = u + 1;
+      continue;
+    }
+    const bool term_delim = op.out >= 0 && term_set.count(op.out) != 0 &&
+                            uses[(size_t)op.out].empty() &&
+                            writers[(size_t)op.out].size() == 1;
+    if (!term_delim && !is_element_store(op)) continue;
+    // Reach back over the ops whose values never leave the lane. An op that
+    // is read later is not part of any lane: it stays where it is, and the
+    // lane starts after it.
+    size_t begin = u;
+    while (begin > run_begin) {
+      ++st.segment_steps;
+      const Op& prev = g.ops[begin - 1];
+      const int o = prev.out;
+      if (o < 0 || prev.out2 >= 0 || g.slots[(size_t)o].is_param ||
+          term_set.count(o) != 0 || root_set.count(o) != 0 ||
+          writers[(size_t)o].size() != 1 ||
+          any_at_or_after(uses[(size_t)o], u + 1))
+        break;
+      --begin;
+    }
+    lanes.push_back(Lane{begin, u + 1});
+    run_begin = u + 1;
+  }
+  if ((int64_t)lanes.size() < kMinLanes) return st;
+
+  // ---- fingerprint and bucket -----------------------------------------
+  std::unordered_map<Key, int, KeyHash> bucket_of;
+  std::vector<std::vector<int>> buckets;  // in first-lane order
+  Key key;
+  std::unordered_map<int, int> pos_of;
+  for (size_t li = 0; li < lanes.size(); ++li) {
+    const Lane& lane = lanes[li];
+    key.w.assign(1, (int64_t)(lane.end - lane.begin));
+    pos_of.clear();
+    bool ok = true;
+    for (size_t u = lane.begin; u < lane.end && ok; ++u) {
+      ++st.fingerprint_steps;
+      const Op& op = g.ops[u];
+      if (is_blocked(op)) {
+        ok = false;
+        break;
+      }
+      key.w.push_back(op.opcode);
+      key.w.push_back(op.variant);
+      key.w.push_back(op.n_in);
+      key.w.push_back(g.slots[(size_t)op.out].len);
+      key.w.push_back(term_set.count(op.out) != 0);
+      for (int j = 0; j < op.n_in; ++j) {
+        const int s = op.in[j];
+        key.w.push_back(s >= 0 ? g.slots[(size_t)s].len : -1);
+        const auto it = pos_of.find(s);
+        key.w.push_back(it == pos_of.end() ? -1 : it->second);
+      }
+      key.w.push_back(op.n_idata);
+      if (!idata_is_shape(op.opcode))
+        for (int64_t m = 0; m < op.n_idata; ++m) key.w.push_back(op.idata[m]);
+      pos_of[op.out] = (int)(u - lane.begin);
+    }
+    if (!ok) continue;
+    const auto ins = bucket_of.emplace(key, (int)buckets.size());
+    if (ins.second) buckets.emplace_back();
+    buckets[(size_t)ins.first->second].push_back((int)li);
+  }
+
+  // The dedup'd constant pool: slot -> value, for len-1 fills.
+  std::unordered_map<int, double> const_val;
+  for (const auto& f : fills)
+    if (f.second.size() == 1) const_val.emplace(f.first, f.second[0]);
+
+  std::vector<char> dropped(n_ops, 0);
+  std::vector<int> emit_at(n_ops, -1);
+  std::vector<std::vector<Op>> emitted;
+
+  for (const std::vector<int>& ids : buckets) {
+    const int64_t L = (int64_t)ids.size();
+    if (L < kMinLanes) continue;
+    const Lane& lane0 = lanes[(size_t)ids[0]];
+    const int k = (int)(lane0.end - lane0.begin);
+    const size_t first_begin = lane0.begin;
+    const auto op_at = [&](int p, int64_t l) -> const Op& {
+      return g.ops[lanes[(size_t)ids[(size_t)l]].begin + (size_t)p];
+    };
+    // Every slot the fused ops read from outside the bucket must be finished
+    // before the first lane: a later writer is a cross-lane recurrence, a
+    // mid-bucket store, or a destructive update, and the fused read happens
+    // at the first lane's position.
+    const auto settled = [&](int s) {
+      return s >= 0 && (size_t)s < n_slots &&
+             !any_at_or_after(writers[(size_t)s], first_begin);
+    };
+
+    pos_of.clear();
+    for (int p = 0; p < k; ++p) pos_of[op_at(p, 0).out] = p;
+
+    std::vector<Pos> pos((size_t)k);
+    bool ok = true;
+    for (int p = 0; p < k && ok; ++p) {
+      const Op& t = op_at(p, 0);
+      Pos& ap = pos[(size_t)p];
+      ap.ins.resize((size_t)t.n_in);
+      const bool is_term = term_set.count(t.out) != 0;
+      bool all_shared = true;   // this op computes one value for every lane
+      int64_t width = 0;        // per-lane elements of the varying inputs
+      bool wide_shared = false; // a shared input the kernels cannot broadcast
+
+      for (int j = 0; j < t.n_in && ok; ++j) {
+        PosIn& in = ap.ins[(size_t)j];
+        const auto local = pos_of.find(t.in[j]);
+        if (local != pos_of.end() && local->second < p) {
+          in.kind = InKind::kLaneLocal;
+          in.producer = local->second;
+          const Pos& prod = pos[(size_t)local->second];
+          if (prod.shared) {
+            if (g.slots[(size_t)t.in[j]].len != 1) wide_shared = true;
+          } else {
+            all_shared = false;
+            if (width && width != prod.width) ok = false;
+            width = prod.width;
+          }
+          continue;
+        }
+        bool invariant = true;
+        for (int64_t l = 1; l < L && invariant; ++l)
+          invariant = op_at(p, l).in[j] == t.in[j];
+        if (invariant) {
+          in.kind = InKind::kInvariant;
+          if (!settled(t.in[j])) ok = false;
+          if (t.in[j] >= 0 && g.slots[(size_t)t.in[j]].len != 1)
+            wide_shared = true;
+          continue;
+        }
+        std::vector<double> vals;
+        vals.reserve((size_t)L);
+        for (int64_t l = 0; l < L; ++l) {
+          const int s = op_at(p, l).in[j];
+          const auto cit = const_val.find(s);
+          if (cit == const_val.end() || !writers[(size_t)s].empty()) break;
+          vals.push_back(cit->second);
+        }
+        if ((int64_t)vals.size() != L) {
+          ok = false;  // a different slot per lane that is not a constant
+          break;
+        }
+        in.kind = InKind::kConstLanes;
+        in.values = std::move(vals);
+        all_shared = false;
+        if (width && width != 1) ok = false;
+        width = 1;
+      }
+      if (!ok) break;
+      if (width == 0) width = 1;
+
+      bool idata_shared = true;
+      for (int64_t l = 1; l < L && idata_shared; ++l)
+        for (int64_t m = 0; m < t.n_idata; ++m)
+          if (op_at(p, l).idata[m] != t.idata[m]) {
+            idata_shared = false;
+            break;
+          }
+
+      // Indexed reads of a base the whole bucket shares. These are the only
+      // positions whose immediates may differ across lanes without the op
+      // itself being lane-varying work.
+      const bool indexed_read =
+          (t.opcode == OP_INDEX || t.opcode == OP_SLICE) && t.n_in == 1 &&
+          t.n_idata == 1 && !is_term &&
+          ap.ins[0].kind == InKind::kInvariant && !idata_shared;
+      if (indexed_read) {
+        const int64_t blen = g.slots[(size_t)t.in[0]].len;
+        const int64_t w = g.slots[(size_t)t.out].len;
+        ap.width = w;
+        ap.idx.reserve((size_t)(L * w));
+        bool run = true;
+        for (int64_t l = 0; l < L; ++l) {
+          const int64_t start = op_at(p, l).idata[0];
+          if (start < 0 || start + w > blen) {
+            ok = false;
+            break;
+          }
+          if (start != t.idata[0] + l * w) run = false;
+          for (int64_t e = 0; e < w; ++e) ap.idx.push_back((int)(start + e));
+        }
+        if (!ok) break;
+        if (run && w == 1 && t.idata[0] == 0 && blen == L) {
+          ap.emit = Emit::kElide;
+        } else if (run && w == 1) {
+          ap.emit = Emit::kSlice;
+          ap.idx.assign(1, t.idata[0]);
+        } else {
+          ap.emit = Emit::kGather;
+        }
+        continue;
+      }
+
+      if (all_shared && idata_shared && !is_term) {
+        ap.emit = Emit::kShared;
+        ap.shared = true;
+        continue;
+      }
+      if (wide_shared) {
+        ok = false;  // the kernels broadcast len-1 arguments, nothing wider
+        break;
+      }
+      // L lanes computing the identical scalar, each one a term: the const
+      // pool dedup'd even the data argument. One fused op would compute one
+      // lane's value where the target owes L of them. An integer-outcome
+      // density is the exception that proves it: concatenating the lanes'
+      // immediates is itself the widening, so its fused form does compute L.
+      if (is_term && all_shared &&
+          !has_op_trait(t.opcode, op_trait::kRerollIdataDensity)) {
+        ok = false;
+        break;
+      }
+      ap.width = width;
+
+      if (t.opcode == OP_SUM_VEC && t.n_in == 1 && !is_term &&
+          ap.ins[0].kind == InKind::kLaneLocal && width >= 2) {
+        ap.emit = Emit::kRowSum;
+        ap.width = 1;
+        continue;
+      }
+      if (has_op_trait(t.opcode, op_trait::kRerollAnyDensity)) {
+        // The idata densities carrying more than one immediate (the
+        // binomials' two integer groups) need the group concatenation that
+        // is not in this slice yet.
+        if (has_op_trait(t.opcode, op_trait::kRerollIdataDensity) &&
+            t.n_idata != 1) {
+          ok = false;
+          break;
+        }
+        if (width != 1) {
+          ok = false;
+          break;
+        }
+        ap.emit = is_term ? Emit::kTermDensity : Emit::kEltDensity;
+        continue;
+      }
+      if (has_op_trait(t.opcode, op_trait::kRerollWidenable)) {
+        if (is_term && width != 1) {
+          ok = false;
+          break;
+        }
+        ap.emit = is_term ? Emit::kTermWiden : Emit::kWiden;
+        continue;
+      }
+      ok = false;
+    }
+    if (!ok) continue;
+    // Exactly one target term per lane, at the delimiter: any other
+    // disposition would leave the term list describing work that no longer
+    // happens.
+    for (int p = 0; p < k && ok; ++p) {
+      const bool term = pos[(size_t)p].emit == Emit::kTermDensity ||
+                        pos[(size_t)p].emit == Emit::kTermWiden;
+      ok = term == (p == k - 1);
+    }
+    if (!ok) continue;
+
+    int64_t added = 0, ops_out = 0;
+    for (const Pos& ap : pos) {
+      switch (ap.emit) {
+        case Emit::kElide:
+          break;
+        case Emit::kSlice:
+          ++ops_out;
+          added += L * ap.width;  // contiguous: no index array, no scatter
+          break;
+        case Emit::kGather:
+          ++ops_out;
+          added += 2 * L * ap.width;  // gathered forward, scattered back
+          break;
+        case Emit::kTermWiden:
+          ops_out += 2;
+          break;
+        default:
+          ++ops_out;
+          break;
+      }
+    }
+    added += ops_out * kOpCost;
+    if (L * (int64_t)k * kOpCost <= added + kPartitionMargin) {
+      ++st.declined;
+      continue;
+    }
+
+    // ---- emit ---------------------------------------------------------
+    std::vector<Op> out_ops;
+    out_ops.reserve((size_t)ops_out);
+    const auto attach_idata = [&](Op& o, std::vector<int> v) {
+      g.idata_pool.push_back(std::move(v));
+      o.idata = g.idata_pool.back().data();
+      o.n_idata = (int64_t)g.idata_pool.back().size();
+    };
+    // The fused lpmf's outcome vector is the lanes' immediates.
+    const auto attach_outcomes = [&](Op& o, int p) {
+      if (!has_op_trait(o.opcode, op_trait::kRerollIdataDensity)) return;
+      std::vector<int> outcomes;
+      outcomes.reserve((size_t)L);
+      for (int64_t l = 0; l < L; ++l) outcomes.push_back(op_at(p, l).idata[0]);
+      attach_idata(o, std::move(outcomes));
+    };
+    const auto swap_terms = [&](int p, int new_term) {
+      std::unordered_set<int> dead;
+      for (int64_t l = 0; l < L; ++l) dead.insert(op_at(p, l).out);
+      std::vector<int> next;
+      next.reserve(target_terms.size());
+      bool placed = false;
+      for (int s : target_terms) {
+        if (dead.count(s) == 0) {
+          next.push_back(s);
+        } else if (!placed) {
+          next.push_back(new_term);
+          placed = true;
+        }
+      }
+      target_terms = std::move(next);
+      for (int s : dead) term_set.erase(s);
+      term_set.insert(new_term);
+    };
+
+    for (int p = 0; p < k; ++p) {
+      const Op& t = op_at(p, 0);
+      Pos& ap = pos[(size_t)p];
+      if (ap.emit == Emit::kElide) {
+        ap.out = t.in[0];
+        continue;
+      }
+      if (ap.emit == Emit::kSlice || ap.emit == Emit::kGather) {
+        Op rd;
+        rd.opcode = ap.emit == Emit::kSlice ? OP_SLICE : OP_GATHER;
+        rd.n_in = 1;
+        rd.in[0] = t.in[0];
+        rd.out = g.add_slot(L * ap.width, false);
+        attach_idata(rd, std::move(ap.idx));
+        ap.out = rd.out;
+        out_ops.push_back(rd);
+        continue;
+      }
+      Op op = t;  // opcode, variant and immediates carry over
+      for (int j = 0; j < t.n_in; ++j) {
+        const PosIn& in = ap.ins[(size_t)j];
+        switch (in.kind) {
+          case InKind::kInvariant:
+            break;
+          case InKind::kLaneLocal:
+            op.in[j] = pos[(size_t)in.producer].out;
+            break;
+          case InKind::kConstLanes: {
+            const int cs = g.add_slot(L, false);
+            fills.emplace_back(cs, in.values);
+            op.in[j] = cs;
+            break;
+          }
+        }
+      }
+      switch (ap.emit) {
+        case Emit::kShared:
+          ap.out = op.out;  // lane 0's own slot, written once
+          break;
+        case Emit::kRowSum:
+          op.opcode = OP_SUM_ROWS;
+          op.out = g.add_slot(L, false);
+          attach_idata(op, std::vector<int>{
+                               (int)pos[(size_t)ap.ins[0].producer].width});
+          ap.out = op.out;
+          break;
+        case Emit::kEltDensity:
+          op.variant = (uint8_t)(op.variant | 0x40u);
+          op.out = g.add_slot(L, false);
+          attach_outcomes(op, p);
+          ap.out = op.out;
+          break;
+        case Emit::kTermDensity:
+          op.out = g.add_slot(1, false);
+          attach_outcomes(op, p);
+          ap.out = op.out;
+          break;
+        default:  // kWiden, kTermWiden
+          op.out = g.add_slot(L * ap.width, false);
+          ap.out = op.out;
+          break;
+      }
+      out_ops.push_back(op);
+      if (ap.emit == Emit::kTermDensity) {
+        swap_terms(p, op.out);
+      } else if (ap.emit == Emit::kTermWiden) {
+        Op sum;
+        sum.opcode = OP_SUM_VEC;
+        sum.n_in = 1;
+        sum.in[0] = op.out;
+        sum.out = g.add_slot(1, false);
+        out_ops.push_back(sum);
+        swap_terms(p, sum.out);
+      }
+    }
+
+    for (int id : ids)
+      for (size_t u = lanes[(size_t)id].begin; u < lanes[(size_t)id].end; ++u)
+        dropped[u] = 1;
+    emit_at[first_begin] = (int)emitted.size();
+    emitted.push_back(std::move(out_ops));
+    ++st.groups;
+    st.lanes += (int)L;
+  }
+
+  if (st.groups == 0) return st;
+  std::vector<Op> result;
+  result.reserve(n_ops);
+  for (size_t u = 0; u < n_ops; ++u) {
+    if (emit_at[u] >= 0) {
+      const std::vector<Op>& ops = emitted[(size_t)emit_at[u]];
+      result.insert(result.end(), ops.begin(), ops.end());
+    }
+    if (!dropped[u]) result.push_back(g.ops[u]);
+  }
+  g.ops = std::move(result);
+  return st;
+}
+
+}  // namespace stanli

--- a/runtime/src/reroll.cpp
+++ b/runtime/src/reroll.cpp
@@ -87,10 +87,7 @@ bool is_element_store(const Op& op) {
 // OP_INDEX (checked as a progression during classification).
 bool ops_match(const Graph& g, const Op& a, const Op& b) {
   if (a.opcode != b.opcode || a.variant != b.variant || a.n_in != b.n_in ||
-      a.out2 >= 0 || b.out2 >= 0 || a.opcode == OP_CHECK_STRUCTURED ||
-      a.opcode == OP_CHECK_MATCHING_DIMS || a.opcode == OP_CHECK_LOWER ||
-      a.opcode == OP_CHECK_UPPER || a.opcode == OP_CATEGORICAL ||
-      a.opcode == OP_RNG || a.opcode == OP_PRINT || a.opcode == OP_REJECT ||
+      a.out2 >= 0 || b.out2 >= 0 || is_effectful_op(a.opcode) ||
       a.opcode == OP_PROD_VEC || a.opcode == OP_EXTREMA_VEC)
     return false;
   for (int j = 0; j < a.n_in; ++j)
@@ -868,8 +865,23 @@ RerollStats reroll(Graph& g,
                   prefix, std::min(br_internal, std::max(br_term, br_nonterm)));
             } else if (has_op_trait(t.opcode, op_trait::kRerollIdataDensity) &&
                        t.n_idata != 1) {
-              ok = false;
-              prefix = 0;  // already a vector op; nothing to fuse
+              // More than one immediate: either already a vector op, or one
+              // of the binomials, whose two integer groups only partition.cpp
+              // concatenates. One lane still stands for all of them when the
+              // real inputs and the immediates alike are lane-invariant.
+              int64_t br_iinv = Luse;
+              for (int64_t l = 1; l < Luse && br_iinv == Luse; ++l)
+                for (int64_t k = 0; k < t.n_idata; ++k)
+                  if (op_at(p, l).idata[k] != t.idata[k]) {
+                    br_iinv = l;
+                    break;
+                  }
+              if (!all_terms && all_inputs_invariant && br_iinv == Luse) {
+                ap.hoist = true;
+              } else {
+                ok = false;
+                prefix = 0;
+              }
             } else if (all_terms) {
               if (!uses[(size_t)t.out].empty()) {
                 ok = false;

--- a/tests/test_mixture.cpp
+++ b/tests/test_mixture.cpp
@@ -419,6 +419,112 @@ static void check_rows() {
   check_row_edge("rows nan", {-1.0, nan, 2.0});
 }
 
+// ---- 4. Packed row-wise plain sum ------------------------------------------
+// The per-lane reduction a partitioned bucket needs: L lanes' width-W windows
+// arrive as one gathered vector, and this maps them back to one value per
+// lane. Row r must equal the OP_SUM_VEC it replaces, bit for bit.
+static RowsRun run_sum_rows(const std::vector<double>& x, int K,
+                            const std::vector<double>& weights = {}) {
+  const int64_t R = (int64_t)x.size() / K;
+  Graph g;
+  const int in = g.add_slot((int64_t)x.size(), true);
+  const int out = g.add_slot(R, false);
+  const int lp = g.add_slot(1, false);
+  g.add_op(OP_SUM_ROWS, {in}, out, {K});
+  int weight_slot = -1;
+  if (weights.empty()) {
+    g.add_op(OP_SUM_VEC, {out}, lp);
+  } else {
+    weight_slot = g.add_slot(R, false);
+    g.add_op(OP_DOT, {out, weight_slot}, lp);
+  }
+  g.result_slot = lp;
+
+  Executor ex(std::move(g));
+  for (size_t i = 0; i < x.size(); ++i) ex.param_ptr(in)[i] = x[i];
+  for (size_t i = 0; i < weights.size(); ++i)
+    ex.value_ptr(weight_slot)[i] = weights[i];
+  RowsRun r;
+  r.grad.resize(x.size());
+  r.value = ex.gradient(r.grad.data());
+  r.out.assign(ex.value_ptr(out), ex.value_ptr(out) + R);
+  return r;
+}
+
+// One row through OP_SUM_VEC, which is the scalar op the fused form replaces.
+static double sum_vec_value(const std::vector<double>& row) {
+  Graph g;
+  const int in = g.add_slot((int64_t)row.size(), false);
+  const int out = g.add_slot(1, false);
+  g.add_op(OP_SUM_VEC, {in}, out);
+  g.result_slot = out;
+  Executor ex(std::move(g));
+  for (size_t i = 0; i < row.size(); ++i) ex.value_ptr(in)[i] = row[i];
+  return ex.forward();
+}
+
+static void check_sum_rows() {
+  const int K = 5;
+  const std::vector<double> x{-1.3,  0.4, 2.1,   -0.7, 0.2,   1e16, 1.0,
+                              -1e16, 0.5, 0.25,  -0.0, 0.0,   -3.0, 4.0,
+                              -5.5,  0.1, 0.125, 0.25, 0.375, 0.5};
+  const int R = (int)x.size() / K;
+  const RowsRun got = run_sum_rows(x, K);
+
+  double want_lp = 0.0;
+  for (int r = 0; r < R; ++r) {
+    const std::vector<double> row(x.begin() + r * K, x.begin() + (r + 1) * K);
+    const double want = sum_vec_value(row);
+    expect_eq("sum_rows out" + std::to_string(r), got.out[(size_t)r], want);
+    want_lp += want;
+  }
+  expect_eq("sum_rows lp", got.value, want_lp);
+  for (size_t i = 0; i < x.size(); ++i)
+    expect_eq("sum_rows g" + std::to_string(i), got.grad[i], 1.0);
+
+  // Each row's own output adjoint reaches its elements, rather than the rows
+  // being treated as one implicit sum.
+  const std::vector<double> weights{0.5, -1.25, 2.0, 0.0};
+  const RowsRun weighted = run_sum_rows(x, K, weights);
+  for (size_t i = 0; i < x.size(); ++i)
+    expect_eq("weighted sum_rows g" + std::to_string(i), weighted.grad[i],
+              weights[i / (size_t)K]);
+
+  Graph shape;
+  const int in = shape.add_slot((int64_t)x.size(), true);
+  const int out = shape.add_slot(R, false);
+  shape.add_op(OP_SUM_ROWS, {in}, out, {K});
+  const Kernel* kernel = find_kernel(OP_SUM_ROWS);
+  expect("sum_rows kernel registered", kernel != nullptr);
+  if (kernel)
+    expect("sum_rows needs no scratch", kernel->scratch_size == nullptr);
+  expect("sum_rows backward is value-free",
+         has_op_trait(OP_SUM_ROWS, op_trait::kBackwardValueFree));
+  expect("sum_rows opcode name",
+         std::string(opcode_name(OP_SUM_ROWS)) == "OP_SUM_ROWS");
+
+  // Widths either side of Eigen's packet boundary, and one row per element.
+  for (int width : {1, 7, 16}) {
+    std::vector<double> wide((size_t)width * 3);
+    for (size_t i = 0; i < wide.size(); ++i)
+      wide[i] = 0.37 * (double)i - 2.1 + 0.05 * (double)(i % 3);
+    const RowsRun w = run_sum_rows(wide, width);
+    for (int r = 0; r < 3; ++r) {
+      const std::vector<double> row(wide.begin() + r * width,
+                                    wide.begin() + (r + 1) * width);
+      expect_eq(
+          "sum_rows K=" + std::to_string(width) + " out" + std::to_string(r),
+          w.out[(size_t)r], sum_vec_value(row));
+    }
+  }
+
+  const double inf = std::numeric_limits<double>::infinity();
+  const double nan = std::numeric_limits<double>::quiet_NaN();
+  const RowsRun edge = run_sum_rows({inf, -inf, 1.0, nan, 0.0, 2.0}, 3);
+  expect("sum_rows inf row", std::isnan(edge.out[0]));
+  expect("sum_rows nan row", std::isnan(edge.out[1]));
+}
+
 int main() {
   const int64_t N = 4;
 
@@ -485,6 +591,7 @@ int main() {
   check_bitwise("unroll lmix vvv", OP_LOG_MIX, N, {TH, A, B});
 
   check_rows();
+  check_sum_rows();
 
   if (failures) {
     std::printf("%d failures\n", failures);

--- a/tests/test_partition.cpp
+++ b/tests/test_partition.cpp
@@ -1,0 +1,492 @@
+// Lane bucketing: lanes found by their delimiter rather than by a period, so
+// they fuse whether or not they are adjacent, and refuse whenever a lane's
+// values would move.
+#include "env_helpers.hpp"
+#include "graph_helpers.hpp"
+#include <stanli/graph.hpp>
+#include <stanli/optable.hpp>
+#include <stanli/partition.hpp>
+
+#ifndef _WIN32
+#include <sys/resource.h>
+#endif
+
+#include <algorithm>
+#include <chrono>
+#include <cmath>
+#include <cstdio>
+#include <string>
+#include <vector>
+
+static int failures = 0;
+static void expect(const char* what, bool ok) {
+  if (!ok) {
+    ++failures;
+    std::printf("FAIL %s\n", what);
+  }
+}
+static void expect_close(const std::string& what, double got, double want) {
+  const double rel = std::abs(got - want) / std::max(std::abs(want), 1e-300);
+  if (!(rel < 1e-12)) {
+    ++failures;
+    std::printf("FAIL %-28s got %.17g want %.17g rel %.2e\n", what.c_str(), got,
+                want, rel);
+  }
+}
+
+using namespace stanli;
+using stanli::testutil::Fills;
+using stanli::testutil::reduce_into_result;
+
+static double fill_at(int64_t i) { return 0.25 + 0.15 * (double)(i % 4); }
+static std::vector<double> run_grad(Graph g, const Fills& fills) {
+  return testutil::run_grad(std::move(g), fills, fill_at);
+}
+
+static int count_opcode(const Graph& g, uint16_t oc) {
+  int n = 0;
+  for (const Op& op : g.ops) n += op.opcode == oc;
+  return n;
+}
+
+// The pre-pass graph is the reference: never an analytic value.
+static void expect_same_grad(const std::string& what, Graph g, Fills fills,
+                             std::vector<int> terms,
+                             const std::vector<double>& want) {
+  reduce_into_result(g, terms);
+  const std::vector<double> got = run_grad(std::move(g), fills);
+  if (got.size() != want.size()) {
+    ++failures;
+    std::printf("FAIL %s gradient size %zu != %zu\n", what.c_str(), got.size(),
+                want.size());
+    return;
+  }
+  for (size_t i = 0; i < want.size(); ++i)
+    expect_close(what + " v" + std::to_string(i), got[i], want[i]);
+}
+
+static std::vector<double> reference(const Graph& g, const Fills& fills,
+                                     const std::vector<int>& terms) {
+  Graph ref = g;
+  reduce_into_result(ref, terms);
+  return run_grad(std::move(ref), fills);
+}
+
+// ---- shapes ----------------------------------------------------------------
+
+// One lane per element of a parameter vector: {INDEX(v, l); NORMAL(y_l, idx,
+// sigma)} with the lp a target term. The whole base is read in order, so the
+// fused density reads it directly and no gather survives.
+struct Lanes {
+  Graph g;
+  Fills fills;
+  std::vector<int> terms;
+  int base = -1, sigma = -1;
+};
+
+static Lanes build_index_lanes(int L) {
+  Lanes b;
+  b.base = b.g.add_slot(L, true);
+  b.sigma = b.g.add_slot(1, true);
+  for (int l = 0; l < L; ++l) {
+    const int y = b.g.add_slot(1, false);
+    b.fills.emplace_back(y, std::vector<double>{0.2 * l - 0.5});
+    const int idx = b.g.add_slot(1, false);
+    b.g.add_op(OP_INDEX, {b.base}, idx, {l});
+    const int lp = b.g.add_slot(1, false);
+    const int id = b.g.add_op(OP_NORMAL_LPDF, {y, idx, b.sigma}, lp);
+    b.g.ops[(size_t)id].variant = 0x06;
+    b.terms.push_back(lp);
+  }
+  return b;
+}
+
+static void test_contiguous_bucket() {
+  Lanes b = build_index_lanes(8);
+  const std::vector<double> want = reference(b.g, b.fills, b.terms);
+
+  std::vector<int> tt = b.terms;
+  Fills f2 = b.fills;
+  const PartitionStats st = partition_lanes(b.g, f2, tt, {});
+  expect("contiguous one group", st.groups == 1 && st.lanes == 8);
+  expect("contiguous one op", b.g.ops.size() == 1);
+  expect("contiguous reads the base", b.g.ops[0].in[1] == b.base);
+  expect("contiguous one term", tt.size() == 1);
+  expect_same_grad("contiguous", std::move(b.g), f2, tt, want);
+}
+
+// The same template, with an unrelated term computed between lanes 3 and 4.
+// Lanes are found by their delimiters, so the intruder neither joins the
+// bucket nor stops it, and it stays where it is.
+static void test_interleaved_lanes() {
+  const int L = 8;
+  Lanes b;
+  b.base = b.g.add_slot(L, true);
+  b.sigma = b.g.add_slot(1, true);
+  const int c = b.g.add_slot(1, false);
+  b.fills.emplace_back(c, std::vector<double>{1.5});
+  int foreign_term = -1;
+  for (int l = 0; l < L; ++l) {
+    if (l == 4) {
+      const int e = b.g.add_slot(1, false);
+      b.g.add_op(OP_EXP, {b.sigma}, e);
+      const int lp = b.g.add_slot(1, false);
+      const int id = b.g.add_op(OP_NORMAL_LPDF, {c, e, b.sigma}, lp);
+      b.g.ops[(size_t)id].variant = 0x06;
+      foreign_term = lp;
+      b.terms.push_back(lp);
+    }
+    const int y = b.g.add_slot(1, false);
+    b.fills.emplace_back(y, std::vector<double>{0.2 * l - 0.5});
+    const int idx = b.g.add_slot(1, false);
+    b.g.add_op(OP_INDEX, {b.base}, idx, {l});
+    const int lp = b.g.add_slot(1, false);
+    const int id = b.g.add_op(OP_NORMAL_LPDF, {y, idx, b.sigma}, lp);
+    b.g.ops[(size_t)id].variant = 0x06;
+    b.terms.push_back(lp);
+  }
+  const std::vector<double> want = reference(b.g, b.fills, b.terms);
+
+  std::vector<int> tt = b.terms;
+  Fills f2 = b.fills;
+  const PartitionStats st = partition_lanes(b.g, f2, tt, {});
+  expect("interleaved one group", st.groups == 1 && st.lanes == 8);
+  expect("interleaved keeps the intruder", count_opcode(b.g, OP_EXP) == 1);
+  expect("interleaved op count", b.g.ops.size() == 3);
+  expect("interleaved two terms",
+         tt.size() == 2 && tt[1] == foreign_term);
+  expect_same_grad("interleaved", std::move(b.g), f2, tt, want);
+}
+
+// The data-condition shape: one bucket whose lanes read a shared base at
+// scattered indices, out of order and with one index twice. The gather is
+// emitted in lane order and its scatter-add is what makes the repeat come out
+// like the scalar loop's two separate reads.
+static void test_scattered_indices() {
+  const int L = 8, N = 6;
+  const int pick[L] = {4, 0, 3, 3, 5, 1, 2, 0};
+  Graph g;
+  Fills fills;
+  const int base = g.add_slot(N, true);
+  const int sigma = g.add_slot(1, true);
+  std::vector<int> terms;
+  for (int l = 0; l < L; ++l) {
+    const int y = g.add_slot(1, false);
+    fills.emplace_back(y, std::vector<double>{0.2 * l - 0.5});
+    const int idx = g.add_slot(1, false);
+    g.add_op(OP_INDEX, {base}, idx, {pick[l]});
+    const int lp = g.add_slot(1, false);
+    const int id = g.add_op(OP_NORMAL_LPDF, {y, idx, sigma}, lp);
+    g.ops[(size_t)id].variant = 0x06;
+    terms.push_back(lp);
+  }
+  const std::vector<double> want = reference(g, fills, terms);
+
+  std::vector<int> tt = terms;
+  Fills f2 = fills;
+  const PartitionStats st = partition_lanes(g, f2, tt, {});
+  expect("scattered one group", st.groups == 1 && st.lanes == L);
+  expect("scattered one gather", count_opcode(g, OP_GATHER) == 1);
+  expect("scattered lane order",
+         g.ops[0].n_idata == L && g.ops[0].idata[0] == pick[0] &&
+             g.ops[0].idata[3] == pick[3]);
+  expect_same_grad("scattered", std::move(g), f2, tt, want);
+}
+
+// A print inside a lane. Hoisting eight of them into one would print once:
+// the effect blocklist is what stops that, so the count is the assertion.
+static void test_refuse_effectful() {
+  const int L = 8;
+  Lanes b;
+  b.base = b.g.add_slot(L, true);
+  b.sigma = b.g.add_slot(1, true);
+  for (int l = 0; l < L; ++l) {
+    const int y = b.g.add_slot(1, false);
+    b.fills.emplace_back(y, std::vector<double>{0.2 * l - 0.5});
+    const int idx = b.g.add_slot(1, false);
+    b.g.add_op(OP_INDEX, {b.base}, idx, {l});
+    const int dead = b.g.add_slot(1, false);
+    b.g.add_op(OP_PRINT, {idx}, dead);
+    const int lp = b.g.add_slot(1, false);
+    const int id = b.g.add_op(OP_NORMAL_LPDF, {y, idx, b.sigma}, lp);
+    b.g.ops[(size_t)id].variant = 0x06;
+    b.terms.push_back(lp);
+  }
+  const size_t before = b.g.ops.size();
+
+  std::vector<int> tt = b.terms;
+  Fills f2 = b.fills;
+  const PartitionStats st = partition_lanes(b.g, f2, tt, {});
+  expect("effectful refuses", st.groups == 0);
+  expect("effectful count unchanged", count_opcode(b.g, OP_PRINT) == L);
+  expect("effectful graph unchanged",
+         b.g.ops.size() == before && tt == b.terms);
+}
+
+// Every lane's intermediate is read after the lane, so the lane is the
+// density alone and its mean is a different slot in every lane: nothing to
+// gather, nothing to invariant, refuse.
+static void test_refuse_escaping_intermediate() {
+  const int L = 8;
+  Graph g;
+  Fills fills;
+  const int p = g.add_slot(1, true);
+  const int sigma = g.add_slot(1, true);
+  std::vector<int> mid, terms;
+  for (int l = 0; l < L; ++l) {
+    const int c = g.add_slot(1, false);
+    fills.emplace_back(c, std::vector<double>{0.3 + 0.1 * l});
+    const int m = g.add_slot(1, false);
+    g.add_op(OP_MUL, {p, c}, m);
+    mid.push_back(m);
+    const int y = g.add_slot(1, false);
+    fills.emplace_back(y, std::vector<double>{0.2 * l - 0.5});
+    const int lp = g.add_slot(1, false);
+    const int id = g.add_op(OP_NORMAL_LPDF, {y, m, sigma}, lp);
+    g.ops[(size_t)id].variant = 0x06;
+    terms.push_back(lp);
+  }
+  int acc = mid[0];
+  for (int l = 1; l < L; ++l) {
+    const int s = g.add_slot(1, false);
+    g.add_op(OP_ADD, {acc, mid[(size_t)l]}, s);
+    acc = s;
+  }
+  terms.push_back(acc);
+  const size_t before = g.ops.size();
+
+  std::vector<int> tt = terms;
+  Fills f2 = fills;
+  const PartitionStats st = partition_lanes(g, f2, tt, {});
+  expect("escaping refuses", st.groups == 0);
+  expect("escaping graph unchanged", g.ops.size() == before && tt == terms);
+}
+
+// Eight terms that are the identical scalar, down to the data argument's
+// slot. Fusing them would compute one lane's lp where the target owes eight.
+static void test_refuse_identical_terms() {
+  const int L = 8;
+  Graph g;
+  Fills fills;
+  const int mu = g.add_slot(1, true);
+  const int sigma = g.add_slot(1, true);
+  const int y = g.add_slot(1, false);
+  fills.emplace_back(y, std::vector<double>{0.75});
+  std::vector<int> terms;
+  for (int l = 0; l < L; ++l) {
+    const int lp = g.add_slot(1, false);
+    const int id = g.add_op(OP_NORMAL_LPDF, {y, mu, sigma}, lp);
+    g.ops[(size_t)id].variant = 0x06;
+    terms.push_back(lp);
+  }
+  const std::vector<double> want = reference(g, fills, terms);
+
+  std::vector<int> tt = terms;
+  Fills f2 = fills;
+  const PartitionStats st = partition_lanes(g, f2, tt, {});
+  expect("identical terms refuse", st.groups == 0 && tt.size() == (size_t)L);
+  expect_same_grad("identical terms", std::move(g), f2, tt, want);
+}
+
+// The same shape with an integer outcome (multi_occupancy's detection terms):
+// here the lanes' immediates concatenate, so the one fused op does compute
+// eight lps and the fusion is the right answer.
+static void test_identical_idata_terms() {
+  const int L = 16;  // one op per lane: below this the margin declines it
+  Graph g;
+  Fills fills;
+  const int theta = g.add_slot(1, true);
+  std::vector<int> terms;
+  for (int l = 0; l < L; ++l) {
+    const int lp = g.add_slot(1, false);
+    const int id = g.add_op(OP_BERNOULLI_LPMF, {theta}, lp, {1});
+    g.ops[(size_t)id].variant = 0x81;
+    terms.push_back(lp);
+  }
+  const std::vector<double> want = reference(g, fills, terms);
+
+  std::vector<int> tt = terms;
+  Fills f2 = fills;
+  const PartitionStats st = partition_lanes(g, f2, tt, {});
+  expect("idata terms fuse", st.groups == 1 && st.lanes == L);
+  expect("idata terms concatenate",
+         g.ops.size() == 1 && g.ops[0].n_idata == L && tt.size() == 1);
+  expect_same_grad("idata terms", std::move(g), f2, tt, want);
+}
+
+static void test_kill_switch() {
+  Lanes b = build_index_lanes(8);
+  const size_t before = b.g.ops.size();
+  std::vector<int> tt = b.terms;
+  Fills f2 = b.fills;
+  test_setenv("STANLI_NO_PARTITION", "1", 1);
+  const PartitionStats st = partition_lanes(b.g, f2, tt, {});
+  test_unsetenv("STANLI_NO_PARTITION");
+  expect("kill switch", st.groups == 0 && b.g.ops.size() == before &&
+                            tt == b.terms);
+}
+
+// state_space_stochastic_level_stochastic_seasonal, in miniature: a window-sum
+// loop followed by a random-walk loop. Re-roll fuses neither -- the first
+// leaves its period scan mis-phased for the second -- and lane bounds are
+// computed here rather than discovered, so both fall out.
+static void test_state_space_shape() {
+  const int N = 24, WIN = 11;
+  Graph g;
+  Fills fills;
+  const int seasonal = g.add_slot(N, true);
+  const int mu = g.add_slot(N, true);
+  const int sig = g.add_slot(2, true);
+  std::vector<int> terms;
+  for (int t = WIN; t < N; ++t) {
+    const int y = g.add_slot(1, false);
+    g.add_op(OP_INDEX, {seasonal}, y, {t});
+    const int win = g.add_slot(WIN, false);
+    g.add_op(OP_SLICE, {seasonal}, win, {t - WIN});
+    const int s = g.add_slot(1, false);
+    g.add_op(OP_SUM_VEC, {win}, s);
+    const int neg = g.add_slot(1, false);
+    g.add_op(OP_NEG, {s}, neg);
+    const int sg = g.add_slot(1, false);
+    g.add_op(OP_INDEX, {sig}, sg, {0});
+    const int lp = g.add_slot(1, false);
+    const int id = g.add_op(OP_NORMAL_LPDF, {y, neg, sg}, lp);
+    g.ops[(size_t)id].variant = 0x07;
+    terms.push_back(lp);
+  }
+  for (int t = 1; t < N; ++t) {
+    const int y = g.add_slot(1, false);
+    g.add_op(OP_INDEX, {mu}, y, {t});
+    const int prev = g.add_slot(1, false);
+    g.add_op(OP_INDEX, {mu}, prev, {t - 1});
+    const int sg = g.add_slot(1, false);
+    g.add_op(OP_INDEX, {sig}, sg, {1});
+    const int lp = g.add_slot(1, false);
+    const int id = g.add_op(OP_NORMAL_LPDF, {y, prev, sg}, lp);
+    g.ops[(size_t)id].variant = 0x07;
+    terms.push_back(lp);
+  }
+  const std::vector<double> want = reference(g, fills, terms);
+
+  std::vector<int> tt = terms;
+  Fills f2 = fills;
+  const PartitionStats st = partition_lanes(g, f2, tt, {});
+  expect("state_space two groups", st.groups == 2);
+  expect("state_space lanes", st.lanes == (N - WIN) + (N - 1));
+  // seasonal: SLICE, GATHER, SUM_ROWS, NEG, INDEX, NORMAL.
+  // mu:       SLICE, SLICE, INDEX, NORMAL.
+  expect("state_space op count", g.ops.size() == 10);
+  expect("state_space window sum", count_opcode(g, OP_SUM_ROWS) == 1);
+  expect("state_space one gather", count_opcode(g, OP_GATHER) == 1);
+  expect("state_space three slices", count_opcode(g, OP_SLICE) == 3);
+  expect("state_space two densities",
+         count_opcode(g, OP_NORMAL_LPDF) == 2 && tt.size() == 2);
+  expect_same_grad("state_space", std::move(g), f2, tt, want);
+}
+
+// Four lanes reading a 64-wide window each: 12 op dispatches saved against
+// two 256-element gathers. The cost model exists to say no to this.
+static void test_cost_declines() {
+  const int L = 4, W = 64;
+  Graph g;
+  Fills fills;
+  const int base = g.add_slot(L + W, true);
+  const int sigma = g.add_slot(1, true);
+  std::vector<int> terms;
+  for (int l = 0; l < L; ++l) {
+    const int y = g.add_slot(1, false);
+    fills.emplace_back(y, std::vector<double>{0.2 * l - 0.5});
+    const int win = g.add_slot(W, false);
+    g.add_op(OP_SLICE, {base}, win, {l});
+    const int s = g.add_slot(1, false);
+    g.add_op(OP_SUM_VEC, {win}, s);
+    const int lp = g.add_slot(1, false);
+    const int id = g.add_op(OP_NORMAL_LPDF, {y, s, sigma}, lp);
+    g.ops[(size_t)id].variant = 0x06;
+    terms.push_back(lp);
+  }
+  const size_t before = g.ops.size();
+
+  std::vector<int> tt = terms;
+  Fills f2 = fills;
+  const PartitionStats st = partition_lanes(g, f2, tt, {});
+  expect("wide lanes decline", st.groups == 0 && st.declined == 1);
+  expect("declined graph unchanged", g.ops.size() == before && tt == terms);
+}
+
+// ---- cost -----------------------------------------------------------------
+
+static double peak_rss_mb() {
+#ifdef _WIN32
+  return -1.0;
+#else
+  struct rusage ru;
+  if (getrusage(RUSAGE_SELF, &ru) != 0) return -1.0;
+#ifdef __APPLE__
+  return (double)ru.ru_maxrss / (1024.0 * 1024.0);
+#else
+  return (double)ru.ru_maxrss / 1024.0;
+#endif
+#endif
+}
+
+struct Cost {
+  double sec;
+  int64_t segment;
+  int64_t list;
+};
+
+static Cost lane_cost(int L) {
+  Lanes b = build_index_lanes(L);
+  std::vector<int> tt = b.terms;
+  const auto t0 = std::chrono::steady_clock::now();
+  const PartitionStats st = partition_lanes(b.g, b.fills, tt, {});
+  const double sec =
+      std::chrono::duration<double>(std::chrono::steady_clock::now() - t0)
+          .count();
+  expect("scaling fused", st.groups == 1 && st.lanes == L);
+  expect("scaling fixed graph", b.g.ops.size() == 1 && tt.size() == 1);
+  return {sec, st.segment_steps, st.list_steps};
+}
+
+// A deterministic integer counter asserted as a ratio between two sizes. Two
+// wall-clock formulations of the same property failed CI on shared runners
+// while the pass was fine.
+static void test_scaling() {
+  const Cost small = lane_cost(8000);
+  const Cost big = lane_cost(16000);
+  const double rss = peak_rss_mb();
+  std::printf(
+      "  partition: n=8000 %.3f s / %lld segment / %lld list,"
+      " n=16000 %.3f s / %lld segment / %lld list, peak RSS %.0f MB\n",
+      small.sec, (long long)small.segment, (long long)small.list, big.sec,
+      (long long)big.segment, (long long)big.list, rss);
+  expect("segmentation is exactly linear",
+         big.segment == 2 * small.segment);
+  expect("list reads stay near-linear", big.list < 3 * small.list);
+  if (rss > 0.0) expect("partition space stays linear", rss < 1024.0);
+}
+
+int main() {
+  {  // kernels register through the first Executor
+    Graph g;
+    const int a = g.add_slot(1, true), o = g.add_slot(1, false);
+    g.add_op(OP_EXP, {a}, o);
+    g.result_slot = o;
+    Executor warm(std::move(g));
+    (void)warm.n_params();
+  }
+  test_contiguous_bucket();
+  test_interleaved_lanes();
+  test_scattered_indices();
+  test_refuse_effectful();
+  test_refuse_escaping_intermediate();
+  test_refuse_identical_terms();
+  test_identical_idata_terms();
+  test_kill_switch();
+  test_state_space_shape();
+  test_cost_declines();
+  test_scaling();
+  if (failures == 0) std::printf("test_partition OK\n");
+  return failures == 0 ? 0 : 1;
+}

--- a/tests/test_pass_safety.cpp
+++ b/tests/test_pass_safety.cpp
@@ -20,6 +20,7 @@
 #include <stanli/inplace.hpp>
 #include <stanli/island.hpp>
 #include <stanli/optable.hpp>
+#include <stanli/partition.hpp>
 #include <stanli/reroll.hpp>
 #include <stanli/wa_interp.hpp>
 
@@ -111,6 +112,7 @@ static std::vector<double> route_adjoints(uint16_t oc, bool poison) {
       out_len = 1;
       break;
     case OP_LOG_SUM_EXP_ROWS:
+    case OP_SUM_ROWS:
       idata = {3};  // two packed rows of width three
       out_len = 2;
       break;
@@ -317,6 +319,8 @@ static void test_random_graphs_preserve_gradients() {
     forward_stores_to_loads(g, {});
     reroll(g, f2, tt, {});
     make_inplace_updates(g, tt);  // slice stores reroll just created
+    partition_lanes(g, f2, tt, {});
+    make_inplace_updates(g, tt);
     // The whole pipeline, in order. Islands are forced on: these graphs
     // are small, so the pass's cost estimate would decline nearly all of
     // them, and it is the compiler that this test is for.

--- a/tests/test_reroll.cpp
+++ b/tests/test_reroll.cpp
@@ -1410,9 +1410,13 @@ static void test_e2e_fixtures() {
   };
   for (const Case& c : cases) {
     size_t ops_unrolled = 0, ops_rerolled = 0;
+    // Both lane passes off: partition finds these same loops from their
+    // delimiters, so leaving it on would compare the fused graph with itself.
     test_setenv("STANLI_NO_REROLL", "1", 1);
+    test_setenv("STANLI_NO_PARTITION", "1", 1);
     const std::vector<double> want = e2e_grad(c.sexp, c.json, &ops_unrolled);
     test_unsetenv("STANLI_NO_REROLL");
+    test_unsetenv("STANLI_NO_PARTITION");
     const std::vector<double> got = e2e_grad(c.sexp, c.json, &ops_rerolled);
     expect((std::string(c.name) + " sizes").c_str(), got.size() == want.size());
     for (size_t i = 0; i < want.size() && i < got.size(); ++i)


### PR DESCRIPTION
Data-partitioned lane fusion (new pass, STANLI_NO_PARTITION to disable): segments the post-reroll graph into lanes at term/store/root delimiters, buckets by a fingerprint that ignores external slot identity, and emits single-template buckets as gathered vector ops regardless of contiguity. Slice 0 adds OP_SUM_ROWS, binomial density traits, and an invariant-idata hoist fix in reroll (Mt_model 70 to 42 ops). The per-pass effectful-op blocklists consolidate into one optable helper.

state_space 1,375 ops to 19 (2.29x ns/grad), sir 84 to 28. Corpus A/B worst 4.53e-16; kill switch reproduces baseline op counts exactly. ctest 61/61, corpus 129/129.