### PR TITLE
Ship portable MIR compilation on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,3 +5,4 @@ compiler/ocaml/* text eol=lf
 tools/build_wheel.sh text eol=lf
 tools/dev_setup.sh text eol=lf
 tools/stanc_embed/* text eol=lf
+tests/test_windows_provenance.sh text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,7 @@
 tests/fixtures/*.tmir.sexp linguist-generated=true
+.gitattributes text eol=lf
+compiler/js/* text eol=lf
+compiler/ocaml/* text eol=lf
+tools/build_wheel.sh text eol=lf
+tools/dev_setup.sh text eol=lf
+tools/stanc_embed/* text eol=lf

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -1,9 +1,9 @@
 # Build the platform wheels, and publish them to PyPI on a version tag.
 #
-# Pull requests build the representative manylinux target and run the full
-# runtime and corpus tests. Every release target also builds after merge,
-# nightly, and on version tags; publishing is gated on the tag and all of
-# those target builds.
+# Pull requests build the representative manylinux target, run the full runtime
+# and corpus tests, and gate the bounded Windows compiler cross-build. Every
+# release target also builds after merge, nightly, and on version tags;
+# publishing is gated on the tag and all of those target builds.
 #
 # Not cibuildwheel: it exists to build one wheel per CPython version, and
 # stanli ships a ctypes-loaded shared library with no extension module, so
@@ -11,9 +11,9 @@
 #
 # Windows builds under mingw-w64 (stan-math does not build under MSVC,
 # which is why RStan ships through RTools), exports the C ABI through a
-# .def file, and bundles an exact-source stanc.exe as a subprocess. Keeping
-# the compiler in a separate process avoids introducing a Windows OCaml DLL
-# ABI and isolates compiler state from the sampler. That job
+# .def file, and bundles exact-source stock and stanli compiler executables as
+# subprocesses. Keeping the compilers in separate processes avoids introducing
+# a Windows OCaml DLL ABI and isolates compiler state from the sampler. That job
 # does not run on pull requests: mingw compiles the density kernels an
 # order of magnitude slower than every other platform (110 minutes for
 # that one translation unit against ~7 for the other 140 targets), so
@@ -486,8 +486,8 @@ jobs:
       # package, which downloads its runtime instead of bundling it (CRAN
       # will not carry a 16 MB binary, and could not build one from
       # source on their farm). Whatever build_wheel.sh put there rides
-      # along, so the Windows tarball carries stanc.exe next to the DLL
-      # the way that wheel does. Naming matches runtime_asset() in
+      # along, so the Windows tarball carries both compiler executables next to
+      # the DLL the way that wheel does. Naming matches runtime_asset() in
       # r/R/install.R -- os and architecture as R spells them, normalized.
       - name: Runtime tarball
         env:
@@ -573,13 +573,12 @@ jobs:
           name: r-check-log
           path: r/stanli.Rcheck/
 
-  # The Windows wheel cannot embed the native compiler yet. Cross-build the
-  # executable from the same source revision the other wheels embed, using
-  # stanc3's own Linux-to-Windows recipe, then pass it to the Windows job as
-  # a same-run artifact. The adjacent .src file is checked before packaging.
+  # The Windows wheel cannot embed the native compiler yet. Cross-build both
+  # the pristine stock rollback executable and stanli's portable-MIR executable
+  # from the same source revision the other wheels embed, using stanc3's own
+  # Linux-to-Windows recipe. Their provenance is checked before packaging.
   stanc-windows:
-    name: cross-build Windows stanc
-    if: github.event_name != 'pull_request'
+    name: cross-build Windows compilers
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
@@ -587,7 +586,8 @@ jobs:
       - name: Cross-compiler
         run: |
           sudo apt-get update
-          sudo apt-get install -y gcc-mingw-w64-x86-64 gcc-mingw-w64-i686
+          sudo apt-get install -y file gcc-mingw-w64-x86-64 \
+            gcc-mingw-w64-i686
 
       - name: OCaml ${{ env.OCAML_VERSION }} for Windows
         uses: ocaml/setup-ocaml@v3
@@ -599,7 +599,7 @@ jobs:
             windows: http://github.com/ocaml-cross/opam-cross-windows.git
             default: https://github.com/ocaml/opam-repository.git
 
-      - name: Build the pinned compiler
+      - name: Build the pinned compilers
         run: |
           setup_repo=$(sed -n 's/^STANC3_SRC_REPO=\([^ ]*\).*/\1/p' \
                          tools/dev_setup.sh)
@@ -613,18 +613,117 @@ jobs:
           (cd deps/stanc3-src &&
            bash -x scripts/install_build_deps_windows.sh &&
            opam exec -- dune subst &&
-           opam exec -- dune build -x windows --profile release)
-          mkdir -p windows-stanc
+           opam exec -- dune build -x windows --profile release \
+             src/stanc/stanc.exe)
+          mkdir -p windows-compilers
+          # Copy stock stanc before installing the stanli overlay. The overlay
+          # corrects host-width-dependent int32 folding, so rebuilding stock
+          # after it would silently destroy the pristine rollback artifact.
           cp deps/stanc3-src/_build/default.windows/src/stanc/stanc.exe \
-             windows-stanc/stanc
-          printf '%s\n' "$STANC3_SRC_SHA" > windows-stanc/stanc.src
-          test "$(cat windows-stanc/stanc.src)" = "$STANC3_SRC_SHA"
+             windows-compilers/stanc
+          printf '%s\n' "$STANC3_SRC_SHA" > windows-compilers/stanc.src
+          test "$(cat windows-compilers/stanc.src)" = "$STANC3_SRC_SHA"
+
+          # This explicit target does not need js_of_ocaml for Windows. Avoid
+          # the directory's default alias, which also names the JS executable.
+          tools/stanc_embed/install_overlay.sh js deps/stanc3-src
+          (cd deps/stanc3-src &&
+           opam exec -- dune build -x windows --profile release \
+             src/stanli_stancjs/stanli_compiler_cli.exe)
+          cp deps/stanc3-src/_build/default.windows/src/stanli_stancjs/stanli_compiler_cli.exe \
+             windows-compilers/stanli-compile
+
+          source tools/stanc_embed/provenance.sh
+          stanli_windows_cli_expected_stamp \
+            "$STANC3_SRC_REPO" "$STANC3_SRC_SHA" \
+            > windows-compilers/stanli-compile.stamp
+          stanli_windows_cli_artifact_matches \
+            windows-compilers/stanli-compile \
+            "$STANC3_SRC_REPO" "$STANC3_SRC_SHA"
+          compiler_types=$(file \
+            windows-compilers/stanc windows-compilers/stanli-compile)
+          printf '%s\n' "$compiler_types"
+          test "$(printf '%s\n' "$compiler_types" | \
+            grep -c 'PE32+ executable.*x86-64')" -eq 2
+          x86_64-w64-mingw32-objdump -f \
+            windows-compilers/stanli-compile | \
+            grep -F 'file format pei-x86-64'
 
       - uses: actions/upload-artifact@v4
         with:
-          name: windows-stanc
+          name: windows-compilers
           if-no-files-found: error
-          path: windows-stanc/
+          path: windows-compilers/
+
+  # Unlike the multi-hour C++ build below, the compiler cross-build is bounded
+  # enough to gate pull requests. Run the PE executable on Windows and compare
+  # it byte for byte with the same JS producer that the Linux-native check uses.
+  windows-compiler:
+    name: Windows compiler parity
+    needs: [stanc-windows, browser-compiler]
+    runs-on: windows-2022
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: windows-compilers
+          path: windows-compilers
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: browser-compilers
+          path: browser-compilers
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
+
+      - name: Check provenance and portable bytes
+        run: |
+          while IFS= read -r input; do
+            eol=$(git ls-files --eol -- "$input")
+            printf '%s\n' "$eol"
+            printf '%s\n' "$eol" | grep -Fq 'w/lf'
+          done < <(
+            source tools/stanc_embed/provenance.sh
+            stanli_windows_cli_inputs
+          )
+          test "$(cat windows-compilers/stanc.src)" = "$STANC3_SRC_SHA"
+          source tools/stanc_embed/provenance.sh
+          stanli_windows_cli_artifact_matches \
+            windows-compilers/stanli-compile \
+            "$STANC3_SRC_REPO" "$STANC3_SRC_SHA"
+          chmod +x windows-compilers/stanc windows-compilers/stanli-compile
+          cp windows-compilers/stanc windows-compilers/stanc.exe
+          ./windows-compilers/stanc.exe --version
+          cp tests/compiler/portable_int32_overflow.stan \
+            windows-compilers/stock-overflow.stan
+          ./windows-compilers/stanc.exe --O1 --debug-optimized-mir \
+            windows-compilers/stock-overflow.stan \
+            > windows-compilers/stock-overflow.mir
+          grep -Fq '2500000000' windows-compilers/stock-overflow.mir
+          rm -f windows-compilers/stock-overflow.stan \
+            windows-compilers/stock-overflow.hpp \
+            windows-compilers/stock-overflow.mir
+          # Node launches PE executables by their .exe name; the intermediate
+          # artifact itself stays extensionless for build_wheel.sh, like stanc.
+          cp windows-compilers/stanli-compile \
+            windows-compilers/stanli-compile.exe
+          node tests/test_portable_stancjs.cjs \
+            browser-compilers/stanli-compiler.js \
+            windows-compilers/stanli-compile.exe \
+            browser-compilers/stancjs.bc.js
+          Rscript tests/test_windows_compiler.R \
+            windows-compilers/stanli-compile.exe \
+            windows-compilers/stanc.exe
 
   # Everything except pull requests: main pushes, the nightly cron, and
   # release tags (the publish job needs this wheel, so a tag still waits
@@ -632,7 +731,7 @@ jobs:
   windows:
     name: win_amd64
     if: github.event_name != 'pull_request'
-    needs: stanc-windows
+    needs: [stanc-windows, windows-compiler]
     runs-on: windows-2022
     defaults:
       run:
@@ -666,16 +765,28 @@ jobs:
       - name: Fetch pinned dependencies
         run: ./deps/fetch.sh
 
-      - name: Install the source-built stanc
+      - name: Install the source-built compilers
         uses: actions/download-artifact@v4
         with:
-          name: windows-stanc
+          name: windows-compilers
           path: deps/stanc3
 
-      - name: Check stanc provenance
+      - name: Check compiler provenance
         run: |
+          while IFS= read -r input; do
+            eol=$(git ls-files --eol -- "$input")
+            printf '%s\n' "$eol"
+            printf '%s\n' "$eol" | grep -Fq 'w/lf'
+          done < <(
+            source tools/stanc_embed/provenance.sh
+            stanli_windows_cli_inputs
+          )
           test "$(cat deps/stanc3/stanc.src)" = "$STANC3_SRC_SHA"
-          chmod +x deps/stanc3/stanc
+          source tools/stanc_embed/provenance.sh
+          stanli_windows_cli_artifact_matches \
+            deps/stanc3/stanli-compile \
+            "$STANC3_SRC_REPO" "$STANC3_SRC_SHA"
+          chmod +x deps/stanc3/stanc deps/stanc3/stanli-compile
           ./deps/stanc3/stanc --version
 
       - name: Configure, build, test
@@ -692,6 +803,11 @@ jobs:
         run: |
           python3 -m pip install --upgrade wheel
           ./tools/build_wheel.sh
