### PR TITLE
test: every graph-pass test evaluates its gradient twice

### DIFF
--- a/tests/graph_helpers.hpp
+++ b/tests/graph_helpers.hpp
@@ -5,6 +5,8 @@
 #include <stanli/graph.hpp>
 #include <stanli/optable.hpp>
 
+#include <cstdio>
+#include <cstdlib>
 #include <utility>
 #include <vector>
 
@@ -29,6 +31,16 @@ inline std::vector<double> run_grad(Graph g, const Fills& fills,
   for (int64_t i = 0; i < ex.n_params(); ++i) ex.params_data()[i] = fill_at(i);
   std::vector<double> out(1 + (size_t)ex.n_params());
   out[0] = ex.gradient(out.data() + 1);
+  // A second evaluation on the same executor must reproduce the first bit
+  // for bit. A pass that lets per-evaluation writes reach a bind-time
+  // buffer is correct on the first evaluation and wrong from the second,
+  // and every other gate in the project evaluates once per process.
+  std::vector<double> again(out.size());
+  again[0] = ex.gradient(again.data() + 1);
+  if (again != out) {
+    std::fprintf(stderr, "run_grad: second evaluation diverged\n");
+    std::abort();
+  }
   return out;
 }
 

--- a/tests/test_constfold.cpp
+++ b/tests/test_constfold.cpp
@@ -84,13 +84,16 @@ static void test_refuses_midchain_reader() {
   Graph g;
   Fills fills;
   const int p = g.add_slot(1, true);
-  const int v = g.add_slot(2, false);
-  fills.emplace_back(v, std::vector<double>{0.0, 0.0});
+  const int v0 = g.add_slot(2, false);
+  fills.emplace_back(v0, std::vector<double>{0.0, 0.0});
   const int c1 = g.add_slot(1, false), c2 = g.add_slot(1, false);
   fills.emplace_back(c1, std::vector<double>{4.0});
   fills.emplace_back(c2, std::vector<double>{9.0});
-  // write v[0] = 4 (constant, in place)
-  g.add_op(OP_SET_INDEX_INPLACE, {v, c1}, v, {0});
+  // write v[0] = 4 into a fresh copy of the base, as lowering's chain
+  // heads do; writing in place into the fill itself would leak state
+  // into the next evaluation
+  const int v = g.add_slot(2, false);
+  g.add_op(OP_SET_INDEX, {v0, c1}, v, {0});
   // a PARAMETER op reads v now: v = [4, 0]
   const int d = g.add_slot(2, false);
   g.add_op(OP_MUL, {p, v}, d);


### PR DESCRIPTION
run_grad evaluates the same executor twice and aborts on any bitwise difference. The state-leak failure mode (per-evaluation writes reaching a bind-time buffer) is correct on evaluation 1 and wrong from evaluation 2, and no existing gate evaluates twice per process; constfold.cpp documents having shipped exactly this class once. Every pass test plus the pass-safety fuzz inherit the property through the shared helper. ctest 61/61.