### PR TITLE
Release the compact-v2 compatibility runtime as 0.9.3

### DIFF
--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -1,15 +1,13 @@
-# R CMD check for the R package, on the platforms CRAN checks on.
+# R CMD check for the R package on its supported desktop platforms.
 #
-# Deliberately without a runtime. CRAN's farm will not have one either --
-# the 16 MB library is downloaded on first use, not built from source --
-# so this job answers the question CRAN asks: does the package install,
-# document, and check cleanly on its own? The sampling tests skip here
-# and say so. They run for real in wheels.yml, against the .so that
-# build job just produced, and that job fails if they skip.
+# Deliberately without a runtime: the 16 MB library is downloaded only when
+# the user asks for it, not built with the package. This job checks that the
+# package installs, documents, and checks cleanly on its own. The sampling
+# tests skip here and say so. They run for real in wheels.yml, against the .so
+# that build job just produced, and that job fails if they skip.
 #
 # What does run here is the JavaScript compiler path: stanc3 through V8,
-# which is the piece that makes the package shippable to CRAN at all and
-# the piece with no runtime dependency.
+# which is the source-compilation path with no runtime dependency.
 name: R
 
 on:
@@ -41,7 +39,8 @@ concurrency:
 jobs:
   # Two constants that must agree and live in different languages in
   # different directories. The runtime and the R bridge are separately
-  # versioned artifacts -- one is downloaded, the other comes from CRAN --
+  # versioned artifacts -- one is downloaded, the other is installed with
+  # the R package --
   # so the bridge refuses to bind when the numbers disagree at runtime.
   # That guard is only as good as the number it compares against, and
   # bumping capi.h without bridge.c would make it accept a runtime it
@@ -90,8 +89,8 @@ jobs:
           # manual and a runner without pdflatex reports the absence as
           # an Rd problem ("LaTeX errors when creating PDF version"),
           # which is a WARNING and an ERROR for something the package
-          # did not do. CRAN builds that manual, so the answer is to
-          # have a pdflatex rather than to stop asking.
+          # did not do. Providing pdflatex keeps this a meaningful package
+          # check rather than an environment failure.
           - {os: ubuntu-latest,  r: 'release', args: '"--as-cran"', tex: true}
           - {os: ubuntu-latest,  r: 'devel',   args: '"--no-manual"'}
           - {os: macos-latest,   r: 'release', args: '"--no-manual"'}
@@ -121,7 +120,6 @@ jobs:
         with:
           working-directory: r
           args: ${{ matrix.args }}
-          # One NOTE is expected and permanent until the package is on
-          # CRAN ("New submission"); nothing else may appear.
+          # One NOTE ("New submission") is expected; nothing else may appear.
           error-on: '"warning"'
           upload-snapshots: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,53 @@
 
 ## Unreleased
 