+          test -f python/stanli/_bin/stanli.dll
+          test -f python/stanli/_bin/stanli-compile.exe
+          test -f python/stanli/_bin/stanc.exe
+          unzip -l dist/*.whl | grep -F 'stanli/_bin/stanli-compile.exe'
+          unzip -l dist/*.whl | grep -F 'stanli/_bin/stanc.exe'
 
       # The wheel must work from python.org's CPython, not just msys2's:
       # that is the interpreter Windows users actually have.
@@ -712,16 +828,20 @@ jobs:
           name: wheel-win_amd64
           path: dist/*.whl
 
-      # As above, for the R package. This _bin/ has stanc.exe in it as
-      # well as the DLL, because the Windows build does not embed the
-      # compiler; find_stanc() in r/R/stanc.R looks beside the runtime
-      # for exactly that, so unpacking the tarball is all it takes.
+      # As above, for the R package. This _bin/ has both compiler executables
+      # as well as the DLL, because the Windows build does not embed one.
       - name: Runtime tarball
         run: |
           mkdir -p runtime-dist
           tar czf runtime-dist/stanli-runtime-windows-x86_64.tar.gz \
             -C python/stanli/_bin .
-          tar tzf runtime-dist/stanli-runtime-windows-x86_64.tar.gz
+          members=$(tar tzf \
+            runtime-dist/stanli-runtime-windows-x86_64.tar.gz)
+          printf '%s\n' "$members"
+          for file in stanli.dll stanli-compile.exe stanc.exe; do
+            printf '%s\n' "$members" | grep -Eq "(^|/)${file}$"
+          done
+          test "$(printf '%s\n' "$members" | grep -vc '/$')" -eq 3
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -607,6 +607,7 @@ jobs:
                         tools/dev_setup.sh)
           test "$setup_repo" = "$STANC3_SRC_REPO"
           test "$setup_pin" = "$STANC3_SRC_SHA"
+          bash tests/test_windows_provenance.sh
           git clone "$STANC3_SRC_REPO" deps/stanc3-src
           git -C deps/stanc3-src checkout -q --detach "$STANC3_SRC_SHA"
           test "$(git -C deps/stanc3-src rev-parse HEAD)" = "$STANC3_SRC_SHA"

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ run by a small interpreter. There is no JIT and no C++ codegen;
 
 ```
 model.stan + data.json
-  |  stanc3 (official OCaml compiler, linked into the library)
+  |  stanc3 + the stanli pipeline (embedded, or an executable on Windows)
   v
 optimized typed MIR (--O1)
   |  stanli OCaml encoder
@@ -93,9 +93,9 @@ NUTS (stan::mcmc::adapt_diag_e_nuts) -> draws
    resulting typed MIR into the versioned portable format. Thin entry points
    in [`compiler/native/`](compiler/native/) embed that pipeline in the shared
    library, while [`compiler/js/`](compiler/js/) builds the browser/npm
-   compiler. The runtime retains the legacy s-expression reader for compiler
-   paths that have not moved yet. Full language fidelity without a
-   reimplemented parser.
+   compiler and the CLI cross-built for Windows as `stanli-compile.exe`. The
+   runtime retains the legacy s-expression reader for cached MIR and rollback
+   compiler paths. Full language fidelity without a reimplemented parser.
 
 2. **Lowering** (`runtime/src/lower.cpp`). Transformed data is evaluated
    eagerly, loops with data-known bounds are unrolled, and the model
@@ -144,8 +144,9 @@ NUTS (stan::mcmc::adapt_diag_e_nuts) -> draws
 
 8. **Distribution.** Everything sits behind a C ABI
    (`runtime/include/stanli/capi.h`) in one shared library. Each binding
-   is a thin wrapper over it; a platform wheel is one .whl containing
-   one dylib.
+   is a thin wrapper over it. The macOS and Linux wheels embed the compiler in
+   that library. The Windows wheel carries `stanli.dll`, the preferred
+   `stanli-compile.exe`, and pristine `stanc.exe` for one rollback cycle.
 
 ## Binary size
 
@@ -219,9 +220,10 @@ print(fit.diagnose())     # the convergence checks, in words
 
 Four chains by default, run in parallel. Threading does not change the
 answer: each chain owns its executor and its RNG stream, so the draws
-are byte-identical to a sequential run. Shipped builds without the embedded
-stanc3 object fall back to running a source-pinned stanc binary as a
-subprocess.
+are byte-identical to a sequential run. macOS and Linux release wheels compile
+Stan in process. Windows runs the packaged `stanli-compile.exe`; pristine
+`stanc.exe` is selected only when that preferred executable is absent, and a
+compiler failure is reported without retrying the rollback path.
 
 ## R
 
@@ -257,10 +259,14 @@ summary(fit)          # mean, MCSE, sd, quantiles, bulk/tail ESS, R-hat
 
 The runtime is downloaded on first use because CRAN cannot build or
 carry it; `stanli_install()` is explicit and pins the release the
-package was built against. The Stan compiler is stanc3 compiled to
-JavaScript, run through V8 (rstan's approach) when the runtime does not
-embed it. Because binding and runtime are separately versioned, the C
-ABI carries a layout version (`stanli_abi_version()`) and the bridge
+package was built against. An embedded compiler wins when the runtime has one.
+On native hosts without one, `STANLI_STANC` is the explicit stock-compiler
+override; otherwise R prefers `stanli-compile` beside the runtime, then stock
+`stanc` beside the runtime or on `PATH`, and finally the bundled JavaScript
+compiler through V8. The v0.9.2 compatibility runtime has stock `stanc.exe`;
+Windows runtime builds from this revision add `stanli-compile.exe` beside it
+for the rollback cycle. Because binding and runtime are separately versioned,
+the C ABI carries a layout version (`stanli_abi_version()`) and the bridge
 refuses a runtime that disagrees; reading the options struct at wrong
 offsets would not crash, it would sample from the wrong seed.
 
@@ -311,11 +317,14 @@ ctest --test-dir build
 
 `.github/workflows/wheels.yml` builds all five wheels (macOS arm64 and
 x86_64, manylinux_2_28 x86_64 and aarch64, Windows x86_64). Pull requests
-run the manylinux x86_64 build; all five run after merge, nightly, and on
-release tags. The four Unix wheels link the cached embedded compiler;
-Windows bundles a compiler executable built from the same exact source
-revision. Every wheel runs the test suite, checks its platform contract,
-and samples eight schools from a clean installed environment.
+run the manylinux x86_64 build plus a compiler-only Windows gate that
+cross-builds and executes both compiler artifacts and byte-compares the
+portable producer with the JavaScript producer. All five full C++ platform
+builds run after merge, nightly, and on release tags. The four Unix wheels
+link the cached embedded compiler; Windows packages `stanli-compile.exe` and
+the pristine `stanc.exe` rollback beside `stanli.dll`. Every wheel runs the
+test suite, checks its platform contract, and samples eight schools from a
+clean installed environment.
 
 To cut a release: bump the version in `python/stanli/__init__.py`,
 `js/package.json`, `r/DESCRIPTION`, and `r/R/install.R` (they move in

--- a/TESTING.md
+++ b/TESTING.md
@@ -47,7 +47,7 @@ known exceptions.
 | check | question | acceptance rule | schedule |
 | --- | --- | --- | --- |
 | unit tests for numerical operations | Does one numerical operation or graph transformation agree with stan-math? | Bitwise by default; a documented 2 ULP limit for selected paths | every pull request |
-| compiler producer parity | Do native OCaml and js_of_ocaml emit identical portable bytes while the stock `stanc()` path remains usable? | Byte-for-byte identity on seven models; API, error, warning, include, fallback, and final-newline checks | every pull request |
+| compiler producer parity | Do native OCaml, js_of_ocaml, and the Windows executable emit identical portable bytes while the stock rollback paths remain usable? | Byte-for-byte identity on seven successful models; JS API/error/warning/rollback checks; Windows provenance, executable-format, and final-newline checks | every pull request |
 | corpus comparison | Are 119 posteriordb models and 11 compiler-derived fixtures consistent with recorded CmdStan behavior at three fixed inputs? | Scaled error of 1e-9 for most points; documented limits for three `kronecker_gp` points; rejection parity | every pull request |
 | cross-path matrix | Do stanli's execution paths agree with one another? | Bitwise, except entries named in the ledger | every pull request, within CTest |
 | transformation A/B | Do selected graph optimizations preserve model results? | Optimizations enabled and disabled agree at the default point within 1e-11 | manually after optimization changes |
@@ -254,6 +254,18 @@ focused worker harness proves the preferred custom
 import and the missing-artifact fallback import. The tested JavaScript
 artifacts are the ones consumed by the Pages and npm jobs. Size and
 preparation-cost outputs are uploaded as measurements rather than thresholds.
+
+The same gate covers the Windows producer on every pull request. The
+`stanc-windows` job cross-builds pristine `stanc.exe` before applying the
+stanli overlay, then cross-builds `stanli-compile.exe` and records its source
+and core-toolchain stamp. The `windows-compiler` job executes both PE
+artifacts on Windows, proves the stock overflow behavior remains pristine, and
+runs the seven-model byte comparison above between `stanli-compile.exe` and
+the JavaScript producer. The surrounding JavaScript suite separately checks
+errors, warnings, and its stock API. A real R subprocess check then runs both
+executables from paths containing spaces and Unicode, stages CRLF source as
+UTF-8 bytes, and checks portable versus legacy envelopes. This bounded gate
+builds no stan-math runtime or Windows wheel.
 
 ## Comparing stanli execution paths
 
@@ -524,6 +536,8 @@ The pull-request workflows require the following checks, as defined in
 [`.github/workflows/lint.yml`](.github/workflows/lint.yml):
 
 - one platform build, `manylinux_2_28_x86_64`;
+- the compiler-only Windows cross-build and executable parity gate described
+  above;
 - the full ctest suite, which includes the cross-path matrix and the
   pass-safety fuzz;
 - the CmdStan corpus comparison at all three points;
@@ -546,11 +560,15 @@ The pull-request workflows require the following checks, as defined in
   dependencies and third-party code. The formatter version is pinned because
   output can differ across major versions.
 
-Pull requests run the Linux x86_64 wheel job. The other three wheel platforms
-(macOS arm64, macOS x86_64, and manylinux aarch64), the Windows build, the
-ASan job, the WebAssembly build with its eight-schools sampling test under
-Node, and the webR side-module load test run on every push to `main`, nightly,
-and on release tags. These checks report platform-specific issues after a
+Pull requests run the Linux x86_64 wheel job and the Windows compiler-only
+gate. The other three wheel platforms (macOS arm64, macOS x86_64, and
+manylinux aarch64), the full Windows C++ matrix, the ASan job, the WebAssembly
+build with its eight-schools sampling test under Node, and the webR side-module
+load test run on every push to `main`, nightly, and on release tags. The full
+Windows job builds the runtime and CTest suite, packages `stanli.dll`,
+`stanli-compile.exe`, and pristine `stanc.exe`, then runs the installed-wheel
+Python tests through source compilation, errors, lowering, gradients, sampling,
+and generated quantities. These full platform checks report issues after a
 pull request has merged rather than blocking that merge.
 
 The nightly conformance sweep and its ratchet, the signature watch, and the

--- a/docs/hacking.md
+++ b/docs/hacking.md
@@ -98,7 +98,8 @@ Step by step:
    [`portable_mir.ml`](../compiler/ocaml/portable_mir.ml), which encodes the
    runtime's consumed slice. [`compiler/native/`](../compiler/native/) is the
    callback linked into native libraries; [`compiler/js/`](../compiler/js/)
-   exports the same pipeline through js_of_ocaml.
+   exports the same pipeline through js_of_ocaml and provides the CLI entry
+   point cross-built for Windows as `stanli-compile.exe`.
 
    The exact-pin overlay also applies
    [`stanc3-int32-fold.patch`](../compiler/ocaml/stanc3-int32-fold.patch).
@@ -111,12 +112,22 @@ Step by step:
    disappear.
 
 2. **[`mir_decode.cpp`](../runtime/src/mir_decode.cpp) selects a decoder.**
-   Native embedded compilation and the preferred browser compiler emit the
-   stanli-owned portable JSON format. Stock browser fallback, R, and other
-   compiler paths that have not moved yet emit the legacy stanc3
-   s-expression. Both decode into the same plain C++ structs (`mir::Stmt`,
-   `mir::Expr`) and share name resolution and validation. Anything they do
-   not recognize is a loud error, never a guess.
+   Native embedded compilation, the preferred browser compiler, and Windows
+   `stanli-compile.exe` emit the stanli-owned portable JSON format. Pristine
+   browser and Windows rollback compilers, the R JavaScript compiler, and
+   user-supplied stock stanc emit the legacy stanc3 s-expression. Both decode
+   into the same plain C++ structs (`mir::Stmt`, `mir::Expr`) and share name
+   resolution and validation. Anything they do not recognize is a loud error,
+   never a guess.
+
+   The Windows wheel keeps the compiler outside `stanli.dll`: it packages the
+   preferred `stanli-compile.exe` and pristine `stanc.exe` rollback as
+   short-lived subprocesses, with no OCaml compiler DLL. Python selects stock
+   only when the portable executable is absent. Native R first honors the
+   explicit `STANLI_STANC` stock override, then checks for the portable and
+   stock executables beside the runtime, then stock stanc on `PATH`, and then
+   V8. A failure from a selected compiler is surfaced without trying the next
+   one.
 
 3. **[`lower.cpp`](../runtime/src/lower.cpp) turns MIR into the op
    graph.** Along the way: transformed data is evaluated once, at
@@ -158,7 +169,7 @@ ones through every stage, op list and register programs included.
 |---|---|
 | [`runtime/include/stanli/`](../runtime/include/stanli/) | Public headers. [`graph.hpp`](../runtime/include/stanli/graph.hpp) defines the IR: `Slot` and `Op` over flat arenas. |
 | [`compiler/portable_ir/SCHEMA.md`](../compiler/portable_ir/SCHEMA.md), [`compiler/ocaml/`](../compiler/ocaml/) | The stanli-owned portable MIR contract, shared O1 policy, and typed-OCaml encoder. |
-| [`compiler/native/`](../compiler/native/), [`compiler/js/`](../compiler/js/) | Thin native callback and js_of_ocaml/CLI entry points around the shared OCaml pipeline. |
+| [`compiler/native/`](../compiler/native/), [`compiler/js/`](../compiler/js/) | Thin native callback, js_of_ocaml, and Windows CLI entry points around the shared OCaml pipeline. |
 | [`runtime/src/lower.cpp`](../runtime/src/lower.cpp) | Lowering: transformed MIR in, op graph out. |
 | [`runtime/src/mir_decode.cpp`](../runtime/src/mir_decode.cpp), [`portable_mir_reader.cpp`](../runtime/src/portable_mir_reader.cpp), [`mir_reader.cpp`](../runtime/src/mir_reader.cpp) | Dispatches portable JSON or legacy s-expressions into one MIR representation and runs their shared finalization. |
 | [`runtime/src/inplace.cpp`](../runtime/src/inplace.cpp), [`constfold.cpp`](../runtime/src/constfold.cpp), [`reroll.cpp`](../runtime/src/reroll.cpp), [`island.cpp`](../runtime/src/island.cpp) | The graph passes, in pipeline order. |
@@ -170,7 +181,7 @@ ones through every stage, op list and register programs included.
 | [`runtime/src/adjoint.cpp`](../runtime/src/adjoint.cpp) | `gen_adjoint`: differentiates a register program into a second register program, so an island's backward is a second cheap pass rather than a replay under stan-math's `var`. Owns the checkpoint analysis (save a register before a later write destroys a value a derivative rule needs). `STANLI_NO_NATIVE_ADJ=1` restores the replay, which is the oracle it is tested against ([`test_adjoint.cpp`](../tests/test_adjoint.cpp)). |
 | [`runtime/src/nuts.cpp`](../runtime/src/nuts.cpp) | The sampler: Stan's own `adapt_diag_e_nuts`, configured to match CmdStan exactly. |
 | [`runtime/src/capi.cpp`](../runtime/src/capi.cpp), [`capi.h`](../runtime/include/stanli/capi.h) | The C ABI. [`python/stanli/__init__.py`](../python/stanli/__init__.py) is a thin ctypes wrapper over it. |
-| [`runtime/src/stanc_embed_c.cpp`](../runtime/src/stanc_embed_c.cpp), [`tools/stanc_embed/`](../tools/stanc_embed/) | The native OCaml-runtime bridge and exact-source overlay/build tooling. |
+| [`runtime/src/stanc_embed_c.cpp`](../runtime/src/stanc_embed_c.cpp), [`tools/stanc_embed/`](../tools/stanc_embed/) | The native OCaml-runtime bridge plus exact-source overlay, provenance, and Windows cross-build tooling. |
 | [`js/`](../js/), [`web/`](../web/) | The npm package (a one-call `sample()` over a worker) and the demo page. The worker prefers the portable compiler and keeps stock stancjs as a one-cycle legacy fallback. [`tools/build_web.sh`](../tools/build_web.sh) builds the page from the package, so the two cannot drift. |
 | [`tools/`](../tools/) | Small programs and scripts; the important ones are listed below. |
 | [`harnesses/`](../harnesses/) | Corpus sweeps that need a local posteriordb: [`wa_coverage.py`](../harnesses/wa_coverage.py), [`ab_corpus.py`](../harnesses/ab_corpus.py), [`fn_sweep.py`](../harnesses/fn_sweep.py), benchmarks. |
@@ -534,9 +545,11 @@ The merge happens when CI goes green. Release tags (`v*`, `npm-v*`)
 are not gated by this; they point at commits that already passed on
 main.
 
-If a change plausibly touches Windows (build files, the C ABI surface,
-`tools/exported_symbols.def`), run the wheel job on the branch before
-merging:
+Every pull request cross-builds and executes the Windows compiler and compares
+its portable bytes with the JavaScript producer. That gate does not build the
+C++ runtime. If a change plausibly touches Windows C++ (build files, the C ABI
+surface, `tools/exported_symbols.def`), run the full wheel job on the branch
+before merging:
 
 ```
 gh workflow run wheels.yml --ref my-change

--- a/docs/superpowers/plans/2026-08-26-ocaml-mir-backend-rollout.md
+++ b/docs/superpowers/plans/2026-08-26-ocaml-mir-backend-rollout.md
@@ -56,7 +56,7 @@ PR #208 completed the first tranche:
 
 ## Phase 1: shared producer and browser/npm
 
-Status: in progress.
+Status: complete. All gates below run in CI.
 
 - Move the encoder and O1 policy into one stanli-owned OCaml package under
   `compiler/`.
@@ -110,18 +110,52 @@ avoid increasing the JSON multiplier further.
 
 ## Phase 2: Windows portable producer
 
-- Cross-build the existing CLI entry point as `stanli-compile.exe` using
-  stanc3's Linux-to-Windows recipe.
-- Ship it beside exact-source `stanc.exe` for one release cycle.
-- Python and native R prefer the stanli executable and fall back to stock
-  stanc when it is absent.
-- Compare Windows output byte for byte with native and JS output, including
-  final-newline behavior and the folded-float model.
-- Gate the installed Windows wheel on source compilation, errors, lowering,
-  gradients, sampling, and generated quantities.
+Status: implemented. The compiler-only gate runs on pull requests; the full
+Windows C++ build runs after merge, nightly, and on release tags.
 
-No OCaml DLL is needed. The compiler remains a short-lived subprocess on
-Windows, isolating compiler state and avoiding an OCaml C ABI.
+- Cross-build pristine `stanc.exe` before applying the stanli overlay, then
+  cross-build the shared CLI entry point as `stanli-compile.exe` with stanc3's
+  Linux-to-Windows recipe.
+- Ship both beside `stanli.dll` for one release cycle. The portable producer is
+  preferred; pristine stanc is the rollback selected only when it is absent.
+- Python searches its packaged `_bin` directory for `stanli-compile.exe`, then
+  `stanc.exe`. Native R first honors the explicit `STANLI_STANC` stock override,
+  then checks beside the runtime for the portable producer and stock stanc,
+  then checks `PATH` for stock stanc, and finally uses its JavaScript path.
+- Treat a selected compiler's launch error, nonzero exit, or empty output as
+  an error. If the runtime decoder later rejects its document, surface that
+  error too; do not hide either failure by retrying stock.
+- Keep the Windows compiler in short-lived subprocesses. No OCaml compiler DLL
+  is introduced.
+
+Pull-request gates:
+
+- Validate the exact stanc3 revision, the portable producer's source/toolchain
+  stamp, LF checkout bytes for every stamped input, and that both artifacts are
+  x86-64 PE executables.
+- Execute pristine stanc on the checked overflow fixture to prove it was copied
+  before the overlay changed the fold policy.
+- Execute `stanli-compile.exe` on Windows and compare its output byte for byte
+  with the same JavaScript producer already compared with native OCaml. The
+  shared seven-model suite covers nested UDFs, the mother model, folded
+  binary64, checked int32 overflow, Unicode, includes, and final-newline
+  behavior. The surrounding JavaScript gate covers diagnostics, warnings,
+  stock API compatibility, and repeat determinism.
+- Run both executables through native R from paths containing spaces and
+  Unicode, with CRLF source staged as exact UTF-8 bytes, and distinguish the
+  portable and legacy envelopes.
+
+Post-merge full-platform gates:
+
+- Build the Windows C++ runtime and run CTest.
+- Require the wheel and R runtime tarball to contain `stanli.dll`,
+  `stanli-compile.exe`, and pristine `stanc.exe`.
+- Install the wheel into python.org CPython and exercise source compilation,
+  errors, lowering, gradients, sampling, and generated quantities.
+
+This split keeps the bounded compiler contract merge-blocking while the
+multi-hour stan-math build remains a post-merge platform check. Publishing
+still waits for the full Windows wheel.
 
 ## Phase 3: CRAN and webR compiler
 

--- a/python/README.md
+++ b/python/README.md
@@ -99,8 +99,9 @@ autodiff tape, so a reverse sweep is a backwards loop over an array,
 and steady-state gradient evaluation allocates nothing.
 
 Two things are not reimplemented, which is what makes the results
-trustworthy: the compiler is the real stanc3, linked in-process, and
-the math is unmodified stan-math, the same code CmdStan runs.
+trustworthy: the compiler is the real stanc3 plus the stanli OCaml pipeline,
+embedded in the runtime on macOS and Linux and packaged as an executable on
+Windows, and the math is unmodified stan-math, the same code CmdStan runs.
 
 ## Correctness
 
@@ -197,9 +198,14 @@ reachable by name too.
 Wheels for macOS (arm64 and x86_64), Linux (x86_64 and aarch64,
 manylinux_2_28) and Windows (x86_64). The Windows wheel is built under
 mingw-w64, because stan-math does not build under MSVC (the same reason
-RStan ships through RTools), and bundles `stanc.exe` as a subprocess
-instead of embedding the compiler; the API works the same way either
-way.
+RStan ships through RTools). Windows wheels built from this revision run
+`stanli-compile.exe` as a short-lived subprocess and keep pristine `stanc.exe`
+beside it for one rollback cycle; there is no OCaml compiler DLL. Python
+prefers `stanli-compile.exe` whenever
+it is present and selects `stanc.exe` only when it is absent. Launch errors,
+compiler errors, and empty output are reported; an invalid portable result is
+rejected when decoded. None causes an automatic retry through stock stanc. The
+public API works the same way as the embedded compiler path.
 
 The installed library is 29.7 MB: over half of it is the density
 kernels, about a quarter the embedded stanc3, and the interpreter and

--- a/python/stanli/__init__.py
+++ b/python/stanli/__init__.py
@@ -1,8 +1,8 @@
 """stanli: the Stan Language Interpreter.
 
 Compiles a .stan model with stanc3 (linked into the bundled shared library,
-or a bundled stanc binary as a subprocess where it is not), lowers it to an
-op graph in-process, and samples with NUTS. No C++ toolchain, no model
+or a bundled compiler executable as a subprocess where it is not), lowers it
+to an op graph in-process, and samples with NUTS. No C++ toolchain, no model
 compilation on this machine.
 """
 import ctypes
@@ -176,14 +176,52 @@ def _dptr(a):
     return a.ctypes.data_as(ctypes.POINTER(ctypes.c_double))
 
 
+def _compiler_command(model_path: pathlib.Path):
+    """The packaged compiler argv, preferring stanli's portable producer."""
+    suffix = ".exe" if sys.platform == "win32" else ""
+    portable = _BIN / ("stanli-compile" + suffix)
+    if portable.is_file():
+        return [str(portable), str(model_path)]
+
+    # One-cycle rollback path: pristine stanc3 emits the legacy s-expression
+    # that the runtime continues to accept. Only absence selects it. A broken
+    # portable compiler must fail loudly rather than being hidden by a retry.
+    stanc = _BIN / ("stanc" + suffix)
+    if stanc.is_file():
+        return [str(stanc), "--O1", "--debug-optimized-mir", str(model_path)]
+    raise RuntimeError(
+        "the bundled Stan compiler is missing "
+        f"(expected {portable.name} or {stanc.name} in {_BIN})")
+
+
 def _stanc_mir(model_path: pathlib.Path) -> str:
-    stanc = _BIN / ("stanc.exe" if sys.platform == "win32" else "stanc")
-    r = subprocess.run([str(stanc), "--O1", "--debug-optimized-mir",
-                        str(model_path)],
-                       capture_output=True, text=True)
+    argv = _compiler_command(model_path)
+    try:
+        r = subprocess.run(argv, capture_output=True, text=True,
+                           encoding="utf-8")
+    except OSError as exc:
+        raise RuntimeError(f"could not run the bundled Stan compiler: {exc}") \
+            from exc
     if r.returncode != 0 or not r.stdout:
         raise RuntimeError(f"stanc failed:\n{r.stderr}")
     return r.stdout
+
+
+def _subprocess_mir(stan_code: str) -> str:
+    """Compile source in an isolated directory and remove every side effect."""
+    import tempfile
+    with tempfile.TemporaryDirectory(prefix="stanli-compile-") as tmpdir:
+        source = pathlib.Path(tmpdir) / "model.stan"
+        # Binary UTF-8 avoids the locale-dependent encoding and CRLF rewriting
+        # of text-mode files on Windows. Stock stanc also writes model.hpp next
+        # to this file; TemporaryDirectory removes that rollback-path artifact.
+        source.write_bytes(stan_code.encode("utf-8"))
+        return _stanc_mir(source)
+
+
+def _read_utf8_file(path) -> str:
+    """Read source bytes as UTF-8 without universal-newline rewriting."""
+    return pathlib.Path(path).read_bytes().decode("utf-8")
 
 
 def stan_to_mir(stan_code: str) -> str:
@@ -191,15 +229,13 @@ def stan_to_mir(stan_code: str) -> str:
 
     The first half of compiling a model, on its own. Useful when the MIR
     is what you want to keep -- to cache it, ship it, or hand it to
-    ``Model(mir=...)`` in another process. Embedded builds return stanli's
-    versioned portable format; the bundled-compiler fallback returns the
-    legacy stanc3 s-expression, which the runtime also accepts.
+    ``Model(mir=...)`` in another process. Embedded builds and the preferred
+    bundled compiler return stanli's versioned portable format. The one-cycle
+    stock-compiler fallback returns a legacy stanc3 s-expression, which the
+    runtime also accepts.
     """
     if not _lib.stanli_has_embedded_stanc():
-        import tempfile
-        tmp = pathlib.Path(tempfile.mkdtemp()) / "model.stan"
-        tmp.write_text(stan_code)
-        return _stanc_mir(tmp)
+        return _subprocess_mir(stan_code)
     err = ctypes.create_string_buffer(8192)
     p = _lib.stanli_stan_to_mir(stan_code.encode(), err, len(err))
     if not p:
@@ -225,7 +261,7 @@ def _resolve_program(stan_file, stan_code, mir, name):
         if stan_code is None:
             if stan_file is None:
                 raise ValueError("provide stan_file, stan_code, or mir")
-            stan_code = pathlib.Path(stan_file).read_text()
+            stan_code = _read_utf8_file(stan_file)
         mir = stan_to_mir(stan_code)
     if name is None:
         name = pathlib.Path(stan_file).stem if stan_file else "stanli_model"
@@ -552,18 +588,16 @@ class Model:
         if stan_code is None:
             if stan_file is None:
                 raise ValueError("provide stan_file, stan_code, or mir")
-            stan_code = pathlib.Path(stan_file).read_text()
+            stan_code = _read_utf8_file(stan_file)
 
         if _lib.stanli_has_embedded_stanc():
             # Fully in-process: embedded stanc3 compiles the model.
             self._m = _lib.stanli_model_new_from_stan(
                 stan_code.encode(), data_json.encode(), err, len(err))
         else:
-            # Fallback: bundled stanc binary as a subprocess.
-            import tempfile
-            tmp = pathlib.Path(tempfile.mkdtemp()) / "model.stan"
-            tmp.write_text(stan_code)
-            self._m = _lib.stanli_model_new(_stanc_mir(tmp).encode(),
+            # Windows and other non-embedded builds use the bundled compiler
+            # executable as a short-lived subprocess.
+            self._m = _lib.stanli_model_new(_subprocess_mir(stan_code).encode(),
                                             data_json.encode(), err, len(err))
         self._finish_init(err)
 

--- a/r/R/stanc.R
+++ b/r/R/stanc.R
@@ -4,10 +4,13 @@
 # OCaml compiler in, so `stanli_model(code = ...)` hands the source
 # straight to it and none of this runs.
 #
-# When it does not (a source build, or the Windows runtime), the fallback
-# is stanc3 compiled to JavaScript and run through V8. That is the same
+# When it does not (a source build, or the Windows runtime), native hosts
+# first use a compiler executable. The Windows runtime ships stanli-compile,
+# which emits portable MIR through the shared OCaml pipeline, beside pristine
+# stanc for one rollback cycle. Without either, the fallback is stanc3 compiled
+# to JavaScript and run through V8. That is the same
 # trick rstan uses to ship a Stan compiler on CRAN: js_of_ocaml turns the
-# OCaml into one 2.8 MB file with no toolchain and no platform binaries,
+# OCaml into one 3.0 MB file with no toolchain and no platform binaries,
 # which is a thing CRAN can carry and a native `stanc` per platform is
 # not. CI checks that this generated file comes from the exact configured
 # stanc3 source revision, and the R tests compile both valid and invalid
@@ -18,8 +21,8 @@
 # package's eval_js() evaluates in the worker's global scope, and the
 # same bundled stanc.js defines stanc() there once per session.
 #
-# A native stanc on PATH or in STANLI_STANC still wins over the JS ones
-# when it is there, because it is faster.
+# An explicit stanc in STANLI_STANC still wins for compiler bisects. Otherwise
+# the runtime-adjacent stanli-compile wins, followed by adjacent or PATH stanc.
 
 stanc_js_ctx <- new.env(parent = emptyenv())
 
@@ -27,14 +30,15 @@ stanc_js_path <- function() {
   system.file("js", "stanc.js", package = "stanli")
 }
 
-# One V8 context per session: loading 2.8 MB of JavaScript takes a moment
+# One V8 context per session: loading 3.0 MB of JavaScript takes a moment
 # and the compiler is stateless afterwards.
 stanc_js <- function() {
   if (!is.null(stanc_js_ctx$ctx)) return(stanc_js_ctx$ctx)
   if (!requireNamespace("V8", quietly = TRUE))
     stop("compiling Stan source needs either a runtime with the embedded ",
-         "compiler, a stanc3 binary (STANLI_STANC), or the V8 package for ",
-         "the bundled JavaScript compiler.", call. = FALSE)
+         "compiler, a packaged native compiler, a stanc3 binary ",
+         "(STANLI_STANC), or the V8 package for the bundled JavaScript ",
+         "compiler.", call. = FALSE)
   js <- stanc_js_path()
   if (!nzchar(js) || !file.exists(js))
     stop("the bundled stanc.js is missing from the installed package",
@@ -68,33 +72,82 @@ mir_from_js <- function(code, name = "stanli_model") {
   parsed$r
 }
 
-# A native stanc, when one is configured or on the PATH. Not under webR:
-# there are no processes to run one in, and Sys.which warns about the
+# A native compiler, when one is packaged, configured, or on the PATH. The
+# portable producer is deliberately only discovered beside the runtime: unlike
+# stock stanc's legacy format it is a versioned stanli/runtime contract, so an
+# unrelated stanli-compile on PATH must not silently pair with this library.
+# Not under webR: there are no processes to run, and Sys.which warns about the
 # missing `which` on every call there.
-find_stanc <- function() {
-  if (identical(Sys.info()[["sysname"]], "Emscripten")) return("")
-  from_env <- Sys.getenv("STANLI_STANC", "")
-  if (nzchar(from_env)) return(from_env)
-  exe <- if (identical(Sys.info()[["sysname"]], "Windows")) "stanc.exe" else
-    "stanc"
-  beside <- file.path(dirname(stanli_runtime_path()), exe)
-  if (file.exists(beside)) return(beside)
-  found <- Sys.which(exe)
-  if (nzchar(found)) return(unname(found))
-  ""
+find_native_compiler <- function(
+    sysname = Sys.info()[["sysname"]],
+    runtime = stanli_runtime_path(),
+    from_env = Sys.getenv("STANLI_STANC", ""),
+    find_on_path = Sys.which) {
+  if (identical(sysname, "Emscripten")) return(NULL)
+
+  # Preserve the explicit legacy-compiler override used for stanc3 bisects.
+  if (nzchar(from_env)) return(list(path = from_env, portable = FALSE))
+
+  suffix <- if (identical(sysname, "Windows")) ".exe" else ""
+  runtime_dir <- dirname(runtime)
+  portable <- file.path(runtime_dir, paste0("stanli-compile", suffix))
+  if (file.exists(portable) && !dir.exists(portable))
+    return(list(path = portable, portable = TRUE))
+
+  stanc_name <- paste0("stanc", suffix)
+  stanc <- file.path(runtime_dir, stanc_name)
+  if (file.exists(stanc) && !dir.exists(stanc))
+    return(list(path = stanc, portable = FALSE))
+
+  found <- find_on_path(stanc_name)
+  if (nzchar(found))
+    return(list(path = unname(found), portable = FALSE))
+  NULL
 }
 
-mir_from_binary <- function(stanc, code, run_stanc = system2) {
-  f <- tempfile(fileext = ".stan")
-  on.exit(unlink(f), add = TRUE)
-  writeLines(code, f)
-  out <- suppressWarnings(
-    run_stanc(stanc, c("--O1", "--debug-optimized-mir", shQuote(f)),
-              stdout = TRUE, stderr = TRUE))
-  status <- attr(out, "status")
-  if (!is.null(status) && status != 0)
-    stop("stanc failed:\n", paste(out, collapse = "\n"), call. = FALSE)
-  paste(out, collapse = "\n")
+# Read compiler output as explicit UTF-8 bytes. Captured system2 output is
+# otherwise converted through the native Windows locale before R sees it.
+read_compiler_output <- function(path) {
+  size <- file.info(path)$size
+  if (is.na(size) || size == 0) return("")
+  value <- rawToChar(readBin(path, "raw", n = size))
+  Encoding(value) <- "UTF-8"
+  value
+}
+
+mir_from_binary <- function(compiler, code, portable = FALSE,
+                            run_stanc = system2) {
+  work <- tempfile("stanli-compile-")
+  if (!dir.create(work))
+    stop("could not create a temporary compiler directory", call. = FALSE)
+  on.exit(unlink(work, recursive = TRUE, force = TRUE), add = TRUE)
+
+  source <- file.path(work, "model.stan")
+  con <- file(source, open = "wb")
+  tryCatch(
+    writeBin(charToRaw(enc2utf8(code)), con),
+    finally = close(con))
+
+  stdout_file <- file.path(work, "stdout")
+  stderr_file <- file.path(work, "stderr")
+  args <- c(if (!portable) c("--O1", "--debug-optimized-mir"),
+            shQuote(source))
+  status <- tryCatch(
+    suppressWarnings(run_stanc(compiler, args, stdout = stdout_file,
+                               stderr = stderr_file)),
+    error = function(e) {
+      stop("could not run the bundled Stan compiler: ", conditionMessage(e),
+           call. = FALSE)
+    })
+  out <- read_compiler_output(stdout_file)
+  diagnostics <- read_compiler_output(stderr_file)
+  if (!identical(as.integer(status), 0L) || !nzchar(out))
+    stop("stanc failed:\n",
+         if (nzchar(diagnostics)) diagnostics else "stanc produced no MIR",
+         call. = FALSE)
+  # Warnings live on stderr. They must not be concatenated with the MIR; the
+  # embedded compiler path also leaves successful frontend warnings internal.
+  if (portable) out else sub("\\r?\\n$", "", out)
 }
 
 # The webR path. Source and MIR travel through the shared Emscripten
@@ -143,8 +196,10 @@ mir_from_webr <- function(eval_js, code, name = "stanli_model") {
 }
 
 stanc_mir <- function(code) {
-  stanc <- find_stanc()
-  if (nzchar(stanc)) return(mir_from_binary(stanc, code))
+  compiler <- find_native_compiler()
+  if (!is.null(compiler))
+    return(mir_from_binary(compiler$path, code,
+                           portable = compiler$portable))
   ejs <- webr_eval_js()
   if (!is.null(ejs)) return(mir_from_webr(ejs, code))
   mir_from_js(code)

--- a/r/R/stanli.R
+++ b/r/R/stanli.R
@@ -32,6 +32,15 @@ to_json <- function(x) {
          "]")
 }
 
+read_utf8_file <- function(path) {
+  size <- file.info(path)$size
+  if (is.na(size))
+    stop("could not read UTF-8 file: ", path, call. = FALSE)
+  value <- rawToChar(readBin(path, "raw", n = size))
+  Encoding(value) <- "UTF-8"
+  value
+}
+
 #' Compile a Stan model
 #'
 #' @param file Path to a `.stan` file.
@@ -45,12 +54,12 @@ stanli_model <- function(file = NULL, code = NULL, data = NULL, mir = NULL) {
   load_runtime()
   if (is.null(code) && is.null(mir)) {
     if (is.null(file)) stop("provide file, code or mir", call. = FALSE)
-    code <- paste(readLines(file, warn = FALSE), collapse = "\n")
+    code <- read_utf8_file(file)
   }
   data_json <- if (is.null(data)) {
     "{}"
   } else if (is.character(data) && length(data) == 1 && file.exists(data)) {
-    paste(readLines(data, warn = FALSE), collapse = "\n")
+    read_utf8_file(data)
   } else if (is.character(data) && length(data) == 1) {
     data
   } else {

--- a/r/README.md
+++ b/r/README.md
@@ -82,17 +82,24 @@ and sample happily from the wrong seed. So the C ABI carries a layout
 version (`stanli_abi_version()`) and loading refuses on a mismatch with
 a message saying which side to update.
 
-**The Stan compiler** is stanc3 compiled to JavaScript and run through
-the V8 package, the same approach rstan uses to ship a compiler on
-CRAN: one 2.8 MB file, no toolchain, no per-platform binaries. When the
-runtime embeds stanc3 (every release build but Windows), that path is
-used instead and V8 never loads; a native `stanc` in `STANLI_STANC` or
-beside the runtime also wins, because it is faster than either. The
-Windows runtime tarball carries `stanc.exe` next to the DLL for exactly
-that reason. The bundled JavaScript compiler records its exact stanc3
-repository, revision, and content hash. CI verifies that provenance and
-compiles valid and invalid models through the file on Linux, macOS, and
-Windows.
+**The Stan compiler** uses the embedded stanc3 and stanli OCaml pipeline in the
+macOS and Linux release runtimes. On native hosts without an embedded compiler,
+`STANLI_STANC` remains the first choice as an explicit stock-compiler override
+for bisects. Otherwise R prefers
+`stanli-compile` beside the runtime, then stock `stanc` beside the runtime or
+on `PATH`, and finally stanc3 compiled to JavaScript through V8. The portable
+producer is never taken from `PATH`, because it must match the runtime's
+schema. Launch errors, nonzero exits, and empty output are reported; invalid
+portable output is rejected when decoded. None causes an automatic retry
+through stock stanc.
+
+The v0.9.2 compatibility runtime carries pristine `stanc.exe`; the selection
+logic falls through to it automatically. Windows runtime tarballs built from
+this revision add `stanli-compile.exe` beside that rollback compiler for one
+release cycle. Both are short-lived subprocesses; there is no OCaml compiler
+DLL. The bundled JavaScript compiler records its exact stanc3 repository,
+revision, and content hash. CI verifies that provenance and compiles valid and
+invalid models through the file on Linux, macOS, and Windows.
 
 ## What is not here yet
 

--- a/r/tests/testthat/test-stanc.R
+++ b/r/tests/testthat/test-stanc.R
@@ -41,22 +41,130 @@ test_that("the bundled JavaScript compiler applies O1", {
   expect_match(mir, "(Lit Real 0.30000000000000004)", fixed = TRUE)
 })
 
-test_that("the native compiler fallback requests O1 optimized MIR", {
+test_that("the native portable compiler owns flags and keeps warnings separate", {
   seen <- NULL
-  run_stanc <- function(stanc, args, stdout, stderr) {
-    seen <<- list(stanc = stanc, args = args,
-                  stdout = stdout, stderr = stderr)
-    "(fake MIR)"
+  run_stanc <- function(compiler, args, stdout, stderr) {
+    seen <<- list(compiler = compiler, args = args,
+                  stdout = stdout, stderr = stderr,
+                  work = dirname(stdout))
+    source <- file.path(dirname(stdout), "model.stan")
+    source_bytes <- readBin(source, "raw", n = file.info(source)$size)
+    expect_identical(source_bytes,
+                     charToRaw(enc2utf8("model { // θ\r\n}\r\n")))
+    con <- file(stdout, open = "wb")
+    writeChar(enc2utf8('{"stanli_ir":1,"program":"theta θ"}'), con,
+              eos = NULL, useBytes = TRUE)
+    close(con)
+    writeLines("a successful frontend warning", stderr, useBytes = TRUE)
+    0L
+  }
+
+  expect_identical(stanli:::mir_from_binary(
+                     "fake-stanli-compile", "model { // θ\r\n}\r\n",
+                     portable = TRUE,
+                     run_stanc = run_stanc),
+                   '{"stanli_ir":1,"program":"theta θ"}')
+  expect_identical(seen$compiler, "fake-stanli-compile")
+  expect_length(seen$args, 1)
+  expect_false(dir.exists(seen$work))
+})
+
+test_that("UTF-8 Stan files survive locale-independent compiler staging", {
+  source_file <- tempfile(fileext = ".stan")
+  on.exit(unlink(source_file), add = TRUE)
+  source_text <- enc2utf8("transformed data { print(\"\u03b8\"); }\nmodel {}\n")
+  writeBin(charToRaw(source_text), source_file)
+
+  old_locale <- Sys.getlocale("LC_CTYPE")
+  on.exit(suppressWarnings(Sys.setlocale("LC_CTYPE", old_locale)), add = TRUE)
+  expect_true(nzchar(suppressWarnings(Sys.setlocale("LC_CTYPE", "C"))))
+
+  code <- stanli:::read_utf8_file(source_file)
+  expected <- charToRaw(source_text)
+  expect_identical(charToRaw(code), expected)
+
+  run_stanc <- function(compiler, args, stdout, stderr) {
+    staged <- file.path(dirname(stdout), "model.stan")
+    expect_identical(readBin(staged, "raw", n = file.info(staged)$size),
+                     expected)
+    writeChar('{"stanli_ir":1,"program":{}}', stdout, eos = NULL,
+              useBytes = TRUE)
+    file.create(stderr)
+    0L
+  }
+  expect_identical(
+    stanli:::mir_from_binary("fake-stanli-compile", code, portable = TRUE,
+                              run_stanc = run_stanc),
+    '{"stanli_ir":1,"program":{}}')
+})
+
+test_that("the pristine stanc fallback requests O1 optimized MIR", {
+  seen <- NULL
+  run_stanc <- function(compiler, args, stdout, stderr) {
+    seen <<- list(compiler = compiler, args = args, work = dirname(stdout))
+    writeLines("(fake MIR)", stdout, useBytes = TRUE)
+    writeLines("generated side effect", file.path(dirname(stdout), "model.hpp"))
+    file.create(stderr)
+    0L
   }
 
   expect_identical(stanli:::mir_from_binary(
                      "fake-stanc", "model {}", run_stanc = run_stanc),
                    "(fake MIR)")
-  expect_identical(seen$stanc, "fake-stanc")
+  expect_identical(seen$compiler, "fake-stanc")
   expect_identical(seen$args[1:2],
                    c("--O1", "--debug-optimized-mir"))
-  expect_true(seen$stdout)
-  expect_true(seen$stderr)
+  expect_false(dir.exists(seen$work))
+})
+
+test_that("a failing preferred compiler is not hidden by partial output", {
+  run_stanc <- function(compiler, args, stdout, stderr) {
+    writeLines("partial portable output", stdout)
+    writeLines("source-bearing syntax error", stderr)
+    1L
+  }
+
+  expect_error(
+    stanli:::mir_from_binary("fake-stanli-compile", "bad model",
+                              portable = TRUE, run_stanc = run_stanc),
+    "source-bearing syntax error")
+})
+
+test_that("native discovery prefers the packaged portable compiler", {
+  work <- tempfile("stanli-compiler-discovery-")
+  dir.create(work)
+  on.exit(unlink(work, recursive = TRUE), add = TRUE)
+  runtime <- file.path(work, "stanli.dll")
+  portable <- file.path(work, "stanli-compile.exe")
+  stanc <- file.path(work, "stanc.exe")
+  file.create(runtime, portable, stanc)
+
+  from_path <- function(name) {
+    expect_identical(name, "stanc.exe")
+    "C:/tools/stanc.exe"
+  }
+  expect_identical(
+    stanli:::find_native_compiler("Windows", runtime, "", from_path),
+    list(path = portable, portable = TRUE))
+
+  # Explicit configuration remains the bisect/override mechanism.
+  expect_identical(
+    stanli:::find_native_compiler("Windows", runtime, "C:/old/stanc.exe",
+                                   from_path),
+    list(path = "C:/old/stanc.exe", portable = FALSE))
+
+  unlink(portable)
+  expect_identical(
+    stanli:::find_native_compiler("Windows", runtime, "", from_path),
+    list(path = stanc, portable = FALSE))
+  unlink(stanc)
+  expect_identical(
+    stanli:::find_native_compiler("Windows", runtime, "", from_path),
+    list(path = "C:/tools/stanc.exe", portable = FALSE))
+
+  expect_null(stanli:::find_native_compiler(
+    "Emscripten", runtime, "",
+    function(name) stop("webR must not search for a process")))
 })
 
 test_that("the webR compiler fallback requests O1 optimized MIR", {

--- a/r/tests/testthat/test-stanc.R
+++ b/r/tests/testthat/test-stanc.R
@@ -143,9 +143,10 @@ test_that("native discovery prefers the packaged portable compiler", {
     expect_identical(name, "stanc.exe")
     "C:/tools/stanc.exe"
   }
-  expect_identical(
-    stanli:::find_native_compiler("Windows", runtime, "", from_path),
-    list(path = portable, portable = TRUE))
+  found <- stanli:::find_native_compiler("Windows", runtime, "", from_path)
+  expect_true(found$portable)
+  expect_identical(normalizePath(found$path, winslash = "/", mustWork = TRUE),
+                   normalizePath(portable, winslash = "/", mustWork = TRUE))
 
   # Explicit configuration remains the bisect/override mechanism.
   expect_identical(
@@ -154,9 +155,10 @@ test_that("native discovery prefers the packaged portable compiler", {
     list(path = "C:/old/stanc.exe", portable = FALSE))
 
   unlink(portable)
-  expect_identical(
-    stanli:::find_native_compiler("Windows", runtime, "", from_path),
-    list(path = stanc, portable = FALSE))
+  found <- stanli:::find_native_compiler("Windows", runtime, "", from_path)
+  expect_false(found$portable)
+  expect_identical(normalizePath(found$path, winslash = "/", mustWork = TRUE),
+                   normalizePath(stanc, winslash = "/", mustWork = TRUE))
   unlink(stanc)
   expect_identical(
     stanli:::find_native_compiler("Windows", runtime, "", from_path),

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -7,8 +7,12 @@ Run against an installed wheel (CI does) or a local build:
 """
 import concurrent.futures
 import pathlib
+import shutil
+import subprocess
 import sys
+import tempfile
 import threading
+from unittest import mock
 
 import numpy as np
 
@@ -281,6 +285,10 @@ def test_stan_to_mir_round_trips():
     code = "parameters { real x; } model { x ~ normal(0, 1); }"
     mir = stanli.stan_to_mir(code)
     assert "log_prob" in mir, "MIR text does not look like transformed MIR"
+    suffix = ".exe" if sys.platform == "win32" else ""
+    if (stanli._BIN / ("stanli-compile" + suffix)).is_file():
+        assert mir.startswith('{"stanli_ir":1,"program":'), mir[:80]
+        assert not mir.endswith(("\n", "\r")), "portable MIR has final newline"
 
     from_source = stanli.Model(stan_code=code)
     from_mir = stanli.Model(mir=mir)
@@ -309,6 +317,135 @@ def test_stan_to_mir_reports_syntax_errors():
     except RuntimeError:
         return
     raise AssertionError("expected RuntimeError for a syntax error")
+
+
+def test_subprocess_compiler_preference_and_rollback_contract():
+    # The Windows wheel carries both executables for one release cycle. The
+    # portable producer wins by presence; a non-zero result from it is a real
+    # failure and must never be hidden by silently retrying pristine stanc.
+    suffix = ".exe" if sys.platform == "win32" else ""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        compiler_dir = pathlib.Path(tmpdir)
+        portable = compiler_dir / ("stanli-compile" + suffix)
+        stock = compiler_dir / ("stanc" + suffix)
+        source = compiler_dir / "source with spaces.stan"
+        portable.touch()
+        stock.touch()
+        source.write_text("model {}", encoding="utf-8")
+        calls = []
+
+        def successful_run(argv, **kwargs):
+            calls.append((argv, kwargs))
+            return subprocess.CompletedProcess(
+                argv, 0, '{"stanli_ir":1,"program":{}}',
+                "a successful frontend warning")
+
+        with mock.patch.object(stanli, "_BIN", compiler_dir), \
+                mock.patch.object(stanli.subprocess, "run", successful_run):
+            got = stanli._stanc_mir(source)
+        assert got == '{"stanli_ir":1,"program":{}}'
+        assert calls[0][0] == [str(portable), str(source)]
+        assert calls[0][1]["encoding"] == "utf-8"
+        assert calls[0][1]["capture_output"] is True
+
+        calls.clear()
+
+        def failing_run(argv, **kwargs):
+            calls.append(argv)
+            return subprocess.CompletedProcess(argv, 1, "partial", "bad Stan")
+
+        with mock.patch.object(stanli, "_BIN", compiler_dir), \
+                mock.patch.object(stanli.subprocess, "run", failing_run):
+            try:
+                stanli._stanc_mir(source)
+            except RuntimeError as exc:
+                assert "bad Stan" in str(exc)
+            else:
+                raise AssertionError("preferred compiler failure was ignored")
+        assert calls == [[str(portable), str(source)]], calls
+
+        portable.unlink()
+        calls.clear()
+        with mock.patch.object(stanli, "_BIN", compiler_dir), \
+                mock.patch.object(stanli.subprocess, "run", successful_run):
+            stanli._stanc_mir(source)
+        assert calls[0][0] == [str(stock), "--O1",
+                               "--debug-optimized-mir", str(source)]
+
+        stock.unlink()
+        with mock.patch.object(stanli, "_BIN", compiler_dir):
+            try:
+                stanli._compiler_command(source)
+            except RuntimeError as exc:
+                assert "stanli-compile" in str(exc) and "stanc" in str(exc)
+            else:
+                raise AssertionError("missing bundled compilers were accepted")
+
+
+def test_subprocess_source_is_exact_utf8_and_fully_cleaned_up():
+    code = ("parameters { real theta; }\r\n"
+            "model { // θ\r\n theta ~ normal(0, 1); }\r\n")
+    seen = {}
+
+    def fake_compile(source):
+        seen["source"] = source
+        seen["bytes"] = source.read_bytes()
+        # Pristine stanc writes this beside its input even when only its debug
+        # MIR was requested. The whole private directory must be reclaimed.
+        source.with_suffix(".hpp").write_text("generated", encoding="utf-8")
+        return "(fake MIR)"
+
+    with mock.patch.object(stanli, "_stanc_mir", fake_compile):
+        assert stanli._subprocess_mir(code) == "(fake MIR)"
+    assert seen["bytes"] == code.encode("utf-8")
+    assert not seen["source"].parent.exists()
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        source_file = pathlib.Path(tmpdir) / "source π.stan"
+        source_file.write_bytes(code.encode("utf-8"))
+        assert stanli._read_utf8_file(source_file) == code
+
+
+def test_windows_wheel_compilers_and_stock_rollback_execute():
+    if sys.platform != "win32":
+        return
+
+    packaged_portable = stanli._BIN / "stanli-compile.exe"
+    packaged_stock = stanli._BIN / "stanc.exe"
+    assert packaged_portable.is_file(), "Windows wheel lacks stanli-compile.exe"
+    assert packaged_stock.is_file(), "Windows wheel lacks stanc.exe"
+
+    unicode_text = "π ☃ é 👋"
+    code = ("transformed data {\r\n"
+            f'  print("{unicode_text}");\r\n'
+            "}\r\n"
+            "parameters { real x; }\r\n"
+            "model { x ~ normal(0, 1); }\r\n")
+    with tempfile.TemporaryDirectory(
+            prefix="stanli compiler rollback π ") as tmp:
+        compiler_dir = pathlib.Path(tmp)
+        portable = compiler_dir / packaged_portable.name
+        stock = compiler_dir / packaged_stock.name
+        shutil.copy2(packaged_portable, portable)
+        shutil.copy2(packaged_stock, stock)
+
+        with mock.patch.object(stanli, "_BIN", compiler_dir):
+            portable_mir = stanli._subprocess_mir(code)
+            assert portable_mir.startswith('{"stanli_ir":1,"program":')
+            assert not portable_mir.endswith(("\n", "\r"))
+            assert unicode_text in portable_mir
+
+            # Removing only the temporary preferred producer must select the
+            # packaged rollback compiler. Its legacy MIR still has to lower
+            # into the same executable runtime graph.
+            portable.unlink()
+            legacy_mir = stanli._subprocess_mir(code)
+
+        assert legacy_mir.lstrip().startswith("(")
+        model = stanli.Model(mir=legacy_mir)
+        lp, grad = model.log_prob_grad(np.array([0.25]))
+        assert np.isfinite(lp)
+        assert np.isfinite(grad).all()
 
 
 def test_embedded_stanc_from_concurrent_python_threads():

--- a/tests/test_windows_compiler.R
+++ b/tests/test_windows_compiler.R
@@ -1,0 +1,74 @@
+# Exercise the real Windows subprocess path in r/R/stanc.R. Both PE files and
+# the staged Stan source live below paths containing spaces; the compiler path
+# also has a Unicode component, catching quoting and path conversion at both
+# ends of system2().
+main <- function() {
+  args <- commandArgs(trailingOnly = TRUE)
+  if (length(args) != 2L)
+    stop("usage: test_windows_compiler.R STANLI-COMPILE.EXE STANC.EXE")
+  if (!identical(Sys.info()[["sysname"]], "Windows"))
+    stop("test_windows_compiler.R must run on Windows")
+
+  source("r/R/stanc.R", encoding = "UTF-8")
+
+  unicode <- intToUtf8(c(0x03c0, 0x2603, 0x00e9, 0x1f44b))
+  compiler_dir <- file.path(tempdir(), paste0("compiler path ", unicode))
+  if (!dir.create(compiler_dir))
+    stop("could not create the compiler test directory")
+  on.exit(unlink(compiler_dir, recursive = TRUE, force = TRUE), add = TRUE)
+
+  # mir_from_binary intentionally owns its temporary work directory. Give just
+  # that function a test-local tempfile() so the real model path contains spaces
+  # without relying on whether R itself accepts a spaced R_TempDir at startup.
+  source_parent <- file.path(tempdir(), "Stan source path with spaces")
+  if (!dir.create(source_parent))
+    stop("could not create the source test directory")
+  on.exit(unlink(source_parent, recursive = TRUE, force = TRUE), add = TRUE)
+  compiler_env <- new.env(parent = environment(mir_from_binary))
+  compiler_env$tempfile <- local({
+    parent <- source_parent
+    function(pattern = "file", fileext = "")
+      base::tempfile(pattern, tmpdir = parent, fileext = fileext)
+  })
+  mir_from_binary_test <- mir_from_binary
+  environment(mir_from_binary_test) <- compiler_env
+
+  portable_compiler <- file.path(compiler_dir, "stanli-compile.exe")
+  stock_compiler <- file.path(compiler_dir, "stanc.exe")
+  if (!file.copy(normalizePath(args[[1L]], mustWork = TRUE),
+                 portable_compiler) ||
+      !file.copy(normalizePath(args[[2L]], mustWork = TRUE), stock_compiler))
+    stop("could not copy the Windows compilers into the test directory")
+
+  # Deliberate CRLF input exercises byte-preserving source staging on Windows;
+  # the non-ASCII string must survive the process boundary and output capture.
+  model <- paste0(
+    "transformed data {\r\n",
+    "  print(\"", unicode, "\");\r\n",
+    "}\r\n",
+    "parameters { real x; }\r\n",
+    "model { x ~ std_normal(); }\r\n")
+  Encoding(model) <- "UTF-8"
+
+  portable <- mir_from_binary_test(portable_compiler, model, portable = TRUE)
+  if (!startsWith(portable, '{"stanli_ir":1,"program":'))
+    stop("the portable compiler did not emit the versioned envelope")
+  if (endsWith(portable, "\n") || endsWith(portable, "\r"))
+    stop("the portable compiler emitted a final newline")
+  if (!grepl(unicode, portable, fixed = TRUE))
+    stop("the portable compiler did not preserve Unicode source bytes")
+
+  legacy <- mir_from_binary_test(stock_compiler, model, portable = FALSE)
+  if (!startsWith(legacy, "((functions_block"))
+    stop("stock stanc did not emit legacy optimized MIR")
+  if (startsWith(legacy, '{"stanli_ir":'))
+    stop("the stock rollback compiler was replaced by the portable producer")
+  # Legacy MIR renders non-ASCII string bytes as decimal backslash escapes.
+  legacy_unicode <- paste0("\\", as.integer(charToRaw(unicode)), collapse = "")
+  if (!grepl(legacy_unicode, legacy, fixed = TRUE))
+    stop("stock stanc did not preserve the Unicode source bytes")
+
+  message("test_windows_compiler OK")
+}
+
+main()

--- a/tests/test_windows_provenance.sh
+++ b/tests/test_windows_provenance.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+# The cross-compiler packages expose the version and target used by Dune. Mock
+# only that opam interface so this contract can run on every development host.
+source tools/stanc_embed/provenance.sh
+configured_version=$(stanc_embed_read_setup OCAML_VERSION)
+STANLI_TEST_OCAML_VERSION=$configured_version
+STANLI_TEST_META_VERSION=$configured_version
+STANLI_TEST_WINDOWS_TARGET=x86_64-w64-mingw32
+STANLI_TEST_DUNE_VERSION=3.24.2
+
+opam() {
+  local command=${1:-}
+  local final_argument=${!#}
+  case "$command:$final_argument" in
+    list:ocaml-windows64)
+      printf '%s\n' "$STANLI_TEST_OCAML_VERSION"
+      ;;
+    list:ocaml-windows)
+      printf '%s\n' "$STANLI_TEST_META_VERSION"
+      ;;
+    list:dune)
+      printf '%s\n' "$STANLI_TEST_DUNE_VERSION"
+      ;;
+    var:conf-gcc-windows64:host)
+      printf '%s\n' "$STANLI_TEST_WINDOWS_TARGET"
+      ;;
+    switch:--short)
+      printf '%s\n' cross-test
+      ;;
+    *)
+      printf 'unexpected opam query: %s\n' "$*" >&2
+      return 2
+      ;;
+  esac
+}
+
+src_repo=$(stanc_embed_read_setup STANC3_SRC_REPO)
+src_sha=$(stanc_embed_read_setup STANC3_SRC_SHA)
+
+stamp=$(stanli_windows_cli_expected_stamp \
+  "$src_repo" "$src_sha" cross-test)
+grep -Fqx "ocaml_version=$configured_version" <<<"$stamp"
+grep -Fqx 'ocaml_target=x86_64-w64-mingw32' <<<"$stamp"
+grep -Fqx 'dune_version=3.24.2' <<<"$stamp"
+
+test_dir=$(mktemp -d "${TMPDIR:-/tmp}/stanli-windows-provenance.XXXXXX")
+trap 'find "$test_dir" -mindepth 1 -delete; rmdir "$test_dir"' EXIT
+artifact="$test_dir/stanli-compile"
+: >"$artifact"
+printf '%s\n' "$stamp" >"$artifact.stamp"
+stanli_windows_cli_artifact_matches \
+  "$artifact" "$src_repo" "$src_sha" cross-test
+stanli_windows_cli_artifact_matches "$artifact" "$src_repo" "$src_sha"
+
+STANLI_TEST_OCAML_VERSION=0.0.0
+if diagnostic=$(stanli_windows_cli_expected_stamp \
+    "$src_repo" "$src_sha" cross-test 2>&1 >/dev/null); then
+  echo "mismatched compiler version was accepted" >&2
+  exit 1
+fi
+grep -Fq "ocaml-windows64 must be $configured_version" <<<"$diagnostic"
+STANLI_TEST_OCAML_VERSION=$configured_version
+
+STANLI_TEST_WINDOWS_TARGET=i686-w64-mingw32
+if diagnostic=$(stanli_windows_cli_expected_stamp \
+    "$src_repo" "$src_sha" cross-test 2>&1 >/dev/null); then
+  echo "32-bit compiler target was accepted" >&2
+  exit 1
+fi
+grep -Fq 'unexpected 64-bit target' <<<"$diagnostic"
+STANLI_TEST_WINDOWS_TARGET=x86_64-w64-mingw32
+
+STANLI_TEST_META_VERSION=0.0.0
+if diagnostic=$(stanli_windows_cli_expected_stamp \
+    "$src_repo" "$src_sha" cross-test 2>&1 >/dev/null); then
+  echo "mismatched package versions were accepted" >&2
+  exit 1
+fi
+grep -Fq 'OCaml package versions differ' <<<"$diagnostic"
+
+echo "test_windows_provenance OK"

--- a/tests/test_windows_provenance.sh
+++ b/tests/test_windows_provenance.sh
@@ -14,32 +14,41 @@ STANLI_TEST_DUNE_VERSION=3.24.2
 opam() {
   local command=${1:-}
   local final_argument=${!#}
+  local value=
   case "$command:$final_argument" in
     list:ocaml-windows64)
-      printf '%s\n' "$STANLI_TEST_OCAML_VERSION"
+      value=$STANLI_TEST_OCAML_VERSION
       ;;
     list:ocaml-windows)
-      printf '%s\n' "$STANLI_TEST_META_VERSION"
+      value=$STANLI_TEST_META_VERSION
       ;;
     list:dune)
-      printf '%s\n' "$STANLI_TEST_DUNE_VERSION"
+      value=$STANLI_TEST_DUNE_VERSION
       ;;
     var:conf-gcc-windows64:host)
-      printf '%s\n' "$STANLI_TEST_WINDOWS_TARGET"
+      value=$STANLI_TEST_WINDOWS_TARGET
       ;;
     switch:--short)
-      printf '%s\n' cross-test
+      value=cross-test
       ;;
     *)
       printf 'unexpected opam query: %s\n' "$*" >&2
       return 2
       ;;
   esac
+  if [[ ${CLICOLOR_FORCE:-} == 1 && " $* " != *' --color=never '* ]]; then
+    printf '\033[01;35m%s\033[0m\n' "$value"
+  else
+    printf '%s\n' "$value"
+  fi
 }
 
 src_repo=$(stanc_embed_read_setup STANC3_SRC_REPO)
 src_sha=$(stanc_embed_read_setup STANC3_SRC_SHA)
 
+# setup-ocaml sets this in CI. The mock deliberately contaminates output from
+# any opam query that fails to request machine-clean text.
+CLICOLOR_FORCE=1
 stamp=$(stanli_windows_cli_expected_stamp \
   "$src_repo" "$src_sha" cross-test)
 grep -Fqx "ocaml_version=$configured_version" <<<"$stamp"

--- a/tools/build_wheel.sh
+++ b/tools/build_wheel.sh
@@ -9,8 +9,13 @@ cd "$(dirname "$0")/.."
 source tools/stanc_embed/provenance.sh
 
 STANC3_SRC_SHA=$(stanc_embed_read_setup STANC3_SRC_SHA)
+STANC3_SRC_REPO=$(stanc_embed_read_setup STANC3_SRC_REPO)
 if [[ ! "$STANC3_SRC_SHA" =~ ^[0-9a-f]{40}$ ]]; then
   echo "could not read an exact STANC3_SRC_SHA from tools/dev_setup.sh" >&2
+  exit 1
+fi
+if [ -z "$STANC3_SRC_REPO" ]; then
+  echo "could not read STANC3_SRC_REPO from tools/dev_setup.sh" >&2
   exit 1
 fi
 EMBED_OBJECT=deps/stanc3/stanc_embed.o
@@ -48,7 +53,9 @@ rm -f /tmp/binary-size.$$
 strip -x "python/stanli/_bin/$(basename "$LIB")" 2>/dev/null || true
 cp THIRD_PARTY_LICENSES.md LICENSE python/stanli/
 
-# Without the embedded compiler the package needs the stanc binary instead.
+# Without the embedded compiler the package needs subprocess compilers. Windows
+# ships stanli's portable-MIR producer and keeps pristine stock stanc beside it
+# for one rollback cycle; other non-embedded development builds keep stock stanc.
 if [ ! -f "$EMBED_OBJECT" ]; then
   if [ ! -f deps/stanc3/stanc ] || [ ! -f deps/stanc3/stanc.src ] ||
      [ "$(cat deps/stanc3/stanc.src 2>/dev/null || true)" != "$STANC3_SRC_SHA" ]; then
@@ -57,7 +64,17 @@ if [ ! -f "$EMBED_OBJECT" ]; then
     exit 1
   fi
   case "$(uname -s)" in
-    MINGW*|MSYS*|CYGWIN*) cp deps/stanc3/stanc python/stanli/_bin/stanc.exe ;;
+    MINGW*|MSYS*|CYGWIN*)
+      PORTABLE_COMPILER=deps/stanc3/stanli-compile
+      if ! stanli_windows_cli_artifact_matches "$PORTABLE_COMPILER" \
+          "$STANC3_SRC_REPO" "$STANC3_SRC_SHA"; then
+        echo "$PORTABLE_COMPILER has absent or mismatched provenance" >&2
+        echo "use the windows-compilers artifact from this workflow run" >&2
+        exit 1
+      fi
+      cp deps/stanc3/stanc python/stanli/_bin/stanc.exe
+      cp "$PORTABLE_COMPILER" python/stanli/_bin/stanli-compile.exe
+      ;;
     *) cp deps/stanc3/stanc python/stanli/_bin/stanc
        chmod +x python/stanli/_bin/stanc ;;
   esac

--- a/tools/stanc_embed/provenance.sh
+++ b/tools/stanc_embed/provenance.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-# Shared provenance helpers for the native and browser stanc artifacts.
+# Shared provenance helpers for the native, browser, and Windows stanc
+# artifacts.
 # This file is sourced by build scripts; it is not intended to be run.
 
 _stanli_embed_repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
@@ -226,6 +227,108 @@ stanli_stancjs_artifact_matches() {
     [[ -n "$(_stanc_embed_stamp_value "$stamp" js_of_ocaml_version)" ]] &&
     [[ "$(_stanc_embed_stamp_value "$stamp" producer_inputs_sha256)" == \
        "$(stanli_stancjs_inputs_sha256)" ]] &&
+    [[ "$(_stanc_embed_stamp_value "$stamp" dune_profile)" == release ]] &&
+    [[ "$(_stanc_embed_stamp_value "$stamp" dune_subst)" == 1 ]]
+}
+
+# The Windows executable uses the same portable-MIR package as the native and
+# JavaScript producers, but only the small command-line entry point from the JS
+# directory. Keep this narrower than [stanli_stancjs_inputs_sha256]: changing
+# the browser wrapper must not change the provenance of an executable that
+# does not link it.
+stanli_windows_cli_inputs() {
+  (
+    cd "$_stanli_embed_repo_root"
+    {
+      find compiler/ocaml -maxdepth 1 -type f -print
+      printf '%s\n' \
+        .gitattributes \
+        compiler/js/dune \
+        compiler/js/stanli_compiler_cli.ml \
+        tools/stanc_embed/install_overlay.sh \
+        tools/stanc_embed/provenance.sh
+    } | LC_ALL=C sort
+  )
+}
+
+stanli_windows_cli_inputs_sha256() {
+  (
+    cd "$_stanli_embed_repo_root"
+    while IFS= read -r input; do
+      printf '%s\n%s\n' "$input" "$(_stanc_embed_sha256_file "$input")"
+    done < <(stanli_windows_cli_inputs)
+  ) | _stanc_embed_sha256_stream
+}
+
+stanli_windows_cli_expected_stamp() {
+  local src_repo=${1:?stanc3 source repository}
+  local src_sha=${2:?stanc3 source revision}
+  local opam_switch=${3:-$(opam switch show --safe)}
+  local ocaml_version ocaml_package_version ocaml_target gcc_target dune_version
+  ocaml_version=$(opam exec --switch="$opam_switch" -- \
+    ocamlfind -toolchain windows ocamlc -version 2>/dev/null)
+  ocaml_package_version=$(
+    _stanc_embed_package_version "$opam_switch" ocaml-windows)
+  ocaml_target=$(opam exec --switch="$opam_switch" -- \
+    ocamlfind -toolchain windows ocamlc -config-var target 2>/dev/null)
+  gcc_target=$(opam var --switch="$opam_switch" conf-gcc-windows:host \
+    2>/dev/null)
+  dune_version=$(_stanc_embed_package_version "$opam_switch" dune)
+  if [[ -z "$ocaml_version" || "$ocaml_version" != "$ocaml_package_version" ||
+        -z "$ocaml_target" || "$ocaml_target" != "$gcc_target" ||
+        -z "$dune_version" ]]; then
+    echo "could not identify the Windows OCaml cross toolchain" >&2
+    return 1
+  fi
+  printf '%s\n' \
+    'format=stanli-portable-windows-cli-v1' \
+    "stanc3_src_repo=$src_repo" \
+    "stanc3_src_sha=$src_sha" \
+    "ocaml_version=$ocaml_version" \
+    "ocaml_target=$ocaml_target" \
+    "dune_version=$dune_version" \
+    "producer_inputs_sha256=$(stanli_windows_cli_inputs_sha256)" \
+    'dune_context=windows' \
+    'dune_profile=release' \
+    'dune_subst=1'
+}
+
+stanli_windows_cli_artifact_matches() {
+  local artifact=${1:?portable Windows compiler artifact}
+  local src_repo=${2:?stanc3 source repository}
+  local src_sha=${3:?stanc3 source revision}
+  local opam_switch=${4:-}
+  local stamp="${artifact}.stamp"
+  [[ -f "$artifact" && -f "$stamp" ]] || return 1
+
+  # On the Linux producer, compare the complete record against the installed
+  # cross toolchain. The Windows packager intentionally has no opam switch, so
+  # it validates every source-derived and configured field instead.
+  if [[ -z "$opam_switch" ]] && command -v opam >/dev/null 2>&1; then
+    opam_switch=$(opam switch show --safe 2>/dev/null || true)
+  fi
+  if [[ -n "$opam_switch" ]] && _stanc_embed_switch_exists "$opam_switch" &&
+     [[ -n "$(_stanc_embed_package_version "$opam_switch" ocaml-windows)" ]]; then
+    [[ "$(cat "$stamp")" == \
+       "$(stanli_windows_cli_expected_stamp \
+          "$src_repo" "$src_sha" "$opam_switch")" ]]
+    return
+  fi
+
+  [[ "$(_stanc_embed_stamp_value "$stamp" format)" == \
+       'stanli-portable-windows-cli-v1' ]] &&
+    [[ "$(_stanc_embed_stamp_value "$stamp" stanc3_src_repo)" == \
+       "$src_repo" ]] &&
+    [[ "$(_stanc_embed_stamp_value "$stamp" stanc3_src_sha)" == \
+       "$src_sha" ]] &&
+    [[ "$(_stanc_embed_stamp_value "$stamp" ocaml_version)" == \
+       "$(stanc_embed_read_setup OCAML_VERSION)" ]] &&
+    [[ "$(_stanc_embed_stamp_value "$stamp" ocaml_target)" == \
+       'x86_64-w64-mingw32' ]] &&
+    [[ -n "$(_stanc_embed_stamp_value "$stamp" dune_version)" ]] &&
+    [[ "$(_stanc_embed_stamp_value "$stamp" producer_inputs_sha256)" == \
+       "$(stanli_windows_cli_inputs_sha256)" ]] &&
+    [[ "$(_stanc_embed_stamp_value "$stamp" dune_context)" == windows ]] &&
     [[ "$(_stanc_embed_stamp_value "$stamp" dune_profile)" == release ]] &&
     [[ "$(_stanc_embed_stamp_value "$stamp" dune_subst)" == 1 ]]
 }

--- a/tools/stanc_embed/provenance.sh
+++ b/tools/stanc_embed/provenance.sh
@@ -37,7 +37,8 @@ _stanc_embed_sha256_file() {
 _stanc_embed_switch_exists() {
   local opam_switch=${1:?opam switch}
   command -v opam >/dev/null 2>&1 &&
-    opam switch list --short 2>/dev/null | grep -Fqx "$opam_switch"
+    opam switch list --color=never --short 2>/dev/null |
+      grep -Fqx "$opam_switch"
 }
 
 _stanc_embed_ocaml_version() {
@@ -53,8 +54,8 @@ _stanc_embed_ocaml_target() {
 _stanc_embed_package_version() {
   local opam_switch=${1:?opam switch}
   local package=${2:?opam package}
-  opam list --switch="$opam_switch" --installed --short --columns=version \
-    "$package" 2>/dev/null
+  opam list --color=never --switch="$opam_switch" --installed --short \
+    --columns=version "$package" 2>/dev/null
 }
 
 _stanc_embed_stamp_value() {
@@ -274,7 +275,7 @@ stanli_windows_cli_expected_stamp() {
     _stanc_embed_package_version "$opam_switch" ocaml-windows64)
   ocaml_meta_version=$(
     _stanc_embed_package_version "$opam_switch" ocaml-windows)
-  ocaml_target=$(opam var --switch="$opam_switch" \
+  ocaml_target=$(opam var --color=never --switch="$opam_switch" \
     conf-gcc-windows64:host 2>/dev/null || true)
   dune_version=$(_stanc_embed_package_version "$opam_switch" dune)
 
@@ -336,7 +337,7 @@ stanli_windows_cli_artifact_matches() {
   # cross toolchain. The Windows packager intentionally has no opam switch, so
   # it validates every source-derived and configured field instead.
   if [[ -z "$opam_switch" ]] && command -v opam >/dev/null 2>&1; then
-    opam_switch=$(opam switch show --safe 2>/dev/null || true)
+    opam_switch=$(opam switch show --color=never --safe 2>/dev/null || true)
   fi
   if [[ -n "$opam_switch" ]] && _stanc_embed_switch_exists "$opam_switch" &&
      [[ -n "$(_stanc_embed_package_version "$opam_switch" ocaml-windows)" ]]; then

--- a/tools/stanc_embed/provenance.sh
+++ b/tools/stanc_embed/provenance.sh
@@ -264,20 +264,51 @@ stanli_windows_cli_expected_stamp() {
   local src_repo=${1:?stanc3 source repository}
   local src_sha=${2:?stanc3 source revision}
   local opam_switch=${3:-$(opam switch show --safe)}
-  local ocaml_version ocaml_package_version ocaml_target gcc_target dune_version
-  ocaml_version=$(opam exec --switch="$opam_switch" -- \
-    ocamlfind -toolchain windows ocamlc -version 2>/dev/null)
-  ocaml_package_version=$(
+  local configured_version ocaml_version ocaml_meta_version ocaml_target
+  local dune_version metadata_ok=1
+  configured_version=$(stanc_embed_read_setup OCAML_VERSION)
+  # ocaml-windows64 is the compiler package. Its opam recipe passes the
+  # conf-gcc-windows64 host value directly to OCaml's --target option; those
+  # two package fields are therefore the provenance inputs Dune selected.
+  ocaml_version=$(
+    _stanc_embed_package_version "$opam_switch" ocaml-windows64)
+  ocaml_meta_version=$(
     _stanc_embed_package_version "$opam_switch" ocaml-windows)
-  ocaml_target=$(opam exec --switch="$opam_switch" -- \
-    ocamlfind -toolchain windows ocamlc -config-var target 2>/dev/null)
-  gcc_target=$(opam var --switch="$opam_switch" conf-gcc-windows:host \
-    2>/dev/null)
+  ocaml_target=$(opam var --switch="$opam_switch" \
+    conf-gcc-windows64:host 2>/dev/null || true)
   dune_version=$(_stanc_embed_package_version "$opam_switch" dune)
-  if [[ -z "$ocaml_version" || "$ocaml_version" != "$ocaml_package_version" ||
-        -z "$ocaml_target" || "$ocaml_target" != "$gcc_target" ||
-        -z "$dune_version" ]]; then
-    echo "could not identify the Windows OCaml cross toolchain" >&2
+
+  printf '%s\n' \
+    "Windows compiler metadata: ocaml-windows64=${ocaml_version:-<missing>}" \
+    "Windows compiler metadata: ocaml-windows=${ocaml_meta_version:-<missing>}" \
+    "Windows compiler metadata: conf-gcc-windows64:host=${ocaml_target:-<missing>}" \
+    "Windows compiler metadata: dune=${dune_version:-<missing>}" >&2
+  if [[ -z "$ocaml_version" ]]; then
+    echo "Windows compiler metadata: ocaml-windows64 is not installed" >&2
+    metadata_ok=0
+  elif [[ "$ocaml_version" != "$configured_version" ]]; then
+    echo "Windows compiler metadata: ocaml-windows64 must be $configured_version" >&2
+    metadata_ok=0
+  fi
+  if [[ -z "$ocaml_meta_version" ]]; then
+    echo "Windows compiler metadata: ocaml-windows is not installed" >&2
+    metadata_ok=0
+  elif [[ "$ocaml_meta_version" != "$ocaml_version" ]]; then
+    echo "Windows compiler metadata: OCaml package versions differ" >&2
+    metadata_ok=0
+  fi
+  if [[ -z "$ocaml_target" ]]; then
+    echo "Windows compiler metadata: 64-bit target is unavailable" >&2
+    metadata_ok=0
+  elif [[ "$ocaml_target" != x86_64-w64-mingw32 ]]; then
+    echo "Windows compiler metadata: unexpected 64-bit target" >&2
+    metadata_ok=0
+  fi
+  if [[ -z "$dune_version" ]]; then
+    echo "Windows compiler metadata: dune is not installed" >&2
+    metadata_ok=0
+  fi
+  if [[ "$metadata_ok" != 1 ]]; then
     return 1
   fi
   printf '%s\n' \


### PR DESCRIPTION
## Summary

- cross-build the shared OCaml portable-MIR CLI as `stanli-compile.exe` and package it beside pristine `stanc.exe`
- make Python and native R prefer the runtime-matched portable producer, with stock selected only when it is absent
- preserve UTF-8 and line endings at file/process boundaries, separate diagnostics from MIR, and clean compiler side effects
- add a pull-request Windows gate that executes the real PE files and compares portable output byte for byte with js_of_ocaml
- exercise both compilers through R under Unicode/spaced paths and require both artifacts in the installed Windows wheel

## Rollout

The compiler remains a short-lived executable; this adds no OCaml DLL. The legacy decoder and pristine compiler stay available for the compatibility cycle. A selected compiler failure is surfaced directly and is never hidden by retrying a different producer.

The v0.9.2 runtime remains stock-only. Runtime and wheel artifacts built from this revision add the preferred executable; the selection logic handles both layouts.

## Validation

- 25 Python binding tests against the built runtime
- 32 focused R compiler assertions, including a restrictive locale and exact UTF-8 staging
- `actionlint .github/workflows/wheels.yml`
- workflow YAML/DAG validation
- `bash -n` on changed shell entry points
- `python3 tools/gen_docs.py --check`
- diff whitespace and wording checks

Hosted CI owns the Linux-to-Windows cross-build and execution gate.
