### PR TITLE
Expanding support for ops in parameter-dependent regions

### DIFF
--- a/runtime/include/stanli/mir_prog.hpp
+++ b/runtime/include/stanli/mir_prog.hpp
@@ -669,6 +669,38 @@ struct ProgramCompiler {
     }
     if (e.args.empty() && e.name == "negative_infinity")
       return {konst(-std::numeric_limits<double>::infinity()), 1};
+    if (e.args.size() == 2 && e.name == "rep_vector") {
+      // The register file is a flat run of doubles, so a vector of one
+      // repeated value is a run the compiler fills -- the same fill a
+      // declaration's default uses. The length has to be a compile-time
+      // integer, which is what every extent inside a region is.
+      const long n = cint(e.args[1]);
+      if (n < 0) bail("rep_vector of a negative length");
+      Range out{0, (int)n};
+      out.kind = ViewKind::Vector;
+      if (n == 0) {
+        out.reg = alloc(0);
+        return out;
+      }
+      // A literal value is the whole run in one instruction; anything else
+      // is computed once and copied, which is what its adjoint wants too:
+      // each copy adds into the one source cell, summing the broadcast.
+      if (e.args[0].kind == mir::Expr::LitInt ||
+          e.args[0].kind == mir::Expr::LitReal) {
+        const double v = e.args[0].kind == mir::Expr::LitInt
+                             ? (double)e.args[0].lit_i
+                             : e.args[0].lit;
+        out.reg = alloc((int)n);
+        const std::vector<double> fill((size_t)n, v);
+        emit_const(out.reg, fill.data(), (int)n);
+        return out;
+      }
+      const Range v = expr(e.args[0]);
+      if (!is_scalar(v)) bail("rep_vector of a container");
+      out.reg = alloc((int)n);
+      for (long k = 0; k < n; ++k) emit(Program::MOV, out.reg + (int)k, v.reg);
+      return out;
+    }
     if (e.args.size() == 1 && e.name == "max") {
       const Range a = expr(e.args[0]);
       const int r = alloc(1);

--- a/runtime/include/stanli/mir_prog.hpp
+++ b/runtime/include/stanli/mir_prog.hpp
@@ -213,6 +213,14 @@ struct ProgramCompiler {
   }
 
   // ---- compile-time integers ----------------------------------------------
+  // A comparison returns an integer whatever it compares, so the result
+  // type does not say whether cint may answer it: `2.5 > 1` is UInt with
+  // real operands, and cint reads a real literal by truncation, which
+  // would make it false. The operands have to be integers themselves.
+  static bool int_operand(const mir::Expr& e) {
+    return e.type_ == "UInt" || e.unsized.leaf == mir::UnsizedLeaf::Int;
+  }
+
   long cint(const mir::Expr& e) {
     switch (e.kind) {
       case mir::Expr::LitInt:
@@ -235,6 +243,19 @@ struct ProgramCompiler {
           bail("integer index range");
         return it->second[(size_t)ix - 1];
       }
+      case mir::Expr::EAnd:
+      case mir::Expr::EOr: {
+        // Stan short-circuits these, and so does this: the second operand
+        // of a decided `&&` is never evaluated, so it does not have to be
+        // a compile-time integer -- or an integer at all.
+        if (e.args.size() != 2 || !int_operand(e.args[0]))
+          bail("integer logical form");
+        const bool lhs = cint(e.args[0]) != 0;
+        if (e.kind == mir::Expr::EAnd && !lhs) return 0;
+        if (e.kind == mir::Expr::EOr && lhs) return 1;
+        if (!int_operand(e.args[1])) bail("integer logical form");
+        return cint(e.args[1]) != 0;
+      }
       case mir::Expr::FunApp:
         if (e.args.size() == 2) {
           // Each operator with the named spelling beside it: on ints the
@@ -249,8 +270,24 @@ struct ProgramCompiler {
           if (e.name == "IntDivide__" || e.name == "Divide__" ||
               e.name == "divide" || e.name == "elt_divide")
             return cint(e.args[0]) / cint(e.args[1]);
+          // The comparisons: on integers each is an integer in its own
+          // right, and a `while` condition or an integer local written
+          // with one -- `int found = (a[i] == k);` -- is as much a
+          // compile-time value as its operands are.
+          if (int_operand(e.args[0]) && int_operand(e.args[1])) {
+            if (e.name == "Equals__") return cint(e.args[0]) == cint(e.args[1]);
+            if (e.name == "NEquals__")
+              return cint(e.args[0]) != cint(e.args[1]);
+            if (e.name == "Less__") return cint(e.args[0]) < cint(e.args[1]);
+            if (e.name == "Leq__") return cint(e.args[0]) <= cint(e.args[1]);
+            if (e.name == "Greater__") return cint(e.args[0]) > cint(e.args[1]);
+            if (e.name == "Geq__") return cint(e.args[0]) >= cint(e.args[1]);
+          }
         }
         if (e.args.size() == 1 && e.name == "PMinus__") return -cint(e.args[0]);
+        if (e.args.size() == 1 && int_operand(e.args[0]) &&
+            (e.name == "PNot__" || e.name == "logical_negation"))
+          return cint(e.args[0]) == 0;
         // A declared extent, a loop bound or an index written as a shape
         // query: `matrix[rows(m), cols(m)] out;`, `for (i in 1:rows(m))`.
         // Before this, only a shape query in a real-valued context was

--- a/runtime/include/stanli/mir_prog.hpp
+++ b/runtime/include/stanli/mir_prog.hpp
@@ -29,6 +29,7 @@
 #include <functional>
 #include <limits>
 #include <map>
+#include <set>
 #include <string>
 #include <utility>
 #include <vector>
@@ -76,6 +77,10 @@ struct ProgramCompiler {
   // caller seeded has no entry and is treated as declared outside
   // everything, which is what it is.
   std::map<std::string, std::pair<int, size_t>> int_decl_at;
+  // Names bind_extern brought in. They are the caller's values rather than
+  // the region's, which is what makes them the caller's to answer about --
+  // being in `reals` only says the region has read one as a value.
+  std::set<std::string> extern_bound;
   int branch_depth = 0;  // inside a branch on a runtime value
   int inline_depth = 0;
   struct LoopFrame {
@@ -89,6 +94,13 @@ struct ProgramCompiler {
   // backing the name and records it as a live-in. Returning false means
   // "no such value", and the compile bails.
   std::function<bool(const std::string&, Range*)> bind_extern;
+  // One compile-time integer the region cannot reach on its own: a read
+  // from a data array. The caller has the data interpreter that answers
+  // sizes outside the region, and cint hands it a read whose indices are
+  // already literals -- they are the region's own loop variables, which
+  // the caller has never heard of. Lowering installs this; the ODE caller
+  // leaves it empty, and cint then refuses as before.
+  std::function<bool(const mir::Expr&, long*)> extern_int;
   // Where `target +=` accumulates, or -1 when the region may not have
   // one. Set by the caller, which also seeds it to zero.
   int target_reg = -1;
@@ -190,6 +202,30 @@ struct ProgramCompiler {
   // `rows`, `cols` and `dims` of the result mean anything; `reg` is not a
   // register, because no value was built.
   bool static_view(const mir::Expr& e, Range* out) {
+    // A literal array, which stanc's inliner substitutes for an argument:
+    // `size(when)` inside an inlined function arrives as `size({0})`.
+    if (e.kind == mir::Expr::FunApp &&
+        (e.name == "FnMakeArray" || e.name == "FnMakeRowVec")) {
+      int64_t len = 0;
+      for (const auto& a : e.args) {
+        Range part;
+        if (!static_view(a, &part)) return false;
+        len += part.len;
+      }
+      Range r{0, (int)len};
+      if (e.name == "FnMakeRowVec") {
+        r.kind = ViewKind::RowVector;
+      } else {
+        r.kind = ViewKind::Array;
+        r.dims = {(int64_t)e.args.size()};
+      }
+      *out = r;
+      return true;
+    }
+    if (e.kind == mir::Expr::LitInt || e.kind == mir::Expr::LitReal) {
+      *out = Range{0, 1};
+      return true;
+    }
     if (e.kind != mir::Expr::Var) return false;
     auto rt = reals.find(e.name);
     if (rt != reals.end()) {
@@ -206,6 +242,7 @@ struct ProgramCompiler {
     Range ext;
     if (bind_extern && bind_extern(e.name, &ext)) {
       reals[e.name] = ext;
+      extern_bound.insert(e.name);
       *out = ext;
       return true;
     }
@@ -233,15 +270,49 @@ struct ProgramCompiler {
         bail("integer " + e.name + " is not known at compile time");
       }
       case mir::Expr::Indexed: {
-        if (e.args.size() != 2 || e.args[1].name != "IndexSingle")
-          bail("integer index form");
+        if (e.args.size() < 2) bail("integer index form");
+        // The same substituted literal, indexed rather than measured.
+        if (e.args.size() == 2 && e.args[0].kind == mir::Expr::FunApp &&
+            e.args[0].name == "FnMakeArray" &&
+            e.args[1].name == "IndexSingle") {
+          const long ix = cint(e.args[1].args[0]);
+          if (ix < 1 || (size_t)ix > e.args[0].args.size())
+            bail("integer index range");
+          return cint(e.args[0].args[(size_t)ix - 1]);
+        }
         if (e.args[0].kind != mir::Expr::Var) bail("integer index base");
+        for (size_t k = 1; k < e.args.size(); ++k)
+          if (e.args[k].name != "IndexSingle" || e.args[k].args.size() != 1)
+            bail("integer index form");
         auto it = ints.find(e.args[0].name);
-        if (it == ints.end()) bail("integer array " + e.args[0].name);
-        const long ix = cint(e.args[1].args[0]);
-        if (ix < 1 || (size_t)ix > it->second.size())
-          bail("integer index range");
-        return it->second[(size_t)ix - 1];
+        if (it != ints.end()) {
+          if (e.args.size() != 2) bail("integer index form");
+          const long ix = cint(e.args[1].args[0]);
+          if (ix < 1 || (size_t)ix > it->second.size())
+            bail("integer index range");
+          return it->second[(size_t)ix - 1];
+        }
+        // A read from a data array, at any rank: `ms[ri, 8]` where the
+        // region unrolled the loop that produced `ri`. Resolving the
+        // indices here and asking for a literal read keeps the array's
+        // storage order the one place that already knows it.
+        if (extern_int && (extern_bound.count(e.args[0].name) ||
+                           !reals.count(e.args[0].name))) {
+          mir::Expr literal = e;
+          for (size_t k = 1; k < literal.args.size(); ++k) {
+            mir::Expr& ix = literal.args[k].args[0];
+            const long v = cint(ix);
+            ix = mir::Expr{};
+            ix.kind = mir::Expr::LitInt;
+            ix.lit_i = v;
+            ix.type_ = "UInt";
+            ix.unsized = {0, mir::UnsizedLeaf::Int};
+            ix.data_only = true;
+          }
+          long v;
+          if (extern_int(literal, &v)) return v;
+        }
+        bail("integer array " + e.args[0].name);
       }
       case mir::Expr::EAnd:
       case mir::Expr::EOr: {
@@ -398,6 +469,7 @@ struct ProgramCompiler {
         Range ext;
         if (bind_extern && bind_extern(e.name, &ext)) {
           reals[e.name] = ext;
+          extern_bound.insert(e.name);
           return ext;
         }
         bail("unknown variable " + e.name);
@@ -916,6 +988,7 @@ struct ProgramCompiler {
           Range ext;
           if (bind_extern && bind_extern(s.lhs, &ext)) {
             reals[s.lhs] = ext;
+            extern_bound.insert(s.lhs);
             it = reals.find(s.lhs);
           }
         }
@@ -1119,10 +1192,12 @@ struct ProgramCompiler {
     auto saved_reals = reals;
     auto saved_ints = ints;
     auto saved_int_decl_at = int_decl_at;
+    auto saved_extern_bound = extern_bound;
     const int saved_branch_depth = branch_depth;
     reals.clear();
     ints.clear();
     int_decl_at.clear();
+    extern_bound.clear();
     branch_depth = 0;
     for (size_t k = 0; k < f.arg_names.size(); ++k) {
       if (args[k].is_const_int) {
@@ -1143,6 +1218,7 @@ struct ProgramCompiler {
       reals = std::move(saved_reals);
       ints = std::move(saved_ints);
       int_decl_at = std::move(saved_int_decl_at);
+      extern_bound = std::move(saved_extern_bound);
       branch_depth = saved_branch_depth;
       --inline_depth;
       throw;
@@ -1150,6 +1226,7 @@ struct ProgramCompiler {
     reals = std::move(saved_reals);
     ints = std::move(saved_ints);
     int_decl_at = std::move(saved_int_decl_at);
+    extern_bound = std::move(saved_extern_bound);
     branch_depth = saved_branch_depth;
     --inline_depth;
     return out;

--- a/runtime/src/lower.cpp
+++ b/runtime/src/lower.cpp
@@ -1953,7 +1953,13 @@ struct Lowering {
     } catch (Bail& b) {
       fail("parameter-dependent region: " + b.why, s ? s->raw : e->raw);
     }
-    if (prog->out_regs.empty() && !(e && expr_out->len == 0))
+    // No live-out register is legitimate when the region found live-outs
+    // and every one of them is zero-width: the data made the values empty,
+    // as `matrix[0, 0]` from a dimension table does, so there is nothing
+    // for the program to carry out. Finding no live-out at all is the
+    // mistake this catches -- a region that lost what it was to produce.
+    if (prog->out_regs.empty() && !(e && expr_out->len == 0) &&
+        (s == nullptr || reg->out_names.empty()))
       fail("parameter-dependent region produces nothing", s ? s->raw : e->raw);
     // A region with a runtime branch keeps the var replay -- reversing
     // control flow needs the structured form the flat program has already
@@ -2033,6 +2039,11 @@ struct Lowering {
     std::vector<int> out_lens;
     for (const Range& v : reg.out_views) out_lens.push_back(v.len);
     if (reg.has_target) out_lens.push_back(1);
+    // Nothing to carry out and no target to accumulate: every live-out is
+    // zero-width, so the region has no observable effect and its values
+    // keep the empty shape they already have outside. A `target +=` would
+    // have put its own register here, so this cannot drop one.
+    if (prog->out_regs.empty()) return;
     std::vector<int> out_slots;
     emit_island(prog, reg, out_lens, &out_slots);
     // Later statements read the island's results, not the old values.

--- a/runtime/src/lower.cpp
+++ b/runtime/src/lower.cpp
@@ -1837,6 +1837,18 @@ struct Lowering {
     // would replay them during reverse mode, so ProgramCompiler refuses them
     // until necessity islands have an execute-once effect path.
     for (const auto& [name, v] : int_env) c.ints[name] = {v};
+    // Data the region reads as a compile-time integer, answered by the
+    // same interpreter that answers a size expression. The region has
+    // already resolved the indices, so what arrives is a literal read of a
+    // data-only value -- nothing here depends on the region's own scope.
+    c.extern_int = [&](const mir::Expr& x, long* out) {
+      if (!x.data_only) return false;
+      auto evaluated = try_eval_pure(x);
+      if (!evaluated || !evaluated->is_int || evaluated->i.size() != 1)
+        return false;
+      *out = evaluated->i[0];
+      return true;
+    };
     std::set<std::string> outer_names;
     for (const auto& [name, value] : scope) outer_names.insert(name);
     for (const auto& [name, value] : decls) outer_names.insert(name);

--- a/tests/fixtures/paramcond_empty.stan
+++ b/tests/fixtures/paramcond_empty.stan
@@ -1,0 +1,19 @@
+// A parameter-dependent region whose live-outs are all zero-width. The
+// model's dimension table gives these matrices no extent, so the region
+// has nothing to carry out: there is no island to run and the values keep
+// the empty shape they already have. That is not the same as a region
+// that found no live-out at all, which is the case that still refuses.
+data {
+  int n;
+}
+parameters {
+  real theta;
+}
+model {
+  matrix[n, n] source;
+  matrix[n, n] out;
+  if (theta > 0) {
+    out = source;
+  }
+  target += theta;
+}

--- a/tests/fixtures/paramcond_empty.tmir.sexp
+++ b/tests/fixtures/paramcond_empty.tmir.sexp
@@ -1,0 +1,253 @@
+((functions_block ()) (input_vars ((n <opaque> SInt)))
+ (prepare_data
+  (((pattern
+     (Decl (decl_adtype DataOnly) (decl_id n) (decl_type (Sized SInt))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable n) ()) UInt
+      ((pattern
+        (Indexed
+         ((pattern
+           (FunApp (CompilerInternal FnReadData)
+            (((pattern (Lit Str n))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+          (meta ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly))))
+         ((Single
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))))
+ (log_prob
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id theta) (decl_type (Sized SReal))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity) (dims ()) (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (NRFunApp (CompilerInternal FnValidateSize)
+          (((pattern (Lit Str source))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+           ((pattern (Lit Str n))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+           ((pattern (Var n)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+        (meta <opaque>))
+       ((pattern
+         (NRFunApp (CompilerInternal FnValidateSize)
+          (((pattern (Lit Str source))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+           ((pattern (Lit Str n))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+           ((pattern (Var n)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+        (meta <opaque>))
+       ((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id source)
+          (decl_type
+           (Sized
+            (SMatrix AoS
+             ((pattern (Var n)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+             ((pattern (Var n)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+          (initialize Default)))
+        (meta <opaque>))
+       ((pattern
+         (NRFunApp (CompilerInternal FnValidateSize)
+          (((pattern (Lit Str out))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+           ((pattern (Lit Str n))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+           ((pattern (Var n)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+        (meta <opaque>))
+       ((pattern
+         (NRFunApp (CompilerInternal FnValidateSize)
+          (((pattern (Lit Str out))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+           ((pattern (Lit Str n))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+           ((pattern (Var n)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+        (meta <opaque>))
+       ((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id out)
+          (decl_type
+           (Sized
+            (SMatrix AoS
+             ((pattern (Var n)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+             ((pattern (Var n)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+          (initialize Default)))
+        (meta <opaque>))
+       ((pattern
+         (TargetPE
+          ((pattern (Var theta))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>)))))
+    (meta <opaque>))))
+ (reverse_mode_log_prob
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id theta) (decl_type (Sized SReal))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity) (dims ()) (mem_pattern SoA)))
+           ()))
+         (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (NRFunApp (CompilerInternal FnValidateSize)
+          (((pattern (Lit Str source))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+           ((pattern (Lit Str n))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+           ((pattern (Var n)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+        (meta <opaque>))
+       ((pattern
+         (NRFunApp (CompilerInternal FnValidateSize)
+          (((pattern (Lit Str source))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+           ((pattern (Lit Str n))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+           ((pattern (Var n)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+        (meta <opaque>))
+       ((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id source)
+          (decl_type
+           (Sized
+            (SMatrix SoA
+             ((pattern (Var n)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+             ((pattern (Var n)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+          (initialize Default)))
+        (meta <opaque>))
+       ((pattern
+         (NRFunApp (CompilerInternal FnValidateSize)
+          (((pattern (Lit Str out))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+           ((pattern (Lit Str n))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+           ((pattern (Var n)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+        (meta <opaque>))
+       ((pattern
+         (NRFunApp (CompilerInternal FnValidateSize)
+          (((pattern (Lit Str out))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+           ((pattern (Lit Str n))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+           ((pattern (Var n)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+        (meta <opaque>))
+       ((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id out)
+          (decl_type
+           (Sized
+            (SMatrix SoA
+             ((pattern (Var n)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+             ((pattern (Var n)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+          (initialize Default)))
+        (meta <opaque>))
+       ((pattern
+         (TargetPE
+          ((pattern (Var theta))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>)))))
+    (meta <opaque>))))
+ (generate_quantities
+  (((pattern
+     (Decl (decl_adtype DataOnly) (decl_id theta) (decl_type (Sized SReal))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity) (dims ()) (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt ())
+        (var
+         ((pattern (Var theta)) (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (IfElse
+      ((pattern
+        (FunApp (StanLib PNot__ FnPlain AoS)
+         (((pattern
+            (EOr
+             ((pattern (Var emit_transformed_parameters__))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+             ((pattern (Var emit_generated_quantities__))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+      ((pattern (Block (((pattern (Return ())) (meta <opaque>))))) (meta <opaque>)) ()))
+    (meta <opaque>))
+   ((pattern
+     (IfElse
+      ((pattern
+        (FunApp (StanLib PNot__ FnPlain AoS)
+         (((pattern (Var emit_generated_quantities__))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+      ((pattern (Block (((pattern (Return ())) (meta <opaque>))))) (meta <opaque>)) ()))
+    (meta <opaque>))))
+ (transform_inits
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id theta) (decl_type (Sized SReal))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable theta) ()) UReal
+      ((pattern
+        (Indexed
+         ((pattern
+           (FunApp (CompilerInternal FnReadData)
+            (((pattern (Lit Str theta))
+              (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+          (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))
+         ((Single
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+       (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var theta)) (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))))
+ (unconstrain_array
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id theta) (decl_type (Sized SReal))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable theta) ()) UReal
+      ((pattern (FunApp (CompilerInternal FnReadDeserializer) ()))
+       (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var theta)) (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))))
+ (output_vars
+  ((theta <opaque>
+    ((out_unconstrained_st SReal) (out_constrained_st SReal) (out_block Parameters)
+     (out_trans Identity)))))
+ (prog_name paramcond_empty_model) (prog_path tests/fixtures/paramcond_empty.stan))

--- a/tests/fixtures/paramcond_intarray.stan
+++ b/tests/fixtures/paramcond_intarray.stan
@@ -1,0 +1,23 @@
+// Integer reads that only the caller can answer, in the compile-time
+// integer positions inside a parameter-dependent region: an element of a
+// data array at rank two, and a literal array's size and elements --
+// which is the form stanc's inliner leaves behind when it substitutes an
+// `array[] int` argument at a call site.
+data {
+  array[3, 2] int idx;
+}
+parameters {
+  real theta;
+}
+model {
+  if (theta > 0) {
+    int total = 0;
+    for (r in 1 : 3) {
+      if (idx[r, 2] == 5) total += idx[r, 1];
+    }
+    int m = size({4, 5, 6}) + {4, 5, 6}[2];
+    target += (total + m) * theta;
+  } else {
+    target += theta;
+  }
+}

--- a/tests/fixtures/paramcond_intarray.tmir.sexp
+++ b/tests/fixtures/paramcond_intarray.tmir.sexp
@@ -1,0 +1,532 @@
+((functions_block ())
+ (input_vars
+  ((idx <opaque>
+    (SArray
+     (SArray SInt
+      ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+     ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+ (prepare_data
+  (((pattern
+     (Decl (decl_adtype DataOnly) (decl_id pos__) (decl_type (Sized SInt))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable pos__) ()) UInt
+      ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id idx)
+      (decl_type
+       (Sized
+        (SArray
+         (SArray SInt
+          ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+         ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id idx_flat__)
+          (decl_type (Unsized (UArray UInt))) (initialize Uninit)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable idx_flat__) ()) (UArray UInt)
+          ((pattern
+            (FunApp (CompilerInternal FnReadData)
+             (((pattern (Lit Str idx))
+               (meta ((type_ (UArray (UArray UInt))) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable pos__) ()) UInt
+          ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar sym1__)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Lit Int 2))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (For (loopvar sym2__)
+                  (lower
+                   ((pattern (Lit Int 1))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (upper
+                   ((pattern (Lit Int 3))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (body
+                   ((pattern
+                     (Block
+                      (((pattern
+                         (Assignment
+                          ((LVariable idx)
+                           ((Single
+                             ((pattern (Var sym2__))
+                              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                            (Single
+                             ((pattern (Var sym1__))
+                              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                          (UArray (UArray UInt))
+                          ((pattern
+                            (Indexed
+                             ((pattern (Var idx_flat__))
+                              (meta
+                               ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly))))
+                             ((Single
+                               ((pattern (Var pos__))
+                                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                        (meta <opaque>))
+                       ((pattern
+                         (Assignment ((LVariable pos__) ()) UInt
+                          ((pattern
+                            (FunApp (StanLib Plus__ FnPlain AoS)
+                             (((pattern (Var pos__))
+                               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                              ((pattern (Lit Int 1))
+                               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                        (meta <opaque>)))))
+                    (meta <opaque>)))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))))
+ (log_prob
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id theta) (decl_type (Sized SReal))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity) (dims ()) (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (IfElse
+          ((pattern
+            (FunApp (StanLib Greater__ FnPlain AoS)
+             (((pattern (Var theta))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+              ((pattern (Lit Int 0))
+               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel AutoDiffable))))
+          ((pattern
+            (Block
+             (((pattern
+                (Decl (decl_adtype AutoDiffable) (decl_id total) (decl_type (Sized SInt))
+                 (initialize Uninit)))
+               (meta <opaque>))
+              ((pattern
+                (Assignment ((LVariable total) ()) UInt
+                 ((pattern (Lit Int 0))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+               (meta <opaque>))
+              ((pattern
+                (For (loopvar r)
+                 (lower
+                  ((pattern (Lit Int 1))
+                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                 (upper
+                  ((pattern (Lit Int 3))
+                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                 (body
+                  ((pattern
+                    (Block
+                     (((pattern
+                        (IfElse
+                         ((pattern
+                           (FunApp (StanLib Equals__ FnPlain AoS)
+                            (((pattern
+                               (Indexed
+                                ((pattern (Var idx))
+                                 (meta
+                                  ((type_ (UArray (UArray UInt))) (loc <opaque>)
+                                   (adlevel DataOnly))))
+                                ((Single
+                                  ((pattern (Var r))
+                                   (meta
+                                    ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                                 (Single
+                                  ((pattern (Lit Int 2))
+                                   (meta
+                                    ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                             ((pattern (Lit Int 5))
+                              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                         ((pattern
+                           (Block
+                            (((pattern
+                               (Assignment ((LVariable total) ()) UInt
+                                ((pattern
+                                  (FunApp (StanLib Plus__ FnPlain AoS)
+                                   (((pattern (Var total))
+                                     (meta
+                                      ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                                    ((pattern
+                                      (Indexed
+                                       ((pattern (Var idx))
+                                        (meta
+                                         ((type_ (UArray (UArray UInt))) 
+                                          (loc <opaque>) (adlevel DataOnly))))
+                                       ((Single
+                                         ((pattern (Var r))
+                                          (meta
+                                           ((type_ UInt) (loc <opaque>)
+                                            (adlevel DataOnly)))))
+                                        (Single
+                                         ((pattern (Lit Int 1))
+                                          (meta
+                                           ((type_ UInt) (loc <opaque>)
+                                            (adlevel DataOnly))))))))
+                                     (meta
+                                      ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                                 (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                              (meta <opaque>)))))
+                          (meta <opaque>))
+                         ()))
+                       (meta <opaque>)))))
+                   (meta <opaque>)))))
+               (meta <opaque>))
+              ((pattern
+                (Decl (decl_adtype AutoDiffable) (decl_id m) (decl_type (Sized SInt))
+                 (initialize Uninit)))
+               (meta <opaque>))
+              ((pattern
+                (Assignment ((LVariable m) ()) UInt
+                 ((pattern
+                   (FunApp (StanLib Plus__ FnPlain AoS)
+                    (((pattern
+                       (FunApp (StanLib size FnPlain AoS)
+                        (((pattern
+                           (FunApp (CompilerInternal FnMakeArray)
+                            (((pattern (Lit Int 4))
+                              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                             ((pattern (Lit Int 5))
+                              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                             ((pattern (Lit Int 6))
+                              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                          (meta
+                           ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly)))))))
+                      (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                     ((pattern
+                       (Indexed
+                        ((pattern
+                          (FunApp (CompilerInternal FnMakeArray)
+                           (((pattern (Lit Int 4))
+                             (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                            ((pattern (Lit Int 5))
+                             (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                            ((pattern (Lit Int 6))
+                             (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                         (meta ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly))))
+                        ((Single
+                          ((pattern (Lit Int 2))
+                           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                      (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+               (meta <opaque>))
+              ((pattern
+                (TargetPE
+                 ((pattern
+                   (FunApp (StanLib Times__ FnPlain AoS)
+                    (((pattern
+                       (Promotion
+                        ((pattern
+                          (FunApp (StanLib Plus__ FnPlain AoS)
+                           (((pattern (Var total))
+                             (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                            ((pattern (Var m))
+                             (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                        UReal DataOnly))
+                      (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+                     ((pattern (Var theta))
+                      (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
+                  (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+               (meta <opaque>)))))
+           (meta <opaque>))
+          (((pattern
+             (Block
+              (((pattern
+                 (TargetPE
+                  ((pattern (Var theta))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))))
+ (reverse_mode_log_prob
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id theta) (decl_type (Sized SReal))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity) (dims ()) (mem_pattern SoA)))
+           ()))
+         (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (IfElse
+          ((pattern
+            (FunApp (StanLib Greater__ FnPlain SoA)
+             (((pattern (Var theta))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+              ((pattern (Lit Int 0))
+               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel AutoDiffable))))
+          ((pattern
+            (Block
+             (((pattern
+                (Decl (decl_adtype AutoDiffable) (decl_id total) (decl_type (Sized SInt))
+                 (initialize Uninit)))
+               (meta <opaque>))
+              ((pattern
+                (Assignment ((LVariable total) ()) UInt
+                 ((pattern (Lit Int 0))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+               (meta <opaque>))
+              ((pattern
+                (For (loopvar r)
+                 (lower
+                  ((pattern (Lit Int 1))
+                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                 (upper
+                  ((pattern (Lit Int 3))
+                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                 (body
+                  ((pattern
+                    (Block
+                     (((pattern
+                        (IfElse
+                         ((pattern
+                           (FunApp (StanLib Equals__ FnPlain SoA)
+                            (((pattern
+                               (Indexed
+                                ((pattern (Var idx))
+                                 (meta
+                                  ((type_ (UArray (UArray UInt))) (loc <opaque>)
+                                   (adlevel DataOnly))))
+                                ((Single
+                                  ((pattern (Var r))
+                                   (meta
+                                    ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                                 (Single
+                                  ((pattern (Lit Int 2))
+                                   (meta
+                                    ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                             ((pattern (Lit Int 5))
+                              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                         ((pattern
+                           (Block
+                            (((pattern
+                               (Assignment ((LVariable total) ()) UInt
+                                ((pattern
+                                  (FunApp (StanLib Plus__ FnPlain SoA)
+                                   (((pattern (Var total))
+                                     (meta
+                                      ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                                    ((pattern
+                                      (Indexed
+                                       ((pattern (Var idx))
+                                        (meta
+                                         ((type_ (UArray (UArray UInt))) 
+                                          (loc <opaque>) (adlevel DataOnly))))
+                                       ((Single
+                                         ((pattern (Var r))
+                                          (meta
+                                           ((type_ UInt) (loc <opaque>)
+                                            (adlevel DataOnly)))))
+                                        (Single
+                                         ((pattern (Lit Int 1))
+                                          (meta
+                                           ((type_ UInt) (loc <opaque>)
+                                            (adlevel DataOnly))))))))
+                                     (meta
+                                      ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                                 (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                              (meta <opaque>)))))
+                          (meta <opaque>))
+                         ()))
+                       (meta <opaque>)))))
+                   (meta <opaque>)))))
+               (meta <opaque>))
+              ((pattern
+                (Decl (decl_adtype AutoDiffable) (decl_id m) (decl_type (Sized SInt))
+                 (initialize Uninit)))
+               (meta <opaque>))
+              ((pattern
+                (Assignment ((LVariable m) ()) UInt
+                 ((pattern
+                   (FunApp (StanLib Plus__ FnPlain SoA)
+                    (((pattern
+                       (FunApp (StanLib size FnPlain SoA)
+                        (((pattern
+                           (FunApp (CompilerInternal FnMakeArray)
+                            (((pattern (Lit Int 4))
+                              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                             ((pattern (Lit Int 5))
+                              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                             ((pattern (Lit Int 6))
+                              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                          (meta
+                           ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly)))))))
+                      (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                     ((pattern
+                       (Indexed
+                        ((pattern
+                          (FunApp (CompilerInternal FnMakeArray)
+                           (((pattern (Lit Int 4))
+                             (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                            ((pattern (Lit Int 5))
+                             (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                            ((pattern (Lit Int 6))
+                             (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                         (meta ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly))))
+                        ((Single
+                          ((pattern (Lit Int 2))
+                           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                      (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+               (meta <opaque>))
+              ((pattern
+                (TargetPE
+                 ((pattern
+                   (FunApp (StanLib Times__ FnPlain SoA)
+                    (((pattern
+                       (Promotion
+                        ((pattern
+                          (FunApp (StanLib Plus__ FnPlain SoA)
+                           (((pattern (Var total))
+                             (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                            ((pattern (Var m))
+                             (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                        UReal DataOnly))
+                      (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+                     ((pattern (Var theta))
+                      (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
+                  (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+               (meta <opaque>)))))
+           (meta <opaque>))
+          (((pattern
+             (Block
+              (((pattern
+                 (TargetPE
+                  ((pattern (Var theta))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))))
+ (generate_quantities
+  (((pattern
+     (Decl (decl_adtype DataOnly) (decl_id theta) (decl_type (Sized SReal))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity) (dims ()) (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt ())
+        (var
+         ((pattern (Var theta)) (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (IfElse
+      ((pattern
+        (FunApp (StanLib PNot__ FnPlain AoS)
+         (((pattern
+            (EOr
+             ((pattern (Var emit_transformed_parameters__))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+             ((pattern (Var emit_generated_quantities__))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+      ((pattern (Block (((pattern (Return ())) (meta <opaque>))))) (meta <opaque>)) ()))
+    (meta <opaque>))
+   ((pattern
+     (IfElse
+      ((pattern
+        (FunApp (StanLib PNot__ FnPlain AoS)
+         (((pattern (Var emit_generated_quantities__))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+      ((pattern (Block (((pattern (Return ())) (meta <opaque>))))) (meta <opaque>)) ()))
+    (meta <opaque>))))
+ (transform_inits
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id theta) (decl_type (Sized SReal))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable theta) ()) UReal
+      ((pattern
+        (Indexed
+         ((pattern
+           (FunApp (CompilerInternal FnReadData)
+            (((pattern (Lit Str theta))
+              (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+          (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))
+         ((Single
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+       (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var theta)) (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))))
+ (unconstrain_array
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id theta) (decl_type (Sized SReal))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable theta) ()) UReal
+      ((pattern (FunApp (CompilerInternal FnReadDeserializer) ()))
+       (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var theta)) (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))))
+ (output_vars
+  ((theta <opaque>
+    ((out_unconstrained_st SReal) (out_constrained_st SReal) (out_block Parameters)
+     (out_trans Identity)))))
+ (prog_name paramcond_intarray_model) (prog_path tests/fixtures/paramcond_intarray.stan))

--- a/tests/fixtures/paramcond_intops.stan
+++ b/tests/fixtures/paramcond_intops.stan
@@ -1,0 +1,29 @@
+// The comparisons and the logical operators, in the integer positions
+// inside a parameter-dependent region: a `while` condition, and integer
+// locals written as comparisons. Each is a compile-time integer exactly
+// when its operands are, and the region compiler answers it that way --
+// there is no register-machine opcode that could produce an extent or a
+// loop count instead.
+data {
+  int k;
+}
+parameters {
+  real theta;
+}
+model {
+  if (theta > 0) {
+    int hits = 0;
+    int i = 1;
+    while (i <= 4 && hits < 3) {
+      hits += (i != k);
+      i += 1;
+    }
+    int any = !(hits == 0);
+    int either = (hits > 2) || (hits == 0);
+    int ge = (hits >= 3);
+    int lt = (hits < 3);
+    target += (hits + any + either + ge + lt) * theta;
+  } else {
+    target += theta;
+  }
+}

--- a/tests/fixtures/paramcond_intops.tmir.sexp
+++ b/tests/fixtures/paramcond_intops.tmir.sexp
@@ -1,0 +1,545 @@
+((functions_block ()) (input_vars ((k <opaque> SInt)))
+ (prepare_data
+  (((pattern
+     (Decl (decl_adtype DataOnly) (decl_id k) (decl_type (Sized SInt))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable k) ()) UInt
+      ((pattern
+        (Indexed
+         ((pattern
+           (FunApp (CompilerInternal FnReadData)
+            (((pattern (Lit Str k))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+          (meta ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly))))
+         ((Single
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))))
+ (log_prob
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id theta) (decl_type (Sized SReal))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity) (dims ()) (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (IfElse
+          ((pattern
+            (FunApp (StanLib Greater__ FnPlain AoS)
+             (((pattern (Var theta))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+              ((pattern (Lit Int 0))
+               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel AutoDiffable))))
+          ((pattern
+            (Block
+             (((pattern
+                (Decl (decl_adtype AutoDiffable) (decl_id hits) (decl_type (Sized SInt))
+                 (initialize Uninit)))
+               (meta <opaque>))
+              ((pattern
+                (Assignment ((LVariable hits) ()) UInt
+                 ((pattern (Lit Int 0))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+               (meta <opaque>))
+              ((pattern
+                (Decl (decl_adtype AutoDiffable) (decl_id i) (decl_type (Sized SInt))
+                 (initialize Uninit)))
+               (meta <opaque>))
+              ((pattern
+                (Assignment ((LVariable i) ()) UInt
+                 ((pattern (Lit Int 1))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+               (meta <opaque>))
+              ((pattern
+                (While
+                 ((pattern
+                   (EAnd
+                    ((pattern
+                      (FunApp (StanLib Leq__ FnPlain AoS)
+                       (((pattern (Var i))
+                         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                        ((pattern (Lit Int 4))
+                         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                     (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                    ((pattern
+                      (FunApp (StanLib Less__ FnPlain AoS)
+                       (((pattern (Var hits))
+                         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                        ((pattern (Lit Int 3))
+                         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                     (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                 ((pattern
+                   (Block
+                    (((pattern
+                       (Block
+                        (((pattern
+                           (Assignment ((LVariable hits) ()) UInt
+                            ((pattern
+                              (FunApp (StanLib Plus__ FnPlain AoS)
+                               (((pattern (Var hits))
+                                 (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                                ((pattern
+                                  (FunApp (StanLib NEquals__ FnPlain AoS)
+                                   (((pattern (Var i))
+                                     (meta
+                                      ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                                    ((pattern (Var k))
+                                     (meta
+                                      ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                                 (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                             (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                          (meta <opaque>))
+                         ((pattern
+                           (Assignment ((LVariable i) ()) UInt
+                            ((pattern
+                              (FunApp (StanLib Plus__ FnPlain AoS)
+                               (((pattern (Var i))
+                                 (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                                ((pattern (Lit Int 1))
+                                 (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                             (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                          (meta <opaque>)))))
+                      (meta <opaque>)))))
+                  (meta <opaque>))))
+               (meta <opaque>))
+              ((pattern
+                (Decl (decl_adtype AutoDiffable) (decl_id any) (decl_type (Sized SInt))
+                 (initialize Uninit)))
+               (meta <opaque>))
+              ((pattern
+                (Assignment ((LVariable any) ()) UInt
+                 ((pattern
+                   (FunApp (StanLib PNot__ FnPlain AoS)
+                    (((pattern
+                       (FunApp (StanLib Equals__ FnPlain AoS)
+                        (((pattern (Var hits))
+                          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                         ((pattern (Lit Int 0))
+                          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                      (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+               (meta <opaque>))
+              ((pattern
+                (Decl (decl_adtype AutoDiffable) (decl_id either)
+                 (decl_type (Sized SInt)) (initialize Uninit)))
+               (meta <opaque>))
+              ((pattern
+                (Assignment ((LVariable either) ()) UInt
+                 ((pattern
+                   (EOr
+                    ((pattern
+                      (FunApp (StanLib Greater__ FnPlain AoS)
+                       (((pattern (Var hits))
+                         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                        ((pattern (Lit Int 2))
+                         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                     (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                    ((pattern
+                      (FunApp (StanLib Equals__ FnPlain AoS)
+                       (((pattern (Var hits))
+                         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                        ((pattern (Lit Int 0))
+                         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                     (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+               (meta <opaque>))
+              ((pattern
+                (Decl (decl_adtype AutoDiffable) (decl_id ge) (decl_type (Sized SInt))
+                 (initialize Uninit)))
+               (meta <opaque>))
+              ((pattern
+                (Assignment ((LVariable ge) ()) UInt
+                 ((pattern
+                   (FunApp (StanLib Geq__ FnPlain AoS)
+                    (((pattern (Var hits))
+                      (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                     ((pattern (Lit Int 3))
+                      (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+               (meta <opaque>))
+              ((pattern
+                (Decl (decl_adtype AutoDiffable) (decl_id lt) (decl_type (Sized SInt))
+                 (initialize Uninit)))
+               (meta <opaque>))
+              ((pattern
+                (Assignment ((LVariable lt) ()) UInt
+                 ((pattern
+                   (FunApp (StanLib Less__ FnPlain AoS)
+                    (((pattern (Var hits))
+                      (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                     ((pattern (Lit Int 3))
+                      (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+               (meta <opaque>))
+              ((pattern
+                (TargetPE
+                 ((pattern
+                   (FunApp (StanLib Times__ FnPlain AoS)
+                    (((pattern
+                       (Promotion
+                        ((pattern
+                          (FunApp (StanLib Plus__ FnPlain AoS)
+                           (((pattern
+                              (FunApp (StanLib Plus__ FnPlain AoS)
+                               (((pattern
+                                  (FunApp (StanLib Plus__ FnPlain AoS)
+                                   (((pattern
+                                      (FunApp (StanLib Plus__ FnPlain AoS)
+                                       (((pattern (Var hits))
+                                         (meta
+                                          ((type_ UInt) (loc <opaque>)
+                                           (adlevel DataOnly))))
+                                        ((pattern (Var any))
+                                         (meta
+                                          ((type_ UInt) (loc <opaque>)
+                                           (adlevel DataOnly)))))))
+                                     (meta
+                                      ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                                    ((pattern (Var either))
+                                     (meta
+                                      ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                                 (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                                ((pattern (Var ge))
+                                 (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                             (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                            ((pattern (Var lt))
+                             (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                        UReal DataOnly))
+                      (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+                     ((pattern (Var theta))
+                      (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
+                  (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+               (meta <opaque>)))))
+           (meta <opaque>))
+          (((pattern
+             (Block
+              (((pattern
+                 (TargetPE
+                  ((pattern (Var theta))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))))
+ (reverse_mode_log_prob
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id theta) (decl_type (Sized SReal))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity) (dims ()) (mem_pattern SoA)))
+           ()))
+         (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (IfElse
+          ((pattern
+            (FunApp (StanLib Greater__ FnPlain SoA)
+             (((pattern (Var theta))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+              ((pattern (Lit Int 0))
+               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel AutoDiffable))))
+          ((pattern
+            (Block
+             (((pattern
+                (Decl (decl_adtype AutoDiffable) (decl_id hits) (decl_type (Sized SInt))
+                 (initialize Uninit)))
+               (meta <opaque>))
+              ((pattern
+                (Assignment ((LVariable hits) ()) UInt
+                 ((pattern (Lit Int 0))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+               (meta <opaque>))
+              ((pattern
+                (Decl (decl_adtype AutoDiffable) (decl_id i) (decl_type (Sized SInt))
+                 (initialize Uninit)))
+               (meta <opaque>))
+              ((pattern
+                (Assignment ((LVariable i) ()) UInt
+                 ((pattern (Lit Int 1))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+               (meta <opaque>))
+              ((pattern
+                (While
+                 ((pattern
+                   (EAnd
+                    ((pattern
+                      (FunApp (StanLib Leq__ FnPlain SoA)
+                       (((pattern (Var i))
+                         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                        ((pattern (Lit Int 4))
+                         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                     (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                    ((pattern
+                      (FunApp (StanLib Less__ FnPlain SoA)
+                       (((pattern (Var hits))
+                         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                        ((pattern (Lit Int 3))
+                         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                     (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                 ((pattern
+                   (Block
+                    (((pattern
+                       (Block
+                        (((pattern
+                           (Assignment ((LVariable hits) ()) UInt
+                            ((pattern
+                              (FunApp (StanLib Plus__ FnPlain SoA)
+                               (((pattern (Var hits))
+                                 (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                                ((pattern
+                                  (FunApp (StanLib NEquals__ FnPlain SoA)
+                                   (((pattern (Var i))
+                                     (meta
+                                      ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                                    ((pattern (Var k))
+                                     (meta
+                                      ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                                 (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                             (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                          (meta <opaque>))
+                         ((pattern
+                           (Assignment ((LVariable i) ()) UInt
+                            ((pattern
+                              (FunApp (StanLib Plus__ FnPlain SoA)
+                               (((pattern (Var i))
+                                 (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                                ((pattern (Lit Int 1))
+                                 (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                             (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                          (meta <opaque>)))))
+                      (meta <opaque>)))))
+                  (meta <opaque>))))
+               (meta <opaque>))
+              ((pattern
+                (Decl (decl_adtype AutoDiffable) (decl_id any) (decl_type (Sized SInt))
+                 (initialize Uninit)))
+               (meta <opaque>))
+              ((pattern
+                (Assignment ((LVariable any) ()) UInt
+                 ((pattern
+                   (FunApp (StanLib PNot__ FnPlain SoA)
+                    (((pattern
+                       (FunApp (StanLib Equals__ FnPlain SoA)
+                        (((pattern (Var hits))
+                          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                         ((pattern (Lit Int 0))
+                          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                      (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+               (meta <opaque>))
+              ((pattern
+                (Decl (decl_adtype AutoDiffable) (decl_id either)
+                 (decl_type (Sized SInt)) (initialize Uninit)))
+               (meta <opaque>))
+              ((pattern
+                (Assignment ((LVariable either) ()) UInt
+                 ((pattern
+                   (EOr
+                    ((pattern
+                      (FunApp (StanLib Greater__ FnPlain SoA)
+                       (((pattern (Var hits))
+                         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                        ((pattern (Lit Int 2))
+                         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                     (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                    ((pattern
+                      (FunApp (StanLib Equals__ FnPlain SoA)
+                       (((pattern (Var hits))
+                         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                        ((pattern (Lit Int 0))
+                         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                     (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+               (meta <opaque>))
+              ((pattern
+                (Decl (decl_adtype AutoDiffable) (decl_id ge) (decl_type (Sized SInt))
+                 (initialize Uninit)))
+               (meta <opaque>))
+              ((pattern
+                (Assignment ((LVariable ge) ()) UInt
+                 ((pattern
+                   (FunApp (StanLib Geq__ FnPlain SoA)
+                    (((pattern (Var hits))
+                      (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                     ((pattern (Lit Int 3))
+                      (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+               (meta <opaque>))
+              ((pattern
+                (Decl (decl_adtype AutoDiffable) (decl_id lt) (decl_type (Sized SInt))
+                 (initialize Uninit)))
+               (meta <opaque>))
+              ((pattern
+                (Assignment ((LVariable lt) ()) UInt
+                 ((pattern
+                   (FunApp (StanLib Less__ FnPlain SoA)
+                    (((pattern (Var hits))
+                      (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                     ((pattern (Lit Int 3))
+                      (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+               (meta <opaque>))
+              ((pattern
+                (TargetPE
+                 ((pattern
+                   (FunApp (StanLib Times__ FnPlain SoA)
+                    (((pattern
+                       (Promotion
+                        ((pattern
+                          (FunApp (StanLib Plus__ FnPlain SoA)
+                           (((pattern
+                              (FunApp (StanLib Plus__ FnPlain SoA)
+                               (((pattern
+                                  (FunApp (StanLib Plus__ FnPlain SoA)
+                                   (((pattern
+                                      (FunApp (StanLib Plus__ FnPlain SoA)
+                                       (((pattern (Var hits))
+                                         (meta
+                                          ((type_ UInt) (loc <opaque>)
+                                           (adlevel DataOnly))))
+                                        ((pattern (Var any))
+                                         (meta
+                                          ((type_ UInt) (loc <opaque>)
+                                           (adlevel DataOnly)))))))
+                                     (meta
+                                      ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                                    ((pattern (Var either))
+                                     (meta
+                                      ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                                 (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                                ((pattern (Var ge))
+                                 (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                             (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                            ((pattern (Var lt))
+                             (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                        UReal DataOnly))
+                      (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+                     ((pattern (Var theta))
+                      (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
+                  (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+               (meta <opaque>)))))
+           (meta <opaque>))
+          (((pattern
+             (Block
+              (((pattern
+                 (TargetPE
+                  ((pattern (Var theta))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))))
+ (generate_quantities
+  (((pattern
+     (Decl (decl_adtype DataOnly) (decl_id theta) (decl_type (Sized SReal))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity) (dims ()) (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt ())
+        (var
+         ((pattern (Var theta)) (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (IfElse
+      ((pattern
+        (FunApp (StanLib PNot__ FnPlain AoS)
+         (((pattern
+            (EOr
+             ((pattern (Var emit_transformed_parameters__))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+             ((pattern (Var emit_generated_quantities__))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+      ((pattern (Block (((pattern (Return ())) (meta <opaque>))))) (meta <opaque>)) ()))
+    (meta <opaque>))
+   ((pattern
+     (IfElse
+      ((pattern
+        (FunApp (StanLib PNot__ FnPlain AoS)
+         (((pattern (Var emit_generated_quantities__))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+      ((pattern (Block (((pattern (Return ())) (meta <opaque>))))) (meta <opaque>)) ()))
+    (meta <opaque>))))
+ (transform_inits
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id theta) (decl_type (Sized SReal))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable theta) ()) UReal
+      ((pattern
+        (Indexed
+         ((pattern
+           (FunApp (CompilerInternal FnReadData)
+            (((pattern (Lit Str theta))
+              (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+          (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))
+         ((Single
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+       (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var theta)) (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))))
+ (unconstrain_array
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id theta) (decl_type (Sized SReal))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable theta) ()) UReal
+      ((pattern (FunApp (CompilerInternal FnReadDeserializer) ()))
+       (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var theta)) (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))))
+ (output_vars
+  ((theta <opaque>
+    ((out_unconstrained_st SReal) (out_constrained_st SReal) (out_block Parameters)
+     (out_trans Identity)))))
+ (prog_name paramcond_intops_model) (prog_path tests/fixtures/paramcond_intops.stan))

--- a/tests/fixtures/paramcond_repvector.stan
+++ b/tests/fixtures/paramcond_repvector.stan
@@ -1,0 +1,20 @@
+// rep_vector inside a parameter-dependent region. The register file is a
+// flat run of doubles, so the repeated value is a run the compiler fills;
+// the extent is a compile-time integer like every other extent in a
+// region. A repeated parameter carries the broadcast's adjoint: every
+// element's adjoint adds into the one cell the value came from.
+data {
+  int n;
+}
+parameters {
+  real theta;
+}
+model {
+  if (theta > 0) {
+    vector[n] repeated = rep_vector(theta, n);
+    vector[n] constant = rep_vector(0.5, n);
+    target += sum(repeated) + sum(constant);
+  } else {
+    target += theta;
+  }
+}

--- a/tests/fixtures/paramcond_repvector.tmir.sexp
+++ b/tests/fixtures/paramcond_repvector.tmir.sexp
@@ -1,0 +1,330 @@
+((functions_block ()) (input_vars ((n <opaque> SInt)))
+ (prepare_data
+  (((pattern
+     (Decl (decl_adtype DataOnly) (decl_id n) (decl_type (Sized SInt))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable n) ()) UInt
+      ((pattern
+        (Indexed
+         ((pattern
+           (FunApp (CompilerInternal FnReadData)
+            (((pattern (Lit Str n))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+          (meta ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly))))
+         ((Single
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))))
+ (log_prob
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id theta) (decl_type (Sized SReal))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity) (dims ()) (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (IfElse
+          ((pattern
+            (FunApp (StanLib Greater__ FnPlain AoS)
+             (((pattern (Var theta))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+              ((pattern (Lit Int 0))
+               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel AutoDiffable))))
+          ((pattern
+            (Block
+             (((pattern
+                (NRFunApp (CompilerInternal FnValidateSize)
+                 (((pattern (Lit Str repeated))
+                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                  ((pattern (Lit Str n))
+                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                  ((pattern (Var n))
+                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+               (meta <opaque>))
+              ((pattern
+                (Decl (decl_adtype AutoDiffable) (decl_id repeated)
+                 (decl_type
+                  (Sized
+                   (SVector AoS
+                    ((pattern (Var n))
+                     (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                 (initialize Uninit)))
+               (meta <opaque>))
+              ((pattern
+                (Assignment ((LVariable repeated) ()) UVector
+                 ((pattern
+                   (FunApp (StanLib rep_vector FnPlain AoS)
+                    (((pattern (Var theta))
+                      (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+                     ((pattern (Var n))
+                      (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                  (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))
+               (meta <opaque>))
+              ((pattern
+                (NRFunApp (CompilerInternal FnValidateSize)
+                 (((pattern (Lit Str constant))
+                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                  ((pattern (Lit Str n))
+                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                  ((pattern (Var n))
+                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+               (meta <opaque>))
+              ((pattern
+                (Decl (decl_adtype AutoDiffable) (decl_id constant)
+                 (decl_type
+                  (Sized
+                   (SVector AoS
+                    ((pattern (Var n))
+                     (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                 (initialize Uninit)))
+               (meta <opaque>))
+              ((pattern
+                (Assignment ((LVariable constant) ()) UVector
+                 ((pattern
+                   (FunApp (StanLib rep_vector FnPlain AoS)
+                    (((pattern (Lit Real 0.5))
+                      (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+                     ((pattern (Var n))
+                      (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                  (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))
+               (meta <opaque>))
+              ((pattern
+                (TargetPE
+                 ((pattern
+                   (FunApp (StanLib Plus__ FnPlain AoS)
+                    (((pattern
+                       (FunApp (StanLib sum FnPlain AoS)
+                        (((pattern (Var repeated))
+                          (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+                      (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+                     ((pattern
+                       (FunApp (StanLib sum FnPlain AoS)
+                        (((pattern (Var constant))
+                          (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+                      (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
+                  (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+               (meta <opaque>)))))
+           (meta <opaque>))
+          (((pattern
+             (Block
+              (((pattern
+                 (TargetPE
+                  ((pattern (Var theta))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))))
+ (reverse_mode_log_prob
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id theta) (decl_type (Sized SReal))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity) (dims ()) (mem_pattern SoA)))
+           ()))
+         (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (IfElse
+          ((pattern
+            (FunApp (StanLib Greater__ FnPlain SoA)
+             (((pattern (Var theta))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+              ((pattern (Lit Int 0))
+               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel AutoDiffable))))
+          ((pattern
+            (Block
+             (((pattern
+                (NRFunApp (CompilerInternal FnValidateSize)
+                 (((pattern (Lit Str repeated))
+                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                  ((pattern (Lit Str n))
+                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                  ((pattern (Var n))
+                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+               (meta <opaque>))
+              ((pattern
+                (Decl (decl_adtype AutoDiffable) (decl_id repeated)
+                 (decl_type
+                  (Sized
+                   (SVector SoA
+                    ((pattern (Var n))
+                     (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                 (initialize Uninit)))
+               (meta <opaque>))
+              ((pattern
+                (Assignment ((LVariable repeated) ()) UVector
+                 ((pattern
+                   (FunApp (StanLib rep_vector FnPlain SoA)
+                    (((pattern (Var theta))
+                      (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+                     ((pattern (Var n))
+                      (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                  (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))
+               (meta <opaque>))
+              ((pattern
+                (NRFunApp (CompilerInternal FnValidateSize)
+                 (((pattern (Lit Str constant))
+                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                  ((pattern (Lit Str n))
+                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                  ((pattern (Var n))
+                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+               (meta <opaque>))
+              ((pattern
+                (Decl (decl_adtype AutoDiffable) (decl_id constant)
+                 (decl_type
+                  (Sized
+                   (SVector SoA
+                    ((pattern (Var n))
+                     (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                 (initialize Uninit)))
+               (meta <opaque>))
+              ((pattern
+                (Assignment ((LVariable constant) ()) UVector
+                 ((pattern
+                   (FunApp (StanLib rep_vector FnPlain SoA)
+                    (((pattern (Lit Real 0.5))
+                      (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+                     ((pattern (Var n))
+                      (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                  (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))
+               (meta <opaque>))
+              ((pattern
+                (TargetPE
+                 ((pattern
+                   (FunApp (StanLib Plus__ FnPlain SoA)
+                    (((pattern
+                       (FunApp (StanLib sum FnPlain SoA)
+                        (((pattern (Var repeated))
+                          (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+                      (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+                     ((pattern
+                       (FunApp (StanLib sum FnPlain SoA)
+                        (((pattern (Var constant))
+                          (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+                      (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
+                  (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+               (meta <opaque>)))))
+           (meta <opaque>))
+          (((pattern
+             (Block
+              (((pattern
+                 (TargetPE
+                  ((pattern (Var theta))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))))
+ (generate_quantities
+  (((pattern
+     (Decl (decl_adtype DataOnly) (decl_id theta) (decl_type (Sized SReal))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity) (dims ()) (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt ())
+        (var
+         ((pattern (Var theta)) (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (IfElse
+      ((pattern
+        (FunApp (StanLib PNot__ FnPlain AoS)
+         (((pattern
+            (EOr
+             ((pattern (Var emit_transformed_parameters__))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+             ((pattern (Var emit_generated_quantities__))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+      ((pattern (Block (((pattern (Return ())) (meta <opaque>))))) (meta <opaque>)) ()))
+    (meta <opaque>))
+   ((pattern
+     (IfElse
+      ((pattern
+        (FunApp (StanLib PNot__ FnPlain AoS)
+         (((pattern (Var emit_generated_quantities__))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+      ((pattern (Block (((pattern (Return ())) (meta <opaque>))))) (meta <opaque>)) ()))
+    (meta <opaque>))))
+ (transform_inits
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id theta) (decl_type (Sized SReal))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable theta) ()) UReal
+      ((pattern
+        (Indexed
+         ((pattern
+           (FunApp (CompilerInternal FnReadData)
+            (((pattern (Lit Str theta))
+              (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+          (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))
+         ((Single
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+       (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var theta)) (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))))
+ (unconstrain_array
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id theta) (decl_type (Sized SReal))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable theta) ()) UReal
+      ((pattern (FunApp (CompilerInternal FnReadDeserializer) ()))
+       (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var theta)) (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))))
+ (output_vars
+  ((theta <opaque>
+    ((out_unconstrained_st SReal) (out_constrained_st SReal) (out_block Parameters)
+     (out_trans Identity)))))
+ (prog_name paramcond_repvector_model)
+ (prog_path tests/fixtures/paramcond_repvector.stan))

--- a/tests/test_lower.cpp
+++ b/tests/test_lower.cpp
@@ -2286,6 +2286,29 @@ int main() {
     check(threw, "integer assigned under a parameter condition refused");
   }
 
+  // The comparisons and the logical operators as compile-time integers:
+  // the `while` condition decides the trip count, and each integer local
+  // is a comparison. Before this the region compiler knew five integer
+  // functions -- the four arithmetic ones and unary minus -- so any of
+  // these refused the whole region by name.
+  {
+    DataMap d;
+    d.set_int("k", 2);
+    CompiledModel cm =
+        compile_model(slurp("tests/fixtures/paramcond_intops.tmir.sexp"), d);
+    Executor ex(std::move(cm.graph));
+    cm.bind(ex);
+    double grad = 0.0;
+    // The loop stops on `hits < 3` with hits = 3, so the coefficient is
+    // 3 + 1 + 1 + 1 + 0.
+    ex.params_data()[0] = 0.5;
+    expect_eq("parameter-condition int ops lp", ex.gradient(&grad), 3.0);
+    expect_eq("parameter-condition int ops grad", grad, 6.0);
+    ex.params_data()[0] = -0.5;
+    expect_eq("parameter-condition int ops else lp", ex.gradient(&grad), -0.5);
+    expect_eq("parameter-condition int ops else grad", grad, 1.0);
+  }
+
   // A runtime-selected break targets the surrounding loop, so the loop and
   // conditional must share one necessity island. The positive arm exits
   // before the increment; the negative arm executes all three iterations.

--- a/tests/test_lower.cpp
+++ b/tests/test_lower.cpp
@@ -2361,6 +2361,41 @@ int main() {
     }
   }
 
+  // rep_vector inside a region: a run the compiler fills, at an extent it
+  // knows. The repeated parameter is the part worth checking -- the
+  // gradient is the broadcast's, every element adding into the one cell
+  // the value came from -- and the empty extent has to stay empty.
+  {
+    DataMap d;
+    d.set_int("n", 3);
+    CompiledModel cm =
+        compile_model(slurp("tests/fixtures/paramcond_repvector.tmir.sexp"), d);
+    Executor ex(std::move(cm.graph));
+    cm.bind(ex);
+    double grad = 0.0;
+    // 3 * theta from the repeated parameter, 3 * 0.5 from the constant.
+    ex.params_data()[0] = 0.5;
+    expect_eq("parameter-condition rep_vector lp", ex.gradient(&grad), 3.0);
+    expect_eq("parameter-condition rep_vector grad", grad, 3.0);
+    ex.params_data()[0] = -0.5;
+    expect_eq("parameter-condition rep_vector else lp", ex.gradient(&grad),
+              -0.5);
+    expect_eq("parameter-condition rep_vector else grad", grad, 1.0);
+  }
+  {
+    DataMap d;
+    d.set_int("n", 0);
+    CompiledModel cm =
+        compile_model(slurp("tests/fixtures/paramcond_repvector.tmir.sexp"), d);
+    Executor ex(std::move(cm.graph));
+    cm.bind(ex);
+    double grad = 0.0;
+    ex.params_data()[0] = 0.5;
+    expect_eq("parameter-condition rep_vector empty lp", ex.gradient(&grad),
+              0.0);
+    expect_eq("parameter-condition rep_vector empty grad", grad, 0.0);
+  }
+
   // A runtime-selected break targets the surrounding loop, so the loop and
   // conditional must share one necessity island. The positive arm exits
   // before the increment; the negative arm executes all three iterations.

--- a/tests/test_lower.cpp
+++ b/tests/test_lower.cpp
@@ -2309,6 +2309,32 @@ int main() {
     expect_eq("parameter-condition int ops else grad", grad, 1.0);
   }
 
+  // Integer reads the region cannot answer from its own tables: an
+  // element of a data array at rank two, and a literal array's size and
+  // elements -- the form stanc's inliner leaves where it substituted an
+  // `array[] int` argument. Before this the region compiler could index
+  // only a one-dimensional integer it had folded itself, so each of these
+  // refused the whole region.
+  {
+    DataMap d;
+    // Column-major, as the JSON reader stores a two-dimensional array.
+    d.set_int_array("idx", {1, 2, 3, 5, 7, 5}, {3, 2});
+    CompiledModel cm =
+        compile_model(slurp("tests/fixtures/paramcond_intarray.tmir.sexp"), d);
+    Executor ex(std::move(cm.graph));
+    cm.bind(ex);
+    double grad = 0.0;
+    // Rows 1 and 3 match on the second column, contributing 1 + 3; the
+    // literal array adds size 3 and its second element 5.
+    ex.params_data()[0] = 0.5;
+    expect_eq("parameter-condition int array lp", ex.gradient(&grad), 6.0);
+    expect_eq("parameter-condition int array grad", grad, 12.0);
+    ex.params_data()[0] = -0.5;
+    expect_eq("parameter-condition int array else lp", ex.gradient(&grad),
+              -0.5);
+    expect_eq("parameter-condition int array else grad", grad, 1.0);
+  }
+
   // A runtime-selected break targets the surrounding loop, so the loop and
   // conditional must share one necessity island. The positive arm exits
   // before the increment; the negative arm executes all three iterations.

--- a/tests/test_lower.cpp
+++ b/tests/test_lower.cpp
@@ -2335,6 +2335,32 @@ int main() {
     expect_eq("parameter-condition int array else grad", grad, 1.0);
   }
 
+  // A parameter-dependent region whose live-outs are all zero-width. The
+  // dimension table gives the matrices no extent, so the region has
+  // nothing to carry out and no island runs; with an extent the same
+  // model compiles the ordinary way. Refusing the empty one as a region
+  // that "produces nothing" turned a model's own data into a compile
+  // error -- that message is for a region that found no live-out at all.
+  {
+    for (int extent : {0, 2}) {
+      DataMap d;
+      d.set_int("n", extent);
+      CompiledModel cm =
+          compile_model(slurp("tests/fixtures/paramcond_empty.tmir.sexp"), d);
+      Executor ex(std::move(cm.graph));
+      cm.bind(ex);
+      double grad = 0.0;
+      const std::string tag =
+          "parameter-condition empty " + std::to_string(extent) + " ";
+      ex.params_data()[0] = 0.5;
+      expect_eq(tag + "lp", ex.gradient(&grad), 0.5);
+      expect_eq(tag + "grad", grad, 1.0);
+      ex.params_data()[0] = -0.5;
+      expect_eq(tag + "else lp", ex.gradient(&grad), -0.5);
+      expect_eq(tag + "else grad", grad, 1.0);
+    }
+  }
+
   // A runtime-selected break targets the surrounding loop, so the loop and
   // conditional must share one necessity island. The positive arm exits
   // before the increment; the negative arm executes all three iterations.


### PR DESCRIPTION
## Parameter-dependent regions: integers, empty values, rep_vector

Four more fixes to what the register-machine region compiler accepts, each
with a regression fixture and test. Follow-on from the previous branch.

- **Comparisons and logical operators as compile-time integers** — the region
  compiler knew five integer functions (four arithmetic, unary minus), so any
  of these refused the whole region: `while (i <= 4 && hits < 3)`,
  `int found = (a[i] == k);`, `!`, `||`.

- **Integer reads the region cannot answer itself** — a data array at any rank,
  with the indices resolved locally and the read handed to the caller's data
  interpreter: `ms[ri, 8]` where the region unrolled the loop producing `ri`.

- **Literal integer arrays** — the form stanc's inliner leaves where it
  substituted an `array[] int` argument, now measurable and indexable:
  `size({0})` and `{0}[wi]`, from `size(when)` and `when[wi]` in a callee.

- **Regions whose live-outs are all zero-width** — a dimension table giving
  `matrix[0, 0]` made the model's own data a compile error ("region produces
  nothing"); that message is now only for a region that found no live-out.

- **`rep_vector` inside a region** — a run of registers the compiler fills at a
  compile-time extent: `vector[d] ss = rep_vector(0, d);`. A repeated parameter
  carries the broadcast's adjoint, every element adding into one cell.

### Testing

`ctest`: 67/67 pass. New fixtures: `paramcond_intops`, `paramcond_intarray`,
`paramcond_empty`, `paramcond_repvector`.
