### PR TITLE
Prepare selective MIR pass configuration

### DIFF
--- a/compiler/native/dune
+++ b/compiler/native/dune
@@ -1,8 +1,22 @@
+(library
+ (name stanli_native_compiler)
+ (wrapped false)
+ (modules portable_mir stanli_pipeline)
+ (libraries fmt common frontend middle driver analysis_and_optimization))
+
 (executable
  (name stanc_embed)
  (modes object)
- (modules portable_mir stanli_pipeline stanc_embed)
- (libraries threads fmt common frontend middle driver analysis_and_optimization)
+ (modules stanc_embed)
+ (libraries
+  threads
+  stanli_native_compiler
+  fmt
+  common
+  frontend
+  middle
+  driver
+  analysis_and_optimization)
  ; -runtime-variant _pic: link the PIC build of the OCaml runtime
  ; (libasmrun_pic.a). The default runtime carries R_X86_64_32 absolute
  ; relocations, which the linker rejects inside a shared object on Linux.
@@ -10,3 +24,8 @@
  (link_flags
   (-runtime-variant _pic -output-complete-obj -cclib
    -L%{env:STANLI_OCAML_SYSTEM_LIBDIR=.})))
+
+(test
+ (name stanli_pipeline_tests)
+ (modules stanli_pipeline_tests)
+ (libraries stanli_native_compiler middle))

