### PR TITLE
Fix static shape guards on parameter values

### DIFF
--- a/docs/hacking.md
+++ b/docs/hacking.md
@@ -324,10 +324,11 @@ Three front ends produce these programs:
   recursion, say). This one is an optimization with a cost model:
   `STANLI_NO_ISLAND=1` turns it off, and `STANLI_ISLAND_ALWAYS=1`
   makes it skip the cost estimate.
-- `lower_param_ifelse` / `lower_param_ternary`
-  ([`lower.cpp`](../runtime/src/lower.cpp)) for parameter-dependent
-  control flow. Not an optimization: without it the model does not
-  compile.
+- `lower_runtime_ifelse` / `lower_runtime_ternary`
+  ([`lower.cpp`](../runtime/src/lower.cpp)) for control flow whose condition
+  is unavailable while the graph is built. This includes genuine parameter
+  branches and data-only predicates computed in graph-local storage. It is
+  not an optimization: without it those models do not compile.
 
 The machine's instruction set covers ordinary arithmetic, every scalar
 continuous density (the `DENSITY` instruction, backed by one table

--- a/runtime/include/stanli/mir_prog.hpp
+++ b/runtime/include/stanli/mir_prog.hpp
@@ -729,7 +729,7 @@ struct ProgramCompiler {
         // by exactly log(2*pi)/2 on a normal.)
         if (e.fn_propto)
           bail(
-              "`~` inside a parameter-dependent region (write it as "
+              "`~` inside a runtime-control region (write it as "
               "`target += " +
               e.name +
               "(...)`, which keeps every "
@@ -1059,7 +1059,7 @@ struct ProgramCompiler {
           return;
         }
         // A single All is the complete destination view. This is reachable
-        // in ODE functions and parameter-dependent statement islands, so it
+        // in ODE functions and runtime-control statement islands, so it
         // must agree with both graph lowering and MirInterp rather than
         // forcing an otherwise supported region onto the fallback path.
         if (s.lhs_idx.size() == 1 && s.lhs_idx[0].name == "IndexAll") {

--- a/runtime/src/lower.cpp
+++ b/runtime/src/lower.cpp
@@ -1701,17 +1701,16 @@ struct Lowering {
       case mir::Expr::FunApp:
         return lower_funapp(e);
       case mir::Expr::TernaryIf: {
-        // Data-only conditions resolve at compile time; either branch may
-        // reference parameters.
-        // A parameter-dependent condition cannot pick an arm at load
-        // time, so the whole expression becomes an island.
-        if (!e.args[0].data_only) return lower_param_ternary(e);
         if (expr_effectful(e.args[0]))
           fail("effectful expression cannot be a compile-time condition",
                e.raw);
-        const bool c =
-            eval_pure(e.args[0], "a compile-time condition").r.at(0) != 0.0;
-        return lower_expr(e.args[c ? 1 : 2]);
+        // Shape specialization and ordinary data evaluation can decide a
+        // condition even when the complete expression's MIR adlevel is not
+        // DataOnly (for example `rows(x) == 0 || theta > 0`).  Only the
+        // genuinely unresolved case needs runtime control.
+        if (auto condition = try_eval_pure(e.args[0]))
+          return lower_expr(e.args[condition->r.at(0) != 0.0 ? 1 : 2]);
+        return lower_runtime_ternary(e);
       }
       case mir::Expr::EOr:
       case mir::Expr::EAnd: {
@@ -1726,9 +1725,10 @@ struct Lowering {
   }
 
   // ---- necessity islands ---------------------------------------------------
-  // A region whose control flow depends on a parameter has no op-graph
-  // form: `if (theta > 0)` picks its arm at evaluation time, and an op
-  // graph is fixed when the model is loaded. Such a region compiles
+  // A region whose control flow is not known when the graph is built has no
+  // op-graph form: `if (theta > 0)` picks its arm at evaluation time, while a
+  // DataOnly graph-local predicate may be unavailable to the data interpreter.
+  // Such a region compiles
   // instead into a register program (mir_prog.hpp) that one OP_ISLAND
   // runs -- forward on doubles, backward replayed under stan-math's
   // nested autodiff, which differentiates the arm that actually ran.
@@ -1762,9 +1762,17 @@ struct Lowering {
   }
 
   bool needs_runtime_control(const mir::Stmt& s) {
-    if (s.kind == mir::Stmt::IfElse && s.cond.data_only &&
-        !try_eval_pure(s.cond))
-      return true;
+    if (s.kind == mir::Stmt::IfElse) {
+      // This is a speculative write_array scan, so follow an already-known
+      // arm exactly as ordinary lowering will.  Besides avoiding needless
+      // work, this preserves Stan's reachability semantics for invalid shape
+      // selectors in a dead statement arm.
+      if (auto evaluated = try_eval_pure(s.cond)) {
+        const size_t arm = evaluated->r.at(0) != 0.0 ? 0 : 1;
+        return arm < s.body.size() && needs_runtime_control(s.body[arm]);
+      }
+      if (s.cond.data_only) return true;
+    }
     if (s.kind == mir::Stmt::For) {
       const long lo = eval_int(s.lower), hi = eval_int(s.upper);
       if (lo > hi) return false;
@@ -1951,7 +1959,7 @@ struct Lowering {
       }
       c.finish();
     } catch (Bail& b) {
-      fail("parameter-dependent region: " + b.why, s ? s->raw : e->raw);
+      fail("runtime-control region: " + b.why, s ? s->raw : e->raw);
     }
     // No live-out register is legitimate when the region found live-outs
     // and every one of them is zero-width: the data made the values empty,
@@ -1960,7 +1968,7 @@ struct Lowering {
     // mistake this catches -- a region that lost what it was to produce.
     if (prog->out_regs.empty() && !(e && expr_out->len == 0) &&
         (s == nullptr || reg->out_names.empty()))
-      fail("parameter-dependent region produces nothing", s ? s->raw : e->raw);
+      fail("runtime-control region produces nothing", s ? s->raw : e->raw);
     // A region with a runtime branch keeps the var replay -- reversing
     // control flow needs the structured form the flat program has already
     // lost -- so this usually declines. It is asked anyway because a region
@@ -2027,8 +2035,8 @@ struct Lowering {
     }
   }
 
-  // `if (<depends on a parameter>) ... else ...`
-  void lower_param_ifelse(const mir::Stmt& s) {
+  // `if (<not known while building the graph>) ... else ...`
+  void lower_runtime_ifelse(const mir::Stmt& s) {
     IslandRegion reg;
     std::shared_ptr<IslandProg> prog;
     Range ignored;
@@ -2075,17 +2083,17 @@ struct Lowering {
           dl->second.si = si;
         }
       }
-      // The island is parameter-dependent regardless of the old binding's
-      // provenance; treating its live-out as data would select kernels that
-      // deliberately omit adjoints for that input.
+      // Runtime regions conservatively return parameter-dependent live-outs;
+      // treating one as data without a per-output dependency proof would
+      // select kernels that deliberately omit adjoints for that input.
       si.param_free = false;
       scope[name] = Val{out_slots[k], scalar_autodiff(), si};
     }
     if (reg.has_target) target_terms.push_back(out_slots.back());
   }
 
-  // `<depends on a parameter> ? a : b`
-  Val lower_param_ternary(const mir::Expr& e) {
+  // `<not known while building the graph> ? a : b`
+  Val lower_runtime_ternary(const mir::Expr& e) {
     IslandRegion reg;
     std::shared_ptr<IslandProg> prog;
     Range value;
@@ -2197,7 +2205,10 @@ struct Lowering {
     return effect;
   }
 
-  std::optional<DataMap::Entry> try_eval_pure(const mir::Expr& e) {
+  // Ask only the MIR interpreter.  Static-shape specialization below uses
+  // this for selector values and for path-sensitive short-circuit decisions;
+  // keeping it separate from try_eval_pure prevents recursive specialization.
+  std::optional<DataMap::Entry> try_eval_interpreter(const mir::Expr& e) {
     if (expr_effectful(e)) return std::nullopt;
     try {
       return td.eval(e);
@@ -2208,6 +2219,234 @@ struct Lowering {
     } catch (const std::invalid_argument&) {
       return std::nullopt;
     }
+  }
+
+  enum class StaticProbeState : uint8_t { Unknown, Known, Invalid };
+
+  template <typename T>
+  struct StaticProbe {
+    StaticProbeState state = StaticProbeState::Unknown;
+    T value{};
+    std::string error;
+  };
+
+  struct StaticView {
+    int64_t len = 0;
+    SlotInfo si;
+  };
+
+  struct StaticSelector {
+    int64_t count = 0;
+    bool drops_dimension = false;
+  };
+
+  static bool is_shape_query(const mir::Expr& e) {
+    return e.kind == mir::Expr::FunApp && e.args.size() == 1 &&
+           (e.name == "rows" || e.name == "cols" || e.name == "size" ||
+            e.name == "num_elements");
+  }
+
+  StaticProbe<long> try_static_int(const mir::Expr& e) {
+    auto evaluated = try_eval_interpreter(e);
+    if (!evaluated) return {};
+    if (!evaluated->is_int || evaluated->i.size() != 1 ||
+        evaluated->r.size() != 1)
+      return {StaticProbeState::Invalid, 0,
+              "static matrix index is not an integer scalar"};
+    return {StaticProbeState::Known, evaluated->i[0], {}};
+  }
+
+  StaticProbe<StaticSelector> try_static_selector(const mir::Expr& index,
+                                                  int64_t extent) {
+    if (index.name == "IndexAll")
+      return {StaticProbeState::Known, {extent, false}, {}};
+    if (index.name == "IndexSingle" && index.args.size() == 1) {
+      const auto at = try_static_int(index.args[0]);
+      if (at.state != StaticProbeState::Known) return {at.state, {}, at.error};
+      if (at.value < 1 || at.value > extent)
+        return {
+            StaticProbeState::Invalid, {}, "static matrix index out of bounds"};
+      return {StaticProbeState::Known, {1, true}, {}};
+    }
+    if (index.name == "IndexBetween" && index.args.size() == 2) {
+      const auto lo = try_static_int(index.args[0]);
+      if (lo.state != StaticProbeState::Known) return {lo.state, {}, lo.error};
+      const auto hi = try_static_int(index.args[1]);
+      if (hi.state != StaticProbeState::Known) return {hi.state, {}, hi.error};
+      // Stan's range indexing treats hi < lo as empty and performs no bounds
+      // check on either endpoint (the same rule check_range implements).
+      if (hi.value < lo.value) return {StaticProbeState::Known, {0, false}, {}};
+      if (lo.value < 1 || hi.value > extent)
+        return {
+            StaticProbeState::Invalid, {}, "static matrix range out of bounds"};
+      return {StaticProbeState::Known, {hi.value - lo.value + 1, false}, {}};
+    }
+    if (index.name == "IndexMulti" && index.args.size() == 1) {
+      auto evaluated = try_eval_interpreter(index.args[0]);
+      if (!evaluated) return {};
+      if (!evaluated->is_int || evaluated->i.size() != evaluated->r.size())
+        return {StaticProbeState::Invalid,
+                {},
+                "static matrix gather index is not integer data"};
+      for (int at : evaluated->i)
+        if (at < 1 || at > extent)
+          return {StaticProbeState::Invalid,
+                  {},
+                  "static matrix gather index out of bounds"};
+      return {StaticProbeState::Known,
+              {static_cast<int64_t>(evaluated->i.size()), false},
+              {}};
+    }
+    return {};
+  }
+
+  // Logical geometry only: this probe must never materialize a data value or
+  // emit a graph op.  The first tranche deliberately handles the expression
+  // forms responsible for the ctsem false island -- named values and matrix
+  // subviews selected by compile-time integer data.  Everything else declines
+  // to the existing runtime-control path.
+  StaticProbe<StaticView> try_static_view(const mir::Expr& e) {
+    if (e.kind == mir::Expr::Var) {
+      auto value = scope.find(e.name);
+      if (value != scope.end())
+        return {StaticProbeState::Known,
+                {g.slots[value->second.slot].len, value->second.si},
+                {}};
+      auto declaration = decls.find(e.name);
+      if (declaration != decls.end())
+        return {StaticProbeState::Known,
+                {declaration->second.len, declaration->second.si},
+                {}};
+      return {};
+    }
+    if (e.kind != mir::Expr::Indexed || e.args.size() < 2 || e.args.size() > 3)
+      return {};
+    const auto base = try_static_view(e.args[0]);
+    if (base.state != StaticProbeState::Known)
+      return {base.state, {}, base.error};
+    if (!is_matrix(base.value.si)) return {};
+
+    const auto rows = try_static_selector(e.args[1], base.value.si.rows);
+    if (rows.state != StaticProbeState::Known)
+      return {rows.state, {}, rows.error};
+    StaticProbe<StaticSelector> cols{
+        StaticProbeState::Known, {base.value.si.cols, false}, {}};
+    if (e.args.size() == 3)
+      cols = try_static_selector(e.args[2], base.value.si.cols);
+    if (cols.state != StaticProbeState::Known)
+      return {cols.state, {}, cols.error};
+
+    const bool rd = rows.value.drops_dimension;
+    const bool cd = cols.value.drops_dimension;
+    StaticView out;
+    out.len = checked_product({rows.value.count, cols.value.count},
+                              "static matrix subview");
+    out.si.param_free = base.value.si.param_free;
+    if (!rd && !cd) {
+      if (e.type_ != "UMatrix")
+        return {StaticProbeState::Invalid,
+                {},
+                "static matrix subview has an inconsistent result type"};
+      out.si = matrix_view(rows.value.count, cols.value.count,
+                           base.value.si.param_free);
+    } else if (rd && !cd) {
+      if (e.type_ != "URowVector")
+        return {StaticProbeState::Invalid,
+                {},
+                "static matrix row has an inconsistent result type"};
+      out.si = view_of("URowVector");
+      out.si.param_free = base.value.si.param_free;
+    } else if (!rd && cd) {
+      if (e.type_ != "UVector")
+        return {StaticProbeState::Invalid,
+                {},
+                "static matrix column has an inconsistent result type"};
+      out.si = view_of("UVector");
+      out.si.param_free = base.value.si.param_free;
+    } else {
+      if (e.type_ != "UReal")
+        return {StaticProbeState::Invalid,
+                {},
+                "static matrix element has an inconsistent result type"};
+      out.si = view_of("UReal");
+      out.si.param_free = base.value.si.param_free;
+    }
+    return {StaticProbeState::Known, out, {}};
+  }
+
+  StaticProbe<long> try_static_shape_query(const mir::Expr& e) {
+    if (!is_shape_query(e)) return {};
+    const auto view = try_static_view(e.args[0]);
+    if (view.state != StaticProbeState::Known)
+      return {view.state, 0, view.error};
+    const StaticView& v = view.value;
+    if (is_array(v.si)) {
+      const ArrayShape& shape = array_shape(v.si);
+      if (e.name == "size")
+        return {StaticProbeState::Known, shape.dims.front(), {}};
+      if (e.name == "num_elements") return {StaticProbeState::Known, v.len, {}};
+      return {StaticProbeState::Invalid, 0,
+              e.name + " is undefined for an array value"};
+    }
+    const LogicalDims dims = logical_dims(v.si, v.len, e.name);
+    if (e.name == "rows") return {StaticProbeState::Known, dims.rows, {}};
+    if (e.name == "cols") return {StaticProbeState::Known, dims.cols, {}};
+    return {StaticProbeState::Known, v.len, {}};
+  }
+
+  // Replace only shape queries proven from immutable logical geometry.  The
+  // walk is lazy across Stan's short-circuit forms: an invalid subview in a
+  // dead RHS/arm must not become a bind-time error merely because this probe
+  // visited it.
+  bool specialize_static_shapes(mir::Expr* e) {
+    bool changed = false;
+    if (e->kind == mir::Expr::EAnd || e->kind == mir::Expr::EOr) {
+      if (e->args.size() != 2) return false;
+      changed = specialize_static_shapes(&e->args[0]);
+      auto lhs = try_eval_interpreter(e->args[0]);
+      if (!lhs || lhs->r.size() != 1) return changed;
+      const bool value = lhs->r[0] != 0.0;
+      const bool reaches_rhs = e->kind == mir::Expr::EAnd ? value : !value;
+      if (reaches_rhs) changed |= specialize_static_shapes(&e->args[1]);
+      return changed;
+    }
+    if (e->kind == mir::Expr::TernaryIf) {
+      if (e->args.size() != 3) return false;
+      changed = specialize_static_shapes(&e->args[0]);
+      auto condition = try_eval_interpreter(e->args[0]);
+      if (!condition || condition->r.size() != 1) return changed;
+      const size_t arm = condition->r[0] != 0.0 ? 1 : 2;
+      changed |= specialize_static_shapes(&e->args[arm]);
+      return changed;
+    }
+    if (is_shape_query(*e)) {
+      const auto value = try_static_shape_query(*e);
+      if (value.state == StaticProbeState::Invalid) fail(value.error, e->raw);
+      if (value.state == StaticProbeState::Known) {
+        if (value.value < std::numeric_limits<int>::min() ||
+            value.value > std::numeric_limits<int>::max())
+          fail("static shape query exceeds the Stan integer range", e->raw);
+        mir::Expr literal;
+        literal.kind = mir::Expr::LitInt;
+        literal.lit_i = value.value;
+        literal.type_ = "UInt";
+        literal.unsized = {0, mir::UnsizedLeaf::Int};
+        literal.data_only = true;
+        literal.raw = e->raw;
+        *e = std::move(literal);
+        return true;
+      }
+    }
+    for (mir::Expr& arg : e->args) changed |= specialize_static_shapes(&arg);
+    return changed;
+  }
+
+  std::optional<DataMap::Entry> try_eval_pure(const mir::Expr& e) {
+    if (expr_effectful(e)) return std::nullopt;
+    if (auto evaluated = try_eval_interpreter(e)) return evaluated;
+    mir::Expr specialized = e;
+    if (!specialize_static_shapes(&specialized)) return std::nullopt;
+    return try_eval_interpreter(specialized);
   }
 
   DataMap::Entry eval_pure(const mir::Expr& e, const std::string& use) {
@@ -4988,7 +5227,7 @@ struct Lowering {
       case mir::Stmt::Block:
       case mir::Stmt::SList:
         if (in_write_array && needs_runtime_control(s)) {
-          lower_param_ifelse(s);
+          lower_runtime_ifelse(s);
           return;
         }
         for (const auto& k : s.body) lower_stmt(k);
@@ -5202,7 +5441,7 @@ struct Lowering {
       case mir::Stmt::For: {
         for (const auto& child : s.body)
           if (runtime_loop_control(child)) {
-            lower_param_ifelse(s);
+            lower_runtime_ifelse(s);
             return;
           }
         const long lo = eval_int(s.lower), hi = eval_int(s.upper);
@@ -5222,7 +5461,7 @@ struct Lowering {
       case mir::Stmt::While: {
         for (const auto& child : s.body)
           if (runtime_loop_control(child)) {
-            lower_param_ifelse(s);
+            lower_runtime_ifelse(s);
             return;
           }
         // Unrolled like For. The bound only turns a nonterminating unroll
@@ -5273,7 +5512,7 @@ struct Lowering {
         // lives in the graph, and only the region compiler can read it there.
         // The island's live-outs come back parameter-dependent, which costs
         // adjoints such a branch does not need but is never wrong.
-        lower_param_ifelse(s);
+        lower_runtime_ifelse(s);
         return;
       }
       case mir::Stmt::Return:

--- a/tests/fixtures/shape_guard_lazy.stan
+++ b/tests/fixtures/shape_guard_lazy.stan
@@ -1,0 +1,30 @@
+functions {
+  real lazy_rows(matrix mat, array[] int empty, array[] int valid,
+                 array[] int bad) {
+    real out = 0.0;
+    if (rows(mat[empty, empty]) == 0 || rows(mat[bad, bad]) == 0)
+      out += 1.0;
+    if (rows(mat[valid, valid]) == 0 && rows(mat[bad, bad]) == 0)
+      out += 10.0;
+    if (rows(mat[empty, empty]) == 0)
+      out += 0.0;
+    else if (rows(mat[bad, bad]) == 0)
+      out += 100.0;
+    out += rows(mat[empty, empty]) == 0
+             ? 0.0
+             : (rows(mat[bad, bad]) == 0 ? 1000.0 : 2000.0);
+    return out;
+  }
+}
+data {
+  array[0] int empty;
+  array[1] int valid;
+  array[1] int bad;
+}
+parameters {
+  matrix[2, 2] M;
+  real theta;
+}
+model {
+  target += lazy_rows(M, empty, valid, bad) * theta;
+}

--- a/tests/fixtures/shape_guard_lazy.tmir.sexp
+++ b/tests/fixtures/shape_guard_lazy.tmir.sexp
@@ -1,0 +1,1312 @@
+((functions_block
+  (((fdrt (ReturnType UReal)) (fdname lazy_rows) (fdsuffix FnPlain)
+    (fdargs
+     ((AutoDiffable mat UMatrix) (AutoDiffable empty (UArray UInt))
+      (AutoDiffable valid (UArray UInt)) (AutoDiffable bad (UArray UInt))))
+    (fdbody
+     (((pattern
+        (Block
+         (((pattern
+            (Decl (decl_adtype AutoDiffable) (decl_id out) (decl_type (Sized SReal))
+             (initialize Uninit)))
+           (meta <opaque>))
+          ((pattern
+            (Assignment ((LVariable out) ()) UReal
+             ((pattern (Lit Real 0.0))
+              (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+           (meta <opaque>))
+          ((pattern
+            (IfElse
+             ((pattern
+               (EOr
+                ((pattern
+                  (FunApp (StanLib Equals__ FnPlain AoS)
+                   (((pattern
+                      (FunApp (StanLib rows FnPlain AoS)
+                       (((pattern
+                          (Indexed
+                           ((pattern (Var mat))
+                            (meta
+                             ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))
+                           ((MultiIndex
+                             ((pattern (Var empty))
+                              (meta
+                               ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly)))))
+                            (MultiIndex
+                             ((pattern (Var empty))
+                              (meta
+                               ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly))))))))
+                         (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable)))))))
+                     (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                    ((pattern (Lit Int 0))
+                     (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                 (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                ((pattern
+                  (FunApp (StanLib Equals__ FnPlain AoS)
+                   (((pattern
+                      (FunApp (StanLib rows FnPlain AoS)
+                       (((pattern
+                          (Indexed
+                           ((pattern (Var mat))
+                            (meta
+                             ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))
+                           ((MultiIndex
+                             ((pattern (Var bad))
+                              (meta
+                               ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly)))))
+                            (MultiIndex
+                             ((pattern (Var bad))
+                              (meta
+                               ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly))))))))
+                         (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable)))))))
+                     (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                    ((pattern (Lit Int 0))
+                     (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                 (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+             ((pattern
+               (Block
+                (((pattern
+                   (Assignment ((LVariable out) ()) UReal
+                    ((pattern (Lit Real 1.))
+                     (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+                  (meta <opaque>)))))
+              (meta <opaque>))
+             ()))
+           (meta <opaque>))
+          ((pattern
+            (IfElse
+             ((pattern
+               (EAnd
+                ((pattern
+                  (FunApp (StanLib Equals__ FnPlain AoS)
+                   (((pattern
+                      (FunApp (StanLib rows FnPlain AoS)
+                       (((pattern
+                          (Indexed
+                           ((pattern (Var mat))
+                            (meta
+                             ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))
+                           ((MultiIndex
+                             ((pattern (Var valid))
+                              (meta
+                               ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly)))))
+                            (MultiIndex
+                             ((pattern (Var valid))
+                              (meta
+                               ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly))))))))
+                         (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable)))))))
+                     (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                    ((pattern (Lit Int 0))
+                     (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                 (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                ((pattern
+                  (FunApp (StanLib Equals__ FnPlain AoS)
+                   (((pattern
+                      (FunApp (StanLib rows FnPlain AoS)
+                       (((pattern
+                          (Indexed
+                           ((pattern (Var mat))
+                            (meta
+                             ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))
+                           ((MultiIndex
+                             ((pattern (Var bad))
+                              (meta
+                               ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly)))))
+                            (MultiIndex
+                             ((pattern (Var bad))
+                              (meta
+                               ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly))))))))
+                         (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable)))))))
+                     (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                    ((pattern (Lit Int 0))
+                     (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                 (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+             ((pattern
+               (Block
+                (((pattern
+                   (Assignment ((LVariable out) ()) UReal
+                    ((pattern
+                      (FunApp (StanLib Plus__ FnPlain AoS)
+                       (((pattern (Var out))
+                         (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+                        ((pattern (Lit Real 10.0))
+                         (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+                     (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+                  (meta <opaque>)))))
+              (meta <opaque>))
+             ()))
+           (meta <opaque>))
+          ((pattern
+            (IfElse
+             ((pattern
+               (FunApp (StanLib Equals__ FnPlain AoS)
+                (((pattern
+                   (FunApp (StanLib rows FnPlain AoS)
+                    (((pattern
+                       (Indexed
+                        ((pattern (Var mat))
+                         (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))
+                        ((MultiIndex
+                          ((pattern (Var empty))
+                           (meta
+                            ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly)))))
+                         (MultiIndex
+                          ((pattern (Var empty))
+                           (meta
+                            ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly))))))))
+                      (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable)))))))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                 ((pattern (Lit Int 0))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+             ((pattern
+               (Block
+                (((pattern
+                   (Assignment ((LVariable out) ()) UReal
+                    ((pattern
+                      (FunApp (StanLib Plus__ FnPlain AoS)
+                       (((pattern (Var out))
+                         (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+                        ((pattern (Lit Real 0.0))
+                         (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+                     (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+                  (meta <opaque>)))))
+              (meta <opaque>))
+             (((pattern
+                (Block
+                 (((pattern
+                    (IfElse
+                     ((pattern
+                       (FunApp (StanLib Equals__ FnPlain AoS)
+                        (((pattern
+                           (FunApp (StanLib rows FnPlain AoS)
+                            (((pattern
+                               (Indexed
+                                ((pattern (Var mat))
+                                 (meta
+                                  ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))
+                                ((MultiIndex
+                                  ((pattern (Var bad))
+                                   (meta
+                                    ((type_ (UArray UInt)) (loc <opaque>)
+                                     (adlevel DataOnly)))))
+                                 (MultiIndex
+                                  ((pattern (Var bad))
+                                   (meta
+                                    ((type_ (UArray UInt)) (loc <opaque>)
+                                     (adlevel DataOnly))))))))
+                              (meta
+                               ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable)))))))
+                          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                         ((pattern (Lit Int 0))
+                          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                      (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                     ((pattern
+                       (Block
+                        (((pattern
+                           (Assignment ((LVariable out) ()) UReal
+                            ((pattern
+                              (FunApp (StanLib Plus__ FnPlain AoS)
+                               (((pattern (Var out))
+                                 (meta
+                                  ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+                                ((pattern (Lit Real 100.0))
+                                 (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+                             (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+                          (meta <opaque>)))))
+                      (meta <opaque>))
+                     ()))
+                   (meta <opaque>)))))
+               (meta <opaque>)))))
+           (meta <opaque>))
+          ((pattern
+            (Assignment ((LVariable out) ()) UReal
+             ((pattern
+               (FunApp (StanLib Plus__ FnPlain AoS)
+                (((pattern (Var out))
+                  (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+                 ((pattern
+                   (TernaryIf
+                    ((pattern
+                      (FunApp (StanLib Equals__ FnPlain AoS)
+                       (((pattern
+                          (FunApp (StanLib rows FnPlain AoS)
+                           (((pattern
+                              (Indexed
+                               ((pattern (Var mat))
+                                (meta
+                                 ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))
+                               ((MultiIndex
+                                 ((pattern (Var empty))
+                                  (meta
+                                   ((type_ (UArray UInt)) (loc <opaque>)
+                                    (adlevel DataOnly)))))
+                                (MultiIndex
+                                 ((pattern (Var empty))
+                                  (meta
+                                   ((type_ (UArray UInt)) (loc <opaque>)
+                                    (adlevel DataOnly))))))))
+                             (meta
+                              ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable)))))))
+                         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                        ((pattern (Lit Int 0))
+                         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                     (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                    ((pattern (Lit Real 0.0))
+                     (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+                    ((pattern
+                      (TernaryIf
+                       ((pattern
+                         (FunApp (StanLib Equals__ FnPlain AoS)
+                          (((pattern
+                             (FunApp (StanLib rows FnPlain AoS)
+                              (((pattern
+                                 (Indexed
+                                  ((pattern (Var mat))
+                                   (meta
+                                    ((type_ UMatrix) (loc <opaque>)
+                                     (adlevel AutoDiffable))))
+                                  ((MultiIndex
+                                    ((pattern (Var bad))
+                                     (meta
+                                      ((type_ (UArray UInt)) (loc <opaque>)
+                                       (adlevel DataOnly)))))
+                                   (MultiIndex
+                                    ((pattern (Var bad))
+                                     (meta
+                                      ((type_ (UArray UInt)) (loc <opaque>)
+                                       (adlevel DataOnly))))))))
+                                (meta
+                                 ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable)))))))
+                            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                           ((pattern (Lit Int 0))
+                            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                       ((pattern (Lit Real 1000.0))
+                        (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+                       ((pattern (Lit Real 2000.0))
+                        (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+                     (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+                  (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+              (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+           (meta <opaque>))
+          ((pattern
+            (Return
+             (((pattern (Var out))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
+           (meta <opaque>)))))
+       (meta <opaque>))))
+    (fdloc <opaque>))))
+ (input_vars
+  ((empty <opaque>
+    (SArray SInt
+     ((pattern (Lit Int 0)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+   (valid <opaque>
+    (SArray SInt
+     ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+   (bad <opaque>
+    (SArray SInt
+     ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+ (prepare_data
+  (((pattern
+     (Decl (decl_adtype DataOnly) (decl_id empty)
+      (decl_type
+       (Sized
+        (SArray SInt
+         ((pattern (Lit Int 0)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable empty) ()) (UArray UInt)
+      ((pattern
+        (FunApp (CompilerInternal FnReadData)
+         (((pattern (Lit Str empty))
+           (meta ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id valid)
+      (decl_type
+       (Sized
+        (SArray SInt
+         ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable valid) ()) (UArray UInt)
+      ((pattern
+        (FunApp (CompilerInternal FnReadData)
+         (((pattern (Lit Str valid))
+           (meta ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id bad)
+      (decl_type
+       (Sized
+        (SArray SInt
+         ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable bad) ()) (UArray UInt)
+      ((pattern
+        (FunApp (CompilerInternal FnReadData)
+         (((pattern (Lit Str bad))
+           (meta ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))))
+ (log_prob
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id M)
+      (decl_type
+       (Sized
+        (SMatrix AoS
+         ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+         ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity)
+             (dims
+              (((pattern (Lit Int 2))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+               ((pattern (Lit Int 2))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id theta) (decl_type (Sized SReal))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity) (dims ()) (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id inline_lazy_rows_return_sym4__)
+          (decl_type (Sized SReal)) (initialize Uninit)))
+        (meta <opaque>))
+       ((pattern
+         (Block
+          (((pattern
+             (Decl (decl_adtype AutoDiffable) (decl_id inline_lazy_rows_out_sym5__)
+              (decl_type (Sized SReal)) (initialize Uninit)))
+            (meta <opaque>))
+           ((pattern
+             (Assignment ((LVariable inline_lazy_rows_out_sym5__) ()) UReal
+              ((pattern (Lit Real 0.0))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+            (meta <opaque>))
+           ((pattern
+             (IfElse
+              ((pattern
+                (EOr
+                 ((pattern
+                   (FunApp (StanLib Equals__ FnPlain AoS)
+                    (((pattern
+                       (FunApp (StanLib rows FnPlain AoS)
+                        (((pattern
+                           (Indexed
+                            ((pattern (Var M))
+                             (meta
+                              ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))
+                            ((MultiIndex
+                              ((pattern (Var empty))
+                               (meta
+                                ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly)))))
+                             (MultiIndex
+                              ((pattern (Var empty))
+                               (meta
+                                ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly))))))))
+                          (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable)))))))
+                      (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                     ((pattern (Lit Int 0))
+                      (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                 ((pattern
+                   (FunApp (StanLib Equals__ FnPlain AoS)
+                    (((pattern
+                       (FunApp (StanLib rows FnPlain AoS)
+                        (((pattern
+                           (Indexed
+                            ((pattern (Var M))
+                             (meta
+                              ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))
+                            ((MultiIndex
+                              ((pattern (Var bad))
+                               (meta
+                                ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly)))))
+                             (MultiIndex
+                              ((pattern (Var bad))
+                               (meta
+                                ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly))))))))
+                          (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable)))))))
+                      (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                     ((pattern (Lit Int 0))
+                      (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+              ((pattern
+                (Block
+                 (((pattern
+                    (Assignment ((LVariable inline_lazy_rows_out_sym5__) ()) UReal
+                     ((pattern (Lit Real 1.))
+                      (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+                   (meta <opaque>)))))
+               (meta <opaque>))
+              ()))
+            (meta <opaque>))
+           ((pattern
+             (IfElse
+              ((pattern
+                (EAnd
+                 ((pattern
+                   (FunApp (StanLib Equals__ FnPlain AoS)
+                    (((pattern
+                       (FunApp (StanLib rows FnPlain AoS)
+                        (((pattern
+                           (Indexed
+                            ((pattern (Var M))
+                             (meta
+                              ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))
+                            ((MultiIndex
+                              ((pattern (Var valid))
+                               (meta
+                                ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly)))))
+                             (MultiIndex
+                              ((pattern (Var valid))
+                               (meta
+                                ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly))))))))
+                          (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable)))))))
+                      (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                     ((pattern (Lit Int 0))
+                      (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                 ((pattern
+                   (FunApp (StanLib Equals__ FnPlain AoS)
+                    (((pattern
+                       (FunApp (StanLib rows FnPlain AoS)
+                        (((pattern
+                           (Indexed
+                            ((pattern (Var M))
+                             (meta
+                              ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))
+                            ((MultiIndex
+                              ((pattern (Var bad))
+                               (meta
+                                ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly)))))
+                             (MultiIndex
+                              ((pattern (Var bad))
+                               (meta
+                                ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly))))))))
+                          (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable)))))))
+                      (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                     ((pattern (Lit Int 0))
+                      (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+              ((pattern
+                (Block
+                 (((pattern
+                    (Assignment ((LVariable inline_lazy_rows_out_sym5__) ()) UReal
+                     ((pattern
+                       (FunApp (StanLib Plus__ FnPlain AoS)
+                        (((pattern (Var inline_lazy_rows_out_sym5__))
+                          (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+                         ((pattern (Lit Real 10.0))
+                          (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+                      (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+                   (meta <opaque>)))))
+               (meta <opaque>))
+              ()))
+            (meta <opaque>))
+           ((pattern
+             (IfElse
+              ((pattern
+                (FunApp (StanLib Equals__ FnPlain AoS)
+                 (((pattern
+                    (FunApp (StanLib rows FnPlain AoS)
+                     (((pattern
+                        (Indexed
+                         ((pattern (Var M))
+                          (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))
+                         ((MultiIndex
+                           ((pattern (Var empty))
+                            (meta
+                             ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly)))))
+                          (MultiIndex
+                           ((pattern (Var empty))
+                            (meta
+                             ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly))))))))
+                       (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable)))))))
+                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                  ((pattern (Lit Int 0))
+                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+              ((pattern
+                (Block
+                 (((pattern
+                    (Assignment ((LVariable inline_lazy_rows_out_sym5__) ()) UReal
+                     ((pattern
+                       (FunApp (StanLib Plus__ FnPlain AoS)
+                        (((pattern (Var inline_lazy_rows_out_sym5__))
+                          (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+                         ((pattern (Lit Real 0.0))
+                          (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+                      (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+                   (meta <opaque>)))))
+               (meta <opaque>))
+              (((pattern
+                 (Block
+                  (((pattern
+                     (IfElse
+                      ((pattern
+                        (FunApp (StanLib Equals__ FnPlain AoS)
+                         (((pattern
+                            (FunApp (StanLib rows FnPlain AoS)
+                             (((pattern
+                                (Indexed
+                                 ((pattern (Var M))
+                                  (meta
+                                   ((type_ UMatrix) (loc <opaque>)
+                                    (adlevel AutoDiffable))))
+                                 ((MultiIndex
+                                   ((pattern (Var bad))
+                                    (meta
+                                     ((type_ (UArray UInt)) (loc <opaque>)
+                                      (adlevel DataOnly)))))
+                                  (MultiIndex
+                                   ((pattern (Var bad))
+                                    (meta
+                                     ((type_ (UArray UInt)) (loc <opaque>)
+                                      (adlevel DataOnly))))))))
+                               (meta
+                                ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable)))))))
+                           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                          ((pattern (Lit Int 0))
+                           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                      ((pattern
+                        (Block
+                         (((pattern
+                            (Assignment ((LVariable inline_lazy_rows_out_sym5__) ())
+                             UReal
+                             ((pattern
+                               (FunApp (StanLib Plus__ FnPlain AoS)
+                                (((pattern (Var inline_lazy_rows_out_sym5__))
+                                  (meta
+                                   ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+                                 ((pattern (Lit Real 100.0))
+                                  (meta
+                                   ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+                              (meta
+                               ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+                           (meta <opaque>)))))
+                       (meta <opaque>))
+                      ()))
+                    (meta <opaque>)))))
+                (meta <opaque>)))))
+            (meta <opaque>))
+           ((pattern
+             (Assignment ((LVariable inline_lazy_rows_out_sym5__) ()) UReal
+              ((pattern
+                (FunApp (StanLib Plus__ FnPlain AoS)
+                 (((pattern (Var inline_lazy_rows_out_sym5__))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+                  ((pattern
+                    (TernaryIf
+                     ((pattern
+                       (FunApp (StanLib Equals__ FnPlain AoS)
+                        (((pattern
+                           (FunApp (StanLib rows FnPlain AoS)
+                            (((pattern
+                               (Indexed
+                                ((pattern (Var M))
+                                 (meta
+                                  ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))
+                                ((MultiIndex
+                                  ((pattern (Var empty))
+                                   (meta
+                                    ((type_ (UArray UInt)) (loc <opaque>)
+                                     (adlevel DataOnly)))))
+                                 (MultiIndex
+                                  ((pattern (Var empty))
+                                   (meta
+                                    ((type_ (UArray UInt)) (loc <opaque>)
+                                     (adlevel DataOnly))))))))
+                              (meta
+                               ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable)))))))
+                          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                         ((pattern (Lit Int 0))
+                          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                      (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                     ((pattern (Lit Real 0.0))
+                      (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+                     ((pattern
+                       (TernaryIf
+                        ((pattern
+                          (FunApp (StanLib Equals__ FnPlain AoS)
+                           (((pattern
+                              (FunApp (StanLib rows FnPlain AoS)
+                               (((pattern
+                                  (Indexed
+                                   ((pattern (Var M))
+                                    (meta
+                                     ((type_ UMatrix) (loc <opaque>)
+                                      (adlevel AutoDiffable))))
+                                   ((MultiIndex
+                                     ((pattern (Var bad))
+                                      (meta
+                                       ((type_ (UArray UInt)) (loc <opaque>)
+                                        (adlevel DataOnly)))))
+                                    (MultiIndex
+                                     ((pattern (Var bad))
+                                      (meta
+                                       ((type_ (UArray UInt)) (loc <opaque>)
+                                        (adlevel DataOnly))))))))
+                                 (meta
+                                  ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable)))))))
+                             (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                            ((pattern (Lit Int 0))
+                             (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                        ((pattern (Lit Real 1000.0))
+                         (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+                        ((pattern (Lit Real 2000.0))
+                         (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+                      (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+            (meta <opaque>))
+           ((pattern
+             (Assignment ((LVariable inline_lazy_rows_return_sym4__) ()) UReal
+              ((pattern (Var inline_lazy_rows_out_sym5__))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+            (meta <opaque>)))))
+        (meta <opaque>))
+       ((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib Times__ FnPlain AoS)
+             (((pattern (Var inline_lazy_rows_return_sym4__))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+              ((pattern (Var theta))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>)))))
+    (meta <opaque>))))
+ (reverse_mode_log_prob
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id M)
+      (decl_type
+       (Sized
+        (SMatrix SoA
+         ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+         ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity)
+             (dims
+              (((pattern (Lit Int 2))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+               ((pattern (Lit Int 2))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern SoA)))
+           ()))
+         (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id theta) (decl_type (Sized SReal))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity) (dims ()) (mem_pattern SoA)))
+           ()))
+         (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id inline_lazy_rows_return_sym1__)
+          (decl_type (Sized SReal)) (initialize Uninit)))
+        (meta <opaque>))
+       ((pattern
+         (Block
+          (((pattern
+             (Decl (decl_adtype AutoDiffable) (decl_id inline_lazy_rows_out_sym2__)
+              (decl_type (Sized SReal)) (initialize Uninit)))
+            (meta <opaque>))
+           ((pattern
+             (Assignment ((LVariable inline_lazy_rows_out_sym2__) ()) UReal
+              ((pattern (Lit Real 0.0))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+            (meta <opaque>))
+           ((pattern
+             (IfElse
+              ((pattern
+                (EOr
+                 ((pattern
+                   (FunApp (StanLib Equals__ FnPlain SoA)
+                    (((pattern
+                       (FunApp (StanLib rows FnPlain SoA)
+                        (((pattern
+                           (Indexed
+                            ((pattern (Var M))
+                             (meta
+                              ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))
+                            ((MultiIndex
+                              ((pattern (Var empty))
+                               (meta
+                                ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly)))))
+                             (MultiIndex
+                              ((pattern (Var empty))
+                               (meta
+                                ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly))))))))
+                          (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable)))))))
+                      (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                     ((pattern (Lit Int 0))
+                      (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                 ((pattern
+                   (FunApp (StanLib Equals__ FnPlain SoA)
+                    (((pattern
+                       (FunApp (StanLib rows FnPlain SoA)
+                        (((pattern
+                           (Indexed
+                            ((pattern (Var M))
+                             (meta
+                              ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))
+                            ((MultiIndex
+                              ((pattern (Var bad))
+                               (meta
+                                ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly)))))
+                             (MultiIndex
+                              ((pattern (Var bad))
+                               (meta
+                                ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly))))))))
+                          (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable)))))))
+                      (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                     ((pattern (Lit Int 0))
+                      (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+              ((pattern
+                (Block
+                 (((pattern
+                    (Assignment ((LVariable inline_lazy_rows_out_sym2__) ()) UReal
+                     ((pattern (Lit Real 1.))
+                      (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+                   (meta <opaque>)))))
+               (meta <opaque>))
+              ()))
+            (meta <opaque>))
+           ((pattern
+             (IfElse
+              ((pattern
+                (EAnd
+                 ((pattern
+                   (FunApp (StanLib Equals__ FnPlain SoA)
+                    (((pattern
+                       (FunApp (StanLib rows FnPlain SoA)
+                        (((pattern
+                           (Indexed
+                            ((pattern (Var M))
+                             (meta
+                              ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))
+                            ((MultiIndex
+                              ((pattern (Var valid))
+                               (meta
+                                ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly)))))
+                             (MultiIndex
+                              ((pattern (Var valid))
+                               (meta
+                                ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly))))))))
+                          (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable)))))))
+                      (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                     ((pattern (Lit Int 0))
+                      (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                 ((pattern
+                   (FunApp (StanLib Equals__ FnPlain SoA)
+                    (((pattern
+                       (FunApp (StanLib rows FnPlain SoA)
+                        (((pattern
+                           (Indexed
+                            ((pattern (Var M))
+                             (meta
+                              ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))
+                            ((MultiIndex
+                              ((pattern (Var bad))
+                               (meta
+                                ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly)))))
+                             (MultiIndex
+                              ((pattern (Var bad))
+                               (meta
+                                ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly))))))))
+                          (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable)))))))
+                      (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                     ((pattern (Lit Int 0))
+                      (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+              ((pattern
+                (Block
+                 (((pattern
+                    (Assignment ((LVariable inline_lazy_rows_out_sym2__) ()) UReal
+                     ((pattern
+                       (FunApp (StanLib Plus__ FnPlain SoA)
+                        (((pattern (Var inline_lazy_rows_out_sym2__))
+                          (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+                         ((pattern (Lit Real 10.0))
+                          (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+                      (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+                   (meta <opaque>)))))
+               (meta <opaque>))
+              ()))
+            (meta <opaque>))
+           ((pattern
+             (IfElse
+              ((pattern
+                (FunApp (StanLib Equals__ FnPlain SoA)
+                 (((pattern
+                    (FunApp (StanLib rows FnPlain SoA)
+                     (((pattern
+                        (Indexed
+                         ((pattern (Var M))
+                          (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))
+                         ((MultiIndex
+                           ((pattern (Var empty))
+                            (meta
+                             ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly)))))
+                          (MultiIndex
+                           ((pattern (Var empty))
+                            (meta
+                             ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly))))))))
+                       (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable)))))))
+                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                  ((pattern (Lit Int 0))
+                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+              ((pattern
+                (Block
+                 (((pattern
+                    (Assignment ((LVariable inline_lazy_rows_out_sym2__) ()) UReal
+                     ((pattern
+                       (FunApp (StanLib Plus__ FnPlain SoA)
+                        (((pattern (Var inline_lazy_rows_out_sym2__))
+                          (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+                         ((pattern (Lit Real 0.0))
+                          (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+                      (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+                   (meta <opaque>)))))
+               (meta <opaque>))
+              (((pattern
+                 (Block
+                  (((pattern
+                     (IfElse
+                      ((pattern
+                        (FunApp (StanLib Equals__ FnPlain SoA)
+                         (((pattern
+                            (FunApp (StanLib rows FnPlain SoA)
+                             (((pattern
+                                (Indexed
+                                 ((pattern (Var M))
+                                  (meta
+                                   ((type_ UMatrix) (loc <opaque>)
+                                    (adlevel AutoDiffable))))
+                                 ((MultiIndex
+                                   ((pattern (Var bad))
+                                    (meta
+                                     ((type_ (UArray UInt)) (loc <opaque>)
+                                      (adlevel DataOnly)))))
+                                  (MultiIndex
+                                   ((pattern (Var bad))
+                                    (meta
+                                     ((type_ (UArray UInt)) (loc <opaque>)
+                                      (adlevel DataOnly))))))))
+                               (meta
+                                ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable)))))))
+                           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                          ((pattern (Lit Int 0))
+                           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                      ((pattern
+                        (Block
+                         (((pattern
+                            (Assignment ((LVariable inline_lazy_rows_out_sym2__) ())
+                             UReal
+                             ((pattern
+                               (FunApp (StanLib Plus__ FnPlain SoA)
+                                (((pattern (Var inline_lazy_rows_out_sym2__))
+                                  (meta
+                                   ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+                                 ((pattern (Lit Real 100.0))
+                                  (meta
+                                   ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+                              (meta
+                               ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+                           (meta <opaque>)))))
+                       (meta <opaque>))
+                      ()))
+                    (meta <opaque>)))))
+                (meta <opaque>)))))
+            (meta <opaque>))
+           ((pattern
+             (Assignment ((LVariable inline_lazy_rows_out_sym2__) ()) UReal
+              ((pattern
+                (FunApp (StanLib Plus__ FnPlain SoA)
+                 (((pattern (Var inline_lazy_rows_out_sym2__))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+                  ((pattern
+                    (TernaryIf
+                     ((pattern
+                       (FunApp (StanLib Equals__ FnPlain SoA)
+                        (((pattern
+                           (FunApp (StanLib rows FnPlain SoA)
+                            (((pattern
+                               (Indexed
+                                ((pattern (Var M))
+                                 (meta
+                                  ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))
+                                ((MultiIndex
+                                  ((pattern (Var empty))
+                                   (meta
+                                    ((type_ (UArray UInt)) (loc <opaque>)
+                                     (adlevel DataOnly)))))
+                                 (MultiIndex
+                                  ((pattern (Var empty))
+                                   (meta
+                                    ((type_ (UArray UInt)) (loc <opaque>)
+                                     (adlevel DataOnly))))))))
+                              (meta
+                               ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable)))))))
+                          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                         ((pattern (Lit Int 0))
+                          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                      (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                     ((pattern (Lit Real 0.0))
+                      (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+                     ((pattern
+                       (TernaryIf
+                        ((pattern
+                          (FunApp (StanLib Equals__ FnPlain SoA)
+                           (((pattern
+                              (FunApp (StanLib rows FnPlain SoA)
+                               (((pattern
+                                  (Indexed
+                                   ((pattern (Var M))
+                                    (meta
+                                     ((type_ UMatrix) (loc <opaque>)
+                                      (adlevel AutoDiffable))))
+                                   ((MultiIndex
+                                     ((pattern (Var bad))
+                                      (meta
+                                       ((type_ (UArray UInt)) (loc <opaque>)
+                                        (adlevel DataOnly)))))
+                                    (MultiIndex
+                                     ((pattern (Var bad))
+                                      (meta
+                                       ((type_ (UArray UInt)) (loc <opaque>)
+                                        (adlevel DataOnly))))))))
+                                 (meta
+                                  ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable)))))))
+                             (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                            ((pattern (Lit Int 0))
+                             (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                        ((pattern (Lit Real 1000.0))
+                         (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+                        ((pattern (Lit Real 2000.0))
+                         (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+                      (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+            (meta <opaque>))
+           ((pattern
+             (Assignment ((LVariable inline_lazy_rows_return_sym1__) ()) UReal
+              ((pattern (Var inline_lazy_rows_out_sym2__))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+            (meta <opaque>)))))
+        (meta <opaque>))
+       ((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib Times__ FnPlain SoA)
+             (((pattern (Var inline_lazy_rows_return_sym1__))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+              ((pattern (Var theta))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>)))))
+    (meta <opaque>))))
+ (generate_quantities
+  (((pattern
+     (Decl (decl_adtype DataOnly) (decl_id M)
+      (decl_type
+       (Sized
+        (SMatrix AoS
+         ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+         ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity)
+             (dims
+              (((pattern (Lit Int 2))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+               ((pattern (Lit Int 2))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id theta) (decl_type (Sized SReal))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity) (dims ()) (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt ())
+        (var
+         ((pattern (Var M)) (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt ())
+        (var
+         ((pattern (Var theta)) (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (IfElse
+      ((pattern
+        (FunApp (StanLib PNot__ FnPlain AoS)
+         (((pattern
+            (EOr
+             ((pattern (Var emit_transformed_parameters__))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+             ((pattern (Var emit_generated_quantities__))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+      ((pattern (Block (((pattern (Return ())) (meta <opaque>))))) (meta <opaque>)) ()))
+    (meta <opaque>))
+   ((pattern
+     (IfElse
+      ((pattern
+        (FunApp (StanLib PNot__ FnPlain AoS)
+         (((pattern (Var emit_generated_quantities__))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+      ((pattern (Block (((pattern (Return ())) (meta <opaque>))))) (meta <opaque>)) ()))
+    (meta <opaque>))))
+ (transform_inits
+  (((pattern
+     (Decl (decl_adtype DataOnly) (decl_id pos__) (decl_type (Sized SInt))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id M)
+      (decl_type
+       (Sized
+        (SMatrix AoS
+         ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+         ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id M_flat__)
+          (decl_type (Unsized (UArray UReal))) (initialize Uninit)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable M_flat__) ()) (UArray UReal)
+          ((pattern
+            (FunApp (CompilerInternal FnReadData)
+             (((pattern (Lit Str M))
+               (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable pos__) ()) UInt
+          ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar sym1__)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Lit Int 2))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (For (loopvar sym2__)
+                  (lower
+                   ((pattern (Lit Int 1))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (upper
+                   ((pattern (Lit Int 2))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (body
+                   ((pattern
+                     (Block
+                      (((pattern
+                         (Assignment
+                          ((LVariable M)
+                           ((Single
+                             ((pattern (Var sym2__))
+                              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                            (Single
+                             ((pattern (Var sym1__))
+                              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                          UMatrix
+                          ((pattern
+                            (Indexed
+                             ((pattern (Var M_flat__))
+                              (meta
+                               ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))
+                             ((Single
+                               ((pattern (Var pos__))
+                                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                           (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+                        (meta <opaque>))
+                       ((pattern
+                         (Assignment ((LVariable pos__) ()) UInt
+                          ((pattern
+                            (FunApp (StanLib Plus__ FnPlain AoS)
+                             (((pattern (Var pos__))
+                               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                              ((pattern (Lit Int 1))
+                               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                        (meta <opaque>)))))
+                    (meta <opaque>)))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var M)) (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id theta) (decl_type (Sized SReal))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable theta) ()) UReal
+      ((pattern
+        (Indexed
+         ((pattern
+           (FunApp (CompilerInternal FnReadData)
+            (((pattern (Lit Str theta))
+              (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+          (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))
+         ((Single
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+       (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var theta)) (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))))
+ (unconstrain_array
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id M)
+      (decl_type
+       (Sized
+        (SMatrix AoS
+         ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+         ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable M) ()) UMatrix
+      ((pattern
+        (FunApp (CompilerInternal FnReadDeserializer)
+         (((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+          ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var M)) (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id theta) (decl_type (Sized SReal))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable theta) ()) UReal
+      ((pattern (FunApp (CompilerInternal FnReadDeserializer) ()))
+       (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var theta)) (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))))
+ (output_vars
+  ((M <opaque>
+    ((out_unconstrained_st
+      (SMatrix AoS
+       ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+       ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+     (out_constrained_st
+      (SMatrix AoS
+       ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+       ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+     (out_block Parameters) (out_trans Identity)))
+   (theta <opaque>
+    ((out_unconstrained_st SReal) (out_constrained_st SReal) (out_block Parameters)
+     (out_trans Identity)))))
+ (prog_name shape_guard_lazy_model) (prog_path tests/fixtures/shape_guard_lazy.stan))

--- a/tests/fixtures/shape_indexed_guard.stan
+++ b/tests/fixtures/shape_indexed_guard.stan
@@ -1,0 +1,21 @@
+functions {
+  real indexed_rows(matrix mat, array[] int idx) {
+    if (rows(mat[idx, idx]) == 0) return 1.0;
+    if (rows(mat[1, idx]) != 1 || cols(mat[1, idx]) != size(idx))
+      return -10.0;
+    if (rows(mat[idx, 1]) != size(idx) || cols(mat[idx, 1]) != 1)
+      return -20.0;
+    return size(idx);
+  }
+}
+data {
+  int<lower=0> K;
+  array[K] int idx;
+}
+parameters {
+  matrix[3, 3] M;
+  real theta;
+}
+model {
+  target += indexed_rows(M, idx) * theta;
+}

--- a/tests/fixtures/shape_indexed_guard.tmir.sexp
+++ b/tests/fixtures/shape_indexed_guard.tmir.sexp
@@ -1,0 +1,1041 @@
+((functions_block
+  (((fdrt (ReturnType UReal)) (fdname indexed_rows) (fdsuffix FnPlain)
+    (fdargs ((AutoDiffable mat UMatrix) (AutoDiffable idx (UArray UInt))))
+    (fdbody
+     (((pattern
+        (Block
+         (((pattern
+            (IfElse
+             ((pattern
+               (FunApp (StanLib Equals__ FnPlain AoS)
+                (((pattern
+                   (FunApp (StanLib rows FnPlain AoS)
+                    (((pattern
+                       (Indexed
+                        ((pattern (Var mat))
+                         (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))
+                        ((MultiIndex
+                          ((pattern (Var idx))
+                           (meta
+                            ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly)))))
+                         (MultiIndex
+                          ((pattern (Var idx))
+                           (meta
+                            ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly))))))))
+                      (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable)))))))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                 ((pattern (Lit Int 0))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+             ((pattern
+               (Block
+                (((pattern
+                   (Return
+                    (((pattern
+                       (Promotion
+                        ((pattern (Lit Real 1.0))
+                         (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+                        UReal AutoDiffable))
+                      (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
+                  (meta <opaque>)))))
+              (meta <opaque>))
+             ()))
+           (meta <opaque>))
+          ((pattern
+            (IfElse
+             ((pattern
+               (EOr
+                ((pattern
+                  (FunApp (StanLib NEquals__ FnPlain AoS)
+                   (((pattern
+                      (FunApp (StanLib rows FnPlain AoS)
+                       (((pattern
+                          (Indexed
+                           ((pattern (Var mat))
+                            (meta
+                             ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))
+                           ((Single
+                             ((pattern (Lit Int 1))
+                              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                            (MultiIndex
+                             ((pattern (Var idx))
+                              (meta
+                               ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly))))))))
+                         (meta
+                          ((type_ URowVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+                     (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                    ((pattern (Lit Int 1))
+                     (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                 (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                ((pattern
+                  (FunApp (StanLib NEquals__ FnPlain AoS)
+                   (((pattern
+                      (FunApp (StanLib cols FnPlain AoS)
+                       (((pattern
+                          (Indexed
+                           ((pattern (Var mat))
+                            (meta
+                             ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))
+                           ((Single
+                             ((pattern (Lit Int 1))
+                              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                            (MultiIndex
+                             ((pattern (Var idx))
+                              (meta
+                               ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly))))))))
+                         (meta
+                          ((type_ URowVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+                     (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                    ((pattern
+                      (FunApp (StanLib size FnPlain AoS)
+                       (((pattern (Var idx))
+                         (meta ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly)))))))
+                     (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                 (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+             ((pattern
+               (Block
+                (((pattern
+                   (Return
+                    (((pattern
+                       (Promotion
+                        ((pattern (Lit Real -10.))
+                         (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+                        UReal AutoDiffable))
+                      (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
+                  (meta <opaque>)))))
+              (meta <opaque>))
+             ()))
+           (meta <opaque>))
+          ((pattern
+            (IfElse
+             ((pattern
+               (EOr
+                ((pattern
+                  (FunApp (StanLib NEquals__ FnPlain AoS)
+                   (((pattern
+                      (FunApp (StanLib rows FnPlain AoS)
+                       (((pattern
+                          (Indexed
+                           ((pattern (Var mat))
+                            (meta
+                             ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))
+                           ((MultiIndex
+                             ((pattern (Var idx))
+                              (meta
+                               ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly)))))
+                            (Single
+                             ((pattern (Lit Int 1))
+                              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                         (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+                     (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                    ((pattern
+                      (FunApp (StanLib size FnPlain AoS)
+                       (((pattern (Var idx))
+                         (meta ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly)))))))
+                     (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                 (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                ((pattern
+                  (FunApp (StanLib NEquals__ FnPlain AoS)
+                   (((pattern
+                      (FunApp (StanLib cols FnPlain AoS)
+                       (((pattern
+                          (Indexed
+                           ((pattern (Var mat))
+                            (meta
+                             ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))
+                           ((MultiIndex
+                             ((pattern (Var idx))
+                              (meta
+                               ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly)))))
+                            (Single
+                             ((pattern (Lit Int 1))
+                              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                         (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+                     (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                    ((pattern (Lit Int 1))
+                     (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                 (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+             ((pattern
+               (Block
+                (((pattern
+                   (Return
+                    (((pattern
+                       (Promotion
+                        ((pattern (Lit Real -20.))
+                         (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+                        UReal AutoDiffable))
+                      (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
+                  (meta <opaque>)))))
+              (meta <opaque>))
+             ()))
+           (meta <opaque>))
+          ((pattern
+            (Return
+             (((pattern
+                (Promotion
+                 ((pattern
+                   (FunApp (StanLib size FnPlain AoS)
+                    (((pattern (Var idx))
+                      (meta ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly)))))))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                 UReal AutoDiffable))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
+           (meta <opaque>)))))
+       (meta <opaque>))))
+    (fdloc <opaque>))))
+ (input_vars
+  ((K <opaque> SInt)
+   (idx <opaque>
+    (SArray SInt
+     ((pattern (Var K)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+ (prepare_data
+  (((pattern
+     (Decl (decl_adtype DataOnly) (decl_id K) (decl_type (Sized SInt))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable K) ()) UInt
+      ((pattern
+        (Indexed
+         ((pattern
+           (FunApp (CompilerInternal FnReadData)
+            (((pattern (Lit Str K))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+          (meta ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly))))
+         ((Single
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnCheck
+        (trans
+         (Lower
+          ((pattern (Lit Int 0)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (var_name K)
+        (var ((pattern (Var K)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (((pattern (Lit Int 0)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp (CompilerInternal FnValidateSize)
+      (((pattern (Lit Str idx)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+       ((pattern (Lit Str K)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+       ((pattern (Var K)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id idx)
+      (decl_type
+       (Sized
+        (SArray SInt
+         ((pattern (Var K)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable idx) ()) (UArray UInt)
+      ((pattern
+        (FunApp (CompilerInternal FnReadData)
+         (((pattern (Lit Str idx))
+           (meta ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))))
+ (log_prob
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id M)
+      (decl_type
+       (Sized
+        (SMatrix AoS
+         ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+         ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity)
+             (dims
+              (((pattern (Lit Int 3))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+               ((pattern (Lit Int 3))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id theta) (decl_type (Sized SReal))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity) (dims ()) (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id inline_indexed_rows_return_sym4__)
+          (decl_type (Sized SReal)) (initialize Uninit)))
+        (meta <opaque>))
+       ((pattern
+         (Decl (decl_adtype DataOnly)
+          (decl_id inline_indexed_rows_early_ret_check_sym5__) (decl_type (Sized SInt))
+          (initialize Default)))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar inline_indexed_rows_iterator_sym6__)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (IfElse
+                  ((pattern
+                    (FunApp (StanLib Equals__ FnPlain AoS)
+                     (((pattern
+                        (FunApp (StanLib rows FnPlain AoS)
+                         (((pattern
+                            (Indexed
+                             ((pattern (Var M))
+                              (meta
+                               ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))
+                             ((MultiIndex
+                               ((pattern (Var idx))
+                                (meta
+                                 ((type_ (UArray UInt)) (loc <opaque>)
+                                  (adlevel DataOnly)))))
+                              (MultiIndex
+                               ((pattern (Var idx))
+                                (meta
+                                 ((type_ (UArray UInt)) (loc <opaque>)
+                                  (adlevel DataOnly))))))))
+                           (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable)))))))
+                       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                      ((pattern (Lit Int 0))
+                       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                  ((pattern
+                    (Block
+                     (((pattern
+                        (Assignment ((LVariable inline_indexed_rows_return_sym4__) ())
+                         UReal
+                         ((pattern
+                           (Promotion
+                            ((pattern (Lit Real 1.0))
+                             (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+                            UReal AutoDiffable))
+                          (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+                       (meta <opaque>))
+                      ((pattern Break) (meta <opaque>)))))
+                   (meta <opaque>))
+                  ()))
+                (meta <opaque>))
+               ((pattern
+                 (IfElse
+                  ((pattern
+                    (EOr
+                     ((pattern
+                       (FunApp (StanLib NEquals__ FnPlain AoS)
+                        (((pattern
+                           (FunApp (StanLib rows FnPlain AoS)
+                            (((pattern
+                               (Indexed
+                                ((pattern (Var M))
+                                 (meta
+                                  ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))
+                                ((Single
+                                  ((pattern (Lit Int 1))
+                                   (meta
+                                    ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                                 (MultiIndex
+                                  ((pattern (Var idx))
+                                   (meta
+                                    ((type_ (UArray UInt)) (loc <opaque>)
+                                     (adlevel DataOnly))))))))
+                              (meta
+                               ((type_ URowVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+                          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                         ((pattern (Lit Int 1))
+                          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                      (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                     ((pattern
+                       (FunApp (StanLib NEquals__ FnPlain AoS)
+                        (((pattern
+                           (FunApp (StanLib cols FnPlain AoS)
+                            (((pattern
+                               (Indexed
+                                ((pattern (Var M))
+                                 (meta
+                                  ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))
+                                ((Single
+                                  ((pattern (Lit Int 1))
+                                   (meta
+                                    ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                                 (MultiIndex
+                                  ((pattern (Var idx))
+                                   (meta
+                                    ((type_ (UArray UInt)) (loc <opaque>)
+                                     (adlevel DataOnly))))))))
+                              (meta
+                               ((type_ URowVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+                          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                         ((pattern
+                           (FunApp (StanLib size FnPlain AoS)
+                            (((pattern (Var idx))
+                              (meta
+                               ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly)))))))
+                          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                      (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                  ((pattern
+                    (Block
+                     (((pattern
+                        (Assignment ((LVariable inline_indexed_rows_return_sym4__) ())
+                         UReal
+                         ((pattern
+                           (Promotion
+                            ((pattern (Lit Real -10.))
+                             (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+                            UReal AutoDiffable))
+                          (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+                       (meta <opaque>))
+                      ((pattern Break) (meta <opaque>)))))
+                   (meta <opaque>))
+                  ()))
+                (meta <opaque>))
+               ((pattern
+                 (IfElse
+                  ((pattern
+                    (EOr
+                     ((pattern
+                       (FunApp (StanLib NEquals__ FnPlain AoS)
+                        (((pattern
+                           (FunApp (StanLib rows FnPlain AoS)
+                            (((pattern
+                               (Indexed
+                                ((pattern (Var M))
+                                 (meta
+                                  ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))
+                                ((MultiIndex
+                                  ((pattern (Var idx))
+                                   (meta
+                                    ((type_ (UArray UInt)) (loc <opaque>)
+                                     (adlevel DataOnly)))))
+                                 (Single
+                                  ((pattern (Lit Int 1))
+                                   (meta
+                                    ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                              (meta
+                               ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+                          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                         ((pattern
+                           (FunApp (StanLib size FnPlain AoS)
+                            (((pattern (Var idx))
+                              (meta
+                               ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly)))))))
+                          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                      (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                     ((pattern
+                       (FunApp (StanLib NEquals__ FnPlain AoS)
+                        (((pattern
+                           (FunApp (StanLib cols FnPlain AoS)
+                            (((pattern
+                               (Indexed
+                                ((pattern (Var M))
+                                 (meta
+                                  ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))
+                                ((MultiIndex
+                                  ((pattern (Var idx))
+                                   (meta
+                                    ((type_ (UArray UInt)) (loc <opaque>)
+                                     (adlevel DataOnly)))))
+                                 (Single
+                                  ((pattern (Lit Int 1))
+                                   (meta
+                                    ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                              (meta
+                               ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+                          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                         ((pattern (Lit Int 1))
+                          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                      (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                  ((pattern
+                    (Block
+                     (((pattern
+                        (Assignment ((LVariable inline_indexed_rows_return_sym4__) ())
+                         UReal
+                         ((pattern
+                           (Promotion
+                            ((pattern (Lit Real -20.))
+                             (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+                            UReal AutoDiffable))
+                          (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+                       (meta <opaque>))
+                      ((pattern Break) (meta <opaque>)))))
+                   (meta <opaque>))
+                  ()))
+                (meta <opaque>))
+               ((pattern
+                 (Assignment ((LVariable inline_indexed_rows_return_sym4__) ()) UReal
+                  ((pattern
+                    (Promotion
+                     ((pattern
+                       (FunApp (StanLib size FnPlain AoS)
+                        (((pattern (Var idx))
+                          (meta
+                           ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly)))))))
+                      (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                     UReal AutoDiffable))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+                (meta <opaque>))
+               ((pattern Break) (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>))
+       ((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib Times__ FnPlain AoS)
+             (((pattern (Var inline_indexed_rows_return_sym4__))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+              ((pattern (Var theta))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>)))))
+    (meta <opaque>))))
+ (reverse_mode_log_prob
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id M)
+      (decl_type
+       (Sized
+        (SMatrix SoA
+         ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+         ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity)
+             (dims
+              (((pattern (Lit Int 3))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+               ((pattern (Lit Int 3))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern SoA)))
+           ()))
+         (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id theta) (decl_type (Sized SReal))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity) (dims ()) (mem_pattern SoA)))
+           ()))
+         (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id inline_indexed_rows_return_sym1__)
+          (decl_type (Sized SReal)) (initialize Uninit)))
+        (meta <opaque>))
+       ((pattern
+         (Decl (decl_adtype DataOnly)
+          (decl_id inline_indexed_rows_early_ret_check_sym2__) (decl_type (Sized SInt))
+          (initialize Default)))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar inline_indexed_rows_iterator_sym3__)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (IfElse
+                  ((pattern
+                    (FunApp (StanLib Equals__ FnPlain SoA)
+                     (((pattern
+                        (FunApp (StanLib rows FnPlain SoA)
+                         (((pattern
+                            (Indexed
+                             ((pattern (Var M))
+                              (meta
+                               ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))
+                             ((MultiIndex
+                               ((pattern (Var idx))
+                                (meta
+                                 ((type_ (UArray UInt)) (loc <opaque>)
+                                  (adlevel DataOnly)))))
+                              (MultiIndex
+                               ((pattern (Var idx))
+                                (meta
+                                 ((type_ (UArray UInt)) (loc <opaque>)
+                                  (adlevel DataOnly))))))))
+                           (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable)))))))
+                       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                      ((pattern (Lit Int 0))
+                       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                  ((pattern
+                    (Block
+                     (((pattern
+                        (Assignment ((LVariable inline_indexed_rows_return_sym1__) ())
+                         UReal
+                         ((pattern
+                           (Promotion
+                            ((pattern (Lit Real 1.0))
+                             (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+                            UReal AutoDiffable))
+                          (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+                       (meta <opaque>))
+                      ((pattern Break) (meta <opaque>)))))
+                   (meta <opaque>))
+                  ()))
+                (meta <opaque>))
+               ((pattern
+                 (IfElse
+                  ((pattern
+                    (EOr
+                     ((pattern
+                       (FunApp (StanLib NEquals__ FnPlain SoA)
+                        (((pattern
+                           (FunApp (StanLib rows FnPlain SoA)
+                            (((pattern
+                               (Indexed
+                                ((pattern (Var M))
+                                 (meta
+                                  ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))
+                                ((Single
+                                  ((pattern (Lit Int 1))
+                                   (meta
+                                    ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                                 (MultiIndex
+                                  ((pattern (Var idx))
+                                   (meta
+                                    ((type_ (UArray UInt)) (loc <opaque>)
+                                     (adlevel DataOnly))))))))
+                              (meta
+                               ((type_ URowVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+                          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                         ((pattern (Lit Int 1))
+                          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                      (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                     ((pattern
+                       (FunApp (StanLib NEquals__ FnPlain SoA)
+                        (((pattern
+                           (FunApp (StanLib cols FnPlain SoA)
+                            (((pattern
+                               (Indexed
+                                ((pattern (Var M))
+                                 (meta
+                                  ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))
+                                ((Single
+                                  ((pattern (Lit Int 1))
+                                   (meta
+                                    ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                                 (MultiIndex
+                                  ((pattern (Var idx))
+                                   (meta
+                                    ((type_ (UArray UInt)) (loc <opaque>)
+                                     (adlevel DataOnly))))))))
+                              (meta
+                               ((type_ URowVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+                          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                         ((pattern
+                           (FunApp (StanLib size FnPlain SoA)
+                            (((pattern (Var idx))
+                              (meta
+                               ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly)))))))
+                          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                      (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                  ((pattern
+                    (Block
+                     (((pattern
+                        (Assignment ((LVariable inline_indexed_rows_return_sym1__) ())
+                         UReal
+                         ((pattern
+                           (Promotion
+                            ((pattern (Lit Real -10.))
+                             (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+                            UReal AutoDiffable))
+                          (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+                       (meta <opaque>))
+                      ((pattern Break) (meta <opaque>)))))
+                   (meta <opaque>))
+                  ()))
+                (meta <opaque>))
+               ((pattern
+                 (IfElse
+                  ((pattern
+                    (EOr
+                     ((pattern
+                       (FunApp (StanLib NEquals__ FnPlain SoA)
+                        (((pattern
+                           (FunApp (StanLib rows FnPlain SoA)
+                            (((pattern
+                               (Indexed
+                                ((pattern (Var M))
+                                 (meta
+                                  ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))
+                                ((MultiIndex
+                                  ((pattern (Var idx))
+                                   (meta
+                                    ((type_ (UArray UInt)) (loc <opaque>)
+                                     (adlevel DataOnly)))))
+                                 (Single
+                                  ((pattern (Lit Int 1))
+                                   (meta
+                                    ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                              (meta
+                               ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+                          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                         ((pattern
+                           (FunApp (StanLib size FnPlain SoA)
+                            (((pattern (Var idx))
+                              (meta
+                               ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly)))))))
+                          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                      (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                     ((pattern
+                       (FunApp (StanLib NEquals__ FnPlain SoA)
+                        (((pattern
+                           (FunApp (StanLib cols FnPlain SoA)
+                            (((pattern
+                               (Indexed
+                                ((pattern (Var M))
+                                 (meta
+                                  ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))
+                                ((MultiIndex
+                                  ((pattern (Var idx))
+                                   (meta
+                                    ((type_ (UArray UInt)) (loc <opaque>)
+                                     (adlevel DataOnly)))))
+                                 (Single
+                                  ((pattern (Lit Int 1))
+                                   (meta
+                                    ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                              (meta
+                               ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+                          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                         ((pattern (Lit Int 1))
+                          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                      (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                  ((pattern
+                    (Block
+                     (((pattern
+                        (Assignment ((LVariable inline_indexed_rows_return_sym1__) ())
+                         UReal
+                         ((pattern
+                           (Promotion
+                            ((pattern (Lit Real -20.))
+                             (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+                            UReal AutoDiffable))
+                          (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+                       (meta <opaque>))
+                      ((pattern Break) (meta <opaque>)))))
+                   (meta <opaque>))
+                  ()))
+                (meta <opaque>))
+               ((pattern
+                 (Assignment ((LVariable inline_indexed_rows_return_sym1__) ()) UReal
+                  ((pattern
+                    (Promotion
+                     ((pattern
+                       (FunApp (StanLib size FnPlain SoA)
+                        (((pattern (Var idx))
+                          (meta
+                           ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly)))))))
+                      (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                     UReal AutoDiffable))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+                (meta <opaque>))
+               ((pattern Break) (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>))
+       ((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib Times__ FnPlain SoA)
+             (((pattern (Var inline_indexed_rows_return_sym1__))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+              ((pattern (Var theta))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>)))))
+    (meta <opaque>))))
+ (generate_quantities
+  (((pattern
+     (Decl (decl_adtype DataOnly) (decl_id M)
+      (decl_type
+       (Sized
+        (SMatrix AoS
+         ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+         ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity)
+             (dims
+              (((pattern (Lit Int 3))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+               ((pattern (Lit Int 3))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id theta) (decl_type (Sized SReal))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity) (dims ()) (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt ())
+        (var
+         ((pattern (Var M)) (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt ())
+        (var
+         ((pattern (Var theta)) (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (IfElse
+      ((pattern
+        (FunApp (StanLib PNot__ FnPlain AoS)
+         (((pattern
+            (EOr
+             ((pattern (Var emit_transformed_parameters__))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+             ((pattern (Var emit_generated_quantities__))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+      ((pattern (Block (((pattern (Return ())) (meta <opaque>))))) (meta <opaque>)) ()))
+    (meta <opaque>))
+   ((pattern
+     (IfElse
+      ((pattern
+        (FunApp (StanLib PNot__ FnPlain AoS)
+         (((pattern (Var emit_generated_quantities__))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+      ((pattern (Block (((pattern (Return ())) (meta <opaque>))))) (meta <opaque>)) ()))
+    (meta <opaque>))))
+ (transform_inits
+  (((pattern
+     (Decl (decl_adtype DataOnly) (decl_id pos__) (decl_type (Sized SInt))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id M)
+      (decl_type
+       (Sized
+        (SMatrix AoS
+         ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+         ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id M_flat__)
+          (decl_type (Unsized (UArray UReal))) (initialize Uninit)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable M_flat__) ()) (UArray UReal)
+          ((pattern
+            (FunApp (CompilerInternal FnReadData)
+             (((pattern (Lit Str M))
+               (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable pos__) ()) UInt
+          ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar sym1__)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Lit Int 3))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (For (loopvar sym2__)
+                  (lower
+                   ((pattern (Lit Int 1))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (upper
+                   ((pattern (Lit Int 3))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (body
+                   ((pattern
+                     (Block
+                      (((pattern
+                         (Assignment
+                          ((LVariable M)
+                           ((Single
+                             ((pattern (Var sym2__))
+                              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                            (Single
+                             ((pattern (Var sym1__))
+                              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                          UMatrix
+                          ((pattern
+                            (Indexed
+                             ((pattern (Var M_flat__))
+                              (meta
+                               ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))
+                             ((Single
+                               ((pattern (Var pos__))
+                                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                           (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+                        (meta <opaque>))
+                       ((pattern
+                         (Assignment ((LVariable pos__) ()) UInt
+                          ((pattern
+                            (FunApp (StanLib Plus__ FnPlain AoS)
+                             (((pattern (Var pos__))
+                               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                              ((pattern (Lit Int 1))
+                               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                        (meta <opaque>)))))
+                    (meta <opaque>)))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var M)) (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id theta) (decl_type (Sized SReal))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable theta) ()) UReal
+      ((pattern
+        (Indexed
+         ((pattern
+           (FunApp (CompilerInternal FnReadData)
+            (((pattern (Lit Str theta))
+              (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+          (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))
+         ((Single
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+       (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var theta)) (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))))
+ (unconstrain_array
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id M)
+      (decl_type
+       (Sized
+        (SMatrix AoS
+         ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+         ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable M) ()) UMatrix
+      ((pattern
+        (FunApp (CompilerInternal FnReadDeserializer)
+         (((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+          ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var M)) (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id theta) (decl_type (Sized SReal))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable theta) ()) UReal
+      ((pattern (FunApp (CompilerInternal FnReadDeserializer) ()))
+       (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var theta)) (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))))
+ (output_vars
+  ((M <opaque>
+    ((out_unconstrained_st
+      (SMatrix AoS
+       ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+       ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+     (out_constrained_st
+      (SMatrix AoS
+       ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+       ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+     (out_block Parameters) (out_trans Identity)))
+   (theta <opaque>
+    ((out_unconstrained_st SReal) (out_constrained_st SReal) (out_block Parameters)
+     (out_trans Identity)))))
+ (prog_name shape_indexed_guard_model)
+ (prog_path tests/fixtures/shape_indexed_guard.stan))

--- a/tests/fixtures/shape_named_guard.stan
+++ b/tests/fixtures/shape_named_guard.stan
@@ -1,0 +1,18 @@
+functions {
+  matrix shape_design(matrix mat) {
+    if (rows(mat) == 0) return rep_matrix(1.0, 1, 1);
+    return rep_matrix(2.0, 1, 1);
+  }
+}
+data {
+  int<lower=0> n;
+  vector[1] y;
+}
+parameters {
+  matrix[n, 2] probe;
+  real alpha;
+  vector[1] beta;
+}
+model {
+  y ~ normal_id_glm(shape_design(probe), alpha, beta, 1);
+}

--- a/tests/fixtures/shape_named_guard.tmir.sexp
+++ b/tests/fixtures/shape_named_guard.tmir.sexp
@@ -1,0 +1,889 @@
+((functions_block
+  (((fdrt (ReturnType UMatrix)) (fdname shape_design) (fdsuffix FnPlain)
+    (fdargs ((AutoDiffable mat UMatrix)))
+    (fdbody
+     (((pattern
+        (Block
+         (((pattern
+            (IfElse
+             ((pattern
+               (FunApp (StanLib Equals__ FnPlain AoS)
+                (((pattern
+                   (FunApp (StanLib rows FnPlain AoS)
+                    (((pattern (Var mat))
+                      (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable)))))))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                 ((pattern (Lit Int 0))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+             ((pattern
+               (Block
+                (((pattern
+                   (Return
+                    (((pattern
+                       (Promotion
+                        ((pattern
+                          (FunApp (StanLib rep_matrix FnPlain AoS)
+                           (((pattern (Lit Real 1.0))
+                             (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+                            ((pattern (Lit Int 1))
+                             (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                            ((pattern (Lit Int 1))
+                             (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                         (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly))))
+                        UReal AutoDiffable))
+                      (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable)))))))
+                  (meta <opaque>)))))
+              (meta <opaque>))
+             ()))
+           (meta <opaque>))
+          ((pattern
+            (Return
+             (((pattern
+                (Promotion
+                 ((pattern
+                   (FunApp (StanLib rep_matrix FnPlain AoS)
+                    (((pattern (Lit Real 2.0))
+                      (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+                     ((pattern (Lit Int 1))
+                      (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                     ((pattern (Lit Int 1))
+                      (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                  (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly))))
+                 UReal AutoDiffable))
+               (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable)))))))
+           (meta <opaque>)))))
+       (meta <opaque>))))
+    (fdloc <opaque>))))
+ (input_vars
+  ((n <opaque> SInt)
+   (y <opaque>
+    (SVector AoS
+     ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+ (prepare_data
+  (((pattern
+     (Decl (decl_adtype DataOnly) (decl_id pos__) (decl_type (Sized SInt))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable pos__) ()) UInt
+      ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id n) (decl_type (Sized SInt))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable n) ()) UInt
+      ((pattern
+        (Indexed
+         ((pattern
+           (FunApp (CompilerInternal FnReadData)
+            (((pattern (Lit Str n))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+          (meta ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly))))
+         ((Single
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnCheck
+        (trans
+         (Lower
+          ((pattern (Lit Int 0)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (var_name n)
+        (var ((pattern (Var n)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (((pattern (Lit Int 0)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id y)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id y_flat__)
+          (decl_type (Unsized (UArray UReal))) (initialize Uninit)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable y_flat__) ()) (UArray UReal)
+          ((pattern
+            (FunApp (CompilerInternal FnReadData)
+             (((pattern (Lit Str y))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable pos__) ()) UInt
+          ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar sym1__)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (Assignment
+                  ((LVariable y)
+                   ((Single
+                     ((pattern (Var sym1__))
+                      (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                  UVector
+                  ((pattern
+                    (Indexed
+                     ((pattern (Var y_flat__))
+                      (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))
+                     ((Single
+                       ((pattern (Var pos__))
+                        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+                (meta <opaque>))
+               ((pattern
+                 (Assignment ((LVariable pos__) ()) UInt
+                  ((pattern
+                    (FunApp (StanLib Plus__ FnPlain AoS)
+                     (((pattern (Var pos__))
+                       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                      ((pattern (Lit Int 1))
+                       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp (CompilerInternal FnValidateSize)
+      (((pattern (Lit Str probe))
+        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+       ((pattern (Lit Str n)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+       ((pattern (Var n)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp (CompilerInternal FnValidateSize)
+      (((pattern (Lit Str beta)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+       ((pattern (Lit Str 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+       ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+    (meta <opaque>))))
+ (log_prob
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id probe)
+      (decl_type
+       (Sized
+        (SMatrix AoS
+         ((pattern (Var n)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+         ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity)
+             (dims
+              (((pattern (Var n))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+               ((pattern (Lit Int 2))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id alpha) (decl_type (Sized SReal))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity) (dims ()) (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id beta)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity)
+             (dims
+              (((pattern (Lit Int 1))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id inline_shape_design_return_sym4__)
+          (decl_type
+           (Sized
+            (SMatrix AoS
+             ((pattern (Lit Int 0))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+             ((pattern (Lit Int 0))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+          (initialize Uninit)))
+        (meta <opaque>))
+       ((pattern
+         (Decl (decl_adtype DataOnly)
+          (decl_id inline_shape_design_early_ret_check_sym5__) (decl_type (Sized SInt))
+          (initialize Default)))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar inline_shape_design_iterator_sym6__)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (IfElse
+                  ((pattern
+                    (FunApp (StanLib Equals__ FnPlain AoS)
+                     (((pattern
+                        (FunApp (StanLib rows FnPlain AoS)
+                         (((pattern (Var probe))
+                           (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable)))))))
+                       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                      ((pattern (Lit Int 0))
+                       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                  ((pattern
+                    (Block
+                     (((pattern
+                        (Assignment ((LVariable inline_shape_design_return_sym4__) ())
+                         UMatrix
+                         ((pattern
+                           (Promotion
+                            ((pattern
+                              (FunApp (StanLib rep_matrix FnPlain AoS)
+                               (((pattern (Lit Real 1.0))
+                                 (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+                                ((pattern (Lit Int 1))
+                                 (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                                ((pattern (Lit Int 1))
+                                 (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                             (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly))))
+                            UReal AutoDiffable))
+                          (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))))
+                       (meta <opaque>))
+                      ((pattern Break) (meta <opaque>)))))
+                   (meta <opaque>))
+                  ()))
+                (meta <opaque>))
+               ((pattern
+                 (Assignment ((LVariable inline_shape_design_return_sym4__) ()) UMatrix
+                  ((pattern
+                    (Promotion
+                     ((pattern
+                       (FunApp (StanLib rep_matrix FnPlain AoS)
+                        (((pattern (Lit Real 2.0))
+                          (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+                         ((pattern (Lit Int 1))
+                          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                         ((pattern (Lit Int 1))
+                          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                      (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly))))
+                     UReal AutoDiffable))
+                   (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))))
+                (meta <opaque>))
+               ((pattern Break) (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>))
+       ((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib normal_id_glm_lpdf (FnLpdf true) AoS)
+             (((pattern (Var y))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly))))
+              ((pattern (Var inline_shape_design_return_sym4__))
+               (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))
+              ((pattern (Var alpha))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+              ((pattern (Var beta))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))
+              ((pattern
+                (Promotion
+                 ((pattern (Lit Int 1))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                 UReal DataOnly))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>)))))
+    (meta <opaque>))))
+ (reverse_mode_log_prob
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id probe)
+      (decl_type
+       (Sized
+        (SMatrix SoA
+         ((pattern (Var n)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+         ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity)
+             (dims
+              (((pattern (Var n))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+               ((pattern (Lit Int 2))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern SoA)))
+           ()))
+         (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id alpha) (decl_type (Sized SReal))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity) (dims ()) (mem_pattern SoA)))
+           ()))
+         (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id beta)
+      (decl_type
+       (Sized
+        (SVector SoA
+         ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity)
+             (dims
+              (((pattern (Lit Int 1))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern SoA)))
+           ()))
+         (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id inline_shape_design_return_sym1__)
+          (decl_type
+           (Sized
+            (SMatrix SoA
+             ((pattern (Lit Int 0))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+             ((pattern (Lit Int 0))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+          (initialize Uninit)))
+        (meta <opaque>))
+       ((pattern
+         (Decl (decl_adtype DataOnly)
+          (decl_id inline_shape_design_early_ret_check_sym2__) (decl_type (Sized SInt))
+          (initialize Default)))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar inline_shape_design_iterator_sym3__)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (IfElse
+                  ((pattern
+                    (FunApp (StanLib Equals__ FnPlain SoA)
+                     (((pattern
+                        (FunApp (StanLib rows FnPlain SoA)
+                         (((pattern (Var probe))
+                           (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable)))))))
+                       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                      ((pattern (Lit Int 0))
+                       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                  ((pattern
+                    (Block
+                     (((pattern
+                        (Assignment ((LVariable inline_shape_design_return_sym1__) ())
+                         UMatrix
+                         ((pattern
+                           (Promotion
+                            ((pattern
+                              (FunApp (StanLib rep_matrix FnPlain SoA)
+                               (((pattern (Lit Real 1.0))
+                                 (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+                                ((pattern (Lit Int 1))
+                                 (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                                ((pattern (Lit Int 1))
+                                 (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                             (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly))))
+                            UReal AutoDiffable))
+                          (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))))
+                       (meta <opaque>))
+                      ((pattern Break) (meta <opaque>)))))
+                   (meta <opaque>))
+                  ()))
+                (meta <opaque>))
+               ((pattern
+                 (Assignment ((LVariable inline_shape_design_return_sym1__) ()) UMatrix
+                  ((pattern
+                    (Promotion
+                     ((pattern
+                       (FunApp (StanLib rep_matrix FnPlain SoA)
+                        (((pattern (Lit Real 2.0))
+                          (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+                         ((pattern (Lit Int 1))
+                          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                         ((pattern (Lit Int 1))
+                          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                      (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly))))
+                     UReal AutoDiffable))
+                   (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))))
+                (meta <opaque>))
+               ((pattern Break) (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>))
+       ((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib normal_id_glm_lpdf (FnLpdf true) SoA)
+             (((pattern (Var y))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly))))
+              ((pattern (Var inline_shape_design_return_sym1__))
+               (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))
+              ((pattern (Var alpha))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+              ((pattern (Var beta))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))
+              ((pattern
+                (Promotion
+                 ((pattern (Lit Int 1))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                 UReal DataOnly))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>)))))
+    (meta <opaque>))))
+ (generate_quantities
+  (((pattern
+     (Decl (decl_adtype DataOnly) (decl_id probe)
+      (decl_type
+       (Sized
+        (SMatrix AoS
+         ((pattern (Var n)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+         ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity)
+             (dims
+              (((pattern (Var n))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+               ((pattern (Lit Int 2))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id alpha) (decl_type (Sized SReal))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity) (dims ()) (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id beta)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity)
+             (dims
+              (((pattern (Lit Int 1))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt ())
+        (var
+         ((pattern (Var probe))
+          (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt ())
+        (var
+         ((pattern (Var alpha)) (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt ())
+        (var
+         ((pattern (Var beta))
+          (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (IfElse
+      ((pattern
+        (FunApp (StanLib PNot__ FnPlain AoS)
+         (((pattern
+            (EOr
+             ((pattern (Var emit_transformed_parameters__))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+             ((pattern (Var emit_generated_quantities__))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+      ((pattern (Block (((pattern (Return ())) (meta <opaque>))))) (meta <opaque>)) ()))
+    (meta <opaque>))
+   ((pattern
+     (IfElse
+      ((pattern
+        (FunApp (StanLib PNot__ FnPlain AoS)
+         (((pattern (Var emit_generated_quantities__))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+      ((pattern (Block (((pattern (Return ())) (meta <opaque>))))) (meta <opaque>)) ()))
+    (meta <opaque>))))
+ (transform_inits
+  (((pattern
+     (Decl (decl_adtype DataOnly) (decl_id pos__) (decl_type (Sized SInt))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable pos__) ()) UInt
+      ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id probe)
+      (decl_type
+       (Sized
+        (SMatrix AoS
+         ((pattern (Var n)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+         ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id probe_flat__)
+          (decl_type (Unsized (UArray UReal))) (initialize Uninit)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable probe_flat__) ()) (UArray UReal)
+          ((pattern
+            (FunApp (CompilerInternal FnReadData)
+             (((pattern (Lit Str probe))
+               (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable pos__) ()) UInt
+          ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar sym1__)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Lit Int 2))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (For (loopvar sym2__)
+                  (lower
+                   ((pattern (Lit Int 1))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (upper
+                   ((pattern (Var n))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (body
+                   ((pattern
+                     (Block
+                      (((pattern
+                         (Assignment
+                          ((LVariable probe)
+                           ((Single
+                             ((pattern (Var sym2__))
+                              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                            (Single
+                             ((pattern (Var sym1__))
+                              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                          UMatrix
+                          ((pattern
+                            (Indexed
+                             ((pattern (Var probe_flat__))
+                              (meta
+                               ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))
+                             ((Single
+                               ((pattern (Var pos__))
+                                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                           (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+                        (meta <opaque>))
+                       ((pattern
+                         (Assignment ((LVariable pos__) ()) UInt
+                          ((pattern
+                            (FunApp (StanLib Plus__ FnPlain AoS)
+                             (((pattern (Var pos__))
+                               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                              ((pattern (Lit Int 1))
+                               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                        (meta <opaque>)))))
+                    (meta <opaque>)))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var probe))
+          (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id alpha) (decl_type (Sized SReal))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable alpha) ()) UReal
+      ((pattern
+        (Indexed
+         ((pattern
+           (FunApp (CompilerInternal FnReadData)
+            (((pattern (Lit Str alpha))
+              (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+          (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))
+         ((Single
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+       (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var alpha)) (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id beta)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id beta_flat__)
+          (decl_type (Unsized (UArray UReal))) (initialize Uninit)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable beta_flat__) ()) (UArray UReal)
+          ((pattern
+            (FunApp (CompilerInternal FnReadData)
+             (((pattern (Lit Str beta))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable pos__) ()) UInt
+          ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar sym1__)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (Assignment
+                  ((LVariable beta)
+                   ((Single
+                     ((pattern (Var sym1__))
+                      (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                  UVector
+                  ((pattern
+                    (Indexed
+                     ((pattern (Var beta_flat__))
+                      (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))
+                     ((Single
+                       ((pattern (Var pos__))
+                        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+                (meta <opaque>))
+               ((pattern
+                 (Assignment ((LVariable pos__) ()) UInt
+                  ((pattern
+                    (FunApp (StanLib Plus__ FnPlain AoS)
+                     (((pattern (Var pos__))
+                       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                      ((pattern (Lit Int 1))
+                       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var beta))
+          (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))))
+ (unconstrain_array
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id probe)
+      (decl_type
+       (Sized
+        (SMatrix AoS
+         ((pattern (Var n)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+         ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable probe) ()) UMatrix
+      ((pattern
+        (FunApp (CompilerInternal FnReadDeserializer)
+         (((pattern (Var n)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+          ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var probe))
+          (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id alpha) (decl_type (Sized SReal))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable alpha) ()) UReal
+      ((pattern (FunApp (CompilerInternal FnReadDeserializer) ()))
+       (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var alpha)) (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id beta)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable beta) ()) UVector
+      ((pattern
+        (FunApp (CompilerInternal FnReadDeserializer)
+         (((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var beta))
+          (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))))
+ (output_vars
+  ((probe <opaque>
+    ((out_unconstrained_st
+      (SMatrix AoS
+       ((pattern (Var n)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+       ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+     (out_constrained_st
+      (SMatrix AoS
+       ((pattern (Var n)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+       ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+     (out_block Parameters) (out_trans Identity)))
+   (alpha <opaque>
+    ((out_unconstrained_st SReal) (out_constrained_st SReal) (out_block Parameters)
+     (out_trans Identity)))
+   (beta <opaque>
+    ((out_unconstrained_st
+      (SVector AoS
+       ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+     (out_constrained_st
+      (SVector AoS
+       ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+     (out_block Parameters) (out_trans Identity)))))
+ (prog_name shape_named_guard_model) (prog_path tests/fixtures/shape_named_guard.stan))

--- a/tests/fixtures/shape_partial_guard.stan
+++ b/tests/fixtures/shape_partial_guard.stan
@@ -1,0 +1,18 @@
+data {
+  int<lower=0> n;
+  int<lower=0, upper=1> flag;
+}
+parameters {
+  matrix[n, 2] M;
+  real theta;
+}
+model {
+  real scale = 0.0;
+  if (rows(M) == 0 || flag == 1)
+    scale += 1.0;
+  if (rows(M) == 0 || theta > 0.0)
+    scale += 10.0;
+  else
+    scale += 20.0;
+  target += scale * theta;
+}

--- a/tests/fixtures/shape_partial_guard.tmir.sexp
+++ b/tests/fixtures/shape_partial_guard.tmir.sexp
@@ -1,0 +1,608 @@
+((functions_block ()) (input_vars ((n <opaque> SInt) (flag <opaque> SInt)))
+ (prepare_data
+  (((pattern
+     (Decl (decl_adtype DataOnly) (decl_id n) (decl_type (Sized SInt))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable n) ()) UInt
+      ((pattern
+        (Indexed
+         ((pattern
+           (FunApp (CompilerInternal FnReadData)
+            (((pattern (Lit Str n))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+          (meta ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly))))
+         ((Single
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnCheck
+        (trans
+         (Lower
+          ((pattern (Lit Int 0)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (var_name n)
+        (var ((pattern (Var n)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (((pattern (Lit Int 0)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id flag) (decl_type (Sized SInt))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable flag) ()) UInt
+      ((pattern
+        (Indexed
+         ((pattern
+           (FunApp (CompilerInternal FnReadData)
+            (((pattern (Lit Str flag))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+          (meta ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly))))
+         ((Single
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnCheck
+        (trans
+         (Lower
+          ((pattern (Lit Int 0)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (var_name flag)
+        (var
+         ((pattern (Var flag)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (((pattern (Lit Int 0)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnCheck
+        (trans
+         (Upper
+          ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (var_name flag)
+        (var
+         ((pattern (Var flag)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp (CompilerInternal FnValidateSize)
+      (((pattern (Lit Str M)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+       ((pattern (Lit Str n)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+       ((pattern (Var n)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+    (meta <opaque>))))
+ (log_prob
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id M)
+      (decl_type
+       (Sized
+        (SMatrix AoS
+         ((pattern (Var n)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+         ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity)
+             (dims
+              (((pattern (Var n))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+               ((pattern (Lit Int 2))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id theta) (decl_type (Sized SReal))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity) (dims ()) (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id scale) (decl_type (Sized SReal))
+          (initialize Uninit)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable scale) ()) UReal
+          ((pattern (Lit Real 0.0))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>))
+       ((pattern
+         (IfElse
+          ((pattern
+            (EOr
+             ((pattern
+               (FunApp (StanLib Equals__ FnPlain AoS)
+                (((pattern
+                   (FunApp (StanLib rows FnPlain AoS)
+                    (((pattern (Var M))
+                      (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable)))))))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                 ((pattern (Lit Int 0))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+             ((pattern
+               (FunApp (StanLib Equals__ FnPlain AoS)
+                (((pattern (Var flag))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                 ((pattern (Lit Int 1))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+          ((pattern
+            (Block
+             (((pattern
+                (Assignment ((LVariable scale) ()) UReal
+                 ((pattern (Lit Real 1.))
+                  (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+               (meta <opaque>)))))
+           (meta <opaque>))
+          ()))
+        (meta <opaque>))
+       ((pattern
+         (IfElse
+          ((pattern
+            (EOr
+             ((pattern
+               (FunApp (StanLib Equals__ FnPlain AoS)
+                (((pattern
+                   (FunApp (StanLib rows FnPlain AoS)
+                    (((pattern (Var M))
+                      (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable)))))))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                 ((pattern (Lit Int 0))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+             ((pattern
+               (FunApp (StanLib Greater__ FnPlain AoS)
+                (((pattern (Var theta))
+                  (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+                 ((pattern (Lit Real 0.0))
+                  (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel AutoDiffable))))))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel AutoDiffable))))
+          ((pattern
+            (Block
+             (((pattern
+                (Assignment ((LVariable scale) ()) UReal
+                 ((pattern
+                   (FunApp (StanLib Plus__ FnPlain AoS)
+                    (((pattern (Var scale))
+                      (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+                     ((pattern (Lit Real 10.0))
+                      (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+                  (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+               (meta <opaque>)))))
+           (meta <opaque>))
+          (((pattern
+             (Block
+              (((pattern
+                 (Assignment ((LVariable scale) ()) UReal
+                  ((pattern
+                    (FunApp (StanLib Plus__ FnPlain AoS)
+                     (((pattern (Var scale))
+                       (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+                      ((pattern (Lit Real 20.0))
+                       (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>))
+       ((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib Times__ FnPlain AoS)
+             (((pattern (Var scale))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+              ((pattern (Var theta))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>)))))
+    (meta <opaque>))))
+ (reverse_mode_log_prob
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id M)
+      (decl_type
+       (Sized
+        (SMatrix SoA
+         ((pattern (Var n)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+         ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity)
+             (dims
+              (((pattern (Var n))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+               ((pattern (Lit Int 2))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern SoA)))
+           ()))
+         (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id theta) (decl_type (Sized SReal))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity) (dims ()) (mem_pattern SoA)))
+           ()))
+         (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id scale) (decl_type (Sized SReal))
+          (initialize Uninit)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable scale) ()) UReal
+          ((pattern (Lit Real 0.0))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>))
+       ((pattern
+         (IfElse
+          ((pattern
+            (EOr
+             ((pattern
+               (FunApp (StanLib Equals__ FnPlain SoA)
+                (((pattern
+                   (FunApp (StanLib rows FnPlain SoA)
+                    (((pattern (Var M))
+                      (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable)))))))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                 ((pattern (Lit Int 0))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+             ((pattern
+               (FunApp (StanLib Equals__ FnPlain SoA)
+                (((pattern (Var flag))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                 ((pattern (Lit Int 1))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+          ((pattern
+            (Block
+             (((pattern
+                (Assignment ((LVariable scale) ()) UReal
+                 ((pattern (Lit Real 1.))
+                  (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+               (meta <opaque>)))))
+           (meta <opaque>))
+          ()))
+        (meta <opaque>))
+       ((pattern
+         (IfElse
+          ((pattern
+            (EOr
+             ((pattern
+               (FunApp (StanLib Equals__ FnPlain SoA)
+                (((pattern
+                   (FunApp (StanLib rows FnPlain SoA)
+                    (((pattern (Var M))
+                      (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable)))))))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                 ((pattern (Lit Int 0))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+             ((pattern
+               (FunApp (StanLib Greater__ FnPlain SoA)
+                (((pattern (Var theta))
+                  (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+                 ((pattern (Lit Real 0.0))
+                  (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel AutoDiffable))))))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel AutoDiffable))))
+          ((pattern
+            (Block
+             (((pattern
+                (Assignment ((LVariable scale) ()) UReal
+                 ((pattern
+                   (FunApp (StanLib Plus__ FnPlain SoA)
+                    (((pattern (Var scale))
+                      (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+                     ((pattern (Lit Real 10.0))
+                      (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+                  (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+               (meta <opaque>)))))
+           (meta <opaque>))
+          (((pattern
+             (Block
+              (((pattern
+                 (Assignment ((LVariable scale) ()) UReal
+                  ((pattern
+                    (FunApp (StanLib Plus__ FnPlain SoA)
+                     (((pattern (Var scale))
+                       (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+                      ((pattern (Lit Real 20.0))
+                       (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>))
+       ((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib Times__ FnPlain SoA)
+             (((pattern (Var scale))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+              ((pattern (Var theta))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>)))))
+    (meta <opaque>))))
+ (generate_quantities
+  (((pattern
+     (Decl (decl_adtype DataOnly) (decl_id M)
+      (decl_type
+       (Sized
+        (SMatrix AoS
+         ((pattern (Var n)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+         ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity)
+             (dims
+              (((pattern (Var n))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+               ((pattern (Lit Int 2))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id theta) (decl_type (Sized SReal))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity) (dims ()) (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt ())
+        (var
+         ((pattern (Var M)) (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt ())
+        (var
+         ((pattern (Var theta)) (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (IfElse
+      ((pattern
+        (FunApp (StanLib PNot__ FnPlain AoS)
+         (((pattern
+            (EOr
+             ((pattern (Var emit_transformed_parameters__))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+             ((pattern (Var emit_generated_quantities__))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+      ((pattern (Block (((pattern (Return ())) (meta <opaque>))))) (meta <opaque>)) ()))
+    (meta <opaque>))
+   ((pattern
+     (IfElse
+      ((pattern
+        (FunApp (StanLib PNot__ FnPlain AoS)
+         (((pattern (Var emit_generated_quantities__))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+      ((pattern (Block (((pattern (Return ())) (meta <opaque>))))) (meta <opaque>)) ()))
+    (meta <opaque>))))
+ (transform_inits
+  (((pattern
+     (Decl (decl_adtype DataOnly) (decl_id pos__) (decl_type (Sized SInt))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id M)
+      (decl_type
+       (Sized
+        (SMatrix AoS
+         ((pattern (Var n)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+         ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id M_flat__)
+          (decl_type (Unsized (UArray UReal))) (initialize Uninit)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable M_flat__) ()) (UArray UReal)
+          ((pattern
+            (FunApp (CompilerInternal FnReadData)
+             (((pattern (Lit Str M))
+               (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable pos__) ()) UInt
+          ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar sym1__)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Lit Int 2))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (For (loopvar sym2__)
+                  (lower
+                   ((pattern (Lit Int 1))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (upper
+                   ((pattern (Var n))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (body
+                   ((pattern
+                     (Block
+                      (((pattern
+                         (Assignment
+                          ((LVariable M)
+                           ((Single
+                             ((pattern (Var sym2__))
+                              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                            (Single
+                             ((pattern (Var sym1__))
+                              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                          UMatrix
+                          ((pattern
+                            (Indexed
+                             ((pattern (Var M_flat__))
+                              (meta
+                               ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))
+                             ((Single
+                               ((pattern (Var pos__))
+                                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                           (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+                        (meta <opaque>))
+                       ((pattern
+                         (Assignment ((LVariable pos__) ()) UInt
+                          ((pattern
+                            (FunApp (StanLib Plus__ FnPlain AoS)
+                             (((pattern (Var pos__))
+                               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                              ((pattern (Lit Int 1))
+                               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                        (meta <opaque>)))))
+                    (meta <opaque>)))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var M)) (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id theta) (decl_type (Sized SReal))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable theta) ()) UReal
+      ((pattern
+        (Indexed
+         ((pattern
+           (FunApp (CompilerInternal FnReadData)
+            (((pattern (Lit Str theta))
+              (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+          (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))
+         ((Single
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+       (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var theta)) (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))))
+ (unconstrain_array
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id M)
+      (decl_type
+       (Sized
+        (SMatrix AoS
+         ((pattern (Var n)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+         ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable M) ()) UMatrix
+      ((pattern
+        (FunApp (CompilerInternal FnReadDeserializer)
+         (((pattern (Var n)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+          ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var M)) (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id theta) (decl_type (Sized SReal))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable theta) ()) UReal
+      ((pattern (FunApp (CompilerInternal FnReadDeserializer) ()))
+       (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var theta)) (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))))
+ (output_vars
+  ((M <opaque>
+    ((out_unconstrained_st
+      (SMatrix AoS
+       ((pattern (Var n)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+       ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+     (out_constrained_st
+      (SMatrix AoS
+       ((pattern (Var n)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+       ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+     (out_block Parameters) (out_trans Identity)))
+   (theta <opaque>
+    ((out_unconstrained_st SReal) (out_constrained_st SReal) (out_block Parameters)
+     (out_trans Identity)))))
+ (prog_name shape_partial_guard_model)
+ (prog_path tests/fixtures/shape_partial_guard.stan))

--- a/tests/test_bridgestan.cpp
+++ b/tests/test_bridgestan.cpp
@@ -751,7 +751,7 @@ void test_necessity_effects_refused() {
       fail("BridgeStan accepted necessity island containing " + effect);
       bs_model_destruct(m);
     } else if (err == nullptr ||
-               std::string(err).find("parameter-dependent region") ==
+               std::string(err).find("runtime-control region") ==
                    std::string::npos ||
                std::string(err).find(effect) == std::string::npos) {
       fail("BridgeStan necessity " + effect +

--- a/tests/test_capi.cpp
+++ b/tests/test_capi.cpp
@@ -378,7 +378,7 @@ void expect_necessity_effects_refused() {
       continue;
     }
     const std::string msg = err;
-    if (msg.find("parameter-dependent region") == std::string::npos ||
+    if (msg.find("runtime-control region") == std::string::npos ||
         msg.find(effect) == std::string::npos) {
       ++failures;
       std::printf("FAIL C API necessity %s error: %s\n", effect.c_str(), err);

--- a/tests/test_lower.cpp
+++ b/tests/test_lower.cpp
@@ -57,6 +57,25 @@ static std::string slurp(const std::string& path) {
   return ss.str();
 }
 
+static stanli::CompiledModel compile_without_optional_islands(
+    const std::string& mir, const stanli::DataMap& data) {
+  test_setenv("STANLI_NO_ISLAND", "1", 1);
+  try {
+    stanli::CompiledModel cm = stanli::compile_model(mir, data);
+    test_unsetenv("STANLI_NO_ISLAND");
+    return cm;
+  } catch (...) {
+    test_unsetenv("STANLI_NO_ISLAND");
+    throw;
+  }
+}
+
+static int count_opcode(const stanli::CompiledModel& cm, uint16_t opcode) {
+  return static_cast<int>(
+      std::count_if(cm.graph.ops.begin(), cm.graph.ops.end(),
+                    [=](const stanli::Op& op) { return op.opcode == opcode; }));
+}
+
 static stanli::DataMap bound_check_data(double raw = 0.0, int N = 1, int M = 1,
                                         int R = 1, int C = 1, int BR = 1,
                                         int BC = 1) {
@@ -2143,6 +2162,138 @@ int main() {
     test_unsetenv("STANLI_NO_ISLAND");
   }
 
+  // A shape-only guard on a parameter matrix is fixed when the data is
+  // bound, despite the matrix values remaining autodiffable.  It must fold
+  // before the UDF's synthetic early-return loop is lowered: the resulting
+  // design matrix is parameter-free (as normal_id_glm requires) and there is
+  // no runtime-control island.
+  {
+    const std::string mir = slurp("tests/fixtures/shape_named_guard.tmir.sexp");
+    for (int n : {0, 3}) {
+      DataMap d;
+      d.set_int("n", n);
+      d.set_real_array("y", {5.0});
+      CompiledModel cm = compile_without_optional_islands(mir, d);
+      const std::string tag = "named shape guard " + std::to_string(n);
+      check(cm.n_unconstrained == 2 * n + 2, tag + " parameter count");
+      check(count_opcode(cm, OP_ISLAND) == 0, tag + " has no island");
+
+      Executor ex(std::move(cm.graph));
+      cm.bind(ex);
+      for (int i = 0; i < 2 * n; ++i) ex.params_data()[i] = 0.1 * (i + 1);
+      ex.params_data()[2 * n] = 0.5;
+      ex.params_data()[2 * n + 1] = 0.25;
+      std::vector<double> grad(static_cast<size_t>(2 * n + 2));
+      const double lp = ex.gradient(grad.data());
+      const double x = n == 0 ? 1.0 : 2.0;
+      const double residual = 5.0 - (0.5 + x * 0.25);
+      expect_eq(tag + " lp", lp, -0.5 * residual * residual);
+      for (int i = 0; i < 2 * n; ++i)
+        expect_eq(tag + " matrix grad " + std::to_string(i), grad[i], 0.0);
+      expect_eq(tag + " alpha grad", grad[2 * n], residual);
+      expect_eq(tag + " beta grad", grad[2 * n + 1], x * residual);
+    }
+  }
+
+  // The same proof through a matrix view.  Empty and duplicate gather lists
+  // determine geometry without materializing the two-dimensional gather,
+  // while a reached out-of-bounds selector retains Stan's bind-time error.
+  {
+    const std::string mir =
+        slurp("tests/fixtures/shape_indexed_guard.tmir.sexp");
+    const auto run = [&](const std::vector<int>& idx, double scale,
+                         const std::string& tag) {
+      DataMap d;
+      d.set_int("K", static_cast<int>(idx.size()));
+      d.set_int_array("idx", idx);
+      CompiledModel cm = compile_without_optional_islands(mir, d);
+      check(cm.n_unconstrained == 10, tag + " parameter count");
+      check(count_opcode(cm, OP_ISLAND) == 0, tag + " has no island");
+      Executor ex(std::move(cm.graph));
+      cm.bind(ex);
+      for (int i = 0; i < 9; ++i) ex.params_data()[i] = 0.1 * (i + 1);
+      ex.params_data()[9] = 0.5;
+      double grad[10] = {};
+      expect_eq(tag + " lp", ex.gradient(grad), 0.5 * scale);
+      for (int i = 0; i < 9; ++i)
+        expect_eq(tag + " matrix grad " + std::to_string(i), grad[i], 0.0);
+      expect_eq(tag + " theta grad", grad[9], scale);
+    };
+    run({}, 1.0, "indexed shape guard empty");
+    run({1}, 1.0, "indexed shape guard row and column");
+    run({2, 2}, 2.0, "indexed shape guard duplicate");
+
+    DataMap bad;
+    bad.set_int("K", 2);
+    bad.set_int_array("idx", {1, 4});
+    bool threw = false;
+    try {
+      (void)compile_without_optional_islands(mir, bad);
+    } catch (const CompileError& e) {
+      threw = std::string(e.what()).find("out of bounds") != std::string::npos;
+    }
+    check(threw, "indexed shape guard rejects reached out-of-bounds index");
+  }
+
+  // Static-shape specialization is lazy across && and ||.  Both bad gathers
+  // below are unreachable through boolean, statement, and expression-ternary
+  // control, so they neither become eager bounds errors nor force runtime
+  // control.
+  {
+    DataMap d;
+    d.set_int_array("empty", {});
+    d.set_int_array("valid", {1});
+    d.set_int_array("bad", {3});
+    CompiledModel cm = compile_without_optional_islands(
+        slurp("tests/fixtures/shape_guard_lazy.tmir.sexp"), d);
+    check(cm.n_unconstrained == 5, "lazy shape guard parameter count");
+    check(count_opcode(cm, OP_ISLAND) == 0, "lazy shape guard has no island");
+    Executor ex(std::move(cm.graph));
+    cm.bind(ex);
+    for (int i = 0; i < 4; ++i) ex.params_data()[i] = 0.1 * (i + 1);
+    ex.params_data()[4] = 0.5;
+    double grad[5] = {};
+    expect_eq("lazy shape guard lp", ex.gradient(grad), 0.5);
+    for (int i = 0; i < 4; ++i)
+      expect_eq("lazy shape guard matrix grad " + std::to_string(i), grad[i],
+                0.0);
+    expect_eq("lazy shape guard theta grad", grad[4], 1.0);
+  }
+
+  // A partially specialized || has two distinct outcomes.  With an empty
+  // matrix the shape lhs is true and a genuine parameter rhs is dead, so no
+  // island is needed.  With a nonempty matrix the same rhs remains a runtime
+  // condition.  The preceding flag guard also pins the opposite walk: a
+  // false shape lhs followed by a true data-only rhs still folds completely.
+  {
+    const std::string mir =
+        slurp("tests/fixtures/shape_partial_guard.tmir.sexp");
+    for (int n : {0, 2}) {
+      DataMap d;
+      d.set_int("n", n);
+      d.set_int("flag", 1);
+      CompiledModel cm = compile_without_optional_islands(mir, d);
+      const std::string tag = "partial shape guard " + std::to_string(n);
+      check(cm.n_unconstrained == 2 * n + 1, tag + " parameter count");
+      check(count_opcode(cm, OP_ISLAND) == (n == 0 ? 0 : 1),
+            tag + " island boundary");
+      Executor ex(std::move(cm.graph));
+      cm.bind(ex);
+      for (int i = 0; i < 2 * n; ++i) ex.params_data()[i] = 0.1 * (i + 1);
+      for (double theta : {0.5, -0.5}) {
+        ex.params_data()[2 * n] = theta;
+        std::vector<double> grad(static_cast<size_t>(2 * n + 1));
+        const double scale = n == 0 || theta > 0.0 ? 11.0 : 21.0;
+        expect_eq(tag + " lp " + std::to_string(theta),
+                  ex.gradient(grad.data()), scale * theta);
+        for (int i = 0; i < 2 * n; ++i)
+          expect_eq(tag + " matrix grad " + std::to_string(i), grad[i], 0.0);
+        expect_eq(tag + " theta grad " + std::to_string(theta), grad[2 * n],
+                  scale);
+      }
+    }
+  }
+
   // A read-only live-in can still be a declared local with no preceding
   // assignment. Ordinary lowering gives it Stan's uninitialized NaN value;
   // the necessity-island binder must materialize the same slot rather than
@@ -2426,7 +2577,7 @@ int main() {
       compile_model(slurp("tests/fixtures/paramcond_tilde.tmir.sexp"), d);
     } catch (const CompileError& e) {
       const std::string msg = e.what();
-      threw = msg.find("`~` inside a parameter-dependent region") !=
+      threw = msg.find("`~` inside a runtime-control region") !=
                   std::string::npos &&
               msg.find("target +=") != std::string::npos;
     }

--- a/tests/test_mir_decode.cpp
+++ b/tests/test_mir_decode.cpp
@@ -1550,6 +1550,10 @@ int main(int argc, char** argv) {
   check_round_trip("tests/fixtures/odefns.tmir.sexp");
   check_round_trip("tests/fixtures/view_udf_local_data_branch.tmir.sexp");
   check_round_trip("tests/fixtures/paramcond_break.tmir.sexp");
+  check_round_trip("tests/fixtures/shape_named_guard.tmir.sexp");
+  check_round_trip("tests/fixtures/shape_indexed_guard.tmir.sexp");
+  check_round_trip("tests/fixtures/shape_guard_lazy.tmir.sexp");
+  check_round_trip("tests/fixtures/shape_partial_guard.tmir.sexp");
   check_lowering_equivalence(argc == 3 ? argv[1] : nullptr,
                              argc == 3 ? argv[2] : nullptr);
   check_full_span_assignment_lowering();

--- a/tests/test_rejectprint.cpp
+++ b/tests/test_rejectprint.cpp
@@ -210,7 +210,7 @@ int main() {
       const std::string tag = "necessity " + effect;
       expect(tag + " refuses compilation", threw);
       expect(tag + " names the unsupported effect: " + msg,
-             msg.find("parameter-dependent region") != std::string::npos &&
+             msg.find("runtime-control region") != std::string::npos &&
                  msg.find(effect) != std::string::npos);
       expect(tag + " is not executed while refusing", lines.empty());
     }

--- a/tests/test_write_array.cpp
+++ b/tests/test_write_array.cpp
@@ -3579,8 +3579,7 @@ void test_runtime_int_sum_is_not_compile_time() {
       "    (meta <opaque>))\n   ";
   std::string condition = base;
   condition.insert(insertion, runtime_condition);
-  expect_reduction_interp(condition,
-                          "parameter-dependent region produces nothing",
+  expect_reduction_interp(condition, "runtime-control region produces nothing",
                           "runtime sum cannot provide a condition", true);
 }
 


### PR DESCRIPTION
## Summary

- classify rows, cols, size, and num_elements from immutable logical geometry without lowering parameter values
- preserve lazy boolean and ternary reachability, while retaining runtime-control islands for genuine parameter branches
- cover named matrices, indexed views, bounds, orientation, mixed parameter conditions, and zero-island behavior

## Validation

- cmake --build build -j 4
- ctest --test-dir build --output-on-failure -j 4 (67/67 passed)
- high-effort secondary review found no blocking issue