### PR TITLE
Support full-span indexed MIR assignments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+### Complete indexed assignments lower everywhere
+
+Assignments such as `x[:] = rhs` now preserve the destination's declared
+shape and integer representation in transformed data, graph lowering,
+parameter-dependent register programs, ODE functions, and generated
+quantities. This also prepares the runtime for assignment loops rewritten by
+the upstream `vectorize_loops` pass.
+
 ## 0.9.5
 
 ### Upstream MIR loop vectorization is enabled

--- a/runtime/include/stanli/mir_interp.hpp
+++ b/runtime/include/stanli/mir_interp.hpp
@@ -302,6 +302,33 @@ class MirInterp {
         Value* en = find(st.lhs);
         if (!en) fail("assignment to unknown " + st.lhs);
         Value v = eval(st.rhs);
+        // A lone All replaces the complete container. Retain the declared
+        // geometry and integer specialization owned by the destination:
+        // replacing the Value object wholesale would let malformed MIR
+        // resize or retag the declaration. The two-index matrix column form
+        // remains on its existing path below.
+        if (st.lhs_idx.size() == 1 && st.lhs_idx[0].name == "IndexAll") {
+          if (en->dims.empty())
+            fail("full-span assignment needs a container", st.raw);
+          if (v.r.size() != en->r.size())
+            fail("full-span assignment size mismatch", st.raw);
+          if (v.dims != en->dims)
+            fail("full-span assignment shape mismatch", st.raw);
+          const bool target_is_int = en->is_int;
+          en->r = std::move(v.r);
+          en->i.clear();
+          en->is_int = target_is_int;
+          if (target_is_int) {
+            en->i.reserve(en->r.size());
+            if (v.is_int && v.i.size() == en->r.size()) {
+              en->i = std::move(v.i);
+            } else {
+              for (const T& value : en->r)
+                en->i.push_back(static_cast<int>(val(value)));
+            }
+          }
+          return;
+        }
         // Fix one or more leading dimensions of an N-D array and replace
         // the complete remaining container. For array[3] matrix[2,4] x,
         // x[i,j] is a row_vector[4]. First-index-fast storage makes those

--- a/runtime/include/stanli/mir_prog.hpp
+++ b/runtime/include/stanli/mir_prog.hpp
@@ -1058,6 +1058,21 @@ struct ProgramCompiler {
             emit(Program::MOV, dst.reg + k, v.reg + k);
           return;
         }
+        // A single All is the complete destination view. This is reachable
+        // in ODE functions and parameter-dependent statement islands, so it
+        // must agree with both graph lowering and MirInterp rather than
+        // forcing an otherwise supported region onto the fallback path.
+        if (s.lhs_idx.size() == 1 && s.lhs_idx[0].name == "IndexAll") {
+          if (dst.kind == ViewKind::Flat)
+            bail("full-span assignment needs a container for " + s.lhs);
+          if (v.len != dst.len)
+            bail("full-span assignment width mismatch for " + s.lhs);
+          if (!same_view(v, dst))
+            bail("full-span assignment logical view mismatch for " + s.lhs);
+          for (int k = 0; k < v.len; ++k)
+            emit(Program::MOV, dst.reg + k, v.reg + k);
+          return;
+        }
         for (const auto& ix : s.lhs_idx)
           if (ix.name != "IndexSingle")
             bail("assignment index form for " + s.lhs);

--- a/runtime/src/lower.cpp
+++ b/runtime/src/lower.cpp
@@ -4744,6 +4744,24 @@ struct Lowering {
           const Val rhs_v = lower_expr(s.rhs);
           const int rhs = rhs_v.slot;
           SlotInfo out_si = prev_v.si;
+          // A one-index All spans the complete logical value. Keep this as
+          // an indexed functional update rather than silently rewriting the
+          // MIR statement: the ordinary binding checks still enforce width
+          // and logical view, while the store path preserves integer-array
+          // initialization and observation metadata. Matrix `[:, j]` is a
+          // separate two-index form below and never enters this branch.
+          if (s.lhs_idx.size() == 1 && s.lhs_idx[0].name == "IndexAll") {
+            if (is_scalar(prev_v))
+              fail("full-span assignment needs a container for " + s.lhs,
+                   s.raw);
+            require_binding(rhs_v, g.slots[prev].len, prev_v.si, s.lhs, s.raw);
+            Val nv = emit_value(OP_SET_SLICE, {prev_v, rhs_v},
+                                g.slots[prev].len, out_si, {0});
+            propagate_int_update(nv, prev_v, rhs_v, 0, 1);
+            scope[s.lhs] = nv;
+            sync_data_local(s.lhs, s.rhs, nv);
+            return;
+          }
           // Whole matrix row write M[i] = row_vector: one value per column,
           // strided by the physical row count.
           if (s.lhs_idx.size() == 1 && s.lhs_idx[0].name == "IndexSingle" &&

--- a/tests/compiler/portable_full_span_assignment.stan
+++ b/tests/compiler/portable_full_span_assignment.stan
@@ -1,0 +1,14 @@
+data {
+  int<lower=0> N;
+  vector[N] x;
+}
+transformed data {
+  vector[N] y;
+  y[:] = x;
+}
+parameters {
+  real z;
+}
+model {
+  z ~ normal(sum(y), 1);
+}

--- a/tests/test_mir.cpp
+++ b/tests/test_mir.cpp
@@ -775,6 +775,101 @@ int main(int argc, char** argv) {
       }
       return false;
     };
+
+    // A one-dimensional All on the LHS replaces the complete value while
+    // retaining the destination's geometry and integer payload. Exercise
+    // both vector orientations, scalar/container arrays, and the mismatch
+    // checks directly in the semantic fallback.
+    auto put_real = [&](const std::string& name, std::vector<double> values,
+                        std::vector<int64_t> dims) {
+      DataMap::Entry entry;
+      entry.r = std::move(values);
+      entry.dims = std::move(dims);
+      interp.env()[name] = std::move(entry);
+    };
+    auto full_write = [&](const std::string& lhs, const std::string& rhs,
+                          const std::string& type, mir::UnsizedView view) {
+      mir::Stmt assignment;
+      assignment.kind = mir::Stmt::Assignment;
+      assignment.lhs = lhs;
+      assignment.lhs_idx = {all()};
+      assignment.rhs.kind = mir::Expr::Var;
+      assignment.rhs.name = rhs;
+      assignment.rhs.type_ = type;
+      assignment.rhs.unsized = view;
+      assignment.rhs.data_only = true;
+      return assignment;
+    };
+
+    put_real("span_vector", {0, 0, 0}, {3});
+    put_real("span_vector_rhs", {1, 2, 3}, {3});
+    interp.run({full_write("span_vector", "span_vector_rhs", "UVector",
+                           {0, mir::UnsizedLeaf::Vector})});
+    check(
+        interp.env().at("span_vector").dims == std::vector<int64_t>({3}) &&
+            interp.env().at("span_vector").r == std::vector<double>({1, 2, 3}),
+        "full-span vector assignment");
+
+    put_real("span_row", {0, 0, 0}, {3});
+    put_real("span_row_rhs", {4, 5, 6}, {3});
+    interp.run({full_write("span_row", "span_row_rhs", "URowVector",
+                           {0, mir::UnsizedLeaf::RowVector})});
+    check(interp.env().at("span_row").dims == std::vector<int64_t>({3}) &&
+              interp.env().at("span_row").r == std::vector<double>({4, 5, 6}),
+          "full-span row-vector assignment");
+
+    DataMap::Entry span_ints;
+    span_ints.is_int = true;
+    span_ints.dims = {3};
+    span_ints.i = {0, 0, 0};
+    span_ints.r = {0, 0, 0};
+    interp.env()["span_ints"] = std::move(span_ints);
+    DataMap::Entry span_ints_rhs;
+    span_ints_rhs.is_int = true;
+    span_ints_rhs.dims = {3};
+    span_ints_rhs.i = {7, 8, 9};
+    span_ints_rhs.r = {7, 8, 9};
+    interp.env()["span_ints_rhs"] = std::move(span_ints_rhs);
+    interp.run({full_write("span_ints", "span_ints_rhs", "UArray",
+                           {1, mir::UnsizedLeaf::Int})});
+    const DataMap::Entry& full_ints = interp.env().at("span_ints");
+    check(full_ints.is_int && full_ints.dims == std::vector<int64_t>({3}) &&
+              full_ints.i == std::vector<int>({7, 8, 9}) &&
+              full_ints.r == std::vector<double>({7, 8, 9}),
+          "full-span int-array assignment retains both payloads");
+
+    put_real("span_nested", {0, 0, 0, 0}, {2, 2});
+    put_real("span_nested_rhs", {11, 12, 21, 22}, {2, 2});
+    interp.run({full_write("span_nested", "span_nested_rhs", "UArray",
+                           {1, mir::UnsizedLeaf::Vector})});
+    check(interp.env().at("span_nested").dims == std::vector<int64_t>({2, 2}) &&
+              interp.env().at("span_nested").r ==
+                  std::vector<double>({11, 12, 21, 22}),
+          "full-span array-container assignment");
+
+    put_real("span_short", {0, 0, 0}, {3});
+    put_real("span_short_rhs", {1, 2}, {2});
+    check(
+        assignment_refused(full_write("span_short", "span_short_rhs", "UVector",
+                                      {0, mir::UnsizedLeaf::Vector})),
+        "full-span assignment checks storage length");
+    put_real("span_shape", {0, 0, 0, 0}, {2, 2});
+    put_real("span_shape_rhs", {1, 2, 3, 4}, {4});
+    check(
+        assignment_refused(full_write("span_shape", "span_shape_rhs", "UArray",
+                                      {1, mir::UnsizedLeaf::Vector})),
+        "full-span assignment checks logical shape");
+
+    // Keep the pre-existing matrix column form on its own two-index path.
+    put_real("span_matrix", {1, 2, 3, 4}, {2, 2});
+    put_real("span_column", {9, 8}, {2});
+    mir::Stmt column_write = full_write("span_matrix", "span_column", "UVector",
+                                        {0, mir::UnsizedLeaf::Vector});
+    column_write.lhs_idx = {all(), single(2)};
+    interp.run({column_write});
+    check(interp.env().at("span_matrix").r == std::vector<double>({1, 2, 9, 8}),
+          "matrix column assignment remains distinct from full-span");
+
     mir::Stmt out_of_bounds = partial_write;
     out_of_bounds.lhs_idx = {single(4), single(1)};
     check(assignment_refused(out_of_bounds),

--- a/tests/test_mir_decode.cpp
+++ b/tests/test_mir_decode.cpp
@@ -3,13 +3,16 @@
 // below mirrors the production OCaml layout for malformed-input coverage.
 #include <stanli/compile.hpp>
 #include <stanli/mir_decode.hpp>
+#include <stanli/wa_interp.hpp>
 
 #include "../runtime/third_party/nlohmann_json.hpp"
 
+#include <algorithm>
 #include <cstdint>
 #include <cstdio>
 #include <cstring>
 #include <fstream>
+#include <functional>
 #include <initializer_list>
 #include <limits>
 #include <optional>
@@ -305,6 +308,31 @@ std::string real_target_v2_payload(uint64_t bits, uint8_t data_only = 1,
   append_u32(payload, 0);      // fun_defs
   append_u32(payload, 0);      // output_vars
   return payload;
+}
+
+size_t replace_assignment_with_all(std::string& text, const std::string& lhs,
+                                   const std::string& type) {
+  const std::string from = "(Assignment ((LVariable " + lhs + ") ()) " + type;
+  const std::string to = "(Assignment ((LVariable " + lhs + ") (All)) " + type;
+  size_t count = 0;
+  for (size_t at = 0; (at = text.find(from, at)) != std::string::npos;) {
+    text.replace(at, from.size(), to);
+    at += to.size();
+    ++count;
+  }
+  return count;
+}
+
+size_t count_full_span_assignments(const std::vector<mir::Stmt>& body,
+                                   const std::string& lhs) {
+  size_t count = 0;
+  for (const mir::Stmt& statement : body) {
+    count += statement.kind == mir::Stmt::Assignment && statement.lhs == lhs &&
+             statement.lhs_idx.size() == 1 &&
+             statement.lhs_idx[0].name == "IndexAll";
+    count += count_full_span_assignments(statement.body, lhs);
+  }
+  return count;
 }
 
 template <typename T, typename Write>
@@ -813,6 +841,262 @@ void check_lowering_equivalence(const char* legacy_fixture,
         "portable lowering gradient bitwise");
 }
 
+void check_full_span_assignment_lowering() {
+  const auto decoded_pair = [](const std::string& legacy_text,
+                               const std::string& what) {
+    const mir::Program legacy_program = decode_program(legacy_text);
+    const std::string portable_text = write_v2(legacy_program);
+    const mir::Program portable_program = decode_program(portable_text);
+    check(write_program_object(portable_program) ==
+              write_program_object(legacy_program),
+          what + " portable decode matches legacy decode");
+    return std::make_pair(portable_text, legacy_program);
+  };
+  const auto run_log = [](CompiledModel& model,
+                          const std::vector<double>& params,
+                          const std::string& what) {
+    Executor executor(std::move(model.graph));
+    model.bind(executor);
+    check(executor.n_params() == static_cast<int64_t>(params.size()),
+          what + " parameter width");
+    const size_t n =
+        std::min(params.size(), static_cast<size_t>(executor.n_params()));
+    std::copy_n(params.begin(), n, executor.params_data());
+    std::vector<double> gradient(static_cast<size_t>(executor.n_params()));
+    const double lp = executor.gradient(gradient.data());
+    return std::make_pair(lp, gradient);
+  };
+
+  // Arrays with vector and row-vector leaves exercise the complete logical
+  // view check in graph lowering, including the leaf orientation carried by
+  // the portable format.
+  {
+    std::string legacy =
+        slurp("tests/fixtures/view_array_container_extract.tmir.sexp");
+    check(replace_assignment_with_all(legacy, "vs", "(UArray UVector)") == 2,
+          "legacy array-vector assignments rewritten for fixture");
+    check(replace_assignment_with_all(legacy, "rs", "(UArray URowVector)") == 2,
+          "legacy array-row assignments rewritten for fixture");
+    const auto decoded =
+        decoded_pair(legacy, "full-span array-container fixture");
+    check(count_full_span_assignments(decoded.second.log_prob, "vs") == 1 &&
+              count_full_span_assignments(decoded.second.log_prob, "rs") == 1,
+          "legacy decoder preserves array-container IndexAll LHS");
+    CompiledModel legacy_model = compile_model(legacy, DataMap{});
+    CompiledModel portable_model = compile_model(decoded.first, DataMap{});
+    const auto legacy_result =
+        run_log(legacy_model, {0.25}, "legacy array-container full-span");
+    const auto portable_result =
+        run_log(portable_model, {0.25}, "portable array-container full-span");
+    check(legacy_result == portable_result,
+          "array-container full-span log_prob format parity");
+    check(legacy_result.first == 1630.25 &&
+              legacy_result.second == std::vector<double>({1.0}),
+          "array-container full-span log_prob value");
+  }
+
+  // Zero storage does not erase the declared array/vector geometry. A
+  // complete assignment of array[2] vector[0] therefore succeeds only when
+  // the logical views, rather than flat widths alone, agree.
+  {
+    std::string legacy =
+        slurp("tests/fixtures/viewa_explicit_zero_vectors.tmir.sexp");
+    check(
+        replace_assignment_with_all(legacy, "values", "(UArray UVector)") == 2,
+        "legacy zero-vector-array assignments rewritten for fixture");
+    const auto decoded =
+        decoded_pair(legacy, "full-span zero-vector-array fixture");
+    CompiledModel legacy_model = compile_model(legacy, DataMap{});
+    CompiledModel portable_model = compile_model(decoded.first, DataMap{});
+    const auto legacy_result =
+        run_log(legacy_model, {0.25}, "legacy zero-vector-array full-span");
+    const auto portable_result =
+        run_log(portable_model, {0.25}, "portable zero-vector-array full-span");
+    check(legacy_result == portable_result && legacy_result.first == 200.25 &&
+              legacy_result.second == std::vector<double>({1.0}),
+          "zero-vector-array full-span value and format parity");
+  }
+
+  // The row-vector form uses the same storage width as a vector but a
+  // distinct logical view, so it is a focused orientation check.
+  {
+    std::string legacy = slurp("tests/fixtures/rep_row_vector.tmir.sexp");
+    check(replace_assignment_with_all(legacy, "x", "URowVector") == 2,
+          "legacy row-vector assignments rewritten for fixture");
+    const auto decoded = decoded_pair(legacy, "full-span row-vector fixture");
+    check(count_full_span_assignments(decoded.second.log_prob, "x") == 1,
+          "legacy decoder preserves row-vector IndexAll LHS");
+    CompiledModel legacy_model = compile_model(legacy, DataMap{});
+    CompiledModel portable_model = compile_model(decoded.first, DataMap{});
+    const auto legacy_result =
+        run_log(legacy_model, {0.25}, "legacy row-vector full-span");
+    const auto portable_result =
+        run_log(portable_model, {0.25}, "portable row-vector full-span");
+    check(legacy_result == portable_result,
+          "row-vector full-span log_prob format parity");
+
+    mir::Program mismatch = decoded.second;
+    std::function<bool(std::vector<mir::Stmt>&)> shorten =
+        [&](std::vector<mir::Stmt>& body) {
+          for (mir::Stmt& statement : body) {
+            if (statement.kind == mir::Stmt::Assignment &&
+                statement.lhs == "x" && statement.lhs_idx.size() == 1 &&
+                statement.lhs_idx[0].name == "IndexAll" &&
+                statement.rhs.args.size() == 2) {
+              statement.rhs.args[1].lit_i = 3;
+              statement.rhs.args[1].lit = 3.0;
+              return true;
+            }
+            if (shorten(statement.body)) return true;
+          }
+          return false;
+        };
+    check(shorten(mismatch.log_prob),
+          "full-span mismatch fixture found its assignment");
+    expect_compile_error(write_v2(mismatch), "assignment width mismatch for x",
+                         "full-span row-vector width mismatch");
+
+    mir::Program wrong_view = decoded.second;
+    std::function<bool(std::vector<mir::Stmt>&)> reorient =
+        [&](std::vector<mir::Stmt>& body) {
+          for (mir::Stmt& statement : body) {
+            if (statement.kind == mir::Stmt::Assignment &&
+                statement.lhs == "x" && statement.lhs_idx.size() == 1 &&
+                statement.lhs_idx[0].name == "IndexAll") {
+              statement.rhs.name = "rep_vector";
+              statement.rhs.type_ = "UVector";
+              statement.rhs.unsized.leaf = mir::UnsizedLeaf::Vector;
+              return true;
+            }
+            if (reorient(statement.body)) return true;
+          }
+          return false;
+        };
+    check(reorient(wrong_view.log_prob),
+          "full-span view mismatch fixture found its assignment");
+    expect_compile_error(write_v2(wrong_view),
+                         "assignment logical view mismatch for x",
+                         "full-span vector orientation mismatch");
+  }
+
+  // A transformed-data scalar array reaches MirInterp during concrete data
+  // specialization, then the graph consumes the assigned values.
+  {
+    std::string legacy = slurp("tests/fixtures/rangeclamp.tmir.sexp");
+    check(replace_assignment_with_all(legacy, "xs", "(UArray UReal)") == 1,
+          "legacy scalar-array assignment rewritten for fixture");
+    const auto decoded = decoded_pair(legacy, "full-span scalar-array fixture");
+    check(count_full_span_assignments(decoded.second.prepare_data, "xs") == 1,
+          "legacy decoder preserves scalar-array IndexAll LHS");
+    DataMap data;
+    data.set_int("K", 3);
+    data.set_int("lo", 1);
+    data.set_int("hi", 4);
+    data.set_real_array("Y", {0, 0, 0, 0}, {4});
+    data.set_real_array("Zm", std::vector<double>(8, 0.0), {4, 2});
+    CompiledModel legacy_model = compile_model(legacy, data);
+    CompiledModel portable_model = compile_model(decoded.first, data);
+    const auto legacy_result =
+        run_log(legacy_model, {0.125}, "legacy scalar-array full-span");
+    const auto portable_result =
+        run_log(portable_model, {0.125}, "portable scalar-array full-span");
+    check(legacy_result == portable_result,
+          "scalar-array full-span specialization format parity");
+  }
+
+  // An integer array initialized through a complete assignment is consumed
+  // later as integer data. Compiling the downstream ldexp expressions proves
+  // the assignment retained both initialized-prefix and observed-value
+  // specialization instead of leaving a typeless real slot behind.
+  {
+    std::string legacy = slurp("tests/fixtures/binint.tmir.sexp");
+    check(replace_assignment_with_all(legacy, "expo",
+                                      "(UArray (UArray UInt))") == 1,
+          "legacy int-array assignment rewritten for fixture");
+    const auto decoded = decoded_pair(legacy, "full-span int-array fixture");
+    const DataMap data = DataMap::from_json_file("tests/fixtures/binint.json");
+    const CompiledModel legacy_model = compile_model(legacy, data);
+    const CompiledModel portable_model = compile_model(decoded.first, data);
+    check(legacy_model.n_unconstrained == portable_model.n_unconstrained &&
+              legacy_model.fills == portable_model.fills &&
+              legacy_model.graph.ops.size() == portable_model.graph.ops.size(),
+          "int-array full-span specialization format parity");
+  }
+
+  // Generated quantities execute a vector full-span assignment whose RHS
+  // uses a draw-dependent array index. Run both formats with identical RNG
+  // streams and compare every emitted column and the stream position.
+  {
+    std::string legacy = slurp("tests/fixtures/gq_runtime_control.tmir.sexp");
+    check(replace_assignment_with_all(legacy, "chosen", "UVector") == 1,
+          "legacy generated vector assignment rewritten for fixture");
+    const auto decoded =
+        decoded_pair(legacy, "full-span generated-vector fixture");
+    check(count_full_span_assignments(decoded.second.generate_quantities,
+                                      "chosen") == 1,
+          "legacy decoder preserves generated-vector IndexAll LHS");
+    CompiledModel legacy_model = compile_model(legacy, DataMap{});
+    CompiledModel portable_model = compile_model(decoded.first, DataMap{});
+    const std::vector<double> params = {
+        0.2,           -0.3,          0.1,  -0.2, 1.0,  2.0,  3.0,  4.0,
+        std::log(1.1), std::log(1.7), 0.25, -0.5, 0.75, -1.0, 1.25, -1.5};
+    const auto legacy_log =
+        run_log(legacy_model, params, "legacy generated-vector full-span");
+    const auto portable_log =
+        run_log(portable_model, params, "portable generated-vector full-span");
+    check(legacy_log == portable_log,
+          "generated-vector full-span log_prob format parity");
+
+    check(legacy_model.write_array && portable_model.write_array,
+          "full-span generated-vector write_array exists");
+    if (legacy_model.write_array && portable_model.write_array) {
+      check(!legacy_model.write_array->interp &&
+                legacy_model.write_array->truncated.empty() &&
+                !portable_model.write_array->interp &&
+                portable_model.write_array->truncated.empty(),
+            "full-span generated-vector write_array lowers completely");
+      check(CompiledModel::csv_names(legacy_model.write_array->columns) ==
+                CompiledModel::csv_names(portable_model.write_array->columns),
+            "full-span generated-vector output columns");
+      Executor legacy_write(std::move(legacy_model.write_array->graph));
+      Executor portable_write(std::move(portable_model.write_array->graph));
+      legacy_model.write_array->bind(legacy_write);
+      portable_model.write_array->bind(portable_write);
+      check(
+          legacy_write.n_params() == static_cast<int64_t>(params.size()) &&
+              portable_write.n_params() == static_cast<int64_t>(params.size()),
+          "full-span generated-vector write_array parameter width");
+      std::copy(params.begin(), params.end(), legacy_write.params_data());
+      std::copy(params.begin(), params.end(), portable_write.params_data());
+      WaRng legacy_rng(81), portable_rng(81);
+      legacy_write.run_forward_only(EvalState{&legacy_rng});
+      portable_write.run_forward_only(EvalState{&portable_rng});
+      const auto collect = [](const CompiledModel::WriteArray& write_array,
+                              Executor& executor) {
+        std::vector<double> row;
+        for (const auto& column : write_array.columns) {
+          const double* values = executor.value_ptr(column.slot);
+          for (int64_t i = 0; i < column.len; ++i)
+            row.push_back(values[column.storage_index(i)]);
+        }
+        return row;
+      };
+      const std::vector<double> legacy_row =
+          collect(*legacy_model.write_array, legacy_write);
+      const std::vector<double> portable_row =
+          collect(*portable_model.write_array, portable_write);
+      const bool same_row =
+          legacy_row.size() == portable_row.size() &&
+          std::memcmp(legacy_row.data(), portable_row.data(),
+                      legacy_row.size() * sizeof(double)) == 0;
+      check(same_row,
+            "full-span generated-vector write_array value format parity");
+      check(legacy_rng.gen()() == portable_rng.gen()(),
+            "full-span generated-vector RNG stream parity");
+    }
+  }
+}
+
 void check_overload_finalization() {
   const mir::Program resolved =
       read_fixture("tests/fixtures/overload.tmir.sexp");
@@ -890,6 +1174,11 @@ void check_structural_rejections() {
   const mir::Program upfrom = decode_program(write_v2(target_program(indexed)));
   check(upfrom.log_prob[0].target.args[1].name == "IndexUpfrom",
         "IndexUpfrom portable shape");
+
+  bad_index.name = "IndexAll";
+  indexed.args[1] = bad_index;
+  expect_error(write_v2(target_program(indexed)), "IndexAll call",
+               "IndexAll with an operand");
 
   bad_index.name = "FutureIndex";
   indexed.args[1] = bad_index;
@@ -1263,6 +1552,7 @@ int main(int argc, char** argv) {
   check_round_trip("tests/fixtures/paramcond_break.tmir.sexp");
   check_lowering_equivalence(argc == 3 ? argv[1] : nullptr,
                              argc == 3 ? argv[2] : nullptr);
+  check_full_span_assignment_lowering();
   check_overload_finalization();
   check_exact_float_bits();
   check_structural_rejections();

--- a/tests/test_mir_program_conformance.cpp
+++ b/tests/test_mir_program_conformance.cpp
@@ -8,6 +8,7 @@
 
 #include <stanli/mir.hpp>
 #include <stanli/mir_interp.hpp>
+#include <stanli/mir_prog.hpp>
 #include <stanli/ode_prog.hpp>
 
 #include <cmath>
@@ -114,6 +115,15 @@ Stmt assignment(std::string name, Expr rhs) {
   s.kind = Stmt::Assignment;
   s.lhs = std::move(name);
   s.rhs = std::move(rhs);
+  return s;
+}
+
+Stmt full_span_assignment(std::string name, Expr rhs) {
+  Stmt s = assignment(std::move(name), std::move(rhs));
+  Expr all;
+  all.kind = Expr::FunApp;
+  all.name = "IndexAll";
+  s.lhs_idx.push_back(std::move(all));
   return s;
 }
 
@@ -506,6 +516,101 @@ void test_uninitialized_real() {
            {std::move(entry)}, 1.0, {std::numeric_limits<double>::quiet_NaN()});
 }
 
+void test_full_span_ode_vector() {
+  // ODE RHS compilation is one production caller of ProgramCompiler. The
+  // destination is vector[1], and y supplies a vector view of exactly that
+  // width, so the indexed assignment must stay on the compiled path.
+  FunDef entry =
+      rhs_function("full_span_vector_rhs",
+                   {declaration("copy", "SVector", {lit_int(1)}),
+                    full_span_assignment("copy", var("y", "UVector")),
+                    return_value(var("copy", "UVector"))});
+  run_case("full-span ODE vector", "vector[1] copy[:] = y returns y",
+           {std::move(entry)}, 1.0, {0.25});
+}
+
+void test_full_span_program_views() {
+  // Statement islands also use ProgramCompiler and can bind complete array
+  // container views from surrounding graph slots. Build those bindings
+  // directly here so vector, row-vector, scalar-array, and array-container
+  // geometry all execute through the register machine.
+  const auto exercise = [&](const std::string& name, stanli::Range dst,
+                            stanli::Range rhs, std::vector<double> values) {
+    stanli::Program program;
+    std::map<std::string, const FunDef*> functions;
+    stanli::ProgramCompiler compiler{program, functions};
+    dst.reg = compiler.alloc(dst.len);
+    rhs.reg = compiler.alloc(rhs.len);
+    std::vector<double> initial(static_cast<size_t>(dst.len), -1.0);
+    compiler.emit_const(dst.reg, initial.data(), dst.len);
+    compiler.emit_const(rhs.reg, values.data(), rhs.len);
+    compiler.reals["dst"] = dst;
+    compiler.reals["rhs"] = rhs;
+    const std::string rhs_type =
+        rhs.kind == stanli::ViewKind::Vector      ? "UVector"
+        : rhs.kind == stanli::ViewKind::RowVector ? "URowVector"
+                                                  : "UArray";
+    compiler.stmt(full_span_assignment("dst", var("rhs", rhs_type)));
+    compiler.finish();
+    const stanli::Range out = compiler.reals.at("dst");
+    std::vector<double> registers(static_cast<size_t>(program.n_regs));
+    stanli::run_program(program, registers);
+    std::vector<double> got(registers.begin() + out.reg,
+                            registers.begin() + out.reg + out.len);
+    if (got != values) {
+      ++failures;
+      std::printf("FAIL %-24s Program full-span value mismatch\n",
+                  name.c_str());
+    }
+  };
+
+  stanli::Range vector;
+  vector.len = 3;
+  vector.kind = stanli::ViewKind::Vector;
+  exercise("full-span vector view", vector, vector, {1, 2, 3});
+
+  stanli::Range row;
+  row.len = 3;
+  row.kind = stanli::ViewKind::RowVector;
+  exercise("full-span row view", row, row, {4, 5, 6});
+
+  stanli::Range scalar_array;
+  scalar_array.len = 4;
+  scalar_array.kind = stanli::ViewKind::Array;
+  scalar_array.dims = {2, 2};
+  exercise("full-span scalar array", scalar_array, scalar_array,
+           {11, 12, 21, 22});
+
+  stanli::Range container_array;
+  container_array.len = 8;
+  container_array.kind = stanli::ViewKind::Array;
+  container_array.dims = {2, 2, 2};
+  exercise("full-span container array", container_array, container_array,
+           {1, 2, 3, 4, 5, 6, 7, 8});
+
+  stanli::Program mismatch_program;
+  std::map<std::string, const FunDef*> functions;
+  stanli::ProgramCompiler mismatch{mismatch_program, functions};
+  stanli::Range dst{mismatch.alloc(4), 4};
+  dst.kind = stanli::ViewKind::Array;
+  dst.dims = {2, 2};
+  stanli::Range rhs{mismatch.alloc(4), 4};
+  rhs.kind = stanli::ViewKind::Array;
+  rhs.dims = {4};
+  mismatch.reals["dst"] = dst;
+  mismatch.reals["rhs"] = rhs;
+  bool refused = false;
+  try {
+    mismatch.stmt(full_span_assignment("dst", var("rhs", "UArray")));
+  } catch (const stanli::Bail& error) {
+    refused = error.why.find("logical view mismatch") != std::string::npos;
+  }
+  if (!refused) {
+    ++failures;
+    std::printf("FAIL full-span Program accepted mismatched array geometry\n");
+  }
+}
+
 void test_matrix_row_indexing() {
   // A[1] is the complete first row.  For [[1,2],[3,4]], sum(A[1]) is 3;
   // indexing a flattened register is not the same operation.
@@ -639,6 +744,8 @@ int main() {
   test_short_circuit_or_requires_rhs();
   test_short_circuit_and_requires_rhs();
   test_uninitialized_real();
+  test_full_span_ode_vector();
+  test_full_span_program_views();
   test_matrix_row_indexing();
   test_mixed_integer_udf_arguments();
   test_nested_print_effect();

--- a/tests/test_portable_stancjs.cjs
+++ b/tests/test_portable_stancjs.cjs
@@ -73,6 +73,8 @@ const models = [
   ["nested-udf", "tests/fixtures/view_udf_local_data_branch.stan"],
   ["loop-control", "tests/fixtures/paramcond_break.stan"],
   ["vectorized-loop", "tests/compiler/portable_vectorize_loop.stan"],
+  ["full-span-assignment",
+    "tests/compiler/portable_full_span_assignment.stan"],
   ["mother", "tests/stanc3/mother.stan"],
   ["folded-float", "tests/compiler/portable_folded_float.stan"],
   ["int32-overflow", "tests/compiler/portable_int32_overflow.stan"],

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -305,6 +305,19 @@ def test_stan_to_mir_round_trips():
     assert (g_a == g_b).all(), f"gradient differs: {g_a} vs {g_b}"
 
 
+def test_full_span_assignment_from_source():
+    code = """
+    data { int<lower=0> N; vector[N] x; }
+    transformed data { vector[N] y; y[:] = x; }
+    parameters { real z; }
+    model { z ~ normal(sum(y), 1); }
+    """
+    model = stanli.Model(stan_code=code, data={"N": 3, "x": [1, 2, 3]})
+    lp, gradient = model.log_prob_grad(np.array([0.0]))
+    assert np.isfinite(lp)
+    assert gradient.tolist() == [6.0]
+
+
 def test_stan_to_mir_is_optimized():
     # The MIR handed to the runtime uses stanli's shared optimization policy,
     # not raw transformed MIR. Partial evaluation is the observable here: at


### PR DESCRIPTION
## Summary

- Support one-dimensional complete-container assignments such as `x[:] = rhs` in graph lowering, the concrete MIR interpreter, and the register program used by ODE functions and parameter-dependent regions.
- Preserve destination geometry and integer specialization, and reject scalar, width, shape, and logical-view mismatches.
- Exercise portable and legacy decoding, transformed data, log density, generated quantities, RNG streams, ODEs, vectors, row vectors, scalar arrays, nested containers, zero-width leaves, and integer arrays.
- Add a source-level compiler fixture to the native/JavaScript/Windows exact-byte matrix and a packaged Python source-to-runtime test.

## Why

This is valid Stan source today and is also the runtime vocabulary needed by the assignment-loop expansion proposed in upstream stanc3 #1678. Landing the capability separately keeps the runtime change independently reviewable and leaves the production compiler policy unchanged.

## Validation

- 67/67 native CTests pass on the exact v0.9.5 merge.
- The focused MIR interpreter, decoder/lowering, and compiled-program conformance tests pass.
- The full staged Python API suite passes 26/26, including the new source-to-runtime case.
- Native OCaml and js_of_ocaml emit byte-identical compact MIR for the new fixture; CI also runs the same comparison against the Windows compiler.
- Formatting, diff integrity, and added-wording checks pass.

Production remains upstream O1 plus the already-enabled `vectorize_loops`; this PR does not repin stanc3 or enable additional transforms.
