### PR TITLE
perf: per-argument activity masks on island densities

### DIFF
--- a/runtime/include/stanli/adjoint.hpp
+++ b/runtime/include/stanli/adjoint.hpp
@@ -44,6 +44,10 @@ namespace stanli {
 // generator had to checkpoint them.
 struct AdjInstr {
   Program::Code code = Program::CONST;
+  // DENSITY only: bit k set where argument k is downstream of a parameter.
+  // Rides in the padding after `code`, as the graph's density ops carry
+  // their activity in Op::variant.
+  uint8_t mask = 0xf;
   int32_t dst = 0, a = 0, b = 0, c = 0;
   int32_t len = 0;
   int32_t vd = 0, va = 0, vb = 0, vc = 0;

--- a/runtime/include/stanli/island.hpp
+++ b/runtime/include/stanli/island.hpp
@@ -23,10 +23,11 @@
 // exists for its adjoints.
 //
 // Densities appear only in propto-OFF form (the carver refuses propto):
-// with no term-dropping, the instantiation is type-uniform and one
-// templated call serves both passes. Propto term-dropping depends on
-// argument TYPES (see legacy_fns.cpp's dirichlet note), which would need
-// per-mask binding -- out of scope until islands absorb target terms.
+// with no term-dropping, the forward is type-uniform and one templated
+// call serves both passes. The backward does bind per mask, to skip the
+// partials of data arguments, but propto term-dropping needs the same
+// masks on the VALUE (see legacy_fns.cpp's dirichlet note) -- out of
+// scope until islands absorb target terms.
 #ifndef STANLI_ISLAND_HPP
 #define STANLI_ISLAND_HPP
 
@@ -50,6 +51,11 @@ struct IslandProg : Program {
     // OP_CONCAT2 and point several register ranges into that one descriptor.
     int input = -1;
     int offset = 0;
+    // Whether the slot it seeds is downstream of a parameter. The carver
+    // knows; the adjoint generator propagates it to reach the densities.
+    // True where nobody says otherwise, which is the all-active binding
+    // this was before.
+    bool active = true;
   };
   std::vector<LiveIn> ins;
   // The generated backward (adjoint.hpp), empty for a program the generator

--- a/runtime/include/stanli/program.hpp
+++ b/runtime/include/stanli/program.hpp
@@ -130,8 +130,9 @@ struct Program {
     // propto-OFF only (the island carver refuses propto). With no
     // term-dropping the value does not depend on which arguments are
     // autodiff, so binding all of them as T reproduces the scalar op's
-    // value exactly; the extra partials computed for data arguments are
-    // discarded when the executor hands the island a null adjoint.
+    // value exactly. The backward is where activity matters, and it is
+    // the generated adjoint that carries the per-argument mask
+    // (adjoint.hpp).
     // Any graph kernel, by opcode: the payload is calls[a]. This is the
     // union point with the graph executor -- one instruction gives the
     // register machine the graph's whole vocabulary, and its derivative

--- a/runtime/include/stanli/program_density.hpp
+++ b/runtime/include/stanli/program_density.hpp
@@ -66,7 +66,17 @@ extern template stan::math::var program_density<stan::math::var>(
 // Returns whether Stan Math built a dependency edge. A constant early return
 // fills zero partials and returns false so reverse mode can skip, rather than
 // form an indeterminate infinite-adjoint-times-zero product.
-bool program_density_partials(int id, const double* args, double* partials);
+//
+// Bit k of `mask` says argument k needs a partial; a clear bit binds it as a
+// plain double, which is what makes stan-math drop that argument's partial
+// expression, and leaves partials[k] untouched. The value is not affected --
+// propto is off and this function's value is discarded anyway, the forward
+// having computed it -- so a mask only removes arithmetic whose result the
+// caller discards. Masks are dispatched for the densities whose tier carries
+// STANLI_DENSITY_FULL_MASKS (optable.hpp) and ignored for the rest, the same
+// trade the graph's density kernels make.
+bool program_density_partials(int id, unsigned mask, const double* args,
+                              double* partials);
 
 }  // namespace stanli
 

--- a/runtime/src/adjoint.cpp
+++ b/runtime/src/adjoint.cpp
@@ -33,6 +33,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <cstdlib>
 #include <limits>
 #include <vector>
 
@@ -142,6 +143,62 @@ bool gen_adjoint(IslandProg& p) {
                                    !(coincident_range && I.dst == I.b))))
       return false;
   }
