### PR TITLE
Measure candidate MIR loop vectorization

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -184,6 +184,8 @@ jobs:
             deps/stanc3/stanc_embed.o.stamp
             deps/stanc3/stanc
             deps/stanc3/stanc.src
+            deps/stanc3/stanli-vectorize-probe
+            deps/stanc3/stanli-vectorize-probe.stamp
             deps/ocaml-include
           key: >-
             stanc-embed-v2-${{ matrix.plat }}-${{ env.STANC3_SRC_SHA }}-ocaml${{ env.OCAML_VERSION }}-${{ hashFiles('compiler/native/**', 'compiler/ocaml/**', 'tools/stanc_embed/**') }}
@@ -194,7 +196,9 @@ jobs:
           # The stanc-embed cache missed, so any object on disk came from
           # another cache and is stale by definition.
           rm -f deps/stanc3/stanc_embed.o deps/stanc3/stanc_embed.o.stamp \
-            deps/stanc3/stanc deps/stanc3/stanc.src
+            deps/stanc3/stanc deps/stanc3/stanc.src \
+            deps/stanc3/stanli-vectorize-probe \
+            deps/stanc3/stanli-vectorize-probe.stamp
           opam init --bare --disable-sandboxing --no-setup -y
           ./tools/dev_setup.sh --embed --no-build
           mkdir -p deps/ocaml-include
@@ -208,6 +212,10 @@ jobs:
         run: |
           source tools/stanc_embed/provenance.sh
           stanc_embed_artifact_matches deps/stanc3/stanc_embed.o \
+            "$STANC3_SRC_SHA" stanc3-55
+          test -x deps/stanc3/stanli-vectorize-probe
+          stanc_embed_artifact_matches \
+            deps/stanc3/stanli-vectorize-probe \
             "$STANC3_SRC_SHA" stanc3-55
           for symbol in caml_c_thread_register caml_c_thread_unregister; do
             nm -g deps/stanc3/stanc_embed.o | awk -v wanted="$symbol" '
@@ -313,6 +321,38 @@ jobs:
         run: |
           python3 tools/verify_refs.py deps/posteriordb \
             --check build-rel/stanli_check --jobs 4
+
+      # This does not select the candidate source pass for any producer. The
+      # test-only OCaml probe emits both inputs, and stanli_check consumes the
+      # saved portable MIR directly so every point reuses the exact bytes.
+      # Semantic/reference parity gates the job; graph sizes, re-roll
+      # dispositions, and preparation timings are published as measurements.
+      - name: Bounded MIR vectorization A/B
+        if: matrix.runtime == 'linux-x86_64'
+        timeout-minutes: 15
+        run: |
+          test -x deps/stanc3/stanli-vectorize-probe
+          source tools/stanc_embed/provenance.sh
+          stanc_embed_artifact_matches \
+            deps/stanc3/stanli-vectorize-probe \
+            "$STANC3_SRC_SHA" stanc3-55
+          python3 harnesses/vectorize_ab.py deps/posteriordb \
+            normal_mixture radon_pooled soil_incubation arK \
+            low_dim_gauss_mix hmm_example \
+            eight_schools_noncentered \
+            --compiler deps/stanc3/stanli-vectorize-probe \
+            --check build-rel/stanli_check \
+            --bench build-rel/bench_grad --dump build-rel/dump_ops \
+            --timeout 30 --gradient-timeout 20 --prep-samples 2 \
+            --output-dir build-rel/vectorize-ab
+
+      - name: Publish MIR vectorization measurements
+        if: always() && matrix.runtime == 'linux-x86_64'
+        uses: actions/upload-artifact@v4
+        with:
+          name: mir-vectorization-measurements
+          if-no-files-found: warn
+          path: build-rel/vectorize-ab
 
       # The headline numbers in both READMEs are derived, not typed.
       - name: Docs match the measured artifacts

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -330,6 +330,7 @@ jobs:
       - name: Bounded MIR vectorization A/B
         if: matrix.runtime == 'linux-x86_64'
         timeout-minutes: 15
+        shell: bash
         run: |
           test -x deps/stanc3/stanli-vectorize-probe
           source tools/stanc_embed/provenance.sh
@@ -351,7 +352,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: mir-vectorization-measurements
-          if-no-files-found: warn
+          if-no-files-found: error
           path: build-rel/vectorize-ab
 
       # The headline numbers in both READMEs are derived, not typed.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -493,6 +493,17 @@ target_link_libraries(stanli_run PRIVATE stanli)
 stanli_embed_stanc(stanli_run)
 add_executable(stanli_check tools/stanli_check.cpp tests/tbb_stub.cpp)
 target_link_libraries(stanli_check PRIVATE stanli)
