### PR TITLE
perf: compact island register programs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -258,6 +258,7 @@ set(STANLI_RUNTIME_SOURCES
   runtime/kernels/scalar_unary_ad.cpp
   runtime/kernels/ode.cpp
   runtime/src/ode_prog.cpp
+  runtime/src/program.cpp
   runtime/kernels/constrain.cpp
   runtime/kernels/eltwise_expr.cpp
   runtime/kernels/mixture.cpp

--- a/runtime/include/stanli/island.hpp
+++ b/runtime/include/stanli/island.hpp
@@ -62,6 +62,12 @@ struct IslandProg : Program {
   bool native_adj = false;
 };
 
+// Run compact_program (program.hpp) over the region's forward code, live-ins
+// included, before the adjoint generator reads it -- so the backward is
+// generated from the compacted program rather than remapped onto it.
+// STANLI_NO_ISLAND_COMPACT=1 disables this pass only.
+void compact_island(IslandProg& p);
+
 // Generate p.adj, appending checkpoint saves to p's forward code. False
 // leaves p untouched and keeps the replay.
 bool gen_adjoint(IslandProg& p);

--- a/runtime/include/stanli/program.hpp
+++ b/runtime/include/stanli/program.hpp
@@ -28,6 +28,7 @@
 #include <cstdint>
 #include <stdexcept>
 #include <type_traits>
+#include <utility>
 #include <vector>
 
 namespace stanli {
@@ -51,49 +52,57 @@ enum ProgramOpFlag : uint16_t {
   kProgramSaveOut = 1u << 7,
   kProgramNoOutput = 1u << 8,
   kProgramRangeOutput = 1u << 9,
+  kProgramReadB = 1u << 10,
+  kProgramReadC = 1u << 11,
 };
 
-#define STANLI_PROGRAM_CODE_LIST(X)                                       \
-  X(CONST, kProgramNoInputs)                                              \
-  X(CONSTR, kProgramNoInputs | kProgramRangeOutput)                       \
-  X(MOV, 0)                                                               \
-  X(MOVR, kProgramRangeA | kProgramRangeOutput)                           \
-  X(ADD, 0)                                                               \
-  X(SUB, 0)                                                               \
-  X(MUL, kProgramSaveA | kProgramSaveB)                                   \
-  X(DIV, kProgramSaveA | kProgramSaveB)                                   \
-  X(POW, kProgramSaveA | kProgramSaveB | kProgramSaveOut)                 \
-  X(FMAX, kProgramSaveA | kProgramSaveB)                                  \
-  X(FMIN, kProgramSaveA | kProgramSaveB)                                  \
-  X(NEG, 0)                                                               \
-  X(EXP, kProgramSaveOut)                                                 \
-  X(LOG, kProgramSaveA)                                                   \
-  X(SQRT, kProgramSaveOut)                                                \
-  X(SQUARE, kProgramSaveA)                                                \
-  X(INV, kProgramSaveA)                                                   \
-  X(FABS, kProgramSaveA)                                                  \
-  X(INV_LOGIT, kProgramSaveOut)                                           \
-  X(LOG1M, kProgramSaveA)                                                 \
-  X(TANH, kProgramSaveA)                                                  \
-  X(GT, 0)                                                                \
-  X(GE, 0)                                                                \
-  X(LT, 0)                                                                \
-  X(LE, 0)                                                                \
-  X(EQ, 0)                                                                \
-  X(NE, 0)                                                                \
-  X(DYN_INDEX, kProgramNoAdjoint)                                         \
-  X(MAX_RANGE, kProgramRangeA | kProgramNoAdjoint)                        \
-  X(JZ, kProgramNoAdjoint | kProgramNoOutput)                             \
-  X(JMP, kProgramNoAdjoint | kProgramNoOutput)                            \
-  X(LOG_RANGE, kProgramRangeA | kProgramSaveA | kProgramRangeOutput)      \
-  X(EXP_RANGE, kProgramRangeA | kProgramSaveOut | kProgramRangeOutput)    \
-  X(DOT, kProgramRangeA | kProgramRangeB | kProgramSaveA | kProgramSaveB) \
-  X(LSE_RANGE, kProgramRangeA | kProgramSaveA | kProgramSaveOut)          \
-  X(SOFTMAX, kProgramRangeA | kProgramSaveOut | kProgramRangeOutput)      \
-  X(LSE2, kProgramSaveA | kProgramSaveB)                                  \
-  X(LOG_MIX, kProgramSaveA | kProgramSaveB | kProgramSaveC)               \
-  X(FMA, kProgramSaveA | kProgramSaveB)                                   \
-  X(DENSITY, 0)                                                           \
+// `a` is an operand wherever kProgramNoInputs is absent; b and c are not,
+// and the ones that are not hold register zero rather than nothing, so
+// which registers a program actually reads needs saying. DENSITY's arity
+// decides its own (program_density.hpp) and CALL's payload decides its own.
+#define STANLI_PROGRAM_CODE_LIST(X)                                          \
+  X(CONST, kProgramNoInputs)                                                 \
+  X(CONSTR, kProgramNoInputs | kProgramRangeOutput)                          \
+  X(MOV, 0)                                                                  \
+  X(MOVR, kProgramRangeA | kProgramRangeOutput)                              \
+  X(ADD, kProgramReadB)                                                      \
+  X(SUB, kProgramReadB)                                                      \
+  X(MUL, kProgramReadB | kProgramSaveA | kProgramSaveB)                      \
+  X(DIV, kProgramReadB | kProgramSaveA | kProgramSaveB)                      \
+  X(POW, kProgramReadB | kProgramSaveA | kProgramSaveB | kProgramSaveOut)    \
+  X(FMAX, kProgramReadB | kProgramSaveA | kProgramSaveB)                     \
+  X(FMIN, kProgramReadB | kProgramSaveA | kProgramSaveB)                     \
+  X(NEG, 0)                                                                  \
+  X(EXP, kProgramSaveOut)                                                    \
+  X(LOG, kProgramSaveA)                                                      \
+  X(SQRT, kProgramSaveOut)                                                   \
+  X(SQUARE, kProgramSaveA)                                                   \
+  X(INV, kProgramSaveA)                                                      \
+  X(FABS, kProgramSaveA)                                                     \
+  X(INV_LOGIT, kProgramSaveOut)                                              \
+  X(LOG1M, kProgramSaveA)                                                    \
+  X(TANH, kProgramSaveA)                                                     \
+  X(GT, kProgramReadB)                                                       \
+  X(GE, kProgramReadB)                                                       \
+  X(LT, kProgramReadB)                                                       \
+  X(LE, kProgramReadB)                                                       \
+  X(EQ, kProgramReadB)                                                       \
+  X(NE, kProgramReadB)                                                       \
+  X(DYN_INDEX, kProgramReadB | kProgramNoAdjoint)                            \
+  X(MAX_RANGE, kProgramRangeA | kProgramNoAdjoint)                           \
+  X(JZ, kProgramNoAdjoint | kProgramNoOutput)                                \
+  X(JMP, kProgramNoInputs | kProgramNoAdjoint | kProgramNoOutput)            \
+  X(LOG_RANGE, kProgramRangeA | kProgramSaveA | kProgramRangeOutput)         \
+  X(EXP_RANGE, kProgramRangeA | kProgramSaveOut | kProgramRangeOutput)       \
+  X(DOT, kProgramRangeA | kProgramRangeB | kProgramReadB | kProgramSaveA |   \
+             kProgramSaveB)                                                  \
+  X(LSE_RANGE, kProgramRangeA | kProgramSaveA | kProgramSaveOut)             \
+  X(SOFTMAX, kProgramRangeA | kProgramSaveOut | kProgramRangeOutput)         \
+  X(LSE2, kProgramReadB | kProgramSaveA | kProgramSaveB)                     \
+  X(LOG_MIX, kProgramReadB | kProgramReadC | kProgramSaveA | kProgramSaveB | \
+                 kProgramSaveC)                                              \
+  X(FMA, kProgramReadB | kProgramReadC | kProgramSaveA | kProgramSaveB)      \
+  X(DENSITY, 0)                                                              \
   X(CALL, 0)
 
 struct Program {
@@ -199,6 +208,13 @@ inline constexpr int program_output_len(const Program::Instr& instr) {
 
 static_assert(program_code_count() == static_cast<size_t>(Program::CALL) + 1,
               "every Program::Code needs exactly one ProgramOpSpec");
+
+// Drop the initializer fills and the copies the MIR spells out, then
+// renumber away whatever registers that leaves unreferenced (program.cpp).
+// `seeded` names the register ranges the caller writes before the program
+// runs -- an ODE argument region, an island live-in -- and comes back in the
+// new numbering along with the program.
+void compact_program(Program& p, std::vector<std::pair<int, int>>& seeded);
 
 // Assemble the forward context for `call` over the register file `reg`.
 // Backward-only fields are left null; run_adjoint fills its own.

--- a/runtime/src/OPTIMIZATIONS.md
+++ b/runtime/src/OPTIMIZATIONS.md
@@ -718,6 +718,31 @@ parameter keeps the autodiff replay, because reversing a branch needs
 the nested if/else shape the flat instruction list has already thrown
 away.
 
+### Register-program compaction (`program.cpp`, disable: `STANLI_NO_ISLAND_COMPACT=1`)
+
+A region's instruction list arrives full of the MIR's declaration
+bookkeeping: a fill of the language-level default, then a copy of the real
+initializer, then more copies through return temporaries. Across the ten
+corpus models with a compiled region, 39% of the instructions were copies.
+The same pass that removed them from ODE right-hand sides
+(`compact_program`) now runs over islands too, before the adjoint generator
+reads the forward -- so the backward is generated from the compacted
+program rather than remapped onto it -- and it drops the registers that
+leaves unreferenced, which shrinks the value file the forward writes and
+the backward reads.
+
+The copy test is deliberately the same one `gen_adjoint` applies before
+letting two registers share an adjoint cell, and a copy this pass will not
+remove keeps the fill that made `gen_adjoint` refuse it. Both halves of
+that are what keeps the generated backward's arithmetic identical: the
+whole corpus is byte-for-byte unchanged with the switch on and off.
+
+Measured (Release, median of nine interleaved runs): `iohmm_reg` 40,968 ->
+31,968 forward instructions and 56,501 -> 43,488 registers, 1.040x;
+`hmm_example` 1.057x; `hmm_gaussian` 1.025x; `hmm_drive_0` 1.015x. `garch11`
+and both `accel_*` models are unchanged, their copies being the ones the
+rule declines.
+
 What is left for this class is the per-instruction cost itself. Both
 directions read one instruction at a time and decide what to do with it,
 where CmdStan's compiler has inlined the equivalent straight into the
@@ -946,7 +971,8 @@ silently. Three layers:
   models a change affects.
 
 The env switches (`STANLI_NO_DATA_PRELOAD`, `STANLI_NO_INPLACE`,
-`STANLI_NO_CONSTFOLD`, `STANLI_NO_REROLL`, `STANLI_NO_ISLAND`) exist so a wrong
+`STANLI_NO_CONSTFOLD`, `STANLI_NO_REROLL`, `STANLI_NO_ISLAND`,
+`STANLI_NO_ISLAND_COMPACT`) exist so a wrong
 result can be attributed to one optimization quickly, and they are how each
 one is measured: every speed number is the same build with one variable set
 and unset.

--- a/runtime/src/island.cpp
+++ b/runtime/src/island.cpp
@@ -444,6 +444,15 @@ struct Compiler {
 
 }  // namespace
 
+void compact_island(IslandProg& p) {
+  if (std::getenv("STANLI_NO_ISLAND_COMPACT")) return;
+  std::vector<std::pair<int, int>> seeded;
+  seeded.reserve(p.ins.size());
+  for (const auto& li : p.ins) seeded.emplace_back(li.reg, li.len);
+  compact_program(p, seeded);
+  for (size_t k = 0; k < p.ins.size(); ++k) p.ins[k].reg = seeded[k].first;
+}
+
 int carve_islands(Graph& g,
                   const std::vector<std::pair<int, std::vector<double>>>& fills,
                   const std::vector<int>& target_terms,
@@ -491,6 +500,41 @@ int carve_islands(Graph& g,
       cc.op_index = u;
       compiled = cc.compile(g.ops[u]) && cc.ok;
     }
+    // Live-outs: written in the region and visible after it, in first-write
+    // order for a deterministic packing. Settled before compaction, because
+    // the program's live-outs are registers and compaction renumbers them.
+    std::vector<int> live_outs;
+    std::unordered_set<int> in_set(cc.live_in_slots.begin(),
+                                   cc.live_in_slots.end());
+    if (compiled) {
+      std::unordered_set<int> seen;
+      for (size_t u = i; u < j; ++u) {
+        const int o = g.ops[u].out;
+        if (seen.count(o)) continue;
+        seen.insert(o);
+        auto lit = last_use.find(o);
+        const bool read_after = lit != last_use.end() && lit->second >= j;
+        if (read_after || root_set.count(o) || term_set.count(o))
+          live_outs.push_back(o);
+      }
+      // A slot that is BOTH a live-in and a live-out (an in-place chain
+      // whose template the region reads first and overwrites last) cannot
+      // keep its id on the output side: the island reads the arena buffer
+      // in the forward, and an extraction writing the same buffer would
+      // feed the NEXT gradient's forward its own previous output. The
+      // extraction gets a fresh slot and later references are renamed --
+      // unless the slot is read from outside the graph, where the id is
+      // the contract, and then the run stays as ops.
+      bool aliased_pinned = false;
+      for (int o : live_outs)
+        if (in_set.count(o) && pinned.count(o)) aliased_pinned = true;
+      if (live_outs.empty() || aliased_pinned) compiled = false;
+    }
+    if (compiled)
+      for (int o : live_outs)
+        for (int e = 0; e < (int)g.slots[o].len; ++e)
+          cc.prog.out_regs.push_back(cc.reg_of.at(o) + e);
+
     // Generate the backward before estimating, because generating it is
     // what the estimate is about: it appends the checkpoint saves the
     // adjoint needs, so both the register count and the instruction count
@@ -498,6 +542,7 @@ int carve_islands(Graph& g,
     // does not skip this -- it only stops the kernel USING the result, so
     // the two backwards can be compared over the same islands.
     if (compiled) {
+      compact_island(cc.prog);
       const bool gen = gen_adjoint(cc.prog);
       cc.prog.native_adj = gen && !std::getenv("STANLI_NO_NATIVE_ADJ");
       // The var replay cannot execute a CALL (kernels are double
@@ -565,100 +610,68 @@ int carve_islands(Graph& g,
       if (graph_cost < island_cost) compiled = false;
     }
     if (compiled) {
-      // Live-outs: written in the region and visible after it, in
-      // first-write order for a deterministic packing.
-      std::vector<int> live_outs;
-      std::unordered_set<int> seen;
-      for (size_t u = i; u < j; ++u) {
-        const int o = g.ops[u].out;
-        if (seen.count(o)) continue;
-        seen.insert(o);
-        auto lit = last_use.find(o);
-        const bool read_after = lit != last_use.end() && lit->second >= j;
-        if (read_after || root_set.count(o) || term_set.count(o))
-          live_outs.push_back(o);
-      }
-      // A slot that is BOTH a live-in and a live-out (an in-place chain
-      // whose template the region reads first and overwrites last) cannot
-      // keep its id on the output side: the island reads the arena buffer
-      // in the forward, and an extraction writing the same buffer would
-      // feed the NEXT gradient's forward its own previous output. The
-      // extraction gets a fresh slot and later references are renamed --
-      // unless the slot is read from outside the graph, where the id is
-      // the contract, and then the run stays as ops.
-      std::unordered_set<int> in_set(cc.live_in_slots.begin(),
-                                     cc.live_in_slots.end());
-      bool aliased_pinned = false;
-      for (int o : live_outs)
-        if (in_set.count(o) && pinned.count(o)) aliased_pinned = true;
-      if (!live_outs.empty() && !aliased_pinned) {
-        int64_t packed = 0;
-        for (int o : live_outs) {
-          for (int e = 0; e < (int)g.slots[o].len; ++e)
-            cc.prog.out_regs.push_back(cc.reg_of.at(o) + e);
-          packed += g.slots[o].len;
-        }
-        auto prog = std::make_shared<IslandProg>(std::move(cc.prog));
-        Op is;
-        is.opcode = OP_ISLAND;
-        is.n_in = (int)cc.live_in_slots.size();
-        for (int k = 0; k < is.n_in; ++k) is.in[k] = cc.live_in_slots[k];
-        is.out = g.add_slot(packed, false);
-        is.udata = prog.get();
-        g.udata_pool.push_back(std::move(prog));
-        result.push_back(is);
-        // Extractions write the ORIGINAL slot ids, so downstream readers,
-        // roots, and target terms are untouched -- except for the
-        // live-in/live-out slots above, which get a fresh slot and a
-        // rename of every later reference (read or write, as reroll's
-        // write fusion does, so the two stay consistent).
-        int64_t off = 0;
-        for (int o : live_outs) {
-          const int64_t len = g.slots[o].len;
-          int dst = o;
-          if (in_set.count(o)) {
-            dst = g.add_slot(len, false);
-            for (size_t u = j; u < g.ops.size(); ++u) {
-              for (int q = 0; q < g.ops[u].n_in; ++q)
-                if (g.ops[u].in[q] == o) g.ops[u].in[q] = dst;
-              if (g.ops[u].out == o) g.ops[u].out = dst;
-              if (g.ops[u].out2 == o) g.ops[u].out2 = dst;
-            }
+      int64_t packed = 0;
+      for (int o : live_outs) packed += g.slots[o].len;
+      auto prog = std::make_shared<IslandProg>(std::move(cc.prog));
+      Op is;
+      is.opcode = OP_ISLAND;
+      is.n_in = (int)cc.live_in_slots.size();
+      for (int k = 0; k < is.n_in; ++k) is.in[k] = cc.live_in_slots[k];
+      is.out = g.add_slot(packed, false);
+      is.udata = prog.get();
+      g.udata_pool.push_back(std::move(prog));
+      result.push_back(is);
+      // Extractions write the ORIGINAL slot ids, so downstream readers,
+      // roots, and target terms are untouched -- except for the
+      // live-in/live-out slots above, which get a fresh slot and a
+      // rename of every later reference (read or write, as reroll's
+      // write fusion does, so the two stay consistent).
+      int64_t off = 0;
+      for (int o : live_outs) {
+        const int64_t len = g.slots[o].len;
+        int dst = o;
+        if (in_set.count(o)) {
+          dst = g.add_slot(len, false);
+          for (size_t u = j; u < g.ops.size(); ++u) {
+            for (int q = 0; q < g.ops[u].n_in; ++q)
+              if (g.ops[u].in[q] == o) g.ops[u].in[q] = dst;
+            if (g.ops[u].out == o) g.ops[u].out = dst;
+            if (g.ops[u].out2 == o) g.ops[u].out2 = dst;
           }
-          Op ex;
-          ex.opcode = len == 1 ? OP_INDEX : OP_SLICE;
-          ex.n_in = 1;
-          ex.in[0] = is.out;
-          ex.out = dst;
-          g.idata_pool.push_back({(int)off});
-          ex.idata = g.idata_pool.back().data();
-          ex.n_idata = 1;
-          result.push_back(ex);
-          off += len;
         }
-        if (std::getenv("STANLI_DEBUG_ISLAND")) {
-          const IslandProg& p = *static_cast<const IslandProg*>(is.udata);
-          std::fprintf(stderr,
-                       "island: ops=%zu instr=%zu regs=%d ins=%zu outs=%zu "
-                       "adj=%zu adj_regs=%d\n",
-                       j - i, p.code.size(), p.n_regs, p.ins.size(),
-                       p.out_regs.size(), p.adj.code.size(), p.adj.n_regs);
-          // Which instructions the region is made of, so a disagreement
-          // with the replay can be attributed to an opcode rather than
-          // guessed at.
-          std::vector<int> hist(64, 0);
-          for (const auto& I : p.code)
-            if ((int)I.code < 64) ++hist[(size_t)I.code];
-          std::fprintf(stderr, "island opcodes:");
-          for (int c = 0; c < 64; ++c)
-            if (hist[(size_t)c])
-              std::fprintf(stderr, " %d:%d", c, hist[(size_t)c]);
-          std::fprintf(stderr, "\n");
-        }
-        ++carved;
-        i = j;
-        continue;
+        Op ex;
+        ex.opcode = len == 1 ? OP_INDEX : OP_SLICE;
+        ex.n_in = 1;
+        ex.in[0] = is.out;
+        ex.out = dst;
+        g.idata_pool.push_back({(int)off});
+        ex.idata = g.idata_pool.back().data();
+        ex.n_idata = 1;
+        result.push_back(ex);
+        off += len;
       }
+      if (std::getenv("STANLI_DEBUG_ISLAND")) {
+        const IslandProg& p = *static_cast<const IslandProg*>(is.udata);
+        std::fprintf(stderr,
+                     "island: ops=%zu instr=%zu regs=%d ins=%zu outs=%zu "
+                     "adj=%zu adj_regs=%d\n",
+                     j - i, p.code.size(), p.n_regs, p.ins.size(),
+                     p.out_regs.size(), p.adj.code.size(), p.adj.n_regs);
+        // Which instructions the region is made of, so a disagreement
+        // with the replay can be attributed to an opcode rather than
+        // guessed at.
+        std::vector<int> hist(64, 0);
+        for (const auto& I : p.code)
+          if ((int)I.code < 64) ++hist[(size_t)I.code];
+        std::fprintf(stderr, "island opcodes:");
+        for (int c = 0; c < 64; ++c)
+          if (hist[(size_t)c])
+            std::fprintf(stderr, " %d:%d", c, hist[(size_t)c]);
+        std::fprintf(stderr, "\n");
+      }
+      ++carved;
+      i = j;
+      continue;
     }
     // Compile failed or nothing escapes: leave the run as ops.
     while (i < j) result.push_back(g.ops[i++]);

--- a/runtime/src/lower.cpp
+++ b/runtime/src/lower.cpp
@@ -1767,6 +1767,7 @@ struct Lowering {
     // lost -- so this usually declines. It is asked anyway because a region
     // can reach here branch-free: a `~` refusal or an unknown name is not
     // the only way to end up compiled.
+    compact_island(*prog);
     prog->native_adj =
         gen_adjoint(*prog) && !std::getenv("STANLI_NO_NATIVE_ADJ");
     *prog_out = std::move(prog);

--- a/runtime/src/ode_prog.cpp
+++ b/runtime/src/ode_prog.cpp
@@ -7,216 +7,22 @@
 
 #include <stanli/mir_prog.hpp>
 
-#include <algorithm>
-#include <cmath>
 #include <stdexcept>
 
 namespace stanli {
 
 namespace {
 
-// The MIR spells an initialized local as its language-level default fill
-// followed by a copy of the initializer, and copies values again through
-// return temporaries. Native C++ optimization removes that bookkeeping. An
-// ODE right-hand side otherwise pays it on every solver callback, including
-// under var where a dead constant also allocates a disconnected tape node.
-//
-// Keep this deliberately narrower than a general Program optimizer. ODE
-// scalar arithmetic has no effects, range reads, densities, or kernel calls;
-// an unfamiliar instruction leaves the program unchanged. Dead constants
-// may disappear only before the next control-flow edge, and a MOV aliases its
-// source only when both registers have stable single definitions. Branch
-// joins therefore retain their initialized value.
-bool scalar_rhs_instruction(Program::Code code) {
-  switch (code) {
-    case Program::CONST:
-    case Program::CONSTR:
-    case Program::MOV:
-    case Program::ADD:
-    case Program::SUB:
-    case Program::MUL:
-    case Program::DIV:
-    case Program::POW:
-    case Program::FMAX:
-    case Program::FMIN:
-    case Program::NEG:
-    case Program::EXP:
-    case Program::LOG:
-    case Program::SQRT:
-    case Program::SQUARE:
-    case Program::INV:
-    case Program::FABS:
-    case Program::INV_LOGIT:
-    case Program::LOG1M:
-    case Program::TANH:
-    case Program::GT:
-    case Program::GE:
-    case Program::LT:
-    case Program::LE:
-    case Program::EQ:
-    case Program::NE:
-    case Program::JZ:
-    case Program::JMP:
-    case Program::LSE2:
-    case Program::LOG_MIX:
-    case Program::FMA:
-      return true;
-    default:
-      return false;
-  }
-}
-
-bool binary_rhs_instruction(Program::Code code) {
-  switch (code) {
-    case Program::ADD:
-    case Program::SUB:
-    case Program::MUL:
-    case Program::DIV:
-    case Program::POW:
-    case Program::FMAX:
-    case Program::FMIN:
-    case Program::GT:
-    case Program::GE:
-    case Program::LT:
-    case Program::LE:
-    case Program::EQ:
-    case Program::NE:
-    case Program::LSE2:
-      return true;
-    default:
-      return false;
-  }
-}
-
-bool unary_rhs_instruction(Program::Code code) {
-  switch (code) {
-    case Program::MOV:
-    case Program::NEG:
-    case Program::EXP:
-    case Program::LOG:
-    case Program::SQRT:
-    case Program::SQUARE:
-    case Program::INV:
-    case Program::FABS:
-    case Program::INV_LOGIT:
-    case Program::LOG1M:
-    case Program::TANH:
-    case Program::JZ:
-      return true;
-    default:
-      return false;
-  }
-}
-
-bool reads_rhs_register(const Program::Instr& instr, int reg) {
-  if (unary_rhs_instruction(instr.code)) return instr.a == reg;
-  if (binary_rhs_instruction(instr.code))
-    return instr.a == reg || instr.b == reg;
-  if (instr.code == Program::LOG_MIX || instr.code == Program::FMA)
-    return instr.a == reg || instr.b == reg || instr.c == reg;
-  return false;
-}
-
-bool writes_rhs_register(const Program::Instr& instr, int reg) {
-  if (instr.code == Program::JZ || instr.code == Program::JMP) return false;
-  if (instr.code == Program::CONSTR)
-    return reg >= instr.dst && reg < instr.dst + instr.len;
-  return instr.dst == reg;
-}
-
-void rewrite_rhs_reads(Program::Instr& instr, const std::vector<int>& alias) {
-  if (unary_rhs_instruction(instr.code)) {
-    instr.a = alias[(size_t)instr.a];
-    return;
-  }
-  if (binary_rhs_instruction(instr.code)) {
-    instr.a = alias[(size_t)instr.a];
-    instr.b = alias[(size_t)instr.b];
-    return;
-  }
-  if (instr.code == Program::LOG_MIX || instr.code == Program::FMA) {
-    instr.a = alias[(size_t)instr.a];
-    instr.b = alias[(size_t)instr.b];
-    instr.c = alias[(size_t)instr.c];
-  }
-}
-
-void optimize_scalar_rhs(RhsProgram& p) {
-  if (!std::all_of(p.code.begin(), p.code.end(), [](const auto& instr) {
-        return scalar_rhs_instruction(instr.code);
-      }))
-    return;
-
-  const size_t n = p.code.size();
-  std::vector<bool> remove(n, false);
-
-  // A scalar declaration fill overwritten before any read or branch is
-  // disconnected bookkeeping. Stop at a jump even when a later assignment
-  // looks unconditional in the linear instruction array.
-  for (size_t i = 0; i < n; ++i) {
-    const Program::Instr& init = p.code[i];
-    if (init.code != Program::CONST) continue;
-    for (size_t j = i + 1; j < n; ++j) {
-      const Program::Instr& next = p.code[j];
-      if (next.code == Program::JZ || next.code == Program::JMP) break;
-      if (reads_rhs_register(next, init.dst)) break;
-      if (writes_rhs_register(next, init.dst)) {
-        remove[i] = true;
-        break;
-      }
-    }
-  }
-
-  std::vector<int> writers((size_t)p.n_regs, 0);
-  std::vector<int> writer_pc((size_t)p.n_regs, -1);
-  for (size_t pc = 0; pc < n; ++pc) {
-    if (remove[pc]) continue;
-    const Program::Instr& instr = p.code[pc];
-    if (instr.code == Program::JZ || instr.code == Program::JMP) continue;
-    const int len = instr.code == Program::CONSTR ? instr.len : 1;
-    for (int k = 0; k < len; ++k) {
-      const size_t reg = (size_t)(instr.dst + k);
-      ++writers[reg];
-      writer_pc[reg] = (int)pc;
-    }
-  }
-
-  std::vector<int> alias((size_t)p.n_regs);
-  for (int reg = 0; reg < p.n_regs; ++reg) alias[(size_t)reg] = reg;
-  for (size_t pc = 0; pc < n; ++pc) {
-    if (remove[pc]) continue;
-    Program::Instr& instr = p.code[pc];
-    rewrite_rhs_reads(instr, alias);
-    if (instr.code == Program::MOV && writers[(size_t)instr.dst] == 1 &&
-        writers[(size_t)instr.a] <= 1 && writer_pc[(size_t)instr.a] < (int)pc) {
-      alias[(size_t)instr.dst] = instr.a;
-      remove[pc] = true;
-      continue;
-    }
-    if (instr.code == Program::JZ || instr.code == Program::JMP) continue;
-    const int len = instr.code == Program::CONSTR ? instr.len : 1;
-    for (int k = 0; k < len; ++k)
-      alias[(size_t)(instr.dst + k)] = instr.dst + k;
-  }
-  for (int& reg : p.out_regs) reg = alias[(size_t)reg];
-
-  std::vector<int> new_pc(n + 1, 0);
-  int at = 0;
-  for (size_t pc = 0; pc < n; ++pc) {
-    new_pc[pc] = at;
-    if (!remove[pc]) ++at;
-  }
-  new_pc[n] = at;
-  std::vector<Program::Instr> compact;
-  compact.reserve((size_t)at);
-  for (size_t pc = 0; pc < n; ++pc) {
-    if (remove[pc]) continue;
-    Program::Instr instr = p.code[pc];
-    if (instr.code == Program::JZ || instr.code == Program::JMP)
-      instr.dst = new_pc[(size_t)instr.dst];
-    compact.push_back(instr);
-  }
-  p.code = std::move(compact);
+// The register regions run_rhs seeds before the program starts, in the order
+// the fields appear on RhsProgram.
+void compact_rhs(RhsProgram& p) {
+  std::vector<std::pair<int, int>> seeded{
+      {p.t_reg, 1}, {p.y0, p.n_y}, {p.th0, p.n_th}, {p.xr0, p.n_xr}};
+  compact_program(p, seeded);
+  p.t_reg = seeded[0].first;
+  p.y0 = seeded[1].first;
+  p.th0 = seeded[2].first;
+  p.xr0 = seeded[3].first;
 }
 
 bool supported_rhs_view(const mir::UnsizedView& view) {
@@ -315,7 +121,7 @@ RhsProgram compile_rhs_args(
              " values for " + std::to_string(n_y) + " states");
     for (int k = 0; k < out.len; ++k) p.out_regs.push_back(out.reg + k);
     c.finish();
-    optimize_scalar_rhs(p);
+    compact_rhs(p);
     p.ok = true;
   } catch (Bail& b) {
     p.ok = false;

--- a/runtime/src/program.cpp
+++ b/runtime/src/program.cpp
@@ -1,0 +1,307 @@
+// Compaction over a compiled register program (program.hpp).
+//
+// The MIR spells an initialized local as its language-level default fill
+// followed by a copy of the initializer, and copies values again through
+// return temporaries. Native C++ optimization removes that bookkeeping. A
+// register program otherwise pays it on every call, and an island pays for it
+// twice: once in the forward instruction stream, once in the register file the
+// generated backward (adjoint.cpp) sizes and reads.
+//
+// A fill whose registers are all overwritten before the next read or
+// control-flow edge goes away. A copy whose destination has no other writer
+// and whose source is never written again goes away, and later reads of the
+// destination are pointed at the source -- the same test gen_adjoint applies
+// before letting the two registers share an adjoint cell. What that leaves
+// unreferenced is renumbered out of the register file.
+//
+// Ranges are the constraint throughout: several opcodes read or write runs of
+// consecutive registers, and every such run has to stay consecutive. So a copy
+// is refused when its block starts or ends strictly inside a range, and the
+// renumbering only drops registers nothing names.
+#include <stanli/program.hpp>
+
+#include <limits>
+#include <vector>
+
+namespace stanli {
+
+namespace {
+
+struct Span {
+  int reg;
+  int len;
+};
+
+template <typename F>
+void each_write(const Program& p, const Program::Instr& I, F fn) {
+  if (I.code == Program::CALL) {
+    const Program::Call& c = p.calls[(size_t)I.a];
+    fn(Span{c.out, c.out_len});
+    fn(Span{c.scratch, c.scratch_len});
+    return;
+  }
+  const int len = program_output_len(I);
+  if (len > 0) fn(Span{I.dst, len});
+}
+
+template <typename F>
+void each_read(const Program& p, const Program::Instr& I, F fn) {
+  if (I.code == Program::CALL) {
+    const Program::Call& c = p.calls[(size_t)I.a];
+    for (int j = 0; j < c.n_in; ++j) fn(Span{c.in[j], c.in_len[j]});
+    return;
+  }
+  if (I.code == Program::DENSITY) {
+    const int arity = program_density_arity(I.len);
+    if (arity > 3) {
+      fn(Span{I.a, arity});
+      return;
+    }
+    fn(Span{I.a, 1});
+    if (arity > 1) fn(Span{I.b, 1});
+    if (arity > 2) fn(Span{I.c, 1});
+    return;
+  }
+  const ProgramOpSpec& spec = program_code_spec(I.code);
+  if (spec.has(kProgramNoInputs)) return;
+  fn(Span{I.a, spec.has(kProgramRangeA) ? I.len : 1});
+  if (spec.has(kProgramReadB))
+    fn(Span{I.b, spec.has(kProgramRangeB) ? I.len : 1});
+  if (spec.has(kProgramReadC)) fn(Span{I.c, 1});
+}
+
+void remap(Program::Call& c, const std::vector<int>& m) {
+  for (int j = 0; j < c.n_in; ++j)
+    if (c.in_len[j] > 0) c.in[j] = m[(size_t)c.in[j]];
+  if (c.out_len > 0) c.out = m[(size_t)c.out];
+  if (c.scratch_len > 0) c.scratch = m[(size_t)c.scratch];
+}
+
+void remap(Program::Instr& I, const std::vector<int>& m) {
+  if (I.code == Program::CALL) return;
+  const ProgramOpSpec& spec = program_code_spec(I.code);
+  if (program_output_len(I) > 0) I.dst = m[(size_t)I.dst];
+  if (spec.has(kProgramNoInputs)) return;
+  I.a = m[(size_t)I.a];
+  if (I.code == Program::DENSITY) {
+    const int arity = program_density_arity(I.len);
+    if (arity > 1) I.b = m[(size_t)I.b];
+    if (arity > 2) I.c = m[(size_t)I.c];
+    return;
+  }
+  if (spec.has(kProgramReadB)) I.b = m[(size_t)I.b];
+  if (spec.has(kProgramReadC)) I.c = m[(size_t)I.c];
+}
+
+bool branches(Program::Code code) {
+  return code == Program::JZ || code == Program::JMP;
+}
+
+}  // namespace
+
+void compact_program(Program& p, std::vector<std::pair<int, int>>& seeded) {
+  const int n_regs = p.n_regs;
+  const size_t n = p.code.size();
+  if (n_regs <= 0) return;
+  // DYN_INDEX's `c` is an offset into a run rather than a register.
+  for (const auto& I : p.code) {
+    if (I.code == Program::DYN_INDEX) return;
+    if (I.code == Program::CALL &&
+        (I.a < 0 || (size_t)I.a >= p.calls.size()))
+      return;
+  }
+
+  auto in_file = [&](Span s) { return s.reg >= 0 && s.reg + s.len <= n_regs; };
+  for (const auto& I : p.code) {
+    bool ok = true;
+    each_write(p, I, [&](Span s) { ok = ok && in_file(s); });
+    each_read(p, I, [&](Span s) { ok = ok && in_file(s); });
+    if (!ok) return;
+  }
+  for (const auto& s : seeded)
+    if (s.second > 0 && !in_file(Span{s.first, s.second})) return;
+  for (int reg : p.out_regs)
+    if (reg < 0 || reg >= n_regs) return;
+
+  std::vector<char> pinned((size_t)n_regs, 0);
+  std::vector<char> interior((size_t)n_regs + 1, 0);
+  auto mark_range = [&](Span s) {
+    for (int k = 1; k < s.len; ++k) interior[(size_t)(s.reg + k)] = 1;
+  };
+  auto mark_pinned = [&](Span s) {
+    for (int k = 0; k < s.len; ++k) pinned[(size_t)(s.reg + k)] = 1;
+  };
+  for (const auto& s : seeded) {
+    mark_pinned(Span{s.first, s.second});
+    mark_range(Span{s.first, s.second});
+  }
+  for (const auto& I : p.code) {
+    each_write(p, I, mark_range);
+    each_read(p, I, mark_range);
+    // The adjoint rules that walk a run of adjoint cells need those cells to
+    // stay where the run is.
+    if (I.code == Program::CALL) {
+      const Program::Call& c = p.calls[(size_t)I.a];
+      for (int j = 0; j < c.n_in; ++j) mark_pinned(Span{c.in[j], c.in_len[j]});
+      mark_pinned(Span{c.out, c.out_len});
+    }
+    if (I.code == Program::DENSITY && program_density_arity(I.len) > 3)
+      mark_pinned(Span{I.a, program_density_arity(I.len)});
+  }
+
+  // Sweeping backwards keeps the "next event on this register" tables to two
+  // arrays. A fill is dead when every register it writes is overwritten
+  // before it is read and before the next branch.
+  std::vector<char> dead_fill(n, 0);
+  const int never = std::numeric_limits<int>::max();
+  std::vector<int> next_read((size_t)n_regs, never),
+      next_write((size_t)n_regs, never);
+  int next_branch = never;
+  for (size_t i = n; i-- > 0;) {
+    const Program::Instr& I = p.code[i];
+    if (I.code == Program::CONST || I.code == Program::CONSTR) {
+      bool dead = true;
+      each_write(p, I, [&](Span s) {
+        for (int k = 0; k < s.len; ++k) {
+          const size_t reg = (size_t)(s.reg + k);
+          if (next_write[reg] >= next_read[reg] ||
+              next_write[reg] >= next_branch)
+            dead = false;
+        }
+      });
+      if (dead) dead_fill[i] = 1;
+    }
+    each_write(p, I, [&](Span s) {
+      for (int k = 0; k < s.len; ++k) next_write[(size_t)(s.reg + k)] = (int)i;
+    });
+    each_read(p, I, [&](Span s) {
+      for (int k = 0; k < s.len; ++k) next_read[(size_t)(s.reg + k)] = (int)i;
+    });
+    if (branches(I.code)) next_branch = (int)i;
+  }
+
+  std::vector<int> declared((size_t)n_regs, -1);
+  for (size_t i = 0; i < n; ++i)
+    each_write(p, p.code[i], [&](Span s) {
+      for (int k = 0; k < s.len; ++k)
+        if (declared[(size_t)(s.reg + k)] < 0)
+          declared[(size_t)(s.reg + k)] = (int)i;
+    });
+
+  // Dropping a fill makes the copy after it the destination's only writer,
+  // which is the test gen_adjoint applies too -- so a copy this pass leaves
+  // standing has to keep its fill, or the generated backward starts sharing
+  // cells the uncompacted one kept apart. Settling the two together takes a
+  // couple of rounds; the fill set only ever shrinks.
+  std::vector<char> remove(n, 0);
+  std::vector<int> alias((size_t)n_regs);
+  std::vector<int> first_write((size_t)n_regs), last_write((size_t)n_regs);
+  for (int round = 0;; ++round) {
+    first_write.assign((size_t)n_regs, -1);
+    last_write.assign((size_t)n_regs, -1);
+    for (size_t i = 0; i < n; ++i) {
+      if (dead_fill[i]) continue;
+      each_write(p, p.code[i], [&](Span s) {
+        for (int k = 0; k < s.len; ++k) {
+          const size_t reg = (size_t)(s.reg + k);
+          if (first_write[reg] < 0) first_write[reg] = (int)i;
+          last_write[reg] = (int)i;
+        }
+      });
+    }
+    for (int reg = 0; reg < n_regs; ++reg) alias[(size_t)reg] = reg;
+    remove = dead_fill;
+    for (size_t i = 0; i < n; ++i) {
+      const Program::Instr& I = p.code[i];
+      if (I.code != Program::MOV && I.code != Program::MOVR) continue;
+      const int len = I.code == Program::MOV ? 1 : I.len;
+      if (len <= 0) continue;
+      if (interior[(size_t)I.dst] || interior[(size_t)(I.dst + len)]) continue;
+      bool ok = true;
+      for (int k = 0; k < len && ok; ++k) {
+        const size_t dst = (size_t)(I.dst + k), src = (size_t)(I.a + k);
+        ok = first_write[dst] == (int)i && last_write[dst] == (int)i &&
+             last_write[src] <= (int)i && !pinned[dst] &&
+             alias[src] == alias[(size_t)I.a] + k;
+      }
+      if (!ok) continue;
+      for (int k = 0; k < len; ++k)
+        alias[(size_t)(I.dst + k)] = alias[(size_t)I.a] + k;
+      remove[i] = 1;
+    }
+    bool settled = true;
+    for (size_t i = 0; i < n; ++i) {
+      const Program::Instr& I = p.code[i];
+      if (remove[i] || (I.code != Program::MOV && I.code != Program::MOVR))
+        continue;
+      const int len = I.code == Program::MOV ? 1 : I.len;
+      bool shares = len > 0;
+      for (int k = 0; k < len && shares; ++k) {
+        const size_t dst = (size_t)(I.dst + k), src = (size_t)(I.a + k);
+        shares = first_write[dst] == (int)i && last_write[dst] == (int)i &&
+                 last_write[src] <= (int)i && !pinned[dst];
+      }
+      for (int k = 0; k < len && shares; ++k) {
+        const int fill = declared[(size_t)(I.dst + k)];
+        if (fill < 0 || fill == (int)i || !dead_fill[(size_t)fill]) continue;
+        dead_fill[(size_t)fill] = 0;
+        settled = false;
+      }
+    }
+    if (settled) break;
+    if (round >= 2) dead_fill.assign(n, 0);
+  }
+
+  std::vector<char> used((size_t)n_regs, 0);
+  auto use = [&](Span s) {
+    for (int k = 0; k < s.len; ++k) used[(size_t)alias[(size_t)(s.reg + k)]] = 1;
+  };
+  bool contiguous = true;
+  auto check = [&](Span s) {
+    for (int k = 1; k < s.len; ++k)
+      if (alias[(size_t)(s.reg + k)] != alias[(size_t)s.reg] + k)
+        contiguous = false;
+    use(s);
+  };
+  for (const auto& s : seeded) check(Span{s.first, s.second});
+  for (size_t i = 0; i < n; ++i) {
+    if (remove[i]) continue;
+    each_write(p, p.code[i], check);
+    each_read(p, p.code[i], check);
+  }
+  for (int reg : p.out_regs) used[(size_t)alias[(size_t)reg]] = 1;
+  if (!contiguous) return;
+
+  std::vector<int> renumber((size_t)n_regs, -1);
+  int at = 0;
+  for (int reg = 0; reg < n_regs; ++reg)
+    if (used[(size_t)reg]) renumber[(size_t)reg] = at++;
+  std::vector<int> map((size_t)n_regs);
+  for (int reg = 0; reg < n_regs; ++reg)
+    map[(size_t)reg] = renumber[(size_t)alias[(size_t)reg]];
+
+  std::vector<int> new_pc(n + 1, 0);
+  int pc = 0;
+  for (size_t i = 0; i < n; ++i) {
+    new_pc[i] = pc;
+    if (!remove[i]) ++pc;
+  }
+  new_pc[n] = pc;
+  std::vector<Program::Instr> code;
+  code.reserve((size_t)pc);
+  for (size_t i = 0; i < n; ++i) {
+    if (remove[i]) continue;
+    Program::Instr I = p.code[i];
+    if (I.code == Program::CALL) remap(p.calls[(size_t)I.a], map);
+    remap(I, map);
+    if (branches(I.code)) I.dst = new_pc[(size_t)I.dst];
+    code.push_back(I);
+  }
+  p.code = std::move(code);
+  for (int& reg : p.out_regs) reg = map[(size_t)reg];
+  for (auto& s : seeded)
+    if (s.second > 0) s.first = map[(size_t)s.first];
+  p.n_regs = at;
+}
+
+}  // namespace stanli

--- a/tests/test_island.cpp
+++ b/tests/test_island.cpp
@@ -167,6 +167,164 @@ static HmmGraph build_hmm(int T, int W = 2) {
   return h;
 }
 
+// compact_program (program.cpp) on programs small enough to write down.
+// The gradients the removals must not move are covered by every other case
+// in this file; these pin which instructions survive.
+static std::string opcodes(const Program& p) {
+  std::string out;
+  for (const auto& I : p.code) {
+    if (!out.empty()) out += ' ';
+    out += program_code_spec(I.code).name;
+  }
+  return out;
+}
+
+static void expect_eq(const std::string& what, const std::string& got,
+                      const std::string& want) {
+  if (got != want) {
+    ++failures;
+    std::printf("FAIL %s: got [%s] want [%s]\n", what.c_str(), got.c_str(),
+                want.c_str());
+  }
+}
+
+static void expect_eq(const std::string& what, int got, int want) {
+  if (got != want) {
+    ++failures;
+    std::printf("FAIL %s: got %d want %d\n", what.c_str(), got, want);
+  }
+}
+
+static void test_compact_copy_chain() {
+  Program p;
+  p.n_regs = 4;
+  p.pool = {2.0};
+  p.code = {
+      {Program::CONST, 1, 0}, {Program::MOV, 2, 1}, {Program::ADD, 3, 0, 2}};
+  p.out_regs = {3};
+  std::vector<std::pair<int, int>> seeded{{0, 1}};
+  compact_program(p, seeded);
+  expect_eq("copy chain code", opcodes(p), "CONST ADD");
+  expect_eq("copy chain regs", p.n_regs, 3);
+  expect_eq("copy chain add reads the source", p.code[1].b, 1);
+  expect_eq("copy chain live-out", p.out_regs[0], 2);
+}
+
+static void test_compact_dead_fill() {
+  Program p;
+  p.n_regs = 5;
+  p.pool = {0.0, 0.0};
+  p.code = {{Program::CONSTR, 2, 0, 0, 0, 2},
+            {Program::EXP_RANGE, 2, 0, 0, 0, 2},
+            {Program::DOT, 4, 2, 0, 0, 2}};
+  p.out_regs = {4};
+  std::vector<std::pair<int, int>> seeded{{0, 2}};
+  compact_program(p, seeded);
+  expect_eq("dead fill code", opcodes(p), "EXP_RANGE DOT");
+  expect_eq("dead fill regs", p.n_regs, 5);
+}
+
+static void test_compact_rewritten_source_kept() {
+  Program p;
+  p.n_regs = 4;
+  p.pool = {2.0, 3.0};
+  p.code = {{Program::CONST, 1, 0},
+            {Program::MOV, 2, 1},
+            {Program::CONST, 1, 1},
+            {Program::ADD, 3, 2, 1}};
+  p.out_regs = {3};
+  std::vector<std::pair<int, int>> seeded{{0, 1}};
+  compact_program(p, seeded);
+  expect_eq("rewritten source keeps the copy", opcodes(p),
+            "CONST MOV CONST ADD");
+}
+
+static void test_compact_second_writer_kept() {
+  Program p;
+  p.n_regs = 4;
+  p.pool = {2.0, 3.0};
+  p.code = {{Program::CONST, 1, 0},
+            {Program::MOV, 2, 1},
+            {Program::CONST, 2, 1},
+            {Program::ADD, 3, 2, 1}};
+  p.out_regs = {3};
+  std::vector<std::pair<int, int>> seeded{{0, 1}};
+  compact_program(p, seeded);
+  expect_eq("second writer keeps the copy", opcodes(p), "CONST MOV CONST ADD");
+}
+
+static void test_compact_range_copy() {
+  Program p;
+  p.n_regs = 10;
+  p.code = {{Program::MOVR, 4, 0, 0, 0, 4},
+            {Program::LSE_RANGE, 8, 4, 0, 0, 4}};
+  p.out_regs = {8};
+  std::vector<std::pair<int, int>> seeded{{0, 4}};
+  compact_program(p, seeded);
+  expect_eq("range copy code", opcodes(p), "LSE_RANGE");
+  expect_eq("range copy reads the source", p.code[0].a, 0);
+  expect_eq("range copy regs", p.n_regs, 5);
+}
+
+// A read that spans two copies must not be split across their sources.
+static void test_compact_straddling_range_kept() {
+  Program p;
+  p.n_regs = 12;
+  p.code = {{Program::MOVR, 4, 0, 0, 0, 2},
+            {Program::MOVR, 6, 2, 0, 0, 2},
+            {Program::LSE_RANGE, 8, 5, 0, 0, 2}};
+  p.out_regs = {8};
+  std::vector<std::pair<int, int>> seeded{{0, 4}};
+  compact_program(p, seeded);
+  expect_eq("straddling range keeps both copies", opcodes(p),
+            "MOVR MOVR LSE_RANGE");
+}
+
+static void test_compact_call_ranges() {
+  Program p;
+  p.n_regs = 8;
+  Program::Call c;
+  c.opcode = OP_ADD;
+  c.n_in = 1;
+  c.in[0] = 2;
+  c.in_len[0] = 2;
+  c.out = 4;
+  c.out_len = 1;
+  c.scratch = 5;
+  c.scratch_len = 2;
+  p.calls = {c};
+  p.code = {{Program::MOVR, 2, 0, 0, 0, 2},
+            {Program::CALL, 0, 0},
+            {Program::MOV, 7, 4}};
+  p.out_regs = {7};
+  std::vector<std::pair<int, int>> seeded{{0, 2}};
+  compact_program(p, seeded);
+  expect_eq("call input range keeps its copy", opcodes(p), "MOVR CALL");
+  expect_eq("call regs", p.n_regs, 7);
+  expect_eq("call live-out", p.out_regs[0], 4);
+}
+
+static size_t hmm_island_instrs(const char* what) {
+  HmmGraph h = build_hmm(8);
+  if (carve_islands(h.g, h.fills, h.terms, {}) != 1) {
+    ++failures;
+    std::printf("FAIL %s: no island carved\n", what);
+    return 0;
+  }
+  for (const Op& op : h.g.ops)
+    if (op.opcode == OP_ISLAND)
+      return static_cast<const IslandProg*>(op.udata)->code.size();
+  return 0;
+}
+
+static void test_compact_env_disable() {
+  test_setenv("STANLI_NO_ISLAND_COMPACT", "1", 1);
+  const size_t off = hmm_island_instrs("compaction off");
+  test_unsetenv("STANLI_NO_ISLAND_COMPACT");
+  const size_t on = hmm_island_instrs("compaction on");
+  expect("compaction shrinks the hmm island", on < off);
+}
+
 static void test_hmm_parity() {
   HmmGraph ref = build_hmm(8);  // 8*11 = 88 body ops, above threshold
   const std::vector<double> want = run_grad(std::move(ref.g), ref.fills);
@@ -325,7 +483,11 @@ static HmmGraph build_compact_cost_boundary() {
   return h;
 }
 
+// The adjoint file is what the boundary is about, so this runs with
+// compaction off: with it on the copies never reach gen_adjoint, and the
+// region clears the estimate by a margin instead of sitting on it.
 static void test_compact_adjoint_cost_boundary() {
+  test_setenv("STANLI_NO_ISLAND_COMPACT", "1", 1);
   HmmGraph forced = build_compact_cost_boundary();
   const int64_t graph_cost = 6 * (int64_t)forced.body_ops;
   test_setenv("STANLI_ISLAND_ALWAYS", "1", 1);
@@ -351,6 +513,11 @@ static void test_compact_adjoint_cost_boundary() {
   HmmGraph normal = build_compact_cost_boundary();
   expect("compact boundary default carve",
          carve_islands(normal.g, normal.fills, normal.terms, {}) == 1);
+  test_unsetenv("STANLI_NO_ISLAND_COMPACT");
+
+  HmmGraph compacted = build_compact_cost_boundary();
+  expect("compact boundary carves compacted too",
+         carve_islands(compacted.g, compacted.fills, compacted.terms, {}) == 1);
 }
 
 // The same recurrence on a two-element state: nothing is copied, so the
@@ -381,7 +548,8 @@ static void test_scalar_chain_carved() {
 // same graph uncarved: a CALL runs the identical kernel, so the graph
 // is the arbiter, not the var replay (which cannot execute a CALL and
 // never meets one).
-static void test_kernel_call_ops_carved() {
+static void test_kernel_call_ops_carved(bool compact) {
+  if (!compact) test_setenv("STANLI_NO_ISLAND_COMPACT", "1", 1);
   Graph g;
   Fills fills;
   const int p0 = g.add_slot(1, true);
@@ -460,11 +628,14 @@ static void test_kernel_call_ops_carved() {
       check_range(call.out, call.out_len);
     }
   }
-  expect("call range actually compacted", shifted_call_range);
+  // With compaction on, the copies gen_adjoint used to share a cell for are
+  // gone before it runs, so the mapping is an identity it never built.
+  if (!compact) expect("call range actually compacted", shifted_call_range);
   const std::vector<double> got = run_grad_twice(std::move(g), fills);
   expect("callops sizes", got.size() == want.size());
   for (size_t i = 0; i < want.size() && i < got.size(); ++i)
     expect_close("callops v" + std::to_string(i), got[i], want[i]);
+  if (!compact) test_unsetenv("STANLI_NO_ISLAND_COMPACT");
 }
 
 static void test_too_many_live_ins() {
@@ -689,6 +860,14 @@ int main() {
   // reason about. The cost estimate would refuse most of them -- it is
   // policy, tested separately below, and these are about correctness.
   test_branch_bound_live_out();
+  test_compact_copy_chain();
+  test_compact_dead_fill();
+  test_compact_rewritten_source_kept();
+  test_compact_second_writer_kept();
+  test_compact_range_copy();
+  test_compact_straddling_range_kept();
+  test_compact_call_ranges();
+  test_compact_env_disable();
   test_setenv("STANLI_ISLAND_ALWAYS", "1", 1);
   test_hmm_parity();
   test_env_disable();
@@ -700,7 +879,8 @@ int main() {
   test_too_many_live_ins();
   test_six_live_ins_ok();
   test_packed_live_ins();
-  test_kernel_call_ops_carved();
+  test_kernel_call_ops_carved(true);
+  test_kernel_call_ops_carved(false);
 
   test_unsetenv("STANLI_ISLAND_ALWAYS");
   test_wide_state_refused();


### PR DESCRIPTION
Generalizes #188's compact_program to the full Program vocabulary (table-driven) and runs it on islands before adjoint generation. Deletes the ODE-specific classification switches (net +49 lines including tests). iohmm_reg/hmm_example 4%, hmm_gaussian 2-3%, register files up to 23% smaller. 120/120 byte-identical under both the native adjoint and STANLI_NO_NATIVE_ADJ var replay; ctest 61/61; corpus worst line unchanged. One subtlety: fill removal alters gen_adjoint's only-writer test, so compaction and adjoint cell-sharing settle jointly, else iohmm's native adjoint falls back to replay.