+## 0.9.3
+
+### Portable MIR is compact and shared
+
+The native, browser, npm, and Windows compilers now run one stanli-owned OCaml
+pipeline over upstream typed MIR (#211, #213). Native OCaml, js_of_ocaml, and
+the Windows executable emit byte-identical canonical output for ordinary
+models, nested user functions, loop control, checked integer folding, exact
+floating-point payloads, Unicode, and includes. Browser and npm packages prefer
+the shared compiler while keeping pristine stancjs as a one-release rollback;
+Windows packages similarly prefer `stanli-compile.exe` and retain `stanc.exe`.
+A selected compiler failure is reported directly rather than hidden by retrying
+another producer.
+
+The first portable JSON envelope never shipped and has been replaced by compact
+Portable MIR v2 (#218). The reader builds the C++ MIR directly, enforces
+canonical base64 and bounded allocations, and retains the legacy S-expression
+reader. Across the 153-program fixture census, v2 uses 823,104 bytes versus
+4,652,169 for legacy MIR. Eight Schools decodes in a 0.074 ms fresh-process
+median versus 0.293 ms for legacy and occupies 6,932 bytes versus 33,320.
+
+### The R and webR bridge is ready for the shared compiler
+
+The real V8 and webR helpers recognize `stanli_compile()` by export presence,
+preserve exact UTF-8 bytes, and keep a selected producer's error final (#225).
+This release intentionally retains the legacy JavaScript compiler inside the R
+package while its runtime gains the compact-v2 reader. It is therefore the
+compatibility anchor for the next release: the next package's v2 compiler can
+run with this runtime, and this package's legacy compiler can run with the next
+runtime.
+
+### Selective upstream MIR passes can be measured independently
+
+The shared OCaml pipeline now has an explicit pass-selection boundary and a
+test-only probe for upstream `vectorize_loops` (#215, #217). The complete
+131-model measurement found no semantic failures; five MIR programs changed
+and two log-density values moved by one ULP. Production vectorization remains
+off, and the existing C++ reroll pass remains enabled.
+
+### More parameter-dependent programs lower
+
+Parameter-dependent regions now handle data-sized empty outputs, rows in size
+expressions, integer assignments and functions, logical and comparison
+operators, multidimensional integer-array reads, literal integer arrays,
+`rep_vector`, and data-dependent `break` and `continue` (#223). Declared but
+uninitialized locals and zero-width data input also lower correctly.
+
 ### The R runtime cache is keyed by release
 
 A runtime downloaded by an older version of the R package survived a

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@seantalts/stanli",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "description": "Full Stan in the browser: stanc3 compiles the model in JS, a WASM runtime lowers it to an op graph and runs NUTS. No server, no C++ toolchain.",
   "type": "module",
   "main": "index.mjs",

--- a/python/stanli/__init__.py
+++ b/python/stanli/__init__.py
@@ -21,7 +21,7 @@ __all__ = ["Model", "Fit", "Summary", "OptimizeResult",
            "SAMPLER_COLUMNS", "__version__"]
 # The one place the version lives. setup.py and the release workflow both
 # read it from here.
-__version__ = "0.9.2"
+__version__ = "0.9.3"
 
 _BIN = pathlib.Path(__file__).parent / "_bin"
 

--- a/r/DESCRIPTION
+++ b/r/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: stanli
 Type: Package
 Title: The Stan Language Interpreter
-Version: 0.9.2
+Version: 0.9.3
 Authors@R: person("Sean", "Talts", email = "xitrium@gmail.com",
                   role = c("aut", "cre"))
 Description: Compile and sample Stan models without a C++ toolchain. Stan

--- a/r/R/install.R
+++ b/r/R/install.R
@@ -14,7 +14,7 @@
 # and a default of "latest" would silently pair a pinned binding with a runtime
 # that has moved. The release workflow asserts this equals the tag being cut,
 # so bumping one without the other fails there rather than at a user's install.
-stanli_runtime_release <- "v0.9.2"
+stanli_runtime_release <- "v0.9.3"
 
 runtime_filename <- function() {
   switch(Sys.info()[["sysname"]],


### PR DESCRIPTION
## Summary

- bump Python, npm, R, and the pinned runtime release together to 0.9.3
- document the shared OCaml producers, compact-v2 runtime reader, Windows compiler, R/webR dispatch readiness, vectorization measurements, and language coverage shipped since 0.9.2
- deliberately keep the R package bundled JavaScript compiler byte-identical to 0.9.2 for the cross-release compatibility handoff
- remove obsolete registry assumptions from the active R workflow comments; `--as-cran` remains only as the strict R CMD check mode

## Compatibility role

This is the dual-reader anchor for the next shipping tranche. Its runtime accepts compact v2 and legacy S-expression MIR, while its R package still produces legacy MIR. The next package can therefore move its bundled compiler to the shared compact-v2 producer and test both directions against a real published predecessor.

No production MIR pass selection changes here; `vectorize_loops` remains off.

## Local evidence

- `R CMD build r`
- `_R_CHECK_FORCE_SUGGESTS_=false R CMD check --no-manual --ignore-vignettes stanli_0.9.3.tar.gz` — Status: OK
- all four release version sources resolve to 0.9.3
- `r/inst/js/stanc.js` and its provenance file are byte-identical to v0.9.2
- repository formatting, generated docs, workflow YAML, and diff whitespace checks pass
- added-code wording check passes

## Merge and tag gate

Merge after the exact-main R/webR/Windows/browser validation and this PR matrix pass. Create and push the v0.9.3 tag only from the verified merge commit; the tag then publishes PyPI, npm, GitHub runtime assets, and the R source package through the existing release workflow.