### PR TITLE
Exercise the R portable compiler candidate

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -507,7 +507,7 @@ jobs:
           name: runtime-${{ matrix.runtime }}
           path: runtime-dist/*.tar.gz
 
-  # The R package's 23 tests, against a real runtime. They skip without
+  # The R package tests, against a real runtime. They skip without
   # one, so this is the only place they actually run: everywhere else
   # (r.yml, CRAN's farm) has the package but no library, and a green
   # check there says nothing about whether sampling works. Not in the
@@ -516,7 +516,7 @@ jobs:
   # its glibc 2.28 floor makes safe.
   r-tests:
     name: R package against the runtime
-    needs: build
+    needs: [build, browser-compiler]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -525,6 +525,19 @@ jobs:
         with:
           name: runtime-linux-x86_64
           path: runtime
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: browser-compilers
+          path: browser-compilers
+
+      - name: Validate the candidate compiler provenance
+        run: |
+          source tools/stanc_embed/provenance.sh
+          stanli_stancjs_artifact_matches \
+            browser-compilers/stanli-compiler.js \
+            "$STANC3_SRC_REPO" "$STANC3_SRC_SHA" stancjs
+          cat browser-compilers/stanli-compiler.js.stamp
 
       - name: Unpack the runtime
         run: |
@@ -537,13 +550,14 @@ jobs:
         with:
           use-public-rspm: true
 
-      # V8 is not needed: the Linux runtime embeds stanc3, so model
-      # source goes straight to the library and the JavaScript compiler
-      # never loads. r.yml is where that path is exercised.
+      # V8 and jsonlite exercise the portable compiler candidate explicitly.
+      # The package's normal source path still goes straight to the embedded
+      # compiler; this does not change which compiler the package ships.
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           working-directory: r
-          extra-packages: any::testthat, any::posterior
+          extra-packages: >-
+            any::testthat, any::posterior, any::V8, any::jsonlite
           dependencies: '"hard"'
 
       # Through R CMD check rather than testthat directly, so the tests
@@ -566,6 +580,16 @@ jobs:
             echo "the sampling tests skipped: the runtime was not seen"
             exit 1
           fi
+
+      - name: Portable compiler candidate through V8 and the runtime
+        working-directory: r
+        run: |
+          candidate_library="$PWD/../r-candidate-library"
+          mkdir -p "$candidate_library"
+          R CMD INSTALL --library="$candidate_library" stanli_*.tar.gz
+          R_LIBS_USER="$candidate_library${R_LIBS_USER:+:$R_LIBS_USER}" \
+            Rscript ../tests/test_r_portable_candidate.R \
+              ../browser-compilers/stanli-compiler.js
 
       - uses: actions/upload-artifact@v4
         if: always()
@@ -1033,9 +1057,14 @@ jobs:
   wasm-webr:
     name: webR runtime
     if: github.event_name != 'pull_request'
+    needs: browser-compiler
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          name: browser-compilers
+          path: browser-compilers
       - uses: mymindstorm/setup-emsdk@v14
         with:
           version: 4.0.8
@@ -1060,7 +1089,8 @@ jobs:
       - name: Load it into webR
         run: |
           npm install webr@0.6.0
-          node tests/test_webr.mjs build-wasm-side/libstanli.so
+          node tests/test_webr.mjs build-wasm-side/libstanli.so \
+            browser-compilers/stanli-compiler.js
       - name: Runtime tarball
         run: |
           mkdir -p runtime-dist

--- a/docs/superpowers/plans/2026-08-26-ocaml-mir-backend-rollout.md
+++ b/docs/superpowers/plans/2026-08-26-ocaml-mir-backend-rollout.md
@@ -159,8 +159,27 @@ still waits for the full Windows wheel.
 
 ## Phase 3: CRAN and webR compiler
 
+Status: compatibility gate not yet open. Stanli has not completed a CRAN
+release, so the compiler carried by the package cannot switch formats yet. The
+v0.9.2 release tarball is the baseline candidate: it carries the legacy
+JavaScript producer and pins a runtime with both decoders. Submit that exact
+artifact first, record its CRAN acceptance, and make the producer switch in a
+later CRAN release.
+
 Switch the compiler carried inside the R package only after a released R
 runtime with the dual decoder has existed for at least one CRAN cycle.
+
+Readiness checks land before that switch without changing the shipped path:
+
+- The browser compiler artifact is provenance-checked, loaded directly into a
+  fresh V8 context, and its portable output is passed through the public
+  `stanli_model(mir=...)` API against the real Linux runtime. That check covers
+  UTF-8, deterministic bytes, warnings, malformed input, gradients, sampling,
+  and generated quantities.
+- The webR side-module job loads the same compiler artifact through webR's
+  host-JavaScript bridge and covers portable output plus malformed source.
+- The R package test asserts that its bundled compiler still emits the legacy
+  s-expression during the compatibility release.
 
 - Build the tracked compiler JS from the shared package.
 - Update V8 and webR to prefer portable output.

--- a/r/tests/testthat/test-stanc.R
+++ b/r/tests/testthat/test-stanc.R
@@ -22,6 +22,11 @@ test_that("the bundled JavaScript compiler produces MIR", {
   expect_match(mir, "\\bmu\\b")
   expect_match(mir, "\\bsigma\\b")
   expect_match(mir, "normal")
+  # The compatibility release must keep carrying the legacy producer. The
+  # portable candidate is exercised separately against this package's dual
+  # decoder; changing this envelope would prematurely open the CRAN gate.
+  expect_match(mir, "^\\(\\(functions_block")
+  expect_false(grepl('{"stanli_ir":', mir, fixed = TRUE))
 })
 
 test_that("the bundled JavaScript compiler applies O1", {

--- a/tests/test_r_portable_candidate.R
+++ b/tests/test_r_portable_candidate.R
@@ -1,0 +1,111 @@
+# Exercise the candidate R/webR compiler without changing the compiler bundled
+# in the R package. The candidate is the exact browser-compiler artifact from
+# this workflow; its output is handed to the public MIR entry point of an
+# installed package backed by the real Linux runtime.
+#
+# Usage: Rscript tests/test_r_portable_candidate.R path/to/stanli-compiler.js
+
+args <- commandArgs(trailingOnly = TRUE)
+if (length(args) != 1L)
+  stop("usage: test_r_portable_candidate.R <stanli-compiler.js>",
+       call. = FALSE)
+
+compiler <- normalizePath(args[[1]], mustWork = TRUE)
+if (!requireNamespace("V8", quietly = TRUE) ||
+    !requireNamespace("jsonlite", quietly = TRUE))
+  stop("the candidate check requires V8 and jsonlite", call. = FALSE)
+
+# Deliberately do not use stanli's compiler helpers here. This is a fresh V8
+# context and an explicit call to the candidate's stanli_compile() export, so
+# the check cannot accidentally pass through the compiler bundled in the R
+# package.
+ctx <- V8::v8()
+ctx$source(compiler)
+
+compile_candidate <- function(name, code) {
+  ctx$assign("stanli_candidate_name", name)
+  ctx$assign("stanli_candidate_source", enc2utf8(code))
+  payload <- ctx$eval(
+    "(function () {
+       var f = globalThis.stanli_compile;
+       if (typeof f !== 'function')
+         return JSON.stringify({internal_error: 'no stanli_compile()'});
+       var r = f(stanli_candidate_name, stanli_candidate_source);
+       function strings(xs) {
+         return xs ? Array.prototype.map.call(xs, String) : [];
+       }
+       return JSON.stringify({
+         result: (typeof r.result === 'undefined') ? null : String(r.result),
+         errors: strings(r.errors),
+         warnings: strings(r.warnings)
+       });
+     })()")
+  out <- jsonlite::fromJSON(payload, simplifyVector = TRUE)
+  if (!is.null(out$internal_error)) stop(out$internal_error, call. = FALSE)
+  out
+}
+
+unicode_source <- enc2utf8("\
+transformed data { print(\"pi: π, snowman: ☃, wave: 👋\"); }
+parameters { real mu; }
+model { mu ~ std_normal(); }")
+first <- compile_candidate("unicode_candidate", unicode_source)
+second <- compile_candidate("unicode_candidate", unicode_source)
+stopifnot(
+  length(first$errors) == 0L,
+  is.character(first$result), length(first$result) == 1L,
+  startsWith(first$result, '{"stanli_ir":1,"program":'),
+  !grepl("[\r\n]$", first$result),
+  validUTF8(first$result),
+  grepl("π", first$result, fixed = TRUE),
+  identical(first$result, second$result),
+  identical(first$warnings, second$warnings)
+)
+
+warning_source <- "
+parameters { real x; }
+model { if (0 < x < 1) target += 0; }"
+warning_result <- compile_candidate("warning_candidate", warning_source)
+stopifnot(length(warning_result$errors) == 0L,
+          length(warning_result$warnings) > 0L)
+
+bad <- compile_candidate(
+  "malformed_candidate", "parameters { real x } model {}")
+stopifnot(is.null(bad$result), length(bad$errors) > 0L)
+
+suppressPackageStartupMessages(library(stanli))
+if (!stanli_available())
+  stop("the real stanli runtime is required for this check", call. = FALSE)
+
+runtime_source <- "
+parameters { real mu; }
+model { mu ~ std_normal(); }
+generated quantities {
+  real mu_twice = 2 * mu;
+  real y_rep = normal_rng(mu, 1);
+}"
+runtime_compilation <- compile_candidate("runtime_candidate", runtime_source)
+stopifnot(length(runtime_compilation$errors) == 0L,
+          startsWith(runtime_compilation$result,
+                     '{"stanli_ir":1,"program":'))
+
+# `mir` is the public compatibility seam. Supplying it forces this exact
+# candidate document through the dual decoder even though the Linux runtime
+# also contains an embedded source compiler.
+model <- stanli_model(mir = runtime_compilation$result)
+gradient <- log_prob_grad(model, 0.25)
+stopifnot(is.finite(gradient$lp),
+          length(gradient$grad) == 1L,
+          isTRUE(all.equal(unname(gradient$grad), -0.25,
+                           tolerance = 1e-12)))
+
+fit <- sample_model(model, chains = 1L, seed = 9182L, warmup = 20L,
+                    samples = 12L, init = 0, init_radius = 0,
+                    parallel_chains = 1L)
+stopifnot(all(c("mu", "mu_twice", "y_rep") %in% fit$columns),
+          all(is.finite(fit$draws[, , "y_rep"])),
+          isTRUE(all.equal(as.numeric(fit$draws[, , "mu_twice"]),
+                           2 * as.numeric(fit$draws[, , "mu"]),
+                           tolerance = 1e-12)))
+
+message("R portable candidate OK: V8, decoder, gradient, sampling, and GQ")

--- a/tests/test_webr.mjs
+++ b/tests/test_webr.mjs
@@ -7,13 +7,19 @@
 // the load-and-resolve half, which needs nothing beyond the npm webr
 // package.
 //
-// Usage: node tests/test_webr.mjs build-wasm-side/libstanli.so
+// When the optional compiler is supplied, load that exact artifact through
+// webR's host-JavaScript bridge and exercise its portable result as well.
+//
+// Usage: node tests/test_webr.mjs build-wasm-side/libstanli.so \
+//          browser-compilers/stanli-compiler.js
 import { WebR } from 'webr';
 import fs from 'node:fs';
 
 const soPath = process.argv[2];
+const compilerPath = process.argv[3];
 if (!soPath) {
-  console.error('usage: node tests/test_webr.mjs <libstanli.so>');
+  console.error(
+      'usage: node tests/test_webr.mjs <libstanli.so> [stanli-compiler.js]');
   process.exit(2);
 }
 
@@ -42,5 +48,77 @@ if (missing.length > 0) {
   console.error('FAIL symbols missing from the side module:', missing.join(' '));
   process.exit(1);
 }
-console.log('webr load OK: side module loads and the bridge symbols resolve');
+
+if (compilerPath) {
+  await webR.FS.writeFile(
+      '/tmp/stanli-compiler.js',
+      new Uint8Array(fs.readFileSync(compilerPath)));
+  await webR.FS.writeFile(
+      '/tmp/portable-unicode.stan',
+      new Uint8Array(fs.readFileSync('tests/compiler/portable_unicode.stan')));
+  await webR.FS.writeFile(
+      '/tmp/portable-bad.stan',
+      new TextEncoder().encode('parameters { real x } model {}'));
+
+  // This is the same mechanism mir_from_webr() uses in the R package. Keep
+  // source and MIR in the shared filesystem, both to cover that transport and
+  // to avoid marshalling a multi-megabyte document through evalR().
+  const candidate = await webR.evalR(String.raw`
+    eval_js <- get0("eval_js", envir = asNamespace("webr"))
+    if (!is.function(eval_js)) stop("webR has no eval_js host bridge")
+    load_compiler <- function() {
+      # A browser worker has no Node process global. The npm webR harness runs
+      # its worker under Node, where js_of_ocaml would otherwise select a
+      # CommonJS filesystem and call an unavailable require(). Mask that test
+      # runner detail while evaluating the exact browser artifact.
+      eval_js('globalThis.__stanli_test_process = {
+        present: Object.prototype.hasOwnProperty.call(globalThis, "process"),
+        value: globalThis.process
+      }; globalThis.process = undefined; "ok"')
+      on.exit(eval_js('if (globalThis.__stanli_test_process.present) {
+        globalThis.process = globalThis.__stanli_test_process.value;
+      } else {
+        delete globalThis.process;
+      }
+      delete globalThis.__stanli_test_process;
+      "ok"'), add = TRUE)
+      eval_js(paste(readLines("/tmp/stanli-compiler.js", warn = FALSE),
+                    collapse = "\n"))
+    }
+    load_compiler()
+    good <- eval_js('(() => {
+      const f = globalThis.stanli_compile;
+      if (typeof f !== "function") return "FAIL no stanli_compile()";
+      const src = Module.FS.readFile("/tmp/portable-unicode.stan",
+                                     {encoding: "utf8"});
+      const r = f("webr_candidate", src);
+      if (r.errors) return "FAIL valid source reported errors";
+      const mir = String(r.result);
+      if (!mir.startsWith("{\\\"stanli_ir\\\":1,\\\"program\\\":"))
+        return "FAIL missing portable envelope";
+      if (!mir.includes("π ☃ é 👋")) return "FAIL UTF-8 changed";
+      Module.FS.writeFile("/tmp/portable-candidate.mir", mir);
+      return "ok";
+    })()')
+    bad <- eval_js('(() => {
+      const src = Module.FS.readFile("/tmp/portable-bad.stan",
+                                     {encoding: "utf8"});
+      const r = globalThis.stanli_compile("webr_bad", src);
+      return (r.errors && typeof r.result === "undefined")
+        ? "ok" : "FAIL malformed source produced a document";
+    })()')
+    mir <- readLines("/tmp/portable-candidate.mir", warn = FALSE)
+    c(good, bad, if (length(mir) > 0L) "ok" else "FAIL MIR file is empty")
+  `);
+  const statuses = (await candidate.toJs()).values;
+  const failure = statuses.find((status) => status !== 'ok');
+  if (failure) {
+    console.error(failure);
+    process.exit(1);
+  }
+}
+
+console.log(compilerPath
+  ? 'webr load OK: runtime symbols and portable compiler resolve'
+  : 'webr load OK: side module loads and the bridge symbols resolve');
 process.exit(0);


### PR DESCRIPTION
## Summary

- validate the future R compiler artifact through a fresh V8 context and the public dual-decoder runtime API
- cover deterministic portable bytes, UTF-8, warnings, errors, gradients, sampling, and generated quantities
- exercise the same artifact through webR's host-JavaScript bridge
- assert that the compiler bundled in the current R package still emits legacy MIR

## Rollout boundary

This is readiness-only. It does not modify the compiler bundled in the R package, its metadata, the production compiler-selection code, or the pinned runtime. The format switch remains blocked until a legacy-producing, dual-decoder R release completes a CRAN cycle.

## Validation

- candidate V8-to-runtime harness passed end to end against the hosted exact-source compiler artifact
- webR 0.6.0 passed both runtime-only and candidate-compiler modes
- package compiler tests passed with the legacy-envelope guard
- workflow YAML, actionlint, JavaScript and R parsing, diff whitespace, and wording checks passed
