### PR TITLE
Prepare R and webR for the portable compiler

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -553,13 +553,11 @@ jobs:
           name: wheel-${{ matrix.plat }}
           path: dist/*.whl
 
-      # The same _bin/ the wheel ships, packaged on its own for the R
-      # package, which downloads its runtime instead of bundling it (CRAN
-      # will not carry a 16 MB binary, and could not build one from
-      # source on their farm). Whatever build_wheel.sh put there rides
-      # along, so the Windows tarball carries both compiler executables next to
-      # the DLL the way that wheel does. Naming matches runtime_asset() in
-      # r/R/install.R -- os and architecture as R spells them, normalized.
+      # The same _bin/ the wheel ships, packaged separately for the small R
+      # bridge. Whatever build_wheel.sh put there rides along, so the Windows
+      # tarball carries both compiler executables next to the DLL the way that
+      # wheel does. Naming matches runtime_asset() in r/R/install.R -- os and
+      # architecture as R spells them, normalized.
       - name: Runtime tarball
         env:
           # BSD tar otherwise writes an AppleDouble ._ entry beside every
@@ -579,9 +577,9 @@ jobs:
           path: runtime-dist/*.tar.gz
 
   # The R package tests, against a real runtime. They skip without
-  # one, so this is the only place they actually run: everywhere else
-  # (r.yml, CRAN's farm) has the package but no library, and a green
-  # check there says nothing about whether sampling works. Not in the
+  # one, so this is the integration job where they actually run; r.yml has the
+  # package but no library, and a green check there says nothing about whether
+  # sampling works. Not in the
   # manylinux container -- that image has no R and installing one into
   # AlmaLinux costs more than running the .so on a normal runner, which
   # its glibc 2.28 floor makes safe.
@@ -631,9 +629,9 @@ jobs:
             any::testthat, any::posterior, any::V8, any::jsonlite
           dependencies: '"hard"'
 
-      # Through R CMD check rather than testthat directly, so the tests
-      # run the way CRAN runs them -- against the installed package, in a
-      # clean temporary directory -- instead of against the source tree.
+      # Through R CMD check rather than testthat directly, so the tests run
+      # against the installed package in a clean temporary directory instead
+      # of against the source tree.
       - name: Build and check
         working-directory: r
         env:
@@ -1464,15 +1462,14 @@ jobs:
           ls -la js/
           cd js && npm publish
 
-  # The R package's distribution channel. CRAN carries the R code and the
-  # 40 KB bridge; the 16 MB runtime it dlopens comes from here, which is
-  # the same split torch uses for libtorch, so this job is what makes
-  # stanli_install() resolve to anything at all.
+  # The R package's runtime distribution channel. The small R bridge is built
+  # by the package repository; the runtime it dlopens comes from here, the same
+  # split torch uses for libtorch. This job is what makes stanli_install()
+  # resolve to anything at all.
   #
-  # Tag-gated with the same reasoning as PyPI, and it runs the R source
-  # tarball up as an asset too: r-universe builds from the repository
-  # continuously, but a CRAN submission is a file a human uploads to a
-  # web form, and this is where that file comes from.
+  # Tag-gated with the same reasoning as PyPI, and it uploads the R source
+  # tarball too, so GitHub installs and the release record use the same package
+  # source R-universe follows.
   runtime-release:
     if: startsWith(github.ref, 'refs/tags/v')
     needs: [build, windows, wasm-webr]

--- a/README.md
+++ b/README.md
@@ -376,13 +376,13 @@ changes signature; adding a function does not need one.
 
 Two R distribution channels:
 
-- **GitHub**, which is what users install from today:
+- **GitHub and R-universe**, the current installation routes:
   `remotes::install_github("seantalts/stanli", subdir = "r")` builds the
   bridge from any commit, and `stanli_install()` then pulls the runtime
-  from the release the package pins. **r-universe** would serve prebuilt
-  binaries from main with no tag, but it is not wired up:
-  `seantalts.r-universe.dev` answers 404 until the one-time registry
-  entry exists in `seantalts/seantalts.r-universe.dev`.
+  from the release the package pins. **R-universe** is registered and serves
+  prebuilt binaries from its selected repository ref, currently the `v0.9.2`
+  tag. Advancing that channel means updating the ref in
+  `seantalts/seantalts.r-universe.dev` and waiting for its platform builds.
 - **CRAN** cannot be automated by policy: a submission is a web-form
   upload confirmed by email. `r.yml` runs `R CMD check --as-cran` on
   every change under `r/`; a CRAN release is then bump `Version:` in

--- a/README.md
+++ b/README.md
@@ -24,12 +24,10 @@ different binding, so a model samples to the same draws from any of them.
 | **R** | `install.packages("stanli", repos = "https://seantalts.r-universe.dev")` then `stanli_install()` | [r/README.md](r/README.md) |
 | **Browser / Node** | `npm install @seantalts/stanli` | [js/README.md](js/README.md), [npm](https://www.npmjs.com/package/@seantalts/stanli) |
 
-The R package is not on CRAN yet; until it is,
-[R-universe](https://seantalts.r-universe.dev) serves prebuilt binaries,
+[R-universe](https://seantalts.r-universe.dev) serves prebuilt R binaries,
 and `remotes::install_github()` or a checkout installs from source (see
-[R](#r) below). It downloads its runtime on first use
-rather than bundling it, because CRAN will not carry a 29 MB binary and
-could not build one on their farm.
+[R](#r) below). The package downloads its matching runtime on first use,
+keeping installation small and avoiding a local stan-math build.
 
 - Performance vs CmdStan: [docs/benchmarks.md](docs/benchmarks.md).
   Median gradient <!--gen:corpus_median-->2.91x<!--/gen--> across
@@ -230,10 +228,14 @@ compiler failure is reported without retrying the rollback path.
 The same runtime behind an R binding, with `posterior`-shaped draws.
 Full documentation in [r/README.md](r/README.md).
 
-Not on CRAN yet, so install from this repository. The package lives in
-the `r/` subdirectory:
+Install a prebuilt package from R-universe, or install the `r/` subdirectory
+from this repository:
 
 ```r
+# prebuilt binary
+install.packages("stanli", repos = "https://seantalts.r-universe.dev")
+
+# source from GitHub
 # install.packages("remotes")
 remotes::install_github("seantalts/stanli", subdir = "r")
 
@@ -257,8 +259,8 @@ fit <- sample_model(m, chains = 4, seed = 1)
 summary(fit)          # mean, MCSE, sd, quantiles, bulk/tail ESS, R-hat
 ```
 
-The runtime is downloaded on first use because CRAN cannot build or
-carry it; `stanli_install()` is explicit and pins the release the
+The runtime is a separate release artifact so installing the R bridge never
+rebuilds stan-math. `stanli_install()` is explicit and pins the release the
 package was built against. An embedded compiler wins when the runtime has one.
 On native hosts without one, `STANLI_STANC` is the explicit stock-compiler
 override; otherwise R prefers `stanli-compile` beside the runtime, then stock
@@ -374,25 +376,20 @@ bumping `STANLI_R_ABI_VERSION` in `r/src/bridge.c` too; `r.yml` fails if
 they disagree. Bump it when a C ABI struct changes layout or a function
 changes signature; adding a function does not need one.
 
-Two R distribution channels:
+Two R installation routes:
 
-- **GitHub and R-universe**, the current installation routes:
-  `remotes::install_github("seantalts/stanli", subdir = "r")` builds the
-  bridge from any commit, and `stanli_install()` then pulls the runtime
-  from the release the package pins. **R-universe** is registered and serves
-  prebuilt binaries from its selected repository ref, currently the `v0.9.2`
-  tag. Advancing that channel means updating the ref in
-  `seantalts/seantalts.r-universe.dev` and waiting for its platform builds.
-- **CRAN** cannot be automated by policy: a submission is a web-form
-  upload confirmed by email. `r.yml` runs `R CMD check --as-cran` on
-  every change under `r/`; a CRAN release is then bump `Version:` in
-  `r/DESCRIPTION` plus the runtime pin, tag, download the tarball from
-  the release, and upload it at
-  [cran.r-project.org/submit.html](https://cran.r-project.org/submit.html).
+- **R-universe** serves prebuilt binaries. Its registry uses `*release`, so a
+  new GitHub Release advances the package source automatically; the remaining
+  delay is R-universe's platform builds.
+- **GitHub** builds the bridge from any selected commit with
+  `remotes::install_github("seantalts/stanli", subdir = "r")`.
+
+Both routes call `stanli_install()` to fetch the runtime release pinned by the
+installed package.
 
 The R sampling tests run in `wheels.yml` against the Linux library that
-build produced (and fail if skipped); `r.yml` has no runtime, which is
-an honest simulation of CRAN's farm.
+build produced (and fail if skipped); `r.yml` separately checks the package
+without a runtime, so both the package-only and integrated paths stay covered.
 
 ## Verification policy
 
@@ -430,8 +427,7 @@ Engine-level items that predate it:
 1. Fusing adjacent elementwise chains into one pass over the arena, now
    that the re-roll pass covers the mixture shape and tape islands
    compile the leftover scalar residue.
-2. A CRAN shim package.
-3. Vectorized kernels via stan-math's varmat (SoA) overloads. Today the
+2. Vectorized kernels via stan-math's varmat (SoA) overloads. Today the
    kernels mirror CmdStan's default AoS arithmetic, which is scalar for
    transcendentals and reductions. The plan: switch kernels to mirror
    the varmat expressions function-by-function where the overload

--- a/r/R/install.R
+++ b/r/R/install.R
@@ -1,10 +1,8 @@
 # Finding and loading the runtime.
 #
-# The stanli runtime is a ~16 MB shared library. CRAN builds its own
-# binaries from source and would have to compile stan-math and every
-# density kernel to produce one, which is neither fast enough for their
-# check farm nor possible for the embedded OCaml compiler. So the library
-# is not part of the package: it is downloaded once into the user's cache
+# The stanli runtime is a shared library containing stan-math and every density
+# kernel. It is released separately so installing the small R bridge never
+# rebuilds that C++ stack. The library is downloaded once into the user's cache
 # directory, the way torch fetches libtorch.
 #
 # Nothing is downloaded without being asked. stanli_install() is
@@ -12,11 +10,10 @@
 # run it.
 
 # The release this package was built against. NOT the package version:
-# a CRAN-requested documentation fix bumps the package without cutting a
-# runtime release, and a default of "latest" would silently pair a
-# pinned binding with a runtime that has moved. The release workflow
-# asserts this equals the tag being cut, so bumping one without the
-# other fails there rather than at a user's install.
+# a package-only fix can bump the package without cutting a runtime release,
+# and a default of "latest" would silently pair a pinned binding with a runtime
+# that has moved. The release workflow asserts this equals the tag being cut,
+# so bumping one without the other fails there rather than at a user's install.
 stanli_runtime_release <- "v0.9.2"
 
 runtime_filename <- function() {

--- a/r/R/stanc.R
+++ b/r/R/stanc.R
@@ -19,7 +19,9 @@
 # Under webR there is no V8 package and no process to run a binary in,
 # but the host already IS a JavaScript engine: the webr support
 # package's eval_js() evaluates in the worker's global scope, and the
-# same bundled stanc.js defines stanc() there once per session.
+# same bundled stanc.js defines stanc() there once per session. The dispatch
+# also understands stanli_compile() before the package starts carrying that
+# producer, so the switch itself does not need a simultaneous R-code change.
 #
 # An explicit stanc in STANLI_STANC still wins for compiler bisects. Otherwise
 # the runtime-adjacent stanli-compile wins, followed by adjacent or PATH stanc.
@@ -51,24 +53,51 @@ stanc_js <- function() {
 
 mir_from_js <- function(code, name = "stanli_model") {
   ctx <- stanc_js()
-  ctx$assign("stanli_src", code)
+  ctx$assign("stanli_src", enc2utf8(code))
   ctx$assign("stanli_name", name)
-  # js_of_ocaml exports stanc() on globalThis under V8. It returns an
-  # object with `result` on success and `errors` otherwise.
+  # Prefer the portable producer by export presence. Once selected, its
+  # diagnostics are final: a bad model must not be compiled again through the
+  # legacy producer and accidentally turn a real error into different output.
   out <- ctx$eval(
     "(function () {
-       var f = (typeof stanc === 'function') ? stanc
-             : (globalThis.stanc || (globalThis.module &&
-                globalThis.module.exports && globalThis.module.exports.stanc));
-       if (typeof f !== 'function') return JSON.stringify({e: 'no stanc()'});
-       var r = f(stanli_name, stanli_src,
-                 ['O1', 'debug-optimized-mir']);
-       if (r.errors) return JSON.stringify({e: String(r.errors)});
-       return JSON.stringify({r: r.result});
+       function exported(name) {
+         if (Object.prototype.hasOwnProperty.call(globalThis, name))
+           return {present: true, value: globalThis[name]};
+         var common = globalThis.module && globalThis.module.exports;
+         if (common && Object.prototype.hasOwnProperty.call(common, name))
+           return {present: true, value: common[name]};
+         return {present: false, value: null};
+       }
+       var portable_export = exported('stanli_compile');
+       var classic_export = exported('stanc');
+       var compiler = portable_export.present ? 'stanli_compile' : 'stanc';
+       var selected = portable_export.present ? portable_export
+                                              : classic_export;
+       if (!selected.present)
+         return JSON.stringify({e: 'no stanli_compile() or stanc() export',
+                                c: 'JavaScript compiler'});
+       if (typeof selected.value !== 'function')
+         return JSON.stringify({e: 'export is not a function', c: compiler});
+       try {
+         var r = portable_export.present
+           ? selected.value(stanli_name, stanli_src)
+           : selected.value(stanli_name, stanli_src,
+                            ['O1', 'debug-optimized-mir']);
+         if (!r || typeof r !== 'object')
+           return JSON.stringify({e: 'compiler returned no result object',
+                                  c: compiler});
+         if (r.errors)
+           return JSON.stringify({e: String(r.errors), c: compiler});
+         if (typeof r.result === 'undefined')
+           return JSON.stringify({e: 'compiler returned no MIR', c: compiler});
+         return JSON.stringify({r: String(r.result), c: compiler});
+       } catch (e) {
+         return JSON.stringify({e: String(e), c: compiler});
+       }
      })()")
   parsed <- jsonlite::fromJSON(out, simplifyVector = TRUE)
   if (!is.null(parsed$e))
-    stop("stanc: ", paste(parsed$e, collapse = "\n"), call. = FALSE)
+    stop(parsed$c, ": ", paste(parsed$e, collapse = "\n"), call. = FALSE)
   parsed$r
 }
 
@@ -115,6 +144,13 @@ read_compiler_output <- function(path) {
   value
 }
 
+write_utf8_file <- function(path, value) {
+  con <- file(path, open = "wb")
+  tryCatch(
+    writeBin(charToRaw(enc2utf8(value)), con),
+    finally = close(con))
+}
+
 mir_from_binary <- function(compiler, code, portable = FALSE,
                             run_stanc = system2) {
   work <- tempfile("stanli-compile-")
@@ -123,10 +159,7 @@ mir_from_binary <- function(compiler, code, portable = FALSE,
   on.exit(unlink(work, recursive = TRUE, force = TRUE), add = TRUE)
 
   source <- file.path(work, "model.stan")
-  con <- file(source, open = "wb")
-  tryCatch(
-    writeBin(charToRaw(enc2utf8(code)), con),
-    finally = close(con))
+  write_utf8_file(source, code)
 
   stdout_file <- file.path(work, "stdout")
   stderr_file <- file.path(work, "stderr")
@@ -181,18 +214,43 @@ mir_from_webr <- function(eval_js, code, name = "stanli_model") {
   src <- tempfile(fileext = ".stan")
   mirf <- tempfile(fileext = ".mir")
   on.exit(unlink(c(src, mirf)), add = TRUE)
-  writeLines(code, src)
+  write_utf8_file(src, code)
   status <- eval_js(sprintf("(() => {
     const src = Module.FS.readFile('%s', {encoding: 'utf8'});
-    const r = globalThis.stanc(
-      '%s', src, ['O1', 'debug-optimized-mir']);
-    if (r.errors) return 'ERR: ' + String(r.errors);
-    Module.FS.writeFile('%s', r.result);
-    return 'ok';
-  })()", src, name, mirf))
+    function exported(name) {
+      if (Object.prototype.hasOwnProperty.call(globalThis, name))
+        return {present: true, value: globalThis[name]};
+      const common = globalThis.module && globalThis.module.exports;
+      if (common && Object.prototype.hasOwnProperty.call(common, name))
+        return {present: true, value: common[name]};
+      return {present: false, value: null};
+    }
+    const portableExport = exported('stanli_compile');
+    const classicExport = exported('stanc');
+    const compiler = portableExport.present ? 'stanli_compile' : 'stanc';
+    const selected = portableExport.present ? portableExport : classicExport;
+    if (!selected.present)
+      return 'ERR:JavaScript compiler: no stanli_compile() or stanc() export';
+    if (typeof selected.value !== 'function')
+      return 'ERR:' + compiler + ': export is not a function';
+    try {
+      const r = portableExport.present
+        ? selected.value('%s', src)
+        : selected.value('%s', src, ['O1', 'debug-optimized-mir']);
+      if (!r || typeof r !== 'object')
+        return 'ERR:' + compiler + ': compiler returned no result object';
+      if (r.errors) return 'ERR:' + compiler + ': ' + String(r.errors);
+      if (typeof r.result === 'undefined')
+        return 'ERR:' + compiler + ': compiler returned no MIR';
+      Module.FS.writeFile('%s', String(r.result));
+      return 'ok';
+    } catch (e) {
+      return 'ERR:' + compiler + ': ' + String(e);
+    }
+  })()", src, name, name, mirf))
   if (!identical(status, "ok"))
-    stop("stanc: ", sub("^ERR: ", "", status), call. = FALSE)
-  paste(readLines(mirf, warn = FALSE), collapse = "\n")
+    stop(sub("^ERR:", "", status), call. = FALSE)
+  read_compiler_output(mirf)
 }
 
 stanc_mir <- function(code) {

--- a/r/R/stanc.R
+++ b/r/R/stanc.R
@@ -149,6 +149,10 @@ write_utf8_file <- function(path, value) {
     finally = close(con))
 }
 
+js_string_literal <- function(value) {
+  encodeString(enc2utf8(value), quote = "'")
+}
+
 mir_from_binary <- function(compiler, code, portable = FALSE,
                             run_stanc = system2) {
   work <- tempfile("stanli-compile-")
@@ -211,8 +215,11 @@ mir_from_webr <- function(eval_js, code, name = "stanli_model") {
   mirf <- tempfile(fileext = ".mir")
   on.exit(unlink(c(src, mirf)), add = TRUE)
   write_utf8_file(src, code)
+  src_js <- js_string_literal(src)
+  name_js <- js_string_literal(name)
+  mirf_js <- js_string_literal(mirf)
   status <- eval_js(sprintf("(() => {
-    const src = Module.FS.readFile('%s', {encoding: 'utf8'});
+    const src = Module.FS.readFile(%s, {encoding: 'utf8'});
     function exported(name) {
       if (Object.prototype.hasOwnProperty.call(globalThis, name))
         return {present: true, value: globalThis[name]};
@@ -231,19 +238,19 @@ mir_from_webr <- function(eval_js, code, name = "stanli_model") {
       return 'ERR:' + compiler + ': export is not a function';
     try {
       const r = portableExport.present
-        ? selected.value('%s', src)
-        : selected.value('%s', src, ['O1', 'debug-optimized-mir']);
+        ? selected.value(%s, src)
+        : selected.value(%s, src, ['O1', 'debug-optimized-mir']);
       if (!r || typeof r !== 'object')
         return 'ERR:' + compiler + ': compiler returned no result object';
       if (r.errors) return 'ERR:' + compiler + ': ' + String(r.errors);
       if (typeof r.result === 'undefined')
         return 'ERR:' + compiler + ': compiler returned no MIR';
-      Module.FS.writeFile('%s', String(r.result));
+      Module.FS.writeFile(%s, String(r.result));
       return 'ok';
     } catch (e) {
       return 'ERR:' + compiler + ': ' + String(e);
     }
-  })()", src, name, name, mirf))
+  })()", src_js, name_js, name_js, mirf_js))
   if (!identical(status, "ok"))
     stop(sub("^ERR:", "", status), call. = FALSE)
   read_compiler_output(mirf)

--- a/r/R/stanc.R
+++ b/r/R/stanc.R
@@ -8,13 +8,11 @@
 # first use a compiler executable. The Windows runtime ships stanli-compile,
 # which emits portable MIR through the shared OCaml pipeline, beside pristine
 # stanc for one rollback cycle. Without either, the fallback is stanc3 compiled
-# to JavaScript and run through V8. That is the same
-# trick rstan uses to ship a Stan compiler on CRAN: js_of_ocaml turns the
-# OCaml into one 3.0 MB file with no toolchain and no platform binaries,
-# which is a thing CRAN can carry and a native `stanc` per platform is
-# not. CI checks that this generated file comes from the exact configured
-# stanc3 source revision, and the R tests compile both valid and invalid
-# models through it on every supported host.
+# to JavaScript and run through V8. js_of_ocaml turns the OCaml into one
+# 3.0 MB file with no toolchain or platform-specific binary, and the same
+# artifact can execute inside webR. CI checks that this generated file comes
+# from the exact configured stanc3 source revision, and the R tests compile
+# both valid and invalid models through it on every supported host.
 #
 # Under webR there is no V8 package and no process to run a binary in,
 # but the host already IS a JavaScript engine: the webr support
@@ -187,13 +185,11 @@ mir_from_binary <- function(compiler, code, portable = FALSE,
 # filesystem rather than through eval_js values: the MIR of a real model
 # is megabytes, a file path survives any marshalling limit, and neither
 # string ever needs escaping into a JavaScript literal.
-# The support package is reached by computed name, and deliberately not
-# declared in Suggests: CRAN has an unrelated package also named `webr`,
-# so a declaration resolves to the wrong one (its 17-dependency install
-# is what broke the macOS and Windows check runners), and webR's own
-# support package exists nowhere a checker could fetch it from. The
-# sysname guard keeps CRAN's webr from ever being touched on a native
-# machine that happens to have it installed.
+# The support package is reached by computed name and deliberately not declared
+# in Suggests: the ordinary R package also named `webr` is unrelated (its
+# 17-dependency install once broke the macOS and Windows check runners), while
+# webR's host support package is supplied by webR itself. The sysname guard
+# keeps the unrelated package from being touched on a native machine.
 webr_eval_js <- function() {
   if (!identical(Sys.info()[["sysname"]], "Emscripten")) return(NULL)
   pkg <- "webr"

--- a/r/README.md
+++ b/r/README.md
@@ -93,6 +93,13 @@ schema. Launch errors, nonzero exits, and empty output are reported; invalid
 portable output is rejected when decoded. None causes an automatic retry
 through stock stanc.
 
+The V8 and webR helpers are ready for a later JavaScript producer switch: they
+use `stanli_compile()` when that export exists and call `stanc()` only when it
+does not. An error from a selected portable producer is final. The JavaScript
+file currently bundled with the package still exports only `stanc()`, so this
+readiness path does not change what the R package ships. The switch follows a
+runtime release containing the compact-v2 reader.
+
 The v0.9.2 compatibility runtime carries pristine `stanc.exe`; the selection
 logic falls through to it automatically. Windows runtime tarballs built from
 this revision add `stanli-compile.exe` beside that rollback compiler for one

--- a/r/README.md
+++ b/r/README.md
@@ -4,8 +4,8 @@ Compile and sample Stan models without a C++ toolchain.
 
 ## Install
 
-Not on CRAN yet. Until it is, install from R-universe or GitHub; the
-package lives in the `r/` subdirectory of the repository:
+Install from R-universe or GitHub; the package lives in the `r/` subdirectory
+of the repository:
 
 ```r
 # prebuilt binaries from R-universe (recommended)
@@ -71,10 +71,10 @@ asserts.
 
 Two pieces are not in the package, for two different reasons.
 
-**The runtime** is a ~29 MB shared library holding stan-math, every
-density kernel, and the interpreter. CRAN builds its own binaries from
-source and would have to compile all of that, so `stanli_install()`
-downloads the prebuilt library instead. Because the package and the
+**The runtime** is a ~29 MB shared library holding stan-math, every density
+kernel, and the interpreter. It is published separately so installing the R
+bridge never compiles all of that; `stanli_install()` downloads the prebuilt
+library instead. Because the package and the
 library are separately versioned, they can drift, and drift here would
 not crash: `stanli_sample_opts` is a struct this package declares a
 copy of, so mismatched layouts would read fields at the wrong offsets

--- a/r/src/bridge.c
+++ b/r/src/bridge.c
@@ -1,11 +1,10 @@
 /* R <-> stanli C ABI.
  *
- * The stanli runtime is a ~16 MB shared library. CRAN builds its own
- * binaries from source and will not carry one that size, so the library
- * is not linked here -- it is dlopen'd at runtime from wherever
- * stanli_install() put it, and every entry point is resolved by name.
- * That is the same shape torch's CRAN package uses for libtorch, and it
- * is why this file has no stan-math in it and compiles in seconds.
+ * The stanli runtime is a separately released shared library, so it is not
+ * linked here -- it is dlopen'd at runtime from wherever stanli_install() put
+ * it, and every entry point is resolved by name. That is the same split torch
+ * uses for libtorch, and it is why this file has no stan-math in it and
+ * compiles in seconds.
  *
  * One consequence worth stating: nothing here is callable until
  * stanli_bridge_load() has succeeded, so every wrapper checks and errors

--- a/r/tests/testthat/test-stanc.R
+++ b/r/tests/testthat/test-stanc.R
@@ -1,7 +1,6 @@
-# The one path that works without a runtime, and so the only thing CRAN's
-# check farm will actually execute: stanc3 compiled to JavaScript, run
-# through V8. It is what makes the package shippable there at all, so it
-# is worth a test that does not skip on the machines that matter.
+# The fallback path works without a runtime: stanc3 compiled to JavaScript and
+# run through V8. Keep one compiler test independent of runtime availability so
+# every package-checking host exercises source compilation.
 
 test_that("the bundled JavaScript compiler produces MIR", {
   skip_if_not_installed("V8")

--- a/r/tests/testthat/test-stanc.R
+++ b/r/tests/testthat/test-stanc.R
@@ -45,6 +45,79 @@ test_that("the bundled JavaScript compiler applies O1", {
   expect_match(mir, "(Lit Real 0.30000000000000004)", fixed = TRUE)
 })
 
+test_that("the V8 helper prefers portable output and never retries its errors", {
+  skip_if_not_installed("V8")
+  skip_if_not_installed("jsonlite")
+
+  state <- stanli:::stanc_js_ctx
+  had_ctx <- exists("ctx", envir = state, inherits = FALSE)
+  old_ctx <- state$ctx
+  on.exit(if (had_ctx) state$ctx <- old_ctx else
+            rm("ctx", envir = state), add = TRUE)
+
+  ctx <- V8::v8()
+  ctx$eval("globalThis.__stanli_calls = {
+    portable: 0, classic: 0, arguments: 0, name: null, source: null
+  };
+  globalThis.stanli_compile = function(name, source) {
+    globalThis.__stanli_calls.portable += 1;
+    globalThis.__stanli_calls.arguments = arguments.length;
+    globalThis.__stanli_calls.name = name;
+    globalThis.__stanli_calls.source = source;
+    return {result: 'STANLI2:ZmFrZQ==', warnings: ['warning with θ']};
+  };
+  globalThis.stanc = function() {
+    globalThis.__stanli_calls.classic += 1;
+    return {result: '(legacy MIR)'};
+  };")
+  state$ctx <- ctx
+
+  source <- enc2utf8("transformed data { print(\"π ☃ θ\"); } model {}")
+  expect_identical(
+    stanli:::mir_from_js(source, enc2utf8("portable_π")),
+    "STANLI2:ZmFrZQ==")
+  calls <- jsonlite::fromJSON(
+    ctx$eval("JSON.stringify(globalThis.__stanli_calls)"))
+  expect_identical(calls$portable, 1L)
+  expect_identical(calls$classic, 0L)
+  expect_identical(calls$arguments, 2L)
+  expect_identical(calls$name, enc2utf8("portable_π"))
+  expect_identical(calls$source, source)
+
+  ctx$eval("globalThis.stanli_compile = function() {
+    globalThis.__stanli_calls.portable += 1;
+    return {errors: ['portable failure'], warnings: []};
+  };")
+  expect_error(stanli:::mir_from_js("bad model"),
+               "stanli_compile: portable failure", fixed = TRUE)
+  calls <- jsonlite::fromJSON(
+    ctx$eval("JSON.stringify(globalThis.__stanli_calls)"))
+  expect_identical(calls$portable, 2L)
+  expect_identical(calls$classic, 0L)
+
+  ctx$eval("globalThis.stanli_compile = {};")
+  expect_error(stanli:::mir_from_js("model {}"),
+               "stanli_compile: export is not a function", fixed = TRUE)
+  calls <- jsonlite::fromJSON(
+    ctx$eval("JSON.stringify(globalThis.__stanli_calls)"))
+  expect_identical(calls$classic, 0L)
+
+  ctx$eval("delete globalThis.stanli_compile;
+  globalThis.stanc = function(name, source, flags) {
+    globalThis.__stanli_calls.classic += 1;
+    globalThis.__stanli_calls.fallback_arguments = arguments.length;
+    globalThis.__stanli_calls.fallback_flags = flags;
+    return {result: '(legacy MIR)'};
+  };")
+  expect_identical(stanli:::mir_from_js("model {}"), "(legacy MIR)")
+  calls <- jsonlite::fromJSON(
+    ctx$eval("JSON.stringify(globalThis.__stanli_calls)"))
+  expect_identical(calls$classic, 1L)
+  expect_identical(calls$fallback_arguments, 3L)
+  expect_identical(calls$fallback_flags,
+                   c("O1", "debug-optimized-mir"))
+})
+
 test_that("the native portable compiler owns flags and keeps warnings separate", {
   seen <- NULL
   run_stanc <- function(compiler, args, stdout, stderr) {
@@ -173,28 +246,108 @@ test_that("native discovery prefers the packaged portable compiler", {
     function(name) stop("webR must not search for a process")))
 })
 
-test_that("the webR compiler fallback requests O1 optimized MIR", {
+test_that("the webR helper selects by presence and never retries errors", {
+  skip_if_not_installed("V8")
+  skip_if_not_installed("jsonlite")
+
   state <- stanli:::stanc_js_ctx
   had_loaded <- exists("webr_loaded", envir = state, inherits = FALSE)
   old_loaded <- state$webr_loaded
   on.exit(if (had_loaded) state$webr_loaded <- old_loaded else
             rm("webr_loaded", envir = state), add = TRUE)
-  if (had_loaded) rm("webr_loaded", envir = state)
+  state$webr_loaded <- TRUE
 
-  compile_script <- NULL
+  ctx <- V8::v8()
+  ctx$eval("globalThis.__stanli_source = '';
+  globalThis.__stanli_written = null;
+  globalThis.__stanli_calls = {
+    portable: 0, classic: 0, arguments: 0,
+    name: null, source: null, warnings: 0
+  };
+  globalThis.Module = {FS: {
+    readFile: function() { return globalThis.__stanli_source; },
+    writeFile: function(path, value) {
+      globalThis.__stanli_written = {path: path, value: String(value)};
+    }
+  }};
+  globalThis.stanli_compile = function(name, source) {
+    globalThis.__stanli_calls.portable += 1;
+    globalThis.__stanli_calls.arguments = arguments.length;
+    globalThis.__stanli_calls.name = name;
+    globalThis.__stanli_calls.source = source;
+    var r = {result: 'STANLI2:ZmFrZQ==', warnings: ['warning with ☃']};
+    globalThis.__stanli_calls.warnings = r.warnings.length;
+    return r;
+  };
+  globalThis.stanc = function() {
+    globalThis.__stanli_calls.classic += 1;
+    return {result: '(legacy MIR)'};
+  };")
+
   eval_js <- function(script) {
-    if (!grepl("const src = Module.FS.readFile", script, fixed = TRUE))
-      return("compiler loaded")
-    compile_script <<- script
-    match <- regexec("Module\\.FS\\.writeFile\\('([^']+)'", script)
+    match <- regexec("Module\\.FS\\.readFile\\('([^']+)'", script)
     groups <- regmatches(script, match)[[1]]
     expect_length(groups, 2)
-    writeLines("(fake MIR)", groups[[2]])
-    "ok"
+    ctx$assign("__stanli_source",
+               stanli:::read_compiler_output(groups[[2]]))
+    status <- ctx$eval(script)
+    payload <- ctx$eval(
+      "globalThis.__stanli_written
+        ? JSON.stringify(globalThis.__stanli_written) : ''")
+    if (nzchar(payload)) {
+      written <- jsonlite::fromJSON(payload, simplifyVector = TRUE)
+      stanli:::write_utf8_file(written$path, written$value)
+      ctx$eval("globalThis.__stanli_written = null")
+    }
+    status
   }
 
-  expect_identical(stanli:::mir_from_webr(eval_js, "model {}"), "(fake MIR)")
-  expect_match(compile_script, "['O1', 'debug-optimized-mir']", fixed = TRUE)
+  source <- enc2utf8("model { // π ☃ θ\n}")
+  expect_identical(
+    stanli:::mir_from_webr(eval_js, source, enc2utf8("webr_π")),
+    "STANLI2:ZmFrZQ==")
+  calls <- jsonlite::fromJSON(
+    ctx$eval("JSON.stringify(globalThis.__stanli_calls)"))
+  expect_identical(calls$portable, 1L)
+  expect_identical(calls$classic, 0L)
+  expect_identical(calls$arguments, 2L)
+  expect_identical(calls$name, enc2utf8("webr_π"))
+  expect_identical(calls$source, source)
+  expect_identical(calls$warnings, 1L)
+
+  ctx$eval("globalThis.stanli_compile = function() {
+    globalThis.__stanli_calls.portable += 1;
+    return {errors: ['portable failure'], warnings: []};
+  };")
+  expect_error(stanli:::mir_from_webr(eval_js, "bad model"),
+               "stanli_compile: portable failure", fixed = TRUE)
+  calls <- jsonlite::fromJSON(
+    ctx$eval("JSON.stringify(globalThis.__stanli_calls)"))
+  expect_identical(calls$portable, 2L)
+  expect_identical(calls$classic, 0L)
+
+  ctx$eval("globalThis.stanli_compile = {};")
+  expect_error(stanli:::mir_from_webr(eval_js, "model {}"),
+               "stanli_compile: export is not a function", fixed = TRUE)
+  calls <- jsonlite::fromJSON(
+    ctx$eval("JSON.stringify(globalThis.__stanli_calls)"))
+  expect_identical(calls$classic, 0L)
+
+  ctx$eval("delete globalThis.stanli_compile;
+  globalThis.stanc = function(name, source, flags) {
+    globalThis.__stanli_calls.classic += 1;
+    globalThis.__stanli_calls.arguments = arguments.length;
+    globalThis.__stanli_calls.fallback_flags = flags;
+    return {result: '(legacy MIR)'};
+  };")
+  expect_identical(stanli:::mir_from_webr(eval_js, "model {}"),
+                   "(legacy MIR)")
+  calls <- jsonlite::fromJSON(
+    ctx$eval("JSON.stringify(globalThis.__stanli_calls)"))
+  expect_identical(calls$classic, 1L)
+  expect_identical(calls$arguments, 3L)
+  expect_identical(calls$fallback_flags,
+                   c("O1", "debug-optimized-mir"))
 })
 
 test_that("a model that does not typecheck is an error, not empty MIR", {

--- a/r/tests/testthat/test-stanc.R
+++ b/r/tests/testthat/test-stanc.R
@@ -257,6 +257,9 @@ test_that("the webR helper selects by presence and never retries errors", {
   state$webr_loaded <- TRUE
 
   ctx <- V8::v8()
+  literal_value <- enc2utf8("C:\\Users\\runner\\file_'π\n")
+  expect_identical(
+    ctx$eval(stanli:::js_string_literal(literal_value)), literal_value)
   ctx$eval("globalThis.__stanli_source = '';
   globalThis.__stanli_written = null;
   globalThis.__stanli_calls = {
@@ -284,11 +287,12 @@ test_that("the webR helper selects by presence and never retries errors", {
   };")
 
   eval_js <- function(script) {
-    match <- regexec("Module\\.FS\\.readFile\\('([^']+)'", script)
+    match <- regexec("Module\\.FS\\.readFile\\(([^,]+),", script)
     groups <- regmatches(script, match)[[1]]
     expect_length(groups, 2)
+    source_path <- ctx$eval(groups[[2]])
     ctx$assign("__stanli_source",
-               stanli:::read_compiler_output(groups[[2]]))
+               stanli:::read_compiler_output(source_path))
     status <- ctx$eval(script)
     payload <- ctx$eval(
       "globalThis.__stanli_written
@@ -302,15 +306,16 @@ test_that("the webR helper selects by presence and never retries errors", {
   }
 
   source <- enc2utf8("model { // π ☃ θ\n}")
+  model_name <- enc2utf8("webr_'π\\name")
   expect_identical(
-    stanli:::mir_from_webr(eval_js, source, enc2utf8("webr_π")),
+    stanli:::mir_from_webr(eval_js, source, model_name),
     "STANLI2:ZmFrZQ==")
   calls <- jsonlite::fromJSON(
     ctx$eval("JSON.stringify(globalThis.__stanli_calls)"))
   expect_identical(calls$portable, 1L)
   expect_identical(calls$classic, 0L)
   expect_identical(calls$arguments, 2L)
-  expect_identical(calls$name, enc2utf8("webr_π"))
+  expect_identical(calls$name, model_name)
   expect_identical(calls$source, source)
   expect_identical(calls$warnings, 1L)
 

--- a/tests/test_r_portable_candidate.R
+++ b/tests/test_r_portable_candidate.R
@@ -1,7 +1,8 @@
 # Exercise the candidate R/webR compiler without changing the compiler bundled
 # in the R package. The candidate is the exact browser-compiler artifact from
-# this workflow; its output is handed to the public MIR entry point of an
-# installed package backed by the real Linux runtime.
+# this workflow. It is installed into the R package's real V8 helper, and that
+# helper's output is handed to the public MIR entry point of an installed
+# package backed by the real Linux runtime.
 #
 # Usage: Rscript tests/test_r_portable_candidate.R path/to/stanli-compiler.js
 
@@ -15,34 +16,63 @@ if (!requireNamespace("V8", quietly = TRUE) ||
     !requireNamespace("jsonlite", quietly = TRUE))
   stop("the candidate check requires V8 and jsonlite", call. = FALSE)
 
-# Deliberately do not use stanli's compiler helpers here. This is a fresh V8
-# context and an explicit call to the candidate's stanli_compile() export, so
-# the check cannot accidentally pass through the compiler bundled in the R
-# package.
+suppressPackageStartupMessages(library(stanli))
+
+# Put the exact candidate artifact in the context cached by mir_from_js(). The
+# package still carries its tracked legacy file; this test changes only its own
+# fresh R session. Wrap both exports so each helper call proves which producer
+# ran and records the portable warnings that the source-compilation API leaves
+# internal on success.
 ctx <- V8::v8()
 ctx$source(compiler)
+ctx$eval("(function () {
+  var portable = globalThis.stanli_compile;
+  var classic = globalThis.stanc;
+  if (typeof portable !== 'function')
+    throw new Error('no stanli_compile() export');
+  if (typeof classic !== 'function') throw new Error('no stanc() export');
+  globalThis.__stanli_candidate = {
+    portable_calls: 0, classic_calls: 0, warnings: []
+  };
+  globalThis.stanli_compile = function() {
+    globalThis.__stanli_candidate.portable_calls += 1;
+    var r = portable.apply(this, arguments);
+    globalThis.__stanli_candidate.warnings = r.warnings
+      ? Array.prototype.map.call(r.warnings, String) : [];
+    return r;
+  };
+  globalThis.stanc = function() {
+    globalThis.__stanli_candidate.classic_calls += 1;
+    return classic.apply(this, arguments);
+  };
+})()")
+
+compiler_state <- function() {
+  jsonlite::fromJSON(
+    ctx$eval("JSON.stringify(globalThis.__stanli_candidate)"),
+    simplifyVector = TRUE)
+}
+
+state <- getFromNamespace("stanc_js_ctx", "stanli")
+state$ctx <- ctx
 
 compile_candidate <- function(name, code) {
-  ctx$assign("stanli_candidate_name", name)
-  ctx$assign("stanli_candidate_source", enc2utf8(code))
-  payload <- ctx$eval(
-    "(function () {
-       var f = globalThis.stanli_compile;
-       if (typeof f !== 'function')
-         return JSON.stringify({internal_error: 'no stanli_compile()'});
-       var r = f(stanli_candidate_name, stanli_candidate_source);
-       function strings(xs) {
-         return xs ? Array.prototype.map.call(xs, String) : [];
-       }
-       return JSON.stringify({
-         result: (typeof r.result === 'undefined') ? null : String(r.result),
-         errors: strings(r.errors),
-         warnings: strings(r.warnings)
-       });
-     })()")
-  out <- jsonlite::fromJSON(payload, simplifyVector = TRUE)
-  if (!is.null(out$internal_error)) stop(out$internal_error, call. = FALSE)
-  out
+  before <- compiler_state()
+  error <- NULL
+  result <- tryCatch(
+    stanli:::mir_from_js(enc2utf8(code), enc2utf8(name)),
+    error = function(e) {
+      error <<- conditionMessage(e)
+      NULL
+    })
+  after <- compiler_state()
+  if (!identical(after$portable_calls, before$portable_calls + 1L) ||
+      !identical(after$classic_calls, before$classic_calls))
+    stop("the R helper did not use exactly one portable compiler call",
+         call. = FALSE)
+  list(result = result,
+       errors = if (is.null(error)) character() else error,
+       warnings = after$warnings)
 }
 
 portable_payload <- function(mir) {
@@ -85,9 +115,10 @@ stopifnot(length(warning_result$errors) == 0L,
 
 bad <- compile_candidate(
   "malformed_candidate", "parameters { real x } model {}")
-stopifnot(is.null(bad$result), length(bad$errors) > 0L)
+stopifnot(is.null(bad$result), length(bad$errors) > 0L,
+          grepl("stanli_compile", bad$errors, fixed = TRUE),
+          compiler_state()$classic_calls == 0L)
 
-suppressPackageStartupMessages(library(stanli))
 if (!stanli_available())
   stop("the real stanli runtime is required for this check", call. = FALSE)
 

--- a/tests/test_webr.mjs
+++ b/tests/test_webr.mjs
@@ -54,71 +54,139 @@ if (compilerPath) {
       '/tmp/stanli-compiler.js',
       new Uint8Array(fs.readFileSync(compilerPath)));
   await webR.FS.writeFile(
+      '/tmp/stanli-stanc.R',
+      new Uint8Array(fs.readFileSync('r/R/stanc.R')));
+  await webR.FS.writeFile(
       '/tmp/portable-unicode.stan',
       new Uint8Array(fs.readFileSync('tests/compiler/portable_unicode.stan')));
   await webR.FS.writeFile(
       '/tmp/portable-bad.stan',
       new TextEncoder().encode('parameters { real x } model {}'));
 
-  // This is the same mechanism mir_from_webr() uses in the R package. Keep
-  // source and MIR in the shared filesystem, both to cover that transport and
-  // to avoid marshalling a multi-megabyte document through evalR().
+  // Source the package's actual helper and point only this webR session at the
+  // candidate artifact. Source and MIR still cross through the shared
+  // filesystem, avoiding evalR() marshalling for a multi-megabyte document.
   const candidate = await webR.evalR(String.raw`
     eval_js <- get0("eval_js", envir = asNamespace("webr"))
     if (!is.function(eval_js)) stop("webR has no eval_js host bridge")
-    load_compiler <- function() {
-      # A browser worker has no Node process global. The npm webR harness runs
-      # its worker under Node, where js_of_ocaml would otherwise select a
-      # CommonJS filesystem and call an unavailable require(). Mask that test
-      # runner detail while evaluating the exact browser artifact.
-      eval_js('globalThis.__stanli_test_process = {
-        present: Object.prototype.hasOwnProperty.call(globalThis, "process"),
-        value: globalThis.process
-      }; globalThis.process = undefined; "ok"')
-      on.exit(eval_js('if (globalThis.__stanli_test_process.present) {
-        globalThis.process = globalThis.__stanli_test_process.value;
+    source("/tmp/stanli-stanc.R", local = .GlobalEnv)
+    stanc_js_path <- function() "/tmp/stanli-compiler.js"
+
+    # A browser worker has no Node process global. The npm webR harness runs
+    # its worker under Node, where js_of_ocaml would otherwise select a
+    # CommonJS filesystem and call an unavailable require(). Mask that test
+    # runner detail while the helper evaluates the exact browser artifact.
+    eval_js('globalThis.__stanli_test_process = {
+      present: Object.prototype.hasOwnProperty.call(globalThis, "process"),
+      value: globalThis.process
+    }; globalThis.process = undefined; "ok"')
+    restore_process <- function() eval_js(
+      'if (globalThis.__stanli_test_process.present) {
+         globalThis.process = globalThis.__stanli_test_process.value;
+       } else {
+         delete globalThis.process;
+       }
+       delete globalThis.__stanli_test_process;
+       "ok"')
+
+    statuses <- tryCatch({
+      unicode_source <- read_compiler_output("/tmp/portable-unicode.stan")
+      mir <- mir_from_webr(eval_js, unicode_source, "webr_candidate")
+      write_utf8_file("/tmp/portable-candidate.mir", mir)
+      unicode_ok <- eval_js('(() => {
+        const mir = Module.FS.readFile("/tmp/portable-candidate.mir",
+                                       {encoding: "utf8"});
+        if (!mir.startsWith("STANLI2:"))
+          return "FAIL missing portable envelope";
+        const payload = Uint8Array.from(atob(mir.slice(8)),
+                                        c => c.charCodeAt(0));
+        const needle = new TextEncoder().encode("π ☃ é 👋");
+        for (let i = 0; i + needle.length <= payload.length; ++i) {
+          let equal = true;
+          for (let j = 0; j < needle.length; ++j)
+            equal = equal && payload[i + j] === needle[j];
+          if (equal) return "ok";
+        }
+        return "FAIL UTF-8 changed";
+      })()')
+      good <- if (!startsWith(mir, "STANLI2:")) {
+        "FAIL missing portable envelope"
       } else {
-        delete globalThis.process;
+        unicode_ok
       }
-      delete globalThis.__stanli_test_process;
-      "ok"'), add = TRUE)
-      eval_js(paste(readLines("/tmp/stanli-compiler.js", warn = FALSE),
-                    collapse = "\n"))
-    }
-    load_compiler()
-    good <- eval_js('(() => {
-      const f = globalThis.stanli_compile;
-      if (typeof f !== "function") return "FAIL no stanli_compile()";
-      const src = Module.FS.readFile("/tmp/portable-unicode.stan",
-                                     {encoding: "utf8"});
-      const r = f("webr_candidate", src);
-      if (r.errors) return "FAIL valid source reported errors";
-      const mir = String(r.result);
-      if (!mir.startsWith("STANLI2:"))
-        return "FAIL missing portable envelope";
-      const payload = Uint8Array.from(atob(mir.slice(8)),
-                                      c => c.charCodeAt(0));
-      const needle = new TextEncoder().encode("π ☃ é 👋");
-      let found = false;
-      for (let i = 0; i + needle.length <= payload.length; ++i) {
-        let equal = true;
-        for (let j = 0; j < needle.length; ++j)
-          equal = equal && payload[i + j] === needle[j];
-        found = found || equal;
+
+      instrumented <- eval_js('(() => {
+        const portable = globalThis.stanli_compile;
+        const classic = globalThis.stanc;
+        if (typeof portable !== "function" || typeof classic !== "function")
+          return "FAIL compiler exports missing";
+        globalThis.__stanli_helper_calls = {
+          portable: 0, classic: 0, warnings: 0,
+          classic_arguments: 0, classic_flags: []
+        };
+        globalThis.stanli_compile = function() {
+          globalThis.__stanli_helper_calls.portable += 1;
+          const r = portable.apply(this, arguments);
+          globalThis.__stanli_helper_calls.warnings = r.warnings
+            ? r.warnings.length : 0;
+          return r;
+        };
+        globalThis.stanc = function() {
+          globalThis.__stanli_helper_calls.classic += 1;
+          globalThis.__stanli_helper_calls.classic_arguments = arguments.length;
+          globalThis.__stanli_helper_calls.classic_flags = arguments[2];
+          return classic.apply(this, arguments);
+        };
+        return "ok";
+      })()')
+
+      warning_source <- paste(
+        "parameters { real x; }",
+        "model { if (0 < x < 1) target += 0; }")
+      warning_mir <- mir_from_webr(eval_js, warning_source, "webr_warning")
+      warning_calls <- eval_js(
+        'JSON.stringify(globalThis.__stanli_helper_calls)')
+      warning_ok <- if (!startsWith(warning_mir, "STANLI2:")) {
+        "FAIL warning source produced no portable MIR"
+      } else if (!grepl('"warnings":[1-9]', warning_calls)) {
+        "FAIL portable warning was not observed"
+      } else {
+        "ok"
       }
-      if (!found) return "FAIL UTF-8 changed";
-      Module.FS.writeFile("/tmp/portable-candidate.mir", mir);
-      return "ok";
-    })()')
-    bad <- eval_js('(() => {
-      const src = Module.FS.readFile("/tmp/portable-bad.stan",
-                                     {encoding: "utf8"});
-      const r = globalThis.stanli_compile("webr_bad", src);
-      return (r.errors && typeof r.result === "undefined")
-        ? "ok" : "FAIL malformed source produced a document";
-    })()')
-    mir <- readLines("/tmp/portable-candidate.mir", warn = FALSE)
-    c(good, bad, if (length(mir) > 0L) "ok" else "FAIL MIR file is empty")
+
+      bad_source <- read_compiler_output("/tmp/portable-bad.stan")
+      bad_message <- tryCatch({
+        mir_from_webr(eval_js, bad_source, "webr_bad")
+        "FAIL malformed source produced a document"
+      }, error = function(e) conditionMessage(e))
+      final_calls <- eval_js('JSON.stringify(globalThis.__stanli_helper_calls)')
+      bad <- if (!grepl("stanli_compile", bad_message, fixed = TRUE)) {
+        "FAIL portable error was not reported"
+      } else if (!grepl('"portable":2', final_calls, fixed = TRUE) ||
+                 !grepl('"classic":0', final_calls, fixed = TRUE)) {
+        "FAIL portable error retried through stanc"
+      } else {
+        "ok"
+      }
+
+      eval_js('delete globalThis.stanli_compile; "ok"')
+      legacy_mir <- mir_from_webr(eval_js, "model {}", "webr_legacy")
+      fallback_calls <- eval_js(
+        'JSON.stringify(globalThis.__stanli_helper_calls)')
+      fallback <- if (!startsWith(legacy_mir, "((functions_block")) {
+        "FAIL absent portable export did not select legacy stanc"
+      } else if (!grepl('"classic":1', fallback_calls, fixed = TRUE) ||
+                 !grepl('"classic_arguments":3', fallback_calls,
+                        fixed = TRUE) ||
+                 !grepl('"classic_flags":["O1","debug-optimized-mir"]',
+                        fallback_calls, fixed = TRUE)) {
+        "FAIL legacy fallback received the wrong call shape"
+      } else {
+        "ok"
+      }
+      c(good, instrumented, warning_ok, bad, fallback)
+    }, finally = restore_process())
+    statuses
   `);
   const statuses = (await candidate.toJs()).values;
   const failure = statuses.find((status) => status !== 'ok');
@@ -129,6 +197,6 @@ if (compilerPath) {
 }
 
 console.log(compilerPath
-  ? 'webr load OK: runtime symbols and portable compiler resolve'
+  ? 'webr load OK: runtime symbols and R portable helper resolve'
   : 'webr load OK: side module loads and the bridge symbols resolve');
 process.exit(0);


### PR DESCRIPTION
## Summary

- make the real V8 and webR helpers select stanli_compile by export presence
- keep stock stanc only as the absent-export fallback and never retry a selected producer error
- preserve source and MIR as exact UTF-8 bytes
- quote paths and model names as JavaScript literals across Windows and webR
- exercise the actual R helpers with the workflow browser compiler in V8 and webR
- document the GitHub and R-universe release routes that are in use

This does not replace the JavaScript compiler bundled in the R package. That switch remains gated on a released runtime containing the compact-v2 reader.

## Evidence

- local installed-package R CMD check passes with zero failures
- hosted R checks pass on Windows, macOS, Ubuntu release, and Ubuntu devel
- the candidate browser compiler passes through the installed R package and real runtime
- an exact-head full workflow passes the real webR side-module and R-helper path
- native, JavaScript, and Windows producer parity gates pass
- workflow YAML, repository format, and generated-document checks pass