### PR TITLE
perf: elementwise binomials and IRT GLM synthesis

### DIFF
--- a/runtime/kernels/densities_lpmf.cpp
+++ b/runtime/kernels/densities_lpmf.cpp
@@ -293,9 +293,92 @@ int int_group_elem(const int* p, int64_t n) {
 const int* int_group_next(const int* p) {
   return p + (p[0] == -1 ? 2 : 1 + p[0]);
 }
-#define STANLI_BINOMIAL_FWD(fname, dist)                                  \
+// The elementwise variant with the per-element recorder call left off: this
+// walks stan-math's own branches for element i's value and its one partial,
+// so each element is what the scalar op it replaces computed, without a
+// tape. Survey_model presents 2,370 of them in one op, and at that width
+// two things the summed form does once per call have to stay once per call:
+// the argument checks, and the logs of a broadcast probability.
+template <bool Logit>
+void binomial_elt_vector_fwd(KernelCtx& ctx) {
+  static constexpr const char* function =
+      Logit ? "binomial_logit_lpmf" : "binomial_lpmf";
+  const int* g1 = ctx.idata;
+  const int* g2 = int_group_next(g1);
+  const Desc& theta = ctx.in[0];
+  const int64_t len = ctx.out.len;
+  const bool active = (ctx.variant & 0x01u) != 0;
+  const bool propto = (ctx.variant & 0x80u) != 0;
+  std::fill_n(ctx.scratch, static_cast<size_t>(2 * len), 0.0);
+  with_int_group(g1, [&](const auto& n, const int*) {
+    with_int_group(g2, [&](const auto& trials, const int*) {
+      stan::math::check_bounded(function, "Successes variable", n, 0, trials);
+      stan::math::check_nonnegative(function, "Population size parameter",
+                                    trials);
+    });
+  });
+  const Eigen::Map<const Eigen::VectorXd> theta_vec(theta.data, theta.len);
+  if constexpr (Logit) {
+    stan::math::check_finite(function, "Probability parameter", theta_vec);
+  } else {
+    stan::math::check_bounded(function, "Probability parameter", theta_vec, 0.0,
+                              1.0);
+  }
+  if (propto && !active) {
+    std::fill_n(ctx.out.data, static_cast<size_t>(len), 0.0);
+    return;
+  }
+  const bool one_theta = theta.len == 1;
+  double la = 0.0, lb = 0.0;
+  const auto logs = [&](double t) {
+    if constexpr (Logit) {
+      la = stan::math::log_inv_logit(t);
+      lb = stan::math::log1m_inv_logit(t);
+    } else {
+      la = std::log(t);
+      lb = stan::math::log1m(t);
+    }
+  };
+  if (one_theta) logs(theta.data[0]);
+  for (int64_t i = 0; i < len; ++i) {
+    const int n = int_group_elem(g1, i);
+    const int trials = int_group_elem(g2, i);
+    const double t = theta.data[one_theta ? 0 : i];
+    if (!one_theta) logs(t);
+    double lp = 0.0, partial = 0.0;
+    if constexpr (Logit) {
+      lp = n * la + (trials - n) * lb;
+      if (!propto) lp += stan::math::binomial_coefficient_log(trials, n);
+      partial = n - trials * std::exp(la);
+    } else {
+      if (!propto) lp += stan::math::binomial_coefficient_log(trials, n);
+      if (trials != 0) {
+        if (n == 0) {
+          lp += trials * lb;
+          partial = -(trials / (1.0 - t));
+        } else if (n == trials) {
+          lp += n * la;
+          partial = n / t;
+        } else {
+          lp += n * la + (trials - n) * lb;
+          partial = n / t - (trials - n) / (1.0 - t);
+        }
+      }
+    }
+    ctx.out.data[i] = lp;
+    if (!active) continue;
+    ctx.scratch[i] = partial;
+    ctx.scratch[len + i] = 1.0;
+  }
+}
+
+#define STANLI_BINOMIAL_FWD(fname, dist, logit)                           \
   void fname(KernelCtx& ctx) {                                            \
     if (ctx.variant & 0x40u) {                                            \
+      if (ctx.out.len > 1) {                                              \
+        binomial_elt_vector_fwd<logit>(ctx);                              \
+        return;                                                           \
+      }                                                                   \
       const int* g1 = ctx.idata;                                          \
       const int* g2 = int_group_next(g1);                                 \
       density_fwd_elt<1, 3>(                                              \
@@ -324,8 +407,8 @@ const int* int_group_next(const int* p) {
     });                                                                   \
   }
 
-STANLI_BINOMIAL_FWD(binomial_fwd, binomial_lpmf)
-STANLI_BINOMIAL_FWD(binomial_logit_fwd, binomial_logit_lpmf)
+STANLI_BINOMIAL_FWD(binomial_fwd, binomial_lpmf, false)
+STANLI_BINOMIAL_FWD(binomial_logit_fwd, binomial_logit_lpmf, true)
 #undef STANLI_BINOMIAL_FWD
 
 // beta_binomial(n | N, alpha, beta): two integer groups, then two real

--- a/runtime/src/partition.cpp
+++ b/runtime/src/partition.cpp
@@ -24,6 +24,14 @@
 // position and the last lane's end. Ops only ever move EARLIER, so an
 // in-place store proven safe against a later reader stays safe, and a bucket
 // that trips the rule splits at the writer rather than declining.
+//
+// One arm rewrites a whole chain rather than widening it. A lane that reads
+// two scalars, multiplies them, subtracts a width-m vector, prepends a zero,
+// cumulatively sums and hands the result to a scalar-outcome categorical is
+// one row of a categorical_logit_glm_lpmf, because
+// cumsum([0, ta - b_1, ...])[j] = j*t*a - sum_{i<=j} b_i. Buckets refine on
+// the subtracted vector -- the item -- and the slope is whichever of the two
+// scalars that refinement holds still.
 #include <stanli/optable.hpp>
 #include <stanli/partition.hpp>
 
@@ -58,7 +66,13 @@ bool is_element_store(const Op& op) {
          op.n_in == 2 && op.n_idata == 1 && op.out == op.in[0];
 }
 
-bool is_blocked(const Op& op) {
+// OP_CATEGORICAL is on ops_match's blocklist because its spec pointer is not
+// comparable; here the spec's fields go into the key instead. It is admitted
+// only as a lane's delimiter, and only the GLM arm below has an emission for
+// it -- every other arm keys off a re-roll trait, which it has none of.
+bool is_blocked(const Op& op, bool is_delimiter) {
+  if (op.opcode == OP_CATEGORICAL)
+    return !is_delimiter || op.udata == nullptr || op.out2 >= 0;
   return is_effectful_op(op.opcode) || op.opcode == OP_PROD_VEC ||
          op.opcode == OP_EXTREMA_VEC || op.out2 >= 0 || op.udata != nullptr;
 }
@@ -153,6 +167,18 @@ struct Pos {
   int64_t rows = 1;      // kEltDensity: outcome elements reduced back per lane
   bool shared = false;   // one value stands for every lane
   int out = -1;          // filled during emission
+};
+
+// The IRT chain, by position within the lane. `sub` holds the OP_SUB
+// positions outermost first and `chain` every position the substitution
+// consumes; anything else in the lane has to be dead.
+struct Glm {
+  const CategoricalSpec* spec = nullptr;
+  std::vector<int> chain;
+  std::vector<int> sub;
+  std::vector<int> held;  // each SUB's subtrahend producer, -1 when external
+  int cat = -1, concat = -1, theta = -1, alpha = -1;
+  int64_t m = 0;
 };
 
 struct Key {
@@ -287,9 +313,16 @@ PartitionStats partition_lanes(Graph& g, Fills& fills,
     for (size_t u = lane.begin; u < lane.end && ok; ++u) {
       ++st.fingerprint_steps;
       const Op& op = g.ops[u];
-      if (is_blocked(op)) {
+      if (is_blocked(op, u + 1 == lane.end)) {
         ok = false;
         break;
+      }
+      if (op.opcode == OP_CATEGORICAL) {
+        const auto& spec = *static_cast<const CategoricalSpec*>(op.udata);
+        key.w.push_back(spec.logit);
+        key.w.push_back(spec.scalar_outcome);
+        key.w.push_back(spec.arg_autodiff);
+        key.w.push_back(spec.propto);
       }
       key.w.push_back(op.opcode);
       key.w.push_back(op.variant);
@@ -331,6 +364,207 @@ PartitionStats partition_lanes(Graph& g, Fills& fills,
   std::vector<char> dropped(n_ops, 0);
   std::vector<int> emit_at(n_ops, -1);
   std::vector<std::vector<Op>> emitted;
+
+  const auto attach_idata = [&](Op& o, std::vector<int> v) {
+    g.idata_pool.push_back(std::move(v));
+    o.idata = g.idata_pool.back().data();
+    o.n_idata = (int64_t)g.idata_pool.back().size();
+  };
+  // Non-contiguous dead terms are what an interleaved bucket produces, so
+  // the replacement takes the first dead entry's position and the rest of
+  // the list closes up around it.
+  const auto retire_terms = [&](const std::unordered_set<int>& dead,
+                                int new_term) {
+    std::vector<int> next;
+    next.reserve(target_terms.size());
+    bool placed = false;
+    for (int s : target_terms) {
+      if (dead.count(s) == 0) {
+        next.push_back(s);
+      } else if (!placed) {
+        next.push_back(new_term);
+        placed = true;
+      }
+    }
+    target_terms = std::move(next);
+    for (int s : dead) term_set.erase(s);
+    term_set.insert(new_term);
+  };
+
+  // Everything an item's chain reads from outside has to hold still from its
+  // first lane to its last, which is the proof the buckets below also make.
+  const auto op_of = [&](int lane_id, int p) -> const Op& {
+    return g.ops[lanes[(size_t)lane_id].begin + (size_t)p];
+  };
+  const auto emit_glm_item = [&](const std::vector<int>& ids, const Glm& glm,
+                                 int x_at, int a_at) {
+    const int64_t n = (int64_t)ids.size();
+    const auto at = [&](int p, int64_t l) -> const Op& {
+      return op_of(ids[(size_t)l], p);
+    };
+    const size_t lo = lanes[(size_t)ids[0]].begin;
+    const size_t hi = lanes[(size_t)ids[(size_t)(n - 1)]].end;
+    const auto settled = [&](int s) {
+      if (s < 0 || (size_t)s >= n_slots) return false;
+      const auto it = first_at_or_after(writers[(size_t)s], lo);
+      return it == writers[(size_t)s].end() || *it >= hi;
+    };
+
+    const int x_base = at(x_at, 0).in[0];
+    const int64_t x_len = g.slots[(size_t)x_base].len;
+    std::vector<int> rows;
+    rows.reserve((size_t)(n + 2));
+    for (int64_t l = 0; l < n; ++l) {
+      const int idx = at(x_at, l).idata[0];
+      if (idx < 0 || idx >= x_len) return false;
+      rows.push_back(idx);
+    }
+    if (!settled(x_base) || !settled(at(a_at, 0).in[0])) return false;
+
+    // The outcome is a 1-based category, and the GLM reads it as an integer
+    // out of its own immediates rather than off a slot.
+    std::vector<int> outcomes;
+    outcomes.reserve((size_t)(n + 2));
+    for (int64_t l = 0; l < n; ++l) {
+      const auto y = const_val.find(at(glm.cat, l).in[0]);
+      if (y == const_val.end() ||
+          !writers[(size_t)at(glm.cat, l).in[0]].empty())
+        return false;
+      if (!(y->second >= 1.0 && y->second <= (double)(glm.m + 1))) return false;
+      const int c = (int)y->second;
+      if ((double)c != y->second) return false;
+      outcomes.push_back(c);
+    }
+
+    std::vector<Op> out_ops;
+    const auto add = [&](uint16_t opcode, std::initializer_list<int> ins,
+                         int64_t len) {
+      Op o;
+      o.opcode = opcode;
+      o.n_in = 0;
+      for (int s : ins) o.in[o.n_in++] = s;
+      o.out = g.add_slot(len, false);
+      out_ops.push_back(o);
+      return o.out;
+    };
+    const auto carry = [&](int p, int64_t len) {
+      Op o = at(p, 0);
+      o.out = g.add_slot(len, false);
+      out_ops.push_back(o);
+      return o.out;
+    };
+
+    // The thresholds this item subtracts, summed: the chain takes them off
+    // one at a time and cumsum is linear, so their sum is the segment.
+    int seg = -1;
+    for (size_t j = 0; j < glm.sub.size(); ++j) {
+      const int q = glm.held[j];
+      const int held = at(glm.sub[j], 0).in[1];
+      int s = held;
+      if (q >= 0) {
+        if (!settled(at(q, 0).in[0])) return false;
+        s = carry(q, g.slots[(size_t)held].len);
+      } else if (!settled(held)) {
+        return false;
+      }
+      if (seg < 0)
+        seg = s;
+      else if (g.slots[(size_t)s].len > g.slots[(size_t)seg].len)
+        seg = add(OP_ADD, {s, seg}, g.slots[(size_t)s].len);
+      else
+        seg = add(OP_ADD, {seg, s}, g.slots[(size_t)seg].len);
+    }
+    if (g.slots[(size_t)seg].len != glm.m) return false;
+
+    Op gather;
+    gather.opcode = OP_GATHER;
+    gather.n_in = 1;
+    gather.in[0] = x_base;
+    gather.out = g.add_slot(n, false);
+    attach_idata(gather, rows);
+    out_ops.push_back(gather);
+
+    const int slope = g.add_slot(glm.m + 1, false);
+    std::vector<double> steps((size_t)(glm.m + 1));
+    for (int64_t j = 0; j <= glm.m; ++j) steps[(size_t)j] = (double)j;
+    fills.emplace_back(slope, std::move(steps));
+    const int zero = g.add_slot(1, false);
+    fills.emplace_back(zero, std::vector<double>{0.0});
+
+    const int beta = add(OP_MUL, {slope, carry(a_at, 1)}, glm.m + 1);
+    const int cs = add(OP_CUMSUM, {seg}, glm.m);
+    const int alpha =
+        add(OP_CONCAT2, {zero, add(OP_NEG, {cs}, glm.m)}, glm.m + 1);
+
+    Op lp;
+    lp.opcode = OP_CATEGORICAL_LOGIT_GLM_LPMF;
+    lp.n_in = 3;
+    lp.in[0] = gather.out;
+    lp.in[1] = alpha;
+    lp.in[2] = beta;
+    lp.out = g.add_slot(1, false);
+    lp.variant = (uint8_t)((glm.spec->propto ? 0x80u : 0u) | 0x7u);
+    outcomes.push_back((int)n);
+    outcomes.push_back(1);
+    attach_idata(lp, std::move(outcomes));
+    out_ops.push_back(lp);
+
+    std::unordered_set<int> dead;
+    for (int64_t l = 0; l < n; ++l) {
+      dead.insert(at(glm.cat, l).out);
+      for (size_t u = lanes[(size_t)ids[(size_t)l]].begin;
+           u < lanes[(size_t)ids[(size_t)l]].end; ++u)
+        dropped[u] = 1;
+    }
+    retire_terms(dead, lp.out);
+    emit_at[lo] = (int)emitted.size();
+    emitted.push_back(std::move(out_ops));
+    ++st.groups;
+    st.lanes += (int)n;
+    return true;
+  };
+
+  // Persons are deliberately not part of the item key: they are what the
+  // design matrix gathers, repeats and all.
+  const auto emit_glm = [&](const std::vector<int>& ids, const Glm& glm) {
+    std::unordered_map<Key, int, KeyHash> item_of;
+    std::vector<std::vector<int>> items;
+    Key key;
+    for (int id : ids) {
+      key.w.clear();
+      for (size_t j = 0; j < glm.sub.size(); ++j) {
+        const int q = glm.held[j];
+        const int held = op_of(id, glm.sub[j]).in[1];
+        key.w.push_back(q >= 0 ? op_of(id, q).in[0] : held);
+        key.w.push_back(q >= 0 ? op_of(id, q).idata[0] : -1);
+        key.w.push_back(g.slots[(size_t)held].len);
+      }
+      const auto ins = item_of.emplace(key, (int)items.size());
+      if (ins.second) items.emplace_back();
+      items[(size_t)ins.first->second].push_back(id);
+    }
+    bool any = false;
+    for (const std::vector<int>& grp : items) {
+      if ((int64_t)grp.size() < kMinLanes) continue;
+      const auto held_still = [&](int p) {
+        for (size_t l = 1; l < grp.size(); ++l)
+          if (op_of(grp[l], p).in[0] != op_of(grp[0], p).in[0] ||
+              op_of(grp[l], p).idata[0] != op_of(grp[0], p).idata[0])
+            return false;
+        return true;
+      };
+      const bool a = held_still(glm.theta), b = held_still(glm.alpha);
+      if (a == b) continue;  // the slope is whichever one the item pins
+      const int a_at = a ? glm.theta : glm.alpha;
+      const int x_at = a ? glm.alpha : glm.theta;
+      bool one_base = true;
+      for (size_t l = 1; l < grp.size(); ++l)
+        one_base =
+            one_base && op_of(grp[l], x_at).in[0] == op_of(grp[0], x_at).in[0];
+      any = (one_base && emit_glm_item(grp, glm, x_at, a_at)) || any;
+    }
+    return any;
+  };
 
   // A worklist rather than a loop: a bucket whose base is written between two
   // of its lanes splits at that op and both halves are reconsidered, so an
@@ -387,6 +621,85 @@ PartitionStats partition_lanes(Graph& g, Fills& fills,
 
     pos_of.clear();
     for (int p = 0; p < k; ++p) pos_of[op_at(p, 0).out] = p;
+    const auto local_at = [&](int slot, int before) {
+      const auto it = pos_of.find(slot);
+      return it != pos_of.end() && it->second < before ? it->second : -1;
+    };
+
+    // ---- GLM synthesis --------------------------------------------------
+    Glm glm;
+    if (op_at(k - 1, 0).opcode == OP_CATEGORICAL) {
+      const Op& cat = op_at(k - 1, 0);
+      glm.spec = static_cast<const CategoricalSpec*>(cat.udata);
+      int at = local_at(cat.in[1], k - 1);
+      bool hit = glm.spec->scalar_outcome && glm.spec->arg_autodiff &&
+                 g.slots[(size_t)cat.in[0]].len == 1 &&
+                 local_at(cat.in[0], k - 1) < 0 && at >= 0;
+      glm.chain.push_back(k - 1);
+      const auto step = [&](uint16_t opcode) {
+        if (!hit) return;
+        const Op& o = op_at(at, 0);
+        glm.chain.push_back(at);
+        hit = o.opcode == opcode && o.n_in == 1 &&
+              (at = local_at(o.in[0], at)) >= 0;
+      };
+      if (hit && !glm.spec->logit) step(OP_SOFTMAX);
+      step(OP_CUMSUM);
+      if (hit) {
+        const Op& cc = op_at(at, 0);
+        glm.chain.push_back(at);
+        glm.concat = at;
+        const auto zero = const_val.find(cc.n_in == 2 ? cc.in[0] : -1);
+        hit = cc.opcode == OP_CONCAT2 && zero != const_val.end() &&
+              zero->second == 0.0 && writers[(size_t)cc.in[0]].empty() &&
+              (at = local_at(cc.in[1], at)) >= 0;
+      }
+      // The subtrahends peel off outermost first; what is left is the
+      // product. Their sum is the segment whose cumsum the intercepts are.
+      while (hit && op_at(at, 0).n_in == 2 && op_at(at, 0).opcode == OP_SUB &&
+             glm.sub.size() < 2) {
+        glm.sub.push_back(at);
+        glm.chain.push_back(at);
+        const int held = local_at(op_at(at, 0).in[1], at);
+        glm.held.push_back(held);
+        if (held >= 0) {
+          const Op& o = op_at(held, 0);
+          glm.chain.push_back(held);
+          hit = (o.opcode == OP_INDEX || o.opcode == OP_SLICE) && o.n_in == 1 &&
+                o.n_idata == 1 && local_at(o.in[0], held) < 0;
+        }
+        at = local_at(op_at(at, 0).in[0], at);
+        hit = hit && at >= 0;
+      }
+      if (hit && !glm.sub.empty()) {
+        const Op& mul = op_at(at, 0);
+        glm.chain.push_back(at);
+        glm.m = g.slots[(size_t)op_at(glm.sub[0], 0).out].len;
+        hit = mul.opcode == OP_MUL && mul.n_in == 2 &&
+              g.slots[(size_t)mul.out].len == 1 && glm.m > 0 &&
+              g.slots[(size_t)op_at(glm.concat, 0).out].len == glm.m + 1 &&
+              (glm.theta = local_at(mul.in[0], at)) >= 0 &&
+              (glm.alpha = local_at(mul.in[1], at)) >= 0 &&
+              glm.theta != glm.alpha;
+      } else {
+        hit = false;
+      }
+      for (int p : {glm.theta, glm.alpha}) {
+        if (!hit) break;
+        const Op& o = op_at(p, 0);
+        glm.chain.push_back(p);
+        hit = o.opcode == OP_INDEX && o.n_in == 1 && o.n_idata == 1 &&
+              g.slots[(size_t)o.out].len == 1 && local_at(o.in[0], p) < 0;
+      }
+      // Everything the substitution does not consume has to be dead: gpcm
+      // emits the same threshold slice three times per lane and reads one.
+      for (int p = 0; hit && p < k; ++p)
+        hit = std::find(glm.chain.begin(), glm.chain.end(), p) !=
+                  glm.chain.end() ||
+              uses[(size_t)op_at(p, 0).out].empty();
+      if (hit) glm.cat = k - 1;
+    }
+    if (glm.cat >= 0 && emit_glm(ids, glm)) continue;
 
     std::vector<Pos> pos((size_t)k);
     bool ok = true;
@@ -659,11 +972,6 @@ PartitionStats partition_lanes(Graph& g, Fills& fills,
           break;
       }
     }
-    const auto attach_idata = [&](Op& o, std::vector<int> v) {
-      g.idata_pool.push_back(std::move(v));
-      o.idata = g.idata_pool.back().data();
-      o.n_idata = (int64_t)g.idata_pool.back().size();
-    };
     added += ops_out * kOpCost + (L - distinct) * lane_elems;
     if (distinct * (int64_t)k * kOpCost <= added + kPartitionMargin) {
       ++st.declined;
@@ -697,20 +1005,7 @@ PartitionStats partition_lanes(Graph& g, Fills& fills,
     const auto swap_terms = [&](int p, int new_term) {
       std::unordered_set<int> dead;
       for (int64_t l = 0; l < L; ++l) dead.insert(op_at(p, l).out);
-      std::vector<int> next;
-      next.reserve(target_terms.size());
-      bool placed = false;
-      for (int s : target_terms) {
-        if (dead.count(s) == 0) {
-          next.push_back(s);
-        } else if (!placed) {
-          next.push_back(new_term);
-          placed = true;
-        }
-      }
-      target_terms = std::move(next);
-      for (int s : dead) term_set.erase(s);
-      term_set.insert(new_term);
+      retire_terms(dead, new_term);
     };
 
     for (int p = 0; p < k; ++p) {

--- a/runtime/src/partition.cpp
+++ b/runtime/src/partition.cpp
@@ -85,11 +85,20 @@ bool has_int_groups(uint16_t opcode) {
 int64_t group_len(const int* p) { return p[0] == -1 ? 2 : 1 + p[0]; }
 int group_elem(const int* p, int64_t e) { return p[0] == -1 ? p[1] : p[1 + e]; }
 
-// The bernoulli kernels evaluate one element at a time in their summed form
-// too (densities_lpmf.cpp), so widening a lane costs them nothing. Every
-// other density trades one vectorized call for W elementwise ones.
+// These kernels have an elementwise form that costs per element what their
+// summed one does (densities_lpmf.cpp), so widening a lane costs them
+// nothing. Every other density trades one vectorized call for W recorder
+// calls.
 bool elt_costs_per_element(uint16_t opcode) {
-  return opcode != OP_BERNOULLI_LPMF && opcode != OP_BERNOULLI_LOGIT_LPMF;
+  switch (opcode) {
+    case OP_BERNOULLI_LPMF:
+    case OP_BERNOULLI_LOGIT_LPMF:
+    case OP_BINOMIAL_LPMF:
+    case OP_BINOMIAL_LOGIT_LPMF:
+      return false;
+    default:
+      return true;
+  }
 }
 
 // Outcome elements per lane, or 0 when the immediates are not a layout this
@@ -650,6 +659,11 @@ PartitionStats partition_lanes(Graph& g, Fills& fills,
           break;
       }
     }
+    const auto attach_idata = [&](Op& o, std::vector<int> v) {
+      g.idata_pool.push_back(std::move(v));
+      o.idata = g.idata_pool.back().data();
+      o.n_idata = (int64_t)g.idata_pool.back().size();
+    };
     added += ops_out * kOpCost + (L - distinct) * lane_elems;
     if (distinct * (int64_t)k * kOpCost <= added + kPartitionMargin) {
       ++st.declined;
@@ -659,11 +673,6 @@ PartitionStats partition_lanes(Graph& g, Fills& fills,
     // ---- emit ---------------------------------------------------------
     std::vector<Op> out_ops;
     out_ops.reserve((size_t)ops_out);
-    const auto attach_idata = [&](Op& o, std::vector<int> v) {
-      g.idata_pool.push_back(std::move(v));
-      o.idata = g.idata_pool.back().data();
-      o.n_idata = (int64_t)g.idata_pool.back().size();
-    };
     // The fused lpmf's outcome vector is the lanes' immediates, laid out the
     // way the kernel unpacks them: one flat array, or group by group with a
     // [len, vals...] header each, every group widened to the fused length.

--- a/tests/test_densities.cpp
+++ b/tests/test_densities.cpp
@@ -1138,10 +1138,29 @@ int main() {
               [&](int64_t i) { return std::vector<int>{counts[i]}; });
 
     // binomial: int groups; y vector, trials a language-level scalar (-1).
+    // The elementwise binomials leave the recorder out entirely, so every
+    // shape they branch on is pinned against the lanes: both distributions,
+    // propto off and on, and a broadcast probability against a vector one.
     std::vector<int> fused_b{N, 3, 0, 7, 1, 2, -1, 20};
-    check_elt(
-        "elt binomial", OP_BINOMIAL_LPMF, 0x01, N, {unit}, {true}, fused_b,
-        [&](int64_t i) { return std::vector<int>{-1, counts[i], -1, 20}; });
+    const auto lane_b = [&](int64_t i) {
+      return std::vector<int>{-1, counts[i], -1, 20};
+    };
+    for (uint8_t v : {0x01, 0x81}) {
+      const std::string tag = v == 0x01 ? "" : " propto";
+      check_elt("elt binomial" + tag, OP_BINOMIAL_LPMF, v, N, {unit}, {true},
+                fused_b, lane_b);
+      check_elt("elt binomial scalar" + tag, OP_BINOMIAL_LPMF, v, N, {{0.4}},
+                {true}, fused_b, lane_b);
+      check_elt("elt binomial_logit" + tag, OP_BINOMIAL_LOGIT_LPMF, v, N, {mus},
+                {true}, fused_b, lane_b);
+      check_elt("elt binomial_logit scalar" + tag, OP_BINOMIAL_LOGIT_LPMF, v, N,
+                {{-0.3}}, {true}, fused_b, lane_b);
+    }
+    // n == 0 and n == N are separate branches of the value and the partial.
+    std::vector<int> edge{0, 20, 0, 20, 10};
+    check_elt("elt binomial edges", OP_BINOMIAL_LPMF, 0x01, N, {unit}, {true},
+              {N, 0, 20, 0, 20, 10, -1, 20},
+              [&](int64_t i) { return std::vector<int>{-1, edge[i], -1, 20}; });
   }
 
   // The two-integer-group cdfs. binomial and beta_binomial carry an

--- a/tests/test_partition.cpp
+++ b/tests/test_partition.cpp
@@ -15,6 +15,7 @@
 #include <chrono>
 #include <cmath>
 #include <cstdio>
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -698,6 +699,192 @@ static void test_cost_declines() {
   expect("declined graph unchanged", g.ops.size() == before && tt == terms);
 }
 
+// gpcm_latent_reg_irt's per-response chain: theta[person] * alpha[item] minus
+// that item's threshold segment, run through a leading zero, a cumsum, a
+// softmax and a categorical. Items interleave, so the lanes are laid down
+// person-major and the item is a refinement of the bucket.
+struct Irt {
+  Graph g;
+  Fills fills;
+  std::vector<int> terms;
+  int theta = -1, alpha = -1, beta = -1;
+};
+
+// item_m[i] thresholds for item i, laid end to end in one beta vector.
+static Irt build_irt(const std::vector<int>& item_m,
+                     const std::vector<int>& person, bool split_sub) {
+  Irt b;
+  const int n_items = (int)item_m.size();
+  int total = 0;
+  for (int m : item_m) total += m;
+  b.theta = b.g.add_slot((int64_t)person.size(), true);
+  b.alpha = b.g.add_slot(n_items, true);
+  b.beta = b.g.add_slot(split_sub ? n_items : total, true);
+  const int shared = split_sub ? b.g.add_slot(item_m[0], true) : -1;
+  int pos = 0;
+  std::vector<int> start((size_t)n_items);
+  for (int i = 0; i < n_items; ++i) {
+    start[(size_t)i] = pos;
+    pos += item_m[(size_t)i];
+  }
+  for (size_t l = 0; l < person.size(); ++l) {
+    for (int i = 0; i < n_items; ++i) {
+      const int m = item_m[(size_t)i];
+      const int th = b.g.add_slot(1, false);
+      b.g.add_op(OP_INDEX, {b.theta}, th, {person[l]});
+      const int al = b.g.add_slot(1, false);
+      b.g.add_op(OP_INDEX, {b.alpha}, al, {i});
+      const int mul = b.g.add_slot(1, false);
+      b.g.add_op(OP_MUL, {th, al}, mul);
+      int diff = -1;
+      if (split_sub) {
+        const int bi = b.g.add_slot(1, false);
+        b.g.add_op(OP_INDEX, {b.beta}, bi, {i});
+        const int d1 = b.g.add_slot(1, false);
+        b.g.add_op(OP_SUB, {mul, bi}, d1);
+        diff = b.g.add_slot(m, false);
+        b.g.add_op(OP_SUB, {d1, shared}, diff);
+      } else {
+        const int seg = b.g.add_slot(m, false);
+        b.g.add_op(OP_SLICE, {b.beta}, seg, {start[(size_t)i]});
+        diff = b.g.add_slot(m, false);
+        b.g.add_op(OP_SUB, {mul, seg}, diff);
+      }
+      const int zero = b.g.add_slot(1, false);
+      b.fills.emplace_back(zero, std::vector<double>{0.0});
+      const int cat_in = b.g.add_slot(m + 1, false);
+      b.g.add_op(OP_CONCAT2, {zero, diff}, cat_in);
+      const int cs = b.g.add_slot(m + 1, false);
+      b.g.add_op(OP_CUMSUM, {cat_in}, cs);
+      const int probs = b.g.add_slot(m + 1, false);
+      b.g.add_op(OP_SOFTMAX, {cs}, probs);
+      const int y = b.g.add_slot(1, false);
+      b.fills.emplace_back(
+          y, std::vector<double>{(double)(1 + ((int)l + i) % (m + 1))});
+      const int lp = b.g.add_slot(1, false);
+      b.g.add_op(OP_CATEGORICAL, {y, probs}, lp);
+      auto spec = std::make_shared<CategoricalSpec>();
+      spec->scalar_outcome = true;
+      spec->arg_autodiff = true;
+      b.g.ops.back().udata = spec.get();
+      b.g.udata_pool.push_back(std::move(spec));
+      b.terms.push_back(lp);
+    }
+  }
+  return b;
+}
+
+static void test_irt_glm_synthesis() {
+  const std::vector<int> item_m{1, 2};
+  const std::vector<int> person{0, 3, 1, 1, 4, 2, 5, 0};
+  Irt b = build_irt(item_m, person, false);
+  const std::vector<double> want = reference(b.g, b.fills, b.terms);
+
+  std::vector<int> tt = b.terms;
+  Fills f2 = b.fills;
+  const PartitionStats st = partition_lanes(b.g, f2, tt, {});
+  expect("irt two items", st.groups == 2 &&
+                              st.lanes == (int)(2 * person.size()) &&
+                              tt.size() == 2);
+  expect("irt one glm per item",
+         count_opcode(b.g, OP_CATEGORICAL_LOGIT_GLM_LPMF) == 2 &&
+             count_opcode(b.g, OP_CATEGORICAL) == 0);
+  expect("irt intercepts negate", count_opcode(b.g, OP_NEG) == 2 &&
+                                      count_opcode(b.g, OP_CUMSUM) == 2 &&
+                                      count_opcode(b.g, OP_SOFTMAX) == 0);
+  // Person indices in lane order, repeats and all; y then rows then cols.
+  bool layout = false;
+  for (const Op& op : b.g.ops) {
+    if (op.opcode != OP_GATHER) continue;
+    layout = op.n_idata == (int64_t)person.size() && op.idata[0] == person[0] &&
+             op.idata[3] == person[3];
+  }
+  expect("irt gathers in lane order", layout);
+  for (const Op& op : b.g.ops) {
+    if (op.opcode != OP_CATEGORICAL_LOGIT_GLM_LPMF) continue;
+    const int64_t rows = op.idata[op.n_idata - 2];
+    expect("irt glm idata", rows == (int64_t)person.size() &&
+                                op.idata[op.n_idata - 1] == 1 &&
+                                op.n_idata == rows + 2);
+  }
+  expect_same_grad("irt", std::move(b.g), f2, tt, want);
+}
+
+// grsm_latent_reg_irt's chain: the item's own difficulty comes off first as a
+// scalar, then a threshold vector every item shares. The segment the
+// intercepts cumsum is their sum.
+static void test_irt_split_subtrahend() {
+  const std::vector<int> item_m{3, 3};
+  const std::vector<int> person{2, 0, 1, 4, 4, 3};
+  Irt b = build_irt(item_m, person, true);
+  const std::vector<double> want = reference(b.g, b.fills, b.terms);
+
+  std::vector<int> tt = b.terms;
+  Fills f2 = b.fills;
+  const PartitionStats st = partition_lanes(b.g, f2, tt, {});
+  expect("irt split two items",
+         st.groups == 2 && st.lanes == (int)(2 * person.size()));
+  expect("irt split one glm per item",
+         count_opcode(b.g, OP_CATEGORICAL_LOGIT_GLM_LPMF) == 2 &&
+             count_opcode(b.g, OP_ADD) == 2);
+  expect_same_grad("irt split", std::move(b.g), f2, tt, want);
+}
+
+// The same chain without the leading zero, and with a leading constant that
+// is not zero. Either way the intercepts stop being -cumsum(segment) behind a
+// reference category, so the substitution does not hold.
+static void test_irt_refuse_near_miss(double lead, bool concat) {
+  const std::vector<int> person{0, 3, 1, 1, 4, 2, 5, 0};
+  const int M = 2;
+  Graph g;
+  Fills fills;
+  const int theta = g.add_slot(6, true);
+  const int alpha = g.add_slot(1, true);
+  const int beta = g.add_slot(M, true);
+  std::vector<int> terms;
+  for (size_t l = 0; l < person.size(); ++l) {
+    const int th = g.add_slot(1, false);
+    g.add_op(OP_INDEX, {theta}, th, {person[l]});
+    const int al = g.add_slot(1, false);
+    g.add_op(OP_INDEX, {alpha}, al, {0});
+    const int mul = g.add_slot(1, false);
+    g.add_op(OP_MUL, {th, al}, mul);
+    const int seg = g.add_slot(M, false);
+    g.add_op(OP_SLICE, {beta}, seg, {0});
+    const int diff = g.add_slot(M, false);
+    g.add_op(OP_SUB, {mul, seg}, diff);
+    int head = diff;
+    const int wide = concat ? M + 1 : M;
+    if (concat) {
+      const int c = g.add_slot(1, false);
+      fills.emplace_back(c, std::vector<double>{lead});
+      head = g.add_slot(wide, false);
+      g.add_op(OP_CONCAT2, {c, diff}, head);
+    }
+    const int cs = g.add_slot(wide, false);
+    g.add_op(OP_CUMSUM, {head}, cs);
+    const int probs = g.add_slot(wide, false);
+    g.add_op(OP_SOFTMAX, {cs}, probs);
+    const int y = g.add_slot(1, false);
+    fills.emplace_back(y, std::vector<double>{(double)(1 + (int)l % wide)});
+    const int lp = g.add_slot(1, false);
+    g.add_op(OP_CATEGORICAL, {y, probs}, lp);
+    auto spec = std::make_shared<CategoricalSpec>();
+    spec->scalar_outcome = true;
+    spec->arg_autodiff = true;
+    g.ops.back().udata = spec.get();
+    g.udata_pool.push_back(std::move(spec));
+    terms.push_back(lp);
+  }
+  const size_t before = g.ops.size();
+
+  std::vector<int> tt = terms;
+  Fills f2 = fills;
+  const PartitionStats st = partition_lanes(g, f2, tt, {});
+  expect("irt near miss refuses",
+         st.groups == 0 && g.ops.size() == before && tt == terms);
+}
+
 // ---- cost -----------------------------------------------------------------
 
 static double peak_rss_mb() {
@@ -776,6 +963,10 @@ int main() {
   test_cross_bucket_read_after_write();
   test_kill_switch();
   test_state_space_shape();
+  test_irt_glm_synthesis();
+  test_irt_split_subtrahend();
+  test_irt_refuse_near_miss(0.0, false);
+  test_irt_refuse_near_miss(1.5, true);
   test_cost_declines();
   test_scaling();
   if (failures == 0) std::printf("test_partition OK\n");

--- a/tests/test_partition.cpp
+++ b/tests/test_partition.cpp
@@ -408,6 +408,49 @@ static void test_width_w_outcome_group() {
   expect_same_grad("width-w", std::move(g), f2, tt, want);
 }
 
+// Survey_model's lane: a width-5 binomial group over one shared probability,
+// added to a per-lane constant and stored. The binomial's elementwise form
+// costs what its summed one does per element, so widening the group is what
+// the cost model has to say yes to.
+static void test_binomial_elt_fusion() {
+  const int L = 16, W = 5, N = 40;
+  Graph g;
+  Fills fills;
+  const int theta = g.add_slot(1, true);
+  const int vec = g.add_slot(N, false);
+  std::vector<double> vals((size_t)N);
+  for (int i = 0; i < N; ++i) vals[(size_t)i] = -0.5 + 0.05 * i;
+  fills.emplace_back(vec, vals);
+  for (int l = 0; l < L; ++l) {
+    const int lp = g.add_slot(1, false);
+    const int id = g.add_op(OP_BINOMIAL_LPMF, {theta}, lp,
+                            {W, l % 3, (l + 1) % 3, l % 2, 1, 0, -1, 4});
+    g.ops[(size_t)id].variant = 0x01;
+    const int c = g.add_slot(1, false);
+    fills.emplace_back(c, std::vector<double>{0.3 + 0.1 * l});
+    const int s = g.add_slot(1, false);
+    g.add_op(OP_ADD, {c, lp}, s);
+    g.add_op(OP_SET_INDEX_INPLACE, {vec, s}, vec, {l});
+  }
+  const int lse = g.add_slot(1, false);
+  g.add_op(OP_LOG_SUM_EXP, {vec}, lse);
+  const std::vector<int> terms{lse};
+  const std::vector<double> want = reference(g, fills, terms);
+
+  std::vector<int> tt = terms;
+  Fills f2 = fills;
+  const PartitionStats st = partition_lanes(g, f2, tt, {});
+  expect("binomial elt one group", st.groups == 1 && st.lanes == L);
+  // BINOMIAL, SUM_ROWS, ADD, SET_SLICE_INPLACE, LOG_SUM_EXP.
+  expect("binomial elt op count", g.ops.size() == 5 && tt == terms);
+  expect("binomial elt widens", count_opcode(g, OP_SUM_ROWS) == 1 &&
+                                    count_opcode(g, OP_BINOMIAL_LPMF) == 1);
+  expect("binomial elt groups concatenate",
+         g.ops[0].n_idata == 2 * (L * W + 1) && g.ops[0].idata[0] == L * W &&
+             g.ops[0].idata[L * W + 1] == L * W);
+  expect_same_grad("binomial elt", std::move(g), f2, tt, want);
+}
+
 // Survey_model's accumulator: lanes delimited by an element store rather
 // than a term, at indices that march by one. The run becomes a single slice
 // store, and the reduction that reads the whole vector afterwards is what
@@ -726,6 +769,7 @@ int main() {
   test_duplicate_lanes_decline();
   test_binomial_idata_groups();
   test_width_w_outcome_group();
+  test_binomial_elt_fusion();
   test_store_delimited_lanes();
   test_two_templates_interleaved();
   test_mid_bucket_writer_split();


### PR DESCRIPTION
Final partition slice. Packet elementwise binomial forms let Survey_model's bucket fuse (1,427 ops to 9, 1.11x, bit-exact). The GLM-synthesis arm recognizes the IRT chain by dataflow (categorical delimiter back through softmax/cumsum/concat-zero/threshold subtraction/scalar product; the cumsum telescopes to j*alpha rows with negated-cumsum intercepts) and emits categorical_logit_glm_lpmf per item: gpcm 34,634 ops to 91 at 6.5x, grsm 6.3x. multi_occupancy stays declined by the cost model; forcing it is a measured 90% regression. ctest 61/61, corpus 129/129 worst line unmoved, A/B worst 5.99e-13.