### PR TITLE
release: 0.9.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,58 @@
 # Changelog
 
+## 0.9.2
+
+### The runtime the R package binds exists again
+
+0.9.1's notes described per-chain write-array streams, but the C-ABI
+half (`stanli_wa_seed_chain`, #207) merged after the tag. Builds of the
+R package from main -- which is what R-universe serves -- paired a
+bridge that binds the new symbol with the pinned v0.9.1 runtime and
+failed to load with `missing symbol in stanli library:
+stanli_wa_seed_chain`. The symbol ships in this release's runtime and
+the pin moves with it. Reported by @StaffanBetner, who also moved the
+install docs to lead with R-universe (#204).
+
+### More of the language lowers
+
+A batch of syntax-coverage fixes from @andrjohns (#205), joining
+0.9.1's conditional container sizes (#185) and transformed-data
+`diag_matrix` (#186): `tcrossprod`, `rep_row_vector`, `while` loops
+(bounded by data, unrolled like `for`), UDF locals whose writes are all
+skipped at runtime, row-range reads `A[i, lo:hi]`, assignment through
+an index vector `x[idx] = rhs` and through row/column index pairs
+`M[I, J] = rhs` (repeats resolve last-wins, as CmdStan's assign does),
+and unfoldable data-only conditions compile to islands instead of
+failing. Landing the batch against the pinned stanc3, which inlines
+user functions itself, also taught size expressions to evaluate `sum()`
+over an int local built by element writes: an indexed write of an
+observed value into an observed container propagates the observation,
+and a materialized fill observes the values the slot really holds.
+
+### Islands, continued
+
+Two follow-ups to 0.9.1's island passes. Island register programs are
+compacted before the adjoint generates -- dead initializer fills, copy
+aliasing, and renumbering away unreferenced registers, table-driven
+over the whole instruction set, deleting the ODE-specific version of
+the pass. And the generated island adjoint no longer accumulates
+partials into data arguments (47% of density arguments across the five
+affected islands), a purely backward win with structural value
+identity.
+
+### Fixes
+
+The legacy Powell `algebra_solver` (added for the mother model in
+\#207) kept its system functor in a temporary while Stan's adapter
+defers a reverse-pass callback that references it; the system now
+outlives the complete Jacobian sweep (#209).
+
+### Build
+
+The stanc3 compiler is built from a pinned source SHA instead of
+fetched from the nightly release (#208), which is replaced in place and
+so cannot identify the compiler bytes a release used.
+
 ## 0.9.1
 
 ### A pass for the lanes re-rolling cannot see

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@seantalts/stanli",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "Full Stan in the browser: stanc3 compiles the model in JS, a WASM runtime lowers it to an op graph and runs NUTS. No server, no C++ toolchain.",
   "type": "module",
   "main": "index.mjs",

--- a/python/stanli/__init__.py
+++ b/python/stanli/__init__.py
@@ -21,7 +21,7 @@ __all__ = ["Model", "Fit", "Summary", "OptimizeResult",
            "SAMPLER_COLUMNS", "__version__"]
 # The one place the version lives. setup.py and the release workflow both
 # read it from here.
-__version__ = "0.9.1"
+__version__ = "0.9.2"
 
 _BIN = pathlib.Path(__file__).parent / "_bin"
 

--- a/r/DESCRIPTION
+++ b/r/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: stanli
 Type: Package
 Title: The Stan Language Interpreter
-Version: 0.9.1
+Version: 0.9.2
 Authors@R: person("Sean", "Talts", email = "xitrium@gmail.com",
                   role = c("aut", "cre"))
 Description: Compile and sample Stan models without a C++ toolchain. Stan

--- a/r/R/install.R
+++ b/r/R/install.R
@@ -17,7 +17,7 @@
 # pinned binding with a runtime that has moved. The release workflow
 # asserts this equals the tag being cut, so bumping one without the
 # other fails there rather than at a user's install.
-stanli_runtime_release <- "v0.9.1"
+stanli_runtime_release <- "v0.9.2"
 
 runtime_filename <- function() {
   switch(Sys.info()[["sysname"]],


### PR DESCRIPTION
Changelog for everything since v0.9.1 and the version/pin bumps. The urgent part: the R bridge on main binds stanli_wa_seed_chain (#207), which v0.9.1's runtime lacks, so fresh R-universe installs fail to load; the tag ships the symbol and moves the pin.