### PR TITLE
Add `log1p_exp` op, support diagonal matrix ops in parameter-dependent regions

### DIFF
--- a/runtime/include/stanli/mir_interp.hpp
+++ b/runtime/include/stanli/mir_interp.hpp
@@ -1717,6 +1717,20 @@ class MirInterp {
         r.r[(size_t)(i * n + i)] = diagonal.r[(size_t)i];
       return r;
     }
+    if (e.name == "diagonal") {
+      if (e.args.size() != 1)
+        fail("diagonal: needs exactly one argument", e.raw);
+      Value matrix = eval(e.args[0]);
+      if (matrix.dims.size() != 2) fail("diagonal: needs a matrix", e.raw);
+      const int64_t rows = matrix.dims[0], cols = matrix.dims[1];
+      const int64_t n = std::min(rows, cols);
+      const int64_t stride = rows + 1;
+      r.dims = {n};
+      r.r.reserve((size_t)n);
+      for (int64_t i = 0; i < n; ++i)
+        r.r.push_back(matrix.r.at((size_t)(i * stride)));
+      return r;
+    }
     if (e.name == "cholesky_decompose" && e.args.size() == 1) {
       // Standard column-oriented Cholesky on the templated scalar.
       Value a = eval(e.args[0]);

--- a/runtime/include/stanli/mir_prog.hpp
+++ b/runtime/include/stanli/mir_prog.hpp
@@ -636,6 +636,18 @@ struct ProgramCompiler {
     return out;
   }
 
+  // The diagonal, on the same terms as a row: column-major storage puts
+  // its elements rows + 1 apart, and Eigen's stops at the shorter side.
+  Range matrix_diagonal(const Range& m) {
+    const int64_t n = m.rows < m.cols ? m.rows : m.cols;
+    const int r = alloc((int)n);
+    for (int64_t k = 0; k < n; ++k)
+      emit(Program::MOV, r + (int)k, m.reg + (int)(k * (m.rows + 1)));
+    Range out{r, (int)n};
+    out.kind = ViewKind::Vector;
+    return out;
+  }
+
   Range fun(const mir::Expr& e) {
     // A shape query is a constant whatever surrounds it. Ahead of every
     // other case because `FnLength` is an internal function and the rest
@@ -694,6 +706,12 @@ struct ProgramCompiler {
     }
     if (e.args.empty() && e.name == "negative_infinity")
       return {konst(-std::numeric_limits<double>::infinity()), 1};
+    if (e.args.size() == 1 && e.name == "diagonal") {
+      const Range a = expr(e.args[0]);
+      if (a.kind != ViewKind::Matrix)
+        bail("diagonal requires a matrix logical view");
+      return matrix_diagonal(a);
+    }
     if (e.args.size() == 2 && e.name == "rep_vector") {
       // The register file is a flat run of doubles, so a vector of one
       // repeated value is a run the compiler fills -- the same fill a

--- a/runtime/include/stanli/mir_prog.hpp
+++ b/runtime/include/stanli/mir_prog.hpp
@@ -897,6 +897,8 @@ struct ProgramCompiler {
         c = Program::FABS;
       else if (e.name == "inv_logit")
         c = Program::INV_LOGIT;
+      else if (e.name == "log1p_exp")
+        c = Program::LOG1P_EXP;
       else
         bail("function " + e.name);
       const int r = alloc(a.len);

--- a/runtime/include/stanli/mir_prog.hpp
+++ b/runtime/include/stanli/mir_prog.hpp
@@ -824,6 +824,32 @@ struct ProgramCompiler {
       out.len = n;
       return typed(out, e.type_);
     }
+    if ((e.name == "diag_pre_multiply" || e.name == "diag_post_multiply") &&
+        e.args.size() == 2) {
+      // These are diagonal matrix products, but forming the diagonal and
+      // running a dense GEMM would multiply and add explicit zeros. Emit the
+      // equivalent row or column scaling directly in column-major order.
+      const bool pre = e.name == "diag_pre_multiply";
+      const Range v = expr(e.args[pre ? 0 : 1]);
+      const Range m = expr(e.args[pre ? 1 : 0]);
+      if (m.kind != ViewKind::Matrix)
+        bail(e.name + " requires a matrix argument");
+      if (v.kind != ViewKind::Vector && v.kind != ViewKind::RowVector)
+        bail(e.name + " requires a vector argument");
+      const int64_t expected = pre ? m.rows : m.cols;
+      if (v.len != expected)
+        bail(e.name + " vector length does not match the matrix");
+      const int r = alloc(m.len);
+      for (int64_t j = 0; j < m.cols; ++j)
+        for (int64_t i = 0; i < m.rows; ++i) {
+          const int64_t k = j * m.rows + i;
+          emit(Program::MUL, r + (int)k, m.reg + (int)k,
+               v.reg + (int)(pre ? i : j));
+        }
+      Range out = m;
+      out.reg = r;
+      return typed(out, e.type_);
+    }
     if (e.args.size() == 2) {
       // An int-typed binary is integer arithmetic, and `divide` truncates
       // where the real DIV below does not: `divide(7, 2)` is 3, not 3.5.

--- a/runtime/include/stanli/mir_prog.hpp
+++ b/runtime/include/stanli/mir_prog.hpp
@@ -826,9 +826,9 @@ struct ProgramCompiler {
     }
     if ((e.name == "diag_pre_multiply" || e.name == "diag_post_multiply") &&
         e.args.size() == 2) {
-      // These are diagonal matrix products, but forming the diagonal and
-      // running a dense GEMM would multiply and add explicit zeros. Emit the
-      // equivalent row or column scaling directly in column-major order.
+      // One instruction preserves stan-math's diagonal-product callback as a
+      // unit. Scalar MULs would accumulate the repeated vector's adjoint in
+      // tape order instead of the callback's rowwise/colwise reduction order.
       const bool pre = e.name == "diag_pre_multiply";
       const Range v = expr(e.args[pre ? 0 : 1]);
       const Range m = expr(e.args[pre ? 1 : 0]);
@@ -840,12 +840,12 @@ struct ProgramCompiler {
       if (v.len != expected)
         bail(e.name + " vector length does not match the matrix");
       const int r = alloc(m.len);
-      for (int64_t j = 0; j < m.cols; ++j)
-        for (int64_t i = 0; i < m.rows; ++i) {
-          const int64_t k = j * m.rows + i;
-          emit(Program::MUL, r + (int)k, m.reg + (int)k,
-               v.reg + (int)(pre ? i : j));
-        }
+      // A zero-size multiplication has no values or adjoints. In particular,
+      // do not narrow an arbitrarily large empty dimension into Instr.
+      if (m.len != 0)
+        p.code.push_back(Program::Instr{
+            pre ? Program::DIAG_PRE_MULTIPLY : Program::DIAG_POST_MULTIPLY, r,
+            v.reg, m.reg, (int32_t)m.rows, (int32_t)m.cols});
       Range out = m;
       out.reg = r;
       return typed(out, e.type_);

--- a/runtime/include/stanli/mir_prog.hpp
+++ b/runtime/include/stanli/mir_prog.hpp
@@ -477,6 +477,13 @@ struct ProgramCompiler {
       case mir::Expr::Indexed: {
         const Range b = expr(e.args[0]);
         if (e.args.size() == 2 && e.args[1].name == "IndexAll") return b;
+        // A matrix row, `m[i]` or `m[i, ]`. Ahead of the all-single check
+        // below, which the explicit `IndexAll` would not pass.
+        if (b.kind == ViewKind::Matrix && e.args.size() >= 2 &&
+            e.args[1].name == "IndexSingle" &&
+            (e.args.size() == 2 ||
+             (e.args.size() == 3 && e.args[2].name == "IndexAll")))
+          return matrix_row(b, cint(e.args[1].args[0]));
         for (size_t k = 1; k < e.args.size(); ++k)
           if (e.args[k].name != "IndexSingle") bail("index form");
 
@@ -488,10 +495,9 @@ struct ProgramCompiler {
               bail("matrix index out of the declared range");
             return {b.reg + (int)((j - 1) * b.rows + i - 1), 1};
           }
-          // A direct matrix row is a strided Eigen view in generated C++.
-          // Materializing it here can change packet grouping in a following
-          // reduction, so this first runtime-control tranche accepts only
-          // explicit scalar matrix elements.
+          // A column, `m[, j]`, is a contiguous run this could return as a
+          // view; nothing reaches it yet, so it stays refused rather than
+          // untested.
           bail("matrix index form");
         }
 
@@ -608,6 +614,25 @@ struct ProgramCompiler {
     p.code[(size_t)jmp].dst = (int)p.code.size();
     Range out = av;
     out.reg = dst;
+    return out;
+  }
+
+  // One row of a matrix, copied into a run of its own. Column-major
+  // storage puts a row's elements `rows` apart, and a strided Eigen block
+  // has no packet access -- so stan-math reduces such a row in ascending
+  // scalar order, which is the order every reduction this compiler emits
+  // walks a run in. That is what makes the copy safe rather than merely
+  // convenient: `sum` accumulates ascending, `max` compares, and the rest
+  // are elementwise. A reduction with its own grouping (DOT, SOFTMAX,
+  // LSE_RANGE) is not one this compiler emits, and adding one would have
+  // to answer this question again.
+  Range matrix_row(const Range& m, long i) {
+    if (i < 1 || i > m.rows) bail("matrix index out of the declared range");
+    const int r = alloc((int)m.cols);
+    for (int64_t j = 0; j < m.cols; ++j)
+      emit(Program::MOV, r + (int)j, m.reg + (int)(j * m.rows + (i - 1)));
+    Range out{r, (int)m.cols};
+    out.kind = ViewKind::RowVector;
     return out;
   }
 

--- a/runtime/include/stanli/program.hpp
+++ b/runtime/include/stanli/program.hpp
@@ -81,6 +81,7 @@ enum ProgramOpFlag : uint16_t {
   X(FABS, kProgramSaveA)                                                     \
   X(INV_LOGIT, kProgramSaveOut)                                              \
   X(LOG1M, kProgramSaveA)                                                    \
+  X(LOG1P_EXP, kProgramSaveA)                                                \
   X(TANH, kProgramSaveA)                                                     \
   X(GT, kProgramReadB)                                                       \
   X(GE, kProgramReadB)                                                       \
@@ -306,6 +307,9 @@ void run_program(const Program& p, T* reg) {
         break;
       case Program::LOG1M:
         d() = stan::math::log1m(ra());
+        break;
+      case Program::LOG1P_EXP:
+        d() = stan::math::log1p_exp(ra());
         break;
       case Program::TANH:
         d() = stan::math::tanh(ra());

--- a/runtime/include/stanli/program.hpp
+++ b/runtime/include/stanli/program.hpp
@@ -103,6 +103,8 @@ enum ProgramOpFlag : uint16_t {
   X(LOG_MIX, kProgramReadB | kProgramReadC | kProgramSaveA | kProgramSaveB | \
                  kProgramSaveC)                                              \
   X(FMA, kProgramReadB | kProgramReadC | kProgramSaveA | kProgramSaveB)      \
+  X(DIAG_PRE_MULTIPLY, kProgramReadB | kProgramNoAdjoint)                    \
+  X(DIAG_POST_MULTIPLY, kProgramReadB | kProgramNoAdjoint)                   \
   X(DENSITY, 0)                                                              \
   X(CALL, 0)
 
@@ -202,6 +204,9 @@ inline constexpr const ProgramOpSpec& program_code_spec(Program::Code code) {
 }
 
 inline constexpr int program_output_len(const Program::Instr& instr) {
+  if (instr.code == Program::DIAG_PRE_MULTIPLY ||
+      instr.code == Program::DIAG_POST_MULTIPLY)
+    return static_cast<int>(static_cast<int64_t>(instr.c) * instr.len);
   const ProgramOpSpec& spec = program_code_spec(instr.code);
   return spec.has(kProgramNoOutput)      ? 0
          : spec.has(kProgramRangeOutput) ? instr.len
@@ -392,6 +397,23 @@ void run_program(const Program& p, T* reg) {
       case Program::FMA:
         d() = stan::math::fma(ra(), rb(), reg[(size_t)I.c]);
         break;
+      case Program::DIAG_PRE_MULTIPLY:
+      case Program::DIAG_POST_MULTIPLY: {
+        using MatT = Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>;
+        const int32_t rows = I.c, cols = I.len;
+        // A zero-size result contributes neither a value nor an adjoint.
+        // Avoid forming Maps from a null register file in the 0x0 case.
+        if (rows == 0 || cols == 0) break;
+        const int32_t vlen = I.code == Program::DIAG_PRE_MULTIPLY ? rows : cols;
+        Eigen::Map<const VecT> v(reg + I.a, vlen);
+        Eigen::Map<const MatT> m(reg + I.b, rows, cols);
+        Eigen::Map<MatT> out(reg + I.dst, rows, cols);
+        if (I.code == Program::DIAG_PRE_MULTIPLY)
+          out = stan::math::diag_pre_multiply(v, m);
+        else
+          out = stan::math::diag_post_multiply(m, v);
+        break;
+      }
         // One call for every scalar continuous density the runtime has;
       // program_density.cpp holds the switch, so the 27 instantiations
       // are paid in one translation unit instead of in every one that

--- a/runtime/src/adjoint.cpp
+++ b/runtime/src/adjoint.cpp
@@ -569,6 +569,13 @@ void run_adjoint(const Program& fwd, const AdjProgram& ap, const double* val,
         adj[I.dst] = 0.0;
         adj[I.a] += t / (val[I.va] - 1.0);
         break;
+      // The derivative stan-math precomputes for its own reverse rule, and
+      // the one OP_LOG1P_EXP carries on the graph side: the two paths have
+      // to agree to the bit, and one expression is how that stays true.
+      case Program::LOG1P_EXP:
+        adj[I.dst] = 0.0;
+        adj[I.a] += t * stan::math::inv_logit(val[I.va]);
+        break;
       case Program::TANH: {
         adj[I.dst] = 0.0;
         const double ch = std::cosh(val[I.va]);

--- a/runtime/src/adjoint.cpp
+++ b/runtime/src/adjoint.cpp
@@ -721,6 +721,8 @@ void run_adjoint(const Program& fwd, const AdjProgram& ap, const double* val,
       case Program::MAX_RANGE:
       case Program::JZ:
       case Program::JMP:
+      case Program::DIAG_PRE_MULTIPLY:
+      case Program::DIAG_POST_MULTIPLY:
         break;  // gen_adjoint refuses these; unreachable
       case Program::CALL:
         break;  // handled before this switch

--- a/runtime/src/lower.cpp
+++ b/runtime/src/lower.cpp
@@ -4035,6 +4035,16 @@ struct Lowering {
       return emit_value(OP_SLICE, {a}, a.si.rows, view_of(e.type_),
                         {(int)((j - 1) * a.si.rows)});
     }
+    if (e.name == "diagonal" && e.args.size() == 1) {
+      Val a = lower_expr(e.args[0]);
+      if (!is_matrix(a.si)) fail("diagonal on a slot without matrix shape");
+      // Eigen's diagonal steps one row and one column at a time, which in
+      // column-major storage is rows + 1 apart, and stops at the shorter
+      // side.
+      const int64_t n = std::min(a.si.rows, a.si.cols);
+      return emit_value(OP_SLICE_STRIDED, {a}, n, view_of(e.type_),
+                        {0, (int)(a.si.rows + 1)});
+    }
     if (e.name == "row" && e.args.size() == 2) {
       Val a = lower_expr(e.args[0]);
       if (!is_matrix(a.si)) fail("row on a slot without matrix shape");

--- a/runtime/src/mir_reader.cpp
+++ b/runtime/src/mir_reader.cpp
@@ -193,6 +193,7 @@ void validate_funapp_arity(const Expr& e) {
                 "dims",
                 "multiply_lower_tri_self_transpose",
                 "diag_matrix",
+                "diagonal",
                 "cholesky_decompose",
                 "eigenvalues_sym",
                 "eigenvectors_sym",

--- a/runtime/src/program.cpp
+++ b/runtime/src/program.cpp
@@ -105,7 +105,9 @@ void compact_program(Program& p, std::vector<std::pair<int, int>>& seeded) {
   if (n_regs <= 0) return;
   // DYN_INDEX's `c` is an offset into a run rather than a register.
   for (const auto& I : p.code) {
-    if (I.code == Program::DYN_INDEX) return;
+    if (I.code == Program::DYN_INDEX || I.code == Program::DIAG_PRE_MULTIPLY ||
+        I.code == Program::DIAG_POST_MULTIPLY)
+      return;
     if (I.code == Program::CALL && (I.a < 0 || (size_t)I.a >= p.calls.size()))
       return;
   }

--- a/tests/fixtures/diagtd.stan
+++ b/tests/fixtures/diagtd.stan
@@ -1,12 +1,14 @@
 data {
   vector[3] diagonal;
+  matrix[3, 2] rectangular;
 }
 transformed data {
   matrix[3, 3] diagonal_matrix = diag_matrix(diagonal);
+  vector[2] extracted = diagonal(rectangular);
 }
 parameters {
   real theta;
 }
 model {
-  theta ~ normal(diagonal_matrix[2, 2] + diagonal_matrix[1, 2], 1);
+  theta ~ normal(diagonal_matrix[2, 2] + diagonal_matrix[1, 2] + extracted[2], 1);
 }

--- a/tests/fixtures/diagtd.tmir.sexp
+++ b/tests/fixtures/diagtd.tmir.sexp
@@ -2,7 +2,11 @@
  (input_vars
   ((diagonal <opaque>
     (SVector AoS
-     ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+     ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+   (rectangular <opaque>
+    (SMatrix AoS
+     ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+     ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
  (prepare_data
   (((pattern
      (Decl (decl_adtype DataOnly) (decl_id pos__) (decl_type (Sized SInt))
@@ -79,6 +83,90 @@
         (meta <opaque>)))))
     (meta <opaque>))
    ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id rectangular)
+      (decl_type
+       (Sized
+        (SMatrix AoS
+         ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+         ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id rectangular_flat__)
+          (decl_type (Unsized (UArray UReal))) (initialize Uninit)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable rectangular_flat__) ()) (UArray UReal)
+          ((pattern
+            (FunApp (CompilerInternal FnReadData)
+             (((pattern (Lit Str rectangular))
+               (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable pos__) ()) UInt
+          ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar sym1__)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Lit Int 2))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (For (loopvar sym2__)
+                  (lower
+                   ((pattern (Lit Int 1))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (upper
+                   ((pattern (Lit Int 3))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (body
+                   ((pattern
+                     (Block
+                      (((pattern
+                         (Assignment
+                          ((LVariable rectangular)
+                           ((Single
+                             ((pattern (Var sym2__))
+                              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                            (Single
+                             ((pattern (Var sym1__))
+                              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                          UMatrix
+                          ((pattern
+                            (Indexed
+                             ((pattern (Var rectangular_flat__))
+                              (meta
+                               ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))
+                             ((Single
+                               ((pattern (Var pos__))
+                                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                           (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+                        (meta <opaque>))
+                       ((pattern
+                         (Assignment ((LVariable pos__) ()) UInt
+                          ((pattern
+                            (FunApp (StanLib Plus__ FnPlain AoS)
+                             (((pattern (Var pos__))
+                               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                              ((pattern (Lit Int 1))
+                               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                        (meta <opaque>)))))
+                    (meta <opaque>)))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))
+   ((pattern
      (Decl (decl_adtype DataOnly) (decl_id diagonal_matrix)
       (decl_type
        (Sized
@@ -94,6 +182,22 @@
          (((pattern (Var diagonal))
            (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
        (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id extracted)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable extracted) ()) UVector
+      ((pattern
+        (FunApp (StanLib diagonal FnPlain AoS)
+         (((pattern (Var rectangular))
+           (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly))))))
     (meta <opaque>))))
  (log_prob
   (((pattern
@@ -118,24 +222,35 @@
               ((pattern
                 (FunApp (StanLib Plus__ FnPlain AoS)
                  (((pattern
-                    (Indexed
-                     ((pattern (Var diagonal_matrix))
-                      (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly))))
-                     ((Single
-                       ((pattern (Lit Int 2))
-                        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-                      (Single
-                       ((pattern (Lit Int 2))
-                        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                    (FunApp (StanLib Plus__ FnPlain AoS)
+                     (((pattern
+                        (Indexed
+                         ((pattern (Var diagonal_matrix))
+                          (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly))))
+                         ((Single
+                           ((pattern (Lit Int 2))
+                            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                          (Single
+                           ((pattern (Lit Int 2))
+                            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                       (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+                      ((pattern
+                        (Indexed
+                         ((pattern (Var diagonal_matrix))
+                          (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly))))
+                         ((Single
+                           ((pattern (Lit Int 1))
+                            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                          (Single
+                           ((pattern (Lit Int 2))
+                            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                       (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
                    (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
                   ((pattern
                     (Indexed
-                     ((pattern (Var diagonal_matrix))
-                      (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly))))
+                     ((pattern (Var extracted))
+                      (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly))))
                      ((Single
-                       ((pattern (Lit Int 1))
-                        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-                      (Single
                        ((pattern (Lit Int 2))
                         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
                    (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
@@ -172,24 +287,35 @@
               ((pattern
                 (FunApp (StanLib Plus__ FnPlain SoA)
                  (((pattern
-                    (Indexed
-                     ((pattern (Var diagonal_matrix))
-                      (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly))))
-                     ((Single
-                       ((pattern (Lit Int 2))
-                        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-                      (Single
-                       ((pattern (Lit Int 2))
-                        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                    (FunApp (StanLib Plus__ FnPlain SoA)
+                     (((pattern
+                        (Indexed
+                         ((pattern (Var diagonal_matrix))
+                          (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly))))
+                         ((Single
+                           ((pattern (Lit Int 2))
+                            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                          (Single
+                           ((pattern (Lit Int 2))
+                            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                       (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+                      ((pattern
+                        (Indexed
+                         ((pattern (Var diagonal_matrix))
+                          (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly))))
+                         ((Single
+                           ((pattern (Lit Int 1))
+                            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                          (Single
+                           ((pattern (Lit Int 2))
+                            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                       (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
                    (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
                   ((pattern
                     (Indexed
-                     ((pattern (Var diagonal_matrix))
-                      (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly))))
+                     ((pattern (Var extracted))
+                      (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly))))
                      ((Single
-                       ((pattern (Lit Int 1))
-                        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-                      (Single
                        ((pattern (Lit Int 2))
                         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
                    (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))

--- a/tests/fixtures/gqconst.stan
+++ b/tests/fixtures/gqconst.stan
@@ -1,6 +1,9 @@
 // A generated quantity the optimizer folds to a constant: at --O1 the
 // FnWriteParam's argument becomes the literal itself, so the column name
 // must come from output_vars instead of the (gone) variable reference.
+data {
+  matrix[3, 2] rectangular;
+}
 parameters {
   real x;
 }
@@ -9,5 +12,7 @@ model {
 }
 generated quantities {
   real z;
+  vector[2] extracted;
   z = 3;
+  extracted = diagonal(rectangular);
 }

--- a/tests/fixtures/gqconst.tmir.sexp
+++ b/tests/fixtures/gqconst.tmir.sexp
@@ -1,4 +1,102 @@
-((functions_block ()) (input_vars ()) (prepare_data ())
+((functions_block ())
+ (input_vars
+  ((rectangular <opaque>
+    (SMatrix AoS
+     ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+     ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+ (prepare_data
+  (((pattern
+     (Decl (decl_adtype DataOnly) (decl_id pos__) (decl_type (Sized SInt))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable pos__) ()) UInt
+      ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id rectangular)
+      (decl_type
+       (Sized
+        (SMatrix AoS
+         ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+         ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id rectangular_flat__)
+          (decl_type (Unsized (UArray UReal))) (initialize Uninit)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable rectangular_flat__) ()) (UArray UReal)
+          ((pattern
+            (FunApp (CompilerInternal FnReadData)
+             (((pattern (Lit Str rectangular))
+               (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable pos__) ()) UInt
+          ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar sym1__)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Lit Int 2))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (For (loopvar sym2__)
+                  (lower
+                   ((pattern (Lit Int 1))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (upper
+                   ((pattern (Lit Int 3))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (body
+                   ((pattern
+                     (Block
+                      (((pattern
+                         (Assignment
+                          ((LVariable rectangular)
+                           ((Single
+                             ((pattern (Var sym2__))
+                              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                            (Single
+                             ((pattern (Var sym1__))
+                              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                          UMatrix
+                          ((pattern
+                            (Indexed
+                             ((pattern (Var rectangular_flat__))
+                              (meta
+                               ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))
+                             ((Single
+                               ((pattern (Var pos__))
+                                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                           (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+                        (meta <opaque>))
+                       ((pattern
+                         (Assignment ((LVariable pos__) ()) UInt
+                          ((pattern
+                            (FunApp (StanLib Plus__ FnPlain AoS)
+                             (((pattern (Var pos__))
+                               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                              ((pattern (Lit Int 1))
+                               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                        (meta <opaque>)))))
+                    (meta <opaque>)))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))))
  (log_prob
   (((pattern
      (Decl (decl_adtype AutoDiffable) (decl_id x) (decl_type (Sized SReal))
@@ -114,7 +212,15 @@
     (meta <opaque>))
    ((pattern
      (Decl (decl_adtype DataOnly) (decl_id z) (decl_type (Sized SReal))
-      (initialize Uninit)))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id extracted)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Default)))
     (meta <opaque>))
    ((pattern
      (Assignment ((LVariable z) ()) UReal
@@ -123,6 +229,14 @@
          ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
          UReal DataOnly))
        (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable extracted) ()) UVector
+      ((pattern
+        (FunApp (StanLib diagonal FnPlain AoS)
+         (((pattern (Var rectangular))
+           (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly))))))
     (meta <opaque>))
    ((pattern
      (NRFunApp
@@ -135,6 +249,15 @@
              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
             UReal DataOnly))
           (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt ())
+        (var
+         ((pattern (Var extracted))
+          (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
       ()))
     (meta <opaque>))))
  (transform_inits
@@ -188,5 +311,13 @@
      (out_trans Identity)))
    (z <opaque>
     ((out_unconstrained_st SReal) (out_constrained_st SReal)
+     (out_block GeneratedQuantities) (out_trans Identity)))
+   (extracted <opaque>
+    ((out_unconstrained_st
+      (SVector AoS
+       ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+     (out_constrained_st
+      (SVector AoS
+       ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
      (out_block GeneratedQuantities) (out_trans Identity)))))
  (prog_name gqconst_model) (prog_path tests/fixtures/gqconst.stan))

--- a/tests/fixtures/paramcond_diag_multiply.stan
+++ b/tests/fixtures/paramcond_diag_multiply.stan
@@ -1,0 +1,16 @@
+// Diagonal matrix products inside a parameter-dependent region use the
+// register program's column-major matrix view and preserve it in the result.
+parameters {
+  matrix[2, 3] m;
+  vector[2] left;
+  vector[3] right;
+  real theta;
+}
+model {
+  if (theta > 0) {
+    target += sum(diag_pre_multiply(left, m));
+    target += sum(diag_post_multiply(m, right));
+  } else {
+    target += theta;
+  }
+}

--- a/tests/fixtures/paramcond_diag_multiply.stan
+++ b/tests/fixtures/paramcond_diag_multiply.stan
@@ -1,15 +1,17 @@
 // Diagonal matrix products inside a parameter-dependent region use the
 // register program's column-major matrix view and preserve it in the result.
 parameters {
-  matrix[2, 3] m;
-  vector[2] left;
-  vector[3] right;
+  matrix[4, 4] m;
+  vector[4] left;
+  vector[4] right;
   real theta;
 }
 model {
   if (theta > 0) {
     target += sum(diag_pre_multiply(left, m));
     target += sum(diag_post_multiply(m, right));
+    if (theta > 1)
+      target += left[1] + right[1];
   } else {
     target += theta;
   }

--- a/tests/fixtures/paramcond_diag_multiply.tmir.sexp
+++ b/tests/fixtures/paramcond_diag_multiply.tmir.sexp
@@ -1,0 +1,770 @@
+((functions_block ()) (input_vars ()) (prepare_data ())
+ (log_prob
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id m)
+      (decl_type
+       (Sized
+        (SMatrix AoS
+         ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+         ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity)
+             (dims
+              (((pattern (Lit Int 2))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+               ((pattern (Lit Int 3))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id left)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity)
+             (dims
+              (((pattern (Lit Int 2))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id right)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity)
+             (dims
+              (((pattern (Lit Int 3))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id theta) (decl_type (Sized SReal))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity) (dims ()) (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (IfElse
+          ((pattern
+            (FunApp (StanLib Greater__ FnPlain AoS)
+             (((pattern (Var theta))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+              ((pattern (Lit Int 0))
+               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel AutoDiffable))))
+          ((pattern
+            (Block
+             (((pattern
+                (TargetPE
+                 ((pattern
+                   (FunApp (StanLib sum FnPlain AoS)
+                    (((pattern
+                       (FunApp (StanLib diag_pre_multiply FnPlain AoS)
+                        (((pattern (Var left))
+                          (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))
+                         ((pattern (Var m))
+                          (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable)))))))
+                      (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable)))))))
+                  (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+               (meta <opaque>))
+              ((pattern
+                (TargetPE
+                 ((pattern
+                   (FunApp (StanLib sum FnPlain AoS)
+                    (((pattern
+                       (FunApp (StanLib diag_post_multiply FnPlain AoS)
+                        (((pattern (Var m))
+                          (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))
+                         ((pattern (Var right))
+                          (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+                      (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable)))))))
+                  (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+               (meta <opaque>)))))
+           (meta <opaque>))
+          (((pattern
+             (Block
+              (((pattern
+                 (TargetPE
+                  ((pattern (Var theta))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))))
+ (reverse_mode_log_prob
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id m)
+      (decl_type
+       (Sized
+        (SMatrix SoA
+         ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+         ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity)
+             (dims
+              (((pattern (Lit Int 2))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+               ((pattern (Lit Int 3))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern SoA)))
+           ()))
+         (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id left)
+      (decl_type
+       (Sized
+        (SVector SoA
+         ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity)
+             (dims
+              (((pattern (Lit Int 2))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern SoA)))
+           ()))
+         (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id right)
+      (decl_type
+       (Sized
+        (SVector SoA
+         ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity)
+             (dims
+              (((pattern (Lit Int 3))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern SoA)))
+           ()))
+         (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id theta) (decl_type (Sized SReal))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity) (dims ()) (mem_pattern SoA)))
+           ()))
+         (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (IfElse
+          ((pattern
+            (FunApp (StanLib Greater__ FnPlain SoA)
+             (((pattern (Var theta))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+              ((pattern (Lit Int 0))
+               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel AutoDiffable))))
+          ((pattern
+            (Block
+             (((pattern
+                (TargetPE
+                 ((pattern
+                   (FunApp (StanLib sum FnPlain SoA)
+                    (((pattern
+                       (FunApp (StanLib diag_pre_multiply FnPlain SoA)
+                        (((pattern (Var left))
+                          (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))
+                         ((pattern (Var m))
+                          (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable)))))))
+                      (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable)))))))
+                  (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+               (meta <opaque>))
+              ((pattern
+                (TargetPE
+                 ((pattern
+                   (FunApp (StanLib sum FnPlain SoA)
+                    (((pattern
+                       (FunApp (StanLib diag_post_multiply FnPlain SoA)
+                        (((pattern (Var m))
+                          (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))
+                         ((pattern (Var right))
+                          (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+                      (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable)))))))
+                  (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+               (meta <opaque>)))))
+           (meta <opaque>))
+          (((pattern
+             (Block
+              (((pattern
+                 (TargetPE
+                  ((pattern (Var theta))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))))
+ (generate_quantities
+  (((pattern
+     (Decl (decl_adtype DataOnly) (decl_id m)
+      (decl_type
+       (Sized
+        (SMatrix AoS
+         ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+         ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity)
+             (dims
+              (((pattern (Lit Int 2))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+               ((pattern (Lit Int 3))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id left)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity)
+             (dims
+              (((pattern (Lit Int 2))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id right)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity)
+             (dims
+              (((pattern (Lit Int 3))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id theta) (decl_type (Sized SReal))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity) (dims ()) (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt ())
+        (var
+         ((pattern (Var m)) (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt ())
+        (var
+         ((pattern (Var left))
+          (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt ())
+        (var
+         ((pattern (Var right))
+          (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt ())
+        (var
+         ((pattern (Var theta)) (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (IfElse
+      ((pattern
+        (FunApp (StanLib PNot__ FnPlain AoS)
+         (((pattern
+            (EOr
+             ((pattern (Var emit_transformed_parameters__))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+             ((pattern (Var emit_generated_quantities__))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+      ((pattern (Block (((pattern (Return ())) (meta <opaque>))))) (meta <opaque>)) ()))
+    (meta <opaque>))
+   ((pattern
+     (IfElse
+      ((pattern
+        (FunApp (StanLib PNot__ FnPlain AoS)
+         (((pattern (Var emit_generated_quantities__))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+      ((pattern (Block (((pattern (Return ())) (meta <opaque>))))) (meta <opaque>)) ()))
+    (meta <opaque>))))
+ (transform_inits
+  (((pattern
+     (Decl (decl_adtype DataOnly) (decl_id pos__) (decl_type (Sized SInt))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id m)
+      (decl_type
+       (Sized
+        (SMatrix AoS
+         ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+         ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id m_flat__)
+          (decl_type (Unsized (UArray UReal))) (initialize Uninit)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable m_flat__) ()) (UArray UReal)
+          ((pattern
+            (FunApp (CompilerInternal FnReadData)
+             (((pattern (Lit Str m))
+               (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable pos__) ()) UInt
+          ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar sym1__)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Lit Int 3))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (For (loopvar sym2__)
+                  (lower
+                   ((pattern (Lit Int 1))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (upper
+                   ((pattern (Lit Int 2))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (body
+                   ((pattern
+                     (Block
+                      (((pattern
+                         (Assignment
+                          ((LVariable m)
+                           ((Single
+                             ((pattern (Var sym2__))
+                              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                            (Single
+                             ((pattern (Var sym1__))
+                              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                          UMatrix
+                          ((pattern
+                            (Indexed
+                             ((pattern (Var m_flat__))
+                              (meta
+                               ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))
+                             ((Single
+                               ((pattern (Var pos__))
+                                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                           (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+                        (meta <opaque>))
+                       ((pattern
+                         (Assignment ((LVariable pos__) ()) UInt
+                          ((pattern
+                            (FunApp (StanLib Plus__ FnPlain AoS)
+                             (((pattern (Var pos__))
+                               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                              ((pattern (Lit Int 1))
+                               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                        (meta <opaque>)))))
+                    (meta <opaque>)))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var m)) (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id left)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id left_flat__)
+          (decl_type (Unsized (UArray UReal))) (initialize Uninit)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable left_flat__) ()) (UArray UReal)
+          ((pattern
+            (FunApp (CompilerInternal FnReadData)
+             (((pattern (Lit Str left))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable pos__) ()) UInt
+          ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar sym1__)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Lit Int 2))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (Assignment
+                  ((LVariable left)
+                   ((Single
+                     ((pattern (Var sym1__))
+                      (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                  UVector
+                  ((pattern
+                    (Indexed
+                     ((pattern (Var left_flat__))
+                      (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))
+                     ((Single
+                       ((pattern (Var pos__))
+                        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+                (meta <opaque>))
+               ((pattern
+                 (Assignment ((LVariable pos__) ()) UInt
+                  ((pattern
+                    (FunApp (StanLib Plus__ FnPlain AoS)
+                     (((pattern (Var pos__))
+                       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                      ((pattern (Lit Int 1))
+                       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var left))
+          (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id right)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id right_flat__)
+          (decl_type (Unsized (UArray UReal))) (initialize Uninit)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable right_flat__) ()) (UArray UReal)
+          ((pattern
+            (FunApp (CompilerInternal FnReadData)
+             (((pattern (Lit Str right))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable pos__) ()) UInt
+          ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar sym1__)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Lit Int 3))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (Assignment
+                  ((LVariable right)
+                   ((Single
+                     ((pattern (Var sym1__))
+                      (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                  UVector
+                  ((pattern
+                    (Indexed
+                     ((pattern (Var right_flat__))
+                      (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))
+                     ((Single
+                       ((pattern (Var pos__))
+                        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+                (meta <opaque>))
+               ((pattern
+                 (Assignment ((LVariable pos__) ()) UInt
+                  ((pattern
+                    (FunApp (StanLib Plus__ FnPlain AoS)
+                     (((pattern (Var pos__))
+                       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                      ((pattern (Lit Int 1))
+                       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var right))
+          (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id theta) (decl_type (Sized SReal))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable theta) ()) UReal
+      ((pattern
+        (Indexed
+         ((pattern
+           (FunApp (CompilerInternal FnReadData)
+            (((pattern (Lit Str theta))
+              (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+          (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))
+         ((Single
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+       (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var theta)) (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))))
+ (unconstrain_array
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id m)
+      (decl_type
+       (Sized
+        (SMatrix AoS
+         ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+         ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable m) ()) UMatrix
+      ((pattern
+        (FunApp (CompilerInternal FnReadDeserializer)
+         (((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+          ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var m)) (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id left)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable left) ()) UVector
+      ((pattern
+        (FunApp (CompilerInternal FnReadDeserializer)
+         (((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var left))
+          (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id right)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable right) ()) UVector
+      ((pattern
+        (FunApp (CompilerInternal FnReadDeserializer)
+         (((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var right))
+          (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id theta) (decl_type (Sized SReal))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable theta) ()) UReal
+      ((pattern (FunApp (CompilerInternal FnReadDeserializer) ()))
+       (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var theta)) (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))))
+ (output_vars
+  ((m <opaque>
+    ((out_unconstrained_st
+      (SMatrix AoS
+       ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+       ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+     (out_constrained_st
+      (SMatrix AoS
+       ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+       ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+     (out_block Parameters) (out_trans Identity)))
+   (left <opaque>
+    ((out_unconstrained_st
+      (SVector AoS
+       ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+     (out_constrained_st
+      (SVector AoS
+       ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+     (out_block Parameters) (out_trans Identity)))
+   (right <opaque>
+    ((out_unconstrained_st
+      (SVector AoS
+       ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+     (out_constrained_st
+      (SVector AoS
+       ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+     (out_block Parameters) (out_trans Identity)))
+   (theta <opaque>
+    ((out_unconstrained_st SReal) (out_constrained_st SReal) (out_block Parameters)
+     (out_trans Identity)))))
+ (prog_name paramcond_diag_multiply_model)
+ (prog_path tests/fixtures/paramcond_diag_multiply.stan))

--- a/tests/fixtures/paramcond_diag_multiply.tmir.sexp
+++ b/tests/fixtures/paramcond_diag_multiply.tmir.sexp
@@ -5,8 +5,8 @@
       (decl_type
        (Sized
         (SMatrix AoS
-         ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
-         ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+         ((pattern (Lit Int 4)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+         ((pattern (Lit Int 4)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
       (initialize
        (Assign
         ((pattern
@@ -14,9 +14,9 @@
            (CompilerInternal
             (FnReadParam (constrain Identity)
              (dims
-              (((pattern (Lit Int 2))
+              (((pattern (Lit Int 4))
                 (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
-               ((pattern (Lit Int 3))
+               ((pattern (Lit Int 4))
                 (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
              (mem_pattern AoS)))
            ()))
@@ -27,7 +27,7 @@
       (decl_type
        (Sized
         (SVector AoS
-         ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+         ((pattern (Lit Int 4)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
       (initialize
        (Assign
         ((pattern
@@ -35,7 +35,7 @@
            (CompilerInternal
             (FnReadParam (constrain Identity)
              (dims
-              (((pattern (Lit Int 2))
+              (((pattern (Lit Int 4))
                 (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
              (mem_pattern AoS)))
            ()))
@@ -46,7 +46,7 @@
       (decl_type
        (Sized
         (SVector AoS
-         ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+         ((pattern (Lit Int 4)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
       (initialize
        (Assign
         ((pattern
@@ -54,7 +54,7 @@
            (CompilerInternal
             (FnReadParam (constrain Identity)
              (dims
-              (((pattern (Lit Int 3))
+              (((pattern (Lit Int 4))
                 (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
              (mem_pattern AoS)))
            ()))
@@ -109,6 +109,44 @@
                           (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable)))))))
                       (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable)))))))
                   (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+               (meta <opaque>))
+              ((pattern
+                (IfElse
+                 ((pattern
+                   (FunApp (StanLib Greater__ FnPlain AoS)
+                    (((pattern (Var theta))
+                      (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+                     ((pattern (Lit Int 1))
+                      (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel AutoDiffable))))
+                 ((pattern
+                   (Block
+                    (((pattern
+                       (TargetPE
+                        ((pattern
+                          (FunApp (StanLib Plus__ FnPlain AoS)
+                           (((pattern
+                              (Indexed
+                               ((pattern (Var left))
+                                (meta
+                                 ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))
+                               ((Single
+                                 ((pattern (Lit Int 1))
+                                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                             (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+                            ((pattern
+                              (Indexed
+                               ((pattern (Var right))
+                                (meta
+                                 ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))
+                               ((Single
+                                 ((pattern (Lit Int 1))
+                                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                             (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
+                         (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+                      (meta <opaque>)))))
+                  (meta <opaque>))
+                 ()))
                (meta <opaque>)))))
            (meta <opaque>))
           (((pattern
@@ -127,8 +165,8 @@
       (decl_type
        (Sized
         (SMatrix SoA
-         ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
-         ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+         ((pattern (Lit Int 4)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+         ((pattern (Lit Int 4)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
       (initialize
        (Assign
         ((pattern
@@ -136,9 +174,9 @@
            (CompilerInternal
             (FnReadParam (constrain Identity)
              (dims
-              (((pattern (Lit Int 2))
+              (((pattern (Lit Int 4))
                 (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
-               ((pattern (Lit Int 3))
+               ((pattern (Lit Int 4))
                 (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
              (mem_pattern SoA)))
            ()))
@@ -149,7 +187,7 @@
       (decl_type
        (Sized
         (SVector SoA
-         ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+         ((pattern (Lit Int 4)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
       (initialize
        (Assign
         ((pattern
@@ -157,7 +195,7 @@
            (CompilerInternal
             (FnReadParam (constrain Identity)
              (dims
-              (((pattern (Lit Int 2))
+              (((pattern (Lit Int 4))
                 (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
              (mem_pattern SoA)))
            ()))
@@ -168,7 +206,7 @@
       (decl_type
        (Sized
         (SVector SoA
-         ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+         ((pattern (Lit Int 4)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
       (initialize
        (Assign
         ((pattern
@@ -176,7 +214,7 @@
            (CompilerInternal
             (FnReadParam (constrain Identity)
              (dims
-              (((pattern (Lit Int 3))
+              (((pattern (Lit Int 4))
                 (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
              (mem_pattern SoA)))
            ()))
@@ -231,6 +269,44 @@
                           (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable)))))))
                       (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable)))))))
                   (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+               (meta <opaque>))
+              ((pattern
+                (IfElse
+                 ((pattern
+                   (FunApp (StanLib Greater__ FnPlain SoA)
+                    (((pattern (Var theta))
+                      (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+                     ((pattern (Lit Int 1))
+                      (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel AutoDiffable))))
+                 ((pattern
+                   (Block
+                    (((pattern
+                       (TargetPE
+                        ((pattern
+                          (FunApp (StanLib Plus__ FnPlain SoA)
+                           (((pattern
+                              (Indexed
+                               ((pattern (Var left))
+                                (meta
+                                 ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))
+                               ((Single
+                                 ((pattern (Lit Int 1))
+                                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                             (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+                            ((pattern
+                              (Indexed
+                               ((pattern (Var right))
+                                (meta
+                                 ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))
+                               ((Single
+                                 ((pattern (Lit Int 1))
+                                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                             (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
+                         (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+                      (meta <opaque>)))))
+                  (meta <opaque>))
+                 ()))
                (meta <opaque>)))))
            (meta <opaque>))
           (((pattern
@@ -249,8 +325,8 @@
       (decl_type
        (Sized
         (SMatrix AoS
-         ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
-         ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+         ((pattern (Lit Int 4)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+         ((pattern (Lit Int 4)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
       (initialize
        (Assign
         ((pattern
@@ -258,9 +334,9 @@
            (CompilerInternal
             (FnReadParam (constrain Identity)
              (dims
-              (((pattern (Lit Int 2))
+              (((pattern (Lit Int 4))
                 (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
-               ((pattern (Lit Int 3))
+               ((pattern (Lit Int 4))
                 (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
              (mem_pattern AoS)))
            ()))
@@ -271,7 +347,7 @@
       (decl_type
        (Sized
         (SVector AoS
-         ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+         ((pattern (Lit Int 4)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
       (initialize
        (Assign
         ((pattern
@@ -279,7 +355,7 @@
            (CompilerInternal
             (FnReadParam (constrain Identity)
              (dims
-              (((pattern (Lit Int 2))
+              (((pattern (Lit Int 4))
                 (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
              (mem_pattern AoS)))
            ()))
@@ -290,7 +366,7 @@
       (decl_type
        (Sized
         (SVector AoS
-         ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+         ((pattern (Lit Int 4)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
       (initialize
        (Assign
         ((pattern
@@ -298,7 +374,7 @@
            (CompilerInternal
             (FnReadParam (constrain Identity)
              (dims
-              (((pattern (Lit Int 3))
+              (((pattern (Lit Int 4))
                 (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
              (mem_pattern AoS)))
            ()))
@@ -382,8 +458,8 @@
       (decl_type
        (Sized
         (SMatrix AoS
-         ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
-         ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+         ((pattern (Lit Int 4)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+         ((pattern (Lit Int 4)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
       (initialize Default)))
     (meta <opaque>))
    ((pattern
@@ -410,7 +486,7 @@
            ((pattern (Lit Int 1))
             (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
           (upper
-           ((pattern (Lit Int 3))
+           ((pattern (Lit Int 4))
             (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
           (body
            ((pattern
@@ -421,7 +497,7 @@
                    ((pattern (Lit Int 1))
                     (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
                   (upper
-                   ((pattern (Lit Int 2))
+                   ((pattern (Lit Int 4))
                     (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
                   (body
                    ((pattern
@@ -474,7 +550,7 @@
       (decl_type
        (Sized
         (SVector AoS
-         ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+         ((pattern (Lit Int 4)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
       (initialize Default)))
     (meta <opaque>))
    ((pattern
@@ -501,7 +577,7 @@
            ((pattern (Lit Int 1))
             (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
           (upper
-           ((pattern (Lit Int 2))
+           ((pattern (Lit Int 4))
             (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
           (body
            ((pattern
@@ -549,7 +625,7 @@
       (decl_type
        (Sized
         (SVector AoS
-         ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+         ((pattern (Lit Int 4)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
       (initialize Default)))
     (meta <opaque>))
    ((pattern
@@ -576,7 +652,7 @@
            ((pattern (Lit Int 1))
             (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
           (upper
-           ((pattern (Lit Int 3))
+           ((pattern (Lit Int 4))
             (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
           (body
            ((pattern
@@ -651,16 +727,16 @@
       (decl_type
        (Sized
         (SMatrix AoS
-         ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
-         ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+         ((pattern (Lit Int 4)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+         ((pattern (Lit Int 4)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
       (initialize Uninit)))
     (meta <opaque>))
    ((pattern
      (Assignment ((LVariable m) ()) UMatrix
       ((pattern
         (FunApp (CompilerInternal FnReadDeserializer)
-         (((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
-          ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+         (((pattern (Lit Int 4)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+          ((pattern (Lit Int 4)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
        (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))))
     (meta <opaque>))
    ((pattern
@@ -676,14 +752,14 @@
       (decl_type
        (Sized
         (SVector AoS
-         ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+         ((pattern (Lit Int 4)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
       (initialize Uninit)))
     (meta <opaque>))
    ((pattern
      (Assignment ((LVariable left) ()) UVector
       ((pattern
         (FunApp (CompilerInternal FnReadDeserializer)
-         (((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+         (((pattern (Lit Int 4)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
        (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))
     (meta <opaque>))
    ((pattern
@@ -700,14 +776,14 @@
       (decl_type
        (Sized
         (SVector AoS
-         ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+         ((pattern (Lit Int 4)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
       (initialize Uninit)))
     (meta <opaque>))
    ((pattern
      (Assignment ((LVariable right) ()) UVector
       ((pattern
         (FunApp (CompilerInternal FnReadDeserializer)
-         (((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+         (((pattern (Lit Int 4)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
        (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))
     (meta <opaque>))
    ((pattern
@@ -740,28 +816,28 @@
   ((m <opaque>
     ((out_unconstrained_st
       (SMatrix AoS
-       ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
-       ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+       ((pattern (Lit Int 4)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+       ((pattern (Lit Int 4)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
      (out_constrained_st
       (SMatrix AoS
-       ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
-       ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+       ((pattern (Lit Int 4)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+       ((pattern (Lit Int 4)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
      (out_block Parameters) (out_trans Identity)))
    (left <opaque>
     ((out_unconstrained_st
       (SVector AoS
-       ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+       ((pattern (Lit Int 4)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
      (out_constrained_st
       (SVector AoS
-       ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+       ((pattern (Lit Int 4)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
      (out_block Parameters) (out_trans Identity)))
    (right <opaque>
     ((out_unconstrained_st
       (SVector AoS
-       ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+       ((pattern (Lit Int 4)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
      (out_constrained_st
       (SVector AoS
-       ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+       ((pattern (Lit Int 4)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
      (out_block Parameters) (out_trans Identity)))
    (theta <opaque>
     ((out_unconstrained_st SReal) (out_constrained_st SReal) (out_block Parameters)

--- a/tests/fixtures/paramcond_diagonal.stan
+++ b/tests/fixtures/paramcond_diagonal.stan
@@ -1,0 +1,18 @@
+// diagonal on both paths. Inside a parameter-dependent region the register
+// program copies the elements into a run of their own -- column-major
+// storage puts them rows + 1 apart, and Eigen's diagonal stops at the
+// shorter side -- and outside it the graph spells the same extraction as a
+// strided slice. Neither existed before: the function was unsupported
+// everywhere in the runtime.
+parameters {
+  matrix[3, 4] m;
+  real theta;
+}
+model {
+  if (theta > 0) {
+    target += sum(square(diagonal(m)));
+  } else {
+    target += theta;
+  }
+  target += diagonal(m)[3];
+}

--- a/tests/fixtures/paramcond_diagonal.tmir.sexp
+++ b/tests/fixtures/paramcond_diagonal.tmir.sexp
@@ -1,0 +1,429 @@
+((functions_block ()) (input_vars ()) (prepare_data ())
+ (log_prob
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id m)
+      (decl_type
+       (Sized
+        (SMatrix AoS
+         ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+         ((pattern (Lit Int 4)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity)
+             (dims
+              (((pattern (Lit Int 3))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+               ((pattern (Lit Int 4))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id theta) (decl_type (Sized SReal))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity) (dims ()) (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (IfElse
+          ((pattern
+            (FunApp (StanLib Greater__ FnPlain AoS)
+             (((pattern (Var theta))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+              ((pattern (Lit Int 0))
+               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel AutoDiffable))))
+          ((pattern
+            (Block
+             (((pattern
+                (TargetPE
+                 ((pattern
+                   (FunApp (StanLib sum FnPlain AoS)
+                    (((pattern
+                       (FunApp (StanLib square FnPlain AoS)
+                        (((pattern
+                           (FunApp (StanLib diagonal FnPlain AoS)
+                            (((pattern (Var m))
+                              (meta
+                               ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable)))))))
+                          (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+                      (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+                  (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+               (meta <opaque>)))))
+           (meta <opaque>))
+          (((pattern
+             (Block
+              (((pattern
+                 (TargetPE
+                  ((pattern (Var theta))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>))
+       ((pattern
+         (TargetPE
+          ((pattern
+            (Indexed
+             ((pattern
+               (FunApp (StanLib diagonal FnPlain AoS)
+                (((pattern (Var m))
+                  (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable)))))))
+              (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))
+             ((Single
+               ((pattern (Lit Int 3))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>)))))
+    (meta <opaque>))))
+ (reverse_mode_log_prob
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id m)
+      (decl_type
+       (Sized
+        (SMatrix SoA
+         ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+         ((pattern (Lit Int 4)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity)
+             (dims
+              (((pattern (Lit Int 3))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+               ((pattern (Lit Int 4))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern SoA)))
+           ()))
+         (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id theta) (decl_type (Sized SReal))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity) (dims ()) (mem_pattern SoA)))
+           ()))
+         (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (IfElse
+          ((pattern
+            (FunApp (StanLib Greater__ FnPlain SoA)
+             (((pattern (Var theta))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+              ((pattern (Lit Int 0))
+               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel AutoDiffable))))
+          ((pattern
+            (Block
+             (((pattern
+                (TargetPE
+                 ((pattern
+                   (FunApp (StanLib sum FnPlain SoA)
+                    (((pattern
+                       (FunApp (StanLib square FnPlain SoA)
+                        (((pattern
+                           (FunApp (StanLib diagonal FnPlain SoA)
+                            (((pattern (Var m))
+                              (meta
+                               ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable)))))))
+                          (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+                      (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+                  (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+               (meta <opaque>)))))
+           (meta <opaque>))
+          (((pattern
+             (Block
+              (((pattern
+                 (TargetPE
+                  ((pattern (Var theta))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>))
+       ((pattern
+         (TargetPE
+          ((pattern
+            (Indexed
+             ((pattern
+               (FunApp (StanLib diagonal FnPlain SoA)
+                (((pattern (Var m))
+                  (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable)))))))
+              (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))
+             ((Single
+               ((pattern (Lit Int 3))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>)))))
+    (meta <opaque>))))
+ (generate_quantities
+  (((pattern
+     (Decl (decl_adtype DataOnly) (decl_id m)
+      (decl_type
+       (Sized
+        (SMatrix AoS
+         ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+         ((pattern (Lit Int 4)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity)
+             (dims
+              (((pattern (Lit Int 3))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+               ((pattern (Lit Int 4))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id theta) (decl_type (Sized SReal))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity) (dims ()) (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt ())
+        (var
+         ((pattern (Var m)) (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt ())
+        (var
+         ((pattern (Var theta)) (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (IfElse
+      ((pattern
+        (FunApp (StanLib PNot__ FnPlain AoS)
+         (((pattern
+            (EOr
+             ((pattern (Var emit_transformed_parameters__))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+             ((pattern (Var emit_generated_quantities__))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+      ((pattern (Block (((pattern (Return ())) (meta <opaque>))))) (meta <opaque>)) ()))
+    (meta <opaque>))
+   ((pattern
+     (IfElse
+      ((pattern
+        (FunApp (StanLib PNot__ FnPlain AoS)
+         (((pattern (Var emit_generated_quantities__))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+      ((pattern (Block (((pattern (Return ())) (meta <opaque>))))) (meta <opaque>)) ()))
+    (meta <opaque>))))
+ (transform_inits
+  (((pattern
+     (Decl (decl_adtype DataOnly) (decl_id pos__) (decl_type (Sized SInt))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id m)
+      (decl_type
+       (Sized
+        (SMatrix AoS
+         ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+         ((pattern (Lit Int 4)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id m_flat__)
+          (decl_type (Unsized (UArray UReal))) (initialize Uninit)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable m_flat__) ()) (UArray UReal)
+          ((pattern
+            (FunApp (CompilerInternal FnReadData)
+             (((pattern (Lit Str m))
+               (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable pos__) ()) UInt
+          ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar sym1__)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Lit Int 4))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (For (loopvar sym2__)
+                  (lower
+                   ((pattern (Lit Int 1))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (upper
+                   ((pattern (Lit Int 3))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (body
+                   ((pattern
+                     (Block
+                      (((pattern
+                         (Assignment
+                          ((LVariable m)
+                           ((Single
+                             ((pattern (Var sym2__))
+                              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                            (Single
+                             ((pattern (Var sym1__))
+                              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                          UMatrix
+                          ((pattern
+                            (Indexed
+                             ((pattern (Var m_flat__))
+                              (meta
+                               ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))
+                             ((Single
+                               ((pattern (Var pos__))
+                                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                           (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+                        (meta <opaque>))
+                       ((pattern
+                         (Assignment ((LVariable pos__) ()) UInt
+                          ((pattern
+                            (FunApp (StanLib Plus__ FnPlain AoS)
+                             (((pattern (Var pos__))
+                               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                              ((pattern (Lit Int 1))
+                               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                        (meta <opaque>)))))
+                    (meta <opaque>)))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var m)) (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id theta) (decl_type (Sized SReal))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable theta) ()) UReal
+      ((pattern
+        (Indexed
+         ((pattern
+           (FunApp (CompilerInternal FnReadData)
+            (((pattern (Lit Str theta))
+              (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+          (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))
+         ((Single
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+       (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var theta)) (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))))
+ (unconstrain_array
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id m)
+      (decl_type
+       (Sized
+        (SMatrix AoS
+         ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+         ((pattern (Lit Int 4)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable m) ()) UMatrix
+      ((pattern
+        (FunApp (CompilerInternal FnReadDeserializer)
+         (((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+          ((pattern (Lit Int 4)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var m)) (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id theta) (decl_type (Sized SReal))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable theta) ()) UReal
+      ((pattern (FunApp (CompilerInternal FnReadDeserializer) ()))
+       (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var theta)) (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))))
+ (output_vars
+  ((m <opaque>
+    ((out_unconstrained_st
+      (SMatrix AoS
+       ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+       ((pattern (Lit Int 4)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+     (out_constrained_st
+      (SMatrix AoS
+       ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+       ((pattern (Lit Int 4)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+     (out_block Parameters) (out_trans Identity)))
+   (theta <opaque>
+    ((out_unconstrained_st SReal) (out_constrained_st SReal) (out_block Parameters)
+     (out_trans Identity)))))
+ (prog_name paramcond_diagonal_model) (prog_path tests/fixtures/paramcond_diagonal.stan))

--- a/tests/fixtures/paramcond_log1pexp.stan
+++ b/tests/fixtures/paramcond_log1pexp.stan
@@ -1,0 +1,15 @@
+// log1p_exp inside a parameter-dependent region. The opcode carries the
+// derivative stan-math precomputes for its own reverse rule -- the input's
+// inv_logit -- which is also what OP_LOG1P_EXP carries on the graph side,
+// so the region's generated backward, the var replay and the graph all
+// agree to the bit.
+parameters {
+  real theta;
+}
+model {
+  if (theta > 0) {
+    target += log1p_exp(2 * theta);
+  } else {
+    target += log1p_exp(theta);
+  }
+}

--- a/tests/fixtures/paramcond_log1pexp.tmir.sexp
+++ b/tests/fixtures/paramcond_log1pexp.tmir.sexp
@@ -1,0 +1,206 @@
+((functions_block ()) (input_vars ()) (prepare_data ())
+ (log_prob
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id theta) (decl_type (Sized SReal))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity) (dims ()) (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (IfElse
+          ((pattern
+            (FunApp (StanLib Greater__ FnPlain AoS)
+             (((pattern (Var theta))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+              ((pattern (Lit Int 0))
+               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel AutoDiffable))))
+          ((pattern
+            (Block
+             (((pattern
+                (TargetPE
+                 ((pattern
+                   (FunApp (StanLib log1p_exp FnPlain AoS)
+                    (((pattern
+                       (FunApp (StanLib Times__ FnPlain AoS)
+                        (((pattern
+                           (Promotion
+                            ((pattern (Lit Int 2))
+                             (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                            UReal DataOnly))
+                          (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+                         ((pattern (Var theta))
+                          (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
+                      (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
+                  (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+               (meta <opaque>)))))
+           (meta <opaque>))
+          (((pattern
+             (Block
+              (((pattern
+                 (TargetPE
+                  ((pattern
+                    (FunApp (StanLib log1p_exp FnPlain AoS)
+                     (((pattern (Var theta))
+                       (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))))
+ (reverse_mode_log_prob
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id theta) (decl_type (Sized SReal))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity) (dims ()) (mem_pattern SoA)))
+           ()))
+         (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (IfElse
+          ((pattern
+            (FunApp (StanLib Greater__ FnPlain SoA)
+             (((pattern (Var theta))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+              ((pattern (Lit Int 0))
+               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel AutoDiffable))))
+          ((pattern
+            (Block
+             (((pattern
+                (TargetPE
+                 ((pattern
+                   (FunApp (StanLib log1p_exp FnPlain SoA)
+                    (((pattern
+                       (FunApp (StanLib Times__ FnPlain SoA)
+                        (((pattern
+                           (Promotion
+                            ((pattern (Lit Int 2))
+                             (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                            UReal DataOnly))
+                          (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+                         ((pattern (Var theta))
+                          (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
+                      (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
+                  (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+               (meta <opaque>)))))
+           (meta <opaque>))
+          (((pattern
+             (Block
+              (((pattern
+                 (TargetPE
+                  ((pattern
+                    (FunApp (StanLib log1p_exp FnPlain SoA)
+                     (((pattern (Var theta))
+                       (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))))
+ (generate_quantities
+  (((pattern
+     (Decl (decl_adtype DataOnly) (decl_id theta) (decl_type (Sized SReal))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity) (dims ()) (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt ())
+        (var
+         ((pattern (Var theta)) (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (IfElse
+      ((pattern
+        (FunApp (StanLib PNot__ FnPlain AoS)
+         (((pattern
+            (EOr
+             ((pattern (Var emit_transformed_parameters__))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+             ((pattern (Var emit_generated_quantities__))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+      ((pattern (Block (((pattern (Return ())) (meta <opaque>))))) (meta <opaque>)) ()))
+    (meta <opaque>))
+   ((pattern
+     (IfElse
+      ((pattern
+        (FunApp (StanLib PNot__ FnPlain AoS)
+         (((pattern (Var emit_generated_quantities__))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+      ((pattern (Block (((pattern (Return ())) (meta <opaque>))))) (meta <opaque>)) ()))
+    (meta <opaque>))))
+ (transform_inits
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id theta) (decl_type (Sized SReal))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable theta) ()) UReal
+      ((pattern
+        (Indexed
+         ((pattern
+           (FunApp (CompilerInternal FnReadData)
+            (((pattern (Lit Str theta))
+              (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+          (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))
+         ((Single
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+       (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var theta)) (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))))
+ (unconstrain_array
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id theta) (decl_type (Sized SReal))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable theta) ()) UReal
+      ((pattern (FunApp (CompilerInternal FnReadDeserializer) ()))
+       (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var theta)) (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))))
+ (output_vars
+  ((theta <opaque>
+    ((out_unconstrained_st SReal) (out_constrained_st SReal) (out_block Parameters)
+     (out_trans Identity)))))
+ (prog_name paramcond_log1pexp_model) (prog_path tests/fixtures/paramcond_log1pexp.stan))

--- a/tests/fixtures/paramcond_matrixrow.stan
+++ b/tests/fixtures/paramcond_matrixrow.stan
@@ -1,0 +1,16 @@
+// A matrix row inside a parameter-dependent region. Column-major storage
+// puts a row's elements `rows` apart, so the region copies them into a run
+// of their own and the reduction that follows walks that run in ascending
+// order -- which is the order stan-math reduces a strided row in, a
+// non-contiguous Eigen block having no packet access.
+parameters {
+  matrix[3, 4] m;
+  real theta;
+}
+model {
+  if (theta > 0) {
+    target += sum(square(m[2, ]));
+  } else {
+    target += theta;
+  }
+}

--- a/tests/fixtures/paramcond_matrixrow.tmir.sexp
+++ b/tests/fixtures/paramcond_matrixrow.tmir.sexp
@@ -1,0 +1,410 @@
+((functions_block ()) (input_vars ()) (prepare_data ())
+ (log_prob
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id m)
+      (decl_type
+       (Sized
+        (SMatrix AoS
+         ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+         ((pattern (Lit Int 4)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity)
+             (dims
+              (((pattern (Lit Int 3))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+               ((pattern (Lit Int 4))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id theta) (decl_type (Sized SReal))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity) (dims ()) (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (IfElse
+          ((pattern
+            (FunApp (StanLib Greater__ FnPlain AoS)
+             (((pattern (Var theta))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+              ((pattern (Lit Int 0))
+               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel AutoDiffable))))
+          ((pattern
+            (Block
+             (((pattern
+                (TargetPE
+                 ((pattern
+                   (FunApp (StanLib sum FnPlain AoS)
+                    (((pattern
+                       (FunApp (StanLib square FnPlain AoS)
+                        (((pattern
+                           (Indexed
+                            ((pattern (Var m))
+                             (meta
+                              ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))
+                            ((Single
+                              ((pattern (Lit Int 2))
+                               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                          (meta
+                           ((type_ URowVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+                      (meta ((type_ URowVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+                  (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+               (meta <opaque>)))))
+           (meta <opaque>))
+          (((pattern
+             (Block
+              (((pattern
+                 (TargetPE
+                  ((pattern (Var theta))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))))
+ (reverse_mode_log_prob
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id m)
+      (decl_type
+       (Sized
+        (SMatrix SoA
+         ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+         ((pattern (Lit Int 4)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity)
+             (dims
+              (((pattern (Lit Int 3))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+               ((pattern (Lit Int 4))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern SoA)))
+           ()))
+         (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id theta) (decl_type (Sized SReal))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity) (dims ()) (mem_pattern SoA)))
+           ()))
+         (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (IfElse
+          ((pattern
+            (FunApp (StanLib Greater__ FnPlain SoA)
+             (((pattern (Var theta))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+              ((pattern (Lit Int 0))
+               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel AutoDiffable))))
+          ((pattern
+            (Block
+             (((pattern
+                (TargetPE
+                 ((pattern
+                   (FunApp (StanLib sum FnPlain SoA)
+                    (((pattern
+                       (FunApp (StanLib square FnPlain SoA)
+                        (((pattern
+                           (Indexed
+                            ((pattern (Var m))
+                             (meta
+                              ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))
+                            ((Single
+                              ((pattern (Lit Int 2))
+                               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                          (meta
+                           ((type_ URowVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+                      (meta ((type_ URowVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+                  (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+               (meta <opaque>)))))
+           (meta <opaque>))
+          (((pattern
+             (Block
+              (((pattern
+                 (TargetPE
+                  ((pattern (Var theta))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))))
+ (generate_quantities
+  (((pattern
+     (Decl (decl_adtype DataOnly) (decl_id m)
+      (decl_type
+       (Sized
+        (SMatrix AoS
+         ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+         ((pattern (Lit Int 4)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity)
+             (dims
+              (((pattern (Lit Int 3))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+               ((pattern (Lit Int 4))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id theta) (decl_type (Sized SReal))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity) (dims ()) (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt ())
+        (var
+         ((pattern (Var m)) (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt ())
+        (var
+         ((pattern (Var theta)) (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (IfElse
+      ((pattern
+        (FunApp (StanLib PNot__ FnPlain AoS)
+         (((pattern
+            (EOr
+             ((pattern (Var emit_transformed_parameters__))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+             ((pattern (Var emit_generated_quantities__))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+      ((pattern (Block (((pattern (Return ())) (meta <opaque>))))) (meta <opaque>)) ()))
+    (meta <opaque>))
+   ((pattern
+     (IfElse
+      ((pattern
+        (FunApp (StanLib PNot__ FnPlain AoS)
+         (((pattern (Var emit_generated_quantities__))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+      ((pattern (Block (((pattern (Return ())) (meta <opaque>))))) (meta <opaque>)) ()))
+    (meta <opaque>))))
+ (transform_inits
+  (((pattern
+     (Decl (decl_adtype DataOnly) (decl_id pos__) (decl_type (Sized SInt))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id m)
+      (decl_type
+       (Sized
+        (SMatrix AoS
+         ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+         ((pattern (Lit Int 4)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id m_flat__)
+          (decl_type (Unsized (UArray UReal))) (initialize Uninit)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable m_flat__) ()) (UArray UReal)
+          ((pattern
+            (FunApp (CompilerInternal FnReadData)
+             (((pattern (Lit Str m))
+               (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable pos__) ()) UInt
+          ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar sym1__)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Lit Int 4))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (For (loopvar sym2__)
+                  (lower
+                   ((pattern (Lit Int 1))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (upper
+                   ((pattern (Lit Int 3))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (body
+                   ((pattern
+                     (Block
+                      (((pattern
+                         (Assignment
+                          ((LVariable m)
+                           ((Single
+                             ((pattern (Var sym2__))
+                              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                            (Single
+                             ((pattern (Var sym1__))
+                              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                          UMatrix
+                          ((pattern
+                            (Indexed
+                             ((pattern (Var m_flat__))
+                              (meta
+                               ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))
+                             ((Single
+                               ((pattern (Var pos__))
+                                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                           (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+                        (meta <opaque>))
+                       ((pattern
+                         (Assignment ((LVariable pos__) ()) UInt
+                          ((pattern
+                            (FunApp (StanLib Plus__ FnPlain AoS)
+                             (((pattern (Var pos__))
+                               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                              ((pattern (Lit Int 1))
+                               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                        (meta <opaque>)))))
+                    (meta <opaque>)))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var m)) (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id theta) (decl_type (Sized SReal))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable theta) ()) UReal
+      ((pattern
+        (Indexed
+         ((pattern
+           (FunApp (CompilerInternal FnReadData)
+            (((pattern (Lit Str theta))
+              (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+          (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))
+         ((Single
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+       (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var theta)) (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))))
+ (unconstrain_array
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id m)
+      (decl_type
+       (Sized
+        (SMatrix AoS
+         ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+         ((pattern (Lit Int 4)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable m) ()) UMatrix
+      ((pattern
+        (FunApp (CompilerInternal FnReadDeserializer)
+         (((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+          ((pattern (Lit Int 4)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var m)) (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id theta) (decl_type (Sized SReal))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable theta) ()) UReal
+      ((pattern (FunApp (CompilerInternal FnReadDeserializer) ()))
+       (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var theta)) (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))))
+ (output_vars
+  ((m <opaque>
+    ((out_unconstrained_st
+      (SMatrix AoS
+       ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+       ((pattern (Lit Int 4)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+     (out_constrained_st
+      (SMatrix AoS
+       ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+       ((pattern (Lit Int 4)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+     (out_block Parameters) (out_trans Identity)))
+   (theta <opaque>
+    ((out_unconstrained_st SReal) (out_constrained_st SReal) (out_block Parameters)
+     (out_trans Identity)))))
+ (prog_name paramcond_matrixrow_model)
+ (prog_path tests/fixtures/paramcond_matrixrow.stan))

--- a/tests/test_adjoint.cpp
+++ b/tests/test_adjoint.cpp
@@ -294,11 +294,12 @@ static void test_fma() {
 
 static void test_unary_ops() {
   const Program::Code codes[] = {
-      Program::NEG,    Program::EXP,       Program::LOG,   Program::SQRT,
-      Program::SQUARE, Program::INV_LOGIT, Program::LOG1M, Program::TANH,
-      Program::INV,    Program::FABS};
-  const char* names[] = {"neg",       "exp",   "log",  "sqrt", "square",
-                         "inv_logit", "log1m", "tanh", "inv",  "fabs"};
+      Program::NEG,    Program::EXP,       Program::LOG,      Program::SQRT,
+      Program::SQUARE, Program::INV_LOGIT, Program::LOG1M,    Program::TANH,
+      Program::INV,    Program::FABS,      Program::LOG1P_EXP};
+  const char* names[] = {"neg",    "exp",       "log",      "sqrt",
+                         "square", "inv_logit", "log1m",    "tanh",
+                         "inv",    "fabs",      "log1p_exp"};
   for (size_t k = 0; k < sizeof(codes) / sizeof(codes[0]); ++k) {
     Build b({0.37});
     const int d = b.emit(codes[k], 0);

--- a/tests/test_lower.cpp
+++ b/tests/test_lower.cpp
@@ -2396,6 +2396,29 @@ int main() {
     expect_eq("parameter-condition rep_vector empty grad", grad, 0.0);
   }
 
+  // log1p_exp in a region, on its own opcode. Both the value and the
+  // derivative are the expressions stan-math uses, which is what keeps
+  // the region's backward, the var replay and the graph's OP_LOG1P_EXP
+  // agreeing to the bit -- so the expectations here are those same calls
+  // rather than decimals.
+  {
+    CompiledModel cm = compile_model(
+        slurp("tests/fixtures/paramcond_log1pexp.tmir.sexp"), DataMap());
+    Executor ex(std::move(cm.graph));
+    cm.bind(ex);
+    double grad = 0.0;
+    ex.params_data()[0] = 0.5;
+    expect_eq("parameter-condition log1p_exp lp", ex.gradient(&grad),
+              stan::math::log1p_exp(1.0));
+    expect_eq("parameter-condition log1p_exp grad", grad,
+              2.0 * stan::math::inv_logit(1.0));
+    ex.params_data()[0] = -0.5;
+    expect_eq("parameter-condition log1p_exp else lp", ex.gradient(&grad),
+              stan::math::log1p_exp(-0.5));
+    expect_eq("parameter-condition log1p_exp else grad", grad,
+              stan::math::inv_logit(-0.5));
+  }
+
   // A runtime-selected break targets the surrounding loop, so the loop and
   // conditional must share one necessity island. The positive arm exits
   // before the increment; the negative arm executes all three iterations.

--- a/tests/test_lower.cpp
+++ b/tests/test_lower.cpp
@@ -2452,54 +2452,102 @@ int main() {
                 grad[(size_t)i], 0.0);
   }
 
-  // Diagonal pre/post multiplication in a runtime region scales matrix rows
-  // and columns without materializing the diagonal matrix. Check the flat
-  // column-major addresses as well as every derivative.
+  // Diagonal pre/post multiplication in a runtime region must replay the
+  // stan-math operations themselves. Their callbacks reduce all coefficients
+  // for one vector element at once; scalarizing the products changes both the
+  // accumulation order and when a prior adjoint is added.
   {
     CompiledModel cm = compile_model(
         slurp("tests/fixtures/paramcond_diag_multiply.tmir.sexp"), DataMap());
     Executor ex(std::move(cm.graph));
     cm.bind(ex);
-    check(ex.n_params() == 12,
+    constexpr int kDim = 4;
+    constexpr int kMatrix = kDim * kDim;
+    constexpr int kLeft = kMatrix;
+    constexpr int kRight = kLeft + kDim;
+    constexpr int kTheta = kRight + kDim;
+    constexpr int kParams = kTheta + 1;
+    check(ex.n_params() == kParams,
           "parameter-condition diagonal multiply parameter count");
-    const double values[12] = {0.2, 0.5,  -0.3, 0.7, 1.1,  -0.4,
-                               1.3, -0.8, 0.6,  1.5, -0.2, 0.4};
-    for (int i = 0; i < 12; ++i) ex.params_data()[i] = values[i];
-    std::vector<double> grad(12);
-    double want = 0.0;
-    for (int j = 0; j < 3; ++j)
-      for (int i = 0; i < 2; ++i)
-        want += values[2 * j + i] * (values[6 + i] + values[8 + j]);
-    expect_ulp("parameter-condition diagonal multiply lp",
-               ex.gradient(grad.data()), want);
-    for (int j = 0; j < 3; ++j)
-      for (int i = 0; i < 2; ++i)
-        expect_eq("parameter-condition diagonal multiply matrix grad " +
-                      std::to_string(2 * j + i),
-                  grad[(size_t)(2 * j + i)], values[6 + i] + values[8 + j]);
-    for (int i = 0; i < 2; ++i) {
-      double sum = 0.0;
-      for (int j = 0; j < 3; ++j) sum += values[2 * j + i];
-      expect_eq(
-          "parameter-condition diagonal pre vector grad " + std::to_string(i),
-          grad[(size_t)(6 + i)], sum);
-    }
-    for (int j = 0; j < 3; ++j)
-      expect_eq(
-          "parameter-condition diagonal post vector grad " + std::to_string(j),
-          grad[(size_t)(8 + j)], values[2 * j] + values[2 * j + 1]);
-    expect_eq("parameter-condition diagonal multiply theta grad", grad[11],
-              0.0);
+    std::vector<double> grad(kParams);
+    auto check_math = [&](const std::string& tag,
+                          const std::vector<double>& values) {
+      check(values.size() == kParams, tag + " input size");
+      for (int i = 0; i < kParams; ++i) ex.params_data()[i] = values[(size_t)i];
+      const double lp = ex.gradient(grad.data());
 
-    ex.params_data()[11] = -0.4;
+      using stan::math::var;
+      Eigen::Matrix<var, Eigen::Dynamic, Eigen::Dynamic> m(kDim, kDim);
+      Eigen::Matrix<var, Eigen::Dynamic, 1> left(kDim), right(kDim);
+      for (int j = 0; j < kDim; ++j)
+        for (int i = 0; i < kDim; ++i) m(i, j) = values[(size_t)(kDim * j + i)];
+      for (int i = 0; i < kDim; ++i) {
+        left(i) = values[(size_t)(kLeft + i)];
+        right(i) = values[(size_t)(kRight + i)];
+      }
+      var ref_lp = stan::math::sum(stan::math::diag_pre_multiply(left, m)) +
+                   stan::math::sum(stan::math::diag_post_multiply(m, right));
+      if (values[kTheta] > 1.0) ref_lp += left(0) + right(0);
+      ref_lp.grad();
+      expect_ulp(tag + " lp", lp, ref_lp.val());
+      for (int j = 0; j < kDim; ++j)
+        for (int i = 0; i < kDim; ++i)
+          expect_eq(tag + " matrix grad " + std::to_string(kDim * j + i),
+                    grad[(size_t)(kDim * j + i)], m(i, j).adj());
+      for (int i = 0; i < kDim; ++i) {
+        expect_eq(tag + " pre vector grad " + std::to_string(i),
+                  grad[(size_t)(kLeft + i)], left(i).adj());
+        expect_eq(tag + " post vector grad " + std::to_string(i),
+                  grad[(size_t)(kRight + i)], right(i).adj());
+      }
+      expect_eq(tag + " theta grad", grad[kTheta], 0.0);
+      stan::math::recover_memory();
+    };
+
+    check_math(
+        "parameter-condition diagonal multiply regular",
+        {0.2, 0.5, -0.3, 0.7, 1.1,  -0.4, 1.3, -0.8, 0.6, 1.5, -0.2, 0.4, -0.6,
+         0.9, 1.2, -0.5, 0.4, -1.1, 0.8,  1.3, -0.7, 0.3, 1.1, -0.2, 0.4});
+
+    // With no prior adjoint, the rowwise callback keeps the trailing unit;
+    // reversing four independent product callbacks loses it.
+    std::vector<double> pre_cancel(kParams, 0.0);
+    pre_cancel[0] = 1e16;
+    pre_cancel[4] = -1e16;
+    pre_cancel[8] = 1.0;
+    pre_cancel[kTheta] = 0.4;
+    check_math("parameter-condition diagonal pre cancellation", pre_cancel);
+
+    // The row and column both reduce to zero. With theta > 1, stan-math adds
+    // each grouped reduction once to the direct vector term's prior adjoint;
+    // independent scalar callbacks instead lose that prior unit.
+    std::vector<double> prior_cancel(kParams, 0.0);
+    prior_cancel[0] = 1e16;
+    prior_cancel[1] = -1e16;
+    prior_cancel[4] = -1e16;
+    prior_cancel[kTheta] = 2.0;
+    check_math("parameter-condition diagonal prior cancellation", prior_cancel);
+
+    // A contiguous four-row column takes Eigen's packet reduction path.
+    // This input also distinguishes that grouping from either scalar fold.
+    std::vector<double> post_cancel(kParams, 0.0);
+    post_cancel[0] = 0x1.0000000000001p+0;
+    post_cancel[1] = 0x1p+53;
+    post_cancel[2] = -0x1p+53;
+    post_cancel[3] = 0x1p-53;
+    post_cancel[kTheta] = 0.4;
+    check_math("parameter-condition diagonal post packet cancellation",
+               post_cancel);
+
+    ex.params_data()[kTheta] = -0.4;
     expect_eq("parameter-condition diagonal multiply else lp",
               ex.gradient(grad.data()), -0.4);
-    for (int i = 0; i < 11; ++i)
+    for (int i = 0; i < kTheta; ++i)
       expect_eq("parameter-condition diagonal multiply else grad " +
                     std::to_string(i),
                 grad[(size_t)i], 0.0);
-    expect_eq("parameter-condition diagonal multiply else theta grad", grad[11],
-              1.0);
+    expect_eq("parameter-condition diagonal multiply else theta grad",
+              grad[kTheta], 1.0);
   }
 
   // diagonal, which no path supported before: the region copies the
@@ -3835,10 +3883,12 @@ int main() {
 
   // Matrix functions used in transformed data run through MirInterp rather
   // than the graph kernels. diag_matrix must preserve column-major layout and
-  // zero every off-diagonal entry on that path too.
+  // zero every off-diagonal entry on that path too; diagonal must extract a
+  // rectangular matrix with the rows+1 column-major stride.
   {
     DataMap d;
     d.set_real_array("diagonal", {1.0, 2.0, 3.0}, {3});
+    d.set_real_array("rectangular", {1.0, 2.0, 3.0, 4.0, 5.0, 6.0}, {3, 2});
     CompiledModel dm =
         compile_model(slurp("tests/fixtures/diagtd.tmir.sexp"), d);
     Executor dex(std::move(dm.graph));
@@ -3849,11 +3899,10 @@ int main() {
 
     using stan::math::var;
     var theta = 0.4;
-    var reference_lp = stan::math::normal_lpdf<true>(theta, 2.0, 1.0);
+    var reference_lp = stan::math::normal_lpdf<true>(theta, 7.0, 1.0);
     reference_lp.grad();
-    expect_eq("transformed-data diag_matrix: lp", lp, reference_lp.val());
-    expect_eq("transformed-data diag_matrix: gradient", gradient[0],
-              theta.adj());
+    expect_eq("transformed-data diagonal: lp", lp, reference_lp.val());
+    expect_eq("transformed-data diagonal: gradient", gradient[0], theta.adj());
   }
 
   // tcrossprod(A) is A * A'. It reuses the transpose and GEMM graph ops, so

--- a/tests/test_lower.cpp
+++ b/tests/test_lower.cpp
@@ -2452,6 +2452,56 @@ int main() {
                 grad[(size_t)i], 0.0);
   }
 
+  // Diagonal pre/post multiplication in a runtime region scales matrix rows
+  // and columns without materializing the diagonal matrix. Check the flat
+  // column-major addresses as well as every derivative.
+  {
+    CompiledModel cm = compile_model(
+        slurp("tests/fixtures/paramcond_diag_multiply.tmir.sexp"), DataMap());
+    Executor ex(std::move(cm.graph));
+    cm.bind(ex);
+    check(ex.n_params() == 12,
+          "parameter-condition diagonal multiply parameter count");
+    const double values[12] = {0.2, 0.5,  -0.3, 0.7, 1.1,  -0.4,
+                               1.3, -0.8, 0.6,  1.5, -0.2, 0.4};
+    for (int i = 0; i < 12; ++i) ex.params_data()[i] = values[i];
+    std::vector<double> grad(12);
+    double want = 0.0;
+    for (int j = 0; j < 3; ++j)
+      for (int i = 0; i < 2; ++i)
+        want += values[2 * j + i] * (values[6 + i] + values[8 + j]);
+    expect_ulp("parameter-condition diagonal multiply lp",
+               ex.gradient(grad.data()), want);
+    for (int j = 0; j < 3; ++j)
+      for (int i = 0; i < 2; ++i)
+        expect_eq("parameter-condition diagonal multiply matrix grad " +
+                      std::to_string(2 * j + i),
+                  grad[(size_t)(2 * j + i)], values[6 + i] + values[8 + j]);
+    for (int i = 0; i < 2; ++i) {
+      double sum = 0.0;
+      for (int j = 0; j < 3; ++j) sum += values[2 * j + i];
+      expect_eq(
+          "parameter-condition diagonal pre vector grad " + std::to_string(i),
+          grad[(size_t)(6 + i)], sum);
+    }
+    for (int j = 0; j < 3; ++j)
+      expect_eq(
+          "parameter-condition diagonal post vector grad " + std::to_string(j),
+          grad[(size_t)(8 + j)], values[2 * j] + values[2 * j + 1]);
+    expect_eq("parameter-condition diagonal multiply theta grad", grad[11],
+              0.0);
+
+    ex.params_data()[11] = -0.4;
+    expect_eq("parameter-condition diagonal multiply else lp",
+              ex.gradient(grad.data()), -0.4);
+    for (int i = 0; i < 11; ++i)
+      expect_eq("parameter-condition diagonal multiply else grad " +
+                    std::to_string(i),
+                grad[(size_t)i], 0.0);
+    expect_eq("parameter-condition diagonal multiply else theta grad", grad[11],
+              1.0);
+  }
+
   // diagonal, which no path supported before: the region copies the
   // elements rows + 1 apart, the graph spells the same extraction as a
   // strided slice, and this model uses both -- the region for the sum of

--- a/tests/test_lower.cpp
+++ b/tests/test_lower.cpp
@@ -2452,6 +2452,45 @@ int main() {
                 grad[(size_t)i], 0.0);
   }
 
+  // diagonal, which no path supported before: the region copies the
+  // elements rows + 1 apart, the graph spells the same extraction as a
+  // strided slice, and this model uses both -- the region for the sum of
+  // squares, the graph for the single element added afterwards. The
+  // expectation accumulates in the order the region emits.
+  {
+    CompiledModel cm = compile_model(
+        slurp("tests/fixtures/paramcond_diagonal.tmir.sexp"), DataMap());
+    Executor ex(std::move(cm.graph));
+    cm.bind(ex);
+    const int64_t n = ex.n_params();
+    check(n == 13, "parameter-condition diagonal parameter count");
+    for (int64_t i = 0; i < n; ++i) ex.params_data()[i] = 0.1 * (double)(i + 1);
+    ex.params_data()[12] = 0.5;
+    std::vector<double> grad((size_t)n);
+    // A 3x4 matrix's diagonal is three long and steps four registers.
+    double want = stan::math::square(ex.params_data()[0]);
+    want += stan::math::square(ex.params_data()[4]);
+    want += stan::math::square(ex.params_data()[8]);
+    want += ex.params_data()[8];
+    expect_eq("parameter-condition diagonal lp", ex.gradient(grad.data()),
+              want);
+    for (int64_t i = 0; i < 12; ++i) {
+      const bool on_diagonal = i % 4 == 0;
+      const double from_square = on_diagonal ? 2.0 * ex.params_data()[i] : 0.0;
+      expect_eq("parameter-condition diagonal grad " + std::to_string(i),
+                grad[(size_t)i], i == 8 ? from_square + 1.0 : from_square);
+    }
+    expect_eq("parameter-condition diagonal theta grad", grad[12], 0.0);
+    // The other arm keeps the graph's element and drops the region's sum.
+    ex.params_data()[12] = -0.5;
+    expect_eq("parameter-condition diagonal else lp", ex.gradient(grad.data()),
+              -0.5 + ex.params_data()[8]);
+    for (int64_t i = 0; i < 12; ++i)
+      expect_eq("parameter-condition diagonal else grad " + std::to_string(i),
+                grad[(size_t)i], i == 8 ? 1.0 : 0.0);
+    expect_eq("parameter-condition diagonal else theta grad", grad[12], 1.0);
+  }
+
   // A runtime-selected break targets the surrounding loop, so the loop and
   // conditional must share one necessity island. The positive arm exits
   // before the increment; the negative arm executes all three iterations.

--- a/tests/test_lower.cpp
+++ b/tests/test_lower.cpp
@@ -2419,6 +2419,39 @@ int main() {
               stan::math::inv_logit(-0.5));
   }
 
+  // A matrix row in a region. Two facts to pin: which elements the row is
+  // -- three apart, in column-major storage -- and the order the sum
+  // accumulates them, which has to be the ascending one stan-math uses on
+  // a strided block. The expectation is built in that order rather than
+  // written as a decimal.
+  {
+    CompiledModel cm = compile_model(
+        slurp("tests/fixtures/paramcond_matrixrow.tmir.sexp"), DataMap());
+    Executor ex(std::move(cm.graph));
+    cm.bind(ex);
+    const int64_t n = ex.n_params();
+    check(n == 13, "parameter-condition matrix row parameter count");
+    for (int64_t i = 0; i < n; ++i) ex.params_data()[i] = 0.1 * (double)(i + 1);
+    ex.params_data()[12] = 0.5;
+    std::vector<double> grad((size_t)n);
+    double want = stan::math::square(ex.params_data()[1]);
+    for (int j = 1; j < 4; ++j)
+      want += stan::math::square(ex.params_data()[1 + 3 * j]);
+    expect_eq("parameter-condition matrix row lp", ex.gradient(grad.data()),
+              want);
+    for (int64_t i = 0; i < 12; ++i)
+      expect_eq("parameter-condition matrix row grad " + std::to_string(i),
+                grad[(size_t)i], i % 3 == 1 ? 2.0 * ex.params_data()[i] : 0.0);
+    expect_eq("parameter-condition matrix row theta grad", grad[12], 0.0);
+    // The other arm never reads the row.
+    ex.params_data()[12] = -0.5;
+    expect_eq("parameter-condition matrix row else lp",
+              ex.gradient(grad.data()), -0.5);
+    for (int64_t i = 0; i < 12; ++i)
+      expect_eq("parameter-condition matrix row else grad " + std::to_string(i),
+                grad[(size_t)i], 0.0);
+  }
+
   // A runtime-selected break targets the surrounding loop, so the loop and
   // conditional must share one necessity island. The positive arm exits
   // before the increment; the negative arm executes all three iterations.

--- a/tests/test_mir.cpp
+++ b/tests/test_mir.cpp
@@ -911,6 +911,56 @@ int main(int argc, char** argv) {
             name + " counts elements of either vector kind");
   }
 
+  // diagonal() is an interpreter primitive as well as a graph slice.  Pin
+  // both rectangular orientations because they choose different sides of
+  // min(rows, cols), while storage always advances by rows+1.
+  {
+    std::map<std::string, const mir::FunDef*> functions;
+    MirInterp<double> interp(functions, "diagonal test");
+    auto set_real = [&](const std::string& name, std::vector<double> values,
+                        std::vector<int64_t> dims) {
+      DataMap::Entry value;
+      value.r = std::move(values);
+      value.dims = std::move(dims);
+      interp.env()[name] = std::move(value);
+    };
+    set_real("tall", {1, 2, 3, 4, 5, 6}, {3, 2});
+    set_real("wide", {1, 2, 3, 4, 5, 6}, {2, 3});
+    set_real("empty", {}, {0, 3});
+    set_real("vector", {1, 2}, {2});
+    auto call = [&](const std::string& name) {
+      mir::Expr argument;
+      argument.kind = mir::Expr::Var;
+      argument.name = name;
+      argument.type_ = name == "vector" ? "UVector" : "UMatrix";
+      argument.data_only = true;
+      mir::Expr expression;
+      expression.kind = mir::Expr::FunApp;
+      expression.name = "diagonal";
+      expression.type_ = "UVector";
+      expression.data_only = true;
+      expression.args = {argument};
+      return interp.eval(expression);
+    };
+    const DataMap::Entry tall = call("tall"), wide = call("wide"),
+                         empty = call("empty");
+    check(tall.dims == std::vector<int64_t>({2}) &&
+              tall.r == std::vector<double>({1, 5}),
+          "diagonal extracts tall rectangular matrix");
+    check(wide.dims == std::vector<int64_t>({2}) &&
+              wide.r == std::vector<double>({1, 4}),
+          "diagonal extracts wide rectangular matrix");
+    check(empty.dims == std::vector<int64_t>({0}) && empty.r.empty(),
+          "diagonal preserves empty vector shape");
+    bool refused_vector = false;
+    try {
+      (void)call("vector");
+    } catch (const std::exception&) {
+      refused_vector = true;
+    }
+    check(refused_vector, "diagonal rejects a non-matrix argument");
+  }
+
   if (failures == 0) std::printf("test_mir OK\n");
   return failures == 0 ? 0 : 1;
 }

--- a/tests/test_mir_decode.cpp
+++ b/tests/test_mir_decode.cpp
@@ -923,8 +923,9 @@ void check_structural_rejections() {
   bad_call.args.push_back(literal());
   expect_compile_error(write_v2(target_program(bad_call)), "Plus__ call",
                        "known function arity");
-  for (const char* name : {"pow", "std_normal_qf", "trigamma", "is_nan",
-                           "tcrossprod", "map_rect", "algebra_solver"}) {
+  for (const char* name :
+       {"pow", "std_normal_qf", "trigamma", "is_nan", "tcrossprod", "diagonal",
+        "map_rect", "algebra_solver"}) {
     bad_call.name = name;
     bad_call.args.clear();
     expect_error(write_v2(target_program(bad_call)),

--- a/tests/test_write_array.cpp
+++ b/tests/test_write_array.cpp
@@ -705,6 +705,7 @@ void test_transformed_parameter_checks() {
 void test_constant_folded_gq_column() {
   using namespace stanli;
   DataMap data;
+  data.set_real_array("rectangular", {1.0, 2.0, 3.0, 4.0, 5.0, 6.0}, {3, 2});
   CompiledModel cm =
       compile_model(slurp("tests/fixtures/gqconst.tmir.sexp"), data);
   if (!cm.write_array || !cm.write_array->interp) {
@@ -719,8 +720,10 @@ void test_constant_folded_gq_column() {
   params["x"] = x;
   WaRng rng(1);
   const std::vector<double> row = wi.eval(params, rng);
-  expect_eq("gqconst header", joined(wi.columns()), "x,z");
-  if (row.size() != 2 || row[0] != 0.25 || row[1] != 3.0) {
+  expect_eq("gqconst header", joined(wi.columns()),
+            "x,z,extracted.1,extracted.2");
+  if (row.size() != 4 || row[0] != 0.25 || row[1] != 3.0 || row[2] != 1.0 ||
+      row[3] != 5.0) {
     ++failures;
     std::printf("FAIL gqconst row: got %zu values\n", row.size());
   }


### PR DESCRIPTION
## Summary of Changes 

- Added `log1p_exp` register-machine and adjoint support, enabling `log1p_exp(x) `inside parameter-dependent control flow such as `if (theta > 0)`.

 - Added matrix-row materialization in runtime regions, enabling both `m[i]` and `m[i, ]` syntax with subsequent elementwise operations and reductions.

 - Added `diagonal(m)` support across graph lowering and parameter-dependent runtime regions, including expressions such as `sum(square(diagonal(m)))` and `diagonal(m)[i]`.

 - Added optimized diagonal matrix products in runtime regions, enabling `diag_pre_multiply(v, m)` and `diag_post_multiply(m, v)` without materializing a dense diagonal matrix.