+
+  // Which registers carry a parameter: seeded from the live-ins the carver
+  // marked active, grown forwards. A density argument outside that set gets
+  // no partial (program_density.hpp) -- its adjoint cell reaches nothing the
+  // executor reads. Read at the density rather than after the sweep, because
+  // registers are cells: one holding data here may hold a parameter later.
+  std::vector<uint8_t> dmask(orig.size(), 0xf);
+  {
+    std::vector<char> active((size_t)n0, 0);
+    for (const auto& li : p.ins)
+      if (li.active)
+        for (int k = 0; k < li.len; ++k) active[(size_t)(li.reg + k)] = 1;
+    bool any = false;
+    auto read = [&](int r, int len) {
+      for (int k = 0; k < len && !any; ++k)
+        if (active[(size_t)(r + k)]) any = true;
+    };
+    auto write = [&](int r, int len) {
+      for (int k = 0; k < len; ++k) active[(size_t)(r + k)] = 1;
+    };
+    for (size_t i = 0; i < orig.size(); ++i) {
+      const Program::Instr& I = orig[i];
+      any = false;
+      if (I.code == Program::CALL) {
+        const Program::Call& call = fwd.calls[(size_t)I.a];
+        for (int j = 0; j < call.n_in; ++j) read(call.in[j], call.in_len[j]);
+        if (!any) continue;
+        write(call.out, call.out_len);
+        write(call.scratch, call.scratch_len);
+        continue;
+      }
+      const ProgramOpSpec& spec = program_code_spec(I.code);
+      if (spec.has(kProgramNoInputs)) continue;
+      if (I.code == Program::DENSITY) {
+        const int ar = program_density_arity(I.len);
+        unsigned m = 0;
+        for (int k = 0; k < ar; ++k) {
+          const int r =
+              ar > 3 ? I.a + k : (k == 0 ? I.a : (k == 1 ? I.b : I.c));
+          if (active[(size_t)r]) m |= 1u << k;
+        }
+        dmask[i] = (uint8_t)m;
+        any = m != 0;
+      } else {
+        read(I.a, spec.has(kProgramRangeA) ? I.len : 1);
+        if (spec.has(kProgramReadB))
+          read(I.b, spec.has(kProgramRangeB) ? I.len : 1);
+        if (spec.has(kProgramReadC)) read(I.c, 1);
+      }
+      if (any) write(I.dst, program_output_len(I));
+    }
+  }
+  // STANLI_NO_DENSITY_MASK=1 binds every density argument as a recorder
+  // scalar again, which is the comparison the masks have to survive.
+  if (std::getenv("STANLI_NO_DENSITY_MASK"))
+    std::fill(dmask.begin(), dmask.end(), (uint8_t)0xf);
 
   std::vector<Program::Instr> ncode;
   ncode.reserve(orig.size());
@@ -262,6 +319,7 @@ bool gen_adjoint(IslandProg& p) {
     }
     AdjInstr A;
     A.code = I.code;
+    A.mask = dmask[(size_t)i];
     A.dst = I.dst;
     A.a = I.a;
     A.b = I.b;
@@ -636,18 +694,20 @@ void run_adjoint(const Program& fwd, const AdjProgram& ap, const double* val,
         // register, and then it is the difference between matching the
         // replay and nearly matching it.
         adj[I.dst] = 0.0;
+        if (I.mask == 0) break;
         const int ar = program_density_arity(I.len);
         double part[kMaxDensityArgs] = {0, 0, 0, 0};
         if (ar > 3) {
-          if (program_density_partials(I.len, val + I.va, part))
-            for (int k = ar; k-- > 0;) adj[I.a + k] += t * part[k];
+          if (program_density_partials(I.len, I.mask, val + I.va, part))
+            for (int k = ar; k-- > 0;)
+              if ((I.mask >> k) & 1u) adj[I.a + k] += t * part[k];
           break;
         }
         const double args[3] = {val[I.va], val[I.vb], val[I.vc]};
-        if (!program_density_partials(I.len, args, part)) break;
-        if (ar > 2) adj[I.c] += t * part[2];
-        if (ar > 1) adj[I.b] += t * part[1];
-        adj[I.a] += t * part[0];
+        if (!program_density_partials(I.len, I.mask, args, part)) break;
+        if (ar > 2 && (I.mask & 4u)) adj[I.c] += t * part[2];
+        if (ar > 1 && (I.mask & 2u)) adj[I.b] += t * part[1];
+        if (I.mask & 1u) adj[I.a] += t * part[0];
         break;
       }
       case Program::DYN_INDEX:

