### PR TITLE
release: move the npm and R versions in lockstep for 0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,16 @@ harness flagged the split. A partially assigned bare container now
 reports NaN in the untouched positions, which is a visible change for any
 model that has one. The integer arm already used its own sentinel.
 
+### Full-extent store chains stop copying
+
+`normal_mixture_k` carried 1,699 full-extent `SET_SLICE_INPLACE` copies
+per gradient, 16.6% of its profile: re-rolling's store fusion forces
+the store form whenever the destination is rewritten later. A pass
+after in-place conversion renames the readers onto the value slot when
+the value has a single reader and the next write is a covering
+destructive store (#195). 7.5-8% per gradient on that model, byte
+identical output on all 120 corpus models, and only its graph changes.
+
 ### Corpus
 
 The full posteriordb benchmark was re-measured on the merged stack

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@seantalts/stanli",
-  "version": "0.8.5",
+  "version": "0.9.0",
   "description": "Full Stan in the browser: stanc3 compiles the model in JS, a WASM runtime lowers it to an op graph and runs NUTS. No server, no C++ toolchain.",
   "type": "module",
   "main": "index.mjs",

--- a/r/DESCRIPTION
+++ b/r/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: stanli
 Type: Package
 Title: The Stan Language Interpreter
-Version: 0.8.5
+Version: 0.9.0
 Authors@R: person("Sean", "Talts", email = "xitrium@gmail.com",
                   role = c("aut", "cre"))
 Description: Compile and sample Stan models without a C++ toolchain. Stan

--- a/r/R/install.R
+++ b/r/R/install.R
@@ -17,7 +17,7 @@
 # pinned binding with a runtime that has moved. The release workflow
 # asserts this equals the tag being cut, so bumping one without the
 # other fails there rather than at a user's install.
-stanli_runtime_release <- "v0.8.5"
+stanli_runtime_release <- "v0.9.0"
 
 runtime_filename <- function() {
   switch(Sys.info()[["sysname"]],


### PR DESCRIPTION
The v0.9.0 tag run failed the lockstep version assertions (js/package.json and the R runtime pin were still 0.8.5). Bumps both plus r/DESCRIPTION, and adds the #195 changelog entry. The tag gets re-pointed at this commit after merge.