### PR TITLE
ci: read the installed webR version directly

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -1175,7 +1175,8 @@ jobs:
       - name: Load it into the newest released webR
         run: |
           npm install webr@latest
-          ver=$(node -p "require('webr/package.json').version")
+          ver=$(python3 -c \
+            'import json; print(json.load(open("node_modules/webr/package.json"))["version"])')
           if node tests/test_webr.mjs build-wasm-side/libstanli.so; then
             echo "canary: loads in webr@$ver"
           else


### PR DESCRIPTION
## Summary

- read the installed webR version from its package metadata on disk
- avoid importing a package subpath that the newest webR no longer exports

## Evidence

- the pinned webR 0.6.0 load and portable compiler test passed in the failed main run
- workflow YAML parses and actionlint passes
- the failure was ERR_PACKAGE_PATH_NOT_EXPORTED from the version-reporting command, before the non-gating newest-webR load ran