+add_test(NAME test_check_precompiled_mir
+         COMMAND stanli_check tests/fixtures/ar1.stan tests/fixtures/ar1.json
+                 --mir tests/fixtures/ar1.tmir.sexp
+         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+set_tests_properties(test_check_precompiled_mir PROPERTIES
+  PASS_REGULAR_EXPRESSION "OK ")
+add_test(NAME test_check_precompiled_mir_conflict
+         COMMAND ${CMAKE_COMMAND}
+                 -DSTANLI_CHECK=$<TARGET_FILE:stanli_check>
+                 -DSOURCE_DIR=${CMAKE_CURRENT_SOURCE_DIR}
+                 -P ${CMAKE_CURRENT_SOURCE_DIR}/tests/check_mir_conflict.cmake)
 add_executable(bench_grad tools/bench_grad.cpp tests/tbb_stub.cpp)
 target_link_libraries(bench_grad PRIVATE stanli)
 add_test(NAME test_prep_only
@@ -511,6 +522,14 @@ set_tests_properties(test_prep_profile PROPERTIES
   ENVIRONMENT "STANLI_PROFILE_PREP=1"
   PASS_REGULAR_EXPRESSION
     "stanli_prep graph=driver stage=total ns=[0-9]+")
+add_test(NAME test_prep_profile_reroll_dispositions
+         COMMAND bench_grad tests/fixtures/ar1.tmir.sexp
+                 tests/fixtures/ar1.json --prep
+         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+set_tests_properties(test_prep_profile_reroll_dispositions PROPERTIES
+  ENVIRONMENT "STANLI_PROFILE_PREP=1"
+  PASS_REGULAR_EXPRESSION
+    "packed_rows=[0-9]+ term_density=[0-9]+ element_density=[0-9]+ term_widen=[0-9]+ element_store=[0-9]+")
 add_executable(bench_opcost tools/bench_opcost.cpp tests/tbb_stub.cpp)
 target_link_libraries(bench_opcost PRIVATE stanli)
 add_executable(bench_dispatch tools/bench_dispatch.cpp)
@@ -575,6 +594,9 @@ if(Python3_Interpreter_FOUND)
            WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
   add_test(NAME test_conformance_harness
            COMMAND ${Python3_EXECUTABLE} tests/test_conformance.py
+           WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+  add_test(NAME test_vectorize_ab
+           COMMAND ${Python3_EXECUTABLE} tests/test_vectorize_ab.py
            WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
   # The model census's coverage ratchet, over synthetic rows plus the
   # checked-in baseline. The census itself needs deps/stanc3-src, a stanc

--- a/TESTING.md
+++ b/TESTING.md
@@ -60,6 +60,45 @@ known exceptions.
 | WebAssembly replay | Does the browser runtime reproduce the recorded corpus? | Same numerical gates; 118 of 119 compiling posteriordb models fit in wasm32 | manually |
 | documentation and formatting | Do generated claims match their artifacts, and is C/C++ formatting current? | Exact generated-file and formatter checks | every pull request |
 
+## MIR loop-vectorization measurement
+
+[`harnesses/vectorize_ab.py`](harnesses/vectorize_ab.py) measures the upstream
+`vectorize_loops` candidate without selecting it in a shipping compiler. The
+test-only OCaml probe compiles each source once with the pass off and once with
+it on; every later check consumes those exact portable MIR files through
+`stanli_check --mir`.
+
+The complete run covers all 130 recorded models plus any posteriordb census
+model without a recorded CmdStan row:
+
+```sh
+python3 harnesses/vectorize_ab.py deps/posteriordb \
+  --compiler deps/stanc3/stanli-vectorize-probe \
+  --check build-rel/stanli_check --bench build-rel/bench_grad \
+  --dump build-rel/dump_ops --output-dir build-rel/vectorize-ab
+```
+
+CI runs the bounded seven-model selection shown by the "Bounded MIR
+vectorization A/B" workflow step. It includes three models whose MIR must
+change and four controls. The hard gates cover command/status consistency,
+result and write-array categories, error parity, per-element finite/NaN/
+infinity classes, shapes and names, and both pass modes against the existing
+CmdStan references. Finite bit differences that remain within those gates are
+listed separately with bit patterns and ULP distances.
+
+The output directory contains `manifest.json`, `corpus.jsonl`,
+`graphs.jsonl`, `bench.tsv`, `summary.json`, and `summary.md`. The manifest
+records source pins, producer provenance, tool hashes, platform, toolchain,
+environment policy, and corpus scope. Compiler wall time, graph and
+preparation counts, separate log-density/write-array reroll dispositions, and
+auto-calibrated ABBA gradient timings are descriptive measurements; their
+ratios do not decide pass/fail. Missing or malformed measurement output does
+fail the run because it would make the report incomplete. The report labels
+CmdStan-referenced and A/B-only models separately; the latter have off/on
+category, error, shape, name, and value parity but no fabricated reference
+gate. [`tools/corpus.py`](tools/corpus.py) remains the source-only census
+report.
+
 ## Comparison with CmdStan on complete models
 
 [`tools/verify_refs.py`](tools/verify_refs.py) replays every referenced

--- a/compiler/native/dune
+++ b/compiler/native/dune
@@ -29,3 +29,12 @@
  (name stanli_pipeline_tests)
  (modules stanli_pipeline_tests)
  (libraries stanli_native_compiler middle))
+
+; Measurement-only source-pass probe. It is copied beside the compiler build
+; for corpus experiments but is not linked into, installed with, or selected
+; by any shipping producer.
+
+(executable
+ (name stanli_vectorize_probe)
+ (modules stanli_vectorize_probe)
+ (libraries stanli_native_compiler fmt common frontend))

--- a/compiler/native/stanli_vectorize_probe.ml
+++ b/compiler/native/stanli_vectorize_probe.ml
@@ -1,0 +1,80 @@
+let usage =
+  "usage: stanli-vectorize-probe --vectorize-loops off|on --output OUT "
+  ^ "MODEL.stan"
+
+let fail_usage message =
+  prerr_endline message;
+  prerr_endline usage;
+  exit 2
+
+let rec parse_args index vectorize output model =
+  if index = Array.length Sys.argv then (vectorize, output, model)
+  else
+    match Sys.argv.(index) with
+    | "--vectorize-loops" when index + 1 < Array.length Sys.argv ->
+        let enabled =
+          match Sys.argv.(index + 1) with
+          | "off" -> false
+          | "on" -> true
+          | value -> fail_usage ("unknown vectorize-loops value: " ^ value)
+        in
+        parse_args (index + 2) (Some enabled) output model
+    | "--output" when index + 1 < Array.length Sys.argv ->
+        parse_args (index + 2) vectorize (Some Sys.argv.(index + 1)) model
+    | ("--vectorize-loops" | "--output") as option ->
+        fail_usage ("missing value for " ^ option)
+    | argument when String.starts_with ~prefix:"-" argument ->
+        fail_usage ("unknown option: " ^ argument)
+    | path -> (
+        match model with
+        | None -> parse_args (index + 1) vectorize output (Some path)
+        | Some _ -> fail_usage "more than one model path was provided")
+
+let () =
+  let vectorize, output, model = parse_args 1 None None None in
+  let vectorize =
+    match vectorize with
+    | Some enabled -> enabled
+    | None -> fail_usage "--vectorize-loops is required" in
+  let output =
+    match output with
+    | Some path -> path
+    | None -> fail_usage "--output is required" in
+  let model =
+    match model with
+    | Some path -> path
+    | None -> fail_usage "MODEL.stan is required" in
+  let code =
+    try In_channel.with_open_bin model In_channel.input_all
+    with Sys_error message ->
+      prerr_endline message;
+      exit 1 in
+  let compilation =
+    Stanli_pipeline.compile_mir_with_passes
+      ~passes:{vectorize_loops= vectorize}
+      ~model_name:"embedded_model" code
+      ~include_source:
+        (Frontend.Include_files.FileSystemPaths [Filename.dirname model]) in
+  List.iter
+    (fun warning ->
+      Fmt.epr "%a@." (Frontend.Warnings.pp ?printed_filename:None) warning)
+    compilation.warnings;
+  match compilation.result with
+  | Error (Stanli_pipeline.Internal_error message) ->
+      prerr_endline message;
+      exit 1
+  | Error (Stanli_pipeline.Frontend_error error) ->
+      Fmt.epr "%a@." (Frontend.Errors.pp ?printed_filename:None ~code) error;
+      exit 1
+  | Ok mir -> (
+      match Common.ICE.with_exn_message (fun () -> Portable_mir.encode mir) with
+      | Error message ->
+          prerr_endline message;
+          exit 1
+      | Ok encoded -> (
+          try
+            Out_channel.with_open_bin output (fun channel ->
+                output_string channel encoded)
+          with Sys_error message ->
+            prerr_endline message;
+            exit 1))

--- a/docs/superpowers/plans/2026-08-26-ocaml-mir-backend-rollout.md
+++ b/docs/superpowers/plans/2026-08-26-ocaml-mir-backend-rollout.md
@@ -197,6 +197,17 @@ The pinned stanc3 contains the pass, but O1 leaves it disabled. Enable O1 plus
 only `vectorize_loops` in the shared stanli pipeline. Do not enable the entire
 experimental suite.
 
+Status: measurement infrastructure only. A test-only native OCaml probe can
+emit pass-off/pass-on portable MIR, and the bounded CI report checks semantic
+and reference parity while publishing graph, preparation, reroll, compiler,
+and interleaved gradient evidence. The production pass selection remains off
+in every native, Windows, browser, Python, and R producer. The no-model harness
+command covers all 130 committed reference models and labels any additional
+posteriordb census model as A/B-only; CI uses seven named models, and the timing
+ratios are descriptive rather than acceptance thresholds. See
+[`TESTING.md`](../../../TESTING.md#mir-loop-vectorization-measurement) for the
+operator command and artifact contract.
+
 Keep C++ reroll enabled initially and measure with the OCaml pass both on and
 off:
 

--- a/docs/superpowers/plans/2026-08-26-ocaml-mir-backend-rollout.md
+++ b/docs/superpowers/plans/2026-08-26-ocaml-mir-backend-rollout.md
@@ -208,6 +208,21 @@ ratios are descriptive rather than acceptance thresholds. See
 [`TESTING.md`](../../../TESTING.md#mir-loop-vectorization-measurement) for the
 operator command and artifact contract.
 
+### 2026-08-26 measurement baseline
+
+The complete Release run at implementation revision `d3b7d26` used macOS
+26.4 arm64 and Apple clang 21. It covered 131 models and 393 evaluation
+points. Enabling the pass changed MIR for `covid19imperial_v2`,
+`covid19imperial_v3`, `normal_mixture`, `radon_pooled`, and
+`soil_incubation`. The only finite arithmetic-order changes were two
+one-ULP log-density results in `soil_incubation`; the run reported zero
+semantic failures and zero infrastructure failures and took 229.898 seconds.
+Timing ratios remain descriptive.
+
+The pass removed only 4 of the 23 `log_prob` term-density reroll hits; 19
+models still reported that rewrite. No C++ reroll case can be retired from
+this evidence, and production pass selection remains off.
+
 Keep C++ reroll enabled initially and measure with the OCaml pass both on and
 off:
 

--- a/harnesses/vectorize_ab.py
+++ b/harnesses/vectorize_ab.py
@@ -133,18 +133,22 @@ def setup_value(key):
 
 
 def git_revision(path):
+    path = pathlib.Path(path).resolve()
     try:
         return subprocess.check_output(
-            ["git", "-C", str(path), "rev-parse", "HEAD"],
+            ["git", "-c", f"safe.directory={path}", "-C", str(path),
+             "rev-parse", "HEAD"],
             text=True, stderr=subprocess.DEVNULL).strip()
     except (OSError, subprocess.SubprocessError):
         return None
 
 
 def git_tracked_dirty(path):
+    path = pathlib.Path(path).resolve()
     proc = subprocess.run(
-        ["git", "-C", str(path), "status", "--porcelain",
-         "--untracked-files=no"], capture_output=True, text=True)
+        ["git", "-c", f"safe.directory={path}", "-C", str(path),
+         "status", "--porcelain", "--untracked-files=no"],
+        capture_output=True, text=True)
     return None if proc.returncode != 0 else bool(proc.stdout.strip())
 
 

--- a/harnesses/vectorize_ab.py
+++ b/harnesses/vectorize_ab.py
@@ -1,0 +1,1349 @@
+#!/usr/bin/env python3
+"""Measure upstream loop vectorization without selecting it for users.
+
+Each selected Stan source is compiled exactly twice by the test-only OCaml
+probe: upstream O1 with vectorize_loops off and with that one pass on. The
+saved portable MIR is then reused for every semantic point and for four graph
+cells (source pass off/on crossed with the C++ re-roll pass off/on).
+
+Hard failures are semantic: result categories, vector shapes, write_array
+names and shapes, nonfinite behavior, and the existing CmdStan reference
+gates. Different finite bits within those gates are reported as arithmetic
+order changes, with one bit-pattern/ULP row per changed off/on value. Op
+counts and preparation timings are evidence only.
+
+Complete semantic report (130 recorded models plus PDB A/B-only models):
+  python3 harnesses/vectorize_ab.py deps/posteriordb \
+    --output-dir build/vectorize-ab
+
+Bounded report:
+  python3 harnesses/vectorize_ab.py deps/posteriordb \
+    normal_mixture radon_pooled soil_incubation arK low_dim_gauss_mix \
+    hmm_example \
+    eight_schools_noncentered --output-dir build/vectorize-ab
+
+The no-model form covers the complete committed reference set, including
+the language fixtures under tests/stanc3, plus every model in posteriordb's
+one-data-per-model census. A model with no CmdStan reference is explicitly
+reported as A/B-only. Gradient timing stays bounded to the seven
+DEFAULT_MODELS in either form, including three pass-activation sentinels.
+"""
+
+import argparse
+import datetime
+import hashlib
+import json
+import math
+import os
+import pathlib
+import platform
+import re
+import shutil
+import statistics
+import struct
+import subprocess
+import sys
+import tempfile
+import time
+
+REPO = pathlib.Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "tools"))
+from verify_refs import (POINTS, corpus_input, corpus_models, gate_for,  # noqa: E402
+                         load_refs, model_files, pair_dev, parse_status,
+                         parse_wa, worst_pair)
+
+DEFAULT_MODELS = (
+    "normal_mixture",
+    "radon_pooled",
+    "soil_incubation",
+    "arK",
+    "low_dim_gauss_mix",
+    "hmm_example",
+    "eight_schools_noncentered",
+)
+
+EXPECTED_MIR_CHANGES = frozenset((
+    "covid19imperial_v2",
+    "covid19imperial_v3",
+    "normal_mixture",
+    "radon_pooled",
+    "soil_incubation",
+))
+
+RUNTIME_ENV_KEYS = (
+    "STANLI_DEBUG_ALGEBRA",
+    "STANLI_DEBUG_INIT",
+    "STANLI_DEBUG_ISLAND",
+    "STANLI_DEBUG_ODE",
+    "STANLI_ISLAND_ALWAYS",
+    "STANLI_NO_CONSTFOLD",
+    "STANLI_NO_CSE",
+    "STANLI_NO_DATA_PRELOAD",
+    "STANLI_NO_DENSITY_MASK",
+    "STANLI_NO_INPLACE",
+    "STANLI_NO_ISLAND",
+    "STANLI_NO_ISLAND_COMPACT",
+    "STANLI_NO_NATIVE_ADJ",
+    "STANLI_NO_PARTITION",
+    "STANLI_NO_REROLL",
+    "STANLI_PACKET_MATH",
+    "STANLI_PROFILE",
+    "STANLI_PROFILE_PREP",
+    "STANLI_WA_FORCE_INTERP",
+)
+CLEAN_RUNTIME_ENV = {key: None for key in RUNTIME_ENV_KEYS}
+
+REROLL_FIELDS = (
+    "regions",
+    "packed_rows",
+    "term_density",
+    "element_density",
+    "term_widen",
+    "element_store",
+)
+
+REQUIRED_PREP_ROWS = {
+    ("driver", "total"): ("ns",),
+    ("compile", "total"): ("ns",),
+    ("log_prob", "total"): ("ns", "ops", "slots"),
+    ("write_array", "total"): ("ns", "ops", "slots"),
+    ("log_prob", "reroll"): ("ns",) + REROLL_FIELDS,
+    ("write_array", "reroll"): ("ns",) + REROLL_FIELDS,
+}
+
+
+def sha256_file(path):
+    path = pathlib.Path(path)
+    if not path.is_file():
+        return None
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for block in iter(lambda: stream.read(1 << 20), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def setup_value(key):
+    pattern = re.compile(rf"^{re.escape(key)}=([^ ]+)")
+    for line in (REPO / "tools" / "dev_setup.sh").read_text().splitlines():
+        match = pattern.match(line)
+        if match:
+            return match.group(1)
+    return None
+
+
+def git_revision(path):
+    try:
+        return subprocess.check_output(
+            ["git", "-C", str(path), "rev-parse", "HEAD"],
+            text=True, stderr=subprocess.DEVNULL).strip()
+    except (OSError, subprocess.SubprocessError):
+        return None
+
+
+def git_tracked_dirty(path):
+    proc = subprocess.run(
+        ["git", "-C", str(path), "status", "--porcelain",
+         "--untracked-files=no"], capture_output=True, text=True)
+    return None if proc.returncode != 0 else bool(proc.stdout.strip())
+
+
+def read_stamp(path):
+    fields = {}
+    if not path.is_file():
+        return fields
+    for line in path.read_text().splitlines():
+        key, separator, value = line.partition("=")
+        if separator:
+            fields[key] = value
+    return fields
+
+
+def probe_provenance_matches(probe, stanc_pin, opam_switch):
+    script = (
+        "source tools/stanc_embed/provenance.sh && "
+        "stanc_embed_artifact_matches \"$1\" \"$2\" \"$3\""
+    )
+    proc = subprocess.run(
+        ["bash", "-c", script, "probe-provenance", str(probe), stanc_pin,
+         opam_switch], cwd=REPO, capture_output=True, text=True)
+    return proc.returncode == 0, proc.stderr.strip()
+
+
+def command_version(command):
+    executable = shutil.which(command)
+    if executable is None:
+        return None
+    proc = subprocess.run([executable, "--version"], capture_output=True,
+                          text=True)
+    lines = (proc.stdout or proc.stderr).strip().splitlines()
+    return {
+        "path": executable,
+        "returncode": proc.returncode,
+        "first_line": lines[0] if lines else "",
+    }
+
+
+def cmake_cache_metadata(tool):
+    cache = tool.parent / "CMakeCache.txt"
+    wanted = {
+        "CMAKE_BUILD_TYPE",
+        "CMAKE_CXX_COMPILER",
+        "CMAKE_CXX_COMPILER_VERSION",
+        "CMAKE_GENERATOR",
+        "CMAKE_SYSTEM_NAME",
+        "CMAKE_SYSTEM_PROCESSOR",
+    }
+    result = {}
+    if cache.is_file():
+        for line in cache.read_text(errors="replace").splitlines():
+            key_type, separator, value = line.partition("=")
+            key = key_type.partition(":")[0]
+            if separator and key in wanted:
+                result[key] = value
+    return result
+
+
+def execution_metadata(check):
+    environment_keys = (
+        "CI", "GITHUB_ACTIONS", "RUNNER_OS", "RUNNER_ARCH", "CC", "CXX",
+        "LANG", "LC_ALL", "TZ",
+    )
+    return {
+        "platform": {
+            "platform": platform.platform(),
+            "system": platform.system(),
+            "release": platform.release(),
+            "machine": platform.machine(),
+        },
+        "python": {
+            "executable": sys.executable,
+            "version": platform.python_version(),
+            "implementation": platform.python_implementation(),
+        },
+        "toolchain": {
+            "cmake": command_version("cmake"),
+            "cxx": command_version(os.environ.get("CXX", "c++")),
+            "cmake_cache": cmake_cache_metadata(check),
+        },
+        "environment": {
+            "ambient": {key: os.environ[key] for key in environment_keys
+                        if key in os.environ},
+            "controlled": {
+                "cleared_for_runtime_commands": list(RUNTIME_ENV_KEYS),
+                "graph_runtime_reroll_off": "STANLI_NO_REROLL=1",
+                "preparation_STANLI_PROFILE_PREP": "1",
+            },
+        },
+    }
+
+
+def run_command(command, timeout, env=None):
+    process_env = dict(os.environ)
+    if env:
+        for key, value in env.items():
+            if value is None:
+                process_env.pop(key, None)
+            else:
+                process_env[key] = value
+    started = time.monotonic_ns()
+    try:
+        proc = subprocess.run(
+            [str(part) for part in command], cwd=REPO, env=process_env,
+            capture_output=True, text=True, timeout=timeout)
+        return {
+            "returncode": proc.returncode,
+            "stdout": proc.stdout,
+            "stderr": proc.stderr,
+            "timeout": False,
+            "elapsed_ns": time.monotonic_ns() - started,
+        }
+    except subprocess.TimeoutExpired as error:
+        stdout = error.stdout or ""
+        stderr = error.stderr or ""
+        if isinstance(stdout, bytes):
+            stdout = stdout.decode(errors="replace")
+        if isinstance(stderr, bytes):
+            stderr = stderr.decode(errors="replace")
+        return {
+            "returncode": None,
+            "stdout": stdout,
+            "stderr": stderr,
+            "timeout": True,
+            "elapsed_ns": time.monotonic_ns() - started,
+        }
+
+
+def metric(value):
+    """A strict-JSON representation of a possibly nonfinite metric."""
+    if isinstance(value, float) and not math.isfinite(value):
+        if math.isnan(value):
+            return "nan"
+        return "inf" if value > 0 else "-inf"
+    return value
+
+
+def same_float(left, right):
+    if math.isnan(left) and math.isnan(right):
+        return True
+    return struct.pack("!d", left) == struct.pack("!d", right)
+
+
+def float_class(value):
+    if math.isnan(value):
+        return "nan"
+    if math.isinf(value):
+        return "positive_infinity" if value > 0 else "negative_infinity"
+    return "finite"
+
+
+def float_bits(value):
+    return f"0x{struct.unpack('!Q', struct.pack('!d', value))[0]:016x}"
+
+
+def compare_vectors(left, right, include_differences=True):
+    """Shape, aggregate metrics, and one bit/ULP row per changed value."""
+    if len(left) != len(right):
+        return {
+            "same_shape": False,
+            "left_size": len(left),
+            "right_size": len(right),
+            "changed": None,
+            "finite_changed": None,
+            "nonfinite_match": None,
+            "max_rel": None,
+            "max_ulp": None,
+            "differences": [],
+        }
+    left_values = [float(value) for value in left]
+    right_values = [float(value) for value in right]
+    rel, ulp = worst_pair(left_values, right_values)
+    differences = []
+    changed = 0
+    finite_changed = 0
+    nonfinite_match = True
+    for index, (a, b) in enumerate(zip(left_values, right_values)):
+        a_class, b_class = float_class(a), float_class(b)
+        if a_class != b_class:
+            nonfinite_match = False
+        if same_float(a, b):
+            continue
+        changed += 1
+        if a_class == "finite" and b_class == "finite":
+            finite_changed += 1
+        if not include_differences:
+            continue
+        value_rel, value_ulp = pair_dev(a, b)
+        differences.append({
+            "index": index,
+            "left": metric(a),
+            "right": metric(b),
+            "left_bits": float_bits(a),
+            "right_bits": float_bits(b),
+            "relative": metric(value_rel),
+            "ulp": value_ulp,
+        })
+    return {
+        "same_shape": True,
+        "left_size": len(left),
+        "right_size": len(right),
+        "changed": changed,
+        "finite_changed": finite_changed,
+        "nonfinite_match": nonfinite_match,
+        "max_rel": metric(rel),
+        "max_ulp": ulp,
+        "differences": differences,
+    }
+
+
+def parse_wa_outcome(stdout):
+    """Preserve absent, successful, and failed write_array outcomes."""
+    parsed = parse_wa(stdout)
+    if parsed is not None:
+        return {
+            "category": "success",
+            "names": parsed[0],
+            "values": parsed[1],
+        }
+    for line in stdout.splitlines():
+        if line == "WANAMES FAIL" or line.startswith("WANAMES FAIL "):
+            return {
+                "category": "failure",
+                "reason": line[len("WANAMES FAIL"):].strip(),
+            }
+    return {"category": "absent"}
+
+
+def compare_wa_outcomes(left, right):
+    category_match = left["category"] == right["category"]
+    result = {
+        "category_match": category_match,
+        "off_category": left["category"],
+        "on_category": right["category"],
+        "reason_match": True,
+        "names_match": True,
+        "values": None,
+    }
+    if not category_match:
+        return result
+    if left["category"] == "failure":
+        result["reason_match"] = left.get("reason") == right.get("reason")
+        result["off_reason"] = left.get("reason", "")
+        result["on_reason"] = right.get("reason", "")
+    elif left["category"] == "success":
+        result["names_match"] = left["names"] == right["names"]
+        result["values"] = compare_vectors(left["values"], right["values"])
+    return result
+
+
+def parse_key_values(line):
+    fields = {}
+    for key, raw in re.findall(r"([A-Za-z_]+)=([^\s]+)", line):
+        try:
+            fields[key] = int(raw)
+        except ValueError:
+            fields[key] = raw
+    return fields
+
+
+def parse_prep(stderr):
+    rows = []
+    for line in stderr.splitlines():
+        if not line.startswith("stanli_prep "):
+            continue
+        fields = parse_key_values(line)
+        if "graph" in fields and "stage" in fields and "ns" in fields:
+            rows.append(fields)
+    return rows
+
+
+def parse_dump(stdout):
+    result = {"opcodes": {}}
+    for line in stdout.splitlines():
+        if line.startswith("slots="):
+            result.update(parse_key_values(line))
+        elif line.startswith("SUMMARY "):
+            result["summary"] = parse_key_values(line)
+        elif line.startswith("  "):
+            fields = line.split()
+            if fields:
+                result["opcodes"][fields[0]] = parse_key_values(line)
+    return result
+
+
+def dump_problems(parsed):
+    problems = []
+    for field in ("slots", "ops", "result"):
+        if not isinstance(parsed.get(field), int):
+            problems.append(f"missing {field}")
+    summary = parsed.get("summary")
+    if not isinstance(summary, dict):
+        problems.append("missing SUMMARY")
+        return problems
+    for field in ("ops", "scalar_out", "vector_out"):
+        if not isinstance(summary.get(field), int):
+            problems.append(f"missing SUMMARY {field}")
+    if (isinstance(parsed.get("ops"), int)
+            and isinstance(summary.get("ops"), int)
+            and parsed["ops"] != summary["ops"]):
+        problems.append("op totals disagree")
+    return problems
+
+
+def prep_problems(rows):
+    problems = []
+    for (graph, stage), fields in REQUIRED_PREP_ROWS.items():
+        row = prep_row(rows, graph, stage)
+        if not row:
+            problems.append(f"missing {graph}/{stage}")
+            continue
+        for field in fields:
+            if not isinstance(row.get(field), int) or row[field] < 0:
+                problems.append(f"missing {graph}/{stage} {field}")
+    return problems
+
+
+def prep_row(rows, graph, stage):
+    return next(
+        (row for row in rows
+         if row.get("graph") == graph and row.get("stage") == stage),
+        {})
+
+
+def compile_source(compiler, source, output, enabled, timeout):
+    command = [
+        compiler,
+        "--vectorize-loops", "on" if enabled else "off",
+        "--output", output,
+        source,
+    ]
+    proc = run_command(command, timeout)
+    produced = output.is_file()
+    info = {
+        "command": [str(part) for part in command],
+        "returncode": proc["returncode"],
+        "timeout": proc["timeout"],
+        "elapsed_ns": proc["elapsed_ns"],
+        "stderr": proc["stderr"].strip(),
+        "produced": produced,
+    }
+    if produced:
+        info.update({
+            "bytes": output.stat().st_size,
+            "sha256": sha256_file(output),
+        })
+    return proc, info
+
+
+def reference_comparison(fields, point_reference, max_rel):
+    if point_reference is None:
+        kind = fields[0] if fields else ""
+        return {
+            "ok": kind in ("OK", "EVAL_FAIL"),
+            "referenced": False,
+            "actual": kind or "NO_STATUS",
+        }
+    kind = fields[0] if fields else ""
+    if "values" not in point_reference:
+        return {
+            "ok": kind == "EVAL_FAIL",
+            "expected": "EVAL_FAIL",
+            "actual": kind or "NO_STATUS",
+            "referenced": True,
+        }
+    if kind != "OK":
+        return {
+            "ok": False,
+            "expected": "OK",
+            "actual": kind or "NO_STATUS",
+            "referenced": True,
+        }
+    values = fields[1:]
+    compared = compare_vectors(point_reference["values"], values, False)
+    gate = gate_for(point_reference, max_rel)
+    rel = compared["max_rel"]
+    within = (compared["same_shape"] and isinstance(rel, (int, float))
+              and rel < gate)
+    return {
+        "ok": within,
+        "expected": "OK",
+        "actual": kind,
+        "gate": gate,
+        "values": compared,
+        "referenced": True,
+    }
+
+
+def wa_comparison(outcome, point_reference, max_rel):
+    if point_reference is None:
+        return {
+            "ok": True,
+            "referenced": False,
+            "actual": outcome["category"],
+        }
+    expected = point_reference.get("wa")
+    if expected is None:
+        return {
+            "ok": True,
+            "referenced": False,
+            "actual": outcome["category"],
+        }
+    if outcome["category"] != "success":
+        return {
+            "ok": False,
+            "referenced": True,
+            "actual": outcome["category"],
+        }
+    compared = compare_vectors(expected["values"], outcome["values"], False)
+    gate = gate_for(point_reference, max_rel)
+    rel = compared["max_rel"]
+    names_match = outcome["names"] == expected["names"]
+    within = (compared["same_shape"] and isinstance(rel, (int, float))
+              and rel < gate)
+    return {
+        "ok": names_match and within,
+        "referenced": True,
+        "names_match": names_match,
+        "gate": gate,
+        "values": compared,
+    }
+
+
+def execution_matches_status(proc, status):
+    if proc["timeout"] or not status:
+        return False
+    expected = {"OK": 0, "EVAL_FAIL": 1, "COMPILE_FAIL": 1}
+    return proc["returncode"] == expected.get(status[0])
+
+
+def ab_only_values_within_gate(compared, max_rel):
+    if compared is None:
+        return True
+    relative = compared["max_rel"]
+    return (compared["same_shape"] and compared["nonfinite_match"]
+            and isinstance(relative, (int, float)) and relative < max_rel)
+
+
+def semantic_point(check, source, data, mirs, point, point_reference,
+                   timeout, max_rel):
+    runs = {}
+    for mode in ("off", "on"):
+        command = [
+            check, source, data, "--mir", mirs[mode], "--point", str(point),
+            "--wa-values",
+        ]
+        # Vectorization is a source-pass comparison. Ambient runtime reroll
+        # settings must not silently change its semantic baseline.
+        proc = run_command(command, timeout, CLEAN_RUNTIME_ENV)
+        status = parse_status(proc["stdout"])
+        wa = parse_wa_outcome(proc["stdout"])
+        runs[mode] = {
+            "command": [str(part) for part in command],
+            "returncode": proc["returncode"],
+            "timeout": proc["timeout"],
+            "execution_matches_status": execution_matches_status(proc,
+                                                                   status),
+            "status": status,
+            "wa": wa,
+            "stderr_tail": proc["stderr"].strip().splitlines()[-1:][0]
+            if proc["stderr"].strip() else "",
+            "reference": reference_comparison(status, point_reference,
+                                                max_rel),
+            "wa_reference": wa_comparison(wa, point_reference, max_rel),
+        }
+
+    left, right = runs["off"], runs["on"]
+    off_status, on_status = left["status"], right["status"]
+    off_kind = off_status[0] if off_status else ""
+    on_kind = on_status[0] if on_status else ""
+    category_match = off_kind == on_kind and bool(off_kind)
+    error_match = True
+    values = None
+    if category_match and off_kind == "OK":
+        values = compare_vectors(off_status[1:], on_status[1:])
+    elif category_match:
+        error_match = off_status[1:] == on_status[1:]
+
+    wa_ab = compare_wa_outcomes(left["wa"], right["wa"])
+    ab_only = point_reference is None
+    value_gate = not ab_only or ab_only_values_within_gate(values, max_rel)
+    wa_value_gate = (not ab_only
+                     or ab_only_values_within_gate(wa_ab["values"], max_rel))
+
+    semantic_ok = (
+        left["execution_matches_status"]
+        and right["execution_matches_status"]
+        and category_match and error_match
+        and left["reference"]["ok"] and right["reference"]["ok"]
+        and left["wa_reference"]["ok"] and right["wa_reference"]["ok"]
+        and (values is None or (values["same_shape"]
+                                and values["nonfinite_match"]))
+        and wa_ab["category_match"] and wa_ab["reason_match"]
+        and wa_ab["names_match"]
+        and (wa_ab["values"] is None
+             or (wa_ab["values"]["same_shape"]
+                 and wa_ab["values"]["nonfinite_match"]))
+        and value_gate and wa_value_gate
+    )
+    return {
+        "point": point,
+        "ok": semantic_ok,
+        "off": {key: value for key, value in left.items() if key != "wa"},
+        "on": {key: value for key, value in right.items() if key != "wa"},
+        "ab": {
+            "category_match": category_match,
+            "error_match": error_match,
+            "values": values,
+            "wa": wa_ab,
+            "ab_only_finite_gate": {
+                "applied": ab_only,
+                "max_rel": max_rel if ab_only else None,
+                "values_ok": value_gate,
+                "wa_values_ok": wa_value_gate,
+            },
+        },
+    }
+
+
+def reroll_fields(rows, graph):
+    row = prep_row(rows, graph, "reroll")
+    return {field: row.get(field) for field in REROLL_FIELDS}
+
+
+def summarize_reroll(records):
+    evidence = []
+    for record in records:
+        samples = []
+        for sample in record["samples"]:
+            log_total = prep_row(sample["rows"], "log_prob", "total")
+            wa_total = prep_row(sample["rows"], "write_array", "total")
+            log_evidence = reroll_fields(sample["rows"], "log_prob")
+            log_evidence["final_ops"] = log_total.get("ops")
+            wa_evidence = reroll_fields(sample["rows"], "write_array")
+            wa_evidence["final_ops"] = wa_total.get("ops")
+            samples.append({
+                "sample": sample["sample"],
+                "log_prob": log_evidence,
+                "write_array": wa_evidence,
+            })
+        evidence.append({
+            "source_pass": record["source_pass"],
+            "runtime_reroll": record["runtime_reroll"],
+            "samples": samples,
+        })
+    return evidence
+
+
+def graph_cell(dump, bench, mir, data, source_mode, reroll_enabled,
+               prep_samples, timeout):
+    env = dict(CLEAN_RUNTIME_ENV)
+    if not reroll_enabled:
+        env["STANLI_NO_REROLL"] = "1"
+    dump_proc = run_command([dump, mir, data, "-1"], timeout, env)
+    parsed_dump = (parse_dump(dump_proc["stdout"])
+                   if dump_proc["returncode"] == 0 else {})
+    dump_issues = dump_problems(parsed_dump)
+    samples = []
+    for sample in range(prep_samples):
+        sample_env = dict(env)
+        sample_env["STANLI_PROFILE_PREP"] = "1"
+        proc = run_command([bench, mir, data, "--prep"], timeout, sample_env)
+        rows = parse_prep(proc["stderr"])
+        profile_issues = prep_problems(rows)
+        samples.append({
+            "sample": sample + 1,
+            "returncode": proc["returncode"],
+            "timeout": proc["timeout"],
+            "elapsed_ns": proc["elapsed_ns"],
+            "rows": rows,
+            "profile_problems": profile_issues,
+            "stdout": proc["stdout"].strip(),
+            "stderr_tail": proc["stderr"].strip().splitlines()[-1:][0]
+            if proc["stderr"].strip() else "",
+        })
+    return {
+        "source_pass": source_mode,
+        "runtime_reroll": "on" if reroll_enabled else "off",
+        "dump_returncode": dump_proc["returncode"],
+        "dump_timeout": dump_proc["timeout"],
+        "dump_elapsed_ns": dump_proc["elapsed_ns"],
+        "dump_problems": dump_issues,
+        "graph": parsed_dump,
+        "samples": samples,
+    }
+
+
+def parse_bench_output(stdout):
+    """Parse only bench_grad's final four-field numeric row."""
+    lines = stdout.rstrip().splitlines()
+    if not lines:
+        return None
+    fields = lines[-1].split()
+    if len(fields) != 4:
+        return None
+    try:
+        gradient_ns = float(fields[0])
+        sink = float(fields[1])
+        forward_ns = float(fields[2])
+        n_params = int(fields[3])
+    except ValueError:
+        return None
+    if (not math.isfinite(gradient_ns) or gradient_ns <= 0
+            or not math.isfinite(forward_ns) or forward_ns < 0
+            or n_params < 0):
+        return None
+    return {
+        "gradient_ns": gradient_ns,
+        "sink": metric(sink),
+        "forward_ns": forward_ns,
+        "n_params": n_params,
+    }
+
+
+def calibrated_iterations(latencies_ns, target_seconds, maximum):
+    usable = [value for value in latencies_ns
+              if isinstance(value, (int, float)) and value > 0
+              and math.isfinite(value)]
+    if not usable:
+        return 1
+    iterations = int(target_seconds * 1e9 / max(usable))
+    return max(1, min(maximum, iterations))
+
+
+def bench_run(bench, mir, data, iterations, timeout):
+    command = [bench, mir, data, str(iterations)]
+    proc = run_command(command, timeout, CLEAN_RUNTIME_ENV)
+    parsed = parse_bench_output(proc["stdout"])
+    return {
+        "command": [str(part) for part in command],
+        "returncode": proc["returncode"],
+        "timeout": proc["timeout"],
+        "elapsed_ns": proc["elapsed_ns"],
+        "result": parsed,
+        "stderr_tail": proc["stderr"].strip().splitlines()[-1:][0]
+        if proc["stderr"].strip() else "",
+        "ok": proc["returncode"] == 0 and not proc["timeout"]
+        and parsed is not None,
+    }
+
+
+def gradient_benchmark(bench, mirs, data, rounds, calibration_n,
+                       target_seconds, max_n, timeout):
+    calibrations = {
+        mode: bench_run(bench, mirs[mode], data, calibration_n, timeout)
+        for mode in ("off", "on")
+    }
+    latency = [
+        run["result"]["gradient_ns"]
+        for run in calibrations.values()
+        if run["ok"]
+    ]
+    iterations = calibrated_iterations(latency, target_seconds, max_n)
+    order = ("off", "on", "on", "off")
+    runs = []
+    for round_index in range(rounds):
+        for order_index, mode in enumerate(order):
+            run = bench_run(bench, mirs[mode], data, iterations, timeout)
+            run.update({
+                "round": round_index + 1,
+                "order": order_index + 1,
+                "source_pass": mode,
+            })
+            runs.append(run)
+    medians = {}
+    for mode in ("off", "on"):
+        values = [
+            run["result"]["gradient_ns"] for run in runs
+            if run["source_pass"] == mode and run["ok"]
+        ]
+        medians[mode] = statistics.median(values) if values else None
+    ratio = None
+    if medians["off"] and medians["on"] is not None:
+        ratio = medians["on"] / medians["off"]
+    ok = all(run["ok"] for run in calibrations.values()) \
+        and all(run["ok"] for run in runs)
+    return {
+        "ok": ok,
+        "target_seconds": target_seconds,
+        "iterations": iterations,
+        "rounds": rounds,
+        "process_order": list(order),
+        "calibration_iterations": calibration_n,
+        "calibrations": calibrations,
+        "runs": runs,
+        "median_gradient_ns": medians,
+        "on_over_off": ratio,
+    }
+
+
+def tsv_value(row, key):
+    return row.get(key, "") if row else ""
+
+
+def write_reports(output_dir, manifest, corpus_records, graph_records,
+                  model_summaries, failures, infrastructure_failures):
+    output_dir.mkdir(parents=True, exist_ok=True)
+    (output_dir / "manifest.json").write_text(
+        json.dumps(manifest, indent=2, sort_keys=True) + "\n")
+    with (output_dir / "corpus.jsonl").open("w") as stream:
+        for record in corpus_records:
+            stream.write(json.dumps(record, sort_keys=True) + "\n")
+    with (output_dir / "graphs.jsonl").open("w") as stream:
+        for record in graph_records:
+            stream.write(json.dumps(record, sort_keys=True) + "\n")
+
+    columns = [
+        "model", "measurement", "source_pass", "runtime_reroll", "sample",
+        "round", "order", "compiler_elapsed_ns", "process_elapsed_ns",
+        "driver_total_ns", "compile_ns", "log_prob_total_ns",
+        "write_array_total_ns", "gradient_n", "gradient_ns", "forward_ns",
+        "n_params", "log_prob_ops", "log_prob_scalar_out",
+        "write_array_ops",
+    ]
+    for graph in ("log_prob", "write_array"):
+        columns.extend(f"{graph}_reroll_{field}" for field in REROLL_FIELDS)
+    with (output_dir / "bench.tsv").open("w") as stream:
+        stream.write("\t".join(columns) + "\n")
+
+        def emit(values):
+            stream.write("\t".join(str(values.get(name, ""))
+                                   for name in columns) + "\n")
+
+        for model in model_summaries:
+            for mode, compiled in model.get("compile", {}).items():
+                emit({
+                    "model": model["model"],
+                    "measurement": "source_compile",
+                    "source_pass": mode,
+                    "compiler_elapsed_ns": compiled.get("elapsed_ns", ""),
+                })
+            gradient = model.get("gradient")
+            if gradient:
+                for mode, run in gradient["calibrations"].items():
+                    result = run.get("result") or {}
+                    emit({
+                        "model": model["model"],
+                        "measurement": "gradient_calibration",
+                        "source_pass": mode,
+                        "sample": 0,
+                        "process_elapsed_ns": run["elapsed_ns"],
+                        "gradient_n": gradient["calibration_iterations"],
+                        "gradient_ns": result.get("gradient_ns", ""),
+                        "forward_ns": result.get("forward_ns", ""),
+                        "n_params": result.get("n_params", ""),
+                    })
+                for run in gradient["runs"]:
+                    result = run.get("result") or {}
+                    emit({
+                        "model": model["model"],
+                        "measurement": "gradient",
+                        "source_pass": run["source_pass"],
+                        "sample": ((run["round"] - 1) * 4
+                                   + run["order"]),
+                        "round": run["round"],
+                        "order": run["order"],
+                        "process_elapsed_ns": run["elapsed_ns"],
+                        "gradient_n": gradient["iterations"],
+                        "gradient_ns": result.get("gradient_ns", ""),
+                        "forward_ns": result.get("forward_ns", ""),
+                        "n_params": result.get("n_params", ""),
+                    })
+        for record in graph_records:
+            summary = record.get("graph", {}).get("summary", {})
+            for sample in record["samples"]:
+                rows = sample["rows"]
+                driver = prep_row(rows, "driver", "total")
+                compile_total = prep_row(rows, "compile", "total")
+                log_total = prep_row(rows, "log_prob", "total")
+                wa_total = prep_row(rows, "write_array", "total")
+                values = {
+                    "model": record["model"],
+                    "measurement": "preparation",
+                    "source_pass": record["source_pass"],
+                    "runtime_reroll": record["runtime_reroll"],
+                    "sample": sample["sample"],
+                    "process_elapsed_ns": sample["elapsed_ns"],
+                    "driver_total_ns": tsv_value(driver, "ns"),
+                    "compile_ns": tsv_value(compile_total, "ns"),
+                    "log_prob_total_ns": tsv_value(log_total, "ns"),
+                    "write_array_total_ns": tsv_value(wa_total, "ns"),
+                    "log_prob_ops": summary.get("ops", ""),
+                    "log_prob_scalar_out": summary.get("scalar_out", ""),
+                    "write_array_ops": tsv_value(wa_total, "ops"),
+                }
+                for graph in ("log_prob", "write_array"):
+                    reroll = prep_row(rows, graph, "reroll")
+                    for field in REROLL_FIELDS:
+                        values[f"{graph}_reroll_{field}"] = tsv_value(
+                            reroll, field)
+                emit(values)
+
+    changed_models = sum(summary["mir_changed"] for summary in model_summaries)
+    changed_values = sum(summary["changed_values"]
+                         for summary in model_summaries)
+    summary = {
+        "schema": 2,
+        "ok": not failures and not infrastructure_failures,
+        "models": len(model_summaries),
+        "referenced_models": sum(
+            item.get("reference_kind") == "cmdstan-recorded"
+            for item in model_summaries),
+        "ab_only_models": sum(
+            item.get("reference_kind") == "ab-only"
+            for item in model_summaries),
+        "points": len(corpus_records),
+        "harness_elapsed_ns": manifest.get("harness_elapsed_ns"),
+        "mir_changed_models": changed_models,
+        "arithmetic_order_changed_values": changed_values,
+        "semantic_failures": failures,
+        "infrastructure_failures": infrastructure_failures,
+        "per_model": model_summaries,
+    }
+    (output_dir / "summary.json").write_text(
+        json.dumps(summary, indent=2, sort_keys=True) + "\n")
+
+    lines = [
+        "# MIR vectorization A/B measurement", "",
+        f"Outcome: **{'PASS' if summary['ok'] else 'FAIL'}**", "",
+        f"- Models: {summary['models']}",
+        f"- CmdStan-referenced models: {summary['referenced_models']}",
+        f"- A/B-only models: {summary['ab_only_models']}",
+        f"- Semantic points: {summary['points']}",
+        f"- Harness elapsed seconds: "
+        f"{summary['harness_elapsed_ns'] / 1e9:.3f}"
+        if summary["harness_elapsed_ns"] is not None
+        else "- Harness elapsed seconds: unavailable",
+        f"- Models with different portable MIR: {changed_models}",
+        f"- Finite values changed by arithmetic order: {changed_values}",
+        f"- Semantic failures: {len(failures)}",
+        f"- Measurement infrastructure failures: "
+        f"{len(infrastructure_failures)}", "",
+        "Op counts, preparation timings, and gradient timings in "
+        "`graphs.jsonl` and `bench.tsv` are measurements, not gates.", "",
+        "| model | comparison | MIR changed | changed values | semantic points | "
+        "gradient on/off |",
+        "| --- | --- | ---: | ---: | ---: | ---: |",
+    ]
+    for item in model_summaries:
+        ratio = item.get("gradient", {}).get("on_over_off")
+        ratio_text = f"{ratio:.4f}" if ratio is not None else ""
+        lines.append(
+            f"| `{item['model']}` | {item.get('reference_kind', '')} | "
+            f"{int(item['mir_changed'])} | "
+            f"{item['changed_values']} | {item['points']} | {ratio_text} |")
+    if failures:
+        lines += ["", "## Semantic failures", ""]
+        lines += [f"- {failure}" for failure in failures]
+    if infrastructure_failures:
+        lines += ["", "## Measurement infrastructure failures", ""]
+        lines += [f"- {failure}" for failure in infrastructure_failures]
+    (output_dir / "summary.md").write_text("\n".join(lines) + "\n")
+    return summary
+
+
+def main():
+    harness_started_ns = time.monotonic_ns()
+    parser = argparse.ArgumentParser()
+    parser.add_argument("pdb", type=pathlib.Path)
+    parser.add_argument("models", nargs="*")
+    parser.add_argument(
+        "--compiler", type=pathlib.Path,
+        default=REPO / "deps" / "stanc3" / "stanli-vectorize-probe")
+    parser.add_argument("--check", type=pathlib.Path,
+                        default=REPO / "build-rel" / "stanli_check")
+    parser.add_argument("--bench", type=pathlib.Path,
+                        default=REPO / "build-rel" / "bench_grad")
+    parser.add_argument("--dump", type=pathlib.Path,
+                        default=REPO / "build-rel" / "dump_ops")
+    parser.add_argument("--output-dir", type=pathlib.Path,
+                        default=REPO / "build" / "vectorize-ab")
+    parser.add_argument("--max-rel", type=float, default=1e-9)
+    parser.add_argument("--timeout", type=float, default=300)
+    parser.add_argument("--prep-samples", type=int, default=1)
+    parser.add_argument("--gradient-rounds", type=int, default=2)
+    parser.add_argument("--gradient-calibration-n", type=int, default=8)
+    parser.add_argument("--gradient-target-seconds", type=float, default=0.75)
+    parser.add_argument("--gradient-max-n", type=int, default=1_000_000)
+    parser.add_argument("--gradient-timeout", type=float, default=20)
+    args = parser.parse_intermixed_args()
+
+    if args.prep_samples < 1:
+        parser.error("--prep-samples must be positive")
+    if args.timeout <= 0:
+        parser.error("--timeout must be positive")
+    if args.gradient_rounds < 2:
+        parser.error("--gradient-rounds must be at least 2")
+    if args.gradient_calibration_n < 1:
+        parser.error("--gradient-calibration-n must be positive")
+    if not 0 < args.gradient_target_seconds <= 5:
+        parser.error("--gradient-target-seconds must be in (0, 5]")
+    if args.gradient_max_n < 1:
+        parser.error("--gradient-max-n must be positive")
+    if not 0 < args.gradient_timeout <= args.timeout:
+        parser.error("--gradient-timeout must be in (0, --timeout]")
+    tools = {
+        "compiler": args.compiler.resolve(),
+        "check": args.check.resolve(),
+        "bench": args.bench.resolve(),
+        "dump": args.dump.resolve(),
+    }
+    missing_tools = [str(path) for path in tools.values() if not path.is_file()]
+    if missing_tools:
+        parser.error("missing tool(s): " + ", ".join(missing_tools))
+
+    probe_stamp_path = pathlib.Path(str(tools["compiler"]) + ".stamp")
+    if not probe_stamp_path.is_file():
+        parser.error(f"missing compiler provenance: {probe_stamp_path}")
+    probe_stamp = read_stamp(probe_stamp_path)
+    stanc_pin = setup_value("STANC3_SRC_SHA")
+    stanc_repo = setup_value("STANC3_SRC_REPO")
+    opam_switch = setup_value("OPAM_SWITCH")
+    if probe_stamp.get("stanc3_src_sha") != stanc_pin:
+        parser.error("compiler provenance does not match STANC3_SRC_SHA")
+    provenance_ok, provenance_error = probe_provenance_matches(
+        tools["compiler"], stanc_pin, opam_switch)
+    if not provenance_ok:
+        detail = f": {provenance_error}" if provenance_error else ""
+        parser.error(f"compiler provenance does not match producer inputs"
+                     f"{detail}")
+
+    pdb_checkout = args.pdb.resolve()
+    pdb = pdb_checkout / "posterior_database"
+    refs, recorded = load_refs()
+    pdb_entries = dict(corpus_models(pdb))
+    selected = args.models or sorted(set(refs) | set(pdb_entries))
+    missing_models = [
+        model for model in selected
+        if model not in refs and model not in pdb_entries
+    ]
+    if missing_models:
+        parser.error("no recorded or posteriordb inputs for: "
+                     + ", ".join(missing_models))
+
+    pdb_pin = setup_value("PDB_SHA")
+    pdb_revision = git_revision(pdb_checkout)
+    if recorded.get("posteriordb") != pdb_pin:
+        parser.error("reference provenance does not match PDB_SHA")
+    if pdb_revision is not None and pdb_revision != pdb_pin:
+        parser.error("posteriordb checkout does not match PDB_SHA")
+    language_models = [
+        model for model in selected
+        if (REPO / "tests" / "stanc3" / f"{model}.stan").is_file()
+    ]
+    selected_pdb_models = [
+        model for model in selected if model not in language_models
+    ]
+    selected_referenced = [model for model in selected if model in refs]
+    selected_ab_only = [model for model in selected if model not in refs]
+    available_pdb_models = len(pdb_entries)
+    if args.models:
+        selection_kind = (
+            "bounded-recorded-reference-selection"
+            if not selected_ab_only else "bounded-mixed-ab-selection"
+        )
+    else:
+        selection_kind = "complete-references-plus-posteriordb-model-census"
+    gradient_models = [model for model in selected if model in DEFAULT_MODELS]
+
+    revision = git_revision(REPO) or "unknown"
+    manifest = {
+        "schema": 2,
+        "generated_at": datetime.datetime.now(
+            datetime.timezone.utc).isoformat(),
+        "repository": str(REPO),
+        "revision": revision,
+        "repository_state": {
+            "revision": revision,
+            "tracked_dirty": git_tracked_dirty(REPO),
+            "harness_sha256": sha256_file(pathlib.Path(__file__)),
+        },
+        "command": sys.argv,
+        "corpus_scope": {
+            "kind": selection_kind,
+            "models": selected,
+            "selected_models": len(selected),
+            "selected_posteriordb_models": len(selected_pdb_models),
+            "selected_language_models": len(language_models),
+            "selected_referenced_models": len(selected_referenced),
+            "selected_ab_only_models": len(selected_ab_only),
+            "ab_only_models": selected_ab_only,
+            "recorded_reference_models": len(refs),
+            "posteriordb_models_available": available_pdb_models,
+            "full_posteriordb_model_census": not bool(args.models),
+            "full_model_data_pair_sweep": False,
+            "gradient_models": gradient_models,
+            "expected_mir_change_sentinels": sorted(
+                EXPECTED_MIR_CHANGES),
+            "note": "Recorded models use CmdStan gates; posteriordb models "
+                    "without a reference use off/on parity only. One data "
+                    "set is selected per posteriordb model.",
+        },
+        "points": list(POINTS),
+        "max_rel": args.max_rel,
+        "prep_samples": args.prep_samples,
+        "gradient": {
+            "rounds": args.gradient_rounds,
+            "process_order": ["off", "on", "on", "off"],
+            "calibration_iterations": args.gradient_calibration_n,
+            "target_seconds": args.gradient_target_seconds,
+            "maximum_iterations": args.gradient_max_n,
+            "process_timeout_seconds": args.gradient_timeout,
+            "gating": False,
+        },
+        "stanc3": {
+            "repository": stanc_repo,
+            "configured_pin": stanc_pin,
+            "source_checkout_revision": git_revision(
+                REPO / "deps" / "stanc3-src"),
+            "source_checkout_tracked_dirty": git_tracked_dirty(
+                REPO / "deps" / "stanc3-src"),
+            "probe_stamp_path": str(probe_stamp_path),
+            "probe_stamp": probe_stamp,
+            "probe_provenance_validated": True,
+        },
+        "posteriordb": {
+            "configured_pin": pdb_pin,
+            "checkout_revision": pdb_revision,
+            "checkout_tracked_dirty": git_tracked_dirty(pdb_checkout),
+            "reference_pin": recorded.get("posteriordb"),
+            "checkout": str(pdb_checkout),
+        },
+        "cmdstan_reference": recorded,
+        "tools": {
+            name: {"path": str(path), "sha256": sha256_file(path)}
+            for name, path in tools.items()
+        },
+    }
+    manifest.update(execution_metadata(tools["check"]))
+
+    output_dir = args.output_dir.resolve()
+    output_dir.mkdir(parents=True, exist_ok=True)
+    (output_dir / "manifest.json").write_text(
+        json.dumps(manifest, indent=2, sort_keys=True) + "\n")
+    corpus_records = []
+    graph_records = []
+    model_summaries = []
+    failures = []
+    infrastructure_failures = []
+    with tempfile.TemporaryDirectory(prefix="stanli_vectorize_ab_") as temp:
+        temp = pathlib.Path(temp)
+        for model in selected:
+            reference_kind = (
+                "cmdstan-recorded" if model in refs else "ab-only"
+            )
+            if model in refs:
+                inputs = model_files(model, refs[model], pdb, temp)
+            else:
+                inputs = corpus_input(
+                    pdb, temp, model, pdb_entries[model])
+            if inputs is None:
+                failures.append(f"{model}: missing posteriordb input")
+                model_summaries.append({
+                    "model": model, "mir_changed": False,
+                    "changed_values": 0, "points": 0,
+                    "reference_kind": reference_kind,
+                })
+                continue
+            source, data = inputs
+            if not source.is_file() or not data.is_file():
+                failures.append(f"{model}: missing input {source} or {data}")
+                model_summaries.append({
+                    "model": model, "mir_changed": False,
+                    "changed_values": 0, "points": 0,
+                    "reference_kind": reference_kind,
+                })
+                continue
+
+            mirs = {
+                mode: temp / f"{model}.{mode}.portable-mir"
+                for mode in ("off", "on")
+            }
+            compile_info = {}
+            compile_ok = True
+            for mode in ("off", "on"):
+                proc, info = compile_source(
+                    tools["compiler"], source, mirs[mode], mode == "on",
+                    args.timeout)
+                compile_info[mode] = info
+                if proc["returncode"] != 0 or not info["produced"]:
+                    compile_ok = False
+                    failures.append(
+                        f"{model}: {mode} source compilation failed: "
+                        f"{info['stderr'][-160:]}")
+
+            if not compile_ok:
+                model_summaries.append({
+                    "model": model, "mir_changed": False,
+                    "changed_values": 0, "points": 0,
+                    "compile": compile_info,
+                    "reference_kind": reference_kind,
+                })
+                continue
+
+            mir_changed = compile_info["off"]["sha256"] != \
+                compile_info["on"]["sha256"]
+            if model in EXPECTED_MIR_CHANGES and not mir_changed:
+                infrastructure_failures.append(
+                    f"{model}: vectorization sentinel MIR did not change")
+            changed_values = 0
+            model_points = 0
+            for point in POINTS:
+                record = semantic_point(
+                    tools["check"], source, data, mirs, point,
+                    refs[model]["points"][str(point)]
+                    if model in refs else None, args.timeout,
+                    args.max_rel)
+                record.update({
+                    "model": model,
+                    "source": str(source),
+                    "data": str(data),
+                    "source_sha256": sha256_file(source),
+                    "data_sha256": sha256_file(data),
+                    "compile": compile_info,
+                    "reference_kind": reference_kind,
+                })
+                corpus_records.append(record)
+                model_points += 1
+                if not record["ok"]:
+                    failures.append(f"{model} point {point}: semantic parity")
+                comparisons = [
+                    record["ab"].get("values"),
+                    record["ab"].get("wa", {}).get("values"),
+                ]
+                for compared in comparisons:
+                    if (compared
+                            and compared.get("finite_changed") is not None):
+                        changed_values += compared["finite_changed"]
+
+            model_graph_records = []
+            for source_mode in ("off", "on"):
+                for reroll_enabled in (False, True):
+                    cell = graph_cell(
+                        tools["dump"], tools["bench"], mirs[source_mode], data,
+                        source_mode, reroll_enabled, args.prep_samples,
+                        args.timeout)
+                    cell["model"] = model
+                    graph_records.append(cell)
+                    model_graph_records.append(cell)
+                    if (cell["dump_returncode"] != 0 or cell["dump_timeout"]
+                            or cell["dump_problems"]):
+                        detail = ", ".join(cell["dump_problems"])
+                        infrastructure_failures.append(
+                            f"{model} {source_mode}/reroll-"
+                            f"{'on' if reroll_enabled else 'off'}: dump_ops"
+                            f"{': ' + detail if detail else ''}")
+                    for sample in cell["samples"]:
+                        if (sample["returncode"] != 0 or sample["timeout"]
+                                or sample["profile_problems"]):
+                            detail = ", ".join(sample["profile_problems"])
+                            infrastructure_failures.append(
+                                f"{model} {source_mode}/reroll-"
+                                f"{'on' if reroll_enabled else 'off'} "
+                                f"sample {sample['sample']}: bench_grad"
+                                f"{': ' + detail if detail else ''}")
+
+            gradient = None
+            if model in gradient_models:
+                gradient = gradient_benchmark(
+                    tools["bench"], mirs, data, args.gradient_rounds,
+                    args.gradient_calibration_n,
+                    args.gradient_target_seconds, args.gradient_max_n,
+                    args.gradient_timeout)
+                if not gradient["ok"]:
+                    infrastructure_failures.append(
+                        f"{model}: gradient benchmark")
+
+            model_summary = {
+                "model": model,
+                "mir_changed": mir_changed,
+                "changed_values": changed_values,
+                "points": model_points,
+                "compile": compile_info,
+                "reroll": summarize_reroll(model_graph_records),
+                "reference_kind": reference_kind,
+            }
+            if gradient is not None:
+                model_summary["gradient"] = gradient
+            model_summaries.append(model_summary)
+            ratio = gradient.get("on_over_off") if gradient else None
+            ratio_text = f", gradient on/off {ratio:.4f}" \
+                if ratio is not None else ""
+            print(
+                f"{model}: MIR {'changed' if mir_changed else 'unchanged'}, "
+                f"{changed_values} arithmetic-order value changes"
+                f"{ratio_text}")
+
+    manifest["harness_elapsed_ns"] = time.monotonic_ns() - harness_started_ns
+    summary = write_reports(
+        output_dir, manifest, corpus_records, graph_records, model_summaries,
+        failures, infrastructure_failures)
+    print(
+        f"\n{summary['models']} models, {summary['points']} points, "
+        f"{len(failures)} semantic failures, "
+        f"{len(infrastructure_failures)} measurement failures")
+    print(f"report: {output_dir}")
+    return 0 if summary["ok"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/runtime/src/lower.cpp
+++ b/runtime/src/lower.cpp
@@ -15,6 +15,8 @@
 #include <stanli/structured_check.hpp>
 #include <stanli/wa_interp.hpp>
 
+#include "reroll_profile.hpp"
+
 #include <algorithm>
 #include <cstdio>
 #include <cstdlib>
@@ -70,6 +72,11 @@ struct PrepTrace {
     int64_t b = 0;
     int64_t c = 0;
     int64_t d = 0;
+    int64_t packed_rows = 0;
+    int64_t term_density = 0;
+    int64_t element_density = 0;
+    int64_t term_widen = 0;
+    int64_t element_store = 0;
     bool deep = false;
     int64_t params = 0;
     int64_t slot_elems = 0;
@@ -80,6 +87,8 @@ struct PrepTrace {
   };
 
   explicit PrepTrace(bool enabled) : enabled_(enabled) {}
+
+  bool enabled() const { return enabled_; }
 
   Time start() const { return enabled_ ? Clock::now() : Time{}; }
 
@@ -99,7 +108,8 @@ struct PrepTrace {
              const std::vector<std::pair<int, std::vector<double>>>& fills,
              size_t terms, size_t views, Extra extra = Extra::None,
              int64_t a = 0, int64_t b = 0, bool deep = false,
-             int64_t params = 0, int64_t c = 0, int64_t d = 0) {
+             int64_t params = 0, int64_t c = 0, int64_t d = 0,
+             const detail::RerollDispositionStats* dispositions = nullptr) {
     if (!enabled_) return;
     Row& r = next();
     r.graph = graph_name;
@@ -116,6 +126,13 @@ struct PrepTrace {
     r.b = b;
     r.c = c;
     r.d = d;
+    if (dispositions) {
+      r.packed_rows = dispositions->packed_rows;
+      r.term_density = dispositions->term_density;
+      r.element_density = dispositions->element_density;
+      r.term_widen = dispositions->term_widen;
+      r.element_store = dispositions->element_store;
+    }
     r.deep = deep;
     r.params = params;
     if (deep) {
@@ -164,6 +181,11 @@ struct PrepTrace {
           field("row_steps", r.d);
           field("list_steps", r.b);
           field("candidate_steps", r.c);
+          field("packed_rows", r.packed_rows);
+          field("term_density", r.term_density);
+          field("element_density", r.element_density);
+          field("term_widen", r.term_widen);
+          field("element_store", r.element_store);
           break;
         case Extra::Partition:
           field("groups", r.a);
@@ -5213,11 +5235,21 @@ struct Lowering {
                target_terms.size(), out.views.size(), PrepTrace::Extra::Removed,
                forwarded);
     const auto reroll_time = prep.start();
-    const RerollStats rerolled = reroll(g, out.fills, target_terms, roots);
+    RerollStats rerolled;
+    detail::RerollDispositionStats reroll_dispositions;
+    if (prep.enabled()) {
+      detail::ProfiledRerollStats profiled =
+          detail::reroll_profiled(g, out.fills, target_terms, roots);
+      rerolled = profiled.work;
+      reroll_dispositions = profiled.dispositions;
+    } else {
+      rerolled = reroll(g, out.fills, target_terms, roots);
+    }
     prep.graph(prep_graph, "reroll", reroll_time, g, out.fills,
                target_terms.size(), out.views.size(), PrepTrace::Extra::Reroll,
                rerolled.regions, rerolled.list_steps, false, 0,
-               rerolled.candidate_steps, rerolled.row_steps);
+               rerolled.candidate_steps, rerolled.row_steps,
+               &reroll_dispositions);
     // Re-roll can replace many element writes with copying slice stores.
     // Give those new ops the same last-use proof as the scalar stores.
     const auto post_reroll_inplace_time = prep.start();
@@ -5291,12 +5323,21 @@ struct Lowering {
                PrepTrace::Extra::ConstFold, constfolded.ops_removed,
                constfolded.slots_folded);
     const auto reroll_time = prep.start();
-    const RerollStats rerolled =
-        reroll(g, out.fills, target_terms, roots);  // STANLI_NO_REROLL
+    RerollStats rerolled;
+    detail::RerollDispositionStats reroll_dispositions;
+    if (prep.enabled()) {
+      detail::ProfiledRerollStats profiled =
+          detail::reroll_profiled(g, out.fills, target_terms, roots);
+      rerolled = profiled.work;
+      reroll_dispositions = profiled.dispositions;
+    } else {
+      rerolled = reroll(g, out.fills, target_terms, roots);  // STANLI_NO_REROLL
+    }
     prep.graph(prep_graph, "reroll", reroll_time, g, out.fills,
                target_terms.size(), out.views.size(), PrepTrace::Extra::Reroll,
                rerolled.regions, rerolled.list_steps, false, 0,
-               rerolled.candidate_steps, rerolled.row_steps);
+               rerolled.candidate_steps, rerolled.row_steps,
+               &reroll_dispositions);
     // Target terms may have been replaced by vector reductions, so rebuild
     // the implicit-root set before considering the slice stores reroll made.
     std::vector<int> post_reroll_roots = roots;

--- a/runtime/src/reroll.cpp
+++ b/runtime/src/reroll.cpp
@@ -37,6 +37,8 @@
 #include <stanli/optable.hpp>
 #include <stanli/reroll.hpp>
 
+#include "reroll_profile.hpp"
+
 #include <algorithm>
 #include <cstdlib>
 #include <limits>
@@ -478,15 +480,17 @@ int fuse_log_sum_exp_rows(Graph& g, std::vector<int>& target_terms,
 
 }  // namespace
 
-RerollStats reroll(Graph& g,
-                   std::vector<std::pair<int, std::vector<double>>>& fills,
-                   std::vector<int>& target_terms,
-                   const std::vector<int>& extra_roots) {
+static RerollStats reroll_impl(
+    Graph& g, std::vector<std::pair<int, std::vector<double>>>& fills,
+    std::vector<int>& target_terms, const std::vector<int>& extra_roots,
+    detail::RerollDispositionStats* dispositions) {
   RerollStats st;
   if (std::getenv("STANLI_NO_REROLL")) return st;
 
-  st.regions +=
+  const int packed_rows =
       fuse_log_sum_exp_rows(g, target_terms, extra_roots, st.row_steps);
+  st.regions += packed_rows;
+  if (dispositions) dispositions->packed_rows += packed_rows;
 
   std::unordered_set<int> term_set(target_terms.begin(), target_terms.end());
   const auto is_candidate_op = [&](const Op& t) {
@@ -1205,6 +1209,14 @@ RerollStats reroll(Graph& g,
       }
       i += (size_t)P * (size_t)Luse;
       ++st.regions;
+      if (dispositions) {
+        for (const Pos& committed : pos) {
+          dispositions->term_density += committed.term_density;
+          dispositions->element_density += committed.elt_density;
+          dispositions->term_widen += committed.term_widen;
+          dispositions->element_store += committed.store_vec >= 0;
+        }
+      }
       rewrote = true;
       break;
     }
@@ -1221,5 +1233,25 @@ RerollStats reroll(Graph& g,
   g.ops = std::move(result);
   return st;
 }
+
+RerollStats reroll(Graph& g,
+                   std::vector<std::pair<int, std::vector<double>>>& fills,
+                   std::vector<int>& target_terms,
+                   const std::vector<int>& extra_roots) {
+  return reroll_impl(g, fills, target_terms, extra_roots, nullptr);
+}
+
+namespace detail {
+
+ProfiledRerollStats reroll_profiled(
+    Graph& g, std::vector<std::pair<int, std::vector<double>>>& fills,
+    std::vector<int>& target_terms, const std::vector<int>& extra_roots) {
+  ProfiledRerollStats result;
+  result.work =
+      reroll_impl(g, fills, target_terms, extra_roots, &result.dispositions);
+  return result;
+}
+
+}  // namespace detail
 
 }  // namespace stanli

--- a/runtime/src/reroll_profile.hpp
+++ b/runtime/src/reroll_profile.hpp
@@ -1,0 +1,35 @@
+// Private preparation diagnostics for the re-roll pass. This header is not
+// installed; the public RerollStats layout and reroll() entrypoint stay
+// unchanged.
+#ifndef STANLI_REROLL_PROFILE_HPP
+#define STANLI_REROLL_PROFILE_HPP
+
+#include <stanli/reroll.hpp>
+
+namespace stanli {
+namespace detail {
+
+struct RerollDispositionStats {
+  int64_t packed_rows = 0;
+  int64_t term_density = 0;
+  int64_t element_density = 0;
+  int64_t term_widen = 0;
+  int64_t element_store = 0;
+};
+
+struct ProfiledRerollStats {
+  RerollStats work;
+  RerollDispositionStats dispositions;
+};
+
+// The lowerer calls this only for STANLI_PROFILE_PREP. Ordinary compilation
+// continues through the public reroll() function and does not count
+// dispositions.
+ProfiledRerollStats reroll_profiled(
+    Graph& g, std::vector<std::pair<int, std::vector<double>>>& fills,
+    std::vector<int>& target_terms, const std::vector<int>& extra_roots);
+
+}  // namespace detail
+}  // namespace stanli
+
+#endif

--- a/tests/check_mir_conflict.cmake
+++ b/tests/check_mir_conflict.cmake
@@ -1,0 +1,21 @@
+execute_process(
+  COMMAND "${STANLI_CHECK}"
+          "${SOURCE_DIR}/tests/fixtures/ar1.stan"
+          "${SOURCE_DIR}/tests/fixtures/ar1.json"
+          --mir "${SOURCE_DIR}/tests/fixtures/ar1.tmir.sexp"
+          --stanc ignored
+  RESULT_VARIABLE result
+  OUTPUT_VARIABLE output
+  ERROR_VARIABLE error)
+
+if(NOT result EQUAL 2)
+  message(FATAL_ERROR
+          "stanli_check --mir/--stanc conflict returned ${result}: ${output}${error}")
+endif()
+
+set(expected "stanli_check: --stanc and --mir are mutually exclusive")
+string(FIND "${error}" "${expected}" diagnostic_position)
+if(diagnostic_position EQUAL -1)
+  message(FATAL_ERROR
+          "stanli_check --mir/--stanc conflict missed diagnostic: ${error}")
+endif()

--- a/tests/test_reroll.cpp
+++ b/tests/test_reroll.cpp
@@ -8,6 +8,8 @@
 #include <stanli/optable.hpp>
 #include <stanli/reroll.hpp>
 
+#include "../runtime/src/reroll_profile.hpp"
+
 #ifndef _WIN32
 #include <sys/resource.h>
 #endif
@@ -83,8 +85,17 @@ static void test_radon_shape() {
 
   std::vector<int> tt = terms;
   Fills f2 = fills;
-  RerollStats st = reroll(g, f2, tt, {});
+  const detail::ProfiledRerollStats profiled =
+      detail::reroll_profiled(g, f2, tt, {});
+  const RerollStats st = profiled.work;
   expect("radon regions==1", st.regions == 1);
+  expect("radon term-density disposition",
+         profiled.dispositions.term_density == 1);
+  expect("radon no other dispositions",
+         profiled.dispositions.packed_rows == 0 &&
+             profiled.dispositions.element_density == 0 &&
+             profiled.dispositions.term_widen == 0 &&
+             profiled.dispositions.element_store == 0);
   // 1 REP_VEC survives; 8 INDEX + 8 NORMAL collapse to 1 NORMAL.
   expect("radon ops==2", g.ops.size() == 2);
   expect("radon one term", tt.size() == 1);
@@ -213,8 +224,13 @@ static void test_gauss_mix_shape() {
 
   std::vector<int> tt = terms;
   Fills f2 = fills;
-  RerollStats st = reroll(g, f2, tt, {});
+  const detail::ProfiledRerollStats profiled =
+      detail::reroll_profiled(g, f2, tt, {});
+  const RerollStats st = profiled.work;
   expect("gmix regions==1", st.regions == 1);
+  expect("gmix element-density dispositions",
+         profiled.dispositions.element_density == 2);
+  expect("gmix term-widen disposition", profiled.dispositions.term_widen == 1);
   // 2 elementwise NORMAL + 1 widened LOG_MIX + 1 SUM_VEC.
   expect("gmix ops==4", g.ops.size() == 4);
   expect("gmix one term", tt.size() == 1);
@@ -852,8 +868,12 @@ static void test_lda_shape_gradients() {
 
       std::vector<int> tt = b.terms;
       Fills f2 = b.fills;
-      RerollStats st = reroll(b.g, f2, tt, {});
+      const detail::ProfiledRerollStats profiled =
+          detail::reroll_profiled(b.g, f2, tt, {});
+      const RerollStats st = profiled.work;
       expect((label + " becomes one region").c_str(), st.regions == 1);
+      expect((label + " records packed-row disposition").c_str(),
+             profiled.dispositions.packed_rows == 1);
       expect((label + " has seven fused ops plus inputs").c_str(),
              b.g.ops.size() == 9);
       expect((label + " has one packed reduction").c_str(),
@@ -1074,9 +1094,13 @@ static void test_write_fusion() {
 
     std::vector<int> tt = b.terms;
     Fills f2 = b.fills;
-    RerollStats st = reroll(b.g, f2, tt, {});
+    const detail::ProfiledRerollStats profiled =
+        detail::reroll_profiled(b.g, f2, tt, {});
+    const RerollStats st = profiled.work;
     const std::string tag = start ? "window" : "whole";
     expect((tag + " regions==1").c_str(), st.regions == 1);
+    expect((tag + " records element-store disposition").c_str(),
+           profiled.dispositions.element_store == 1);
     expect((tag + " one gather").c_str(), count(b.g, OP_GATHER) == 1);
     expect((tag + " no element writes left").c_str(),
            count(b.g, OP_SET_INDEX_INPLACE) == 0);

--- a/tests/test_vectorize_ab.py
+++ b/tests/test_vectorize_ab.py
@@ -1,0 +1,263 @@
+#!/usr/bin/env python3
+"""Unit tests for the measurement report parsers and artifact schema."""
+
+import json
+import pathlib
+import subprocess
+import sys
+import tempfile
+import unittest
+from unittest import mock
+
+REPO = pathlib.Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "harnesses"))
+import vectorize_ab  # noqa: E402
+
+
+class VectorizeAbTest(unittest.TestCase):
+    def test_vector_comparison_is_nonfinite_safe(self):
+        same = vectorize_ab.compare_vectors(
+            ["1", "nan", "-inf"], ["1.0", "nan", "-inf"])
+        self.assertTrue(same["same_shape"])
+        self.assertEqual(same["changed"], 0)
+        self.assertEqual(same["max_rel"], 0.0)
+        self.assertTrue(same["nonfinite_match"])
+
+        mismatch = vectorize_ab.compare_vectors(["1"], ["inf"])
+        self.assertEqual(mismatch["max_rel"], "inf")
+        self.assertEqual(mismatch["changed"], 1)
+        self.assertEqual(mismatch["finite_changed"], 0)
+        self.assertFalse(mismatch["nonfinite_match"])
+        self.assertEqual(mismatch["differences"][0]["index"], 0)
+        self.assertRegex(mismatch["differences"][0]["left_bits"],
+                         r"^0x[0-9a-f]{16}$")
+
+    def test_execution_status_includes_exit_and_timeout(self):
+        ok = {"returncode": 0, "timeout": False}
+        rejected = {"returncode": 1, "timeout": False}
+        timed_out = {"returncode": 0, "timeout": True}
+        self.assertTrue(vectorize_ab.execution_matches_status(ok, ["OK"]))
+        self.assertTrue(vectorize_ab.execution_matches_status(
+            rejected, ["EVAL_FAIL", "domain"]))
+        self.assertFalse(vectorize_ab.execution_matches_status(
+            rejected, ["OK", "1"]))
+        self.assertFalse(vectorize_ab.execution_matches_status(
+            timed_out, ["OK", "1"]))
+
+    def test_ab_only_matching_evaluation_failure_passes(self):
+        rejected = {
+            "returncode": 1,
+            "timeout": False,
+            "elapsed_ns": 1,
+            "stdout": "EVAL_FAIL identical domain error\n",
+            "stderr": "WA none\n",
+        }
+        with mock.patch.object(vectorize_ab, "run_command",
+                               side_effect=[rejected, rejected]):
+            result = vectorize_ab.semantic_point(
+                "check", "model", "data", {"off": "a", "on": "b"},
+                0, None, 1, 1e-9)
+        self.assertTrue(result["ok"])
+        self.assertFalse(result["off"]["reference"]["referenced"])
+        self.assertTrue(result["ab"]["error_match"])
+
+    def test_ab_only_matching_compile_failure_fails(self):
+        failed = {
+            "returncode": 1,
+            "timeout": False,
+            "elapsed_ns": 1,
+            "stdout": "COMPILE_FAIL identical lower error\n",
+            "stderr": "",
+        }
+        with mock.patch.object(vectorize_ab, "run_command",
+                               side_effect=[failed, failed]):
+            result = vectorize_ab.semantic_point(
+                "check", "model", "data", {"off": "a", "on": "b"},
+                0, None, 1, 1e-9)
+        self.assertFalse(result["ok"])
+        self.assertFalse(result["off"]["reference"]["ok"])
+
+    def test_ab_only_finite_values_must_meet_gate(self):
+        off = {
+            "returncode": 0, "timeout": False, "elapsed_ns": 1,
+            "stdout": "OK 1 2\n", "stderr": "WA none\n",
+        }
+        on = {
+            "returncode": 0, "timeout": False, "elapsed_ns": 1,
+            "stdout": "OK 1 3\n", "stderr": "WA none\n",
+        }
+        with mock.patch.object(vectorize_ab, "run_command",
+                               side_effect=[off, on]):
+            result = vectorize_ab.semantic_point(
+                "check", "model", "data", {"off": "a", "on": "b"},
+                0, None, 1, 1e-9)
+        self.assertFalse(result["ok"])
+        self.assertTrue(result["ab"]["ab_only_finite_gate"]["applied"])
+        self.assertFalse(result["ab"]["ab_only_finite_gate"]["values_ok"])
+
+    def test_ab_only_write_array_values_must_meet_gate(self):
+        off = {
+            "returncode": 0, "timeout": False, "elapsed_ns": 1,
+            "stdout": "WANAMES x\nWAVALS 1\nOK 0\n", "stderr": "",
+        }
+        on = {
+            "returncode": 0, "timeout": False, "elapsed_ns": 1,
+            "stdout": "WANAMES x\nWAVALS 2\nOK 0\n", "stderr": "",
+        }
+        with mock.patch.object(vectorize_ab, "run_command",
+                               side_effect=[off, on]):
+            result = vectorize_ab.semantic_point(
+                "check", "model", "data", {"off": "a", "on": "b"},
+                0, None, 1, 1e-9)
+        self.assertFalse(result["ok"])
+        self.assertFalse(
+            result["ab"]["ab_only_finite_gate"]["wa_values_ok"])
+
+    def test_write_array_failure_outcomes_do_not_collapse(self):
+        absent = vectorize_ab.parse_wa_outcome("OK 1\n")
+        failed_a = vectorize_ab.parse_wa_outcome(
+            "WANAMES FAIL domain A\nWAVALS FAIL\nOK 1\n")
+        failed_b = vectorize_ab.parse_wa_outcome(
+            "WANAMES FAIL domain B\nWAVALS FAIL\nOK 1\n")
+        self.assertFalse(vectorize_ab.compare_wa_outcomes(
+            absent, failed_a)["category_match"])
+        compared = vectorize_ab.compare_wa_outcomes(failed_a, failed_b)
+        self.assertTrue(compared["category_match"])
+        self.assertFalse(compared["reason_match"])
+
+    def test_timeout_output_is_decoded(self):
+        timeout = subprocess.TimeoutExpired(
+            ["probe"], 1, output=b"OK 1\n", stderr=b"last line\n")
+        with mock.patch.object(vectorize_ab.subprocess, "run",
+                               side_effect=timeout):
+            result = vectorize_ab.run_command(["probe"], 1)
+        self.assertTrue(result["timeout"])
+        self.assertEqual(result["stdout"], "OK 1\n")
+        self.assertEqual(result["stderr"], "last line\n")
+
+    def test_prep_dispositions_are_parsed(self):
+        rows = vectorize_ab.parse_prep(
+            "noise\n"
+            "stanli_prep graph=log_prob stage=reroll ns=41 ops=7 "
+            "regions=2 packed_rows=1 term_density=3 element_density=4 "
+            "term_widen=5 element_store=6\n")
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]["graph"], "log_prob")
+        self.assertEqual(rows[0]["packed_rows"], 1)
+        self.assertEqual(rows[0]["element_store"], 6)
+
+    def test_reroll_summary_keeps_both_final_op_counts(self):
+        rows = vectorize_ab.parse_prep(
+            "stanli_prep graph=log_prob stage=total ns=1 ops=7 slots=8\n"
+            "stanli_prep graph=write_array stage=total ns=2 ops=5 slots=6\n"
+            "stanli_prep graph=log_prob stage=reroll ns=3 regions=1 "
+            "packed_rows=0 term_density=1 element_density=0 term_widen=0 "
+            "element_store=0\n"
+            "stanli_prep graph=write_array stage=reroll ns=4 regions=2 "
+            "packed_rows=0 term_density=0 element_density=0 term_widen=0 "
+            "element_store=2\n")
+        evidence = vectorize_ab.summarize_reroll([{
+            "source_pass": "on",
+            "runtime_reroll": "on",
+            "samples": [{"sample": 1, "rows": rows}],
+        }])
+        sample = evidence[0]["samples"][0]
+        self.assertEqual(sample["log_prob"]["final_ops"], 7)
+        self.assertEqual(sample["write_array"]["final_ops"], 5)
+        self.assertEqual(sample["write_array"]["element_store"], 2)
+
+    def test_dump_summary_is_parsed(self):
+        parsed = vectorize_ab.parse_dump(
+            "slots=19 ops=7 result=18\n"
+            "SUMMARY ops=7 scalar_out=2 vector_out=5\n"
+            "  NORMAL_LPDF total=1 scalar=0\n")
+        self.assertEqual(parsed["ops"], 7)
+        self.assertEqual(parsed["summary"]["scalar_out"], 2)
+        self.assertEqual(parsed["opcodes"]["NORMAL_LPDF"]["total"], 1)
+        self.assertEqual(vectorize_ab.dump_problems(parsed), [])
+        self.assertIn("missing SUMMARY",
+                      vectorize_ab.dump_problems({"slots": 1, "ops": 1,
+                                                  "result": 0}))
+
+    def test_gradient_output_calibration_and_abba_order(self):
+        self.assertIsNone(vectorize_ab.parse_bench_output(
+            "1 2 3 4\nnot the final row\n"))
+        parsed = vectorize_ab.parse_bench_output(
+            "model output\n200.0 3.5 80.0 7\n")
+        self.assertEqual(parsed["gradient_ns"], 200.0)
+        self.assertEqual(parsed["n_params"], 7)
+        self.assertEqual(vectorize_ab.calibrated_iterations(
+            [100.0, 200.0], 0.001, 10_000), 5000)
+
+        calls = []
+
+        def fake_run(_bench, mir, _data, iterations, _timeout):
+            mode = str(mir)
+            calls.append((mode, iterations))
+            latency = 100.0 if mode == "off" else 200.0
+            return {
+                "ok": True,
+                "returncode": 0,
+                "timeout": False,
+                "elapsed_ns": 1,
+                "stderr_tail": "",
+                "result": {
+                    "gradient_ns": latency,
+                    "sink": 0.0,
+                    "forward_ns": 50.0,
+                    "n_params": 2,
+                },
+            }
+
+        with mock.patch.object(vectorize_ab, "bench_run",
+                               side_effect=fake_run):
+            measured = vectorize_ab.gradient_benchmark(
+                "bench", {"off": "off", "on": "on"}, "data", 2, 8,
+                0.001, 10_000, 5)
+        self.assertEqual(calls[:2], [("off", 8), ("on", 8)])
+        self.assertEqual(
+            [run["source_pass"] for run in measured["runs"]],
+            ["off", "on", "on", "off"] * 2)
+        self.assertEqual(measured["iterations"], 5000)
+        self.assertEqual(measured["on_over_off"], 2.0)
+
+    def test_report_writes_all_artifacts(self):
+        graph = {
+            "model": "probe",
+            "source_pass": "off",
+            "runtime_reroll": "on",
+            "graph": {"summary": {"ops": 1, "scalar_out": 1}},
+            "samples": [{
+                "sample": 1,
+                "elapsed_ns": 4,
+                "rows": [{
+                    "graph": "log_prob", "stage": "reroll", "ns": 3,
+                    "regions": 0, "packed_rows": 0, "term_density": 0,
+                    "element_density": 0, "term_widen": 0,
+                    "element_store": 0,
+                }],
+            }],
+        }
+        with tempfile.TemporaryDirectory() as temp:
+            out = pathlib.Path(temp)
+            summary = vectorize_ab.write_reports(
+                out, {"schema": 1}, [{"model": "probe", "ok": True}],
+                [graph], [{
+                    "model": "probe", "mir_changed": False,
+                    "changed_values": 0, "points": 1,
+                }], [], [])
+            self.assertTrue(summary["ok"])
+            expected = {
+                "manifest.json", "corpus.jsonl", "graphs.jsonl",
+                "bench.tsv", "summary.json", "summary.md",
+            }
+            self.assertEqual({path.name for path in out.iterdir()}, expected)
+            self.assertTrue(json.loads((out / "summary.json").read_text())["ok"])
+            header = (out / "bench.tsv").read_text().splitlines()[0]
+            self.assertIn("write_array_ops", header)
+            self.assertIn("log_prob_reroll_packed_rows", header)
+            self.assertIn("write_array_reroll_element_store", header)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_vectorize_ab.py
+++ b/tests/test_vectorize_ab.py
@@ -15,6 +15,25 @@ import vectorize_ab  # noqa: E402
 
 
 class VectorizeAbTest(unittest.TestCase):
+    def test_git_identity_scopes_the_checkout_as_safe(self):
+        expected = str(vectorize_ab.REPO.resolve())
+        with mock.patch.object(
+                vectorize_ab.subprocess, "check_output",
+                return_value="0123456789abcdef\n") as check_output:
+            self.assertEqual(
+                vectorize_ab.git_revision(vectorize_ab.REPO),
+                "0123456789abcdef")
+        command = check_output.call_args.args[0]
+        self.assertIn(f"safe.directory={expected}", command)
+
+        clean = subprocess.CompletedProcess([], 0, stdout="", stderr="")
+        with mock.patch.object(vectorize_ab.subprocess, "run",
+                               return_value=clean) as run:
+            self.assertFalse(vectorize_ab.git_tracked_dirty(
+                vectorize_ab.REPO))
+        command = run.call_args.args[0]
+        self.assertIn(f"safe.directory={expected}", command)
+
     def test_vector_comparison_is_nonfinite_safe(self):
         same = vectorize_ab.compare_vectors(
             ["1", "nan", "-inf"], ["1.0", "nan", "-inf"])

--- a/tools/dev_setup.sh
+++ b/tools/dev_setup.sh
@@ -116,10 +116,13 @@ fi
 if [ "$WANT_EMBED" = 1 ]; then
   step "building the embeddable stanc object"
   if stanc_embed_artifact_matches deps/stanc3/stanc_embed.o \
+       "$STANC3_SRC_SHA" &&
+     [ -x deps/stanc3/stanli-vectorize-probe ] &&
+     stanc_embed_artifact_matches deps/stanc3/stanli-vectorize-probe \
        "$STANC3_SRC_SHA"; then
-    echo "deps/stanc3/stanc_embed.o matches the source and producer inputs"
+    echo "embedded compiler artifacts match the source and producer inputs"
   else
-    echo "embedded object is absent or its provenance does not match; rebuilding"
+    echo "embedded compiler artifacts are absent or mismatched; rebuilding"
     tools/stanc_embed/build.sh deps/stanc3-src "$OPAM_SWITCH"
   fi
 fi

--- a/tools/stanc_embed/build.sh
+++ b/tools/stanc_embed/build.sh
@@ -43,24 +43,44 @@ fi
 (cd "$SRC" && dune build --profile release src/stanc_embed/stanc_embed.exe.o \
    2>&1 | tail -5 ||
  dune build --profile release src/stanc_embed 2>&1 | tail -5)
+(cd "$SRC" &&
+ dune build --profile release src/stanc_embed/stanli_vectorize_probe.exe)
 OBJ=$(find "$SRC/_build" -path '*/src/stanc_embed/stanc_embed*.o' | head -1)
 [ -n "$OBJ" ] && [ -f "$OBJ" ] || {
   echo "dune did not produce the embedded stanc object" >&2
   exit 1
 }
+PROBE=$(find "$SRC/_build" \
+  -path '*/src/stanc_embed/stanli_vectorize_probe.exe' | head -1)
+[ -n "$PROBE" ] && [ -f "$PROBE" ] || {
+  echo "dune did not produce the vectorization measurement probe" >&2
+  exit 1
+}
 
-# Publish the object and its adjacent provenance record together. The record
-# is recomputed from the source pin and every local producer input, so callers
-# can reject a cache entry left behind by an earlier encoder or build recipe.
+# Publish each artifact with an adjacent provenance record. The record is
+# recomputed from the source pin and every local producer input, so callers can
+# reject a cache entry left behind by an earlier encoder or build recipe. Each
+# stamp moves last and therefore commits the artifact beside it.
 OUT=deps/stanc3/stanc_embed.o
+PROBE_OUT=deps/stanc3/stanli-vectorize-probe
 TMP_OBJECT="${OUT}.tmp.$$"
 TMP_STAMP="${OUT}.stamp.tmp.$$"
-cleanup() { rm -f "$TMP_OBJECT" "$TMP_STAMP"; }
+TMP_PROBE="${PROBE_OUT}.tmp.$$"
+TMP_PROBE_STAMP="${PROBE_OUT}.stamp.tmp.$$"
+cleanup() {
+  rm -f "$TMP_OBJECT" "$TMP_STAMP" "$TMP_PROBE" "$TMP_PROBE_STAMP"
+}
 trap cleanup EXIT
 cp -f "$OBJ" "$TMP_OBJECT"
 chmod u+w "$TMP_OBJECT"
+cp -f "$PROBE" "$TMP_PROBE"
+chmod 755 "$TMP_PROBE"
 stanc_embed_expected_stamp "$STANC3_SRC_SHA" "$SWITCH" > "$TMP_STAMP"
+cp -f "$TMP_STAMP" "$TMP_PROBE_STAMP"
 mv -f "$TMP_OBJECT" "$OUT"
 mv -f "$TMP_STAMP" "${OUT}.stamp"
+mv -f "$TMP_PROBE" "$PROBE_OUT"
+mv -f "$TMP_PROBE_STAMP" "${PROBE_OUT}.stamp"
 trap - EXIT
 echo "embedded stanc object: $OUT ($(du -h "$OUT" | cut -f1))"
+echo "vectorization measurement probe: $PROBE_OUT"

--- a/tools/stanli_check.cpp
+++ b/tools/stanli_check.cpp
@@ -14,6 +14,8 @@
 //             write_array mode, ODE mode
 //   --cross   the cross-path agreement matrix: recompile once per engine
 //             configuration and demand the answers agree bitwise
+//   --mir P   read already-compiled MIR from P, keeping model.stan as the
+//             report/ledger identity; mutually exclusive with --stanc
 #include "../tests/cross_path.hpp"
 
 #include <stanli/compile.hpp>
@@ -24,8 +26,10 @@
 #include <cmath>
 #include <cstdio>
 #include <cstdlib>
+#include <fstream>
 #include <map>
 #include <memory>
+#include <sstream>
 #include <string>
 #include <vector>
 
@@ -59,16 +63,27 @@ static std::string run_stanc(const std::string& stanc,
   return out;
 }
 
+static std::string read_mir(const std::string& path) {
+  std::ifstream file(path, std::ios::binary);
+  if (!file) throw std::runtime_error("cannot open MIR file " + path);
+  std::ostringstream contents;
+  contents << file.rdbuf();
+  if (file.bad()) throw std::runtime_error("cannot read MIR file " + path);
+  return contents.str();
+}
+
 int main(int argc, char** argv) {
   if (argc < 3) {
     std::fprintf(stderr,
                  "usage: stanli_check model.stan data.json "
-                 "[--stanc PATH] [--point N] [--columns]\n"
+                 "[--stanc PATH | --mir PATH] [--point N] [--columns]\n"
                  "       [--paths] [--cross [--cross-one lp|grad|wa] "
                  "[--draw-variant N] [--ledger PATH]]\n");
     return 2;
   }
   std::string stanc = "deps/stanc3/stanc";
+  std::string mir_path;
+  bool stanc_arg = false;
   int variant = 0;
   bool columns_only = false;
   bool wa_values = false;
@@ -93,22 +108,32 @@ int main(int argc, char** argv) {
       draw_variant = std::atoi(argv[++i]);
     else if (a == "--ledger" && i + 1 < argc)
       ledger_path = argv[++i];
-    else if (a == "--stanc" && i + 1 < argc)
+    else if (a == "--stanc" && i + 1 < argc) {
       stanc = argv[++i];
+      stanc_arg = true;
+    } else if (a == "--mir" && i + 1 < argc)
+      mir_path = argv[++i];
     else if (a == "--point" && i + 1 < argc)
       variant = std::atoi(argv[++i]);
+  }
+  if (stanc_arg && !mir_path.empty()) {
+    std::fprintf(stderr,
+                 "stanli_check: --stanc and --mir are mutually exclusive\n");
+    return 2;
   }
   if (const char* env = std::getenv("STANC")) stanc = env;
 
   std::string mir;
   try {
-    mir = run_stanc(stanc, argv[1]);
+    mir = mir_path.empty() ? run_stanc(stanc, argv[1]) : read_mir(mir_path);
     if (mir.empty()) {
-      std::printf("COMPILE_FAIL stanc produced no MIR\n");
+      std::printf("COMPILE_FAIL %s produced no MIR\n",
+                  mir_path.empty() ? "stanc" : "MIR file");
       return 1;
     }
   } catch (const std::exception& e) {
-    std::printf("COMPILE_FAIL stanc: %s\n", e.what());
+    std::printf("COMPILE_FAIL %s: %s\n",
+                mir_path.empty() ? "stanc" : "MIR file", e.what());
     return 1;
   }
 


### PR DESCRIPTION
## Summary

- add a measurement-only native OCaml probe that emits portable MIR with upstream vectorize_loops off or on while every shipping producer remains off
- replay the exact saved MIR through semantic, write-array, graph, preparation, reroll-attribution, compile-time, and interleaved gradient checks
- run a bounded seven-model gate in pull-request CI and publish its report artifacts
- document the complete 131-model baseline and keep all C++ reroll cases

## Complete baseline

A clean Release run at d3b7d26 covered 131 models and 393 points: 130 CmdStan-referenced models plus sir as an explicitly labeled A/B-only rejection case.

- zero semantic failures
- zero measurement failures
- five models with changed MIR: covid19imperial_v2, covid19imperial_v3, normal_mixture, radon_pooled, and soil_incubation
- two finite changes, both one-ULP log-density results in soil_incubation
- vectorization removed only 4 of 23 log_prob term-density reroll hits; 19 models still used that C++ rewrite
- 229.898 seconds on macOS 26.4 arm64 with Apple clang 21

Timing ratios are descriptive. This evidence supports the measurement infrastructure, but not enabling the pass or retiring a reroll case.

## Validation

- full CTest: 67/67
- focused CTest: 5/5
- Python harness tests: 13/13
- complete and bounded A/B reports: PASS
- docs generation and formatting checks
- producer-byte/default-pass assertions remain unchanged