### PR TITLE
perf: elide full-extent destructive store chains

### DIFF
--- a/runtime/include/stanli/inplace.hpp
+++ b/runtime/include/stanli/inplace.hpp
@@ -39,6 +39,13 @@ int make_inplace_updates(Graph& g, const std::vector<int>& roots);
 // STANLI_NO_INPLACE.
 int forward_stores_to_loads(Graph& g, const std::vector<int>& roots);
 
+// Drops slice stores that overwrite their whole destination: the value the
+// store writes IS the vector its readers want, so they read it directly.
+// Applies to the four OP_SET_SLICE forms with start 0, unit stride and a
+// value as long as the destination. Returns the number of stores dropped.
+// Disabled under STANLI_NO_INPLACE.
+int elide_full_extent_stores(Graph& g, const std::vector<int>& roots);
+
 }  // namespace stanli
 
 #endif

--- a/runtime/src/inplace.cpp
+++ b/runtime/src/inplace.cpp
@@ -311,4 +311,102 @@ int forward_stores_to_loads(Graph& g, const std::vector<int>& roots) {
   return removed;
 }
 
+int elide_full_extent_stores(Graph& g, const std::vector<int>& roots) {
+  if (std::getenv("STANLI_NO_INPLACE")) return 0;
+
+  std::unordered_set<int> root_set(roots.begin(), roots.end());
+  if (g.result_slot >= 0) root_set.insert(g.result_slot);
+
+  const size_t n_ops = g.ops.size();
+  std::vector<std::vector<size_t>> readers(g.slots.size());
+  std::vector<std::vector<size_t>> writers(g.slots.size());
+  for (size_t i = 0; i < n_ops; ++i) {
+    const Op& op = g.ops[i];
+    for (int j = 0; j < op.n_in; ++j)
+      if (op.in[j] >= 0) readers[(size_t)op.in[j]].push_back(i);
+    if (op.out >= 0) writers[(size_t)op.out].push_back(i);
+    if (op.out2 >= 0) writers[(size_t)op.out2].push_back(i);
+  }
+
+  const auto covers_destination = [&g](const Op& op) {
+    const bool strided = op.opcode == OP_SET_SLICE_STRIDED ||
+                         op.opcode == OP_SET_SLICE_STRIDED_INPLACE;
+    if (op.opcode != OP_SET_SLICE && op.opcode != OP_SET_SLICE_INPLACE &&
+        !strided)
+      return false;
+    return op.n_in == 2 && op.out >= 0 && op.in[1] >= 0 && op.n_idata >= 1 &&
+           op.idata[0] == 0 && (!strided || op.idata[1] == 1) &&
+           g.slots[(size_t)op.in[1]].len == g.slots[(size_t)op.out].len;
+  };
+
+  std::vector<char> drop(n_ops, 0);
+  int removed = 0;
+  for (size_t i = 0; i < n_ops; ++i) {
+    const Op& op = g.ops[i];
+    if (!covers_destination(op)) continue;
+    const int dest = op.out, val = op.in[1];
+    if (dest == val) continue;
+    if (root_set.count(dest) || root_set.count(val)) continue;
+    if (g.slots[(size_t)dest].is_param || g.slots[(size_t)val].is_param)
+      continue;
+    // The destination's adjoints reach the value in one move today and one
+    // per reader afterwards. Those sums agree to the bit only while the
+    // value's own adjoint starts the region at zero, which a second reader
+    // would break.
+    const std::vector<size_t>& val_readers = readers[(size_t)val];
+    if (val_readers.size() != 1 || val_readers[0] != i) continue;
+    const std::vector<size_t>& val_writers = writers[(size_t)val];
+    if (!val_writers.empty() && val_writers.back() >= i) continue;
+
+    const std::vector<size_t>& dest_writers = writers[(size_t)dest];
+    size_t next_write = n_ops;
+    for (size_t w : dest_writers)
+      if (w > i) {
+        next_write = w;
+        break;
+      }
+    // Whoever writes the destination next must neither read what this store
+    // put there nor leave its adjoints for the reverse sweep to carry past
+    // this point. A covering destructive store does neither: it only writes
+    // forward, and it clears the range it owns in reverse.
+    if (next_write < n_ops &&
+        !((g.ops[next_write].opcode == OP_SET_SLICE_INPLACE ||
+           g.ops[next_write].opcode == OP_SET_SLICE_STRIDED_INPLACE) &&
+          g.ops[next_write].out == dest &&
+          covers_destination(g.ops[next_write])))
+      continue;
+
+    std::vector<size_t> window;
+    bool ok = true;
+    for (size_t r : readers[(size_t)dest]) {
+      if (r <= i || r >= next_write) continue;
+      // Island bodies name outer slots in a payload this rename cannot
+      // reach.
+      if (g.ops[r].opcode == OP_ISLAND) {
+        ok = false;
+        break;
+      }
+      window.push_back(r);
+    }
+    if (!ok) continue;
+
+    for (size_t r : window) {
+      Op& reader = g.ops[r];
+      for (int j = 0; j < reader.n_in; ++j)
+        if (reader.in[j] == dest) reader.in[j] = val;
+    }
+    drop[i] = 1;
+    ++removed;
+  }
+
+  if (removed) {
+    std::vector<Op> kept;
+    kept.reserve(n_ops - (size_t)removed);
+    for (size_t i = 0; i < n_ops; ++i)
+      if (!drop[i]) kept.push_back(g.ops[i]);
+    g.ops = std::move(kept);
+  }
+  return removed;
+}
+
 }  // namespace stanli

