### PR TITLE
fix: keep algebra system alive through reverse pass

### DIFF
--- a/runtime/kernels/algebra.cpp
+++ b/runtime/kernels/algebra.cpp
@@ -93,12 +93,15 @@ void algebra_fwd(KernelCtx& ctx) {
   Eigen::Map<const Eigen::VectorXd> y(ctx.in[1].data, ctx.in[1].len);
   Eigen::VectorXd solved;
   Eigen::MatrixXd jacobian;
+  // Stan's adapter retains a reference to the system for its deferred
+  // reverse-pass callback, so it must outlive the complete Jacobian sweep.
+  const MirSystem system{&spec};
   stan::math::jacobian(
       [&](const auto& y_var) {
-        return stan::math::algebra_solver(
-            MirSystem{&spec}, x, y_var, spec.x_r, spec.x_i, nullptr,
-            spec.relative_tolerance, spec.function_tolerance,
-            spec.max_num_steps);
+        return stan::math::algebra_solver(system, x, y_var, spec.x_r, spec.x_i,
+                                          nullptr, spec.relative_tolerance,
+                                          spec.function_tolerance,
+                                          spec.max_num_steps);
       },
       y, solved, jacobian);
   if (solved.size() != ctx.out.len || jacobian.rows() != ctx.out.len ||


### PR DESCRIPTION
## Summary

- keep the `MirSystem` functor alive through the complete Stan Math Jacobian sweep
- prevent the deferred algebra-solver reverse callback from retaining a dangling reference
- document the non-obvious callback lifetime requirement

## Failure fixed

Post-merge ASan run 32980769052 reported `stack-use-after-scope` in `runtime/kernels/algebra.cpp:37`, failing `test_cross_path` and `test_algebra`. The solver adapter stores `const F&`; the former temporary functor expired before the reverse callback ran.

## Validation

- `ASAN_OPTIONS=detect_leaks=0 ctest --test-dir build-asan -R "^(test_algebra|test_cross_path)$" --output-on-failure`
- `ctest --test-dir build --output-on-failure -j8` — 62/62 passed
- `clang-format --dry-run --Werror runtime/kernels/algebra.cpp`
- `git diff --check`

This is a one-file lifetime fix and does not change solver inputs, numerical behavior, RNG streams, or mother-model references.