--- a/compiler/native/stanli_pipeline_tests.ml
+++ b/compiler/native/stanli_pipeline_tests.ml
@@ -1,0 +1,175 @@
+open Middle
+
+let compile ?(passes = Stanli_pipeline.default_pass_selection) code =
+  match
+    Stanli_pipeline.compile_mir_with_passes ~passes
+      ~model_name:"pass_selection_test" code
+  with
+  | {result= Ok mir; _} -> mir
+  | {result= Error _; _} -> failwith "Stan source did not compile"
+
+let compile_portable code =
+  match
+    Stanli_pipeline.compile_portable ~model_name:"pass_selection_test" code
+  with
+  | {result= Ok encoded; _} -> encoded
+  | {result= Error _; _} -> failwith "Stan source did not compile"
+
+let compile_upstream_o1 code =
+  let flags =
+    { Driver.Flags.default with
+      optimization_level= Analysis_and_optimization.Optimize.O1 } in
+  match
+    Driver.Entry.stan2mir "pass_selection_test" (`Code code) flags (fun _ -> ())
+  with
+  | Ok mir -> mir
+  | Error _ -> failwith "Stan source did not compile"
+
+let encode mir = Portable_mir.encode mir
+
+let rec count_for_stmt (stmt : Stmt.Located.t) =
+  let current = match stmt.pattern with Stmt.Pattern.For _ -> 1 | _ -> 0 in
+  Stmt.Pattern.fold
+    (fun count (_ : Expr.Typed.t) -> count)
+    (fun count child -> count + count_for_stmt child)
+    current stmt.pattern
+
+let count_log_prob_fors mir =
+  List.fold_left
+    (fun count stmt -> count + count_for_stmt stmt)
+    0 mir.Program.log_prob
+
+let rec has_vector_density_stmt (stmt : Stmt.Located.t) =
+  let current =
+    match stmt.pattern with
+    | Stmt.Pattern.TargetPE
+        { Expr.pattern=
+            Expr.Pattern.FunApp
+              ( Fun_kind.StanLib (_, (Fun_kind.FnLpdf _ | FnLpmf _), _)
+              , {Expr.meta= {Expr.Typed.Meta.type_= UnsizedType.UVector; _}; _}
+                :: _ )
+        ; _ } ->
+        true
+    | _ -> false in
+  current
+  || Stmt.Pattern.fold
+       (fun found (_ : Expr.Typed.t) -> found)
+       (fun found child -> found || has_vector_density_stmt child)
+       false stmt.pattern
+
+let log_prob_has_vector_density mir =
+  List.exists has_vector_density_stmt mir.Program.log_prob
+
+let require condition message = if not condition then failwith message
+
+let matching_loop =
+  {|
+    data {
+      int<lower=0> N;
+      vector[N] y;
+    }
+    parameters {
+      real mu;
+      real<lower=0> sigma;
+    }
+    model {
+      for (n in 1:N) {
+        y[n] ~ normal(mu, sigma);
+      }
+    }
+  |}
+
+let side_effect_loop =
+  {|
+    functions {
+      real bump_lp(real x) {
+        target += x;
+        return x;
+      }
+    }
+    data {
+      int<lower=0> N;
+      vector[N] y;
+    }
+    parameters {
+      real<lower=0> sigma;
+    }
+    model {
+      for (n in 1:N) {
+        target += normal_lpdf(y[n] | bump_lp(sigma), sigma);
+      }
+    }
+  |}
+
+let o1_equivalence_models =
+  [ ( "ordinary"
+    , {|
+        data { int<lower=0> N; vector[N] y; }
+        parameters { real mu; real<lower=0> sigma; }
+        model { y ~ normal(mu, sigma); }
+      |} )
+  ; ( "nested UDF"
+    , {|
+        functions {
+          real inner(real x) { return square(x); }
+          real outer(real x) { return inner(x) + 1; }
+        }
+        parameters { real x; }
+        model { target += outer(x); }
+      |} )
+  ; ( "folded binary64"
+    , {|
+        parameters { real x; }
+        model { target += x + (0.1 + 0.2); }
+      |} )
+  ; ( "checked int32 overflow"
+    , {|
+        transformed data {
+          int x = 50000 * 50000;
+          int y = (50000 * 50000) / 50000;
+        }
+      |} )
+  ; ( "Unicode"
+    , {|
+        transformed data { print("pi π, snowman ☃, wave 👋"); }
+        parameters { real x; }
+        model { x ~ std_normal(); }
+      |} )
+  ; ( "generated quantities"
+    , {|
+        parameters { real x; }
+        model { x ~ std_normal(); }
+        generated quantities {
+          real twice_x = 2 * x;
+          real y = normal_rng(x, 1);
+        }
+      |} )
+  ; ("matching loop", matching_loop) ]
+
+let () =
+  List.iter
+    (fun (name, code) ->
+      let production_bytes = compile_portable code in
+      let upstream_o1_bytes = encode (compile_upstream_o1 code) in
+      require
+        (String.equal production_bytes upstream_o1_bytes)
+        ("pass-off output differs from upstream O1 for " ^ name))
+    o1_equivalence_models;
+
+  let off = compile matching_loop in
+  let on = compile ~passes:{vectorize_loops= true} matching_loop in
+  require (count_log_prob_fors off > 0) "pass-off removed the matching loop";
+  require (count_log_prob_fors on = 0) "pass-on did not vectorize the loop";
+  require
+    (log_prob_has_vector_density on)
+    "pass-on did not produce a vector density statement";
+
+  let side_effect_off = compile side_effect_loop in
+  let side_effect_on =
+    compile ~passes:{vectorize_loops= true} side_effect_loop in
+  require
+    (count_log_prob_fors side_effect_on > 0)
+    "pass-on rewrote a side-effecting loop";
+  require
+    (String.equal (encode side_effect_off) (encode side_effect_on))
+    "pass-on changed a side-effecting loop"

--- a/compiler/ocaml/stanli_pipeline.ml
+++ b/compiler/ocaml/stanli_pipeline.ml
@@ -6,12 +6,15 @@ type 'a compilation =
   { result: ('a, error) result
   ; warnings: Frontend.Warnings.t list }
 
-let compile_mir ?(include_source = Driver.Flags.default.include_source)
+type pass_selection = {vectorize_loops: bool}
+
+let default_pass_selection = {vectorize_loops= false}
+
+let compile_mir_at_level
+    ?(include_source = Driver.Flags.default.include_source) ~optimization_level
     ~model_name (code : string) =
   let flags =
-    { Driver.Flags.default with
-      optimization_level= Analysis_and_optimization.Optimize.O1
-    ; include_source } in
+    {Driver.Flags.default with optimization_level; include_source} in
   let warnings = ref [] in
   let output : Driver.Entry.other_output -> unit = function
     | Warnings emitted -> warnings := !warnings @ emitted
@@ -27,6 +30,31 @@ let compile_mir ?(include_source = Driver.Flags.default.include_source)
     | Ok (Error error) -> Error (Frontend_error error)
     | Ok (Ok mir) -> Ok mir in
   {result; warnings= !warnings}
+
+let compile_mir_with_passes ?include_source ~passes ~model_name code =
+  let compiled =
+    compile_mir_at_level ?include_source
+      ~optimization_level:Analysis_and_optimization.Optimize.O0 ~model_name code
+  in
+  let result =
+    match compiled.result with
+    | Error error -> Error error
+    | Ok mir -> (
+      let settings =
+        { (Analysis_and_optimization.Optimize.level_optimizations O1) with
+          vectorize_loops= passes.vectorize_loops } in
+      match
+        Common.ICE.with_exn_message (fun () ->
+            Analysis_and_optimization.Optimize.optimization_suite ~settings
+              mir)
+      with
+      | Error internal -> Error (Internal_error internal)
+      | Ok optimized -> Ok optimized ) in
+  {result; warnings= compiled.warnings}
+
+let compile_mir ?include_source ~model_name code =
+  compile_mir_with_passes ?include_source ~passes:default_pass_selection
+    ~model_name code
 
 let compile_portable ?include_source ~model_name code =
   let compiled = compile_mir ?include_source ~model_name code in

--- a/compiler/ocaml/stanli_pipeline.mli
+++ b/compiler/ocaml/stanli_pipeline.mli
@@ -6,6 +6,12 @@ type 'a compilation =
   { result: ('a, error) result
   ; warnings: Frontend.Warnings.t list }
 
+(** Source-level MIR passes that stanli may add to upstream's O1 policy. *)
+type pass_selection = {vectorize_loops: bool}
+
+val default_pass_selection : pass_selection
+(** The pass-off selection used by every shipped producer entrypoint. *)
+
 val compile_mir :
      ?include_source:Frontend.Include_files.t
   -> model_name:string
@@ -13,6 +19,15 @@ val compile_mir :
   -> Middle.Program.Typed.t compilation
 (** Parse, typecheck, apply the Stan Math MIR transform, and run the exact
     optimization policy selected by stanli. *)
+
+val compile_mir_with_passes :
+     ?include_source:Frontend.Include_files.t
+  -> passes:pass_selection
+  -> model_name:string
+  -> string
+  -> Middle.Program.Typed.t compilation
+(** Internal pass-selection entrypoint. It obtains backend-transformed MIR at
+    O0, then applies upstream O1 with only the selected additive passes. *)
 
 val compile_portable :
      ?include_source:Frontend.Include_files.t

--- a/tools/stanc_embed/build.sh
+++ b/tools/stanc_embed/build.sh
@@ -39,6 +39,7 @@ fi
 # Release profile: dune's dev profile links the inline-test and expect-test
 # runners into every library, which ride into the shipped binary for no
 # reason. Worth 364 KB of the final shared library.
+(cd "$SRC" && dune runtest --profile release src/stanc_embed)
 (cd "$SRC" && dune build --profile release src/stanc_embed/stanc_embed.exe.o \
    2>&1 | tail -5 ||
  dune build --profile release src/stanc_embed 2>&1 | tail -5)


### PR DESCRIPTION
## Summary

- add an internal stanli pass-selection boundary around upstream typed MIR
- obtain backend-transformed MIR through O0, then run exactly one explicit O1 suite with only selected additive passes varied
- keep vectorize_loops off in every shipped native, JavaScript, and Windows producer
- add direct-O1 byte oracles plus pass-on and refusal tests, and run them in the ordinary embedded-compiler build

## Why this shape

Calling vectorize_loops after stan2mir at O1 would put it after partial evaluation and run optimization twice. At the pinned stanc3 revision, O0 is an identity optimization suite, so O0 followed by one explicit O1 settings record preserves upstream phase ordering and exactly reproduces current output when the selection is off.

## Validation

- exact-pin native Dune tests pass
- pass-off canonical bytes match direct upstream O1 across ordinary, UDF, folded-float, checked-overflow, Unicode, generated-quantity, and loop models
- pass-on vectorizes a matching density loop and leaves a side-effecting loop unchanged
- the complete embedded object and unchanged host JS/CLI builds pass
- producer provenance hashes invalidate every affected artifact

This PR prepares the switch only. It does not enable vectorization in production.
