### PR TITLE
ci: webR latest-release load canary

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -1138,6 +1138,21 @@ jobs:
           npm install webr@0.6.0
           node tests/test_webr.mjs build-wasm-side/libstanli.so \
             browser-compilers/stanli-compiler.js
+
+      # Not a gate: webR releases on its own schedule. The module loads
+      # across Emscripten majors (measured both directions on 4.0.8 and
+      # 5.0.7), so this failing means a webR release finally broke the
+      # dylink ABI -- caught here, that is a pin bump and a release cut
+      # before any user sees it.
+      - name: Load it into the newest released webR
+        run: |
+          npm install webr@latest
+          ver=$(node -p "require('webr/package.json').version")
+          if node tests/test_webr.mjs build-wasm-side/libstanli.so; then
+            echo "canary: loads in webr@$ver"
+          else
+            echo "::warning title=webR canary::the side module does not load in webr@$ver; bump the emsdk pin and cut a release"
+          fi
       - name: Runtime tarball
         run: |
           mkdir -p runtime-dist


### PR DESCRIPTION
Follow-up to the emsdk/webR coupling question. Measured: the 4.0.8-built side module loads with all bridge symbols in webR built from main with Emscripten 5.0.7 (their toolchain since May), and a 5.0.7-built module loads in webr@0.6.0, so the next webR release is not a break and no dual-build is needed. This adds a non-fatal load test against webr@latest next to the pinned one, so an actual dylink ABI break in a future webR release shows up as a CI warning the day it ships.