--- a/runtime/src/lower.cpp
+++ b/runtime/src/lower.cpp
@@ -4987,6 +4987,13 @@ struct Lowering {
                post_partition_inplace_time, g, out.fills, target_terms.size(),
                out.views.size(), PrepTrace::Extra::Rewrites,
                post_partition_inplace);
+    // After every pass that emits a slice store, and before islands, whose
+    // bodies name outer slots in a payload this rename cannot reach.
+    const auto elide_time = prep.start();
+    const int elided = elide_full_extent_stores(g, post_partition_roots);
+    prep.graph(prep_graph, "elide_stores", elide_time, g, out.fills,
+               target_terms.size(), out.views.size(), PrepTrace::Extra::Removed,
+               elided);
     // After reroll, whose lane matching needs the repeated ops it hoists to
     // still be there, and before islands, so they compile the smaller
     // residue.

--- a/tests/test_inplace.cpp
+++ b/tests/test_inplace.cpp
@@ -656,6 +656,151 @@ static void test_env_disable() {
   expect("enabled: stores forwarded", forward_stores_to_loads(g, {}) == 2 * L);
 }
 
+// normal_mixture_k's shape: per data point the vectorized lanes fill a
+// K-element scratch vector whole, then reduce it. `partial` leaves the
+// first element to an earlier write, which is what a real window store
+// looks like; `elsewhere` gives the stored value a second reader.
+static Graph build_full_store_chain(int L, int K, Fills& fills,
+                                    std::vector<int>& terms, int* vec_out,
+                                    bool partial = false,
+                                    bool elsewhere = false) {
+  Graph g;
+  const int p = g.add_slot(K, true);
+  const int c = g.add_slot(K, false);
+  fills.push_back({c, std::vector<double>((size_t)K, 0.5)});
+  const int vec = g.add_slot(K, false);
+  *vec_out = vec;
+  g.add_op(OP_ADD, {p, c}, vec);  // the scratch starts out defined
+  for (int l = 0; l < L; ++l) {
+    const int val = g.add_slot(partial ? K - 1 : K, false);
+    if (partial) {
+      const int w = g.add_slot(K - 1, false);
+      g.add_op(OP_SLICE, {p}, w, {1});
+      g.add_op(OP_EXPV, {w}, val);
+    } else {
+      g.add_op(OP_EXPV, {p}, val);
+    }
+    Op st;
+    st.opcode = OP_SET_SLICE_INPLACE;
+    st.n_in = 2;
+    st.in[0] = vec;
+    st.in[1] = val;
+    st.out = vec;
+    g.idata_pool.push_back({partial ? 1 : 0});
+    st.idata = g.idata_pool.back().data();
+    st.n_idata = 1;
+    g.ops.push_back(st);
+    const int lse = g.add_slot(1, false);
+    g.add_op(OP_LOG_SUM_EXP, {vec}, lse);
+    terms.push_back(lse);
+    if (elsewhere) {
+      const int s = g.add_slot(1, false);
+      g.add_op(OP_LOG_SUM_EXP, {val}, s);
+      terms.push_back(s);
+    }
+  }
+  return g;
+}
+
+static int count_opcode(const Graph& g, uint16_t oc) {
+  int n = 0;
+  for (const Op& op : g.ops) n += op.opcode == oc;
+  return n;
+}
+
+// The whole destination is overwritten every iteration, so every store is
+// a rename: the reduction reads the fused value itself.
+static void test_full_extent_stores_elided() {
+  const int L = 6, K = 5;
+  Fills fills;
+  std::vector<int> terms;
+  int vec = 0;
+  Graph g = build_full_store_chain(L, K, fills, terms, &vec);
+
+  Graph ref = g;
+  reduce_into_result(ref, terms);
+  const std::vector<double> want = run_grad(std::move(ref), fills);
+
+  expect("elided every full store", elide_full_extent_stores(g, {}) == L);
+  expect("no slice stores left", count_opcode(g, OP_SET_SLICE_INPLACE) == 0);
+  reduce_into_result(g, terms);
+  const std::vector<double> got = run_grad_twice(std::move(g), fills);
+  expect("elide sizes", got.size() == want.size());
+  for (size_t i = 0; i < want.size() && i < got.size(); ++i)
+    expect(("elide bitwise v" + std::to_string(i)).c_str(), got[i] == want[i]);
+}
+
+// A window store leaves elements the value does not supply: it stays.
+static void test_window_store_kept() {
+  const int L = 4, K = 5;
+  Fills fills;
+  std::vector<int> terms;
+  int vec = 0;
+  Graph g = build_full_store_chain(L, K, fills, terms, &vec, true);
+  expect("window store not elided", elide_full_extent_stores(g, {}) == 0);
+  expect("window stores intact", count_opcode(g, OP_SET_SLICE_INPLACE) == L);
+}
+
+// A second reader of the stored value would receive the destination's
+// adjoints in a different order, so the store stays.
+static void test_shared_value_kept() {
+  const int L = 4, K = 5;
+  Fills fills;
+  std::vector<int> terms;
+  int vec = 0;
+  Graph g = build_full_store_chain(L, K, fills, terms, &vec, false, true);
+  expect("shared value not elided", elide_full_extent_stores(g, {}) == 0);
+}
+
+// The destination is read from outside the graph: it must still be written.
+static void test_root_destination_kept() {
+  const int L = 3, K = 5;
+  Fills fills;
+  std::vector<int> terms;
+  int vec = 0;
+  Graph g = build_full_store_chain(L, K, fills, terms, &vec);
+  expect("root destination not elided",
+         elide_full_extent_stores(g, {vec}) == 0);
+}
+
+static void test_elide_env_disable() {
+  const int L = 3, K = 5;
+  Fills fills;
+  std::vector<int> terms;
+  int vec = 0;
+  Graph g = build_full_store_chain(L, K, fills, terms, &vec);
+  test_setenv("STANLI_NO_INPLACE", "1", 1);
+  expect("disabled: no stores elided", elide_full_extent_stores(g, {}) == 0);
+  test_unsetenv("STANLI_NO_INPLACE");
+}
+
+// The copying form covers its whole fresh output too: its readers want the
+// value it was handed, so the copy goes.
+static void test_copying_full_store_elided() {
+  const int K = 4;
+  Fills fills;
+  Graph g;
+  const int p = g.add_slot(K, true);
+  const int base = g.add_slot(K, false);
+  fills.push_back({base, std::vector<double>((size_t)K, 0.25)});
+  const int val = g.add_slot(K, false);
+  g.add_op(OP_EXPV, {p}, val);
+  const int copy = g.add_slot(K, false);
+  g.add_op(OP_SET_SLICE, {base, val}, copy, {0});
+  const int out = g.add_slot(1, false);
+  g.add_op(OP_LOG_SUM_EXP, {copy}, out);
+  g.result_slot = out;
+
+  Graph ref = g;
+  const std::vector<double> want = run_grad(std::move(ref), fills);
+  expect("copying full store elided", elide_full_extent_stores(g, {}) == 1);
+  expect("copy gone", count_opcode(g, OP_SET_SLICE) == 0);
+  const std::vector<double> got = run_grad_twice(std::move(g), fills);
+  for (size_t i = 0; i < want.size() && i < got.size(); ++i)
+    expect(("copying elide bitwise v" + std::to_string(i)).c_str(),
+           got[i] == want[i]);
+}
+
 int main() {
   test_chain_collapses();
   test_slice_chain(false);
@@ -673,6 +818,12 @@ int main() {
   test_bail_later_reader();
   test_bail_root();
   test_dead_slots_freed();
+  test_full_extent_stores_elided();
+  test_copying_full_store_elided();
+  test_window_store_kept();
+  test_shared_value_kept();
+  test_root_destination_kept();
+  test_elide_env_disable();
   if (failures) {
     std::printf("%d failures\n", failures);
     return 1;


### PR DESCRIPTION
Follow-up to the degenerate-form audit: the named full-extent SLICE/SET_SLICE/identity-GATHER forms are nearly absent from final graphs (7+2 instances, sub-1% ceilings, left alone), but the inplace-rewritten SET_SLICE_INPLACE variant carries 1,699 full-extent stores in normal_mixture_k at a 16.6% ceiling. New elision pass renames readers onto the value slot under single-reader/no-later-writer/covering-next-writer guards. normal_mixture_k 7.5-8% faster; all 120 corpus models byte-identical output; ctest 61/61.