--- a/runtime/src/island.cpp
+++ b/runtime/src/island.cpp
@@ -477,6 +477,21 @@ int carve_islands(Graph& g,
   for (const auto& f : fills)
     if (!written.count(f.first)) const_slots[f.first] = &f.second;
 
+  // Which slots carry a parameter. The adjoint generator turns this into
+  // per-argument masks on the densities it differentiates; slots added
+  // below are active until something says otherwise.
+  std::vector<char> slot_active(g.slots.size(), 0);
+  for (size_t s = 0; s < g.slots.size(); ++s)
+    slot_active[s] = g.slots[s].is_param ? 1 : 0;
+  for (const Op& op : g.ops) {
+    bool any = false;
+    for (int j = 0; j < op.n_in && !any; ++j)
+      if (op.in[j] >= 0 && slot_active[(size_t)op.in[j]]) any = true;
+    if (!any) continue;
+    if (op.out >= 0) slot_active[(size_t)op.out] = 1;
+    if (op.out2 >= 0) slot_active[(size_t)op.out2] = 1;
+  }
+
   std::vector<Op> result;
   result.reserve(g.ops.size());
   int carved = 0;
@@ -542,6 +557,8 @@ int carve_islands(Graph& g,
     // does not skip this -- it only stops the kernel USING the result, so
     // the two backwards can be compared over the same islands.
     if (compiled) {
+      for (size_t k = 0; k < cc.prog.ins.size(); ++k)
+        cc.prog.ins[k].active = slot_active[(size_t)cc.live_in_slots[k]] != 0;
       compact_island(cc.prog);
       const bool gen = gen_adjoint(cc.prog);
       cc.prog.native_adj = gen && !std::getenv("STANLI_NO_NATIVE_ADJ");
@@ -618,6 +635,7 @@ int carve_islands(Graph& g,
       is.n_in = (int)cc.live_in_slots.size();
       for (int k = 0; k < is.n_in; ++k) is.in[k] = cc.live_in_slots[k];
       is.out = g.add_slot(packed, false);
+      slot_active.resize(g.slots.size(), 1);
       is.udata = prog.get();
       g.udata_pool.push_back(std::move(prog));
       result.push_back(is);
@@ -632,6 +650,8 @@ int carve_islands(Graph& g,
         int dst = o;
         if (in_set.count(o)) {
           dst = g.add_slot(len, false);
+          slot_active.resize(g.slots.size(), 1);
+          slot_active[(size_t)dst] = slot_active[(size_t)o];
           for (size_t u = j; u < g.ops.size(); ++u) {
             for (int q = 0; q < g.ops[u].n_in; ++q)
               if (g.ops[u].in[q] == o) g.ops[u].in[q] = dst;

--- a/runtime/src/program_density.cpp
+++ b/runtime/src/program_density.cpp
@@ -15,6 +15,8 @@
 
 #include <stan/math.hpp>
 
+#include <type_traits>
+
 namespace stanli {
 namespace {
 
@@ -56,18 +58,68 @@ auto call_with(F&& f, const T* a) {
   }
 }
 
-// The same, promoting doubles to the recording scalar on the way in.
-template <int Arity, typename F>
+// The same, promoting the arguments Mask names to the recording scalar and
+// leaving the rest as doubles. A double argument selects stan-math's
+// arithmetic edge, which computes no partial.
+template <unsigned Mask, int K>
+auto bind_arg(const double* a) {
+  if constexpr ((Mask >> K) & 1u) {
+    return rvar(a[K]);
+  } else {
+    return a[K];
+  }
+}
+
+template <int Arity, unsigned Mask, typename F>
 auto call_rvar(F&& f, const double* a) {
   static_assert(Arity >= 1 && Arity <= 4, "density arity out of range");
   if constexpr (Arity == 1) {
-    return f(rvar(a[0]));
+    return f(bind_arg<Mask, 0>(a));
   } else if constexpr (Arity == 2) {
-    return f(rvar(a[0]), rvar(a[1]));
+    return f(bind_arg<Mask, 0>(a), bind_arg<Mask, 1>(a));
   } else if constexpr (Arity == 3) {
-    return f(rvar(a[0]), rvar(a[1]), rvar(a[2]));
+    return f(bind_arg<Mask, 0>(a), bind_arg<Mask, 1>(a), bind_arg<Mask, 2>(a));
   } else {
-    return f(rvar(a[0]), rvar(a[1]), rvar(a[2]), rvar(a[3]));
+    return f(bind_arg<Mask, 0>(a), bind_arg<Mask, 1>(a), bind_arg<Mask, 2>(a),
+             bind_arg<Mask, 3>(a));
+  }
+}
+
+// Run `f` with the mask as a constant. Densities whose tier does not carry
+// STANLI_DENSITY_FULL_MASKS get one all-active binding instead of 2^arity of
+// them: the value is the same either way, and the instantiations are what a
+// density costs to compile.
+template <int Arity, int Tier, typename F>
+void with_mask(unsigned mask, F&& f) {
+  constexpr unsigned kAll = (1u << Arity) - 1u;
+  if constexpr ((Tier & STANLI_DENSITY_FULL_MASKS) == 0) {
+    f(std::integral_constant<unsigned, kAll>{});
+  } else {
+    switch (mask & kAll) {
+#define STANLI_PD_MASK_CASE(k)                            \
+  case (unsigned)k:                                       \
+    if constexpr ((unsigned)k <= kAll)                    \
+      f(std::integral_constant<unsigned, (unsigned)k>{}); \
+    break;
+      STANLI_PD_MASK_CASE(1)
+      STANLI_PD_MASK_CASE(2)
+      STANLI_PD_MASK_CASE(3)
+      STANLI_PD_MASK_CASE(4)
+      STANLI_PD_MASK_CASE(5)
+      STANLI_PD_MASK_CASE(6)
+      STANLI_PD_MASK_CASE(7)
+      STANLI_PD_MASK_CASE(8)
+      STANLI_PD_MASK_CASE(9)
+      STANLI_PD_MASK_CASE(10)
+      STANLI_PD_MASK_CASE(11)
+      STANLI_PD_MASK_CASE(12)
+      STANLI_PD_MASK_CASE(13)
+      STANLI_PD_MASK_CASE(14)
+      STANLI_PD_MASK_CASE(15)
+#undef STANLI_PD_MASK_CASE
+      default:  // no argument wants a partial; the caller skips the call
+        break;
+    }
   }
 }
 
@@ -113,21 +165,25 @@ template double program_density<double>(int, const double*);
 template stan::math::var program_density<stan::math::var>(
     int, const stan::math::var*);
 
-bool program_density_partials(int id, const double* args, double* partials) {
+bool program_density_partials(int id, unsigned mask, const double* args,
+                              double* partials) {
   const int n = program_density_arity(id);
   sink s;
   for (int k = 0; k < n; ++k) {
-    s.buf[k] = &partials[k];
+    s.buf[k] = (mask >> k) & 1u ? &partials[k] : nullptr;
     s.len[k] = 1;
   }
   sink_scope active(s);
   switch (id) {
-#define STANLI_PD_PARTIALS(opc, fn, arity, tier)                               \
-  case kId_##fn:                                                               \
-    record_probability_call([&] {                                              \
-      return call_rvar<arity>(                                                 \
-          [](const auto&... x) { return stan::math::fn<false>(x...); }, args); \
-    });                                                                        \
+#define STANLI_PD_PARTIALS(opc, fn, arity, tier)                          \
+  case kId_##fn:                                                          \
+    with_mask<arity, density_tier(tier)>(mask, [&](auto m) {              \
+      record_probability_call([&] {                                       \
+        return call_rvar<arity, m.value>(                                 \
+            [](const auto&... x) { return stan::math::fn<false>(x...); }, \
+            args);                                                        \
+      });                                                                 \
+    });                                                                   \
     break;
     STANLI_SCALAR_DENSITY_LIST(STANLI_PD_PARTIALS)
 #undef STANLI_PD_PARTIALS

--- a/tests/test_adjoint.cpp
+++ b/tests/test_adjoint.cpp
@@ -579,7 +579,7 @@ static void test_densities() {
       try {
         double probe[kMaxDensityArgs] = {0, 0, 0, 0};
         const double v = program_density<double>(id, args.data());
-        program_density_partials(id, args.data(), probe);
+        program_density_partials(id, 0xf, args.data(), probe);
         usable = std::isfinite(v);
         for (int k = 0; k < arity; ++k)
           if (!std::isfinite(probe[k])) usable = false;
@@ -602,6 +602,63 @@ static void test_densities() {
   }
 }
 
+// Dropping a data argument's partial must not move the partials that are
+// kept. Bitwise, every density, every mask: an argument bound as a double
+// takes a different stan-math instantiation, and a reassociated intermediate
+// there would show up as a last-bit gradient difference in a model nobody
+// would think to attribute to activity.
+static void test_density_masked_partials() {
+  static const double kPoints[][kMaxDensityArgs] = {
+      {0.63, 0.4, 1.7, 0.5}, {0.63, 1.4, 2.2, 0.25}, {2.5, 3.0, 1.0, 0.75},
+      {0.35, 2.0, 0.8, 0.5}, {1.25, 0.7, 1.3, 0.9},  {0.5, 4.0, 0.25, 0.5},
+  };
+  const int n_points = (int)(sizeof(kPoints) / sizeof(kPoints[0]));
+  for (int id = 0; id < program_density_count(); ++id) {
+    const int arity = program_density_arity(id);
+    const std::string name = program_density_name(id);
+    const unsigned all = (1u << arity) - 1u;
+    bool tested = false;
+    for (int pt = 0; pt < n_points && !tested; ++pt) {
+      const double* args = kPoints[pt];
+      double full[kMaxDensityArgs] = {0, 0, 0, 0};
+      try {
+        if (!std::isfinite(program_density<double>(id, args))) continue;
+        if (!program_density_partials(id, all, args, full)) continue;
+      } catch (const std::exception&) {
+        continue;
+      }
+      bool finite = true;
+      for (int k = 0; k < arity; ++k)
+        if (!std::isfinite(full[k])) finite = false;
+      if (!finite) continue;
+      tested = true;
+      for (unsigned mask = 1; mask <= all; ++mask) {
+        double part[kMaxDensityArgs] = {-1, -1, -1, -1};
+        const bool built = program_density_partials(id, mask, args, part);
+        expect((name + " mask connected").c_str(), built);
+        for (int k = 0; k < arity; ++k) {
+          const bool want = (mask >> k) & 1u;
+          const std::string what = name + " mask " + std::to_string(mask) +
+                                   " arg " + std::to_string(k);
+          if (want && part[k] != full[k]) {
+            ++failures;
+            std::printf("FAIL %s: got %.17g want %.17g\n", what.c_str(),
+                        part[k], full[k]);
+          }
+          if (!want && part[k] != -1.0) {
+            ++failures;
+            std::printf("FAIL %s: masked-off partial written\n", what.c_str());
+          }
+        }
+      }
+    }
+    if (!tested) {
+      ++failures;
+      std::printf("FAIL density %s: no masked probe point\n", name.c_str());
+    }
+  }
+}
+
 // Stan Math can return a constant support value before constructing its
 // partials propagator. The register-program API promises to fill every
 // partial, so it must write zeros rather than leave the caller's old values.
@@ -613,7 +670,7 @@ static void test_density_early_return_partials() {
                                       -std::numeric_limits<double>::infinity());
   double partials[3] = {4.0, 5.0, 6.0};
   expect("inv_gamma early disconnected",
-         !program_density_partials(id, args, partials));
+         !program_density_partials(id, 0xf, args, partials));
   for (double partial : partials)
     expect("inv_gamma early partial", partial == 0.0);
 
@@ -639,7 +696,7 @@ static void test_density_early_return_partials() {
   const double bad_domain[3] = {1.0, -2.0, 3.0};
   bool threw = false;
   try {
-    program_density_partials(id, bad_domain, partials);
+    program_density_partials(id, 0xf, bad_domain, partials);
   } catch (const std::domain_error&) {
     threw = true;
   }
@@ -860,6 +917,7 @@ int main() {
   test_nan_operands();
   test_reductions();
   test_densities();
+  test_density_masked_partials();
   test_density_early_return_partials();
   test_recurrence();
   test_two_gradients();

--- a/tests/test_island.cpp
+++ b/tests/test_island.cpp
@@ -855,6 +855,64 @@ static void test_inplace_slice_cost_refuses_wide_state() {
   expect("wide inplace slice graph unchanged", g.ops.size() == before);
 }
 
+// The hmm region's densities are `normal_lpdf(y | mu, sigma)` with y a fill
+// slot and mu/sigma parameters, so the generated adjoint should ask
+// stan-math for two partials out of three.
+static std::vector<uint8_t> hmm_density_masks(Graph& g, const Fills& fills,
+                                              const std::vector<int>& terms) {
+  std::vector<uint8_t> masks;
+  if (carve_islands(g, fills, terms, {}) != 1) return masks;
+  for (const Op& op : g.ops) {
+    if (op.opcode != OP_ISLAND) continue;
+    for (const AdjInstr& I : static_cast<const IslandProg*>(op.udata)->adj.code)
+      if (I.code == Program::DENSITY) masks.push_back(I.mask);
+  }
+  return masks;
+}
+
+static void test_density_mask_data_argument() {
+  HmmGraph h = build_hmm(8);
+  const std::vector<uint8_t> masks = hmm_density_masks(h.g, h.fills, h.terms);
+  expect_eq("mask: densities differentiated", (int)masks.size(), 16);
+  int wrong = 0;
+  for (uint8_t m : masks)
+    if (m != 0x6) ++wrong;
+  expect_eq("mask: data outcome dropped", wrong, 0);
+}
+
+// STANLI_NO_DENSITY_MASK restores the all-active binding. ab_corpus.py's A
+// side is built out of switches like this one.
+static void test_density_mask_env_disable() {
+  test_setenv("STANLI_NO_DENSITY_MASK", "1", 1);
+  HmmGraph h = build_hmm(8);
+  const std::vector<uint8_t> masks = hmm_density_masks(h.g, h.fills, h.terms);
+  test_unsetenv("STANLI_NO_DENSITY_MASK");
+  expect_eq("mask off: densities differentiated", (int)masks.size(), 16);
+  int masked = 0;
+  for (uint8_t m : masks)
+    if (m != 0xf) ++masked;
+  expect_eq("mask off: nothing dropped", masked, 0);
+}
+
+// The masks remove partials the executor discards, so lp and every gradient
+// must come out to the bit -- not close, identical.
+static void test_density_mask_gradient_identical() {
+  HmmGraph on = build_hmm(8);
+  expect("mask: carved", carve_islands(on.g, on.fills, on.terms, {}) == 1);
+  const std::vector<double> got = run_grad(std::move(on.g), on.fills);
+  test_setenv("STANLI_NO_DENSITY_MASK", "1", 1);
+  HmmGraph off = build_hmm(8);
+  expect("mask off: carved",
+         carve_islands(off.g, off.fills, off.terms, {}) == 1);
+  const std::vector<double> want = run_grad(std::move(off.g), off.fills);
+  test_unsetenv("STANLI_NO_DENSITY_MASK");
+  expect("mask: sizes", got.size() == want.size());
+  int wrong = 0;
+  for (size_t i = 0; i < want.size() && i < got.size(); ++i)
+    if (got[i] != want[i]) ++wrong;
+  expect_eq("mask: bitwise identical", wrong, 0);
+}
+
 int main() {
   // What the compiler does with a region, on graphs small enough to
   // reason about. The cost estimate would refuse most of them -- it is
@@ -881,6 +939,9 @@ int main() {
   test_packed_live_ins();
   test_kernel_call_ops_carved(true);
   test_kernel_call_ops_carved(false);
+  test_density_mask_data_argument();
+  test_density_mask_env_disable();
+  test_density_mask_gradient_identical();
 
   test_unsetenv("STANLI_ISLAND_ALWAYS");
   test_wide_state_refused();


### PR DESCRIPTION
The generated island adjoint accumulated density partials into every argument's cell; 47% of the arguments across the five affected islands are data. Mask derived at carve time from data live-ins, carried in AdjInstr padding, dispatched in program_density_partials. Purely a backward win (the all-double forward constexpr-skips partials already). Measured first: hmm_drive_0 ~6%, the other HMM islands 1.3-2.9%, iohmm 0.5%; the survey's arithmetic ~11% did not survive contact and the report says why. 120/120 byte-identical mask on/off, ab_corpus A/B 0.00e+00, var-replay oracle unchanged, ctest 61/61. STANLI_NO_DENSITY_MASK disables.