### PR TITLE
perf: partition slices 2 and 3

### DIFF
--- a/runtime/kernels/densities_lpmf.cpp
+++ b/runtime/kernels/densities_lpmf.cpp
@@ -138,6 +138,51 @@ void bernoulli_logit_vector_fwd(KernelCtx& ctx) {
   ctx.scratch[theta.len] = 1.0;
 }
 
+// The same expression with the reduction left off: out[i] is element i's lp.
+// The per-element arm of bernoulli_native_fwd calls Stan Math once per
+// element, which costs about four times as much per element as this does,
+// and a partitioned width-W lane presents thousands of them at once.
+void bernoulli_logit_elt_vector_fwd(KernelCtx& ctx) {
+  static constexpr const char* function = "bernoulli_logit_lpmf";
+  static constexpr double cutoff = 20.0;
+  const Desc& theta = ctx.in[0];
+  const Eigen::Index n = static_cast<Eigen::Index>(ctx.out.len);
+  const Eigen::Map<const Eigen::VectorXi> y(ctx.idata, n);
+  std::fill_n(ctx.scratch, static_cast<size_t>(2 * n), 0.0);
+  stan::math::check_bounded(function, "n", y, 0, 1);
+  Eigen::ArrayXd theta_val(n);
+  if (theta.len == 1)
+    theta_val.setConstant(theta.data[0]);
+  else
+    theta_val = Eigen::Map<const Eigen::ArrayXd>(theta.data, n);
+  stan::math::check_not_nan(function, "Logit transformed probability parameter",
+                            theta_val);
+  Eigen::Map<Eigen::ArrayXd> out(ctx.out.data, n);
+  if (bernoulli_drop_propto(ctx)) {
+    out.setZero();
+    return;
+  }
+
+  const auto& n_col = stan::math::as_column_vector_or_scalar(y);
+  const auto& n_double = stan::math::value_of_rec(n_col);
+  const Eigen::ArrayXd signs = 2 * stan::math::as_array_or_scalar(n_double) - 1;
+  const Eigen::ArrayXd ntheta = signs * theta_val;
+  const Eigen::ArrayXd exp_m_ntheta = stan::math::exp(-ntheta);
+  out = (ntheta > cutoff)
+            .select(-exp_m_ntheta,
+                    (ntheta < -cutoff)
+                        .select(ntheta, -stan::math::log1p(exp_m_ntheta)));
+  if (!bernoulli_arg_active(ctx)) return;
+  Eigen::Map<Eigen::ArrayXd>(ctx.scratch, n) =
+      (ntheta > cutoff)
+          .select(-exp_m_ntheta,
+                  (ntheta >= -cutoff)
+                      .select(stan::math::promote_scalar<double>(
+                                  signs * exp_m_ntheta / (exp_m_ntheta + 1)),
+                              stan::math::promote_scalar<double>(signs)));
+  Eigen::Map<Eigen::ArrayXd>(ctx.scratch + n, n).setConstant(1.0);
+}
+
 template <bool Logit>
 void bernoulli_native_fwd(KernelCtx& ctx) {
   const bool active = bernoulli_arg_active(ctx);
@@ -214,6 +259,10 @@ void bernoulli_logit_fwd(KernelCtx& ctx) {
   }
   if ((ctx.variant & 0x40u) == 0 && ctx.in[0].len > 1) {
     bernoulli_logit_vector_fwd(ctx);
+    return;
+  }
+  if ((ctx.variant & 0x40u) != 0 && ctx.out.len > 1) {
+    bernoulli_logit_elt_vector_fwd(ctx);
     return;
   }
   bernoulli_native_fwd<true>(ctx);

--- a/runtime/src/partition.cpp
+++ b/runtime/src/partition.cpp
@@ -16,13 +16,14 @@
 // a data condition share a bucket), and a bucket is rewritten in place of its
 // first lane.
 //
-// What a bucket's ops read is proven, not assumed: every slot the fused ops
-// read from outside must be finished before the first lane starts. That one
-// rule carries three of the soundness obligations at once -- no cross-lane
+// What a bucket's ops read is proven, not assumed: no slot the fused ops read
+// from outside may be written while the run is in flight. That one rule
+// carries three of the soundness obligations at once -- no cross-lane
 // recurrence, no mid-bucket writer, and no destructive in-place store between
-// the lanes -- because all three appear as a writer at or after the first
-// lane's position. Ops only ever move EARLIER, so an in-place store proven
-// safe against a later reader stays safe.
+// the lanes -- because all three appear as a writer between the first lane's
+// position and the last lane's end. Ops only ever move EARLIER, so an
+// in-place store proven safe against a later reader stays safe, and a bucket
+// that trips the rule splits at the writer rather than declining.
 #include <stanli/optable.hpp>
 #include <stanli/partition.hpp>
 
@@ -41,6 +42,14 @@ constexpr int64_t kMinLanes = 4;
 // churns the graph for nothing.
 constexpr int64_t kOpCost = 5;
 constexpr int64_t kPartitionMargin = 8 * kOpCost;
+// A density element costs about six op dispatches to evaluate. It is the
+// term that decides whether re-evaluating a lane the CSE pass would have
+// collapsed, or trading a vector density call for W elementwise ones, pays.
+constexpr int64_t kDensityElem = 6;
+// Splitting is bounded work, not a retry loop: each one costs a re-pass over
+// a bucket, and a graph that presents thousands of interleaved writers must
+// not turn that into a quadratic term.
+constexpr int64_t kMaxSplits = 32;
 
 using Fills = std::vector<std::pair<int, std::vector<double>>>;
 
@@ -63,6 +72,42 @@ bool idata_is_shape(uint16_t opcode) {
          opcode == OP_SET_INDEX_INPLACE || opcode == OP_SLICE ||
          opcode == OP_SLICE_STRIDED ||
          has_op_trait(opcode, op_trait::kRerollIdataDensity);
+}
+
+// densities_lpmf.cpp's with_int_group: these carry their outcomes as two
+// [len, vals...] groups, len == -1 marking a language-level scalar.
+// Everything else with kRerollIdataDensity carries one flat outcome array.
+bool has_int_groups(uint16_t opcode) {
+  return opcode == OP_BINOMIAL_LPMF || opcode == OP_BINOMIAL_LOGIT_LPMF ||
+         opcode == OP_BETA_BINOMIAL_LPMF;
+}
+
+int64_t group_len(const int* p) { return p[0] == -1 ? 2 : 1 + p[0]; }
+int group_elem(const int* p, int64_t e) { return p[0] == -1 ? p[1] : p[1 + e]; }
+
+// The bernoulli kernels evaluate one element at a time in their summed form
+// too (densities_lpmf.cpp), so widening a lane costs them nothing. Every
+// other density trades one vectorized call for W elementwise ones.
+bool elt_costs_per_element(uint16_t opcode) {
+  return opcode != OP_BERNOULLI_LPMF && opcode != OP_BERNOULLI_LOGIT_LPMF;
+}
+
+// Outcome elements per lane, or 0 when the immediates are not a layout this
+// pass knows how to concatenate. Groups may be scalar or exactly W wide.
+int64_t idata_width(const Op& op) {
+  if (!has_op_trait(op.opcode, op_trait::kRerollIdataDensity)) return 1;
+  if (!has_int_groups(op.opcode)) return op.n_idata;
+  int64_t w = 1, m = 0;
+  while (m < op.n_idata) {
+    const int64_t len = op.idata[m];
+    if (len != -1) {
+      if (len < 1 || m + 1 + len > op.n_idata) return 0;
+      if (w != 1 && w != len) return 0;
+      w = len;
+    }
+    m += group_len(op.idata + m);
+  }
+  return m == op.n_idata ? w : 0;
 }
 
 struct Lane {
@@ -88,13 +133,15 @@ enum class Emit {
   kEltDensity,   // density consumed in-lane: variant bit 6, out[l] is lane l
   kTermDensity,  // every lane's out is a term: one summed density
   kTermWiden,    // every lane's out is a term: widen, then reduce
+  kStore,        // the lane ends in an element store: one slice store
 };
 
 struct Pos {
   Emit emit = Emit::kShared;
   std::vector<PosIn> ins;
-  std::vector<int> idx;  // kSlice: {start}; kGather: L * width indices
+  std::vector<int> idx;  // kSlice/kStore: {start[, stride]}; kGather: indices
   int64_t width = 1;     // output elements per lane; ignored when kShared
+  int64_t rows = 1;      // kEltDensity: outcome elements reduced back per lane
   bool shared = false;   // one value stands for every lane
   int out = -1;          // filled during emission
 };
@@ -170,6 +217,16 @@ PartitionStats partition_lanes(Graph& g, Fills& fills,
   const auto any_at_or_after = [&](const std::vector<size_t>& v, size_t x) {
     return first_at_or_after(v, x) != v.end();
   };
+  // The first entry in [lo, hi) that is not one of `mine`, else n_ops.
+  const auto first_in_range_but = [&](const std::vector<size_t>& v, size_t lo,
+                                      size_t hi,
+                                      const std::unordered_set<size_t>& mine) {
+    for (auto it = first_at_or_after(v, lo); it != v.end() && *it < hi; ++it) {
+      ++st.list_steps;
+      if (mine.count(*it) == 0) return *it;
+    }
+    return n_ops;
+  };
 
   // ---- segmentation ---------------------------------------------------
   std::vector<Lane> lanes;
@@ -237,8 +294,18 @@ PartitionStats partition_lanes(Graph& g, Fills& fills,
         key.w.push_back(it == pos_of.end() ? -1 : it->second);
       }
       key.w.push_back(op.n_idata);
-      if (!idata_is_shape(op.opcode))
+      if (!idata_is_shape(op.opcode)) {
         for (int64_t m = 0; m < op.n_idata; ++m) key.w.push_back(op.idata[m]);
+      } else if (has_int_groups(op.opcode)) {
+        // The group widths, not their values: a scalar group and a vector
+        // group concatenate differently and must not share a bucket.
+        for (int64_t m = 0; m < op.n_idata;) {
+          key.w.push_back(op.idata[m]);
+          const int64_t step = group_len(op.idata + m);
+          if (step < 2) break;
+          m += step;
+        }
+      }
       pos_of[op.out] = (int)(u - lane.begin);
     }
     if (!ok) continue;
@@ -256,7 +323,14 @@ PartitionStats partition_lanes(Graph& g, Fills& fills,
   std::vector<int> emit_at(n_ops, -1);
   std::vector<std::vector<Op>> emitted;
 
-  for (const std::vector<int>& ids : buckets) {
+  // A worklist rather than a loop: a bucket whose base is written between two
+  // of its lanes splits at that op and both halves are reconsidered, so an
+  // interleaved model still gets the lanes on either side. Splits are capped
+  // for the reason the per-period arrays in reroll.cpp are.
+  std::vector<std::vector<int>> work(buckets.begin(), buckets.end());
+  int64_t splits = 0;
+  for (size_t bi = 0; bi < work.size(); ++bi) {
+    const std::vector<int> ids = work[bi];
     const int64_t L = (int64_t)ids.size();
     if (L < kMinLanes) continue;
     const Lane& lane0 = lanes[(size_t)ids[0]];
@@ -265,14 +339,42 @@ PartitionStats partition_lanes(Graph& g, Fills& fills,
     const auto op_at = [&](int p, int64_t l) -> const Op& {
       return g.ops[lanes[(size_t)ids[(size_t)l]].begin + (size_t)p];
     };
-    // Every slot the fused ops read from outside the bucket must be finished
-    // before the first lane: a later writer is a cross-lane recurrence, a
-    // mid-bucket store, or a destructive update, and the fused read happens
-    // at the first lane's position.
-    const auto settled = [&](int s) {
-      return s >= 0 && (size_t)s < n_slots &&
-             !any_at_or_after(writers[(size_t)s], first_begin);
+    // Split at the op that broke the run and requeue the halves. A lane
+    // straddling it belongs to neither.
+    size_t split_at = n_ops;
+    const auto split_here = [&]() {
+      if (split_at >= n_ops || splits >= kMaxSplits) return;
+      std::vector<int> lo, hi;
+      for (int id : ids) {
+        if (lanes[(size_t)id].end <= split_at)
+          lo.push_back(id);
+        else if (lanes[(size_t)id].begin > split_at)
+          hi.push_back(id);
+      }
+      if (lo.size() == ids.size() || hi.size() == ids.size()) return;
+      ++splits;
+      if ((int64_t)lo.size() >= kMinLanes) work.push_back(std::move(lo));
+      if ((int64_t)hi.size() >= kMinLanes) work.push_back(std::move(hi));
     };
+    // Every slot the fused ops read from outside the bucket must hold still
+    // for the length of the run: a writer between the lanes is a cross-lane
+    // recurrence, a mid-bucket store, or a destructive update, and the fused
+    // read happens at the first lane's position.
+    const size_t last_end = lanes[(size_t)ids[(size_t)(L - 1)]].end;
+    const auto settled = [&](int s) {
+      if (s < 0 || (size_t)s >= n_slots) return false;
+      const auto it = first_at_or_after(writers[(size_t)s], first_begin);
+      if (it == writers[(size_t)s].end() || *it >= last_end) return true;
+      split_at = std::min(split_at, *it);
+      return false;
+    };
+    // A store-delimited bucket owns its base: the base is the one slot the
+    // lanes write, so its proof runs against the whole run instead.
+    const bool store_delim = is_element_store(op_at(k - 1, 0));
+    std::unordered_set<size_t> delim_at;
+    if (store_delim)
+      for (int64_t l = 0; l < L; ++l)
+        delim_at.insert(lanes[(size_t)ids[(size_t)l]].end - 1);
 
     pos_of.clear();
     for (int p = 0; p < k; ++p) pos_of[op_at(p, 0).out] = p;
@@ -284,9 +386,9 @@ PartitionStats partition_lanes(Graph& g, Fills& fills,
       Pos& ap = pos[(size_t)p];
       ap.ins.resize((size_t)t.n_in);
       const bool is_term = term_set.count(t.out) != 0;
-      bool all_shared = true;   // this op computes one value for every lane
-      int64_t width = 0;        // per-lane elements of the varying inputs
-      bool wide_shared = false; // a shared input the kernels cannot broadcast
+      bool all_shared = true;    // this op computes one value for every lane
+      int64_t width = 0;         // per-lane elements of the varying inputs
+      bool wide_shared = false;  // a shared input the kernels cannot broadcast
 
       for (int j = 0; j < t.n_in && ok; ++j) {
         PosIn& in = ap.ins[(size_t)j];
@@ -309,6 +411,7 @@ PartitionStats partition_lanes(Graph& g, Fills& fills,
           invariant = op_at(p, l).in[j] == t.in[j];
         if (invariant) {
           in.kind = InKind::kInvariant;
+          if (store_delim && p == k - 1 && j == 0) continue;
           if (!settled(t.in[j])) ok = false;
           if (t.in[j] >= 0 && g.slots[(size_t)t.in[j]].len != 1)
             wide_shared = true;
@@ -346,24 +449,29 @@ PartitionStats partition_lanes(Graph& g, Fills& fills,
       // Indexed reads of a base the whole bucket shares. These are the only
       // positions whose immediates may differ across lanes without the op
       // itself being lane-varying work.
+      const bool strided_read = t.opcode == OP_SLICE_STRIDED && t.n_idata == 2;
       const bool indexed_read =
-          (t.opcode == OP_INDEX || t.opcode == OP_SLICE) && t.n_in == 1 &&
-          t.n_idata == 1 && !is_term &&
-          ap.ins[0].kind == InKind::kInvariant && !idata_shared;
-      if (indexed_read) {
+          ((t.opcode == OP_INDEX || t.opcode == OP_SLICE) && t.n_idata == 1) ||
+          strided_read;
+      if (indexed_read && t.n_in == 1 && !is_term &&
+          ap.ins[0].kind == InKind::kInvariant && !idata_shared) {
         const int64_t blen = g.slots[(size_t)t.in[0]].len;
         const int64_t w = g.slots[(size_t)t.out].len;
+        const int64_t step = strided_read ? t.idata[1] : 1;
         ap.width = w;
         ap.idx.reserve((size_t)(L * w));
-        bool run = true;
+        bool run = step == 1;
         for (int64_t l = 0; l < L; ++l) {
-          const int64_t start = op_at(p, l).idata[0];
-          if (start < 0 || start + w > blen) {
+          const Op& o = op_at(p, l);
+          const int64_t start = o.idata[0];
+          if (start < 0 || step < 1 || start + (w - 1) * step >= blen ||
+              (strided_read && o.idata[1] != step)) {
             ok = false;
             break;
           }
           if (start != t.idata[0] + l * w) run = false;
-          for (int64_t e = 0; e < w; ++e) ap.idx.push_back((int)(start + e));
+          for (int64_t e = 0; e < w; ++e)
+            ap.idx.push_back((int)(start + e * step));
         }
         if (!ok) break;
         if (run && w == 1 && t.idata[0] == 0 && blen == L) {
@@ -374,6 +482,45 @@ PartitionStats partition_lanes(Graph& g, Fills& fills,
         } else {
           ap.emit = Emit::kGather;
         }
+        continue;
+      }
+
+      // The lane ends by writing one element of a vector nothing else reads
+      // while the run is in flight (Survey_model's lp_parts accumulator).
+      // Indices that march by a constant stride become one slice store.
+      if (store_delim && p == k - 1) {
+        const int vec = t.in[0];
+        const int64_t blen = g.slots[(size_t)vec].len;
+        const int64_t start = t.idata[0];
+        const int64_t step = L >= 2 ? (int64_t)op_at(p, 1).idata[0] - start : 1;
+        ok = ap.ins[0].kind == InKind::kInvariant &&
+             (ap.ins[1].kind == InKind::kLaneLocal ||
+              ap.ins[1].kind == InKind::kConstLanes) &&
+             width == 1 && step >= 1 && start >= 0 &&
+             start + (L - 1) * step < blen && root_set.count(vec) == 0 &&
+             term_set.count(vec) == 0;
+        for (int64_t l = 1; l < L && ok; ++l)
+          ok = op_at(p, l).idata[0] == start + l * step;
+        // The whole run moves to the first lane's position, so nothing may
+        // read the vector half-written, and a writer after it would need the
+        // tail renaming this pass deliberately does not do.
+        if (ok) {
+          const size_t reader = first_in_range_but(
+              uses[(size_t)vec], first_begin, last_end, delim_at);
+          const size_t other = first_in_range_but(
+              writers[(size_t)vec], first_begin, last_end, delim_at);
+          if (reader < n_ops || other < n_ops) {
+            split_at = std::min(split_at, std::min(reader, other));
+            ok = false;
+          } else if (any_at_or_after(writers[(size_t)vec], last_end)) {
+            ok = false;
+          }
+        }
+        if (!ok) break;
+        ap.emit = Emit::kStore;
+        ap.width = 1;
+        ap.idx.assign(1, (int)start);
+        if (step != 1) ap.idx.push_back((int)step);
         continue;
       }
 
@@ -405,18 +552,17 @@ PartitionStats partition_lanes(Graph& g, Fills& fills,
         continue;
       }
       if (has_op_trait(t.opcode, op_trait::kRerollAnyDensity)) {
-        // The idata densities carrying more than one immediate (the
-        // binomials' two integer groups) need the group concatenation that
-        // is not in this slice yet.
-        if (has_op_trait(t.opcode, op_trait::kRerollIdataDensity) &&
-            t.n_idata != 1) {
+        // A width-W outcome group is W lps per lane: the real arguments are
+        // W wide too, and a lane that consumes its density rather than
+        // ending at it needs them summed back per lane.
+        const int64_t dw = idata_width(t);
+        const int64_t w = all_shared ? dw : width;
+        if (dw < 1 || (dw != 1 && dw != w)) {
           ok = false;
           break;
         }
-        if (width != 1) {
-          ok = false;
-          break;
-        }
+        ap.width = 1;
+        ap.rows = w;
         ap.emit = is_term ? Emit::kTermDensity : Emit::kEltDensity;
         continue;
       }
@@ -430,40 +576,82 @@ PartitionStats partition_lanes(Graph& g, Fills& fills,
       }
       ok = false;
     }
-    if (!ok) continue;
-    // Exactly one target term per lane, at the delimiter: any other
-    // disposition would leave the term list describing work that no longer
-    // happens.
+    if (!ok) {
+      split_here();
+      continue;
+    }
+    // Exactly one delimiter per lane, at its end: any other disposition
+    // would leave the term list -- or the vector the lane stores into --
+    // describing work that no longer happens.
     for (int p = 0; p < k && ok; ++p) {
-      const bool term = pos[(size_t)p].emit == Emit::kTermDensity ||
-                        pos[(size_t)p].emit == Emit::kTermWiden;
-      ok = term == (p == k - 1);
+      const Emit e = pos[(size_t)p].emit;
+      const bool delim =
+          e == Emit::kTermDensity || e == Emit::kTermWiden || e == Emit::kStore;
+      ok = delim == (p == k - 1);
     }
     if (!ok) continue;
 
-    int64_t added = 0, ops_out = 0;
-    for (const Pos& ap : pos) {
+    // Lanes identical down to their immediates and their external slots are
+    // one op once CSE runs, and the fused form evaluates all L of them. That
+    // is the whole cost of fusing a bucket the const pool already collapsed.
+    std::unordered_set<uint64_t> lane_hash;
+    for (int64_t l = 0; l < L; ++l) {
+      uint64_t h = 1469598103934665603ull;
+      const auto mix = [&h](int64_t v) {
+        h = (h ^ (uint64_t)v) * 1099511628211ull;
+      };
+      for (int p = 0; p < k; ++p) {
+        const Op& o = op_at(p, l);
+        const Pos& ap = pos[(size_t)p];
+        for (int j = 0; j < o.n_in; ++j)
+          mix(ap.ins[(size_t)j].kind == InKind::kLaneLocal ? -1 : o.in[j]);
+        for (int64_t m = 0; m < o.n_idata; ++m) mix(o.idata[m]);
+      }
+      lane_hash.insert(h);
+    }
+    const int64_t distinct = (int64_t)lane_hash.size();
+
+    int64_t added = 0, ops_out = 0, lane_elems = 0;
+    for (int p = 0; p < k; ++p) {
+      const Pos& ap = pos[(size_t)p];
       switch (ap.emit) {
         case Emit::kElide:
           break;
         case Emit::kSlice:
           ++ops_out;
           added += L * ap.width;  // contiguous: no index array, no scatter
+          lane_elems += 2 * ap.width;
           break;
         case Emit::kGather:
           ++ops_out;
           added += 2 * L * ap.width;  // gathered forward, scattered back
+          lane_elems += 2 * ap.width;
           break;
         case Emit::kTermWiden:
           ops_out += 2;
+          lane_elems += 2 * ap.width;
+          break;
+        case Emit::kShared:
+          ++ops_out;
+          break;
+        case Emit::kEltDensity:
+          ops_out += ap.rows > 1 ? 2 : 1;
+          lane_elems += ap.rows * kDensityElem;
+          if (ap.rows > 1 && elt_costs_per_element(op_at(p, 0).opcode))
+            added += L * ap.rows * kDensityElem;
+          break;
+        case Emit::kTermDensity:
+          ++ops_out;
+          lane_elems += ap.rows * kDensityElem;
           break;
         default:
           ++ops_out;
+          lane_elems += 2 * ap.width;
           break;
       }
     }
-    added += ops_out * kOpCost;
-    if (L * (int64_t)k * kOpCost <= added + kPartitionMargin) {
+    added += ops_out * kOpCost + (L - distinct) * lane_elems;
+    if (distinct * (int64_t)k * kOpCost <= added + kPartitionMargin) {
       ++st.declined;
       continue;
     }
@@ -476,13 +664,26 @@ PartitionStats partition_lanes(Graph& g, Fills& fills,
       o.idata = g.idata_pool.back().data();
       o.n_idata = (int64_t)g.idata_pool.back().size();
     };
-    // The fused lpmf's outcome vector is the lanes' immediates.
-    const auto attach_outcomes = [&](Op& o, int p) {
+    // The fused lpmf's outcome vector is the lanes' immediates, laid out the
+    // way the kernel unpacks them: one flat array, or group by group with a
+    // [len, vals...] header each, every group widened to the fused length.
+    const auto attach_outcomes = [&](Op& o, int p, int64_t w) {
       if (!has_op_trait(o.opcode, op_trait::kRerollIdataDensity)) return;
-      std::vector<int> outcomes;
-      outcomes.reserve((size_t)L);
-      for (int64_t l = 0; l < L; ++l) outcomes.push_back(op_at(p, l).idata[0]);
-      attach_idata(o, std::move(outcomes));
+      const Op& t = op_at(p, 0);
+      std::vector<int> v;
+      if (!has_int_groups(o.opcode)) {
+        v.reserve((size_t)(L * w));
+        for (int64_t l = 0; l < L; ++l)
+          for (int64_t e = 0; e < w; ++e) v.push_back(op_at(p, l).idata[e]);
+      } else {
+        for (int64_t m = 0; m < t.n_idata; m += group_len(t.idata + m)) {
+          v.push_back((int)(L * w));
+          for (int64_t l = 0; l < L; ++l)
+            for (int64_t e = 0; e < w; ++e)
+              v.push_back(group_elem(op_at(p, l).idata + m, e));
+        }
+      }
+      attach_idata(o, std::move(v));
     };
     const auto swap_terms = [&](int p, int new_term) {
       std::unordered_set<int> dead;
@@ -545,19 +746,26 @@ PartitionStats partition_lanes(Graph& g, Fills& fills,
         case Emit::kRowSum:
           op.opcode = OP_SUM_ROWS;
           op.out = g.add_slot(L, false);
-          attach_idata(op, std::vector<int>{
-                               (int)pos[(size_t)ap.ins[0].producer].width});
+          attach_idata(
+              op, std::vector<int>{(int)pos[(size_t)ap.ins[0].producer].width});
           ap.out = op.out;
           break;
         case Emit::kEltDensity:
           op.variant = (uint8_t)(op.variant | 0x40u);
-          op.out = g.add_slot(L, false);
-          attach_outcomes(op, p);
+          op.out = g.add_slot(L * ap.rows, false);
+          attach_outcomes(op, p, ap.rows);
           ap.out = op.out;
           break;
         case Emit::kTermDensity:
           op.out = g.add_slot(1, false);
-          attach_outcomes(op, p);
+          attach_outcomes(op, p, ap.rows);
+          ap.out = op.out;
+          break;
+        case Emit::kStore:
+          op.opcode = ap.idx.size() == 1 ? OP_SET_SLICE_INPLACE
+                                         : OP_SET_SLICE_STRIDED_INPLACE;
+          op.out = t.in[0];
+          attach_idata(op, std::move(ap.idx));
           ap.out = op.out;
           break;
         default:  // kWiden, kTermWiden
@@ -566,7 +774,16 @@ PartitionStats partition_lanes(Graph& g, Fills& fills,
           break;
       }
       out_ops.push_back(op);
-      if (ap.emit == Emit::kTermDensity) {
+      if (ap.emit == Emit::kEltDensity && ap.rows > 1) {
+        Op rows;
+        rows.opcode = OP_SUM_ROWS;
+        rows.n_in = 1;
+        rows.in[0] = op.out;
+        rows.out = g.add_slot(L, false);
+        attach_idata(rows, std::vector<int>{(int)ap.rows});
+        out_ops.push_back(rows);
+        ap.out = rows.out;
+      } else if (ap.emit == Emit::kTermDensity) {
         swap_terms(p, op.out);
       } else if (ap.emit == Emit::kTermWiden) {
         Op sum;

--- a/tests/test_partition.cpp
+++ b/tests/test_partition.cpp
@@ -153,8 +153,7 @@ static void test_interleaved_lanes() {
   expect("interleaved one group", st.groups == 1 && st.lanes == 8);
   expect("interleaved keeps the intruder", count_opcode(b.g, OP_EXP) == 1);
   expect("interleaved op count", b.g.ops.size() == 3);
-  expect("interleaved two terms",
-         tt.size() == 2 && tt[1] == foreign_term);
+  expect("interleaved two terms", tt.size() == 2 && tt[1] == foreign_term);
   expect_same_grad("interleaved", std::move(b.g), f2, tt, want);
 }
 
@@ -187,9 +186,9 @@ static void test_scattered_indices() {
   const PartitionStats st = partition_lanes(g, f2, tt, {});
   expect("scattered one group", st.groups == 1 && st.lanes == L);
   expect("scattered one gather", count_opcode(g, OP_GATHER) == 1);
-  expect("scattered lane order",
-         g.ops[0].n_idata == L && g.ops[0].idata[0] == pick[0] &&
-             g.ops[0].idata[3] == pick[3]);
+  expect("scattered lane order", g.ops[0].n_idata == L &&
+                                     g.ops[0].idata[0] == pick[0] &&
+                                     g.ops[0].idata[3] == pick[3]);
   expect_same_grad("scattered", std::move(g), f2, tt, want);
 }
 
@@ -290,8 +289,8 @@ static void test_refuse_identical_terms() {
 
 // The same shape with an integer outcome (multi_occupancy's detection terms):
 // here the lanes' immediates concatenate, so the one fused op does compute
-// eight lps and the fusion is the right answer.
-static void test_identical_idata_terms() {
+// L lps and the fusion is the right answer.
+static void test_idata_terms() {
   const int L = 16;  // one op per lane: below this the margin declines it
   Graph g;
   Fills fills;
@@ -299,7 +298,7 @@ static void test_identical_idata_terms() {
   std::vector<int> terms;
   for (int l = 0; l < L; ++l) {
     const int lp = g.add_slot(1, false);
-    const int id = g.add_op(OP_BERNOULLI_LPMF, {theta}, lp, {1});
+    const int id = g.add_op(OP_POISSON_LPMF, {theta}, lp, {l});
     g.ops[(size_t)id].variant = 0x81;
     terms.push_back(lp);
   }
@@ -314,6 +313,248 @@ static void test_identical_idata_terms() {
   expect_same_grad("idata terms", std::move(g), f2, tt, want);
 }
 
+// The lanes above with the outcome held constant: byte-identical lanes are
+// one op once CSE runs, so fusing them evaluates the density L times where
+// the scalar graph evaluates it once.
+static void test_duplicate_lanes_decline() {
+  const int L = 16;
+  Graph g;
+  Fills fills;
+  const int theta = g.add_slot(1, true);
+  std::vector<int> terms;
+  for (int l = 0; l < L; ++l) {
+    const int lp = g.add_slot(1, false);
+    const int id = g.add_op(OP_BERNOULLI_LPMF, {theta}, lp, {1});
+    g.ops[(size_t)id].variant = 0x81;
+    terms.push_back(lp);
+  }
+  const size_t before = g.ops.size();
+
+  std::vector<int> tt = terms;
+  Fills f2 = fills;
+  const PartitionStats st = partition_lanes(g, f2, tt, {});
+  expect("duplicate lanes decline", st.groups == 0 && st.declined == 1);
+  expect("duplicate graph unchanged", g.ops.size() == before && tt == terms);
+}
+
+// The capture-recapture shape: a density carrying two integer groups, one
+// varying per lane and one not. Fusing concatenates group by group, in the
+// [len, vals...] layout the kernels unpack.
+static void test_binomial_idata_groups() {
+  const int L = 8;
+  Graph g;
+  Fills fills;
+  const int theta = g.add_slot(1, true);
+  const int prior = g.add_slot(1, true);
+  std::vector<int> terms;
+  for (int l = 0; l < L; ++l) {
+    const int lp = g.add_slot(1, false);
+    const int id = g.add_op(OP_BINOMIAL_LPMF, {theta}, lp, {-1, l, -1, L});
+    g.ops[(size_t)id].variant = 0x01;
+    const int t = g.add_slot(1, false);
+    g.add_op(OP_ADD, {prior, lp}, t);
+    terms.push_back(t);
+  }
+  const std::vector<double> want = reference(g, fills, terms);
+
+  std::vector<int> tt = terms;
+  Fills f2 = fills;
+  const PartitionStats st = partition_lanes(g, f2, tt, {});
+  expect("groups one group", st.groups == 1 && st.lanes == L);
+  expect("groups op count", g.ops.size() == 3 && tt.size() == 1);
+  bool layout = g.ops[0].n_idata == 2 * (L + 1);
+  if (layout) {
+    layout = g.ops[0].idata[0] == L && g.ops[0].idata[L + 1] == L;
+    for (int l = 0; l < L; ++l)
+      layout = layout && g.ops[0].idata[1 + l] == l &&
+               g.ops[0].idata[L + 2 + l] == L;
+  }
+  expect("groups concatenate per group", layout);
+  expect_same_grad("groups", std::move(g), f2, tt, want);
+}
+
+// A width-5 outcome group read through a strided window: the lanes' real
+// arguments become one gather and the lps come back per lane through
+// OP_SUM_ROWS, because the lane consumes its density rather than ending at it.
+static void test_width_w_outcome_group() {
+  const int L = 24, W = 5;
+  Graph g;
+  Fills fills;
+  const int base = g.add_slot(L * W, true);
+  const int prior = g.add_slot(1, true);
+  std::vector<int> terms;
+  for (int l = 0; l < L; ++l) {
+    const int win = g.add_slot(W, false);
+    g.add_op(OP_SLICE_STRIDED, {base}, win, {l, L});
+    const int lp = g.add_slot(1, false);
+    const int id = g.add_op(OP_BERNOULLI_LOGIT_LPMF, {win}, lp,
+                            {l % 2, 1, 0, (l + 1) % 2, 1});
+    g.ops[(size_t)id].variant = 0x01;
+    const int t = g.add_slot(1, false);
+    g.add_op(OP_ADD, {prior, lp}, t);
+    terms.push_back(t);
+  }
+  const std::vector<double> want = reference(g, fills, terms);
+
+  std::vector<int> tt = terms;
+  Fills f2 = fills;
+  const PartitionStats st = partition_lanes(g, f2, tt, {});
+  expect("width-w one group", st.groups == 1 && st.lanes == L);
+  expect("width-w op count", g.ops.size() == 5 && tt.size() == 1);
+  expect("width-w one gather",
+         count_opcode(g, OP_GATHER) == 1 && g.ops[0].n_idata == L * W);
+  expect("width-w row sum", count_opcode(g, OP_SUM_ROWS) == 1);
+  expect("width-w idata concatenates", g.ops[1].n_idata == L * W);
+  expect_same_grad("width-w", std::move(g), f2, tt, want);
+}
+
+// Survey_model's accumulator: lanes delimited by an element store rather
+// than a term, at indices that march by one. The run becomes a single slice
+// store, and the reduction that reads the whole vector afterwards is what
+// the values have to be right for.
+static void test_store_delimited_lanes() {
+  const int L = 16, N = 40, START = 4;
+  Graph g;
+  Fills fills;
+  const int p = g.add_slot(1, true);
+  const int vec = g.add_slot(N, false);
+  std::vector<double> vals((size_t)N);
+  for (int i = 0; i < N; ++i) vals[(size_t)i] = -0.5 + 0.05 * i;
+  fills.emplace_back(vec, vals);
+  for (int l = 0; l < L; ++l) {
+    const int c = g.add_slot(1, false);
+    fills.emplace_back(c, std::vector<double>{0.3 + 0.1 * l});
+    const int m = g.add_slot(1, false);
+    g.add_op(OP_MUL, {p, c}, m);
+    g.add_op(OP_SET_INDEX_INPLACE, {vec, m}, vec, {START + l});
+  }
+  const int lse = g.add_slot(1, false);
+  g.add_op(OP_LOG_SUM_EXP, {vec}, lse);
+  const std::vector<int> terms{lse};
+  const std::vector<double> want = reference(g, fills, terms);
+
+  std::vector<int> tt = terms;
+  Fills f2 = fills;
+  const PartitionStats st = partition_lanes(g, f2, tt, {});
+  expect("store one group", st.groups == 1 && st.lanes == L);
+  expect("store op count", g.ops.size() == 3 && tt == terms);
+  expect("store one slice store",
+         count_opcode(g, OP_SET_SLICE_INPLACE) == 1 &&
+             count_opcode(g, OP_SET_INDEX_INPLACE) == 0);
+  expect("store start", g.ops[1].n_idata == 1 && g.ops[1].idata[0] == START);
+  expect_same_grad("store", std::move(g), f2, tt, want);
+}
+
+// multi_occupancy's branch structure: two templates chosen by a data
+// condition, alternating, the second a prefix-extension of the first. The
+// fingerprint separates them and each bucket is rewritten at its own first
+// lane.
+static void test_two_templates_interleaved() {
+  const int L = 12;
+  Graph g;
+  Fills fills;
+  const int base = g.add_slot(2 * L, true);
+  const int sigma = g.add_slot(1, true);
+  std::vector<int> terms;
+  for (int l = 0; l < 2 * L; ++l) {
+    const int idx = g.add_slot(1, false);
+    g.add_op(OP_INDEX, {base}, idx, {l});
+    const int y = g.add_slot(1, false);
+    fills.emplace_back(y, std::vector<double>{0.2 * l - 0.5});
+    const int lp = g.add_slot(1, false);
+    const int id = g.add_op(OP_NORMAL_LPDF, {y, idx, sigma}, lp);
+    g.ops[(size_t)id].variant = 0x06;
+    if (l % 2 == 0) {
+      terms.push_back(lp);
+      continue;
+    }
+    const int mixed = g.add_slot(1, false);
+    g.add_op(OP_LSE2, {lp, sigma}, mixed);
+    terms.push_back(mixed);
+  }
+  const std::vector<double> want = reference(g, fills, terms);
+
+  std::vector<int> tt = terms;
+  Fills f2 = fills;
+  const PartitionStats st = partition_lanes(g, f2, tt, {});
+  expect("two templates two groups", st.groups == 2 && st.lanes == 2 * L);
+  expect("two templates op count", g.ops.size() == 6 && tt.size() == 2);
+  expect("two templates two gathers", count_opcode(g, OP_GATHER) == 2);
+  expect_same_grad("two templates", std::move(g), f2, tt, want);
+}
+
+// A write to the gathered base between lanes 7 and 8. The lanes on either
+// side read different contents, so the bucket splits at the writer instead of
+// declining -- and the split is what the gradient check is really testing.
+static void test_mid_bucket_writer_split() {
+  const int L = 16, N = 20;
+  Graph g;
+  Fills fills;
+  const int p = g.add_slot(N, true);
+  const int sigma = g.add_slot(1, true);
+  const int base = g.add_slot(N, false);
+  g.add_op(OP_EXPV, {p}, base);
+  std::vector<int> terms;
+  for (int l = 0; l < L; ++l) {
+    if (l == 8) g.add_op(OP_SET_INDEX_INPLACE, {base, sigma}, base, {3});
+    const int idx = g.add_slot(1, false);
+    g.add_op(OP_INDEX, {base}, idx, {(3 * l) % N});
+    const int y = g.add_slot(1, false);
+    fills.emplace_back(y, std::vector<double>{0.2 * l - 0.5});
+    const int lp = g.add_slot(1, false);
+    const int id = g.add_op(OP_NORMAL_LPDF, {y, idx, sigma}, lp);
+    g.ops[(size_t)id].variant = 0x06;
+    terms.push_back(lp);
+  }
+  const std::vector<double> want = reference(g, fills, terms);
+
+  std::vector<int> tt = terms;
+  Fills f2 = fills;
+  const PartitionStats st = partition_lanes(g, f2, tt, {});
+  expect("split two groups", st.groups == 2 && st.lanes == L);
+  expect("split keeps the writer", count_opcode(g, OP_SET_INDEX_INPLACE) == 1);
+  expect("split two gathers", count_opcode(g, OP_GATHER) == 2);
+  expect_same_grad("split", std::move(g), f2, tt, want);
+}
+
+// The reader half of the same hazard: a second bucket's lanes read the vector
+// the first bucket's lanes store into. Nothing may read a vector while its
+// run is in flight, so the store bucket refuses and the readers still see
+// every element written.
+static void test_cross_bucket_read_after_write() {
+  const int L = 8, N = 24;
+  Graph g;
+  Fills fills;
+  const int p = g.add_slot(1, true);
+  const int vec = g.add_slot(N, false);
+  std::vector<double> vals((size_t)N);
+  for (int i = 0; i < N; ++i) vals[(size_t)i] = 0.1 + 0.05 * i;
+  fills.emplace_back(vec, vals);
+  std::vector<int> terms;
+  for (int l = 0; l < L; ++l) {
+    const int c = g.add_slot(1, false);
+    fills.emplace_back(c, std::vector<double>{0.3 + 0.1 * l});
+    const int m = g.add_slot(1, false);
+    g.add_op(OP_MUL, {p, c}, m);
+    g.add_op(OP_SET_INDEX_INPLACE, {vec, m}, vec, {l});
+    const int r = g.add_slot(1, false);
+    g.add_op(OP_INDEX, {vec}, r, {l});
+    const int lp = g.add_slot(1, false);
+    const int id = g.add_op(OP_NORMAL_LPDF, {r, p, p}, lp);
+    g.ops[(size_t)id].variant = 0x07;
+    terms.push_back(lp);
+  }
+  const std::vector<double> want = reference(g, fills, terms);
+
+  std::vector<int> tt = terms;
+  Fills f2 = fills;
+  const PartitionStats st = partition_lanes(g, f2, tt, {});
+  expect("cross-bucket store refuses",
+         st.groups == 0 && count_opcode(g, OP_SET_INDEX_INPLACE) == L &&
+             count_opcode(g, OP_SET_SLICE_INPLACE) == 0);
+  expect_same_grad("cross-bucket", std::move(g), f2, tt, want);
+}
+
 static void test_kill_switch() {
   Lanes b = build_index_lanes(8);
   const size_t before = b.g.ops.size();
@@ -322,8 +563,8 @@ static void test_kill_switch() {
   test_setenv("STANLI_NO_PARTITION", "1", 1);
   const PartitionStats st = partition_lanes(b.g, f2, tt, {});
   test_unsetenv("STANLI_NO_PARTITION");
-  expect("kill switch", st.groups == 0 && b.g.ops.size() == before &&
-                            tt == b.terms);
+  expect("kill switch",
+         st.groups == 0 && b.g.ops.size() == before && tt == b.terms);
 }
 
 // state_space_stochastic_level_stochastic_seasonal, in miniature: a window-sum
@@ -461,8 +702,7 @@ static void test_scaling() {
       " n=16000 %.3f s / %lld segment / %lld list, peak RSS %.0f MB\n",
       small.sec, (long long)small.segment, (long long)small.list, big.sec,
       (long long)big.segment, (long long)big.list, rss);
-  expect("segmentation is exactly linear",
-         big.segment == 2 * small.segment);
+  expect("segmentation is exactly linear", big.segment == 2 * small.segment);
   expect("list reads stay near-linear", big.list < 3 * small.list);
   if (rss > 0.0) expect("partition space stays linear", rss < 1024.0);
 }
@@ -482,7 +722,14 @@ int main() {
   test_refuse_effectful();
   test_refuse_escaping_intermediate();
   test_refuse_identical_terms();
-  test_identical_idata_terms();
+  test_idata_terms();
+  test_duplicate_lanes_decline();
+  test_binomial_idata_groups();
+  test_width_w_outcome_group();
+  test_store_delimited_lanes();
+  test_two_templates_interleaved();
+  test_mid_bucket_writer_split();
+  test_cross_bucket_read_after_write();
   test_kill_switch();
   test_state_space_shape();
   test_cost_declines();


### PR DESCRIPTION
Idata-group concatenation (binomial n/y pairs, width-W outcomes, store-delimited lanes) and multi-template bucket emission with mid-range-writer splitting. Two measured pessimizations are encoded in the cost model instead of shipped: the per-element density arm costs more than the summed vector form (bernoulli_logit gains a packet elementwise form; the binomials decline until they have one), and fusing duplicate lanes re-expands what CSE collapsed.

Mth 1,563 to 35 ops (1.63x), Mh 1,542 to 18 (1.53x), Mtbh 1.43x, Mb 1.09x, multi_occupancy 1.05x. ctest 61/61, corpus 129/129 unmoved, A/B worst 7.87e-16, kill switch exact.