### PR TITLE
More fixes for Stan models

### DIFF
--- a/compiler/ocaml/portable_mir.ml
+++ b/compiler/ocaml/portable_mir.ml
@@ -447,9 +447,11 @@ let rec stmt_of_t (stmt : Stmt.Located.t) =
         st_kind= "Return"
       ; st_has_init= Option.is_some expr
       ; st_rhs= Option.value_map expr ~default:(default_expr ()) ~f:expr_of_t }
+  | Break -> {(default_stmt ()) with st_kind= "Break"}
+  | Continue -> {(default_stmt ()) with st_kind= "Continue"}
   | Skip -> {(default_stmt ()) with st_kind= "Skip"}
   | NRFunApp (kind, args) -> nr_fun_app_of_t kind args
-  | JacobianPE _ | Break | Continue | Profile _ ->
+  | JacobianPE _ | Profile _ ->
       { (default_stmt ()) with
         st_kind= "Unsupported"
       ; st_raw= raw_stmt_pattern stmt.pattern }

--- a/runtime/include/stanli/mir.hpp
+++ b/runtime/include/stanli/mir.hpp
@@ -212,6 +212,8 @@ struct Stmt {
     While,
     NRFunApp,
     Return,
+    Break,
+    Continue,
     Skip,
     Unsupported
   } kind = Unsupported;

--- a/runtime/include/stanli/mir_interp.hpp
+++ b/runtime/include/stanli/mir_interp.hpp
@@ -468,7 +468,13 @@ class MirInterp {
           lv.i = {(int)v};
           lv.r = {T((double)v)};
           env_[st.loopvar] = lv;
-          for (const auto& k : st.body) exec(k);
+          try {
+            for (const auto& k : st.body) exec(k);
+          } catch (ContinueV&) {
+            continue;
+          } catch (BreakV&) {
+            break;
+          }
         }
         env_.erase(st.loopvar);
         return;
@@ -487,12 +493,22 @@ class MirInterp {
         int64_t guard = 0;
         while (val(eval(st.cond).r.at(0)) != 0.0) {
           if (++guard > 100000000) fail("while loop did not terminate");
-          for (const auto& k : st.body) exec(k);
+          try {
+            for (const auto& k : st.body) exec(k);
+          } catch (ContinueV&) {
+            continue;
+          } catch (BreakV&) {
+            break;
+          }
         }
         return;
       }
       case mir::Stmt::Return:
         throw ReturnV{st.has_init ? eval(st.rhs) : Value{}};
+      case mir::Stmt::Break:
+        throw BreakV{};
+      case mir::Stmt::Continue:
+        throw ContinueV{};
       case mir::Stmt::NRFunApp:
         // Constraint checks are not executed here, but reject() and
         // print() are: a `reject` in transformed data is how a model
@@ -562,6 +578,8 @@ class MirInterp {
   struct ReturnV {
     Value v;
   };
+  struct BreakV {};
+  struct ContinueV {};
 
   const std::map<std::string, const mir::FunDef*>& funs_;
   std::string where_;

--- a/runtime/include/stanli/mir_prog.hpp
+++ b/runtime/include/stanli/mir_prog.hpp
@@ -71,6 +71,11 @@ struct ProgramCompiler {
   std::map<std::string, std::vector<long>> ints;
   int branch_depth = 0;  // inside a branch on a runtime value
   int inline_depth = 0;
+  struct LoopFrame {
+    std::vector<int> breaks;
+    std::vector<int> continues;
+  };
+  std::vector<LoopFrame> loops;
   // A name that is neither a local nor a compile-time integer. The ODE
   // caller leaves this empty (its arguments are all bound up front);
   // lowering installs a hook that allocates registers for the graph slot
@@ -661,6 +666,8 @@ struct ProgramCompiler {
   struct Returned {
     Range r;
   };
+  struct CompileBreak {};
+  struct CompileContinue {};
 
   int64_t sized_len(const mir::SizedType& t) {
     int64_t n = 1;
@@ -831,13 +838,66 @@ struct ProgramCompiler {
         // program has no way to express; the interpreter still handles it.
         if (branch_depth) bail("return inside a data-dependent branch");
         throw Returned{s.has_init ? expr(s.rhs) : Range{0, 0}};
+      case mir::Stmt::Break:
+        if (loops.empty()) bail("break outside a loop");
+        if (branch_depth) {
+          loops.back().breaks.push_back(emit(Program::JMP, 0));
+          return;
+        }
+        throw CompileBreak{};
+      case mir::Stmt::Continue:
+        if (loops.empty()) bail("continue outside a loop");
+        if (branch_depth) {
+          loops.back().continues.push_back(emit(Program::JMP, 0));
+          return;
+        }
+        throw CompileContinue{};
       case mir::Stmt::For: {
         const long lo = cint(s.lower), hi = cint(s.upper);
+        loops.push_back({});
+        bool broken = false;
         for (long v = lo; v <= hi; ++v) {
           ints[s.loopvar] = {v};
-          for (const auto& k : s.body) stmt(k);
+          try {
+            for (const auto& k : s.body) stmt(k);
+          } catch (CompileContinue&) {
+          } catch (CompileBreak&) {
+            broken = true;
+          }
+          for (int jump : loops.back().continues)
+            p.code[(size_t)jump].dst = (int)p.code.size();
+          loops.back().continues.clear();
+          if (broken) break;
         }
         ints.erase(s.loopvar);
+        for (int jump : loops.back().breaks)
+          p.code[(size_t)jump].dst = (int)p.code.size();
+        loops.pop_back();
+        return;
+      }
+      case mir::Stmt::While: {
+        loops.push_back({});
+        bool broken = false;
+        for (int64_t guard = 0;; ++guard) {
+          long condition;
+          if (!try_cint(s.cond, &condition))
+            bail("while condition is not known at compile time");
+          if (!condition) break;
+          if (guard > 1000000) bail("while loop did not terminate");
+          try {
+            for (const auto& k : s.body) stmt(k);
+          } catch (CompileContinue&) {
+          } catch (CompileBreak&) {
+            broken = true;
+          }
+          for (int jump : loops.back().continues)
+            p.code[(size_t)jump].dst = (int)p.code.size();
+          loops.back().continues.clear();
+          if (broken) break;
+        }
+        for (int jump : loops.back().breaks)
+          p.code[(size_t)jump].dst = (int)p.code.size();
+        loops.pop_back();
         return;
       }
       case mir::Stmt::IfElse: {

--- a/runtime/include/stanli/mir_prog.hpp
+++ b/runtime/include/stanli/mir_prog.hpp
@@ -141,6 +141,70 @@ struct ProgramCompiler {
     return r;
   }
 
+  // ---- shape queries -------------------------------------------------------
+  // rows/cols/size/num_elements are integer functions of a logical view,
+  // and every view inside a region is fixed at compile time even where the
+  // value is a parameter and the branch around it is not. Answering from
+  // the view is the only way these can be answered at all: the register
+  // file holds doubles, and no opcode reports an extent.
+  static bool is_shape_query(const mir::Expr& e) {
+    return e.args.size() == 1 &&
+           (e.name == "rows" || e.name == "cols" || e.name == "size" ||
+            e.name == "num_elements" || e.name == "FnLength");
+  }
+
+  // The answers match the graph lowering's (lower.cpp): `size` and
+  // `FnLength` are an array's first extent and any other value's length,
+  // `num_elements` is the total, and rows/cols read a matrix's declared
+  // extents or a vector's orientation.
+  long shape_query(const std::string& fn, const Range& v) {
+    if (v.kind == ViewKind::Array) {
+      const std::vector<int64_t> dims =
+          v.dims.empty() ? std::vector<int64_t>{v.len} : v.dims;
+      if (fn == "size" || fn == "FnLength") return (long)dims.front();
+      if (fn == "num_elements") return v.len;
+      bail(fn + " is undefined for an array value");
+    }
+    if (fn == "rows")
+      return (long)(v.kind == ViewKind::Matrix      ? v.rows
+                    : v.kind == ViewKind::RowVector ? 1
+                                                    : v.len);
+    if (fn == "cols")
+      return (long)(v.kind == ViewKind::Matrix   ? v.cols
+                    : v.kind == ViewKind::Vector ? 1
+                                                 : v.len);
+    return v.len;
+  }
+
+  // The view of a named value, without building it: a shape query in an
+  // integer position (a declared extent, a loop bound, an index) may not
+  // emit, because try_cint swallows a Bail and a half-built branch would
+  // leave an unpatched jump in the program behind it. Only `len`, `kind`,
+  // `rows`, `cols` and `dims` of the result mean anything; `reg` is not a
+  // register, because no value was built.
+  bool static_view(const mir::Expr& e, Range* out) {
+    if (e.kind != mir::Expr::Var) return false;
+    auto rt = reals.find(e.name);
+    if (rt != reals.end()) {
+      *out = rt->second;
+      return true;
+    }
+    // Every `ints` entry is a compile-time scalar.
+    if (ints.count(e.name)) {
+      *out = Range{0, 1};
+      return true;
+    }
+    // An outside name: bind it the way expr() would. The binding is one
+    // live-in whether it is the shape that is wanted or the value.
+    Range ext;
+    if (bind_extern && bind_extern(e.name, &ext)) {
+      reals[e.name] = ext;
+      *out = ext;
+      return true;
+    }
+    return false;
+  }
+
   // ---- compile-time integers ----------------------------------------------
   long cint(const mir::Expr& e) {
     switch (e.kind) {
@@ -180,6 +244,14 @@ struct ProgramCompiler {
             return cint(e.args[0]) / cint(e.args[1]);
         }
         if (e.args.size() == 1 && e.name == "PMinus__") return -cint(e.args[0]);
+        // A declared extent, a loop bound or an index written as a shape
+        // query: `matrix[rows(m), cols(m)] out;`, `for (i in 1:rows(m))`.
+        // Before this, only a shape query in a real-valued context was
+        // answered, and these were refused as unknown integer functions.
+        if (is_shape_query(e)) {
+          Range v;
+          if (static_view(e.args[0], &v)) return shape_query(e.name, v);
+        }
         bail("integer function " + e.name);
       default:
         bail("integer expression");
@@ -408,6 +480,16 @@ struct ProgramCompiler {
   }
 
   Range fun(const mir::Expr& e) {
+    // A shape query is a constant whatever surrounds it. Ahead of every
+    // other case because `FnLength` is an internal function and the rest
+    // are library ones, and they are all answered the same way: from the
+    // named value's view where there is one, and otherwise from the view
+    // of the value the argument builds.
+    if (is_shape_query(e)) {
+      Range v;
+      if (!static_view(e.args[0], &v)) v = expr(e.args[0]);
+      return {konst((double)shape_query(e.name, v)), 1};
+    }
     if (e.fn_lib == mir::Expr::Lib::UserDefined) {
       auto it = funs.find(e.name);
       if (it == funs.end()) bail("unknown function " + e.name);
@@ -455,19 +537,6 @@ struct ProgramCompiler {
     }
     if (e.args.empty() && e.name == "negative_infinity")
       return {konst(-std::numeric_limits<double>::infinity()), 1};
-    if (e.args.size() == 1 && e.name == "rows") {
-      const Range a = expr(e.args[0]);
-      int64_t n = 0;
-      if (a.kind == ViewKind::Matrix)
-        n = a.rows;
-      else if (a.kind == ViewKind::Vector)
-        n = a.len;
-      else if (a.kind == ViewKind::RowVector)
-        n = 1;
-      else
-        bail("rows requires a matrix or vector logical view");
-      return {konst((double)n), 1};
-    }
     if (e.args.size() == 1 && e.name == "max") {
       const Range a = expr(e.args[0]);
       const int r = alloc(1);

--- a/runtime/include/stanli/mir_prog.hpp
+++ b/runtime/include/stanli/mir_prog.hpp
@@ -69,6 +69,13 @@ struct ProgramCompiler {
   const std::map<std::string, const mir::FunDef*>& funs;
   std::map<std::string, Range> reals;
   std::map<std::string, std::vector<long>> ints;
+  // Where each `ints` entry was declared: its branch depth, and how many
+  // loops enclosed it. Folding an assignment records a value for every
+  // later read of the name, so it is only sound where the assignment
+  // certainly runs -- which is where the declaration itself is. A name the
+  // caller seeded has no entry and is treated as declared outside
+  // everything, which is what it is.
+  std::map<std::string, std::pair<int, size_t>> int_decl_at;
   int branch_depth = 0;  // inside a branch on a runtime value
   int inline_depth = 0;
   struct LoopFrame {
@@ -274,6 +281,22 @@ struct ProgramCompiler {
       return a.len == b.len;
     if (a.kind == ViewKind::Array) return a.len == b.len && a.dims == b.dims;
     return a.rows == b.rows && a.cols == b.cols;
+  }
+
+  // Does an assignment to `name` here run on every path that can reach a
+  // read of it? It does when it sits at the declaration's own branch
+  // depth, and when no loop entered since the declaration has already
+  // taken a data-dependent break or continue -- either would jump from
+  // ahead of the assignment to behind it, past a read that the fold has
+  // already been applied to.
+  bool fold_is_certain(const std::string& name) const {
+    auto it = int_decl_at.find(name);
+    const int depth = it == int_decl_at.end() ? 0 : it->second.first;
+    const size_t enclosing = it == int_decl_at.end() ? 0 : it->second.second;
+    if (branch_depth != depth) return false;
+    for (size_t k = enclosing; k < loops.size(); ++k)
+      if (!loops[k].breaks.empty() || !loops[k].continues.empty()) return false;
+    return true;
   }
 
   static bool is_scalar(const Range& r) {
@@ -799,6 +822,7 @@ struct ProgramCompiler {
     switch (s.kind) {
       case mir::Stmt::Decl: {
         if (s.decl_type.base == "SInt") {
+          int_decl_at[s.decl_id] = {branch_depth, loops.size()};
           if (s.has_init) {
             ints[s.decl_id] = {cint(s.init)};
           } else {
@@ -832,6 +856,17 @@ struct ProgramCompiler {
       }
       case mir::Stmt::Assignment: {
         if (ints.count(s.lhs) && s.lhs_idx.empty()) {
+          // An integer is a compile-time value here: folding this
+          // assignment rewrites every later read of the name, so a path
+          // that skips the assignment and reaches a read would see the
+          // assigned value anyway. Registers hold doubles and cannot carry
+          // an integer instead, so this is refused rather than lowered.
+          // (Before the check, `if (theta > 0) n = 2;` inside a region
+          // took effect on both paths -- and the caller kept its own
+          // pre-region value, so a read after the region saw neither.)
+          if (!fold_is_certain(s.lhs))
+            bail("integer " + s.lhs +
+                 " assigned inside data-dependent control flow");
           ints[s.lhs] = {cint(s.rhs)};
           return;
         }
@@ -940,6 +975,7 @@ struct ProgramCompiler {
         bool broken = false;
         for (long v = lo; v <= hi; ++v) {
           ints[s.loopvar] = {v};
+          int_decl_at[s.loopvar] = {branch_depth, loops.size()};
           try {
             for (const auto& k : s.body) stmt(k);
           } catch (CompileContinue&) {
@@ -952,6 +988,7 @@ struct ProgramCompiler {
           if (broken) break;
         }
         ints.erase(s.loopvar);
+        int_decl_at.erase(s.loopvar);
         for (int jump : loops.back().breaks)
           p.code[(size_t)jump].dst = (int)p.code.size();
         loops.pop_back();
@@ -1044,15 +1081,20 @@ struct ProgramCompiler {
     // restore afterwards. Registers are never reused, so nothing aliases.
     auto saved_reals = reals;
     auto saved_ints = ints;
+    auto saved_int_decl_at = int_decl_at;
     const int saved_branch_depth = branch_depth;
     reals.clear();
     ints.clear();
+    int_decl_at.clear();
     branch_depth = 0;
     for (size_t k = 0; k < f.arg_names.size(); ++k) {
-      if (args[k].is_const_int)
+      if (args[k].is_const_int) {
         ints[f.arg_names[k]] = args[k].ints;
-      else
+        // The body starts here, inside whatever loop the call sits in.
+        int_decl_at[f.arg_names[k]] = {0, loops.size()};
+      } else {
         reals[f.arg_names[k]] = args[k].real;
+      }
     }
     Range out{0, 0};
     try {
@@ -1063,12 +1105,14 @@ struct ProgramCompiler {
     } catch (...) {
       reals = std::move(saved_reals);
       ints = std::move(saved_ints);
+      int_decl_at = std::move(saved_int_decl_at);
       branch_depth = saved_branch_depth;
       --inline_depth;
       throw;
     }
     reals = std::move(saved_reals);
     ints = std::move(saved_ints);
+    int_decl_at = std::move(saved_int_decl_at);
     branch_depth = saved_branch_depth;
     --inline_depth;
     return out;

--- a/runtime/include/stanli/mir_prog.hpp
+++ b/runtime/include/stanli/mir_prog.hpp
@@ -455,6 +455,19 @@ struct ProgramCompiler {
     }
     if (e.args.empty() && e.name == "negative_infinity")
       return {konst(-std::numeric_limits<double>::infinity()), 1};
+    if (e.args.size() == 1 && e.name == "rows") {
+      const Range a = expr(e.args[0]);
+      int64_t n = 0;
+      if (a.kind == ViewKind::Matrix)
+        n = a.rows;
+      else if (a.kind == ViewKind::Vector)
+        n = a.len;
+      else if (a.kind == ViewKind::RowVector)
+        n = 1;
+      else
+        bail("rows requires a matrix or vector logical view");
+      return {konst((double)n), 1};
+    }
     if (e.args.size() == 1 && e.name == "max") {
       const Range a = expr(e.args[0]);
       const int r = alloc(1);

--- a/runtime/src/data.cpp
+++ b/runtime/src/data.cpp
@@ -40,6 +40,13 @@ static DataMap::Entry entry_from_json(const std::string& name, const json& v) {
         dims.push_back(static_cast<int64_t>(cur->size()));
         cur = &(*cur)[0];
       }
+      // The first empty nested array still contributes a trailing zero
+      // extent.  Without it, JSON such as [[], []] was inferred as a
+      // one-dimensional value of length two and the N-D walker then tried
+      // to convert each empty array to a number.  This is the ordinary JSON
+      // representation of array[2] vector[0] (and likewise for deeper
+      // zero-width containers).
+      if (cur->is_array()) dims.push_back(0);
       e.dims = dims;
       if (dims.size() == 2) {
         // Column-major, the Stan/Eigen convention (and what stanc's data

--- a/runtime/src/lower.cpp
+++ b/runtime/src/lower.cpp
@@ -1794,6 +1794,32 @@ struct Lowering {
     return false;
   }
 
+  // A Break/Continue selected by a runtime condition cannot be lowered as a
+  // standalone conditional island: its jump target belongs to the enclosing
+  // loop. Promote that whole loop to the necessity island instead. Nested
+  // loops own their own control statements and therefore stop this search.
+  bool runtime_loop_control(const mir::Stmt& s, bool runtime_path = false) {
+    if (s.kind == mir::Stmt::Break || s.kind == mir::Stmt::Continue)
+      return runtime_path;
+    if (s.kind == mir::Stmt::For || s.kind == mir::Stmt::While) return false;
+    if (s.kind == mir::Stmt::IfElse) {
+      if (auto evaluated = try_eval_pure(s.cond)) {
+        const bool take_then = evaluated->r.at(0) != 0.0;
+        if (take_then && !s.body.empty())
+          return runtime_loop_control(s.body[0], runtime_path);
+        if (!take_then && s.body.size() > 1)
+          return runtime_loop_control(s.body[1], runtime_path);
+        return false;
+      }
+      for (const auto& arm : s.body)
+        if (runtime_loop_control(arm, true)) return true;
+      return false;
+    }
+    for (const auto& child : s.body)
+      if (runtime_loop_control(child, runtime_path)) return true;
+    return false;
+  }
+
   // Every name an Assignment targets anywhere in `s`, in first-seen order.
   void assigned_names(const mir::Stmt& s, std::vector<std::string>* out) {
     if (s.kind == mir::Stmt::Assignment &&
@@ -5119,6 +5145,11 @@ struct Lowering {
         }
         fail("unsupported statement function " + s.fn_name);
       case mir::Stmt::For: {
+        for (const auto& child : s.body)
+          if (runtime_loop_control(child)) {
+            lower_param_ifelse(s);
+            return;
+          }
         const long lo = eval_int(s.lower), hi = eval_int(s.upper);
         for (long v = lo; v <= hi; ++v) {
           int_env[s.loopvar] = v;
@@ -5134,6 +5165,11 @@ struct Lowering {
         return;
       }
       case mir::Stmt::While: {
+        for (const auto& child : s.body)
+          if (runtime_loop_control(child)) {
+            lower_param_ifelse(s);
+            return;
+          }
         // Unrolled like For. The bound only turns a nonterminating unroll
         // into an error instead of an out-of-memory kill.
         for (int64_t guard = 0;; ++guard) {

--- a/runtime/src/lower.cpp
+++ b/runtime/src/lower.cpp
@@ -1370,6 +1370,30 @@ struct Lowering {
     return s;
   }
 
+  // Materialize a declared local that has not received its first value yet.
+  // Stan initializes real locals and containers to NaN (and integer arrays
+  // to INT_MIN).  Both ordinary expression lowering and a runtime region's
+  // live-in binder must see that same value: a name can be read inside a
+  // parameter-dependent branch without being assigned by the branch, so it
+  // will not appear in the region's live-out/assignment scan.
+  int uninitialized_decl_slot(const std::string& name) {
+    auto dl = decls.find(name);
+    if (dl == decls.end()) return -1;
+    SlotInfo si = dl->second.si;
+    si.param_free = true;
+    Val value{add_slot(dl->second.len, false), dl->second.autodiff, si};
+    const double initial =
+        dl->second.int_array
+            ? static_cast<double>(std::numeric_limits<int>::min())
+            : std::numeric_limits<double>::quiet_NaN();
+    out.fills.emplace_back(value.slot,
+                           std::vector<double>(dl->second.len, initial));
+    if (dl->second.int_array) set_uninitialized_int_array(value);
+    observe_fill(value, dl->second.int_array, initial, dl->second.len);
+    scope[name] = value;
+    return value.slot;
+  }
+
   // ---- expressions ----------------------------------------------------------
   Val lower_expr(const mir::Expr& e) {
     Val value = lower_expr_impl(e);
@@ -1399,22 +1423,7 @@ struct Lowering {
           if (s >= 0) return scope.at(e.name);
           // A declared local read before its first write: Materialize
           // the same uninitialized container the indexed-assignment path would.
-          auto dl = decls.find(e.name);
-          if (dl != decls.end()) {
-            SlotInfo si = dl->second.si;
-            si.param_free = true;
-            Val value{add_slot(dl->second.len, false), dl->second.autodiff, si};
-            const double initial =
-                dl->second.int_array
-                    ? static_cast<double>(std::numeric_limits<int>::min())
-                    : std::numeric_limits<double>::quiet_NaN();
-            out.fills.emplace_back(
-                value.slot, std::vector<double>(dl->second.len, initial));
-            if (dl->second.int_array) set_uninitialized_int_array(value);
-            observe_fill(value, dl->second.int_array, initial, dl->second.len);
-            scope[e.name] = value;
-            return value;
-          }
+          if (uninitialized_decl_slot(e.name) >= 0) return scope.at(e.name);
           fail("unknown variable " + e.name);
         }
         return it->second;
@@ -1807,7 +1816,8 @@ struct Lowering {
     for (const auto& [name, value] : decls) outer_names.insert(name);
     c.bind_extern = [&](const std::string& name, Range* r) {
       auto sc = scope.find(name);
-      const int slot = sc != scope.end() ? sc->second.slot : env_slot(name);
+      int slot = sc != scope.end() ? sc->second.slot : env_slot(name);
+      if (slot < 0) slot = uninitialized_decl_slot(name);
       if (slot < 0) return false;
       const int64_t len = g.slots[slot].len;
       r->reg = c.alloc((int)len);

--- a/runtime/src/lower.cpp
+++ b/runtime/src/lower.cpp
@@ -2402,6 +2402,8 @@ struct Lowering {
   struct LpReturn {
     Val v;
   };
+  struct LoopBreak {};
+  struct LoopContinue {};
 
   // Inline a user-defined function at its call site: arguments are lowered
   // in the caller's scope, bound under the parameter names in a shadowed
@@ -5120,7 +5122,13 @@ struct Lowering {
         const long lo = eval_int(s.lower), hi = eval_int(s.upper);
         for (long v = lo; v <= hi; ++v) {
           int_env[s.loopvar] = v;
-          for (const auto& k : s.body) lower_stmt(k);
+          try {
+            for (const auto& k : s.body) lower_stmt(k);
+          } catch (LoopContinue&) {
+            continue;
+          } catch (LoopBreak&) {
+            break;
+          }
         }
         int_env.erase(s.loopvar);
         return;
@@ -5133,7 +5141,13 @@ struct Lowering {
           if (!c) fail("while condition is not data", s.raw);
           if (c->r.at(0) == 0.0) return;
           if (guard > 1000000) fail("while loop did not terminate", s.raw);
-          for (const auto& k : s.body) lower_stmt(k);
+          try {
+            for (const auto& k : s.body) lower_stmt(k);
+          } catch (LoopContinue&) {
+            continue;
+          } catch (LoopBreak&) {
+            return;
+          }
         }
       }
       case mir::Stmt::IfElse: {
@@ -5176,6 +5190,10 @@ struct Lowering {
         // value returns); unwinds to lower_call_udf.
         if (!s.has_init) fail("void return unsupported in UDF inlining");
         throw LpReturn{lower_expr(s.rhs)};
+      case mir::Stmt::Break:
+        throw LoopBreak{};
+      case mir::Stmt::Continue:
+        throw LoopContinue{};
       default:
         fail("unsupported statement", s.raw);
     }

--- a/runtime/src/lower.cpp
+++ b/runtime/src/lower.cpp
@@ -1918,6 +1918,20 @@ struct Lowering {
           reg->has_target = true;
           prog->out_regs.push_back(target_reg);
         }
+        // An integer the region folded is one this lowering holds a copy
+        // of, and the copy is a compile-time constant every later size,
+        // index and read would keep using. The region compiler folds only
+        // what certainly happens, so the value it ends with is the one
+        // every path through the region leaves behind. Nothing carries an
+        // integer out of the program itself: a live-out is a register, and
+        // registers hold doubles.
+        for (const std::string& name : assigned) {
+          auto folded = c.ints.find(name);
+          auto held = int_env.find(name);
+          if (folded != c.ints.end() && folded->second.size() == 1 &&
+              held != int_env.end())
+            held->second = folded->second[0];
+        }
       } else {
         *expr_out = c.expr(*e);
         for (int k = 0; k < expr_out->len; ++k)

--- a/runtime/src/mir_reader.cpp
+++ b/runtime/src/mir_reader.cpp
@@ -633,6 +633,10 @@ Stmt read_stmt(const Node& n) {
   if (p.is_atom()) {
     if (p.atom == "Skip")
       s.kind = Stmt::Skip;
+    else if (p.atom == "Break")
+      s.kind = Stmt::Break;
+    else if (p.atom == "Continue")
+      s.kind = Stmt::Continue;
     else
       s.raw = p.atom;
     return s;

--- a/runtime/src/portable_mir_reader.cpp
+++ b/runtime/src/portable_mir_reader.cpp
@@ -444,6 +444,8 @@ Stmt::Kind read_stmt_kind(const json& value, const std::string& path) {
   STANLI_ENUM_CASE(While);
   STANLI_ENUM_CASE(NRFunApp);
   STANLI_ENUM_CASE(Return);
+  STANLI_ENUM_CASE(Break);
+  STANLI_ENUM_CASE(Continue);
   STANLI_ENUM_CASE(Skip);
   STANLI_ENUM_CASE(Unsupported);
 #undef STANLI_ENUM_CASE

--- a/tests/fixtures/early_return.stan
+++ b/tests/fixtures/early_return.stan
@@ -1,0 +1,18 @@
+// O1 inlining implements an early UDF return with a single-iteration loop
+// and Break statements. The runtime must retain and execute that control
+// flow even though the source contains no explicit break.
+functions {
+  real choose(real x, int first) {
+    if (first) return 2 * x;
+    return 3 * x;
+  }
+}
+data {
+  int first;
+}
+parameters {
+  real theta;
+}
+model {
+  target += choose(theta, first);
+}

--- a/tests/fixtures/early_return.tmir.sexp
+++ b/tests/fixtures/early_return.tmir.sexp
@@ -1,0 +1,320 @@
+((functions_block
+  (((fdrt (ReturnType UReal)) (fdname choose) (fdsuffix FnPlain)
+    (fdargs ((AutoDiffable x UReal) (AutoDiffable first UInt)))
+    (fdbody
+     (((pattern
+        (Block
+         (((pattern
+            (IfElse
+             ((pattern (Var first))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+             ((pattern
+               (Block
+                (((pattern
+                   (Return
+                    (((pattern
+                       (FunApp (StanLib Times__ FnPlain AoS)
+                        (((pattern
+                           (Promotion
+                            ((pattern (Lit Int 2))
+                             (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                            UReal DataOnly))
+                          (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+                         ((pattern (Var x))
+                          (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
+                      (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
+                  (meta <opaque>)))))
+              (meta <opaque>))
+             ()))
+           (meta <opaque>))
+          ((pattern
+            (Return
+             (((pattern
+                (FunApp (StanLib Times__ FnPlain AoS)
+                 (((pattern
+                    (Promotion
+                     ((pattern (Lit Int 3))
+                      (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                     UReal DataOnly))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+                  ((pattern (Var x))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
+           (meta <opaque>)))))
+       (meta <opaque>))))
+    (fdloc <opaque>))))
+ (input_vars ((first <opaque> SInt)))
+ (prepare_data
+  (((pattern
+     (Decl (decl_adtype DataOnly) (decl_id first) (decl_type (Sized SInt))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable first) ()) UInt
+      ((pattern
+        (Indexed
+         ((pattern
+           (FunApp (CompilerInternal FnReadData)
+            (((pattern (Lit Str first))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+          (meta ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly))))
+         ((Single
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))))
+ (log_prob
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id theta) (decl_type (Sized SReal))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity) (dims ()) (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id inline_choose_return_sym4__)
+          (decl_type (Sized SReal)) (initialize Uninit)))
+        (meta <opaque>))
+       ((pattern
+         (Decl (decl_adtype DataOnly) (decl_id inline_choose_early_ret_check_sym5__)
+          (decl_type (Sized SInt)) (initialize Default)))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar inline_choose_iterator_sym6__)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (IfElse
+                  ((pattern (Var first))
+                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                  ((pattern
+                    (Block
+                     (((pattern
+                        (Assignment ((LVariable inline_choose_return_sym4__) ()) UReal
+                         ((pattern
+                           (FunApp (StanLib Times__ FnPlain AoS)
+                            (((pattern
+                               (Promotion
+                                ((pattern (Lit Int 2))
+                                 (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                                UReal DataOnly))
+                              (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+                             ((pattern (Var theta))
+                              (meta
+                               ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
+                          (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+                       (meta <opaque>))
+                      ((pattern Break) (meta <opaque>)))))
+                   (meta <opaque>))
+                  ()))
+                (meta <opaque>))
+               ((pattern
+                 (Assignment ((LVariable inline_choose_return_sym4__) ()) UReal
+                  ((pattern
+                    (FunApp (StanLib Times__ FnPlain AoS)
+                     (((pattern
+                        (Promotion
+                         ((pattern (Lit Int 3))
+                          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                         UReal DataOnly))
+                       (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+                      ((pattern (Var theta))
+                       (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+                (meta <opaque>))
+               ((pattern Break) (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>))
+       ((pattern
+         (TargetPE
+          ((pattern (Var inline_choose_return_sym4__))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>)))))
+    (meta <opaque>))))
+ (reverse_mode_log_prob
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id theta) (decl_type (Sized SReal))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity) (dims ()) (mem_pattern SoA)))
+           ()))
+         (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id inline_choose_return_sym1__)
+          (decl_type (Sized SReal)) (initialize Uninit)))
+        (meta <opaque>))
+       ((pattern
+         (Decl (decl_adtype DataOnly) (decl_id inline_choose_early_ret_check_sym2__)
+          (decl_type (Sized SInt)) (initialize Default)))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar inline_choose_iterator_sym3__)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (IfElse
+                  ((pattern (Var first))
+                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                  ((pattern
+                    (Block
+                     (((pattern
+                        (Assignment ((LVariable inline_choose_return_sym1__) ()) UReal
+                         ((pattern
+                           (FunApp (StanLib Times__ FnPlain SoA)
+                            (((pattern
+                               (Promotion
+                                ((pattern (Lit Int 2))
+                                 (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                                UReal DataOnly))
+                              (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+                             ((pattern (Var theta))
+                              (meta
+                               ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
+                          (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+                       (meta <opaque>))
+                      ((pattern Break) (meta <opaque>)))))
+                   (meta <opaque>))
+                  ()))
+                (meta <opaque>))
+               ((pattern
+                 (Assignment ((LVariable inline_choose_return_sym1__) ()) UReal
+                  ((pattern
+                    (FunApp (StanLib Times__ FnPlain SoA)
+                     (((pattern
+                        (Promotion
+                         ((pattern (Lit Int 3))
+                          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                         UReal DataOnly))
+                       (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+                      ((pattern (Var theta))
+                       (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+                (meta <opaque>))
+               ((pattern Break) (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>))
+       ((pattern
+         (TargetPE
+          ((pattern (Var inline_choose_return_sym1__))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>)))))
+    (meta <opaque>))))
+ (generate_quantities
+  (((pattern
+     (Decl (decl_adtype DataOnly) (decl_id theta) (decl_type (Sized SReal))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity) (dims ()) (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt ())
+        (var
+         ((pattern (Var theta)) (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (IfElse
+      ((pattern
+        (FunApp (StanLib PNot__ FnPlain AoS)
+         (((pattern
+            (EOr
+             ((pattern (Var emit_transformed_parameters__))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+             ((pattern (Var emit_generated_quantities__))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+      ((pattern (Block (((pattern (Return ())) (meta <opaque>))))) (meta <opaque>)) ()))
+    (meta <opaque>))
+   ((pattern
+     (IfElse
+      ((pattern
+        (FunApp (StanLib PNot__ FnPlain AoS)
+         (((pattern (Var emit_generated_quantities__))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+      ((pattern (Block (((pattern (Return ())) (meta <opaque>))))) (meta <opaque>)) ()))
+    (meta <opaque>))))
+ (transform_inits
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id theta) (decl_type (Sized SReal))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable theta) ()) UReal
+      ((pattern
+        (Indexed
+         ((pattern
+           (FunApp (CompilerInternal FnReadData)
+            (((pattern (Lit Str theta))
+              (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+          (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))
+         ((Single
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+       (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var theta)) (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))))
+ (unconstrain_array
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id theta) (decl_type (Sized SReal))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable theta) ()) UReal
+      ((pattern (FunApp (CompilerInternal FnReadDeserializer) ()))
+       (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var theta)) (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))))
+ (output_vars
+  ((theta <opaque>
+    ((out_unconstrained_st SReal) (out_constrained_st SReal) (out_block Parameters)
+     (out_trans Identity)))))
+ (prog_name early_return_model) (prog_path tests/fixtures/early_return.stan))

--- a/tests/fixtures/paramcond_break.stan
+++ b/tests/fixtures/paramcond_break.stan
@@ -1,0 +1,13 @@
+// A break selected by a parameter must be compiled with its enclosing loop,
+// otherwise a conditional island has no jump target for the break.
+parameters {
+  real theta;
+}
+model {
+  real contribution = 0;
+  for (i in 1:3) {
+    if (theta > 0) break;
+    contribution += theta;
+  }
+  target += contribution;
+}

--- a/tests/fixtures/paramcond_break.tmir.sexp
+++ b/tests/fixtures/paramcond_break.tmir.sexp
@@ -1,0 +1,230 @@
+((functions_block ()) (input_vars ()) (prepare_data ())
+ (log_prob
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id theta) (decl_type (Sized SReal))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity) (dims ()) (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id contribution)
+          (decl_type (Sized SReal)) (initialize Uninit)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable contribution) ()) UReal
+          ((pattern
+            (Promotion
+             ((pattern (Lit Int 0))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel AutoDiffable))))
+             UReal AutoDiffable))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar i)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Lit Int 3))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (IfElse
+                  ((pattern
+                    (FunApp (StanLib Greater__ FnPlain AoS)
+                     (((pattern (Var theta))
+                       (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+                      ((pattern (Lit Int 0))
+                       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                   (meta ((type_ UInt) (loc <opaque>) (adlevel AutoDiffable))))
+                  ((pattern (Block (((pattern Break) (meta <opaque>))))) (meta <opaque>))
+                  ()))
+                (meta <opaque>))
+               ((pattern
+                 (Assignment ((LVariable contribution) ()) UReal
+                  ((pattern
+                    (FunApp (StanLib Plus__ FnPlain AoS)
+                     (((pattern (Var contribution))
+                       (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+                      ((pattern (Var theta))
+                       (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>))
+       ((pattern
+         (TargetPE
+          ((pattern (Var contribution))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>)))))
+    (meta <opaque>))))
+ (reverse_mode_log_prob
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id theta) (decl_type (Sized SReal))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity) (dims ()) (mem_pattern SoA)))
+           ()))
+         (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id contribution)
+          (decl_type (Sized SReal)) (initialize Uninit)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable contribution) ()) UReal
+          ((pattern
+            (Promotion
+             ((pattern (Lit Int 0))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel AutoDiffable))))
+             UReal AutoDiffable))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar i)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Lit Int 3))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (IfElse
+                  ((pattern
+                    (FunApp (StanLib Greater__ FnPlain SoA)
+                     (((pattern (Var theta))
+                       (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+                      ((pattern (Lit Int 0))
+                       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                   (meta ((type_ UInt) (loc <opaque>) (adlevel AutoDiffable))))
+                  ((pattern (Block (((pattern Break) (meta <opaque>))))) (meta <opaque>))
+                  ()))
+                (meta <opaque>))
+               ((pattern
+                 (Assignment ((LVariable contribution) ()) UReal
+                  ((pattern
+                    (FunApp (StanLib Plus__ FnPlain SoA)
+                     (((pattern (Var contribution))
+                       (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+                      ((pattern (Var theta))
+                       (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>))
+       ((pattern
+         (TargetPE
+          ((pattern (Var contribution))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>)))))
+    (meta <opaque>))))
+ (generate_quantities
+  (((pattern
+     (Decl (decl_adtype DataOnly) (decl_id theta) (decl_type (Sized SReal))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity) (dims ()) (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt ())
+        (var
+         ((pattern (Var theta)) (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (IfElse
+      ((pattern
+        (FunApp (StanLib PNot__ FnPlain AoS)
+         (((pattern
+            (EOr
+             ((pattern (Var emit_transformed_parameters__))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+             ((pattern (Var emit_generated_quantities__))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+      ((pattern (Block (((pattern (Return ())) (meta <opaque>))))) (meta <opaque>)) ()))
+    (meta <opaque>))
+   ((pattern
+     (IfElse
+      ((pattern
+        (FunApp (StanLib PNot__ FnPlain AoS)
+         (((pattern (Var emit_generated_quantities__))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+      ((pattern (Block (((pattern (Return ())) (meta <opaque>))))) (meta <opaque>)) ()))
+    (meta <opaque>))))
+ (transform_inits
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id theta) (decl_type (Sized SReal))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable theta) ()) UReal
+      ((pattern
+        (Indexed
+         ((pattern
+           (FunApp (CompilerInternal FnReadData)
+            (((pattern (Lit Str theta))
+              (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+          (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))
+         ((Single
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+       (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var theta)) (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))))
+ (unconstrain_array
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id theta) (decl_type (Sized SReal))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable theta) ()) UReal
+      ((pattern (FunApp (CompilerInternal FnReadDeserializer) ()))
+       (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var theta)) (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))))
+ (output_vars
+  ((theta <opaque>
+    ((out_unconstrained_st SReal) (out_constrained_st SReal) (out_block Parameters)
+     (out_trans Identity)))))
+ (prog_name paramcond_break_model) (prog_path tests/fixtures/paramcond_break.stan))

--- a/tests/fixtures/paramcond_int.stan
+++ b/tests/fixtures/paramcond_int.stan
@@ -1,0 +1,21 @@
+// An integer assigned inside parameter-dependent control flow. The region
+// compiles it as a compile-time value, so a fold is sound only where the
+// assignment certainly runs: `n` is assigned before the break, in a loop
+// that runs once, and the lowering takes the folded value back for the
+// statements after the region. `k` is declared and assigned inside the
+// region, where the fold applies to exactly the reads it should.
+parameters {
+  real theta;
+}
+model {
+  int n = 1;
+  real z = 0;
+  for (i in 1 : 1) {
+    n = 2;
+    if (theta > 0) break;
+    int k = 3;
+    k = k + 1;
+    z += k * theta;
+  }
+  target += n * theta + z;
+}

--- a/tests/fixtures/paramcond_int.tmir.sexp
+++ b/tests/fixtures/paramcond_int.tmir.sexp
@@ -1,0 +1,298 @@
+((functions_block ()) (input_vars ()) (prepare_data ())
+ (log_prob
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id theta) (decl_type (Sized SReal))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity) (dims ()) (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id n) (decl_type (Sized SInt))
+          (initialize Uninit)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable n) ()) UInt
+          ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id z) (decl_type (Sized SReal))
+          (initialize Uninit)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable z) ()) UReal
+          ((pattern
+            (Promotion
+             ((pattern (Lit Int 0))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel AutoDiffable))))
+             UReal AutoDiffable))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar i)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (Assignment ((LVariable n) ()) UInt
+                  ((pattern (Lit Int 2))
+                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                (meta <opaque>))
+               ((pattern
+                 (IfElse
+                  ((pattern
+                    (FunApp (StanLib Greater__ FnPlain AoS)
+                     (((pattern (Var theta))
+                       (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+                      ((pattern (Lit Int 0))
+                       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                   (meta ((type_ UInt) (loc <opaque>) (adlevel AutoDiffable))))
+                  ((pattern (Block (((pattern Break) (meta <opaque>))))) (meta <opaque>))
+                  ()))
+                (meta <opaque>))
+               ((pattern
+                 (Decl (decl_adtype AutoDiffable) (decl_id k) (decl_type (Sized SInt))
+                  (initialize Default)))
+                (meta <opaque>))
+               ((pattern
+                 (Assignment ((LVariable z) ()) UReal
+                  ((pattern
+                    (FunApp (StanLib fma FnPlain AoS)
+                     (((pattern
+                        (Promotion
+                         ((pattern (Lit Int 4))
+                          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                         UReal DataOnly))
+                       (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+                      ((pattern (Var theta))
+                       (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+                      ((pattern (Var z))
+                       (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>))
+       ((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib fma FnPlain AoS)
+             (((pattern
+                (Promotion
+                 ((pattern (Var n))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                 UReal DataOnly))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+              ((pattern (Var theta))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+              ((pattern (Var z))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>)))))
+    (meta <opaque>))))
+ (reverse_mode_log_prob
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id theta) (decl_type (Sized SReal))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity) (dims ()) (mem_pattern SoA)))
+           ()))
+         (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id n) (decl_type (Sized SInt))
+          (initialize Uninit)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable n) ()) UInt
+          ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id z) (decl_type (Sized SReal))
+          (initialize Uninit)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable z) ()) UReal
+          ((pattern
+            (Promotion
+             ((pattern (Lit Int 0))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel AutoDiffable))))
+             UReal AutoDiffable))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar i)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (Assignment ((LVariable n) ()) UInt
+                  ((pattern (Lit Int 2))
+                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                (meta <opaque>))
+               ((pattern
+                 (IfElse
+                  ((pattern
+                    (FunApp (StanLib Greater__ FnPlain SoA)
+                     (((pattern (Var theta))
+                       (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+                      ((pattern (Lit Int 0))
+                       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                   (meta ((type_ UInt) (loc <opaque>) (adlevel AutoDiffable))))
+                  ((pattern (Block (((pattern Break) (meta <opaque>))))) (meta <opaque>))
+                  ()))
+                (meta <opaque>))
+               ((pattern
+                 (Decl (decl_adtype AutoDiffable) (decl_id k) (decl_type (Sized SInt))
+                  (initialize Default)))
+                (meta <opaque>))
+               ((pattern
+                 (Assignment ((LVariable z) ()) UReal
+                  ((pattern
+                    (FunApp (StanLib fma FnPlain SoA)
+                     (((pattern
+                        (Promotion
+                         ((pattern (Lit Int 4))
+                          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                         UReal DataOnly))
+                       (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+                      ((pattern (Var theta))
+                       (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+                      ((pattern (Var z))
+                       (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>))
+       ((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib fma FnPlain SoA)
+             (((pattern
+                (Promotion
+                 ((pattern (Var n))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                 UReal DataOnly))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+              ((pattern (Var theta))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+              ((pattern (Var z))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>)))))
+    (meta <opaque>))))
+ (generate_quantities
+  (((pattern
+     (Decl (decl_adtype DataOnly) (decl_id theta) (decl_type (Sized SReal))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity) (dims ()) (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt ())
+        (var
+         ((pattern (Var theta)) (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (IfElse
+      ((pattern
+        (FunApp (StanLib PNot__ FnPlain AoS)
+         (((pattern
+            (EOr
+             ((pattern (Var emit_transformed_parameters__))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+             ((pattern (Var emit_generated_quantities__))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+      ((pattern (Block (((pattern (Return ())) (meta <opaque>))))) (meta <opaque>)) ()))
+    (meta <opaque>))
+   ((pattern
+     (IfElse
+      ((pattern
+        (FunApp (StanLib PNot__ FnPlain AoS)
+         (((pattern (Var emit_generated_quantities__))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+      ((pattern (Block (((pattern (Return ())) (meta <opaque>))))) (meta <opaque>)) ()))
+    (meta <opaque>))))
+ (transform_inits
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id theta) (decl_type (Sized SReal))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable theta) ()) UReal
+      ((pattern
+        (Indexed
+         ((pattern
+           (FunApp (CompilerInternal FnReadData)
+            (((pattern (Lit Str theta))
+              (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+          (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))
+         ((Single
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+       (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var theta)) (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))))
+ (unconstrain_array
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id theta) (decl_type (Sized SReal))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable theta) ()) UReal
+      ((pattern (FunApp (CompilerInternal FnReadDeserializer) ()))
+       (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var theta)) (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))))
+ (output_vars
+  ((theta <opaque>
+    ((out_unconstrained_st SReal) (out_constrained_st SReal) (out_block Parameters)
+     (out_trans Identity)))))
+ (prog_name paramcond_int_model) (prog_path tests/fixtures/paramcond_int.stan))

--- a/tests/fixtures/paramcond_intbranch.stan
+++ b/tests/fixtures/paramcond_intbranch.stan
@@ -1,0 +1,16 @@
+// The same integer, assigned where the assignment may not run. Folding it
+// would apply to every later read, including on the path that skipped it,
+// and no register can carry an integer back to the lowering instead --
+// which held its own pre-region copy. Refused, by name.
+parameters {
+  real theta;
+}
+model {
+  int n = 1;
+  real z = 0;
+  if (theta > 0) {
+    n = 2;
+    z = theta * 5;
+  }
+  target += n * theta + z;
+}

--- a/tests/fixtures/paramcond_intbranch.tmir.sexp
+++ b/tests/fixtures/paramcond_intbranch.tmir.sexp
@@ -1,0 +1,265 @@
+((functions_block ()) (input_vars ()) (prepare_data ())
+ (log_prob
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id theta) (decl_type (Sized SReal))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity) (dims ()) (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id n) (decl_type (Sized SInt))
+          (initialize Uninit)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable n) ()) UInt
+          ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id z) (decl_type (Sized SReal))
+          (initialize Uninit)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable z) ()) UReal
+          ((pattern
+            (Promotion
+             ((pattern (Lit Int 0))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel AutoDiffable))))
+             UReal AutoDiffable))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>))
+       ((pattern
+         (IfElse
+          ((pattern
+            (FunApp (StanLib Greater__ FnPlain AoS)
+             (((pattern (Var theta))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+              ((pattern (Lit Int 0))
+               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel AutoDiffable))))
+          ((pattern
+            (Block
+             (((pattern
+                (Assignment ((LVariable n) ()) UInt
+                 ((pattern (Lit Int 2))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+               (meta <opaque>))
+              ((pattern
+                (Assignment ((LVariable z) ()) UReal
+                 ((pattern
+                   (FunApp (StanLib Times__ FnPlain AoS)
+                    (((pattern (Var theta))
+                      (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+                     ((pattern
+                       (Promotion
+                        ((pattern (Lit Int 5))
+                         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                        UReal DataOnly))
+                      (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+                  (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+               (meta <opaque>)))))
+           (meta <opaque>))
+          ()))
+        (meta <opaque>))
+       ((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib fma FnPlain AoS)
+             (((pattern
+                (Promotion
+                 ((pattern (Var n))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                 UReal DataOnly))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+              ((pattern (Var theta))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+              ((pattern (Var z))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>)))))
+    (meta <opaque>))))
+ (reverse_mode_log_prob
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id theta) (decl_type (Sized SReal))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity) (dims ()) (mem_pattern SoA)))
+           ()))
+         (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id n) (decl_type (Sized SInt))
+          (initialize Uninit)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable n) ()) UInt
+          ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id z) (decl_type (Sized SReal))
+          (initialize Uninit)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable z) ()) UReal
+          ((pattern
+            (Promotion
+             ((pattern (Lit Int 0))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel AutoDiffable))))
+             UReal AutoDiffable))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>))
+       ((pattern
+         (IfElse
+          ((pattern
+            (FunApp (StanLib Greater__ FnPlain SoA)
+             (((pattern (Var theta))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+              ((pattern (Lit Int 0))
+               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel AutoDiffable))))
+          ((pattern
+            (Block
+             (((pattern
+                (Assignment ((LVariable n) ()) UInt
+                 ((pattern (Lit Int 2))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+               (meta <opaque>))
+              ((pattern
+                (Assignment ((LVariable z) ()) UReal
+                 ((pattern
+                   (FunApp (StanLib Times__ FnPlain SoA)
+                    (((pattern (Var theta))
+                      (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+                     ((pattern
+                       (Promotion
+                        ((pattern (Lit Int 5))
+                         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                        UReal DataOnly))
+                      (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+                  (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+               (meta <opaque>)))))
+           (meta <opaque>))
+          ()))
+        (meta <opaque>))
+       ((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib fma FnPlain SoA)
+             (((pattern
+                (Promotion
+                 ((pattern (Var n))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                 UReal DataOnly))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+              ((pattern (Var theta))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+              ((pattern (Var z))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>)))))
+    (meta <opaque>))))
+ (generate_quantities
+  (((pattern
+     (Decl (decl_adtype DataOnly) (decl_id theta) (decl_type (Sized SReal))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity) (dims ()) (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt ())
+        (var
+         ((pattern (Var theta)) (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (IfElse
+      ((pattern
+        (FunApp (StanLib PNot__ FnPlain AoS)
+         (((pattern
+            (EOr
+             ((pattern (Var emit_transformed_parameters__))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+             ((pattern (Var emit_generated_quantities__))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+      ((pattern (Block (((pattern (Return ())) (meta <opaque>))))) (meta <opaque>)) ()))
+    (meta <opaque>))
+   ((pattern
+     (IfElse
+      ((pattern
+        (FunApp (StanLib PNot__ FnPlain AoS)
+         (((pattern (Var emit_generated_quantities__))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+      ((pattern (Block (((pattern (Return ())) (meta <opaque>))))) (meta <opaque>)) ()))
+    (meta <opaque>))))
+ (transform_inits
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id theta) (decl_type (Sized SReal))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable theta) ()) UReal
+      ((pattern
+        (Indexed
+         ((pattern
+           (FunApp (CompilerInternal FnReadData)
+            (((pattern (Lit Str theta))
+              (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+          (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))
+         ((Single
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+       (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var theta)) (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))))
+ (unconstrain_array
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id theta) (decl_type (Sized SReal))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable theta) ()) UReal
+      ((pattern (FunApp (CompilerInternal FnReadDeserializer) ()))
+       (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var theta)) (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))))
+ (output_vars
+  ((theta <opaque>
+    ((out_unconstrained_st SReal) (out_constrained_st SReal) (out_block Parameters)
+     (out_trans Identity)))))
+ (prog_name paramcond_intbranch_model)
+ (prog_path tests/fixtures/paramcond_intbranch.stan))

--- a/tests/fixtures/paramcond_rows.stan
+++ b/tests/fixtures/paramcond_rows.stan
@@ -1,0 +1,16 @@
+// A shape query inside parameter-dependent control flow is compiled by the
+// runtime-region register machine. Its answer comes from the logical matrix
+// view and remains a constant while the surrounding expression differentiates.
+parameters {
+  real theta;
+  matrix[2, 3] x;
+}
+model {
+  real contribution;
+  if (theta > 0) {
+    contribution = rows(x) * theta;
+  } else {
+    contribution = theta;
+  }
+  target += contribution;
+}

--- a/tests/fixtures/paramcond_rows.tmir.sexp
+++ b/tests/fixtures/paramcond_rows.tmir.sexp
@@ -1,0 +1,425 @@
+((functions_block ()) (input_vars ()) (prepare_data ())
+ (log_prob
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id theta) (decl_type (Sized SReal))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity) (dims ()) (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id x)
+      (decl_type
+       (Sized
+        (SMatrix AoS
+         ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+         ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity)
+             (dims
+              (((pattern (Lit Int 2))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+               ((pattern (Lit Int 3))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id contribution)
+          (decl_type (Sized SReal)) (initialize Default)))
+        (meta <opaque>))
+       ((pattern
+         (IfElse
+          ((pattern
+            (FunApp (StanLib Greater__ FnPlain AoS)
+             (((pattern (Var theta))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+              ((pattern (Lit Int 0))
+               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel AutoDiffable))))
+          ((pattern
+            (Block
+             (((pattern
+                (Assignment ((LVariable contribution) ()) UReal
+                 ((pattern
+                   (FunApp (StanLib Times__ FnPlain AoS)
+                    (((pattern
+                       (Promotion
+                        ((pattern
+                          (FunApp (StanLib rows FnPlain AoS)
+                           (((pattern (Var x))
+                             (meta
+                              ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable)))))))
+                         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                        UReal DataOnly))
+                      (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+                     ((pattern (Var theta))
+                      (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
+                  (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+               (meta <opaque>)))))
+           (meta <opaque>))
+          (((pattern
+             (Block
+              (((pattern
+                 (Assignment ((LVariable contribution) ()) UReal
+                  ((pattern (Var theta))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>))
+       ((pattern
+         (TargetPE
+          ((pattern (Var contribution))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>)))))
+    (meta <opaque>))))
+ (reverse_mode_log_prob
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id theta) (decl_type (Sized SReal))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity) (dims ()) (mem_pattern SoA)))
+           ()))
+         (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id x)
+      (decl_type
+       (Sized
+        (SMatrix SoA
+         ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+         ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity)
+             (dims
+              (((pattern (Lit Int 2))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+               ((pattern (Lit Int 3))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern SoA)))
+           ()))
+         (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id contribution)
+          (decl_type (Sized SReal)) (initialize Default)))
+        (meta <opaque>))
+       ((pattern
+         (IfElse
+          ((pattern
+            (FunApp (StanLib Greater__ FnPlain SoA)
+             (((pattern (Var theta))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+              ((pattern (Lit Int 0))
+               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel AutoDiffable))))
+          ((pattern
+            (Block
+             (((pattern
+                (Assignment ((LVariable contribution) ()) UReal
+                 ((pattern
+                   (FunApp (StanLib Times__ FnPlain SoA)
+                    (((pattern
+                       (Promotion
+                        ((pattern
+                          (FunApp (StanLib rows FnPlain SoA)
+                           (((pattern (Var x))
+                             (meta
+                              ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable)))))))
+                         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                        UReal DataOnly))
+                      (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+                     ((pattern (Var theta))
+                      (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
+                  (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+               (meta <opaque>)))))
+           (meta <opaque>))
+          (((pattern
+             (Block
+              (((pattern
+                 (Assignment ((LVariable contribution) ()) UReal
+                  ((pattern (Var theta))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>))
+       ((pattern
+         (TargetPE
+          ((pattern (Var contribution))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>)))))
+    (meta <opaque>))))
+ (generate_quantities
+  (((pattern
+     (Decl (decl_adtype DataOnly) (decl_id theta) (decl_type (Sized SReal))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity) (dims ()) (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id x)
+      (decl_type
+       (Sized
+        (SMatrix AoS
+         ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+         ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity)
+             (dims
+              (((pattern (Lit Int 2))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+               ((pattern (Lit Int 3))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt ())
+        (var
+         ((pattern (Var theta)) (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt ())
+        (var
+         ((pattern (Var x)) (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (IfElse
+      ((pattern
+        (FunApp (StanLib PNot__ FnPlain AoS)
+         (((pattern
+            (EOr
+             ((pattern (Var emit_transformed_parameters__))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+             ((pattern (Var emit_generated_quantities__))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+      ((pattern (Block (((pattern (Return ())) (meta <opaque>))))) (meta <opaque>)) ()))
+    (meta <opaque>))
+   ((pattern
+     (IfElse
+      ((pattern
+        (FunApp (StanLib PNot__ FnPlain AoS)
+         (((pattern (Var emit_generated_quantities__))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+      ((pattern (Block (((pattern (Return ())) (meta <opaque>))))) (meta <opaque>)) ()))
+    (meta <opaque>))))
+ (transform_inits
+  (((pattern
+     (Decl (decl_adtype DataOnly) (decl_id pos__) (decl_type (Sized SInt))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id theta) (decl_type (Sized SReal))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable theta) ()) UReal
+      ((pattern
+        (Indexed
+         ((pattern
+           (FunApp (CompilerInternal FnReadData)
+            (((pattern (Lit Str theta))
+              (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+          (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))
+         ((Single
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+       (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var theta)) (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id x)
+      (decl_type
+       (Sized
+        (SMatrix AoS
+         ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+         ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id x_flat__)
+          (decl_type (Unsized (UArray UReal))) (initialize Uninit)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable x_flat__) ()) (UArray UReal)
+          ((pattern
+            (FunApp (CompilerInternal FnReadData)
+             (((pattern (Lit Str x))
+               (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable pos__) ()) UInt
+          ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar sym1__)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Lit Int 3))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (For (loopvar sym2__)
+                  (lower
+                   ((pattern (Lit Int 1))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (upper
+                   ((pattern (Lit Int 2))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (body
+                   ((pattern
+                     (Block
+                      (((pattern
+                         (Assignment
+                          ((LVariable x)
+                           ((Single
+                             ((pattern (Var sym2__))
+                              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                            (Single
+                             ((pattern (Var sym1__))
+                              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                          UMatrix
+                          ((pattern
+                            (Indexed
+                             ((pattern (Var x_flat__))
+                              (meta
+                               ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))
+                             ((Single
+                               ((pattern (Var pos__))
+                                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                           (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+                        (meta <opaque>))
+                       ((pattern
+                         (Assignment ((LVariable pos__) ()) UInt
+                          ((pattern
+                            (FunApp (StanLib Plus__ FnPlain AoS)
+                             (((pattern (Var pos__))
+                               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                              ((pattern (Lit Int 1))
+                               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                        (meta <opaque>)))))
+                    (meta <opaque>)))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var x)) (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))))
+ (unconstrain_array
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id theta) (decl_type (Sized SReal))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable theta) ()) UReal
+      ((pattern (FunApp (CompilerInternal FnReadDeserializer) ()))
+       (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var theta)) (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id x)
+      (decl_type
+       (Sized
+        (SMatrix AoS
+         ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+         ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable x) ()) UMatrix
+      ((pattern
+        (FunApp (CompilerInternal FnReadDeserializer)
+         (((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+          ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var x)) (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))))
+ (output_vars
+  ((theta <opaque>
+    ((out_unconstrained_st SReal) (out_constrained_st SReal) (out_block Parameters)
+     (out_trans Identity)))
+   (x <opaque>
+    ((out_unconstrained_st
+      (SMatrix AoS
+       ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+       ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+     (out_constrained_st
+      (SMatrix AoS
+       ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+       ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+     (out_block Parameters) (out_trans Identity)))))
+ (prog_name paramcond_rows_model) (prog_path tests/fixtures/paramcond_rows.stan))

--- a/tests/fixtures/paramcond_shape.stan
+++ b/tests/fixtures/paramcond_shape.stan
@@ -1,0 +1,20 @@
+// Shape queries in the integer positions inside parameter-dependent
+// control flow: declared extents, an integer local, a loop bound. The
+// register-machine region answers each from the logical view, which is
+// fixed even where the value is a parameter and the branch is not.
+parameters {
+  real theta;
+  matrix[2, 3] x;
+  array[4] real a;
+}
+model {
+  if (theta > 0) {
+    matrix[rows(x), cols(x)] y = x;
+    int k = num_elements(y) + cols(y);
+    real acc = 0;
+    for (i in 1 : size(a)) acc += a[i];
+    target += k * theta + acc;
+  } else {
+    target += theta;
+  }
+}

--- a/tests/fixtures/paramcond_shape.tmir.sexp
+++ b/tests/fixtures/paramcond_shape.tmir.sexp
@@ -1,0 +1,750 @@
+((functions_block ()) (input_vars ()) (prepare_data ())
+ (log_prob
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id theta) (decl_type (Sized SReal))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity) (dims ()) (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id x)
+      (decl_type
+       (Sized
+        (SMatrix AoS
+         ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+         ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity)
+             (dims
+              (((pattern (Lit Int 2))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+               ((pattern (Lit Int 3))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id a)
+      (decl_type
+       (Sized
+        (SArray SReal
+         ((pattern (Lit Int 4)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity)
+             (dims
+              (((pattern (Lit Int 4))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern AoS)))
+           ()))
+         (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (IfElse
+          ((pattern
+            (FunApp (StanLib Greater__ FnPlain AoS)
+             (((pattern (Var theta))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+              ((pattern (Lit Int 0))
+               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel AutoDiffable))))
+          ((pattern
+            (Block
+             (((pattern
+                (NRFunApp (CompilerInternal FnValidateSize)
+                 (((pattern (Lit Str y))
+                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                  ((pattern (Lit Str "rows(x)"))
+                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                  ((pattern
+                    (FunApp (StanLib rows FnPlain AoS)
+                     (((pattern (Var x))
+                       (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable)))))))
+                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+               (meta <opaque>))
+              ((pattern
+                (NRFunApp (CompilerInternal FnValidateSize)
+                 (((pattern (Lit Str y))
+                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                  ((pattern (Lit Str "cols(x)"))
+                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                  ((pattern
+                    (FunApp (StanLib cols FnPlain AoS)
+                     (((pattern (Var x))
+                       (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable)))))))
+                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+               (meta <opaque>))
+              ((pattern
+                (Decl (decl_adtype AutoDiffable) (decl_id y)
+                 (decl_type
+                  (Sized
+                   (SMatrix AoS
+                    ((pattern
+                      (FunApp (StanLib rows FnPlain AoS)
+                       (((pattern (Var x))
+                         (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable)))))))
+                     (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                    ((pattern
+                      (FunApp (StanLib cols FnPlain AoS)
+                       (((pattern (Var x))
+                         (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable)))))))
+                     (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                 (initialize Default)))
+               (meta <opaque>))
+              ((pattern
+                (Decl (decl_adtype AutoDiffable) (decl_id k) (decl_type (Sized SInt))
+                 (initialize Uninit)))
+               (meta <opaque>))
+              ((pattern
+                (Assignment ((LVariable k) ()) UInt
+                 ((pattern
+                   (FunApp (StanLib Plus__ FnPlain AoS)
+                    (((pattern
+                       (FunApp (StanLib num_elements FnPlain AoS)
+                        (((pattern (Var x))
+                          (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable)))))))
+                      (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                     ((pattern
+                       (FunApp (StanLib cols FnPlain AoS)
+                        (((pattern (Var x))
+                          (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable)))))))
+                      (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+               (meta <opaque>))
+              ((pattern
+                (Decl (decl_adtype AutoDiffable) (decl_id acc) (decl_type (Sized SReal))
+                 (initialize Uninit)))
+               (meta <opaque>))
+              ((pattern
+                (Assignment ((LVariable acc) ()) UReal
+                 ((pattern
+                   (Promotion
+                    ((pattern (Lit Int 0))
+                     (meta ((type_ UInt) (loc <opaque>) (adlevel AutoDiffable))))
+                    UReal AutoDiffable))
+                  (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+               (meta <opaque>))
+              ((pattern
+                (For (loopvar i)
+                 (lower
+                  ((pattern (Lit Int 1))
+                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                 (upper
+                  ((pattern
+                    (FunApp (StanLib size FnPlain AoS)
+                     (((pattern (Var a))
+                       (meta
+                        ((type_ (UArray UReal)) (loc <opaque>) (adlevel AutoDiffable)))))))
+                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                 (body
+                  ((pattern
+                    (Block
+                     (((pattern
+                        (Assignment ((LVariable acc) ()) UReal
+                         ((pattern
+                           (FunApp (StanLib Plus__ FnPlain AoS)
+                            (((pattern (Var acc))
+                              (meta
+                               ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+                             ((pattern
+                               (Indexed
+                                ((pattern (Var a))
+                                 (meta
+                                  ((type_ (UArray UReal)) (loc <opaque>)
+                                   (adlevel AutoDiffable))))
+                                ((Single
+                                  ((pattern (Var i))
+                                   (meta
+                                    ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                              (meta
+                               ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
+                          (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+                       (meta <opaque>)))))
+                   (meta <opaque>)))))
+               (meta <opaque>))
+              ((pattern
+                (TargetPE
+                 ((pattern
+                   (FunApp (StanLib fma FnPlain AoS)
+                    (((pattern
+                       (Promotion
+                        ((pattern (Var k))
+                         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                        UReal DataOnly))
+                      (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+                     ((pattern (Var theta))
+                      (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+                     ((pattern (Var acc))
+                      (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
+                  (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+               (meta <opaque>)))))
+           (meta <opaque>))
+          (((pattern
+             (Block
+              (((pattern
+                 (TargetPE
+                  ((pattern (Var theta))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))))
+ (reverse_mode_log_prob
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id theta) (decl_type (Sized SReal))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity) (dims ()) (mem_pattern SoA)))
+           ()))
+         (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id x)
+      (decl_type
+       (Sized
+        (SMatrix SoA
+         ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+         ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity)
+             (dims
+              (((pattern (Lit Int 2))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+               ((pattern (Lit Int 3))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern SoA)))
+           ()))
+         (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id a)
+      (decl_type
+       (Sized
+        (SArray SReal
+         ((pattern (Lit Int 4)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity)
+             (dims
+              (((pattern (Lit Int 4))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern SoA)))
+           ()))
+         (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (IfElse
+          ((pattern
+            (FunApp (StanLib Greater__ FnPlain SoA)
+             (((pattern (Var theta))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+              ((pattern (Lit Int 0))
+               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel AutoDiffable))))
+          ((pattern
+            (Block
+             (((pattern
+                (NRFunApp (CompilerInternal FnValidateSize)
+                 (((pattern (Lit Str y))
+                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                  ((pattern (Lit Str "rows(x)"))
+                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                  ((pattern
+                    (FunApp (StanLib rows FnPlain SoA)
+                     (((pattern (Var x))
+                       (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable)))))))
+                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+               (meta <opaque>))
+              ((pattern
+                (NRFunApp (CompilerInternal FnValidateSize)
+                 (((pattern (Lit Str y))
+                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                  ((pattern (Lit Str "cols(x)"))
+                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                  ((pattern
+                    (FunApp (StanLib cols FnPlain SoA)
+                     (((pattern (Var x))
+                       (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable)))))))
+                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+               (meta <opaque>))
+              ((pattern
+                (Decl (decl_adtype AutoDiffable) (decl_id y)
+                 (decl_type
+                  (Sized
+                   (SMatrix SoA
+                    ((pattern
+                      (FunApp (StanLib rows FnPlain SoA)
+                       (((pattern (Var x))
+                         (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable)))))))
+                     (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                    ((pattern
+                      (FunApp (StanLib cols FnPlain SoA)
+                       (((pattern (Var x))
+                         (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable)))))))
+                     (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                 (initialize Default)))
+               (meta <opaque>))
+              ((pattern
+                (Decl (decl_adtype AutoDiffable) (decl_id k) (decl_type (Sized SInt))
+                 (initialize Uninit)))
+               (meta <opaque>))
+              ((pattern
+                (Assignment ((LVariable k) ()) UInt
+                 ((pattern
+                   (FunApp (StanLib Plus__ FnPlain SoA)
+                    (((pattern
+                       (FunApp (StanLib num_elements FnPlain SoA)
+                        (((pattern (Var x))
+                          (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable)))))))
+                      (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                     ((pattern
+                       (FunApp (StanLib cols FnPlain SoA)
+                        (((pattern (Var x))
+                          (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable)))))))
+                      (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+               (meta <opaque>))
+              ((pattern
+                (Decl (decl_adtype AutoDiffable) (decl_id acc) (decl_type (Sized SReal))
+                 (initialize Uninit)))
+               (meta <opaque>))
+              ((pattern
+                (Assignment ((LVariable acc) ()) UReal
+                 ((pattern
+                   (Promotion
+                    ((pattern (Lit Int 0))
+                     (meta ((type_ UInt) (loc <opaque>) (adlevel AutoDiffable))))
+                    UReal AutoDiffable))
+                  (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+               (meta <opaque>))
+              ((pattern
+                (For (loopvar i)
+                 (lower
+                  ((pattern (Lit Int 1))
+                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                 (upper
+                  ((pattern
+                    (FunApp (StanLib size FnPlain SoA)
+                     (((pattern (Var a))
+                       (meta
+                        ((type_ (UArray UReal)) (loc <opaque>) (adlevel AutoDiffable)))))))
+                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                 (body
+                  ((pattern
+                    (Block
+                     (((pattern
+                        (Assignment ((LVariable acc) ()) UReal
+                         ((pattern
+                           (FunApp (StanLib Plus__ FnPlain SoA)
+                            (((pattern (Var acc))
+                              (meta
+                               ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+                             ((pattern
+                               (Indexed
+                                ((pattern (Var a))
+                                 (meta
+                                  ((type_ (UArray UReal)) (loc <opaque>)
+                                   (adlevel AutoDiffable))))
+                                ((Single
+                                  ((pattern (Var i))
+                                   (meta
+                                    ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                              (meta
+                               ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
+                          (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+                       (meta <opaque>)))))
+                   (meta <opaque>)))))
+               (meta <opaque>))
+              ((pattern
+                (TargetPE
+                 ((pattern
+                   (FunApp (StanLib fma FnPlain SoA)
+                    (((pattern
+                       (Promotion
+                        ((pattern (Var k))
+                         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                        UReal DataOnly))
+                      (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+                     ((pattern (Var theta))
+                      (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+                     ((pattern (Var acc))
+                      (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
+                  (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+               (meta <opaque>)))))
+           (meta <opaque>))
+          (((pattern
+             (Block
+              (((pattern
+                 (TargetPE
+                  ((pattern (Var theta))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))))
+ (generate_quantities
+  (((pattern
+     (Decl (decl_adtype DataOnly) (decl_id theta) (decl_type (Sized SReal))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity) (dims ()) (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id x)
+      (decl_type
+       (Sized
+        (SMatrix AoS
+         ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+         ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity)
+             (dims
+              (((pattern (Lit Int 2))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+               ((pattern (Lit Int 3))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id a)
+      (decl_type
+       (Sized
+        (SArray SReal
+         ((pattern (Lit Int 4)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity)
+             (dims
+              (((pattern (Lit Int 4))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern AoS)))
+           ()))
+         (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt ())
+        (var
+         ((pattern (Var theta)) (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt ())
+        (var
+         ((pattern (Var x)) (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt ())
+        (var
+         ((pattern (Var a))
+          (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (IfElse
+      ((pattern
+        (FunApp (StanLib PNot__ FnPlain AoS)
+         (((pattern
+            (EOr
+             ((pattern (Var emit_transformed_parameters__))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+             ((pattern (Var emit_generated_quantities__))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+      ((pattern (Block (((pattern (Return ())) (meta <opaque>))))) (meta <opaque>)) ()))
+    (meta <opaque>))
+   ((pattern
+     (IfElse
+      ((pattern
+        (FunApp (StanLib PNot__ FnPlain AoS)
+         (((pattern (Var emit_generated_quantities__))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+      ((pattern (Block (((pattern (Return ())) (meta <opaque>))))) (meta <opaque>)) ()))
+    (meta <opaque>))))
+ (transform_inits
+  (((pattern
+     (Decl (decl_adtype DataOnly) (decl_id pos__) (decl_type (Sized SInt))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id theta) (decl_type (Sized SReal))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable theta) ()) UReal
+      ((pattern
+        (Indexed
+         ((pattern
+           (FunApp (CompilerInternal FnReadData)
+            (((pattern (Lit Str theta))
+              (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+          (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))
+         ((Single
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+       (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var theta)) (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id x)
+      (decl_type
+       (Sized
+        (SMatrix AoS
+         ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+         ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id x_flat__)
+          (decl_type (Unsized (UArray UReal))) (initialize Uninit)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable x_flat__) ()) (UArray UReal)
+          ((pattern
+            (FunApp (CompilerInternal FnReadData)
+             (((pattern (Lit Str x))
+               (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable pos__) ()) UInt
+          ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar sym1__)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Lit Int 3))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (For (loopvar sym2__)
+                  (lower
+                   ((pattern (Lit Int 1))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (upper
+                   ((pattern (Lit Int 2))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (body
+                   ((pattern
+                     (Block
+                      (((pattern
+                         (Assignment
+                          ((LVariable x)
+                           ((Single
+                             ((pattern (Var sym2__))
+                              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                            (Single
+                             ((pattern (Var sym1__))
+                              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                          UMatrix
+                          ((pattern
+                            (Indexed
+                             ((pattern (Var x_flat__))
+                              (meta
+                               ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))
+                             ((Single
+                               ((pattern (Var pos__))
+                                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                           (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+                        (meta <opaque>))
+                       ((pattern
+                         (Assignment ((LVariable pos__) ()) UInt
+                          ((pattern
+                            (FunApp (StanLib Plus__ FnPlain AoS)
+                             (((pattern (Var pos__))
+                               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                              ((pattern (Lit Int 1))
+                               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                        (meta <opaque>)))))
+                    (meta <opaque>)))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var x)) (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id a)
+      (decl_type
+       (Sized
+        (SArray SReal
+         ((pattern (Lit Int 4)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable a) ()) (UArray UReal)
+      ((pattern
+        (FunApp (CompilerInternal FnReadData)
+         (((pattern (Lit Str a))
+           (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var a))
+          (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))))
+ (unconstrain_array
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id theta) (decl_type (Sized SReal))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable theta) ()) UReal
+      ((pattern (FunApp (CompilerInternal FnReadDeserializer) ()))
+       (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var theta)) (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id x)
+      (decl_type
+       (Sized
+        (SMatrix AoS
+         ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+         ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable x) ()) UMatrix
+      ((pattern
+        (FunApp (CompilerInternal FnReadDeserializer)
+         (((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+          ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var x)) (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id a)
+      (decl_type
+       (Sized
+        (SArray SReal
+         ((pattern (Lit Int 4)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable a) ()) (UArray UReal)
+      ((pattern
+        (FunApp (CompilerInternal FnReadDeserializer)
+         (((pattern (Lit Int 4)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel AutoDiffable))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var a))
+          (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))))
+ (output_vars
+  ((theta <opaque>
+    ((out_unconstrained_st SReal) (out_constrained_st SReal) (out_block Parameters)
+     (out_trans Identity)))
+   (x <opaque>
+    ((out_unconstrained_st
+      (SMatrix AoS
+       ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+       ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+     (out_constrained_st
+      (SMatrix AoS
+       ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+       ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+     (out_block Parameters) (out_trans Identity)))
+   (a <opaque>
+    ((out_unconstrained_st
+      (SArray SReal
+       ((pattern (Lit Int 4)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+     (out_constrained_st
+      (SArray SReal
+       ((pattern (Lit Int 4)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+     (out_block Parameters) (out_trans Identity)))))
+ (prog_name paramcond_shape_model) (prog_path tests/fixtures/paramcond_shape.stan))

--- a/tests/fixtures/paramcond_uninitialized.stan
+++ b/tests/fixtures/paramcond_uninitialized.stan
@@ -1,0 +1,15 @@
+// A declared but uninitialized local read only inside a parameter-dependent
+// branch must be a NaN-filled island live-in, not an unknown variable.
+parameters {
+  real theta;
+}
+model {
+  matrix[1, 1] uninitialized;
+  real contribution;
+  if (theta > 0) {
+    contribution = uninitialized[1, 1];
+  } else {
+    contribution = theta;
+  }
+  target += contribution;
+}

--- a/tests/fixtures/paramcond_uninitialized.tmir.sexp
+++ b/tests/fixtures/paramcond_uninitialized.tmir.sexp
@@ -1,0 +1,235 @@
+((functions_block ()) (input_vars ()) (prepare_data ())
+ (log_prob
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id theta) (decl_type (Sized SReal))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity) (dims ()) (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id uninitialized)
+          (decl_type
+           (Sized
+            (SMatrix AoS
+             ((pattern (Lit Int 1))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+             ((pattern (Lit Int 1))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+          (initialize Default)))
+        (meta <opaque>))
+       ((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id contribution)
+          (decl_type (Sized SReal)) (initialize Default)))
+        (meta <opaque>))
+       ((pattern
+         (IfElse
+          ((pattern
+            (FunApp (StanLib Greater__ FnPlain AoS)
+             (((pattern (Var theta))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+              ((pattern (Lit Int 0))
+               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel AutoDiffable))))
+          ((pattern
+            (Block
+             (((pattern
+                (Assignment ((LVariable contribution) ()) UReal
+                 ((pattern
+                   (Indexed
+                    ((pattern (Var uninitialized))
+                     (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))
+                    ((Single
+                      ((pattern (Lit Int 1))
+                       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                     (Single
+                      ((pattern (Lit Int 1))
+                       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                  (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+               (meta <opaque>)))))
+           (meta <opaque>))
+          (((pattern
+             (Block
+              (((pattern
+                 (Assignment ((LVariable contribution) ()) UReal
+                  ((pattern (Var theta))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>))
+       ((pattern
+         (TargetPE
+          ((pattern (Var contribution))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>)))))
+    (meta <opaque>))))
+ (reverse_mode_log_prob
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id theta) (decl_type (Sized SReal))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity) (dims ()) (mem_pattern SoA)))
+           ()))
+         (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id uninitialized)
+          (decl_type
+           (Sized
+            (SMatrix SoA
+             ((pattern (Lit Int 1))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+             ((pattern (Lit Int 1))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+          (initialize Default)))
+        (meta <opaque>))
+       ((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id contribution)
+          (decl_type (Sized SReal)) (initialize Default)))
+        (meta <opaque>))
+       ((pattern
+         (IfElse
+          ((pattern
+            (FunApp (StanLib Greater__ FnPlain SoA)
+             (((pattern (Var theta))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+              ((pattern (Lit Int 0))
+               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel AutoDiffable))))
+          ((pattern
+            (Block
+             (((pattern
+                (Assignment ((LVariable contribution) ()) UReal
+                 ((pattern
+                   (Indexed
+                    ((pattern (Var uninitialized))
+                     (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))
+                    ((Single
+                      ((pattern (Lit Int 1))
+                       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                     (Single
+                      ((pattern (Lit Int 1))
+                       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                  (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+               (meta <opaque>)))))
+           (meta <opaque>))
+          (((pattern
+             (Block
+              (((pattern
+                 (Assignment ((LVariable contribution) ()) UReal
+                  ((pattern (Var theta))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>))
+       ((pattern
+         (TargetPE
+          ((pattern (Var contribution))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>)))))
+    (meta <opaque>))))
+ (generate_quantities
+  (((pattern
+     (Decl (decl_adtype DataOnly) (decl_id theta) (decl_type (Sized SReal))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity) (dims ()) (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt ())
+        (var
+         ((pattern (Var theta)) (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (IfElse
+      ((pattern
+        (FunApp (StanLib PNot__ FnPlain AoS)
+         (((pattern
+            (EOr
+             ((pattern (Var emit_transformed_parameters__))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+             ((pattern (Var emit_generated_quantities__))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+      ((pattern (Block (((pattern (Return ())) (meta <opaque>))))) (meta <opaque>)) ()))
+    (meta <opaque>))
+   ((pattern
+     (IfElse
+      ((pattern
+        (FunApp (StanLib PNot__ FnPlain AoS)
+         (((pattern (Var emit_generated_quantities__))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+      ((pattern (Block (((pattern (Return ())) (meta <opaque>))))) (meta <opaque>)) ()))
+    (meta <opaque>))))
+ (transform_inits
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id theta) (decl_type (Sized SReal))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable theta) ()) UReal
+      ((pattern
+        (Indexed
+         ((pattern
+           (FunApp (CompilerInternal FnReadData)
+            (((pattern (Lit Str theta))
+              (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+          (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))
+         ((Single
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+       (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var theta)) (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))))
+ (unconstrain_array
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id theta) (decl_type (Sized SReal))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable theta) ()) UReal
+      ((pattern (FunApp (CompilerInternal FnReadDeserializer) ()))
+       (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var theta)) (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))))
+ (output_vars
+  ((theta <opaque>
+    ((out_unconstrained_st SReal) (out_constrained_st SReal) (out_block Parameters)
+     (out_trans Identity)))))
+ (prog_name paramcond_uninitialized_model)
+ (prog_path tests/fixtures/paramcond_uninitialized.stan))

--- a/tests/test_data.cpp
+++ b/tests/test_data.cpp
@@ -43,6 +43,19 @@ int main() {
         "matrix column-major with dims");
   check(m.at("yi").is_int && m.at("yi").i[2] == 1, "yi int array");
 
+  // Empty leaves retain their zero-width dimension.  Stan models commonly
+  // receive array[N] vector[0] when an optional predictor count is zero.
+  DataMap z = DataMap::from_json(R"({
+    "Z2": [[], [], []],
+    "Z3": [[[], []], [[], []]]
+  })");
+  check(z.at("Z2").dims == std::vector<int64_t>({3, 0}) &&
+            z.at("Z2").r.empty() && z.at("Z2").i.empty(),
+        "JSON zero-width matrix shape");
+  check(z.at("Z3").dims == std::vector<int64_t>({2, 2, 0}) &&
+            z.at("Z3").r.empty() && z.at("Z3").i.empty(),
+        "JSON nested zero-width shape");
+
   // A var_context keeps reals and ints under separate name lists, and its
   // flat values are already column-major -- the same layout the JSON reader
   // produces -- so the conversion copies rather than reorders.

--- a/tests/test_lower.cpp
+++ b/tests/test_lower.cpp
@@ -2164,6 +2164,27 @@ int main() {
     check(std::isnan(nan_lp), "uninitialized island selected arm is NaN");
   }
 
+  // stanc's O1 inliner lowers a UDF return through an early-return flag and
+  // Break statements inside a single-iteration loop. Both return paths must
+  // leave that synthetic loop without escaping the caller's surrounding
+  // control flow.
+  for (int first : {0, 1}) {
+    DataMap d;
+    d.set_int("first", first);
+    CompiledModel cm =
+        compile_model(slurp("tests/fixtures/early_return.tmir.sexp"), d);
+    Executor ex(std::move(cm.graph));
+    cm.bind(ex);
+    ex.params_data()[0] = 0.4;
+    double grad = 0.0;
+    const double lp = ex.gradient(&grad);
+    const double scale = first ? 2.0 : 3.0;
+    expect_eq("inlined early return lp " + std::to_string(first), lp,
+              scale * 0.4);
+    expect_eq("inlined early return grad " + std::to_string(first), grad,
+              scale);
+  }
+
   // The same region written with `~`: refused, by name, with the fix in
   // the message. Before the check existed this compiled and was wrong in
   // lp by exactly the dropped constant, with a correct gradient.

--- a/tests/test_lower.cpp
+++ b/tests/test_lower.cpp
@@ -2143,6 +2143,27 @@ int main() {
     test_unsetenv("STANLI_NO_ISLAND");
   }
 
+  // A read-only live-in can still be a declared local with no preceding
+  // assignment. Ordinary lowering gives it Stan's uninitialized NaN value;
+  // the necessity-island binder must materialize the same slot rather than
+  // rejecting the name. The negative arm avoids reading it and remains a
+  // finite identity function, while the positive arm proves the NaN fill is
+  // visible when selected.
+  {
+    CompiledModel cm = compile_model(
+        slurp("tests/fixtures/paramcond_uninitialized.tmir.sexp"), DataMap());
+    Executor ex(std::move(cm.graph));
+    cm.bind(ex);
+    double grad = 0.0;
+    ex.params_data()[0] = -0.25;
+    const double finite_lp = ex.gradient(&grad);
+    expect_eq("uninitialized island finite arm lp", finite_lp, -0.25);
+    expect_eq("uninitialized island finite arm grad", grad, 1.0);
+    ex.params_data()[0] = 0.25;
+    const double nan_lp = ex.gradient(&grad);
+    check(std::isnan(nan_lp), "uninitialized island selected arm is NaN");
+  }
+
   // The same region written with `~`: refused, by name, with the fix in
   // the message. Before the check existed this compiled and was wrong in
   // lp by exactly the dropped constant, with a correct gradient.

--- a/tests/test_lower.cpp
+++ b/tests/test_lower.cpp
@@ -2247,6 +2247,45 @@ int main() {
           grad[i], 0.0);
   }
 
+  // An integer assigned inside a parameter-dependent region. `n = 2` runs
+  // before the break in a loop that runs once, so the fold is sound and
+  // the lowering takes the value back for `target += n * theta + z`:
+  // without that, the statements after the region kept reading the
+  // pre-region 1, silently, in both lp and the gradient. `k` is folded
+  // within the region, where the reads are the ones the fold belongs to.
+  {
+    CompiledModel cm = compile_model(
+        slurp("tests/fixtures/paramcond_int.tmir.sexp"), DataMap());
+    Executor ex(std::move(cm.graph));
+    cm.bind(ex);
+    double grad = 0.0;
+    // The break skips k and z: 2 * theta.
+    ex.params_data()[0] = 0.5;
+    expect_eq("parameter-condition int break lp", ex.gradient(&grad), 1.0);
+    expect_eq("parameter-condition int break grad", grad, 2.0);
+    // Without the break, z is k * theta with k folded to 4: 6 * theta.
+    ex.params_data()[0] = -0.5;
+    expect_eq("parameter-condition int no-break lp", ex.gradient(&grad), -3.0);
+    expect_eq("parameter-condition int no-break grad", grad, 6.0);
+  }
+
+  // The same integer where the assignment may not run: refused by name.
+  // Before the check it was folded anyway -- every later read in the
+  // region saw 2 on both paths -- while the lowering outside kept its own
+  // 1, so the answer matched neither branch.
+  {
+    bool threw = false;
+    try {
+      compile_model(slurp("tests/fixtures/paramcond_intbranch.tmir.sexp"),
+                    DataMap());
+    } catch (const CompileError& e) {
+      threw = std::string(e.what()).find(
+                  "integer n assigned inside data-dependent control flow") !=
+              std::string::npos;
+    }
+    check(threw, "integer assigned under a parameter condition refused");
+  }
+
   // A runtime-selected break targets the surrounding loop, so the loop and
   // conditional must share one necessity island. The positive arm exits
   // before the increment; the negative arm executes all three iterations.

--- a/tests/test_lower.cpp
+++ b/tests/test_lower.cpp
@@ -2209,6 +2209,44 @@ int main() {
     expect_eq("parameter-condition rows negative theta grad", grad[0], 1.0);
   }
 
+  // The rest of the shape queries, in the integer positions: a declared
+  // extent, an integer local, a loop bound. Each is a constant the region
+  // reads off the logical view; before, only a shape query in a
+  // real-valued context was answered, and `matrix[rows(m), cols(m)] out;`
+  // inside a parameter-dependent region was refused as an unknown integer
+  // function.
+  {
+    CompiledModel cm = compile_model(
+        slurp("tests/fixtures/paramcond_shape.tmir.sexp"), DataMap());
+    Executor ex(std::move(cm.graph));
+    cm.bind(ex);
+    const int64_t n = ex.n_params();
+    check(n == 11, "parameter-condition shape parameter count");
+    for (int64_t i = 0; i < n; ++i) ex.params_data()[i] = 0.0;
+    double grad[11] = {};
+    // num_elements(y) + cols(y) over a 2x3 matrix is 9, and the loop runs
+    // size(a) = 4 times over the array.
+    ex.params_data()[0] = 0.5;
+    for (int i = 7; i < 11; ++i) ex.params_data()[i] = 0.25;
+    const double positive_lp = ex.gradient(grad);
+    expect_eq("parameter-condition shape positive lp", positive_lp, 5.5);
+    expect_eq("parameter-condition shape theta grad", grad[0], 9.0);
+    for (int i = 1; i < 7; ++i)
+      expect_eq("parameter-condition shape matrix grad " + std::to_string(i),
+                grad[i], 0.0);
+    for (int i = 7; i < 11; ++i)
+      expect_eq("parameter-condition shape array grad " + std::to_string(i),
+                grad[i], 1.0);
+    ex.params_data()[0] = -0.5;
+    const double negative_lp = ex.gradient(grad);
+    expect_eq("parameter-condition shape negative lp", negative_lp, -0.5);
+    expect_eq("parameter-condition shape negative theta grad", grad[0], 1.0);
+    for (int i = 7; i < 11; ++i)
+      expect_eq(
+          "parameter-condition shape negative array grad " + std::to_string(i),
+          grad[i], 0.0);
+  }
+
   // A runtime-selected break targets the surrounding loop, so the loop and
   // conditional must share one necessity island. The positive arm exits
   // before the increment; the negative arm executes all three iterations.

--- a/tests/test_lower.cpp
+++ b/tests/test_lower.cpp
@@ -2185,6 +2185,30 @@ int main() {
               scale);
   }
 
+  // rows() in a necessity island reads the logical matrix geometry rather
+  // than being rejected as an unknown register-machine function.
+  {
+    CompiledModel cm = compile_model(
+        slurp("tests/fixtures/paramcond_rows.tmir.sexp"), DataMap());
+    Executor ex(std::move(cm.graph));
+    cm.bind(ex);
+    const int64_t n = ex.n_params();
+    check(n == 7, "parameter-condition rows parameter count");
+    for (int64_t i = 0; i < n; ++i) ex.params_data()[i] = 0.0;
+    double grad[7] = {};
+    ex.params_data()[0] = 0.4;
+    const double positive_lp = ex.gradient(grad);
+    expect_eq("parameter-condition rows positive lp", positive_lp, 0.8);
+    expect_eq("parameter-condition rows positive theta grad", grad[0], 2.0);
+    for (int i = 1; i < 7; ++i)
+      expect_eq("parameter-condition rows matrix grad " + std::to_string(i),
+                grad[i], 0.0);
+    ex.params_data()[0] = -0.4;
+    const double negative_lp = ex.gradient(grad);
+    expect_eq("parameter-condition rows negative lp", negative_lp, -0.4);
+    expect_eq("parameter-condition rows negative theta grad", grad[0], 1.0);
+  }
+
   // The same region written with `~`: refused, by name, with the fix in
   // the message. Before the check existed this compiled and was wrong in
   // lp by exactly the dropped constant, with a correct gradient.

--- a/tests/test_lower.cpp
+++ b/tests/test_lower.cpp
@@ -2209,6 +2209,25 @@ int main() {
     expect_eq("parameter-condition rows negative theta grad", grad[0], 1.0);
   }
 
+  // A runtime-selected break targets the surrounding loop, so the loop and
+  // conditional must share one necessity island. The positive arm exits
+  // before the increment; the negative arm executes all three iterations.
+  {
+    CompiledModel cm = compile_model(
+        slurp("tests/fixtures/paramcond_break.tmir.sexp"), DataMap());
+    Executor ex(std::move(cm.graph));
+    cm.bind(ex);
+    double grad = 0.0;
+    ex.params_data()[0] = 0.4;
+    const double breaking_lp = ex.gradient(&grad);
+    expect_eq("parameter-condition break lp", breaking_lp, 0.0);
+    expect_eq("parameter-condition break grad", grad, 0.0);
+    ex.params_data()[0] = -0.4;
+    const double looping_lp = ex.gradient(&grad);
+    expect_eq("parameter-condition no-break lp", looping_lp, 3.0 * -0.4);
+    expect_eq("parameter-condition no-break grad", grad, 3.0);
+  }
+
   // The same region written with `~`: refused, by name, with the fix in
   // the message. Before the check existed this compiled and was wrong in
   // lp by exactly the dropped constant, with a correct gradient.

--- a/tests/test_mir_decode.cpp
+++ b/tests/test_mir_decode.cpp
@@ -224,6 +224,10 @@ const char* write_stmt_kind(mir::Stmt::Kind value) {
       return "NRFunApp";
     case mir::Stmt::Return:
       return "Return";
+    case mir::Stmt::Break:
+      return "Break";
+    case mir::Stmt::Continue:
+      return "Continue";
     case mir::Stmt::Skip:
       return "Skip";
     case mir::Stmt::Unsupported:


### PR DESCRIPTION
## Stan language fixes

Seven fixes to the runtime's handling of Stan constructs, each with a regression
fixture and test.

- **Zero-width data input** — a first empty nested array now contributes a
  trailing zero extent, so JSON `[[], [], []]` reads as `array[3] vector[0] Z;`
  instead of a length-3 one-dimensional value the N-D walker then choked on.

- **Declared-but-uninitialised locals** — a local read only inside a
  parameter-dependent branch is now a NaN-filled island live-in rather than an
  unknown variable: `matrix[1,1] u; if (theta > 0) c = u[1,1];`

- **stanc-emitted break/continue** — `--O1` inlining implements an early `return`
  as a single-iteration loop with `break`, so Break/Continue now exist end-to-end
  in the MIR: `real f(real x, int first) { if (first) return 2*x; return 3*x; }`

- **`rows()` in parameter-dependent control flow** — answered from the logical
  matrix view instead of being refused as an unknown register-machine function:
  `if (theta > 0) c = rows(x) * theta;`

- **Parameter-dependent `break`** — a break selected by a parameter compiles with
  its enclosing loop, which is the only thing that gives the jump a target:
  `for (i in 1:3) { if (theta > 0) break; c += theta; }`

- **Shape queries in integer positions** — `rows`/`cols`/`size`/`num_elements`
  now answer in declared extents, loop bounds and integer locals, not just in
  real-valued contexts: `matrix[rows(m), cols(m)] out;`, `for (i in 1:size(a))`

- **`int` assignment in parameter-dependent control flow** — folding one applied
  it on both paths while the lowering kept its pre-region copy, so `if (theta > 0)
  n = 2;` silently matched neither branch. Now folded only where the assignment
  certainly runs (and the value copied back), and refused by name otherwise.

### Testing

`ctest`: 67/67 pass. New fixtures: `paramcond_uninitialized`, `early_return`,
`paramcond_rows`, `paramcond_break`, `paramcond_shape`, `paramcond_int`,
`paramcond_intbranch`.
