### PR TITLE
Additional indexing and function support

### DIFF
--- a/runtime/include/stanli/mir.hpp
+++ b/runtime/include/stanli/mir.hpp
@@ -198,6 +198,9 @@ struct SizedType {
   std::vector<Expr> dims;  // outer-to-inner for SArray chains
   std::string elem_base;   // for SArray: the innermost element base
   std::string raw;         // Unsupported diagnostics
+  // stanc also uses unsized declarations for optimizer temporaries. Their
+  // shape is supplied by the first whole-variable assignment.
+  UnsizedView unsized;
 };
 
 struct Stmt {

--- a/runtime/include/stanli/mir_interp.hpp
+++ b/runtime/include/stanli/mir_interp.hpp
@@ -30,6 +30,7 @@
 
 #include <stan/math.hpp>
 
+#include <algorithm>
 #include <cmath>
 #include <cstdint>
 #include <functional>
@@ -1589,6 +1590,26 @@ class MirInterp {
                                      v.r.at((size_t)j);
       return o;
     }
+    if (e.name == "matrix_exp" && e.args.size() == 1) {
+      using Mat = Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>;
+      Value a = eval(e.args[0]);
+      if (a.dims.size() != 2 || a.dims[0] != a.dims[1])
+        fail("matrix_exp: needs a square matrix", e.raw);
+      const int64_t n = a.dims[0];
+      if (n < 0 || (n != 0 && n > std::numeric_limits<int64_t>::max() / n) ||
+          n * n != static_cast<int64_t>(a.r.size()))
+        fail("matrix_exp: matrix shape does not match storage", e.raw);
+      Mat A(n, n);
+      for (int64_t j = 0; j < n; ++j)
+        for (int64_t i = 0; i < n; ++i) A(i, j) = a.r[(size_t)(j * n + i)];
+      const Mat c = stan::math::matrix_exp(A);
+      Value o;
+      o.dims = {n, n};
+      o.r.resize((size_t)(n * n));
+      for (int64_t j = 0; j < n; ++j)
+        for (int64_t i = 0; i < n; ++i) o.r[(size_t)(j * n + i)] = c(i, j);
+      return o;
+    }
     if (e.name == "quad_form_sym" && e.args.size() == 2) {
       // B' A B, symmetrised. Overload resolution on T reaches the same
       // stan-math call the graph kernel makes -- prim's B.dot(A * B) at
@@ -2300,6 +2321,71 @@ class MirInterp {
       r.dims = {n};
       r.r.assign(n, v.r.at(0));
       if (v.is_int) r.i.assign(n, v.i.at(0));
+      return r;
+    }
+    if (e.name == "append_array" && e.args.size() == 2) {
+      Value a = eval(e.args[0]), b = eval(e.args[1]);
+      if (a.dims.empty() || b.dims.empty() || a.dims.size() != b.dims.size())
+        fail("append_array: arguments must be arrays of the same rank", e.raw);
+      const int64_t a_outer = a.dims[0], b_outer = b.dims[0];
+      if (a_outer < 0 || b_outer < 0 ||
+          a_outer > std::numeric_limits<int64_t>::max() - b_outer)
+        fail("append_array: invalid or overflowing outer extent", e.raw);
+      if (a_outer != 0 && b_outer != 0 &&
+          !std::equal(a.dims.begin() + 1, a.dims.end(), b.dims.begin() + 1,
+                      b.dims.end()))
+        fail("append_array: element shapes must match", e.raw);
+
+      const auto checked_product = [&](const std::vector<int64_t>& dims,
+                                       size_t begin,
+                                       const char* what) -> int64_t {
+        int64_t n = 1;
+        for (size_t k = begin; k < dims.size(); ++k) {
+          const int64_t d = dims[k];
+          if (d < 0 || (d != 0 && n > std::numeric_limits<int64_t>::max() / d))
+            fail(std::string("append_array: invalid or overflowing ") + what,
+                 e.raw);
+          n *= d;
+        }
+        return n;
+      };
+      const int64_t a_count = checked_product(a.dims, 0, "left shape");
+      const int64_t b_count = checked_product(b.dims, 0, "right shape");
+      if (a_count != static_cast<int64_t>(a.r.size()) ||
+          b_count != static_cast<int64_t>(b.r.size()))
+        fail("append_array: argument shape does not match storage", e.raw);
+
+      r.dims = a_outer == 0 && b_outer != 0 ? b.dims : a.dims;
+      r.dims[0] = a_outer + b_outer;
+      const int64_t suffix_count = checked_product(r.dims, 1, "element shape");
+      if (a_count > std::numeric_limits<int64_t>::max() - b_count ||
+          (a_outer + b_outer != 0 &&
+           suffix_count >
+               std::numeric_limits<int64_t>::max() / (a_outer + b_outer)) ||
+          (a_outer + b_outer) * suffix_count != a_count + b_count)
+        fail("append_array: storage length overflows", e.raw);
+
+      const auto append_first_axis = [&](const auto& av, const auto& bv,
+                                         auto* out) {
+        using Size = typename std::decay_t<decltype(av)>::size_type;
+        const Size aw = static_cast<Size>(a_outer);
+        const Size bw = static_cast<Size>(b_outer);
+        out->reserve(av.size() + bv.size());
+        const int64_t lanes = a_outer + b_outer == 0 ? 0 : suffix_count;
+        for (int64_t lane = 0; lane < lanes; ++lane) {
+          const Size ai = static_cast<Size>(lane) * aw;
+          const Size bi = static_cast<Size>(lane) * bw;
+          out->insert(out->end(), av.begin() + ai, av.begin() + ai + aw);
+          out->insert(out->end(), bv.begin() + bi, bv.begin() + bi + bw);
+        }
+      };
+      append_first_axis(a.r, b.r, &r.r);
+      r.is_int = a.is_int && b.is_int;
+      if (r.is_int) {
+        if (a.i.size() != a.r.size() || b.i.size() != b.r.size())
+          fail("append_array: integer mirror does not match storage", e.raw);
+        append_first_axis(a.i, b.i, &r.i);
+      }
       return r;
     }
     if (e.name == "rep_matrix" && e.args.size() == 3) {

--- a/runtime/include/stanli/mir_interp.hpp
+++ b/runtime/include/stanli/mir_interp.hpp
@@ -1589,6 +1589,41 @@ class MirInterp {
                                      v.r.at((size_t)j);
       return o;
     }
+    if (e.name == "quad_form_sym" && e.args.size() == 2) {
+      // B' A B, symmetrised. Overload resolution on T reaches the same
+      // stan-math call the graph kernel makes -- prim's B.dot(A * B) at
+      // double, quad_form_vari's B' * A * B at var -- so the two paths
+      // group the arithmetic the same way. stan-math checks A for symmetry
+      // and throws the std::domain_error CmdStan would.
+      using Mat = Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>;
+      Value a = eval(e.args[0]);
+      Value b = eval(e.args[1]);
+      if (a.dims.size() != 2 || a.dims[0] != a.dims[1])
+        fail("quad_form_sym: needs a square matrix", e.raw);
+      const int64_t n = a.dims[0];
+      Mat A(n, n);
+      for (int64_t j = 0; j < n; ++j)
+        for (int64_t i = 0; i < n; ++i) A(i, j) = a.r.at((size_t)(j * n + i));
+      Value o;
+      if (b.dims.size() != 2) {
+        // A vector goes in as a vector: the one-column matrix would take
+        // Eigen's matrix paths and associate the product differently.
+        Eigen::Matrix<T, Eigen::Dynamic, 1> B((Eigen::Index)b.r.size());
+        for (size_t i = 0; i < b.r.size(); ++i) B((Eigen::Index)i) = b.r[i];
+        o.r = {stan::math::quad_form_sym(A, B)};
+        return o;
+      }
+      const int64_t rb = b.dims[0], m = b.dims[1];
+      Mat B(rb, m);
+      for (int64_t j = 0; j < m; ++j)
+        for (int64_t i = 0; i < rb; ++i) B(i, j) = b.r.at((size_t)(j * rb + i));
+      const Mat c = stan::math::quad_form_sym(A, B);
+      o.dims = {m, m};
+      o.r.resize((size_t)(m * m));
+      for (int64_t j = 0; j < m; ++j)
+        for (int64_t i = 0; i < m; ++i) o.r[(size_t)(j * m + i)] = c(i, j);
+      return o;
+    }
     if (e.name == "gp_exp_quad_cov" && e.args.size() == 3) {
       // K(i,j) = alpha^2 exp(-|x_i - x_j|^2 / (2 rho^2)); x is array[N]
       // real or array[N] vector[D] in Fortran storage.

--- a/runtime/include/stanli/mir_prog.hpp
+++ b/runtime/include/stanli/mir_prog.hpp
@@ -70,6 +70,18 @@ struct ProgramCompiler {
   const std::map<std::string, const mir::FunDef*>& funs;
   std::map<std::string, Range> reals;
   std::map<std::string, std::vector<long>> ints;
+  // Integer containers still occupy registers when a real-valued expression
+  // consumes them, but their values are data and therefore available while
+  // the program is being compiled.  Keep that provenance beside the register
+  // view: stanc's O1 lowering spells `for (i in {2, 3})` as an unsized array
+  // temporary, a whole-array assignment, then scalar indexed reads.
+  std::map<std::string, std::vector<long>> known_int_arrays;
+  std::set<std::string> int_array_names;
+  // Optimizer temporaries declared with an Unsized container acquire their
+  // complete Range from the first whole-variable assignment.  A zero-width
+  // sized declaration is not the same thing, so keep the protocol explicit
+  // rather than inferring it from Range::len.
+  std::map<std::string, mir::UnsizedView> deferred_shapes;
   // Where each `ints` entry was declared: its branch depth, and how many
   // loops enclosed it. Folding an assignment records a value for every
   // later read of the name, so it is only sound where the assignment
@@ -227,14 +239,20 @@ struct ProgramCompiler {
       return true;
     }
     if (e.kind != mir::Expr::Var) return false;
+    if (deferred_shapes.count(e.name)) return false;
     auto rt = reals.find(e.name);
     if (rt != reals.end()) {
       *out = rt->second;
       return true;
     }
-    // Every `ints` entry is a compile-time scalar.
-    if (ints.count(e.name)) {
-      *out = Range{0, 1};
+    auto ii = ints.find(e.name);
+    if (ii != ints.end()) {
+      Range r{0, (int)ii->second.size()};
+      if (e.unsized.depth != 0) {
+        r.kind = ViewKind::Array;
+        r.dims = {(int64_t)ii->second.size()};
+      }
+      *out = r;
       return true;
     }
     // An outside name: bind it the way expr() would. The binding is one
@@ -284,6 +302,14 @@ struct ProgramCompiler {
         for (size_t k = 1; k < e.args.size(); ++k)
           if (e.args[k].name != "IndexSingle" || e.args[k].args.size() != 1)
             bail("integer index form");
+        auto known = known_int_arrays.find(e.args[0].name);
+        if (known != known_int_arrays.end()) {
+          if (e.args.size() != 2) bail("integer index form");
+          const long ix = cint(e.args[1].args[0]);
+          if (ix < 1 || (size_t)ix > known->second.size())
+            bail("integer index range");
+          return known->second[(size_t)ix - 1];
+        }
         auto it = ints.find(e.args[0].name);
         if (it != ints.end()) {
           if (e.args.size() != 2) bail("integer index form");
@@ -382,6 +408,90 @@ struct ProgramCompiler {
     }
   }
 
+  // A data-only integer array used by IndexMulti.  Literal arrays are the
+  // form O1 emits for source selectors such as `{3, 1}`.  Named arrays cover
+  // both ODE x_i arguments and statement-island data bindings; the latter are
+  // read one scalar at a time through extern_int, the callback that already
+  // owns their storage-order semantics.
+  std::vector<long> cints(const mir::Expr& e) {
+    if (e.kind == mir::Expr::Var) {
+      auto known = known_int_arrays.find(e.name);
+      if (known != known_int_arrays.end()) return known->second;
+      auto held = ints.find(e.name);
+      if (held != ints.end()) return held->second;
+
+      Range view;
+      if (static_view(e, &view) && view.kind == ViewKind::Array &&
+          view.len >= 0) {
+        std::vector<long> values;
+        values.reserve((size_t)view.len);
+        for (int k = 0; k < view.len; ++k) {
+          mir::Expr literal;
+          literal.kind = mir::Expr::LitInt;
+          literal.lit_i = k + 1;
+          literal.type_ = "UInt";
+          literal.unsized = {0, mir::UnsizedLeaf::Int};
+          literal.data_only = true;
+
+          mir::Expr single;
+          single.kind = mir::Expr::FunApp;
+          single.name = "IndexSingle";
+          single.args.push_back(std::move(literal));
+
+          mir::Expr indexed;
+          indexed.kind = mir::Expr::Indexed;
+          indexed.type_ = "UInt";
+          indexed.unsized = {0, mir::UnsizedLeaf::Int};
+          indexed.data_only = true;
+          indexed.args.push_back(e);
+          indexed.args.push_back(std::move(single));
+          values.push_back(cint(indexed));
+        }
+        return values;
+      }
+      bail("integer array " + e.name + " is not known at compile time");
+    }
+    if (e.kind == mir::Expr::FunApp && e.name == "FnMakeArray") {
+      std::vector<long> values;
+      values.reserve(e.args.size());
+      for (const auto& value : e.args) values.push_back(cint(value));
+      return values;
+    }
+    if (e.kind == mir::Expr::FunApp && e.name == "append_array" &&
+        e.args.size() == 2) {
+      std::vector<long> values = cints(e.args[0]);
+      std::vector<long> tail = cints(e.args[1]);
+      values.insert(values.end(), tail.begin(), tail.end());
+      return values;
+    }
+    bail("integer gather selector is not known at compile time");
+  }
+
+  bool try_cints(const mir::Expr& e, std::vector<long>* out) {
+    try {
+      *out = cints(e);
+      return true;
+    } catch (Bail&) {
+      return false;
+    }
+  }
+
+  std::vector<int64_t> matrix_gather_positions(const mir::Expr& index,
+                                               int64_t extent,
+                                               const std::string& axis) {
+    if (index.name != "IndexMulti" || index.args.size() != 1)
+      bail("matrix " + axis + " gather index form");
+    const std::vector<long> values = cints(index.args[0]);
+    std::vector<int64_t> positions;
+    positions.reserve(values.size());
+    for (long value : values) {
+      if (value < 1 || value > extent)
+        bail("matrix " + axis + " gather out of the declared range");
+      positions.push_back((int64_t)value - 1);
+    }
+    return positions;
+  }
+
   static bool same_view(const Range& a, const Range& b) {
     if (a.kind != b.kind) return false;
     if (a.kind == ViewKind::Flat) return a.len == 1 && b.len == 1;
@@ -449,6 +559,32 @@ struct ProgramCompiler {
     return r;
   }
 
+  static bool unsized_accepts(const mir::UnsizedView& type, const Range& r) {
+    if (type.leaf == mir::UnsizedLeaf::Unknown ||
+        type.leaf == mir::UnsizedLeaf::Complex)
+      return false;
+    if (type.depth != 0) {
+      if (r.kind != ViewKind::Array) return false;
+      const size_t leaf_rank = type.leaf == mir::UnsizedLeaf::Matrix ? 2
+                               : type.leaf == mir::UnsizedLeaf::Vector ||
+                                       type.leaf == mir::UnsizedLeaf::RowVector
+                                   ? 1
+                                   : 0;
+      // Old register ranges did not stamp the sole scalar-array extent.
+      // Retain that compatibility while requiring complete geometry for
+      // every structural container newly represented here.
+      if (r.dims.empty()) return type.depth == 1 && leaf_rank == 0;
+      return r.dims.size() == (size_t)type.depth + leaf_rank;
+    }
+    if (type.leaf == mir::UnsizedLeaf::Vector)
+      return r.kind == ViewKind::Vector;
+    if (type.leaf == mir::UnsizedLeaf::RowVector)
+      return r.kind == ViewKind::RowVector;
+    if (type.leaf == mir::UnsizedLeaf::Matrix)
+      return r.kind == ViewKind::Matrix;
+    return is_scalar(r);
+  }
+
   // ---- expressions ---------------------------------------------------------
   Range expr(const mir::Expr& e) {
     switch (e.kind) {
@@ -457,6 +593,8 @@ struct ProgramCompiler {
       case mir::Expr::LitReal:
         return {konst(e.lit), 1};
       case mir::Expr::Var: {
+        if (deferred_shapes.count(e.name))
+          bail("unsized local read before its first assignment: " + e.name);
         auto it = reals.find(e.name);
         if (it != reals.end()) return it->second;
         auto ii = ints.find(e.name);
@@ -464,7 +602,12 @@ struct ProgramCompiler {
           const std::vector<double> vals(ii->second.begin(), ii->second.end());
           const int r = alloc((int)vals.size());
           emit_const(r, vals.data(), (int)vals.size());
-          return {r, (int)vals.size()};
+          Range out{r, (int)vals.size()};
+          if (e.unsized.depth != 0) {
+            out.kind = ViewKind::Array;
+            out.dims = {(int64_t)vals.size()};
+          }
+          return out;
         }
         Range ext;
         if (bind_extern && bind_extern(e.name, &ext)) {
@@ -475,8 +618,46 @@ struct ProgramCompiler {
         bail("unknown variable " + e.name);
       }
       case mir::Expr::Indexed: {
+        // O1's index-composition pass may retain a base-only outer Indexed
+        // node.  Its metadata is the final type while the inner node still
+        // carries the pre-composition matrix type, so collapse it before any
+        // logical-view decision.
+        if (e.args.size() == 1 && e.args[0].kind == mir::Expr::Indexed) {
+          mir::Expr composed = e.args[0];
+          composed.type_ = e.type_;
+          composed.unsized = e.unsized;
+          composed.data_only = e.data_only;
+          composed.promoted = e.promoted;
+          composed.raw = e.raw;
+          return expr(composed);
+        }
+        if (e.args.empty()) bail("index form");
         const Range b = expr(e.args[0]);
         if (e.args.size() == 2 && e.args[1].name == "IndexAll") return b;
+        // Two IndexMulti axes select their Cartesian submatrix.  Matrix
+        // registers are column-major, so selected columns are the outer loop
+        // and selected rows the inner loop; this preserves selector order and
+        // duplicates exactly as the graph lowerer does.
+        if (b.kind == ViewKind::Matrix && e.args.size() == 3 &&
+            e.args[1].name == "IndexMulti" && e.args[2].name == "IndexMulti") {
+          const std::vector<int64_t> rows =
+              matrix_gather_positions(e.args[1], b.rows, "row");
+          const std::vector<int64_t> cols =
+              matrix_gather_positions(e.args[2], b.cols, "column");
+          if (!rows.empty() && cols.size() > (size_t)kMaxRegs / rows.size())
+            bail("matrix gather needs too many registers");
+          const size_t width = rows.size() * cols.size();
+          const int r = alloc((int)width);
+          int at = 0;
+          for (int64_t j : cols)
+            for (int64_t i : rows)
+              emit(Program::MOV, r + at++, b.reg + (int)(j * b.rows + i));
+          Range out{r, (int)width};
+          out.kind = ViewKind::Matrix;
+          out.rows = (int64_t)rows.size();
+          out.cols = (int64_t)cols.size();
+          return out;
+        }
         // A matrix row, `m[i]` or `m[i, ]`. Ahead of the all-single check
         // below, which the explicit `IndexAll` would not pass.
         if (b.kind == ViewKind::Matrix && e.args.size() >= 2 &&
@@ -547,10 +728,24 @@ struct ProgramCompiler {
         }
         int64_t len = 1;
         for (size_t d = n_idx; d < dims.size(); ++d) len *= dims[d];
-        if (len == 1) return {b.reg + (int)off, 1};
+        if (len == 1 && (e.type_ == "UReal" || e.type_ == "UInt"))
+          return {b.reg + (int)off, 1};
         Range out{b.reg + (int)off, (int)len};
-        out.kind = ViewKind::Array;
-        out.dims.assign(dims.begin() + (long)n_idx, dims.end());
+        if (e.type_ == "UVector") {
+          out.kind = ViewKind::Vector;
+        } else if (e.type_ == "URowVector") {
+          out.kind = ViewKind::RowVector;
+        } else if (e.type_ == "UMatrix") {
+          // Matrix leaves need a leaf tag as well as two extents to prove
+          // their column-major subrange. Range intentionally has no such tag,
+          // so retain the established fail-loud boundary.
+          bail(
+              "array-of-matrix indexing is unsupported by the register "
+              "program");
+        } else {
+          out.kind = ViewKind::Array;
+          out.dims.assign(dims.begin() + (long)n_idx, dims.end());
+        }
         return out;
       }
       case mir::Expr::TernaryIf: {
@@ -670,6 +865,14 @@ struct ProgramCompiler {
         if (a.type_ == "UInt" && try_cint(a, &v)) {
           arg.is_const_int = true;
           arg.ints = {v};
+        } else if (a.unsized.depth == 1 &&
+                   a.unsized.leaf == mir::UnsizedLeaf::Int &&
+                   try_cints(a, &arg.ints)) {
+          // Function arguments are rebound in a fresh compiler scope. Carry
+          // a data-only selector as values, not merely as its register Range,
+          // so the callee (and a nested inline call) can still use it in
+          // IndexMulti or a compile-time scalar indexed read.
+          arg.is_const_int = true;
         } else {
           arg.real = expr(a);
         }
@@ -683,14 +886,31 @@ struct ProgramCompiler {
         int total = 0;
         for (const auto& a : e.args) {
           parts.push_back(expr(a));
+          if (parts.back().len > kMaxRegs - total)
+            bail("array literal needs too many registers");
           total += parts.back().len;
         }
+        ViewKind array_leaf = ViewKind::Flat;
+        int array_leaf_width = 1;
         if (e.name == "FnMakeArray") {
-          for (const Range& q : parts)
-            if (!is_scalar(q))
+          if (!parts.empty() && !is_scalar(parts.front())) {
+            array_leaf = parts.front().kind;
+            if (array_leaf != ViewKind::Vector &&
+                array_leaf != ViewKind::RowVector)
               bail(
-                  "only flat scalar arrays are supported by the register "
-                  "program");
+                  "array literal element view is unsupported by the "
+                  "register program");
+            if (e.type_ == "UMatrix")
+              bail("matrix literals are unsupported by the register program");
+            array_leaf_width = parts.front().len;
+            for (const Range& q : parts)
+              if (!same_view(q, parts.front()))
+                bail("array literal elements have different logical views");
+          } else {
+            for (const Range& q : parts)
+              if (!is_scalar(q))
+                bail("array literal mixes scalar and container elements");
+          }
         }
         const int r = alloc(total);
         int at = 0;
@@ -700,12 +920,69 @@ struct ProgramCompiler {
         Range out{r, total};
         out.kind =
             e.name == "FnMakeRowVec" ? ViewKind::RowVector : ViewKind::Array;
+        if (e.name == "FnMakeArray") {
+          out.dims = {(int64_t)e.args.size()};
+          if (array_leaf != ViewKind::Flat)
+            out.dims.push_back(array_leaf_width);
+        }
         return out;
       }
       bail("internal function " + e.name);
     }
     if (e.args.empty() && e.name == "negative_infinity")
       return {konst(-std::numeric_limits<double>::infinity()), 1};
+    if (e.args.size() == 2 && e.name == "append_array") {
+      const Range a = expr(e.args[0]);
+      const Range b = expr(e.args[1]);
+      if (a.kind != ViewKind::Array || b.kind != ViewKind::Array)
+        bail("append_array requires two array arguments");
+      if (e.args[0].unsized.depth != e.args[1].unsized.depth ||
+          e.args[0].unsized.leaf != e.args[1].unsized.leaf)
+        bail("append_array element logical views differ");
+
+      const auto dimensions = [&](const Range& value) {
+        return value.dims.empty() ? std::vector<int64_t>{value.len}
+                                  : value.dims;
+      };
+      const auto validate_dimensions = [&](const Range& value,
+                                           const std::vector<int64_t>& dims) {
+        int64_t product = 1;
+        for (int64_t extent : dims) {
+          if (extent < 0 ||
+              (extent != 0 && product > (int64_t)kMaxRegs / extent))
+            bail("append_array has an invalid element shape");
+          product *= extent;
+        }
+        if (product != value.len)
+          bail("append_array storage and logical shape disagree");
+      };
+      const std::vector<int64_t> adims = dimensions(a);
+      const std::vector<int64_t> bdims = dimensions(b);
+      validate_dimensions(a, adims);
+      validate_dimensions(b, bdims);
+      if (adims.size() != bdims.size())
+        bail("append_array element shapes differ");
+      const int64_t a_outer = adims.front();
+      const int64_t b_outer = bdims.front();
+      if (a_outer != 0 && b_outer != 0 &&
+          !std::equal(adims.begin() + 1, adims.end(), bdims.begin() + 1))
+        bail("append_array element shapes differ");
+      if (a_outer > std::numeric_limits<int64_t>::max() - b_outer ||
+          b.len > kMaxRegs - a.len)
+        bail("append_array result is too large");
+
+      std::vector<int64_t> out_dims =
+          a_outer == 0 && b_outer != 0 ? bdims : adims;
+      out_dims[0] = a_outer + b_outer;
+      const int r = alloc(a.len + b.len);
+      for (int k = 0; k < a.len; ++k) emit(Program::MOV, r + k, a.reg + k);
+      for (int k = 0; k < b.len; ++k)
+        emit(Program::MOV, r + a.len + k, b.reg + k);
+      Range out{r, a.len + b.len};
+      out.kind = ViewKind::Array;
+      out.dims = std::move(out_dims);
+      return out;
+    }
     if (e.args.size() == 1 && e.name == "diagonal") {
       const Range a = expr(e.args[0]);
       if (a.kind != ViewKind::Matrix)
@@ -1033,6 +1310,57 @@ struct ProgramCompiler {
   void stmt(const mir::Stmt& s) {
     switch (s.kind) {
       case mir::Stmt::Decl: {
+        // A declaration shadows every compile-time fact retained for an
+        // earlier optimized symbol with the same name.
+        deferred_shapes.erase(s.decl_id);
+        known_int_arrays.erase(s.decl_id);
+        int_array_names.erase(s.decl_id);
+        int_decl_at.erase(s.decl_id);
+        if (s.decl_type.base.empty() &&
+            s.decl_type.unsized.leaf != mir::UnsizedLeaf::Unknown) {
+          const mir::UnsizedView view = s.decl_type.unsized;
+          if (view.leaf == mir::UnsizedLeaf::Complex)
+            bail("complex unsized declaration " + s.decl_id);
+          // Scalar Unsized declarations are normalized to SInt/SReal by the
+          // reader.  Refuse an unnormalized scalar here rather than treating
+          // its fixed width as a deferred container shape.
+          if (view.depth == 0 && view.leaf != mir::UnsizedLeaf::Vector &&
+              view.leaf != mir::UnsizedLeaf::RowVector &&
+              view.leaf != mir::UnsizedLeaf::Matrix)
+            bail("scalar unsized declaration " + s.decl_id);
+
+          reals.erase(s.decl_id);
+          ints.erase(s.decl_id);
+          if (view.depth != 0 && view.leaf == mir::UnsizedLeaf::Int) {
+            int_array_names.insert(s.decl_id);
+            int_decl_at[s.decl_id] = {branch_depth, loops.size()};
+          }
+          if (!s.has_init) {
+            reals[s.decl_id] = Range{};
+            deferred_shapes[s.decl_id] = view;
+            return;
+          }
+
+          const Range v = expr(s.init);
+          if (!unsized_accepts(view, v))
+            bail("declaration logical view mismatch for " + s.decl_id);
+          const double fill =
+              int_array_names.count(s.decl_id)
+                  ? static_cast<double>(std::numeric_limits<int>::min())
+                  : std::numeric_limits<double>::quiet_NaN();
+          const Range d = declare(s.decl_id, v.len, v, fill);
+          for (int k = 0; k < v.len; ++k)
+            emit(Program::MOV, d.reg + k, v.reg + k);
+          if (int_array_names.count(s.decl_id)) {
+            std::vector<long> values;
+            if (try_cints(s.init, &values) && values.size() == (size_t)v.len)
+              known_int_arrays[s.decl_id] = std::move(values);
+          }
+          return;
+        }
+        if (s.decl_type.base.empty())
+          bail("declaration has no sized or unsized logical view: " +
+               s.decl_id);
         if (s.decl_type.base == "SInt") {
           int_decl_at[s.decl_id] = {branch_depth, loops.size()};
           if (s.has_init) {
@@ -1041,6 +1369,12 @@ struct ProgramCompiler {
             ints[s.decl_id] = {std::numeric_limits<int>::min()};
           }
           return;
+        }
+        const bool int_array =
+            s.decl_type.base == "SArray" && s.decl_type.elem_base == "SInt";
+        if (int_array) {
+          int_array_names.insert(s.decl_id);
+          int_decl_at[s.decl_id] = {branch_depth, loops.size()};
         }
         if (s.has_init) {
           const Range v = expr(s.init);
@@ -1055,6 +1389,11 @@ struct ProgramCompiler {
           const Range d = declare(s.decl_id, want, expected);
           for (int k = 0; k < want; ++k)
             emit(Program::MOV, d.reg + k, v.reg + k);
+          if (int_array) {
+            std::vector<long> values;
+            if (try_cints(s.init, &values) && values.size() == (size_t)want)
+              known_int_arrays[s.decl_id] = std::move(values);
+          }
         } else {
           Range view;
           const double fill =
@@ -1063,10 +1402,46 @@ struct ProgramCompiler {
                   : std::numeric_limits<double>::quiet_NaN();
           declare(s.decl_id, (int)sized_len(s.decl_type),
                   declared(view, s.decl_type), fill);
+          if (int_array)
+            known_int_arrays[s.decl_id] =
+                std::vector<long>((size_t)sized_len(s.decl_type),
+                                  std::numeric_limits<int>::min());
         }
         return;
       }
       case mir::Stmt::Assignment: {
+        auto deferred = deferred_shapes.find(s.lhs);
+        if (deferred != deferred_shapes.end()) {
+          if (!s.lhs_idx.empty())
+            bail("indexed assignment before unsized shape adoption for " +
+                 s.lhs);
+          const Range v = expr(s.rhs);
+          if (!unsized_accepts(deferred->second, v))
+            bail("assignment logical view mismatch for " + s.lhs);
+          auto binding = reals.find(s.lhs);
+          if (binding == reals.end()) bail("assignment to undeclared " + s.lhs);
+
+          Range adopted = v;
+          adopted.reg = alloc(v.len);
+          // The assignment may be under a runtime jump.  Fill the adopted
+          // run before control flow starts so backward replay and an untaken
+          // path never observe uninitialized register cells.
+          if (v.len != 0) late_bound.emplace_back(adopted.reg, v.len);
+          for (int k = 0; k < v.len; ++k)
+            emit(Program::MOV, adopted.reg + k, v.reg + k);
+          binding->second = adopted;
+          deferred_shapes.erase(deferred);
+
+          if (int_array_names.count(s.lhs)) {
+            std::vector<long> values;
+            if (fold_is_certain(s.lhs) && try_cints(s.rhs, &values) &&
+                values.size() == (size_t)v.len)
+              known_int_arrays[s.lhs] = std::move(values);
+            else
+              known_int_arrays.erase(s.lhs);
+          }
+          return;
+        }
         if (ints.count(s.lhs) && s.lhs_idx.empty()) {
           // An integer is a compile-time value here: folding this
           // assignment rewrites every later read of the name, so a path
@@ -1099,6 +1474,11 @@ struct ProgramCompiler {
         const Range dst = it->second;
         const Range v = expr(s.rhs);
         if (s.lhs_idx.empty()) {
+          std::vector<long> folded_ints;
+          const bool have_folded_ints = int_array_names.count(s.lhs) &&
+                                        fold_is_certain(s.lhs) &&
+                                        try_cints(s.rhs, &folded_ints) &&
+                                        folded_ints.size() == (size_t)v.len;
           if (dst.len == 0 && v.len != 0) {
             // The zero-length declaration is stanc3's --O1 inliner
             // leaving a return variable unsized (`vector[0]`) for the
@@ -1120,6 +1500,10 @@ struct ProgramCompiler {
             for (int k = 0; k < v.len; ++k)
               emit(Program::MOV, nd.reg + k, v.reg + k);
             it->second = nd;
+            if (have_folded_ints)
+              known_int_arrays[s.lhs] = std::move(folded_ints);
+            else if (int_array_names.count(s.lhs))
+              known_int_arrays.erase(s.lhs);
             return;
           }
           if (v.len != dst.len) bail("assignment width mismatch for " + s.lhs);
@@ -1127,6 +1511,10 @@ struct ProgramCompiler {
             bail("assignment logical view mismatch for " + s.lhs);
           for (int k = 0; k < v.len; ++k)
             emit(Program::MOV, dst.reg + k, v.reg + k);
+          if (have_folded_ints)
+            known_int_arrays[s.lhs] = std::move(folded_ints);
+          else if (int_array_names.count(s.lhs))
+            known_int_arrays.erase(s.lhs);
           return;
         }
         // A single All is the complete destination view. This is reachable
@@ -1142,6 +1530,14 @@ struct ProgramCompiler {
             bail("full-span assignment logical view mismatch for " + s.lhs);
           for (int k = 0; k < v.len; ++k)
             emit(Program::MOV, dst.reg + k, v.reg + k);
+          if (int_array_names.count(s.lhs)) {
+            std::vector<long> values;
+            if (fold_is_certain(s.lhs) && try_cints(s.rhs, &values) &&
+                values.size() == (size_t)v.len)
+              known_int_arrays[s.lhs] = std::move(values);
+            else
+              known_int_arrays.erase(s.lhs);
+          }
           return;
         }
         for (const auto& ix : s.lhs_idx)
@@ -1176,6 +1572,16 @@ struct ProgramCompiler {
           flat = ix - 1;
         }
         emit(Program::MOV, dst.reg + (int)flat, v.reg);
+        if (int_array_names.count(s.lhs)) {
+          long value = 0;
+          auto known = known_int_arrays.find(s.lhs);
+          if (fold_is_certain(s.lhs) && try_cint(s.rhs, &value) &&
+              known != known_int_arrays.end() && flat >= 0 &&
+              (size_t)flat < known->second.size())
+            known->second[(size_t)flat] = value;
+          else
+            known_int_arrays.erase(s.lhs);
+        }
         return;
       }
       case mir::Stmt::Return:
@@ -1309,11 +1715,17 @@ struct ProgramCompiler {
     // restore afterwards. Registers are never reused, so nothing aliases.
     auto saved_reals = reals;
     auto saved_ints = ints;
+    auto saved_known_int_arrays = known_int_arrays;
+    auto saved_int_array_names = int_array_names;
+    auto saved_deferred_shapes = deferred_shapes;
     auto saved_int_decl_at = int_decl_at;
     auto saved_extern_bound = extern_bound;
     const int saved_branch_depth = branch_depth;
     reals.clear();
     ints.clear();
+    known_int_arrays.clear();
+    int_array_names.clear();
+    deferred_shapes.clear();
     int_decl_at.clear();
     extern_bound.clear();
     branch_depth = 0;
@@ -1335,6 +1747,9 @@ struct ProgramCompiler {
     } catch (...) {
       reals = std::move(saved_reals);
       ints = std::move(saved_ints);
+      known_int_arrays = std::move(saved_known_int_arrays);
+      int_array_names = std::move(saved_int_array_names);
+      deferred_shapes = std::move(saved_deferred_shapes);
       int_decl_at = std::move(saved_int_decl_at);
       extern_bound = std::move(saved_extern_bound);
       branch_depth = saved_branch_depth;
@@ -1343,6 +1758,9 @@ struct ProgramCompiler {
     }
     reals = std::move(saved_reals);
     ints = std::move(saved_ints);
+    known_int_arrays = std::move(saved_known_int_arrays);
+    int_array_names = std::move(saved_int_array_names);
+    deferred_shapes = std::move(saved_deferred_shapes);
     int_decl_at = std::move(saved_int_decl_at);
     extern_bound = std::move(saved_extern_bound);
     branch_depth = saved_branch_depth;

--- a/runtime/include/stanli/optable.hpp
+++ b/runtime/include/stanli/optable.hpp
@@ -153,7 +153,8 @@ namespace stanli {
   X(OP_DIRICHLET_LPDF)              \
   X(OP_PROD_VEC)                    \
   X(OP_EXTREMA_VEC)                 \
-  X(OP_DYNAMIC_SLICE)
+  X(OP_DYNAMIC_SLICE)               \
+  X(OP_MATRIX_EXP)
 
 // Scalar densities, one line each: this list generates the opcode, the
 // name, the kernel, its registration, and the lowering table entry

--- a/runtime/include/stanli/optable.hpp
+++ b/runtime/include/stanli/optable.hpp
@@ -154,7 +154,8 @@ namespace stanli {
   X(OP_PROD_VEC)                    \
   X(OP_EXTREMA_VEC)                 \
   X(OP_DYNAMIC_SLICE)               \
-  X(OP_MATRIX_EXP)
+  X(OP_MATRIX_EXP)                  \
+  X(OP_QUAD_FORM_SYM)
 
 // Scalar densities, one line each: this list generates the opcode, the
 // name, the kernel, its registration, and the lowering table entry

--- a/runtime/kernels/matrix_fns.cpp
+++ b/runtime/kernels/matrix_fns.cpp
@@ -131,6 +131,20 @@ void chol_bwd(KernelCtx& ctx) {
              [](const auto& a) { return stan::math::cholesky_decompose(a); });
 }
 
+// ---- matrix_exp(A) ---------------------------------------------------------
+void matrix_exp_fwd(KernelCtx& ctx) {
+  const int64_t n = ctx.idata[0];
+  MapM(ctx.out.data, n, n) =
+      stan::math::matrix_exp(CMapM(ctx.in[0].data, n, n));
+}
+void matrix_exp_bwd(KernelCtx& ctx) {
+  const int64_t n = ctx.idata[0];
+  nary_bwd(ctx, [n](std::vector<VarV>& xs) {
+    Eigen::Map<VarM> a(xs[0].data(), n, n);
+    return stan::math::matrix_exp(a);
+  });
+}
+
 // Bind a slot as a var matrix or vector, and scatter the adjoints back
 // afterwards. Shared by the multivariate densities below and by the tail
 // densities further down.
@@ -1165,6 +1179,8 @@ void register_matrix_kernels() {
       Kernel{olglm_fwd, tail_density_bwd<3>, tail_density_scratch<3>});
   register_kernel(OP_DIAG_MATRIX, Kernel{diag_fwd, diag_bwd, nullptr});
   register_kernel(OP_CHOLESKY, Kernel{chol_fwd, chol_bwd, nullptr});
+  register_kernel(OP_MATRIX_EXP,
+                  Kernel{matrix_exp_fwd, matrix_exp_bwd, nullptr});
   register_kernel(OP_MULTI_NORMAL_CHOL_LPDF,
                   Kernel{mnc_fwd, mnc_bwd, mnc_scratch});
   register_kernel(OP_MULTI_NORMAL_LPDF,

--- a/runtime/kernels/matrix_fns.cpp
+++ b/runtime/kernels/matrix_fns.cpp
@@ -147,10 +147,12 @@ void matrix_exp_bwd(KernelCtx& ctx) {
 
 // ---- quad_form_sym(A, B) --------------------------------------------------
 // in = {A (n x n), B (n x m)}; idata = {n, m}. The output is the m x m
-// matrix 0.5 * (C + C') with C = B' A B, or the single scalar B' A B when B
-// is a vector -- there C is 1 x 1, where the symmetrisation is exact and so
-// does nothing. stan-math checks A for symmetry and throws what CmdStan
-// would when it is not.
+// matrix 0.5 * (C + C') with C = B' A B, or the single scalar extracted from
+// that 1 x 1 symmetrised matrix when B is a reverse-mode vector. The latter
+// still performs the add and multiply: although algebraically redundant,
+// those operations affect IEEE overflow and must match CmdStan exactly.
+// stan-math checks A for symmetry and throws what CmdStan would when it is
+// not.
 //
 // Variant bit 0 says the second operand is a vector; bit 1 says CmdStan
 // would have typed this expression `var`. Only the vector overload needs
@@ -173,7 +175,9 @@ void qfs_fwd(KernelCtx& ctx) {
   }
   stan::math::check_multiplicable("quad_form_sym", "A", a, "B", b);
   stan::math::check_symmetric("quad_form_sym", "A", a);
-  const MatD c = b.transpose() * a * b;
+  MatD c = b.transpose() * a * b;
+  const MatD sym = 0.5 * (c + c.transpose());
+  c = sym;
   ctx.out.data[0] = c(0, 0);
 }
 void qfs_bwd(KernelCtx& ctx) {

--- a/runtime/kernels/matrix_fns.cpp
+++ b/runtime/kernels/matrix_fns.cpp
@@ -145,6 +145,55 @@ void matrix_exp_bwd(KernelCtx& ctx) {
   });
 }
 
+// ---- quad_form_sym(A, B) --------------------------------------------------
+// in = {A (n x n), B (n x m)}; idata = {n, m}. The output is the m x m
+// matrix 0.5 * (C + C') with C = B' A B, or the single scalar B' A B when B
+// is a vector -- there C is 1 x 1, where the symmetrisation is exact and so
+// does nothing. stan-math checks A for symmetry and throws what CmdStan
+// would when it is not.
+//
+// Variant bit 0 says the second operand is a vector; bit 1 says CmdStan
+// would have typed this expression `var`. Only the vector overload needs
+// that second bit, because stan-math associates it two ways: prim computes
+// B.dot(A * B), a gemv and then a dot, while the rev path builds a
+// quad_form_vari over a column vector and evaluates B' * A * B, grouping
+// from the other end. The matrix overload has one association in both.
+void qfs_fwd(KernelCtx& ctx) {
+  const int64_t n = ctx.idata[0], m = ctx.idata[1];
+  const CMapM a(ctx.in[0].data, n, n);
+  if (!(ctx.variant & 1u)) {
+    const CMapM b(ctx.in[1].data, n, m);
+    MapM(ctx.out.data, m, m) = stan::math::quad_form_sym(a, b);
+    return;
+  }
+  const VecD b = CMapV(ctx.in[1].data, n);
+  if (!(ctx.variant & 2u)) {
+    ctx.out.data[0] = stan::math::quad_form_sym(a, b);
+    return;
+  }
+  stan::math::check_multiplicable("quad_form_sym", "A", a, "B", b);
+  stan::math::check_symmetric("quad_form_sym", "A", a);
+  const MatD c = b.transpose() * a * b;
+  ctx.out.data[0] = c(0, 0);
+}
+void qfs_bwd(KernelCtx& ctx) {
+  const int64_t n = ctx.idata[0], m = ctx.idata[1];
+  // The rev overload is the one CmdStan reaches at either shape, so the
+  // replay needs no variant beyond the operand shape itself.
+  if (ctx.variant & 1u) {
+    nary_bwd(ctx, [n](std::vector<VarV>& xs) {
+      Eigen::Map<VarM> a(xs[0].data(), n, n);
+      return stan::math::quad_form_sym(a, xs[1]);
+    });
+    return;
+  }
+  nary_bwd(ctx, [n, m](std::vector<VarV>& xs) {
+    Eigen::Map<VarM> a(xs[0].data(), n, n);
+    Eigen::Map<VarM> b(xs[1].data(), n, m);
+    return stan::math::quad_form_sym(a, b);
+  });
+}
+
 // Bind a slot as a var matrix or vector, and scatter the adjoints back
 // afterwards. Shared by the multivariate densities below and by the tail
 // densities further down.
@@ -1181,6 +1230,7 @@ void register_matrix_kernels() {
   register_kernel(OP_CHOLESKY, Kernel{chol_fwd, chol_bwd, nullptr});
   register_kernel(OP_MATRIX_EXP,
                   Kernel{matrix_exp_fwd, matrix_exp_bwd, nullptr});
+  register_kernel(OP_QUAD_FORM_SYM, Kernel{qfs_fwd, qfs_bwd, nullptr});
   register_kernel(OP_MULTI_NORMAL_CHOL_LPDF,
                   Kernel{mnc_fwd, mnc_bwd, mnc_scratch});
   register_kernel(OP_MULTI_NORMAL_LPDF,

--- a/runtime/src/lower.cpp
+++ b/runtime/src/lower.cpp
@@ -3283,6 +3283,52 @@ struct Lowering {
     if (auto v = lower_density_fn(e)) return *v;
     if (auto v = lower_bound_transform(e)) return *v;
     if (auto v = lower_eltwise_fn(e)) return *v;
+    if (e.name == "append_array" && e.args.size() == 2) {
+      Val a = lower_expr(e.args[0]);
+      Val b = lower_expr(e.args[1]);
+      if (!is_array(a.si) || !is_array(b.si))
+        fail("append_array: arguments must be arrays", e.raw);
+      const ArrayShape& ash = array_shape(a.si);
+      const ArrayShape& bsh = array_shape(b.si);
+      if (ash.dims.empty() || bsh.dims.empty() ||
+          ash.dims.size() != bsh.dims.size() || ash.leaf != bsh.leaf ||
+          !std::equal(ash.dims.begin() + 1, ash.dims.end(),
+                      bsh.dims.begin() + 1, bsh.dims.end()))
+        fail("append_array: element shapes must match", e.raw);
+      if (ash.dims[0] > std::numeric_limits<int64_t>::max() - bsh.dims[0])
+        fail("append_array: outer extent overflows", e.raw);
+      const int64_t alen = g.slots[a.slot].len;
+      const int64_t blen = g.slots[b.slot].len;
+      if (alen > std::numeric_limits<int64_t>::max() - blen)
+        fail("append_array: storage length overflows", e.raw);
+      std::vector<int64_t> dims = ash.dims;
+      dims[0] += bsh.dims[0];
+      SlotInfo si = array_view(std::move(dims), ash.leaf);
+      Val joined = emit_value(OP_CONCAT2, {a, b}, alen + blen, si);
+
+      // Preserve exact data values for compile-time integer loops and index
+      // expressions. Integer arrays are always data-only in Stan, but this
+      // also keeps real data arrays available to the ordinary const folder.
+      const DataMap::Entry* ao = observation(a);
+      const DataMap::Entry* bo = observation(b);
+      if (ao && bo && ao->is_int == bo->is_int) {
+        DataMap::Entry en;
+        en.is_int = ao->is_int;
+        en.r = ao->r;
+        en.r.insert(en.r.end(), bo->r.begin(), bo->r.end());
+        if (en.is_int) {
+          en.i = ao->i;
+          en.i.insert(en.i.end(), bo->i.begin(), bo->i.end());
+          set_int_initialized(joined);
+          if (!en.i.empty()) {
+            const auto bounds = std::minmax_element(en.i.begin(), en.i.end());
+            set_int_range(joined, *bounds.first, *bounds.second);
+          }
+        }
+        observe(joined, std::move(en));
+      }
+      return joined;
+    }
     if (auto v = lower_matrix_fn(e)) return *v;
     if (auto v = lower_algebra_fn(e)) return *v;
     if (auto v = lower_ode_fn(e)) return *v;

--- a/runtime/src/lower.cpp
+++ b/runtime/src/lower.cpp
@@ -4272,6 +4272,14 @@ struct Lowering {
       return emit_value(OP_CHOLESKY, {a}, g.slots[a.slot].len, si,
                         {(int)a.si.rows});
     }
+    if (e.name == "matrix_exp" && e.args.size() == 1) {
+      Val a = lower_expr(e.args[0]);
+      if (!is_matrix(a.si)) fail("matrix_exp: needs a matrix", e.raw);
+      if (a.si.rows != a.si.cols)
+        fail("matrix_exp: needs a square matrix", e.raw);
+      return emit_value(OP_MATRIX_EXP, {a}, g.slots[a.slot].len, a.si,
+                        {checked_immediate(a.si.rows, "matrix_exp extent")});
+    }
 
     if ((e.name == "eigenvalues_sym" || e.name == "eigenvectors_sym") &&
         e.args.size() == 1) {

--- a/runtime/src/lower.cpp
+++ b/runtime/src/lower.cpp
@@ -1379,6 +1379,8 @@ struct Lowering {
   int uninitialized_decl_slot(const std::string& name) {
     auto dl = decls.find(name);
     if (dl == decls.end()) return -1;
+    if (dl->second.deferred_shape)
+      fail("unsized local read before its first assignment: " + name);
     SlotInfo si = dl->second.si;
     si.param_free = true;
     Val value{add_slot(dl->second.len, false), dl->second.autodiff, si};
@@ -4905,6 +4907,7 @@ struct Lowering {
     bool autodiff = false;
     SlotInfo si;
     bool int_array = false;
+    bool deferred_shape = false;
   };
   // The only name-keyed declaration protocol. Runtime values carry the same
   // static scalar type and SlotInfo in `scope`; this registry is needed only
@@ -4948,6 +4951,30 @@ struct Lowering {
           // a shape query on a slot-bound value (rows(lscale) inside an
           // inlined function), which only eval_int can answer.
           if (s.has_init) int_env[s.decl_id] = eval_int(s.init);
+        } else if (s.decl_type.base.empty() &&
+                   s.decl_type.unsized.leaf != mir::UnsizedLeaf::Unknown) {
+          // O1 introduces unsized container temporaries for expressions such
+          // as a for-loop sequence built with append_array. C++ assignment
+          // gives these locals the RHS shape, so delay allocating or checking
+          // their view until the first whole-variable assignment does likewise.
+          scope.erase(s.decl_id);
+          DeclView sh;
+          sh.autodiff = s.decl_type.unsized.leaf != mir::UnsizedLeaf::Int &&
+                        !s.decl_data_only && scalar_autodiff();
+          sh.int_array = s.decl_type.unsized.leaf == mir::UnsizedLeaf::Int;
+          sh.deferred_shape = true;
+          if (s.has_init) {
+            Val v = lower_expr(s.init);
+            sh.len = g.slots[v.slot].len;
+            sh.si = v.si;
+            sh.deferred_shape = false;
+            v.autodiff = sh.autodiff;
+            scope[s.decl_id] = v;
+            sync_data_local(s.decl_id, s.init, v);
+          } else {
+            td.env().erase(s.decl_id);
+          }
+          decls[s.decl_id] = sh;
         } else {
           // A redeclaration shadows whatever the name held: --O1 inlining
           // reuses one symbol for a callee's local across loop iterations,
@@ -5237,7 +5264,11 @@ struct Lowering {
           } else {
             auto dl = decls.find(s.lhs);
             if (dl != decls.end()) {
-              if (dl->second.len == 0 && g.slots[rhs.slot].len != 0) {
+              if (dl->second.deferred_shape) {
+                dl->second.len = g.slots[rhs.slot].len;
+                dl->second.si = rhs.si;
+                dl->second.deferred_shape = false;
+              } else if (dl->second.len == 0 && g.slots[rhs.slot].len != 0) {
                 // stanc3's --O1 inliner declares a function's return
                 // variable zero-length (`array[real, 0]`, `vector[0]`)
                 // because the returned size is the callee's business, and

--- a/runtime/src/lower.cpp
+++ b/runtime/src/lower.cpp
@@ -4309,6 +4309,41 @@ struct Lowering {
                         {(int)n, (int)n, (int)n});
     }
 
+    if (e.name == "quad_form_sym" && e.args.size() == 2) {
+      // 0.5 * (C + C') with C = B' A B, and the plain scalar B' A B when B
+      // is a vector. This stays one op rather than a transpose and two
+      // GEMMs because stan-math's own association is part of the answer:
+      // the kernel makes the same calls CmdStan does, including the
+      // symmetry check on A, which throws when A is only nearly symmetric.
+      Val a = lower_expr(e.args[0]);
+      Val b = lower_expr(e.args[1]);
+      if (!is_matrix(a.si)) fail("quad_form_sym: needs a matrix", e.raw);
+      if (a.si.rows != a.si.cols)
+        fail("quad_form_sym: needs a square matrix", e.raw);
+      const bool b_matrix = is_matrix(b.si);
+      if (!b_matrix && !is_vector(b.si))
+        fail("quad_form_sym: second argument is not a matrix or vector", e.raw);
+      const int64_t n = a.si.rows;
+      const int64_t rb = b_matrix ? b.si.rows : g.slots[b.slot].len;
+      const int64_t m = b_matrix ? b.si.cols : 1;
+      if (rb != n)
+        fail("quad_form_sym: inner dimension mismatch (" + std::to_string(n) +
+                 "x" + std::to_string(n) + " against " + std::to_string(rb) +
+                 ")",
+             e.raw);
+      const SlotInfo si = b_matrix ? matrix_view(m, m) : SlotInfo{};
+      Val v = emit_value(OP_QUAD_FORM_SYM, {a, b}, m * m, si,
+                         {checked_immediate(n, "quad_form_sym extent"),
+                          checked_immediate(m, "quad_form_sym extent")});
+      // Bit 0 is the operand shape. Bit 1 says CmdStan would have typed
+      // this expression `var`, which for a vector B picks stan-math's other
+      // association of the same product -- the same distinction the matrix
+      // solves make, and for the same reason.
+      g.ops.back().variant =
+          (uint8_t)((b_matrix ? 0u : 1u) | (v.autodiff ? 2u : 0u));
+      return v;
+    }
+
     if ((e.name == "append_row" || e.name == "append_col") &&
         e.args.size() == 2) {
       Val a = lower_expr(e.args[0]);

--- a/runtime/src/lower.cpp
+++ b/runtime/src/lower.cpp
@@ -1429,6 +1429,21 @@ struct Lowering {
         return it->second;
       }
       case mir::Expr::Indexed: {
+        // O1 index composition can leave an empty outer Indexed node around
+        // an already-indexed value. The outer node owns the final result
+        // type: for M[idx, idx] passed to a UDF that reads x[i, j], the inner
+        // single/single access still says UMatrix and this wrapper says UReal.
+        // Collapse the wrapper and lower the composed access with that final
+        // type instead of rejecting the stale intermediate matrix type.
+        if (e.args.size() == 1 && e.args[0].kind == mir::Expr::Indexed) {
+          mir::Expr composed = e.args[0];
+          composed.type_ = e.type_;
+          composed.unsized = e.unsized;
+          composed.data_only = e.data_only;
+          composed.promoted = e.promoted;
+          composed.raw = e.raw;
+          return lower_expr(composed);
+        }
         // All-Single indices with compile-time values -> element read.
         Val base = lower_expr(e.args[0]);
         if (e.args.size() == 2 && e.args[1].name == "IndexAll") return base;

--- a/runtime/src/lower.cpp
+++ b/runtime/src/lower.cpp
@@ -1498,6 +1498,28 @@ struct Lowering {
           return emit_value(OP_GATHER, {base},
                             (int64_t)rows.size() * base.si.cols, si, gather);
         }
+        // A two-axis matrix gather is the Cartesian selection M[rows, cols],
+        // not a pairwise zip. Preserve both index arrays' order and
+        // duplicates; column-major output means selected columns are outer
+        // and selected rows are inner in the flat gather list.
+        if (e.args.size() == 3 && is_matrix(base.si) &&
+            e.args[1].name == "IndexMulti" && e.args[2].name == "IndexMulti") {
+          const std::vector<int64_t> rows = index_positions(
+              e.args[1], base.si.rows, "matrix row gather", e.raw);
+          const std::vector<int64_t> cols = index_positions(
+              e.args[2], base.si.cols, "matrix column gather", e.raw);
+          std::vector<int> gather;
+          gather.reserve(rows.size() * cols.size());
+          for (int64_t j : cols)
+            for (int64_t i : rows)
+              gather.push_back(checked_immediate(j * base.si.rows + i,
+                                                 "matrix gather offset"));
+          SlotInfo si = matrix_view((int64_t)rows.size(), (int64_t)cols.size(),
+                                    base.si.param_free);
+          return emit_value(OP_GATHER, {base},
+                            (int64_t)rows.size() * (int64_t)cols.size(), si,
+                            gather);
+        }
         // A range over the outermost array dimension is contiguous because
         // graph storage keeps each whole outer element together. Preserve
         // the complete suffix shape even when its storage width is zero.

--- a/runtime/src/lower.cpp
+++ b/runtime/src/lower.cpp
@@ -3291,18 +3291,28 @@ struct Lowering {
       const ArrayShape& ash = array_shape(a.si);
       const ArrayShape& bsh = array_shape(b.si);
       if (ash.dims.empty() || bsh.dims.empty() ||
-          ash.dims.size() != bsh.dims.size() || ash.leaf != bsh.leaf ||
+          ash.dims.size() != bsh.dims.size() || ash.leaf != bsh.leaf)
+        fail("append_array: element shapes must match", e.raw);
+      const int64_t a_outer = ash.dims[0], b_outer = bsh.dims[0];
+      // stan-math checks element geometry only when both sides contain an
+      // element. An empty side contributes no value whose shape could
+      // disagree, and the nonempty side supplies the result's suffix.
+      if (a_outer != 0 && b_outer != 0 &&
           !std::equal(ash.dims.begin() + 1, ash.dims.end(),
                       bsh.dims.begin() + 1, bsh.dims.end()))
         fail("append_array: element shapes must match", e.raw);
-      if (ash.dims[0] > std::numeric_limits<int64_t>::max() - bsh.dims[0])
+      if (a_outer > std::numeric_limits<int64_t>::max() - b_outer)
         fail("append_array: outer extent overflows", e.raw);
       const int64_t alen = g.slots[a.slot].len;
       const int64_t blen = g.slots[b.slot].len;
       if (alen > std::numeric_limits<int64_t>::max() - blen)
         fail("append_array: storage length overflows", e.raw);
-      std::vector<int64_t> dims = ash.dims;
-      dims[0] += bsh.dims[0];
+      std::vector<int64_t> dims =
+          a_outer == 0 && b_outer != 0 ? bsh.dims : ash.dims;
+      dims[0] = a_outer + b_outer;
+      const int64_t suffix_count =
+          checked_product(std::vector<int64_t>(dims.begin() + 1, dims.end()),
+                          "append_array element shape");
       SlotInfo si = array_view(std::move(dims), ash.leaf);
       Val joined = emit_value(OP_CONCAT2, {a, b}, alen + blen, si);
 
@@ -3314,11 +3324,26 @@ struct Lowering {
       if (ao && bo && ao->is_int == bo->is_int) {
         DataMap::Entry en;
         en.is_int = ao->is_int;
-        en.r = ao->r;
-        en.r.insert(en.r.end(), bo->r.begin(), bo->r.end());
+        en.r.reserve((size_t)(alen + blen));
+        // DataMap is first-index-fast, unlike the graph's outer-major array
+        // storage. Concatenation along dimension zero therefore interleaves
+        // the two outer-axis blocks once for every suffix coordinate.
+        const int64_t observation_lanes =
+            a_outer + b_outer == 0 ? 0 : suffix_count;
+        for (int64_t lane = 0; lane < observation_lanes; ++lane) {
+          const auto ab = ao->r.begin() + lane * a_outer;
+          const auto bb = bo->r.begin() + lane * b_outer;
+          en.r.insert(en.r.end(), ab, ab + a_outer);
+          en.r.insert(en.r.end(), bb, bb + b_outer);
+        }
         if (en.is_int) {
-          en.i = ao->i;
-          en.i.insert(en.i.end(), bo->i.begin(), bo->i.end());
+          en.i.reserve((size_t)(alen + blen));
+          for (int64_t lane = 0; lane < observation_lanes; ++lane) {
+            const auto ab = ao->i.begin() + lane * a_outer;
+            const auto bb = bo->i.begin() + lane * b_outer;
+            en.i.insert(en.i.end(), ab, ab + a_outer);
+            en.i.insert(en.i.end(), bb, bb + b_outer);
+          }
           set_int_initialized(joined);
           if (!en.i.empty()) {
             const auto bounds = std::minmax_element(en.i.begin(), en.i.end());

--- a/runtime/src/mir_reader.cpp
+++ b/runtime/src/mir_reader.cpp
@@ -147,6 +147,7 @@ void validate_funapp_arity(const Expr& e) {
                 "diag_pre_multiply",
                 "diag_post_multiply",
                 "quad_form_diag",
+                "quad_form_sym",
                 "append_row",
                 "append_col",
                 "rep_vector",

--- a/runtime/src/mir_reader.cpp
+++ b/runtime/src/mir_reader.cpp
@@ -148,6 +148,7 @@ void validate_funapp_arity(const Expr& e) {
                 "diag_post_multiply",
                 "quad_form_diag",
                 "quad_form_sym",
+                "append_array",
                 "append_row",
                 "append_col",
                 "rep_vector",
@@ -196,6 +197,7 @@ void validate_funapp_arity(const Expr& e) {
                 "diag_matrix",
                 "diagonal",
                 "cholesky_decompose",
+                "matrix_exp",
                 "eigenvalues_sym",
                 "eigenvectors_sym",
                 "categorical_rng",
@@ -1028,6 +1030,8 @@ using Bindings = std::map<std::string, Binding>;
 using Functions = std::map<std::string, const FunDef*>;
 
 UnsizedView declared_view(const SizedType& type) {
+  if (type.unsized.leaf != UnsizedLeaf::Unknown) return type.unsized;
+
   const std::string& base = type.base == "SArray" ? type.elem_base : type.base;
   UnsizedView view;
   if (base == "SInt")
@@ -1187,8 +1191,28 @@ void validate_bindings(const Stmt& s, Bindings& bindings,
             "mir: FnCheck value type disagrees with its declaration");
     }
   }
+  if (strict_variable_metadata && s.kind == Stmt::Assignment &&
+      s.lhs_idx.empty()) {
+    const auto binding = bindings.find(s.lhs);
+    if (binding != bindings.end() &&
+        binding->second.view.leaf != UnsizedLeaf::Unknown &&
+        s.rhs.unsized.leaf != UnsizedLeaf::Unknown &&
+        (binding->second.view.depth != s.rhs.unsized.depth ||
+         binding->second.view.leaf != s.rhs.unsized.leaf))
+      throw std::runtime_error(
+          "mir: assignment type disagrees with its binding for " + s.lhs);
+  }
   if (s.kind == Stmt::Decl) {
-    bindings[s.decl_id] = Binding{declared_view(s.decl_type), s.decl_data_only};
+    const UnsizedView view = declared_view(s.decl_type);
+    if (strict_variable_metadata &&
+        s.decl_type.unsized.leaf != UnsizedLeaf::Unknown && s.has_init &&
+        s.init.unsized.leaf != UnsizedLeaf::Unknown &&
+        (view.depth != s.init.unsized.depth ||
+         view.leaf != s.init.unsized.leaf))
+      throw std::runtime_error(
+          "mir: declaration initializer type disagrees with its binding for " +
+          s.decl_id);
+    bindings[s.decl_id] = Binding{view, s.decl_data_only};
   }
   if (s.kind == Stmt::SList) {
     validate_bindings(s.body, bindings, functions, strict_variable_metadata);
@@ -1303,24 +1327,30 @@ void resolve_calls(Stmt& s, const Overloads& overloads) {
   for (Stmt& k : s.body) resolve_calls(k, overloads);
 }
 
-void restore_unsized_decls(Stmt& s) {
-  if (s.kind == Stmt::Decl && s.decl_type.base.empty() &&
-      s.decl_type.raw.size() > 10 &&
-      s.decl_type.raw.compare(0, 9, "(Unsized ") == 0 &&
-      s.decl_type.raw.back() == ')') {
-    const std::string_view spelling(s.decl_type.raw.data() + 9,
-                                    s.decl_type.raw.size() - 10);
-    parse_unsized_spelling(spelling, &s.decl_type.unsized);
+void restore_unsized_decls(Stmt& s, bool strict) {
+  if (s.kind == Stmt::Decl && s.decl_type.base.empty()) {
+    const std::string& raw = s.decl_type.raw;
+    const bool looks_unsized = raw.compare(0, 8, "(Unsized") == 0;
+    const bool wrapped = raw.size() > 10 &&
+                         raw.compare(0, 9, "(Unsized ") == 0 &&
+                         raw.back() == ')';
+    bool parsed = false;
+    if (wrapped) {
+      const std::string_view spelling(raw.data() + 9, raw.size() - 10);
+      parsed = parse_unsized_spelling(spelling, &s.decl_type.unsized);
+    }
+    if (strict && looks_unsized && !parsed)
+      malformed("unsized declaration type");
   }
-  for (Stmt& child : s.body) restore_unsized_decls(child);
+  for (Stmt& child : s.body) restore_unsized_decls(child, strict);
 }
 
-void restore_unsized_decls(Program& prog) {
+void restore_unsized_decls(Program& prog, bool strict) {
   for (auto* body :
        {&prog.prepare_data, &prog.log_prob, &prog.generate_quantities})
-    for (Stmt& s : *body) restore_unsized_decls(s);
+    for (Stmt& s : *body) restore_unsized_decls(s, strict);
   for (FunDef& f : prog.fun_defs)
-    for (Stmt& s : f.body) restore_unsized_decls(s);
+    for (Stmt& s : f.body) restore_unsized_decls(s, strict);
 }
 
 void resolve_overloads(Program& prog) {
@@ -1354,7 +1384,7 @@ void detail::validate_portable_program(const Program& prog) {
 }
 
 void detail::finalize_program(Program& prog, bool strict_variable_metadata) {
-  restore_unsized_decls(prog);
+  restore_unsized_decls(prog, strict_variable_metadata);
   resolve_overloads(prog);
   Functions functions;
   for (const auto& f : prog.fun_defs) {

--- a/runtime/src/mir_reader.cpp
+++ b/runtime/src/mir_reader.cpp
@@ -653,12 +653,10 @@ Stmt read_stmt(const Node& n) {
       s.decl_type = t.head_is("Sized") ? read_sized(t[1]) : SizedType{};
       if (!t.head_is("Sized")) {
         s.decl_type.raw = dump(t);
-        // stanc3 declares scalar temporaries unsized. A vectorized `T[,]`
-        // whose location is a container loops over the elements and hoists
-        // the scale into one of these. A scalar carries no size
-        // expression, so give it the sized spelling. Unsized containers
-        // still reach the failure in sized_len, which is where their
-        // missing size belongs.
+        // stanc3 declares scalar and container temporaries unsized. Scalars
+        // have a fixed width, so retain the historical sized spelling;
+        // container shapes are restored during finalization and supplied by
+        // their first whole-variable assignment during lowering.
         if (t.size() > 1 && t[1].is_atom()) {
           if (t[1].atom == "UReal")
             s.decl_type.base = "SReal";
@@ -1304,6 +1302,26 @@ void resolve_calls(Stmt& s, const Overloads& overloads) {
   for (Stmt& k : s.body) resolve_calls(k, overloads);
 }
 
+void restore_unsized_decls(Stmt& s) {
+  if (s.kind == Stmt::Decl && s.decl_type.base.empty() &&
+      s.decl_type.raw.size() > 10 &&
+      s.decl_type.raw.compare(0, 9, "(Unsized ") == 0 &&
+      s.decl_type.raw.back() == ')') {
+    const std::string_view spelling(s.decl_type.raw.data() + 9,
+                                    s.decl_type.raw.size() - 10);
+    parse_unsized_spelling(spelling, &s.decl_type.unsized);
+  }
+  for (Stmt& child : s.body) restore_unsized_decls(child);
+}
+
+void restore_unsized_decls(Program& prog) {
+  for (auto* body :
+       {&prog.prepare_data, &prog.log_prob, &prog.generate_quantities})
+    for (Stmt& s : *body) restore_unsized_decls(s);
+  for (FunDef& f : prog.fun_defs)
+    for (Stmt& s : f.body) restore_unsized_decls(s);
+}
+
 void resolve_overloads(Program& prog) {
   std::map<std::string, std::vector<FunDef*>> by_name;
   for (FunDef& f : prog.fun_defs) by_name[f.name].push_back(&f);
@@ -1335,6 +1353,7 @@ void detail::validate_portable_program(const Program& prog) {
 }
 
 void detail::finalize_program(Program& prog, bool strict_variable_metadata) {
+  restore_unsized_decls(prog);
   resolve_overloads(prog);
   Functions functions;
   for (const auto& f : prog.fun_defs) {

--- a/tests/fixtures/append_regression.stan
+++ b/tests/fixtures/append_regression.stan
@@ -1,0 +1,19 @@
+data {
+  array[1, 2] int a;
+  array[1, 2] int b;
+}
+parameters {
+  real theta;
+  vector[3] v;
+}
+model {
+  array[2, 2] int joined_ints = append_array(a, b);
+  for (i in joined_ints[2])
+    target += i * theta;
+
+  array[0] vector[2] empty;
+  array[1] vector[3] one = {v};
+  array[1] vector[3] left_empty = append_array(empty, one);
+  array[1] vector[3] right_empty = append_array(one, empty);
+  target += sum(left_empty[1]) + 2 * sum(right_empty[1]);
+}

--- a/tests/fixtures/append_regression.tmir.sexp
+++ b/tests/fixtures/append_regression.tmir.sexp
@@ -1,0 +1,898 @@
+((functions_block ())
+ (input_vars
+  ((a <opaque>
+    (SArray
+     (SArray SInt
+      ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+     ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+   (b <opaque>
+    (SArray
+     (SArray SInt
+      ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+     ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+ (prepare_data
+  (((pattern
+     (Decl (decl_adtype DataOnly) (decl_id pos__) (decl_type (Sized SInt))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable pos__) ()) UInt
+      ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id a)
+      (decl_type
+       (Sized
+        (SArray
+         (SArray SInt
+          ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+         ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id a_flat__)
+          (decl_type (Unsized (UArray UInt))) (initialize Uninit)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable a_flat__) ()) (UArray UInt)
+          ((pattern
+            (FunApp (CompilerInternal FnReadData)
+             (((pattern (Lit Str a))
+               (meta ((type_ (UArray (UArray UInt))) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable pos__) ()) UInt
+          ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar sym1__)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Lit Int 2))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (For (loopvar sym2__)
+                  (lower
+                   ((pattern (Lit Int 1))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (upper
+                   ((pattern (Lit Int 1))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (body
+                   ((pattern
+                     (Block
+                      (((pattern
+                         (Assignment
+                          ((LVariable a)
+                           ((Single
+                             ((pattern (Var sym2__))
+                              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                            (Single
+                             ((pattern (Var sym1__))
+                              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                          (UArray (UArray UInt))
+                          ((pattern
+                            (Indexed
+                             ((pattern (Var a_flat__))
+                              (meta
+                               ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly))))
+                             ((Single
+                               ((pattern (Var pos__))
+                                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                        (meta <opaque>))
+                       ((pattern
+                         (Assignment ((LVariable pos__) ()) UInt
+                          ((pattern
+                            (FunApp (StanLib Plus__ FnPlain AoS)
+                             (((pattern (Var pos__))
+                               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                              ((pattern (Lit Int 1))
+                               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                        (meta <opaque>)))))
+                    (meta <opaque>)))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id b)
+      (decl_type
+       (Sized
+        (SArray
+         (SArray SInt
+          ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+         ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id b_flat__)
+          (decl_type (Unsized (UArray UInt))) (initialize Uninit)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable b_flat__) ()) (UArray UInt)
+          ((pattern
+            (FunApp (CompilerInternal FnReadData)
+             (((pattern (Lit Str b))
+               (meta ((type_ (UArray (UArray UInt))) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable pos__) ()) UInt
+          ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar sym1__)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Lit Int 2))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (For (loopvar sym2__)
+                  (lower
+                   ((pattern (Lit Int 1))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (upper
+                   ((pattern (Lit Int 1))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (body
+                   ((pattern
+                     (Block
+                      (((pattern
+                         (Assignment
+                          ((LVariable b)
+                           ((Single
+                             ((pattern (Var sym2__))
+                              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                            (Single
+                             ((pattern (Var sym1__))
+                              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                          (UArray (UArray UInt))
+                          ((pattern
+                            (Indexed
+                             ((pattern (Var b_flat__))
+                              (meta
+                               ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly))))
+                             ((Single
+                               ((pattern (Var pos__))
+                                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                        (meta <opaque>))
+                       ((pattern
+                         (Assignment ((LVariable pos__) ()) UInt
+                          ((pattern
+                            (FunApp (StanLib Plus__ FnPlain AoS)
+                             (((pattern (Var pos__))
+                               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                              ((pattern (Lit Int 1))
+                               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                        (meta <opaque>)))))
+                    (meta <opaque>)))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))))
+ (log_prob
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id theta) (decl_type (Sized SReal))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity) (dims ()) (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id v)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity)
+             (dims
+              (((pattern (Lit Int 3))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id joined_ints)
+          (decl_type
+           (Sized
+            (SArray
+             (SArray SInt
+              ((pattern (Lit Int 2))
+               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+             ((pattern (Lit Int 2))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+          (initialize Default)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable joined_ints) ()) (UArray (UArray UInt))
+          ((pattern
+            (FunApp (StanLib append_array FnPlain AoS)
+             (((pattern (Var a))
+               (meta ((type_ (UArray (UArray UInt))) (loc <opaque>) (adlevel DataOnly))))
+              ((pattern (Var b))
+               (meta ((type_ (UArray (UArray UInt))) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ (UArray (UArray UInt))) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (Block
+          (((pattern
+             (Decl (decl_adtype DataOnly) (decl_id sym1__)
+              (decl_type (Unsized (UArray UInt))) (initialize Default)))
+            (meta <opaque>))
+           ((pattern
+             (Assignment ((LVariable sym1__) ()) (UArray UInt)
+              ((pattern
+                (Indexed
+                 ((pattern (Var joined_ints))
+                  (meta
+                   ((type_ (UArray (UArray UInt))) (loc <opaque>) (adlevel DataOnly))))
+                 ((Single
+                   ((pattern (Lit Int 2))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+               (meta ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly))))))
+            (meta <opaque>))
+           ((pattern
+             (For (loopvar sym3__)
+              (lower
+               ((pattern (Lit Int 1))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+              (upper
+               ((pattern
+                 (FunApp (CompilerInternal FnLength)
+                  (((pattern (Var sym1__))
+                    (meta ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly)))))))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+              (body
+               ((pattern
+                 (Block
+                  (((pattern
+                     (Block
+                      (((pattern
+                         (Decl (decl_adtype DataOnly) (decl_id i)
+                          (decl_type (Unsized UInt)) (initialize Uninit)))
+                        (meta <opaque>))
+                       ((pattern
+                         (Assignment ((LVariable i) ()) UInt
+                          ((pattern
+                            (Indexed
+                             ((pattern (Var sym1__))
+                              (meta
+                               ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly))))
+                             ((Single
+                               ((pattern (Var sym3__))
+                                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                        (meta <opaque>))
+                       ((pattern
+                         (TargetPE
+                          ((pattern
+                            (FunApp (StanLib Times__ FnPlain AoS)
+                             (((pattern
+                                (Promotion
+                                 ((pattern (Var i))
+                                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                                 UReal DataOnly))
+                               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+                              ((pattern (Var theta))
+                               (meta
+                                ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
+                           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+                        (meta <opaque>)))))
+                    (meta <opaque>)))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>))
+       ((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id empty)
+          (decl_type
+           (Sized
+            (SArray
+             (SVector AoS
+              ((pattern (Lit Int 2))
+               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+             ((pattern (Lit Int 0))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+          (initialize Default)))
+        (meta <opaque>))
+       ((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id one)
+          (decl_type
+           (Sized
+            (SArray
+             (SVector AoS
+              ((pattern (Lit Int 3))
+               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+             ((pattern (Lit Int 1))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+          (initialize Uninit)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable one) ()) (UArray UVector)
+          ((pattern
+            (FunApp (CompilerInternal FnMakeArray)
+             (((pattern (Var v))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+           (meta ((type_ (UArray UVector)) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>))
+       ((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id left_empty)
+          (decl_type
+           (Sized
+            (SArray
+             (SVector AoS
+              ((pattern (Lit Int 3))
+               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+             ((pattern (Lit Int 1))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+          (initialize Uninit)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable left_empty) ()) (UArray UVector)
+          ((pattern
+            (FunApp (StanLib append_array FnPlain AoS)
+             (((pattern (Var empty))
+               (meta ((type_ (UArray UVector)) (loc <opaque>) (adlevel AutoDiffable))))
+              ((pattern (Var one))
+               (meta ((type_ (UArray UVector)) (loc <opaque>) (adlevel AutoDiffable)))))))
+           (meta ((type_ (UArray UVector)) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>))
+       ((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id right_empty)
+          (decl_type
+           (Sized
+            (SArray
+             (SVector AoS
+              ((pattern (Lit Int 3))
+               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+             ((pattern (Lit Int 1))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+          (initialize Uninit)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable right_empty) ()) (UArray UVector)
+          ((pattern
+            (FunApp (StanLib append_array FnPlain AoS)
+             (((pattern (Var one))
+               (meta ((type_ (UArray UVector)) (loc <opaque>) (adlevel AutoDiffable))))
+              ((pattern (Var empty))
+               (meta ((type_ (UArray UVector)) (loc <opaque>) (adlevel AutoDiffable)))))))
+           (meta ((type_ (UArray UVector)) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>))
+       ((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib fma FnPlain AoS)
+             (((pattern
+                (Promotion
+                 ((pattern (Lit Int 2))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                 UReal DataOnly))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+              ((pattern
+                (FunApp (StanLib sum FnPlain AoS)
+                 (((pattern
+                    (Indexed
+                     ((pattern (Var right_empty))
+                      (meta
+                       ((type_ (UArray UVector)) (loc <opaque>) (adlevel AutoDiffable))))
+                     ((Single
+                       ((pattern (Lit Int 1))
+                        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                   (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+              ((pattern
+                (FunApp (StanLib sum FnPlain AoS)
+                 (((pattern
+                    (Indexed
+                     ((pattern (Var left_empty))
+                      (meta
+                       ((type_ (UArray UVector)) (loc <opaque>) (adlevel AutoDiffable))))
+                     ((Single
+                       ((pattern (Lit Int 1))
+                        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                   (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>)))))
+    (meta <opaque>))))
+ (reverse_mode_log_prob
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id theta) (decl_type (Sized SReal))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity) (dims ()) (mem_pattern SoA)))
+           ()))
+         (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id v)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity)
+             (dims
+              (((pattern (Lit Int 3))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id joined_ints)
+          (decl_type
+           (Sized
+            (SArray
+             (SArray SInt
+              ((pattern (Lit Int 2))
+               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+             ((pattern (Lit Int 2))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+          (initialize Default)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable joined_ints) ()) (UArray (UArray UInt))
+          ((pattern
+            (FunApp (StanLib append_array FnPlain AoS)
+             (((pattern (Var a))
+               (meta ((type_ (UArray (UArray UInt))) (loc <opaque>) (adlevel DataOnly))))
+              ((pattern (Var b))
+               (meta ((type_ (UArray (UArray UInt))) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ (UArray (UArray UInt))) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (Block
+          (((pattern
+             (Decl (decl_adtype DataOnly) (decl_id sym1__)
+              (decl_type (Unsized (UArray UInt))) (initialize Default)))
+            (meta <opaque>))
+           ((pattern
+             (Assignment ((LVariable sym1__) ()) (UArray UInt)
+              ((pattern
+                (Indexed
+                 ((pattern (Var joined_ints))
+                  (meta
+                   ((type_ (UArray (UArray UInt))) (loc <opaque>) (adlevel DataOnly))))
+                 ((Single
+                   ((pattern (Lit Int 2))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+               (meta ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly))))))
+            (meta <opaque>))
+           ((pattern
+             (For (loopvar sym3__)
+              (lower
+               ((pattern (Lit Int 1))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+              (upper
+               ((pattern
+                 (FunApp (CompilerInternal FnLength)
+                  (((pattern (Var sym1__))
+                    (meta ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly)))))))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+              (body
+               ((pattern
+                 (Block
+                  (((pattern
+                     (Block
+                      (((pattern
+                         (Decl (decl_adtype DataOnly) (decl_id i)
+                          (decl_type (Unsized UInt)) (initialize Uninit)))
+                        (meta <opaque>))
+                       ((pattern
+                         (Assignment ((LVariable i) ()) UInt
+                          ((pattern
+                            (Indexed
+                             ((pattern (Var sym1__))
+                              (meta
+                               ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly))))
+                             ((Single
+                               ((pattern (Var sym3__))
+                                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                        (meta <opaque>))
+                       ((pattern
+                         (TargetPE
+                          ((pattern
+                            (FunApp (StanLib Times__ FnPlain SoA)
+                             (((pattern
+                                (Promotion
+                                 ((pattern (Var i))
+                                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                                 UReal DataOnly))
+                               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+                              ((pattern (Var theta))
+                               (meta
+                                ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
+                           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+                        (meta <opaque>)))))
+                    (meta <opaque>)))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>))
+       ((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id empty)
+          (decl_type
+           (Sized
+            (SArray
+             (SVector AoS
+              ((pattern (Lit Int 2))
+               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+             ((pattern (Lit Int 0))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+          (initialize Default)))
+        (meta <opaque>))
+       ((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id one)
+          (decl_type
+           (Sized
+            (SArray
+             (SVector AoS
+              ((pattern (Lit Int 3))
+               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+             ((pattern (Lit Int 1))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+          (initialize Uninit)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable one) ()) (UArray UVector)
+          ((pattern
+            (FunApp (CompilerInternal FnMakeArray)
+             (((pattern (Var v))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+           (meta ((type_ (UArray UVector)) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>))
+       ((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id left_empty)
+          (decl_type
+           (Sized
+            (SArray
+             (SVector AoS
+              ((pattern (Lit Int 3))
+               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+             ((pattern (Lit Int 1))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+          (initialize Uninit)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable left_empty) ()) (UArray UVector)
+          ((pattern
+            (FunApp (StanLib append_array FnPlain AoS)
+             (((pattern (Var empty))
+               (meta ((type_ (UArray UVector)) (loc <opaque>) (adlevel AutoDiffable))))
+              ((pattern (Var one))
+               (meta ((type_ (UArray UVector)) (loc <opaque>) (adlevel AutoDiffable)))))))
+           (meta ((type_ (UArray UVector)) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>))
+       ((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id right_empty)
+          (decl_type
+           (Sized
+            (SArray
+             (SVector AoS
+              ((pattern (Lit Int 3))
+               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+             ((pattern (Lit Int 1))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+          (initialize Uninit)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable right_empty) ()) (UArray UVector)
+          ((pattern
+            (FunApp (StanLib append_array FnPlain AoS)
+             (((pattern (Var one))
+               (meta ((type_ (UArray UVector)) (loc <opaque>) (adlevel AutoDiffable))))
+              ((pattern (Var empty))
+               (meta ((type_ (UArray UVector)) (loc <opaque>) (adlevel AutoDiffable)))))))
+           (meta ((type_ (UArray UVector)) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>))
+       ((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib fma FnPlain SoA)
+             (((pattern
+                (Promotion
+                 ((pattern (Lit Int 2))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                 UReal DataOnly))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+              ((pattern
+                (FunApp (StanLib sum FnPlain AoS)
+                 (((pattern
+                    (Indexed
+                     ((pattern (Var right_empty))
+                      (meta
+                       ((type_ (UArray UVector)) (loc <opaque>) (adlevel AutoDiffable))))
+                     ((Single
+                       ((pattern (Lit Int 1))
+                        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                   (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+              ((pattern
+                (FunApp (StanLib sum FnPlain AoS)
+                 (((pattern
+                    (Indexed
+                     ((pattern (Var left_empty))
+                      (meta
+                       ((type_ (UArray UVector)) (loc <opaque>) (adlevel AutoDiffable))))
+                     ((Single
+                       ((pattern (Lit Int 1))
+                        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                   (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>)))))
+    (meta <opaque>))))
+ (generate_quantities
+  (((pattern
+     (Decl (decl_adtype DataOnly) (decl_id theta) (decl_type (Sized SReal))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity) (dims ()) (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id v)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity)
+             (dims
+              (((pattern (Lit Int 3))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt ())
+        (var
+         ((pattern (Var theta)) (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt ())
+        (var
+         ((pattern (Var v)) (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (IfElse
+      ((pattern
+        (FunApp (StanLib PNot__ FnPlain AoS)
+         (((pattern
+            (EOr
+             ((pattern (Var emit_transformed_parameters__))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+             ((pattern (Var emit_generated_quantities__))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+      ((pattern (Block (((pattern (Return ())) (meta <opaque>))))) (meta <opaque>)) ()))
+    (meta <opaque>))
+   ((pattern
+     (IfElse
+      ((pattern
+        (FunApp (StanLib PNot__ FnPlain AoS)
+         (((pattern (Var emit_generated_quantities__))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+      ((pattern (Block (((pattern (Return ())) (meta <opaque>))))) (meta <opaque>)) ()))
+    (meta <opaque>))))
+ (transform_inits
+  (((pattern
+     (Decl (decl_adtype DataOnly) (decl_id pos__) (decl_type (Sized SInt))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable pos__) ()) UInt
+      ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id theta) (decl_type (Sized SReal))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable theta) ()) UReal
+      ((pattern
+        (Indexed
+         ((pattern
+           (FunApp (CompilerInternal FnReadData)
+            (((pattern (Lit Str theta))
+              (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+          (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))
+         ((Single
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+       (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var theta)) (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id v)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id v_flat__)
+          (decl_type (Unsized (UArray UReal))) (initialize Uninit)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable v_flat__) ()) (UArray UReal)
+          ((pattern
+            (FunApp (CompilerInternal FnReadData)
+             (((pattern (Lit Str v))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable pos__) ()) UInt
+          ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar sym1__)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Lit Int 3))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (Assignment
+                  ((LVariable v)
+                   ((Single
+                     ((pattern (Var sym1__))
+                      (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                  UVector
+                  ((pattern
+                    (Indexed
+                     ((pattern (Var v_flat__))
+                      (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))
+                     ((Single
+                       ((pattern (Var pos__))
+                        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+                (meta <opaque>))
+               ((pattern
+                 (Assignment ((LVariable pos__) ()) UInt
+                  ((pattern
+                    (FunApp (StanLib Plus__ FnPlain AoS)
+                     (((pattern (Var pos__))
+                       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                      ((pattern (Lit Int 1))
+                       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var v)) (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))))
+ (unconstrain_array
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id theta) (decl_type (Sized SReal))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable theta) ()) UReal
+      ((pattern (FunApp (CompilerInternal FnReadDeserializer) ()))
+       (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var theta)) (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id v)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable v) ()) UVector
+      ((pattern
+        (FunApp (CompilerInternal FnReadDeserializer)
+         (((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var v)) (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))))
+ (output_vars
+  ((theta <opaque>
+    ((out_unconstrained_st SReal) (out_constrained_st SReal) (out_block Parameters)
+     (out_trans Identity)))
+   (v <opaque>
+    ((out_unconstrained_st
+      (SVector AoS
+       ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+     (out_constrained_st
+      (SVector AoS
+       ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+     (out_block Parameters) (out_trans Identity)))))
+ (prog_name append_regression_model) (prog_path tests/fixtures/append_regression.stan))

--- a/tests/fixtures/interp_new_functions.stan
+++ b/tests/fixtures/interp_new_functions.stan
@@ -1,0 +1,21 @@
+data {
+  array[1] int a;
+  matrix[2, 2] m;
+}
+transformed data {
+  array[2] int joined = append_array(a, {2});
+  matrix[2, 2] e = matrix_exp(m);
+  real td = sum(joined) + sum(e);
+}
+parameters {
+  real theta;
+}
+model {
+  target += td * theta;
+}
+generated quantities {
+  array[2] real g_joined = append_array({theta}, {2.0});
+  matrix[2, 2] g_exp = matrix_exp([[theta, 0.0], [0.0, 0.0]]);
+  vector[2] product_terms = exp([theta, 2.0]');
+  real product = prod(product_terms);
+}

--- a/tests/fixtures/interp_new_functions.tmir.sexp
+++ b/tests/fixtures/interp_new_functions.tmir.sexp
@@ -1,0 +1,480 @@
+((functions_block ())
+ (input_vars
+  ((a <opaque>
+    (SArray SInt
+     ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+   (m <opaque>
+    (SMatrix AoS
+     ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+     ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+ (prepare_data
+  (((pattern
+     (Decl (decl_adtype DataOnly) (decl_id pos__) (decl_type (Sized SInt))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable pos__) ()) UInt
+      ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id a)
+      (decl_type
+       (Sized
+        (SArray SInt
+         ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable a) ()) (UArray UInt)
+      ((pattern
+        (FunApp (CompilerInternal FnReadData)
+         (((pattern (Lit Str a))
+           (meta ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id m)
+      (decl_type
+       (Sized
+        (SMatrix AoS
+         ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+         ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id m_flat__)
+          (decl_type (Unsized (UArray UReal))) (initialize Uninit)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable m_flat__) ()) (UArray UReal)
+          ((pattern
+            (FunApp (CompilerInternal FnReadData)
+             (((pattern (Lit Str m))
+               (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable pos__) ()) UInt
+          ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar sym1__)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Lit Int 2))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (For (loopvar sym2__)
+                  (lower
+                   ((pattern (Lit Int 1))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (upper
+                   ((pattern (Lit Int 2))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (body
+                   ((pattern
+                     (Block
+                      (((pattern
+                         (Assignment
+                          ((LVariable m)
+                           ((Single
+                             ((pattern (Var sym2__))
+                              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                            (Single
+                             ((pattern (Var sym1__))
+                              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                          UMatrix
+                          ((pattern
+                            (Indexed
+                             ((pattern (Var m_flat__))
+                              (meta
+                               ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))
+                             ((Single
+                               ((pattern (Var pos__))
+                                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                           (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+                        (meta <opaque>))
+                       ((pattern
+                         (Assignment ((LVariable pos__) ()) UInt
+                          ((pattern
+                            (FunApp (StanLib Plus__ FnPlain AoS)
+                             (((pattern (Var pos__))
+                               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                              ((pattern (Lit Int 1))
+                               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                        (meta <opaque>)))))
+                    (meta <opaque>)))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id joined)
+      (decl_type
+       (Sized
+        (SArray SInt
+         ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable joined) ()) (UArray UInt)
+      ((pattern
+        (FunApp (StanLib append_array FnPlain AoS)
+         (((pattern (Var a))
+           (meta ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly))))
+          ((pattern
+            (FunApp (CompilerInternal FnMakeArray)
+             (((pattern (Lit Int 2))
+               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id e)
+      (decl_type
+       (Sized
+        (SMatrix AoS
+         ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+         ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable e) ()) UMatrix
+      ((pattern
+        (FunApp (StanLib matrix_exp FnPlain AoS)
+         (((pattern (Var m)) (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id td) (decl_type (Sized SReal))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable td) ()) UReal
+      ((pattern
+        (FunApp (StanLib Plus__ FnPlain AoS)
+         (((pattern
+            (Promotion
+             ((pattern
+               (FunApp (StanLib sum FnPlain AoS)
+                (((pattern (Var joined))
+                  (meta ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly)))))))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+             UReal DataOnly))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+          ((pattern
+            (FunApp (StanLib sum FnPlain AoS)
+             (((pattern (Var e))
+               (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))))
+ (log_prob
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id theta) (decl_type (Sized SReal))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity) (dims ()) (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib Times__ FnPlain AoS)
+             (((pattern (Var td))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+              ((pattern (Var theta))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>)))))
+    (meta <opaque>))))
+ (reverse_mode_log_prob
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id theta) (decl_type (Sized SReal))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity) (dims ()) (mem_pattern SoA)))
+           ()))
+         (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib Times__ FnPlain SoA)
+             (((pattern (Var td))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+              ((pattern (Var theta))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>)))))
+    (meta <opaque>))))
+ (generate_quantities
+  (((pattern
+     (Decl (decl_adtype DataOnly) (decl_id theta) (decl_type (Sized SReal))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity) (dims ()) (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt ())
+        (var
+         ((pattern (Var theta)) (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (IfElse
+      ((pattern
+        (FunApp (StanLib PNot__ FnPlain AoS)
+         (((pattern
+            (EOr
+             ((pattern (Var emit_transformed_parameters__))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+             ((pattern (Var emit_generated_quantities__))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+      ((pattern (Block (((pattern (Return ())) (meta <opaque>))))) (meta <opaque>)) ()))
+    (meta <opaque>))
+   ((pattern
+     (IfElse
+      ((pattern
+        (FunApp (StanLib PNot__ FnPlain AoS)
+         (((pattern (Var emit_generated_quantities__))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+      ((pattern (Block (((pattern (Return ())) (meta <opaque>))))) (meta <opaque>)) ()))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id g_joined)
+      (decl_type
+       (Sized
+        (SArray SReal
+         ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable g_joined) ()) (UArray UReal)
+      ((pattern
+        (FunApp (StanLib append_array FnPlain AoS)
+         (((pattern
+            (FunApp (CompilerInternal FnMakeArray)
+             (((pattern (Var theta))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))
+          ((pattern
+            (FunApp (CompilerInternal FnMakeArray)
+             (((pattern (Lit Real 2.0))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id g_exp)
+      (decl_type
+       (Sized
+        (SMatrix AoS
+         ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+         ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable g_exp) ()) UMatrix
+      ((pattern
+        (FunApp (StanLib matrix_exp FnPlain AoS)
+         (((pattern
+            (FunApp (CompilerInternal FnMakeRowVec)
+             (((pattern
+                (FunApp (CompilerInternal FnMakeRowVec)
+                 (((pattern (Var theta))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+                  ((pattern (Lit Real 0.0))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+               (meta ((type_ URowVector) (loc <opaque>) (adlevel DataOnly))))
+              ((pattern
+                (FunApp (CompilerInternal FnMakeRowVec)
+                 (((pattern (Lit Real 0.0))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+                  ((pattern (Lit Real 0.0))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+               (meta ((type_ URowVector) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id product_terms)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable product_terms) ()) UVector
+      ((pattern
+        (FunApp (StanLib exp FnPlain AoS)
+         (((pattern
+            (FunApp (StanLib Transpose__ FnPlain AoS)
+             (((pattern
+                (FunApp (CompilerInternal FnMakeRowVec)
+                 (((pattern (Var theta))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+                  ((pattern (Lit Real 2.0))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+               (meta ((type_ URowVector) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id product) (decl_type (Sized SReal))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable product) ()) UReal
+      ((pattern
+        (FunApp (StanLib prod FnPlain AoS)
+         (((pattern (Var product_terms))
+           (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt ())
+        (var
+         ((pattern (Var g_joined))
+          (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt ())
+        (var
+         ((pattern (Var g_exp))
+          (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt ())
+        (var
+         ((pattern (Var product_terms))
+          (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt ())
+        (var
+         ((pattern (Var product))
+          (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))))
+ (transform_inits
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id theta) (decl_type (Sized SReal))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable theta) ()) UReal
+      ((pattern
+        (Indexed
+         ((pattern
+           (FunApp (CompilerInternal FnReadData)
+            (((pattern (Lit Str theta))
+              (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+          (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))
+         ((Single
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+       (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var theta)) (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))))
+ (unconstrain_array
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id theta) (decl_type (Sized SReal))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable theta) ()) UReal
+      ((pattern (FunApp (CompilerInternal FnReadDeserializer) ()))
+       (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var theta)) (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))))
+ (output_vars
+  ((theta <opaque>
+    ((out_unconstrained_st SReal) (out_constrained_st SReal) (out_block Parameters)
+     (out_trans Identity)))
+   (g_joined <opaque>
+    ((out_unconstrained_st
+      (SArray SReal
+       ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+     (out_constrained_st
+      (SArray SReal
+       ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+     (out_block GeneratedQuantities) (out_trans Identity)))
+   (g_exp <opaque>
+    ((out_unconstrained_st
+      (SMatrix AoS
+       ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+       ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+     (out_constrained_st
+      (SMatrix AoS
+       ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+       ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+     (out_block GeneratedQuantities) (out_trans Identity)))
+   (product_terms <opaque>
+    ((out_unconstrained_st
+      (SVector AoS
+       ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+     (out_constrained_st
+      (SVector AoS
+       ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+     (out_block GeneratedQuantities) (out_trans Identity)))
+   (product <opaque>
+    ((out_unconstrained_st SReal) (out_constrained_st SReal)
+     (out_block GeneratedQuantities) (out_trans Identity)))))
+ (prog_name interp_new_functions_model)
+ (prog_path tests/fixtures/interp_new_functions.stan))

--- a/tests/fixtures/matrix_exp.stan
+++ b/tests/fixtures/matrix_exp.stan
@@ -1,0 +1,7 @@
+parameters {
+  matrix[2, 2] a;
+}
+model {
+  matrix[2, 2] e = matrix_exp(a);
+  target += e[1, 1] - 0.7 * e[2, 1] + 1.3 * e[1, 2] + 0.4 * e[2, 2];
+}

--- a/tests/fixtures/matrix_exp.tmir.sexp
+++ b/tests/fixtures/matrix_exp.tmir.sexp
@@ -1,0 +1,412 @@
+((functions_block ()) (input_vars ()) (prepare_data ())
+ (log_prob
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id a)
+      (decl_type
+       (Sized
+        (SMatrix AoS
+         ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+         ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity)
+             (dims
+              (((pattern (Lit Int 2))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+               ((pattern (Lit Int 2))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id e)
+          (decl_type
+           (Sized
+            (SMatrix AoS
+             ((pattern (Lit Int 2))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+             ((pattern (Lit Int 2))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+          (initialize Uninit)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable e) ()) UMatrix
+          ((pattern
+            (FunApp (StanLib matrix_exp FnPlain AoS)
+             (((pattern (Var a))
+               (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable)))))))
+           (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>))
+       ((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib fma FnPlain AoS)
+             (((pattern (Lit Real 0.4))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+              ((pattern
+                (Indexed
+                 ((pattern (Var e))
+                  (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))
+                 ((Single
+                   ((pattern (Lit Int 2))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (Single
+                   ((pattern (Lit Int 2))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+              ((pattern
+                (FunApp (StanLib fma FnPlain AoS)
+                 (((pattern (Lit Real 1.3))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+                  ((pattern
+                    (Indexed
+                     ((pattern (Var e))
+                      (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))
+                     ((Single
+                       ((pattern (Lit Int 1))
+                        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                      (Single
+                       ((pattern (Lit Int 2))
+                        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+                  ((pattern
+                    (FunApp (StanLib Minus__ FnPlain AoS)
+                     (((pattern
+                        (Indexed
+                         ((pattern (Var e))
+                          (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))
+                         ((Single
+                           ((pattern (Lit Int 1))
+                            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                          (Single
+                           ((pattern (Lit Int 1))
+                            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                       (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+                      ((pattern
+                        (FunApp (StanLib Times__ FnPlain AoS)
+                         (((pattern (Lit Real 0.7))
+                           (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+                          ((pattern
+                            (Indexed
+                             ((pattern (Var e))
+                              (meta
+                               ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))
+                             ((Single
+                               ((pattern (Lit Int 2))
+                                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                              (Single
+                               ((pattern (Lit Int 1))
+                                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
+                       (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>)))))
+    (meta <opaque>))))
+ (reverse_mode_log_prob
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id a)
+      (decl_type
+       (Sized
+        (SMatrix AoS
+         ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+         ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity)
+             (dims
+              (((pattern (Lit Int 2))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+               ((pattern (Lit Int 2))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id e)
+          (decl_type
+           (Sized
+            (SMatrix AoS
+             ((pattern (Lit Int 2))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+             ((pattern (Lit Int 2))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+          (initialize Uninit)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable e) ()) UMatrix
+          ((pattern
+            (FunApp (StanLib matrix_exp FnPlain AoS)
+             (((pattern (Var a))
+               (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable)))))))
+           (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>))
+       ((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib fma FnPlain SoA)
+             (((pattern (Lit Real 0.4))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+              ((pattern
+                (Indexed
+                 ((pattern (Var e))
+                  (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))
+                 ((Single
+                   ((pattern (Lit Int 2))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (Single
+                   ((pattern (Lit Int 2))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+              ((pattern
+                (FunApp (StanLib fma FnPlain SoA)
+                 (((pattern (Lit Real 1.3))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+                  ((pattern
+                    (Indexed
+                     ((pattern (Var e))
+                      (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))
+                     ((Single
+                       ((pattern (Lit Int 1))
+                        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                      (Single
+                       ((pattern (Lit Int 2))
+                        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+                  ((pattern
+                    (FunApp (StanLib Minus__ FnPlain SoA)
+                     (((pattern
+                        (Indexed
+                         ((pattern (Var e))
+                          (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))
+                         ((Single
+                           ((pattern (Lit Int 1))
+                            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                          (Single
+                           ((pattern (Lit Int 1))
+                            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                       (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+                      ((pattern
+                        (FunApp (StanLib Times__ FnPlain SoA)
+                         (((pattern (Lit Real 0.7))
+                           (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+                          ((pattern
+                            (Indexed
+                             ((pattern (Var e))
+                              (meta
+                               ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))
+                             ((Single
+                               ((pattern (Lit Int 2))
+                                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                              (Single
+                               ((pattern (Lit Int 1))
+                                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
+                       (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>)))))
+    (meta <opaque>))))
+ (generate_quantities
+  (((pattern
+     (Decl (decl_adtype DataOnly) (decl_id a)
+      (decl_type
+       (Sized
+        (SMatrix AoS
+         ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+         ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity)
+             (dims
+              (((pattern (Lit Int 2))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+               ((pattern (Lit Int 2))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt ())
+        (var
+         ((pattern (Var a)) (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (IfElse
+      ((pattern
+        (FunApp (StanLib PNot__ FnPlain AoS)
+         (((pattern
+            (EOr
+             ((pattern (Var emit_transformed_parameters__))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+             ((pattern (Var emit_generated_quantities__))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+      ((pattern (Block (((pattern (Return ())) (meta <opaque>))))) (meta <opaque>)) ()))
+    (meta <opaque>))
+   ((pattern
+     (IfElse
+      ((pattern
+        (FunApp (StanLib PNot__ FnPlain AoS)
+         (((pattern (Var emit_generated_quantities__))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+      ((pattern (Block (((pattern (Return ())) (meta <opaque>))))) (meta <opaque>)) ()))
+    (meta <opaque>))))
+ (transform_inits
+  (((pattern
+     (Decl (decl_adtype DataOnly) (decl_id pos__) (decl_type (Sized SInt))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id a)
+      (decl_type
+       (Sized
+        (SMatrix AoS
+         ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+         ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id a_flat__)
+          (decl_type (Unsized (UArray UReal))) (initialize Uninit)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable a_flat__) ()) (UArray UReal)
+          ((pattern
+            (FunApp (CompilerInternal FnReadData)
+             (((pattern (Lit Str a))
+               (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable pos__) ()) UInt
+          ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar sym1__)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Lit Int 2))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (For (loopvar sym2__)
+                  (lower
+                   ((pattern (Lit Int 1))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (upper
+                   ((pattern (Lit Int 2))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (body
+                   ((pattern
+                     (Block
+                      (((pattern
+                         (Assignment
+                          ((LVariable a)
+                           ((Single
+                             ((pattern (Var sym2__))
+                              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                            (Single
+                             ((pattern (Var sym1__))
+                              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                          UMatrix
+                          ((pattern
+                            (Indexed
+                             ((pattern (Var a_flat__))
+                              (meta
+                               ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))
+                             ((Single
+                               ((pattern (Var pos__))
+                                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                           (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+                        (meta <opaque>))
+                       ((pattern
+                         (Assignment ((LVariable pos__) ()) UInt
+                          ((pattern
+                            (FunApp (StanLib Plus__ FnPlain AoS)
+                             (((pattern (Var pos__))
+                               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                              ((pattern (Lit Int 1))
+                               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                        (meta <opaque>)))))
+                    (meta <opaque>)))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var a)) (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))))
+ (unconstrain_array
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id a)
+      (decl_type
+       (Sized
+        (SMatrix AoS
+         ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+         ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable a) ()) UMatrix
+      ((pattern
+        (FunApp (CompilerInternal FnReadDeserializer)
+         (((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+          ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var a)) (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))))
+ (output_vars
+  ((a <opaque>
+    ((out_unconstrained_st
+      (SMatrix AoS
+       ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+       ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+     (out_constrained_st
+      (SMatrix AoS
+       ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+       ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+     (out_block Parameters) (out_trans Identity)))))
+ (prog_name matrix_exp_model) (prog_path tests/fixtures/matrix_exp.stan))

--- a/tests/fixtures/matrix_multi_multi.stan
+++ b/tests/fixtures/matrix_multi_multi.stan
@@ -1,0 +1,13 @@
+// Two integer arrays select the Cartesian submatrix, retaining their order in
+// each axis rather than pairing corresponding indices.
+data {
+  array[2] int row_indices;
+  array[2] int column_indices;
+}
+parameters {
+  matrix[3, 3] m;
+}
+model {
+  matrix[3, 3] computed = 2.0 * m;
+  target += sum(computed[row_indices, column_indices]);
+}

--- a/tests/fixtures/matrix_multi_multi.tmir.sexp
+++ b/tests/fixtures/matrix_multi_multi.tmir.sexp
@@ -1,0 +1,358 @@
+((functions_block ())
+ (input_vars
+  ((row_indices <opaque>
+    (SArray SInt
+     ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+   (column_indices <opaque>
+    (SArray SInt
+     ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+ (prepare_data
+  (((pattern
+     (Decl (decl_adtype DataOnly) (decl_id row_indices)
+      (decl_type
+       (Sized
+        (SArray SInt
+         ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable row_indices) ()) (UArray UInt)
+      ((pattern
+        (FunApp (CompilerInternal FnReadData)
+         (((pattern (Lit Str row_indices))
+           (meta ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id column_indices)
+      (decl_type
+       (Sized
+        (SArray SInt
+         ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable column_indices) ()) (UArray UInt)
+      ((pattern
+        (FunApp (CompilerInternal FnReadData)
+         (((pattern (Lit Str column_indices))
+           (meta ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))))
+ (log_prob
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id m)
+      (decl_type
+       (Sized
+        (SMatrix AoS
+         ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+         ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity)
+             (dims
+              (((pattern (Lit Int 3))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+               ((pattern (Lit Int 3))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id computed)
+          (decl_type
+           (Sized
+            (SMatrix AoS
+             ((pattern (Lit Int 3))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+             ((pattern (Lit Int 3))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+          (initialize Uninit)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable computed) ()) UMatrix
+          ((pattern
+            (FunApp (StanLib Times__ FnPlain AoS)
+             (((pattern (Lit Real 2.0))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+              ((pattern (Var m))
+               (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable)))))))
+           (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>))
+       ((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib sum FnPlain AoS)
+             (((pattern
+                (Indexed
+                 ((pattern (Var computed))
+                  (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))
+                 ((MultiIndex
+                   ((pattern (Var row_indices))
+                    (meta ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly)))))
+                  (MultiIndex
+                   ((pattern (Var column_indices))
+                    (meta ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly))))))))
+               (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>)))))
+    (meta <opaque>))))
+ (reverse_mode_log_prob
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id m)
+      (decl_type
+       (Sized
+        (SMatrix SoA
+         ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+         ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity)
+             (dims
+              (((pattern (Lit Int 3))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+               ((pattern (Lit Int 3))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern SoA)))
+           ()))
+         (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id computed)
+          (decl_type
+           (Sized
+            (SMatrix SoA
+             ((pattern (Lit Int 3))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+             ((pattern (Lit Int 3))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+          (initialize Uninit)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable computed) ()) UMatrix
+          ((pattern
+            (FunApp (StanLib Times__ FnPlain SoA)
+             (((pattern (Lit Real 2.0))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+              ((pattern (Var m))
+               (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable)))))))
+           (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>))
+       ((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib sum FnPlain SoA)
+             (((pattern
+                (Indexed
+                 ((pattern (Var computed))
+                  (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))
+                 ((MultiIndex
+                   ((pattern (Var row_indices))
+                    (meta ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly)))))
+                  (MultiIndex
+                   ((pattern (Var column_indices))
+                    (meta ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly))))))))
+               (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>)))))
+    (meta <opaque>))))
+ (generate_quantities
+  (((pattern
+     (Decl (decl_adtype DataOnly) (decl_id m)
+      (decl_type
+       (Sized
+        (SMatrix AoS
+         ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+         ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity)
+             (dims
+              (((pattern (Lit Int 3))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+               ((pattern (Lit Int 3))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt ())
+        (var
+         ((pattern (Var m)) (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (IfElse
+      ((pattern
+        (FunApp (StanLib PNot__ FnPlain AoS)
+         (((pattern
+            (EOr
+             ((pattern (Var emit_transformed_parameters__))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+             ((pattern (Var emit_generated_quantities__))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+      ((pattern (Block (((pattern (Return ())) (meta <opaque>))))) (meta <opaque>)) ()))
+    (meta <opaque>))
+   ((pattern
+     (IfElse
+      ((pattern
+        (FunApp (StanLib PNot__ FnPlain AoS)
+         (((pattern (Var emit_generated_quantities__))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+      ((pattern (Block (((pattern (Return ())) (meta <opaque>))))) (meta <opaque>)) ()))
+    (meta <opaque>))))
+ (transform_inits
+  (((pattern
+     (Decl (decl_adtype DataOnly) (decl_id pos__) (decl_type (Sized SInt))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id m)
+      (decl_type
+       (Sized
+        (SMatrix AoS
+         ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+         ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id m_flat__)
+          (decl_type (Unsized (UArray UReal))) (initialize Uninit)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable m_flat__) ()) (UArray UReal)
+          ((pattern
+            (FunApp (CompilerInternal FnReadData)
+             (((pattern (Lit Str m))
+               (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable pos__) ()) UInt
+          ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar sym1__)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Lit Int 3))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (For (loopvar sym2__)
+                  (lower
+                   ((pattern (Lit Int 1))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (upper
+                   ((pattern (Lit Int 3))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (body
+                   ((pattern
+                     (Block
+                      (((pattern
+                         (Assignment
+                          ((LVariable m)
+                           ((Single
+                             ((pattern (Var sym2__))
+                              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                            (Single
+                             ((pattern (Var sym1__))
+                              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                          UMatrix
+                          ((pattern
+                            (Indexed
+                             ((pattern (Var m_flat__))
+                              (meta
+                               ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))
+                             ((Single
+                               ((pattern (Var pos__))
+                                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                           (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+                        (meta <opaque>))
+                       ((pattern
+                         (Assignment ((LVariable pos__) ()) UInt
+                          ((pattern
+                            (FunApp (StanLib Plus__ FnPlain AoS)
+                             (((pattern (Var pos__))
+                               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                              ((pattern (Lit Int 1))
+                               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                        (meta <opaque>)))))
+                    (meta <opaque>)))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var m)) (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))))
+ (unconstrain_array
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id m)
+      (decl_type
+       (Sized
+        (SMatrix AoS
+         ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+         ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable m) ()) UMatrix
+      ((pattern
+        (FunApp (CompilerInternal FnReadDeserializer)
+         (((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+          ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var m)) (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))))
+ (output_vars
+  ((m <opaque>
+    ((out_unconstrained_st
+      (SMatrix AoS
+       ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+       ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+     (out_constrained_st
+      (SMatrix AoS
+       ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+       ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+     (out_block Parameters) (out_trans Identity)))))
+ (prog_name matrix_multi_multi_model) (prog_path tests/fixtures/matrix_multi_multi.stan))

--- a/tests/fixtures/matrix_multi_multi_nested.stan
+++ b/tests/fixtures/matrix_multi_multi_nested.stan
@@ -1,0 +1,18 @@
+// O1 substitutes the gathered matrix argument into the UDF's scalar index,
+// leaving an empty outer Indexed node that carries the final scalar type.
+functions {
+  real selected_cell(matrix x) {
+    return x[1, 2];
+  }
+}
+data {
+  array[2] int row_indices;
+  array[2] int column_indices;
+}
+parameters {
+  matrix[3, 3] m;
+}
+model {
+  matrix[3, 3] computed = 2.0 * m;
+  target += selected_cell(computed[row_indices, column_indices]);
+}

--- a/tests/fixtures/matrix_multi_multi_nested.tmir.sexp
+++ b/tests/fixtures/matrix_multi_multi_nested.tmir.sexp
@@ -1,0 +1,434 @@
+((functions_block
+  (((fdrt (ReturnType UReal)) (fdname selected_cell) (fdsuffix FnPlain)
+    (fdargs ((AutoDiffable x UMatrix)))
+    (fdbody
+     (((pattern
+        (Block
+         (((pattern
+            (Return
+             (((pattern
+                (Indexed
+                 ((pattern (Var x))
+                  (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))
+                 ((Single
+                   ((pattern (Lit Int 1))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (Single
+                   ((pattern (Lit Int 2))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
+           (meta <opaque>)))))
+       (meta <opaque>))))
+    (fdloc <opaque>))))
+ (input_vars
+  ((row_indices <opaque>
+    (SArray SInt
+     ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+   (column_indices <opaque>
+    (SArray SInt
+     ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+ (prepare_data
+  (((pattern
+     (Decl (decl_adtype DataOnly) (decl_id row_indices)
+      (decl_type
+       (Sized
+        (SArray SInt
+         ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable row_indices) ()) (UArray UInt)
+      ((pattern
+        (FunApp (CompilerInternal FnReadData)
+         (((pattern (Lit Str row_indices))
+           (meta ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id column_indices)
+      (decl_type
+       (Sized
+        (SArray SInt
+         ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable column_indices) ()) (UArray UInt)
+      ((pattern
+        (FunApp (CompilerInternal FnReadData)
+         (((pattern (Lit Str column_indices))
+           (meta ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))))
+ (log_prob
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id m)
+      (decl_type
+       (Sized
+        (SMatrix AoS
+         ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+         ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity)
+             (dims
+              (((pattern (Lit Int 3))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+               ((pattern (Lit Int 3))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id computed)
+          (decl_type
+           (Sized
+            (SMatrix AoS
+             ((pattern (Lit Int 3))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+             ((pattern (Lit Int 3))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+          (initialize Uninit)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable computed) ()) UMatrix
+          ((pattern
+            (FunApp (StanLib Times__ FnPlain AoS)
+             (((pattern (Lit Real 2.0))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+              ((pattern (Var m))
+               (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable)))))))
+           (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>))
+       ((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id inline_selected_cell_return_sym3__)
+          (decl_type (Sized SReal)) (initialize Uninit)))
+        (meta <opaque>))
+       ((pattern
+         (Block
+          (((pattern
+             (Assignment ((LVariable inline_selected_cell_return_sym3__) ()) UReal
+              ((pattern
+                (Indexed
+                 ((pattern
+                   (Indexed
+                    ((pattern (Var computed))
+                     (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))
+                    ((Single
+                      ((pattern
+                        (Indexed
+                         ((pattern (Var row_indices))
+                          (meta
+                           ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly))))
+                         ((Single
+                           ((pattern (Lit Int 1))
+                            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                       (meta ((type_ UInt) (loc <opaque>) (adlevel AutoDiffable)))))
+                     (Single
+                      ((pattern
+                        (Indexed
+                         ((pattern (Var column_indices))
+                          (meta
+                           ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly))))
+                         ((Single
+                           ((pattern (Lit Int 2))
+                            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                       (meta ((type_ UInt) (loc <opaque>) (adlevel AutoDiffable))))))))
+                  (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))
+                 ()))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+            (meta <opaque>)))))
+        (meta <opaque>))
+       ((pattern
+         (TargetPE
+          ((pattern (Var inline_selected_cell_return_sym3__))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>)))))
+    (meta <opaque>))))
+ (reverse_mode_log_prob
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id m)
+      (decl_type
+       (Sized
+        (SMatrix SoA
+         ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+         ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity)
+             (dims
+              (((pattern (Lit Int 3))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+               ((pattern (Lit Int 3))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern SoA)))
+           ()))
+         (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id computed)
+          (decl_type
+           (Sized
+            (SMatrix SoA
+             ((pattern (Lit Int 3))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+             ((pattern (Lit Int 3))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+          (initialize Uninit)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable computed) ()) UMatrix
+          ((pattern
+            (FunApp (StanLib Times__ FnPlain SoA)
+             (((pattern (Lit Real 2.0))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+              ((pattern (Var m))
+               (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable)))))))
+           (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>))
+       ((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id inline_selected_cell_return_sym1__)
+          (decl_type (Sized SReal)) (initialize Uninit)))
+        (meta <opaque>))
+       ((pattern
+         (Block
+          (((pattern
+             (Assignment ((LVariable inline_selected_cell_return_sym1__) ()) UReal
+              ((pattern
+                (Indexed
+                 ((pattern
+                   (Indexed
+                    ((pattern (Var computed))
+                     (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))
+                    ((Single
+                      ((pattern
+                        (Indexed
+                         ((pattern (Var row_indices))
+                          (meta
+                           ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly))))
+                         ((Single
+                           ((pattern (Lit Int 1))
+                            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                       (meta ((type_ UInt) (loc <opaque>) (adlevel AutoDiffable)))))
+                     (Single
+                      ((pattern
+                        (Indexed
+                         ((pattern (Var column_indices))
+                          (meta
+                           ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly))))
+                         ((Single
+                           ((pattern (Lit Int 2))
+                            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                       (meta ((type_ UInt) (loc <opaque>) (adlevel AutoDiffable))))))))
+                  (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))
+                 ()))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+            (meta <opaque>)))))
+        (meta <opaque>))
+       ((pattern
+         (TargetPE
+          ((pattern (Var inline_selected_cell_return_sym1__))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>)))))
+    (meta <opaque>))))
+ (generate_quantities
+  (((pattern
+     (Decl (decl_adtype DataOnly) (decl_id m)
+      (decl_type
+       (Sized
+        (SMatrix AoS
+         ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+         ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity)
+             (dims
+              (((pattern (Lit Int 3))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+               ((pattern (Lit Int 3))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt ())
+        (var
+         ((pattern (Var m)) (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (IfElse
+      ((pattern
+        (FunApp (StanLib PNot__ FnPlain AoS)
+         (((pattern
+            (EOr
+             ((pattern (Var emit_transformed_parameters__))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+             ((pattern (Var emit_generated_quantities__))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+      ((pattern (Block (((pattern (Return ())) (meta <opaque>))))) (meta <opaque>)) ()))
+    (meta <opaque>))
+   ((pattern
+     (IfElse
+      ((pattern
+        (FunApp (StanLib PNot__ FnPlain AoS)
+         (((pattern (Var emit_generated_quantities__))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+      ((pattern (Block (((pattern (Return ())) (meta <opaque>))))) (meta <opaque>)) ()))
+    (meta <opaque>))))
+ (transform_inits
+  (((pattern
+     (Decl (decl_adtype DataOnly) (decl_id pos__) (decl_type (Sized SInt))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id m)
+      (decl_type
+       (Sized
+        (SMatrix AoS
+         ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+         ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id m_flat__)
+          (decl_type (Unsized (UArray UReal))) (initialize Uninit)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable m_flat__) ()) (UArray UReal)
+          ((pattern
+            (FunApp (CompilerInternal FnReadData)
+             (((pattern (Lit Str m))
+               (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable pos__) ()) UInt
+          ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar sym1__)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Lit Int 3))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (For (loopvar sym2__)
+                  (lower
+                   ((pattern (Lit Int 1))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (upper
+                   ((pattern (Lit Int 3))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (body
+                   ((pattern
+                     (Block
+                      (((pattern
+                         (Assignment
+                          ((LVariable m)
+                           ((Single
+                             ((pattern (Var sym2__))
+                              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                            (Single
+                             ((pattern (Var sym1__))
+                              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                          UMatrix
+                          ((pattern
+                            (Indexed
+                             ((pattern (Var m_flat__))
+                              (meta
+                               ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))
+                             ((Single
+                               ((pattern (Var pos__))
+                                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                           (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+                        (meta <opaque>))
+                       ((pattern
+                         (Assignment ((LVariable pos__) ()) UInt
+                          ((pattern
+                            (FunApp (StanLib Plus__ FnPlain AoS)
+                             (((pattern (Var pos__))
+                               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                              ((pattern (Lit Int 1))
+                               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                        (meta <opaque>)))))
+                    (meta <opaque>)))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var m)) (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))))
+ (unconstrain_array
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id m)
+      (decl_type
+       (Sized
+        (SMatrix AoS
+         ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+         ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable m) ()) UMatrix
+      ((pattern
+        (FunApp (CompilerInternal FnReadDeserializer)
+         (((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+          ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var m)) (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))))
+ (output_vars
+  ((m <opaque>
+    ((out_unconstrained_st
+      (SMatrix AoS
+       ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+       ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+     (out_constrained_st
+      (SMatrix AoS
+       ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+       ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+     (out_block Parameters) (out_trans Identity)))))
+ (prog_name matrix_multi_multi_nested_model)
+ (prog_path tests/fixtures/matrix_multi_multi_nested.stan))

--- a/tests/fixtures/pr236_island.stan
+++ b/tests/fixtures/pr236_island.stan
@@ -1,0 +1,19 @@
+functions {
+  real selected_cell(matrix x) {
+    return x[1, 2];
+  }
+}
+parameters {
+  matrix[3, 3] m;
+}
+model {
+  matrix[3, 3] x = 2 * m;
+  if (m[1, 1] > 0) {
+    target += sum(x[{3, 1}, {2, 3}]);
+    target += selected_cell(x[{3, 1}, {2, 3}]);
+    for (i in {2, 3})
+      target += i * m[1, 1];
+  } else {
+    target += m[1, 1];
+  }
+}

--- a/tests/fixtures/pr236_island.tmir.sexp
+++ b/tests/fixtures/pr236_island.tmir.sexp
@@ -1,0 +1,758 @@
+((functions_block
+  (((fdrt (ReturnType UReal)) (fdname selected_cell) (fdsuffix FnPlain)
+    (fdargs ((AutoDiffable x UMatrix)))
+    (fdbody
+     (((pattern
+        (Block
+         (((pattern
+            (Return
+             (((pattern
+                (Indexed
+                 ((pattern (Var x))
+                  (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))
+                 ((Single
+                   ((pattern (Lit Int 1))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (Single
+                   ((pattern (Lit Int 2))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
+           (meta <opaque>)))))
+       (meta <opaque>))))
+    (fdloc <opaque>))))
+ (input_vars ()) (prepare_data ())
+ (log_prob
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id m)
+      (decl_type
+       (Sized
+        (SMatrix AoS
+         ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+         ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity)
+             (dims
+              (((pattern (Lit Int 3))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+               ((pattern (Lit Int 3))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id x)
+          (decl_type
+           (Sized
+            (SMatrix AoS
+             ((pattern (Lit Int 3))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+             ((pattern (Lit Int 3))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+          (initialize Uninit)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable x) ()) UMatrix
+          ((pattern
+            (FunApp (StanLib Times__ FnPlain AoS)
+             (((pattern
+                (Promotion
+                 ((pattern (Lit Int 2))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                 UReal DataOnly))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+              ((pattern (Var m))
+               (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable)))))))
+           (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>))
+       ((pattern
+         (IfElse
+          ((pattern
+            (FunApp (StanLib Greater__ FnPlain AoS)
+             (((pattern
+                (Indexed
+                 ((pattern (Var m))
+                  (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))
+                 ((Single
+                   ((pattern (Lit Int 1))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (Single
+                   ((pattern (Lit Int 1))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+              ((pattern (Lit Int 0))
+               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel AutoDiffable))))
+          ((pattern
+            (Block
+             (((pattern
+                (TargetPE
+                 ((pattern
+                   (FunApp (StanLib sum FnPlain AoS)
+                    (((pattern
+                       (Indexed
+                        ((pattern (Var x))
+                         (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))
+                        ((MultiIndex
+                          ((pattern
+                            (FunApp (CompilerInternal FnMakeArray)
+                             (((pattern (Lit Int 3))
+                               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                              ((pattern (Lit Int 1))
+                               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                           (meta
+                            ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly)))))
+                         (MultiIndex
+                          ((pattern
+                            (FunApp (CompilerInternal FnMakeArray)
+                             (((pattern (Lit Int 2))
+                               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                              ((pattern (Lit Int 3))
+                               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                           (meta
+                            ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly))))))))
+                      (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable)))))))
+                  (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+               (meta <opaque>))
+              ((pattern
+                (Decl (decl_adtype AutoDiffable)
+                 (decl_id inline_selected_cell_return_sym3__) (decl_type (Sized SReal))
+                 (initialize Uninit)))
+               (meta <opaque>))
+              ((pattern
+                (Block
+                 (((pattern
+                    (Assignment ((LVariable inline_selected_cell_return_sym3__) ()) UReal
+                     ((pattern
+                       (Indexed
+                        ((pattern
+                          (Indexed
+                           ((pattern (Var x))
+                            (meta
+                             ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))
+                           ((Single
+                             ((pattern
+                               (Indexed
+                                ((pattern
+                                  (FunApp (CompilerInternal FnMakeArray)
+                                   (((pattern (Lit Int 3))
+                                     (meta
+                                      ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                                    ((pattern (Lit Int 1))
+                                     (meta
+                                      ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                                 (meta
+                                  ((type_ (UArray UInt)) (loc <opaque>)
+                                   (adlevel DataOnly))))
+                                ((Single
+                                  ((pattern (Lit Int 1))
+                                   (meta
+                                    ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                              (meta ((type_ UInt) (loc <opaque>) (adlevel AutoDiffable)))))
+                            (Single
+                             ((pattern
+                               (Indexed
+                                ((pattern
+                                  (FunApp (CompilerInternal FnMakeArray)
+                                   (((pattern (Lit Int 2))
+                                     (meta
+                                      ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                                    ((pattern (Lit Int 3))
+                                     (meta
+                                      ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                                 (meta
+                                  ((type_ (UArray UInt)) (loc <opaque>)
+                                   (adlevel DataOnly))))
+                                ((Single
+                                  ((pattern (Lit Int 2))
+                                   (meta
+                                    ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                              (meta ((type_ UInt) (loc <opaque>) (adlevel AutoDiffable))))))))
+                         (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))
+                        ()))
+                      (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+                   (meta <opaque>)))))
+               (meta <opaque>))
+              ((pattern
+                (TargetPE
+                 ((pattern (Var inline_selected_cell_return_sym3__))
+                  (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+               (meta <opaque>))
+              ((pattern
+                (Block
+                 (((pattern
+                    (Decl (decl_adtype DataOnly) (decl_id sym1__)
+                     (decl_type (Unsized (UArray UInt))) (initialize Default)))
+                   (meta <opaque>))
+                  ((pattern
+                    (Assignment ((LVariable sym1__) ()) (UArray UInt)
+                     ((pattern
+                       (FunApp (CompilerInternal FnMakeArray)
+                        (((pattern (Lit Int 2))
+                          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                         ((pattern (Lit Int 3))
+                          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                      (meta ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly))))))
+                   (meta <opaque>))
+                  ((pattern
+                    (For (loopvar sym3__)
+                     (lower
+                      ((pattern (Lit Int 1))
+                       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                     (upper
+                      ((pattern
+                        (FunApp (CompilerInternal FnLength)
+                         (((pattern (Var sym1__))
+                           (meta
+                            ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly)))))))
+                       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                     (body
+                      ((pattern
+                        (Block
+                         (((pattern
+                            (Block
+                             (((pattern
+                                (Decl (decl_adtype DataOnly) (decl_id i)
+                                 (decl_type (Unsized UInt)) (initialize Uninit)))
+                               (meta <opaque>))
+                              ((pattern
+                                (Assignment ((LVariable i) ()) UInt
+                                 ((pattern
+                                   (Indexed
+                                    ((pattern (Var sym1__))
+                                     (meta
+                                      ((type_ (UArray UInt)) (loc <opaque>)
+                                       (adlevel DataOnly))))
+                                    ((Single
+                                      ((pattern (Var sym3__))
+                                       (meta
+                                        ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                               (meta <opaque>))
+                              ((pattern
+                                (TargetPE
+                                 ((pattern
+                                   (FunApp (StanLib Times__ FnPlain AoS)
+                                    (((pattern
+                                       (Promotion
+                                        ((pattern (Var i))
+                                         (meta
+                                          ((type_ UInt) (loc <opaque>)
+                                           (adlevel DataOnly))))
+                                        UReal DataOnly))
+                                      (meta
+                                       ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+                                     ((pattern
+                                       (Indexed
+                                        ((pattern (Var m))
+                                         (meta
+                                          ((type_ UMatrix) (loc <opaque>)
+                                           (adlevel AutoDiffable))))
+                                        ((Single
+                                          ((pattern (Lit Int 1))
+                                           (meta
+                                            ((type_ UInt) (loc <opaque>)
+                                             (adlevel DataOnly)))))
+                                         (Single
+                                          ((pattern (Lit Int 1))
+                                           (meta
+                                            ((type_ UInt) (loc <opaque>)
+                                             (adlevel DataOnly))))))))
+                                      (meta
+                                       ((type_ UReal) (loc <opaque>)
+                                        (adlevel AutoDiffable)))))))
+                                  (meta
+                                   ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+                               (meta <opaque>)))))
+                           (meta <opaque>)))))
+                       (meta <opaque>)))))
+                   (meta <opaque>)))))
+               (meta <opaque>)))))
+           (meta <opaque>))
+          (((pattern
+             (Block
+              (((pattern
+                 (TargetPE
+                  ((pattern
+                    (Indexed
+                     ((pattern (Var m))
+                      (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))
+                     ((Single
+                       ((pattern (Lit Int 1))
+                        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                      (Single
+                       ((pattern (Lit Int 1))
+                        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))))
+ (reverse_mode_log_prob
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id m)
+      (decl_type
+       (Sized
+        (SMatrix AoS
+         ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+         ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity)
+             (dims
+              (((pattern (Lit Int 3))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+               ((pattern (Lit Int 3))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id x)
+          (decl_type
+           (Sized
+            (SMatrix AoS
+             ((pattern (Lit Int 3))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+             ((pattern (Lit Int 3))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+          (initialize Uninit)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable x) ()) UMatrix
+          ((pattern
+            (FunApp (StanLib Times__ FnPlain AoS)
+             (((pattern
+                (Promotion
+                 ((pattern (Lit Int 2))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                 UReal DataOnly))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+              ((pattern (Var m))
+               (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable)))))))
+           (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>))
+       ((pattern
+         (IfElse
+          ((pattern
+            (FunApp (StanLib Greater__ FnPlain SoA)
+             (((pattern
+                (Indexed
+                 ((pattern (Var m))
+                  (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))
+                 ((Single
+                   ((pattern (Lit Int 1))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (Single
+                   ((pattern (Lit Int 1))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+              ((pattern (Lit Int 0))
+               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel AutoDiffable))))
+          ((pattern
+            (Block
+             (((pattern
+                (TargetPE
+                 ((pattern
+                   (FunApp (StanLib sum FnPlain AoS)
+                    (((pattern
+                       (Indexed
+                        ((pattern (Var x))
+                         (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))
+                        ((MultiIndex
+                          ((pattern
+                            (FunApp (CompilerInternal FnMakeArray)
+                             (((pattern (Lit Int 3))
+                               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                              ((pattern (Lit Int 1))
+                               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                           (meta
+                            ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly)))))
+                         (MultiIndex
+                          ((pattern
+                            (FunApp (CompilerInternal FnMakeArray)
+                             (((pattern (Lit Int 2))
+                               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                              ((pattern (Lit Int 3))
+                               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                           (meta
+                            ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly))))))))
+                      (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable)))))))
+                  (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+               (meta <opaque>))
+              ((pattern
+                (Decl (decl_adtype AutoDiffable)
+                 (decl_id inline_selected_cell_return_sym1__) (decl_type (Sized SReal))
+                 (initialize Uninit)))
+               (meta <opaque>))
+              ((pattern
+                (Block
+                 (((pattern
+                    (Assignment ((LVariable inline_selected_cell_return_sym1__) ()) UReal
+                     ((pattern
+                       (Indexed
+                        ((pattern
+                          (Indexed
+                           ((pattern (Var x))
+                            (meta
+                             ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))
+                           ((Single
+                             ((pattern
+                               (Indexed
+                                ((pattern
+                                  (FunApp (CompilerInternal FnMakeArray)
+                                   (((pattern (Lit Int 3))
+                                     (meta
+                                      ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                                    ((pattern (Lit Int 1))
+                                     (meta
+                                      ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                                 (meta
+                                  ((type_ (UArray UInt)) (loc <opaque>)
+                                   (adlevel DataOnly))))
+                                ((Single
+                                  ((pattern (Lit Int 1))
+                                   (meta
+                                    ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                              (meta ((type_ UInt) (loc <opaque>) (adlevel AutoDiffable)))))
+                            (Single
+                             ((pattern
+                               (Indexed
+                                ((pattern
+                                  (FunApp (CompilerInternal FnMakeArray)
+                                   (((pattern (Lit Int 2))
+                                     (meta
+                                      ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                                    ((pattern (Lit Int 3))
+                                     (meta
+                                      ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                                 (meta
+                                  ((type_ (UArray UInt)) (loc <opaque>)
+                                   (adlevel DataOnly))))
+                                ((Single
+                                  ((pattern (Lit Int 2))
+                                   (meta
+                                    ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                              (meta ((type_ UInt) (loc <opaque>) (adlevel AutoDiffable))))))))
+                         (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))
+                        ()))
+                      (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+                   (meta <opaque>)))))
+               (meta <opaque>))
+              ((pattern
+                (TargetPE
+                 ((pattern (Var inline_selected_cell_return_sym1__))
+                  (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+               (meta <opaque>))
+              ((pattern
+                (Block
+                 (((pattern
+                    (Decl (decl_adtype DataOnly) (decl_id sym1__)
+                     (decl_type (Unsized (UArray UInt))) (initialize Default)))
+                   (meta <opaque>))
+                  ((pattern
+                    (Assignment ((LVariable sym1__) ()) (UArray UInt)
+                     ((pattern
+                       (FunApp (CompilerInternal FnMakeArray)
+                        (((pattern (Lit Int 2))
+                          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                         ((pattern (Lit Int 3))
+                          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                      (meta ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly))))))
+                   (meta <opaque>))
+                  ((pattern
+                    (For (loopvar sym3__)
+                     (lower
+                      ((pattern (Lit Int 1))
+                       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                     (upper
+                      ((pattern
+                        (FunApp (CompilerInternal FnLength)
+                         (((pattern (Var sym1__))
+                           (meta
+                            ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly)))))))
+                       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                     (body
+                      ((pattern
+                        (Block
+                         (((pattern
+                            (Block
+                             (((pattern
+                                (Decl (decl_adtype DataOnly) (decl_id i)
+                                 (decl_type (Unsized UInt)) (initialize Uninit)))
+                               (meta <opaque>))
+                              ((pattern
+                                (Assignment ((LVariable i) ()) UInt
+                                 ((pattern
+                                   (Indexed
+                                    ((pattern (Var sym1__))
+                                     (meta
+                                      ((type_ (UArray UInt)) (loc <opaque>)
+                                       (adlevel DataOnly))))
+                                    ((Single
+                                      ((pattern (Var sym3__))
+                                       (meta
+                                        ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                               (meta <opaque>))
+                              ((pattern
+                                (TargetPE
+                                 ((pattern
+                                   (FunApp (StanLib Times__ FnPlain SoA)
+                                    (((pattern
+                                       (Promotion
+                                        ((pattern (Var i))
+                                         (meta
+                                          ((type_ UInt) (loc <opaque>)
+                                           (adlevel DataOnly))))
+                                        UReal DataOnly))
+                                      (meta
+                                       ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+                                     ((pattern
+                                       (Indexed
+                                        ((pattern (Var m))
+                                         (meta
+                                          ((type_ UMatrix) (loc <opaque>)
+                                           (adlevel AutoDiffable))))
+                                        ((Single
+                                          ((pattern (Lit Int 1))
+                                           (meta
+                                            ((type_ UInt) (loc <opaque>)
+                                             (adlevel DataOnly)))))
+                                         (Single
+                                          ((pattern (Lit Int 1))
+                                           (meta
+                                            ((type_ UInt) (loc <opaque>)
+                                             (adlevel DataOnly))))))))
+                                      (meta
+                                       ((type_ UReal) (loc <opaque>)
+                                        (adlevel AutoDiffable)))))))
+                                  (meta
+                                   ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+                               (meta <opaque>)))))
+                           (meta <opaque>)))))
+                       (meta <opaque>)))))
+                   (meta <opaque>)))))
+               (meta <opaque>)))))
+           (meta <opaque>))
+          (((pattern
+             (Block
+              (((pattern
+                 (TargetPE
+                  ((pattern
+                    (Indexed
+                     ((pattern (Var m))
+                      (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))
+                     ((Single
+                       ((pattern (Lit Int 1))
+                        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                      (Single
+                       ((pattern (Lit Int 1))
+                        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))))
+ (generate_quantities
+  (((pattern
+     (Decl (decl_adtype DataOnly) (decl_id m)
+      (decl_type
+       (Sized
+        (SMatrix AoS
+         ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+         ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity)
+             (dims
+              (((pattern (Lit Int 3))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+               ((pattern (Lit Int 3))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt ())
+        (var
+         ((pattern (Var m)) (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (IfElse
+      ((pattern
+        (FunApp (StanLib PNot__ FnPlain AoS)
+         (((pattern
+            (EOr
+             ((pattern (Var emit_transformed_parameters__))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+             ((pattern (Var emit_generated_quantities__))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+      ((pattern (Block (((pattern (Return ())) (meta <opaque>))))) (meta <opaque>)) ()))
+    (meta <opaque>))
+   ((pattern
+     (IfElse
+      ((pattern
+        (FunApp (StanLib PNot__ FnPlain AoS)
+         (((pattern (Var emit_generated_quantities__))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+      ((pattern (Block (((pattern (Return ())) (meta <opaque>))))) (meta <opaque>)) ()))
+    (meta <opaque>))))
+ (transform_inits
+  (((pattern
+     (Decl (decl_adtype DataOnly) (decl_id pos__) (decl_type (Sized SInt))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id m)
+      (decl_type
+       (Sized
+        (SMatrix AoS
+         ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+         ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id m_flat__)
+          (decl_type (Unsized (UArray UReal))) (initialize Uninit)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable m_flat__) ()) (UArray UReal)
+          ((pattern
+            (FunApp (CompilerInternal FnReadData)
+             (((pattern (Lit Str m))
+               (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable pos__) ()) UInt
+          ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar sym1__)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Lit Int 3))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (For (loopvar sym2__)
+                  (lower
+                   ((pattern (Lit Int 1))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (upper
+                   ((pattern (Lit Int 3))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (body
+                   ((pattern
+                     (Block
+                      (((pattern
+                         (Assignment
+                          ((LVariable m)
+                           ((Single
+                             ((pattern (Var sym2__))
+                              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                            (Single
+                             ((pattern (Var sym1__))
+                              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                          UMatrix
+                          ((pattern
+                            (Indexed
+                             ((pattern (Var m_flat__))
+                              (meta
+                               ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))
+                             ((Single
+                               ((pattern (Var pos__))
+                                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                           (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+                        (meta <opaque>))
+                       ((pattern
+                         (Assignment ((LVariable pos__) ()) UInt
+                          ((pattern
+                            (FunApp (StanLib Plus__ FnPlain AoS)
+                             (((pattern (Var pos__))
+                               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                              ((pattern (Lit Int 1))
+                               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                        (meta <opaque>)))))
+                    (meta <opaque>)))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var m)) (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))))
+ (unconstrain_array
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id m)
+      (decl_type
+       (Sized
+        (SMatrix AoS
+         ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+         ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable m) ()) UMatrix
+      ((pattern
+        (FunApp (CompilerInternal FnReadDeserializer)
+         (((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+          ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var m)) (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))))
+ (output_vars
+  ((m <opaque>
+    ((out_unconstrained_st
+      (SMatrix AoS
+       ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+       ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+     (out_constrained_st
+      (SMatrix AoS
+       ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+       ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+     (out_block Parameters) (out_trans Identity)))))
+ (prog_name pr236_island_model) (prog_path tests/fixtures/pr236_island.stan))

--- a/tests/fixtures/pr236_island_udf.stan
+++ b/tests/fixtures/pr236_island_udf.stan
@@ -1,0 +1,12 @@
+functions {
+  real pick(matrix x, array[] int rows, array[] int columns) {
+    return sum(x[rows, columns]);
+  }
+}
+parameters {
+  matrix[3, 3] m;
+}
+model {
+  if (m[1, 1] > 0)
+    target += pick(m, {3, 1}, {2, 3});
+}

--- a/tests/fixtures/pr236_island_udf.tmir.sexp
+++ b/tests/fixtures/pr236_island_udf.tmir.sexp
@@ -1,0 +1,363 @@
+((functions_block
+  (((fdrt (ReturnType UReal)) (fdname pick) (fdsuffix FnPlain)
+    (fdargs
+     ((AutoDiffable x UMatrix) (AutoDiffable rows (UArray UInt))
+      (AutoDiffable columns (UArray UInt))))
+    (fdbody
+     (((pattern
+        (Block
+         (((pattern
+            (Return
+             (((pattern
+                (FunApp (StanLib sum FnPlain AoS)
+                 (((pattern
+                    (Indexed
+                     ((pattern (Var x))
+                      (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))
+                     ((MultiIndex
+                       ((pattern (Var rows))
+                        (meta ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly)))))
+                      (MultiIndex
+                       ((pattern (Var columns))
+                        (meta ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly))))))))
+                   (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable)))))))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
+           (meta <opaque>)))))
+       (meta <opaque>))))
+    (fdloc <opaque>))))
+ (input_vars ()) (prepare_data ())
+ (log_prob
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id m)
+      (decl_type
+       (Sized
+        (SMatrix AoS
+         ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+         ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity)
+             (dims
+              (((pattern (Lit Int 3))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+               ((pattern (Lit Int 3))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (IfElse
+          ((pattern
+            (FunApp (StanLib Greater__ FnPlain AoS)
+             (((pattern
+                (Indexed
+                 ((pattern (Var m))
+                  (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))
+                 ((Single
+                   ((pattern (Lit Int 1))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (Single
+                   ((pattern (Lit Int 1))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+              ((pattern (Lit Int 0))
+               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel AutoDiffable))))
+          ((pattern
+            (Block
+             (((pattern
+                (TargetPE
+                 ((pattern
+                   (FunApp (UserDefined pick FnPlain)
+                    (((pattern (Var m))
+                      (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))
+                     ((pattern
+                       (FunApp (CompilerInternal FnMakeArray)
+                        (((pattern (Lit Int 3))
+                          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                         ((pattern (Lit Int 1))
+                          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                      (meta ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly))))
+                     ((pattern
+                       (FunApp (CompilerInternal FnMakeArray)
+                        (((pattern (Lit Int 2))
+                          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                         ((pattern (Lit Int 3))
+                          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                      (meta ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly)))))))
+                  (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+               (meta <opaque>)))))
+           (meta <opaque>))
+          ()))
+        (meta <opaque>)))))
+    (meta <opaque>))))
+ (reverse_mode_log_prob
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id m)
+      (decl_type
+       (Sized
+        (SMatrix AoS
+         ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+         ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity)
+             (dims
+              (((pattern (Lit Int 3))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+               ((pattern (Lit Int 3))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (IfElse
+          ((pattern
+            (FunApp (StanLib Greater__ FnPlain AoS)
+             (((pattern
+                (Indexed
+                 ((pattern (Var m))
+                  (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))
+                 ((Single
+                   ((pattern (Lit Int 1))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (Single
+                   ((pattern (Lit Int 1))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+              ((pattern (Lit Int 0))
+               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel AutoDiffable))))
+          ((pattern
+            (Block
+             (((pattern
+                (TargetPE
+                 ((pattern
+                   (FunApp (UserDefined pick FnPlain)
+                    (((pattern (Var m))
+                      (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))
+                     ((pattern
+                       (FunApp (CompilerInternal FnMakeArray)
+                        (((pattern (Lit Int 3))
+                          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                         ((pattern (Lit Int 1))
+                          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                      (meta ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly))))
+                     ((pattern
+                       (FunApp (CompilerInternal FnMakeArray)
+                        (((pattern (Lit Int 2))
+                          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                         ((pattern (Lit Int 3))
+                          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                      (meta ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly)))))))
+                  (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+               (meta <opaque>)))))
+           (meta <opaque>))
+          ()))
+        (meta <opaque>)))))
+    (meta <opaque>))))
+ (generate_quantities
+  (((pattern
+     (Decl (decl_adtype DataOnly) (decl_id m)
+      (decl_type
+       (Sized
+        (SMatrix AoS
+         ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+         ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity)
+             (dims
+              (((pattern (Lit Int 3))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+               ((pattern (Lit Int 3))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt ())
+        (var
+         ((pattern (Var m)) (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (IfElse
+      ((pattern
+        (FunApp (StanLib PNot__ FnPlain AoS)
+         (((pattern
+            (EOr
+             ((pattern (Var emit_transformed_parameters__))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+             ((pattern (Var emit_generated_quantities__))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+      ((pattern (Block (((pattern (Return ())) (meta <opaque>))))) (meta <opaque>)) ()))
+    (meta <opaque>))
+   ((pattern
+     (IfElse
+      ((pattern
+        (FunApp (StanLib PNot__ FnPlain AoS)
+         (((pattern (Var emit_generated_quantities__))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+      ((pattern (Block (((pattern (Return ())) (meta <opaque>))))) (meta <opaque>)) ()))
+    (meta <opaque>))))
+ (transform_inits
+  (((pattern
+     (Decl (decl_adtype DataOnly) (decl_id pos__) (decl_type (Sized SInt))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable pos__) ()) UInt
+      ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id m)
+      (decl_type
+       (Sized
+        (SMatrix AoS
+         ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+         ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id m_flat__)
+          (decl_type (Unsized (UArray UReal))) (initialize Uninit)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable m_flat__) ()) (UArray UReal)
+          ((pattern
+            (FunApp (CompilerInternal FnReadData)
+             (((pattern (Lit Str m))
+               (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable pos__) ()) UInt
+          ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar sym1__)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Lit Int 3))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (For (loopvar sym2__)
+                  (lower
+                   ((pattern (Lit Int 1))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (upper
+                   ((pattern (Lit Int 3))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (body
+                   ((pattern
+                     (Block
+                      (((pattern
+                         (Assignment
+                          ((LVariable m)
+                           ((Single
+                             ((pattern (Var sym2__))
+                              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                            (Single
+                             ((pattern (Var sym1__))
+                              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                          UMatrix
+                          ((pattern
+                            (Indexed
+                             ((pattern (Var m_flat__))
+                              (meta
+                               ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))
+                             ((Single
+                               ((pattern (Var pos__))
+                                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                           (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+                        (meta <opaque>))
+                       ((pattern
+                         (Assignment ((LVariable pos__) ()) UInt
+                          ((pattern
+                            (FunApp (StanLib Plus__ FnPlain AoS)
+                             (((pattern (Var pos__))
+                               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                              ((pattern (Lit Int 1))
+                               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                        (meta <opaque>)))))
+                    (meta <opaque>)))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var m)) (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))))
+ (unconstrain_array
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id m)
+      (decl_type
+       (Sized
+        (SMatrix AoS
+         ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+         ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable m) ()) UMatrix
+      ((pattern
+        (FunApp (CompilerInternal FnReadDeserializer)
+         (((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+          ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var m)) (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))))
+ (output_vars
+  ((m <opaque>
+    ((out_unconstrained_st
+      (SMatrix AoS
+       ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+       ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+     (out_constrained_st
+      (SMatrix AoS
+       ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+       ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+     (out_block Parameters) (out_trans Identity)))))
+ (prog_name pr236_island_udf_model) (prog_path tests/fixtures/pr236_island_udf.stan))

--- a/tests/fixtures/pr236_unsized_island.stan
+++ b/tests/fixtures/pr236_unsized_island.stan
@@ -1,0 +1,14 @@
+data {
+  array[1] int d;
+}
+parameters {
+  real theta;
+}
+model {
+  if (theta > 0) {
+    for (i in append_array({1}, d))
+      target += i * theta;
+    for (x in {[1.0, 2.0], [3.0, 4.0]})
+      target += sum(x) * theta;
+  }
+}

--- a/tests/fixtures/pr236_unsized_island.tmir.sexp
+++ b/tests/fixtures/pr236_unsized_island.tmir.sexp
@@ -1,0 +1,510 @@
+((functions_block ())
+ (input_vars
+  ((d <opaque>
+    (SArray SInt
+     ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+ (prepare_data
+  (((pattern
+     (Decl (decl_adtype DataOnly) (decl_id d)
+      (decl_type
+       (Sized
+        (SArray SInt
+         ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable d) ()) (UArray UInt)
+      ((pattern
+        (FunApp (CompilerInternal FnReadData)
+         (((pattern (Lit Str d))
+           (meta ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))))
+ (log_prob
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id theta) (decl_type (Sized SReal))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity) (dims ()) (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (IfElse
+          ((pattern
+            (FunApp (StanLib Greater__ FnPlain AoS)
+             (((pattern (Var theta))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+              ((pattern (Lit Int 0))
+               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel AutoDiffable))))
+          ((pattern
+            (Block
+             (((pattern
+                (Block
+                 (((pattern
+                    (Decl (decl_adtype DataOnly) (decl_id sym1__)
+                     (decl_type (Unsized (UArray UInt))) (initialize Default)))
+                   (meta <opaque>))
+                  ((pattern
+                    (Assignment ((LVariable sym1__) ()) (UArray UInt)
+                     ((pattern
+                       (FunApp (StanLib append_array FnPlain AoS)
+                        (((pattern
+                           (FunApp (CompilerInternal FnMakeArray)
+                            (((pattern (Lit Int 1))
+                              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                          (meta
+                           ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly))))
+                         ((pattern (Var d))
+                          (meta
+                           ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly)))))))
+                      (meta ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly))))))
+                   (meta <opaque>))
+                  ((pattern
+                    (For (loopvar sym3__)
+                     (lower
+                      ((pattern (Lit Int 1))
+                       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                     (upper
+                      ((pattern
+                        (FunApp (CompilerInternal FnLength)
+                         (((pattern (Var sym1__))
+                           (meta
+                            ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly)))))))
+                       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                     (body
+                      ((pattern
+                        (Block
+                         (((pattern
+                            (Block
+                             (((pattern
+                                (Decl (decl_adtype DataOnly) (decl_id i)
+                                 (decl_type (Unsized UInt)) (initialize Uninit)))
+                               (meta <opaque>))
+                              ((pattern
+                                (Assignment ((LVariable i) ()) UInt
+                                 ((pattern
+                                   (Indexed
+                                    ((pattern (Var sym1__))
+                                     (meta
+                                      ((type_ (UArray UInt)) (loc <opaque>)
+                                       (adlevel DataOnly))))
+                                    ((Single
+                                      ((pattern (Var sym3__))
+                                       (meta
+                                        ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                               (meta <opaque>))
+                              ((pattern
+                                (TargetPE
+                                 ((pattern
+                                   (FunApp (StanLib Times__ FnPlain AoS)
+                                    (((pattern
+                                       (Promotion
+                                        ((pattern (Var i))
+                                         (meta
+                                          ((type_ UInt) (loc <opaque>)
+                                           (adlevel DataOnly))))
+                                        UReal DataOnly))
+                                      (meta
+                                       ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+                                     ((pattern (Var theta))
+                                      (meta
+                                       ((type_ UReal) (loc <opaque>)
+                                        (adlevel AutoDiffable)))))))
+                                  (meta
+                                   ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+                               (meta <opaque>)))))
+                           (meta <opaque>)))))
+                       (meta <opaque>)))))
+                   (meta <opaque>)))))
+               (meta <opaque>))
+              ((pattern
+                (Block
+                 (((pattern
+                    (Decl (decl_adtype DataOnly) (decl_id sym1__)
+                     (decl_type (Unsized (UArray URowVector))) (initialize Default)))
+                   (meta <opaque>))
+                  ((pattern
+                    (Assignment ((LVariable sym1__) ()) (UArray URowVector)
+                     ((pattern
+                       (FunApp (CompilerInternal FnMakeArray)
+                        (((pattern
+                           (FunApp (CompilerInternal FnMakeRowVec)
+                            (((pattern (Lit Real 1.0))
+                              (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+                             ((pattern (Lit Real 2.0))
+                              (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+                          (meta ((type_ URowVector) (loc <opaque>) (adlevel DataOnly))))
+                         ((pattern
+                           (FunApp (CompilerInternal FnMakeRowVec)
+                            (((pattern (Lit Real 3.0))
+                              (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+                             ((pattern (Lit Real 4.0))
+                              (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+                          (meta ((type_ URowVector) (loc <opaque>) (adlevel DataOnly)))))))
+                      (meta
+                       ((type_ (UArray URowVector)) (loc <opaque>) (adlevel DataOnly))))))
+                   (meta <opaque>))
+                  ((pattern
+                    (For (loopvar sym3__)
+                     (lower
+                      ((pattern (Lit Int 1))
+                       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                     (upper
+                      ((pattern
+                        (FunApp (CompilerInternal FnLength)
+                         (((pattern (Var sym1__))
+                           (meta
+                            ((type_ (UArray URowVector)) (loc <opaque>)
+                             (adlevel DataOnly)))))))
+                       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                     (body
+                      ((pattern
+                        (Block
+                         (((pattern
+                            (Block
+                             (((pattern
+                                (Decl (decl_adtype DataOnly) (decl_id x)
+                                 (decl_type (Unsized URowVector)) (initialize Uninit)))
+                               (meta <opaque>))
+                              ((pattern
+                                (Assignment ((LVariable x) ()) URowVector
+                                 ((pattern
+                                   (Indexed
+                                    ((pattern (Var sym1__))
+                                     (meta
+                                      ((type_ (UArray URowVector)) (loc <opaque>)
+                                       (adlevel DataOnly))))
+                                    ((Single
+                                      ((pattern (Var sym3__))
+                                       (meta
+                                        ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                                  (meta
+                                   ((type_ URowVector) (loc <opaque>) (adlevel DataOnly))))))
+                               (meta <opaque>))
+                              ((pattern
+                                (TargetPE
+                                 ((pattern
+                                   (FunApp (StanLib Times__ FnPlain AoS)
+                                    (((pattern
+                                       (FunApp (StanLib sum FnPlain AoS)
+                                        (((pattern (Var x))
+                                          (meta
+                                           ((type_ URowVector) (loc <opaque>)
+                                            (adlevel AutoDiffable)))))))
+                                      (meta
+                                       ((type_ UReal) (loc <opaque>)
+                                        (adlevel AutoDiffable))))
+                                     ((pattern (Var theta))
+                                      (meta
+                                       ((type_ UReal) (loc <opaque>)
+                                        (adlevel AutoDiffable)))))))
+                                  (meta
+                                   ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+                               (meta <opaque>)))))
+                           (meta <opaque>)))))
+                       (meta <opaque>)))))
+                   (meta <opaque>)))))
+               (meta <opaque>)))))
+           (meta <opaque>))
+          ()))
+        (meta <opaque>)))))
+    (meta <opaque>))))
+ (reverse_mode_log_prob
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id theta) (decl_type (Sized SReal))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity) (dims ()) (mem_pattern SoA)))
+           ()))
+         (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (IfElse
+          ((pattern
+            (FunApp (StanLib Greater__ FnPlain SoA)
+             (((pattern (Var theta))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+              ((pattern (Lit Int 0))
+               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel AutoDiffable))))
+          ((pattern
+            (Block
+             (((pattern
+                (Block
+                 (((pattern
+                    (Decl (decl_adtype DataOnly) (decl_id sym1__)
+                     (decl_type (Unsized (UArray UInt))) (initialize Default)))
+                   (meta <opaque>))
+                  ((pattern
+                    (Assignment ((LVariable sym1__) ()) (UArray UInt)
+                     ((pattern
+                       (FunApp (StanLib append_array FnPlain AoS)
+                        (((pattern
+                           (FunApp (CompilerInternal FnMakeArray)
+                            (((pattern (Lit Int 1))
+                              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                          (meta
+                           ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly))))
+                         ((pattern (Var d))
+                          (meta
+                           ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly)))))))
+                      (meta ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly))))))
+                   (meta <opaque>))
+                  ((pattern
+                    (For (loopvar sym3__)
+                     (lower
+                      ((pattern (Lit Int 1))
+                       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                     (upper
+                      ((pattern
+                        (FunApp (CompilerInternal FnLength)
+                         (((pattern (Var sym1__))
+                           (meta
+                            ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly)))))))
+                       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                     (body
+                      ((pattern
+                        (Block
+                         (((pattern
+                            (Block
+                             (((pattern
+                                (Decl (decl_adtype DataOnly) (decl_id i)
+                                 (decl_type (Unsized UInt)) (initialize Uninit)))
+                               (meta <opaque>))
+                              ((pattern
+                                (Assignment ((LVariable i) ()) UInt
+                                 ((pattern
+                                   (Indexed
+                                    ((pattern (Var sym1__))
+                                     (meta
+                                      ((type_ (UArray UInt)) (loc <opaque>)
+                                       (adlevel DataOnly))))
+                                    ((Single
+                                      ((pattern (Var sym3__))
+                                       (meta
+                                        ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                               (meta <opaque>))
+                              ((pattern
+                                (TargetPE
+                                 ((pattern
+                                   (FunApp (StanLib Times__ FnPlain SoA)
+                                    (((pattern
+                                       (Promotion
+                                        ((pattern (Var i))
+                                         (meta
+                                          ((type_ UInt) (loc <opaque>)
+                                           (adlevel DataOnly))))
+                                        UReal DataOnly))
+                                      (meta
+                                       ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+                                     ((pattern (Var theta))
+                                      (meta
+                                       ((type_ UReal) (loc <opaque>)
+                                        (adlevel AutoDiffable)))))))
+                                  (meta
+                                   ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+                               (meta <opaque>)))))
+                           (meta <opaque>)))))
+                       (meta <opaque>)))))
+                   (meta <opaque>)))))
+               (meta <opaque>))
+              ((pattern
+                (Block
+                 (((pattern
+                    (Decl (decl_adtype DataOnly) (decl_id sym1__)
+                     (decl_type (Unsized (UArray URowVector))) (initialize Default)))
+                   (meta <opaque>))
+                  ((pattern
+                    (Assignment ((LVariable sym1__) ()) (UArray URowVector)
+                     ((pattern
+                       (FunApp (CompilerInternal FnMakeArray)
+                        (((pattern
+                           (FunApp (CompilerInternal FnMakeRowVec)
+                            (((pattern (Lit Real 1.0))
+                              (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+                             ((pattern (Lit Real 2.0))
+                              (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+                          (meta ((type_ URowVector) (loc <opaque>) (adlevel DataOnly))))
+                         ((pattern
+                           (FunApp (CompilerInternal FnMakeRowVec)
+                            (((pattern (Lit Real 3.0))
+                              (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+                             ((pattern (Lit Real 4.0))
+                              (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+                          (meta ((type_ URowVector) (loc <opaque>) (adlevel DataOnly)))))))
+                      (meta
+                       ((type_ (UArray URowVector)) (loc <opaque>) (adlevel DataOnly))))))
+                   (meta <opaque>))
+                  ((pattern
+                    (For (loopvar sym3__)
+                     (lower
+                      ((pattern (Lit Int 1))
+                       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                     (upper
+                      ((pattern
+                        (FunApp (CompilerInternal FnLength)
+                         (((pattern (Var sym1__))
+                           (meta
+                            ((type_ (UArray URowVector)) (loc <opaque>)
+                             (adlevel DataOnly)))))))
+                       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                     (body
+                      ((pattern
+                        (Block
+                         (((pattern
+                            (Block
+                             (((pattern
+                                (Decl (decl_adtype DataOnly) (decl_id x)
+                                 (decl_type (Unsized URowVector)) (initialize Uninit)))
+                               (meta <opaque>))
+                              ((pattern
+                                (Assignment ((LVariable x) ()) URowVector
+                                 ((pattern
+                                   (Indexed
+                                    ((pattern (Var sym1__))
+                                     (meta
+                                      ((type_ (UArray URowVector)) (loc <opaque>)
+                                       (adlevel DataOnly))))
+                                    ((Single
+                                      ((pattern (Var sym3__))
+                                       (meta
+                                        ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                                  (meta
+                                   ((type_ URowVector) (loc <opaque>) (adlevel DataOnly))))))
+                               (meta <opaque>))
+                              ((pattern
+                                (TargetPE
+                                 ((pattern
+                                   (FunApp (StanLib Times__ FnPlain SoA)
+                                    (((pattern
+                                       (FunApp (StanLib sum FnPlain SoA)
+                                        (((pattern (Var x))
+                                          (meta
+                                           ((type_ URowVector) (loc <opaque>)
+                                            (adlevel AutoDiffable)))))))
+                                      (meta
+                                       ((type_ UReal) (loc <opaque>)
+                                        (adlevel AutoDiffable))))
+                                     ((pattern (Var theta))
+                                      (meta
+                                       ((type_ UReal) (loc <opaque>)
+                                        (adlevel AutoDiffable)))))))
+                                  (meta
+                                   ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+                               (meta <opaque>)))))
+                           (meta <opaque>)))))
+                       (meta <opaque>)))))
+                   (meta <opaque>)))))
+               (meta <opaque>)))))
+           (meta <opaque>))
+          ()))
+        (meta <opaque>)))))
+    (meta <opaque>))))
+ (generate_quantities
+  (((pattern
+     (Decl (decl_adtype DataOnly) (decl_id theta) (decl_type (Sized SReal))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity) (dims ()) (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt ())
+        (var
+         ((pattern (Var theta)) (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (IfElse
+      ((pattern
+        (FunApp (StanLib PNot__ FnPlain AoS)
+         (((pattern
+            (EOr
+             ((pattern (Var emit_transformed_parameters__))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+             ((pattern (Var emit_generated_quantities__))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+      ((pattern (Block (((pattern (Return ())) (meta <opaque>))))) (meta <opaque>)) ()))
+    (meta <opaque>))
+   ((pattern
+     (IfElse
+      ((pattern
+        (FunApp (StanLib PNot__ FnPlain AoS)
+         (((pattern (Var emit_generated_quantities__))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+      ((pattern (Block (((pattern (Return ())) (meta <opaque>))))) (meta <opaque>)) ()))
+    (meta <opaque>))))
+ (transform_inits
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id theta) (decl_type (Sized SReal))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable theta) ()) UReal
+      ((pattern
+        (Indexed
+         ((pattern
+           (FunApp (CompilerInternal FnReadData)
+            (((pattern (Lit Str theta))
+              (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+          (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))
+         ((Single
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+       (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var theta)) (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))))
+ (unconstrain_array
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id theta) (decl_type (Sized SReal))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable theta) ()) UReal
+      ((pattern (FunApp (CompilerInternal FnReadDeserializer) ()))
+       (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var theta)) (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))))
+ (output_vars
+  ((theta <opaque>
+    ((out_unconstrained_st SReal) (out_constrained_st SReal) (out_block Parameters)
+     (out_trans Identity)))))
+ (prog_name pr236_unsized_island_model)
+ (prog_path tests/fixtures/pr236_unsized_island.stan))

--- a/tests/fixtures/quad_form_sym.stan
+++ b/tests/fixtures/quad_form_sym.stan
@@ -1,0 +1,16 @@
+data {
+  matrix[3, 3] d;
+  vector[3] dv;
+}
+parameters {
+  matrix[3, 3] a;
+  matrix[3, 2] b;
+  vector[3] v;
+}
+model {
+  matrix[2, 2] q = quad_form_sym(a + a', b);
+  target += q[1, 1] - 0.7 * q[2, 1] + 1.3 * q[1, 2] + 0.4 * q[2, 2];
+  target += 0.9 * quad_form_sym(a + a', v);
+  target += 1.7 * quad_form_sym(d, dv);
+  target += 0.3 * quad_form_sym(d, v);
+}

--- a/tests/fixtures/quad_form_sym.tmir.sexp
+++ b/tests/fixtures/quad_form_sym.tmir.sexp
@@ -1,0 +1,1080 @@
+((functions_block ())
+ (input_vars
+  ((d <opaque>
+    (SMatrix AoS
+     ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+     ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+   (dv <opaque>
+    (SVector AoS
+     ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+ (prepare_data
+  (((pattern
+     (Decl (decl_adtype DataOnly) (decl_id pos__) (decl_type (Sized SInt))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable pos__) ()) UInt
+      ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id d)
+      (decl_type
+       (Sized
+        (SMatrix AoS
+         ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+         ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id d_flat__)
+          (decl_type (Unsized (UArray UReal))) (initialize Uninit)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable d_flat__) ()) (UArray UReal)
+          ((pattern
+            (FunApp (CompilerInternal FnReadData)
+             (((pattern (Lit Str d))
+               (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable pos__) ()) UInt
+          ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar sym1__)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Lit Int 3))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (For (loopvar sym2__)
+                  (lower
+                   ((pattern (Lit Int 1))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (upper
+                   ((pattern (Lit Int 3))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (body
+                   ((pattern
+                     (Block
+                      (((pattern
+                         (Assignment
+                          ((LVariable d)
+                           ((Single
+                             ((pattern (Var sym2__))
+                              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                            (Single
+                             ((pattern (Var sym1__))
+                              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                          UMatrix
+                          ((pattern
+                            (Indexed
+                             ((pattern (Var d_flat__))
+                              (meta
+                               ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))
+                             ((Single
+                               ((pattern (Var pos__))
+                                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                           (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+                        (meta <opaque>))
+                       ((pattern
+                         (Assignment ((LVariable pos__) ()) UInt
+                          ((pattern
+                            (FunApp (StanLib Plus__ FnPlain AoS)
+                             (((pattern (Var pos__))
+                               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                              ((pattern (Lit Int 1))
+                               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                        (meta <opaque>)))))
+                    (meta <opaque>)))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id dv)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id dv_flat__)
+          (decl_type (Unsized (UArray UReal))) (initialize Uninit)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable dv_flat__) ()) (UArray UReal)
+          ((pattern
+            (FunApp (CompilerInternal FnReadData)
+             (((pattern (Lit Str dv))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable pos__) ()) UInt
+          ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar sym1__)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Lit Int 3))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (Assignment
+                  ((LVariable dv)
+                   ((Single
+                     ((pattern (Var sym1__))
+                      (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                  UVector
+                  ((pattern
+                    (Indexed
+                     ((pattern (Var dv_flat__))
+                      (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))
+                     ((Single
+                       ((pattern (Var pos__))
+                        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+                (meta <opaque>))
+               ((pattern
+                 (Assignment ((LVariable pos__) ()) UInt
+                  ((pattern
+                    (FunApp (StanLib Plus__ FnPlain AoS)
+                     (((pattern (Var pos__))
+                       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                      ((pattern (Lit Int 1))
+                       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))))
+ (log_prob
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id a)
+      (decl_type
+       (Sized
+        (SMatrix AoS
+         ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+         ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity)
+             (dims
+              (((pattern (Lit Int 3))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+               ((pattern (Lit Int 3))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id b)
+      (decl_type
+       (Sized
+        (SMatrix AoS
+         ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+         ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity)
+             (dims
+              (((pattern (Lit Int 3))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+               ((pattern (Lit Int 2))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id v)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity)
+             (dims
+              (((pattern (Lit Int 3))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id q)
+          (decl_type
+           (Sized
+            (SMatrix AoS
+             ((pattern (Lit Int 2))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+             ((pattern (Lit Int 2))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+          (initialize Uninit)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable q) ()) UMatrix
+          ((pattern
+            (FunApp (StanLib quad_form_sym FnPlain AoS)
+             (((pattern
+                (FunApp (StanLib Plus__ FnPlain AoS)
+                 (((pattern (Var a))
+                   (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))
+                  ((pattern
+                    (FunApp (StanLib Transpose__ FnPlain AoS)
+                     (((pattern (Var a))
+                       (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable)))))))
+                   (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable)))))))
+               (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))
+              ((pattern (Var b))
+               (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable)))))))
+           (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>))
+       ((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib fma FnPlain AoS)
+             (((pattern (Lit Real 0.4))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+              ((pattern
+                (Indexed
+                 ((pattern (Var q))
+                  (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))
+                 ((Single
+                   ((pattern (Lit Int 2))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (Single
+                   ((pattern (Lit Int 2))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+              ((pattern
+                (FunApp (StanLib fma FnPlain AoS)
+                 (((pattern (Lit Real 1.3))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+                  ((pattern
+                    (Indexed
+                     ((pattern (Var q))
+                      (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))
+                     ((Single
+                       ((pattern (Lit Int 1))
+                        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                      (Single
+                       ((pattern (Lit Int 2))
+                        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+                  ((pattern
+                    (FunApp (StanLib Minus__ FnPlain AoS)
+                     (((pattern
+                        (Indexed
+                         ((pattern (Var q))
+                          (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))
+                         ((Single
+                           ((pattern (Lit Int 1))
+                            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                          (Single
+                           ((pattern (Lit Int 1))
+                            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                       (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+                      ((pattern
+                        (FunApp (StanLib Times__ FnPlain AoS)
+                         (((pattern (Lit Real 0.7))
+                           (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+                          ((pattern
+                            (Indexed
+                             ((pattern (Var q))
+                              (meta
+                               ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))
+                             ((Single
+                               ((pattern (Lit Int 2))
+                                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                              (Single
+                               ((pattern (Lit Int 1))
+                                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
+                       (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>))
+       ((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib Times__ FnPlain AoS)
+             (((pattern (Lit Real 0.9))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+              ((pattern
+                (FunApp (StanLib quad_form_sym FnPlain AoS)
+                 (((pattern
+                    (FunApp (StanLib Plus__ FnPlain AoS)
+                     (((pattern (Var a))
+                       (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))
+                      ((pattern
+                        (FunApp (StanLib Transpose__ FnPlain AoS)
+                         (((pattern (Var a))
+                           (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable)))))))
+                       (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable)))))))
+                   (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))
+                  ((pattern (Var v))
+                   (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>))
+       ((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib Times__ FnPlain AoS)
+             (((pattern (Lit Real 1.7))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+              ((pattern
+                (FunApp (StanLib quad_form_sym FnPlain AoS)
+                 (((pattern (Var d))
+                   (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly))))
+                  ((pattern (Var dv))
+                   (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib Times__ FnPlain AoS)
+             (((pattern (Lit Real 0.3))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+              ((pattern
+                (FunApp (StanLib quad_form_sym FnPlain AoS)
+                 (((pattern (Var d))
+                   (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly))))
+                  ((pattern (Var v))
+                   (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>)))))
+    (meta <opaque>))))
+ (reverse_mode_log_prob
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id a)
+      (decl_type
+       (Sized
+        (SMatrix AoS
+         ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+         ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity)
+             (dims
+              (((pattern (Lit Int 3))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+               ((pattern (Lit Int 3))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id b)
+      (decl_type
+       (Sized
+        (SMatrix AoS
+         ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+         ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity)
+             (dims
+              (((pattern (Lit Int 3))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+               ((pattern (Lit Int 2))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id v)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity)
+             (dims
+              (((pattern (Lit Int 3))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id q)
+          (decl_type
+           (Sized
+            (SMatrix AoS
+             ((pattern (Lit Int 2))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+             ((pattern (Lit Int 2))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+          (initialize Uninit)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable q) ()) UMatrix
+          ((pattern
+            (FunApp (StanLib quad_form_sym FnPlain AoS)
+             (((pattern
+                (FunApp (StanLib Plus__ FnPlain AoS)
+                 (((pattern (Var a))
+                   (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))
+                  ((pattern
+                    (FunApp (StanLib Transpose__ FnPlain AoS)
+                     (((pattern (Var a))
+                       (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable)))))))
+                   (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable)))))))
+               (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))
+              ((pattern (Var b))
+               (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable)))))))
+           (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>))
+       ((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib fma FnPlain SoA)
+             (((pattern (Lit Real 0.4))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+              ((pattern
+                (Indexed
+                 ((pattern (Var q))
+                  (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))
+                 ((Single
+                   ((pattern (Lit Int 2))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (Single
+                   ((pattern (Lit Int 2))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+              ((pattern
+                (FunApp (StanLib fma FnPlain SoA)
+                 (((pattern (Lit Real 1.3))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+                  ((pattern
+                    (Indexed
+                     ((pattern (Var q))
+                      (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))
+                     ((Single
+                       ((pattern (Lit Int 1))
+                        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                      (Single
+                       ((pattern (Lit Int 2))
+                        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+                  ((pattern
+                    (FunApp (StanLib Minus__ FnPlain SoA)
+                     (((pattern
+                        (Indexed
+                         ((pattern (Var q))
+                          (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))
+                         ((Single
+                           ((pattern (Lit Int 1))
+                            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                          (Single
+                           ((pattern (Lit Int 1))
+                            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                       (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+                      ((pattern
+                        (FunApp (StanLib Times__ FnPlain SoA)
+                         (((pattern (Lit Real 0.7))
+                           (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+                          ((pattern
+                            (Indexed
+                             ((pattern (Var q))
+                              (meta
+                               ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))
+                             ((Single
+                               ((pattern (Lit Int 2))
+                                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                              (Single
+                               ((pattern (Lit Int 1))
+                                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
+                       (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>))
+       ((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib Times__ FnPlain SoA)
+             (((pattern (Lit Real 0.9))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+              ((pattern
+                (FunApp (StanLib quad_form_sym FnPlain AoS)
+                 (((pattern
+                    (FunApp (StanLib Plus__ FnPlain AoS)
+                     (((pattern (Var a))
+                       (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))
+                      ((pattern
+                        (FunApp (StanLib Transpose__ FnPlain AoS)
+                         (((pattern (Var a))
+                           (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable)))))))
+                       (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable)))))))
+                   (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))
+                  ((pattern (Var v))
+                   (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>))
+       ((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib Times__ FnPlain SoA)
+             (((pattern (Lit Real 1.7))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+              ((pattern
+                (FunApp (StanLib quad_form_sym FnPlain AoS)
+                 (((pattern (Var d))
+                   (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly))))
+                  ((pattern (Var dv))
+                   (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib Times__ FnPlain SoA)
+             (((pattern (Lit Real 0.3))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+              ((pattern
+                (FunApp (StanLib quad_form_sym FnPlain AoS)
+                 (((pattern (Var d))
+                   (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly))))
+                  ((pattern (Var v))
+                   (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>)))))
+    (meta <opaque>))))
+ (generate_quantities
+  (((pattern
+     (Decl (decl_adtype DataOnly) (decl_id a)
+      (decl_type
+       (Sized
+        (SMatrix AoS
+         ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+         ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity)
+             (dims
+              (((pattern (Lit Int 3))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+               ((pattern (Lit Int 3))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id b)
+      (decl_type
+       (Sized
+        (SMatrix AoS
+         ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+         ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity)
+             (dims
+              (((pattern (Lit Int 3))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+               ((pattern (Lit Int 2))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id v)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity)
+             (dims
+              (((pattern (Lit Int 3))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt ())
+        (var
+         ((pattern (Var a)) (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt ())
+        (var
+         ((pattern (Var b)) (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt ())
+        (var
+         ((pattern (Var v)) (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (IfElse
+      ((pattern
+        (FunApp (StanLib PNot__ FnPlain AoS)
+         (((pattern
+            (EOr
+             ((pattern (Var emit_transformed_parameters__))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+             ((pattern (Var emit_generated_quantities__))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+      ((pattern (Block (((pattern (Return ())) (meta <opaque>))))) (meta <opaque>)) ()))
+    (meta <opaque>))
+   ((pattern
+     (IfElse
+      ((pattern
+        (FunApp (StanLib PNot__ FnPlain AoS)
+         (((pattern (Var emit_generated_quantities__))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+      ((pattern (Block (((pattern (Return ())) (meta <opaque>))))) (meta <opaque>)) ()))
+    (meta <opaque>))))
+ (transform_inits
+  (((pattern
+     (Decl (decl_adtype DataOnly) (decl_id pos__) (decl_type (Sized SInt))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable pos__) ()) UInt
+      ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id a)
+      (decl_type
+       (Sized
+        (SMatrix AoS
+         ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+         ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id a_flat__)
+          (decl_type (Unsized (UArray UReal))) (initialize Uninit)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable a_flat__) ()) (UArray UReal)
+          ((pattern
+            (FunApp (CompilerInternal FnReadData)
+             (((pattern (Lit Str a))
+               (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable pos__) ()) UInt
+          ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar sym1__)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Lit Int 3))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (For (loopvar sym2__)
+                  (lower
+                   ((pattern (Lit Int 1))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (upper
+                   ((pattern (Lit Int 3))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (body
+                   ((pattern
+                     (Block
+                      (((pattern
+                         (Assignment
+                          ((LVariable a)
+                           ((Single
+                             ((pattern (Var sym2__))
+                              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                            (Single
+                             ((pattern (Var sym1__))
+                              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                          UMatrix
+                          ((pattern
+                            (Indexed
+                             ((pattern (Var a_flat__))
+                              (meta
+                               ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))
+                             ((Single
+                               ((pattern (Var pos__))
+                                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                           (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+                        (meta <opaque>))
+                       ((pattern
+                         (Assignment ((LVariable pos__) ()) UInt
+                          ((pattern
+                            (FunApp (StanLib Plus__ FnPlain AoS)
+                             (((pattern (Var pos__))
+                               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                              ((pattern (Lit Int 1))
+                               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                        (meta <opaque>)))))
+                    (meta <opaque>)))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var a)) (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id b)
+      (decl_type
+       (Sized
+        (SMatrix AoS
+         ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+         ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id b_flat__)
+          (decl_type (Unsized (UArray UReal))) (initialize Uninit)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable b_flat__) ()) (UArray UReal)
+          ((pattern
+            (FunApp (CompilerInternal FnReadData)
+             (((pattern (Lit Str b))
+               (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable pos__) ()) UInt
+          ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar sym1__)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Lit Int 2))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (For (loopvar sym2__)
+                  (lower
+                   ((pattern (Lit Int 1))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (upper
+                   ((pattern (Lit Int 3))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (body
+                   ((pattern
+                     (Block
+                      (((pattern
+                         (Assignment
+                          ((LVariable b)
+                           ((Single
+                             ((pattern (Var sym2__))
+                              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                            (Single
+                             ((pattern (Var sym1__))
+                              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                          UMatrix
+                          ((pattern
+                            (Indexed
+                             ((pattern (Var b_flat__))
+                              (meta
+                               ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))
+                             ((Single
+                               ((pattern (Var pos__))
+                                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                           (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+                        (meta <opaque>))
+                       ((pattern
+                         (Assignment ((LVariable pos__) ()) UInt
+                          ((pattern
+                            (FunApp (StanLib Plus__ FnPlain AoS)
+                             (((pattern (Var pos__))
+                               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                              ((pattern (Lit Int 1))
+                               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                        (meta <opaque>)))))
+                    (meta <opaque>)))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var b)) (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id v)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id v_flat__)
+          (decl_type (Unsized (UArray UReal))) (initialize Uninit)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable v_flat__) ()) (UArray UReal)
+          ((pattern
+            (FunApp (CompilerInternal FnReadData)
+             (((pattern (Lit Str v))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable pos__) ()) UInt
+          ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar sym1__)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Lit Int 3))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (Assignment
+                  ((LVariable v)
+                   ((Single
+                     ((pattern (Var sym1__))
+                      (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                  UVector
+                  ((pattern
+                    (Indexed
+                     ((pattern (Var v_flat__))
+                      (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))
+                     ((Single
+                       ((pattern (Var pos__))
+                        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+                (meta <opaque>))
+               ((pattern
+                 (Assignment ((LVariable pos__) ()) UInt
+                  ((pattern
+                    (FunApp (StanLib Plus__ FnPlain AoS)
+                     (((pattern (Var pos__))
+                       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                      ((pattern (Lit Int 1))
+                       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var v)) (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))))
+ (unconstrain_array
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id a)
+      (decl_type
+       (Sized
+        (SMatrix AoS
+         ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+         ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable a) ()) UMatrix
+      ((pattern
+        (FunApp (CompilerInternal FnReadDeserializer)
+         (((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+          ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var a)) (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id b)
+      (decl_type
+       (Sized
+        (SMatrix AoS
+         ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+         ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable b) ()) UMatrix
+      ((pattern
+        (FunApp (CompilerInternal FnReadDeserializer)
+         (((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+          ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var b)) (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id v)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable v) ()) UVector
+      ((pattern
+        (FunApp (CompilerInternal FnReadDeserializer)
+         (((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var v)) (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))))
+ (output_vars
+  ((a <opaque>
+    ((out_unconstrained_st
+      (SMatrix AoS
+       ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+       ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+     (out_constrained_st
+      (SMatrix AoS
+       ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+       ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+     (out_block Parameters) (out_trans Identity)))
+   (b <opaque>
+    ((out_unconstrained_st
+      (SMatrix AoS
+       ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+       ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+     (out_constrained_st
+      (SMatrix AoS
+       ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+       ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+     (out_block Parameters) (out_trans Identity)))
+   (v <opaque>
+    ((out_unconstrained_st
+      (SVector AoS
+       ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+     (out_constrained_st
+      (SVector AoS
+       ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+     (out_block Parameters) (out_trans Identity)))))
+ (prog_name quad_form_sym_model) (prog_path tests/fixtures/quad_form_sym.stan))

--- a/tests/fixtures/unsized_append_loop.stan
+++ b/tests/fixtures/unsized_append_loop.stan
@@ -1,7 +1,16 @@
+data {
+  array[2] int selected;
+}
 parameters {
-  real theta;
+  array[3] vector[2] x;
 }
 model {
-  for (i in {0, 2, 4})
-    target += (i + 1) * theta;
+  array[1] int baseline = {0};
+  for (i in append_array(baseline, selected))
+    target += (i + 1) * x[1][1];
+
+  array[1] vector[2] head = {x[1]};
+  array[2] vector[2] tail = {x[2], x[3]};
+  array[3] vector[2] joined = append_array(head, tail);
+  target += joined[1][1] + 2 * joined[2][2] + 3 * joined[3][1];
 }

--- a/tests/fixtures/unsized_append_loop.stan
+++ b/tests/fixtures/unsized_append_loop.stan
@@ -1,0 +1,7 @@
+parameters {
+  real theta;
+}
+model {
+  for (i in {0, 2, 4})
+    target += (i + 1) * theta;
+}

--- a/tests/fixtures/unsized_append_loop.tmir.sexp
+++ b/tests/fixtures/unsized_append_loop.tmir.sexp
@@ -1,19 +1,69 @@
-((functions_block ()) (input_vars ()) (prepare_data ())
+((functions_block ())
+ (input_vars
+  ((selected <opaque>
+    (SArray SInt
+     ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+ (prepare_data
+  (((pattern
+     (Decl (decl_adtype DataOnly) (decl_id selected)
+      (decl_type
+       (Sized
+        (SArray SInt
+         ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable selected) ()) (UArray UInt)
+      ((pattern
+        (FunApp (CompilerInternal FnReadData)
+         (((pattern (Lit Str selected))
+           (meta ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))))
  (log_prob
   (((pattern
-     (Decl (decl_adtype AutoDiffable) (decl_id theta) (decl_type (Sized SReal))
+     (Decl (decl_adtype AutoDiffable) (decl_id x)
+      (decl_type
+       (Sized
+        (SArray
+         (SVector AoS
+          ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+         ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
       (initialize
        (Assign
         ((pattern
           (FunApp
            (CompilerInternal
-            (FnReadParam (constrain Identity) (dims ()) (mem_pattern AoS)))
+            (FnReadParam (constrain Identity)
+             (dims
+              (((pattern (Lit Int 3))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+               ((pattern (Lit Int 2))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern AoS)))
            ()))
-         (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))))
+         (meta ((type_ (UArray UVector)) (loc <opaque>) (adlevel AutoDiffable))))))))
     (meta <opaque>))
    ((pattern
      (Block
       (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id baseline)
+          (decl_type
+           (Sized
+            (SArray SInt
+             ((pattern (Lit Int 1))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+          (initialize Default)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable baseline) ()) (UArray UInt)
+          ((pattern
+            (FunApp (CompilerInternal FnMakeArray)
+             (((pattern (Lit Int 0))
+               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
          (Block
           (((pattern
              (Decl (decl_adtype DataOnly) (decl_id sym1__)
@@ -22,13 +72,11 @@
            ((pattern
              (Assignment ((LVariable sym1__) ()) (UArray UInt)
               ((pattern
-                (FunApp (CompilerInternal FnMakeArray)
-                 (((pattern (Lit Int 0))
-                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
-                  ((pattern (Lit Int 2))
-                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
-                  ((pattern (Lit Int 4))
-                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                (FunApp (StanLib append_array FnPlain AoS)
+                 (((pattern (Var baseline))
+                   (meta ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly))))
+                  ((pattern (Var selected))
+                   (meta ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly)))))))
                (meta ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly))))))
             (meta <opaque>))
            ((pattern
@@ -80,7 +128,25 @@
                                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
                                  UReal DataOnly))
                                (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
-                              ((pattern (Var theta))
+                              ((pattern
+                                (Indexed
+                                 ((pattern
+                                   (Indexed
+                                    ((pattern (Var x))
+                                     (meta
+                                      ((type_ (UArray UVector)) (loc <opaque>)
+                                       (adlevel AutoDiffable))))
+                                    ((Single
+                                      ((pattern (Lit Int 1))
+                                       (meta
+                                        ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                                  (meta
+                                   ((type_ UVector) (loc <opaque>)
+                                    (adlevel AutoDiffable))))
+                                 ((Single
+                                   ((pattern (Lit Int 1))
+                                    (meta
+                                     ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
                                (meta
                                 ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
                            (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
@@ -88,23 +154,202 @@
                     (meta <opaque>)))))
                 (meta <opaque>)))))
             (meta <opaque>)))))
+        (meta <opaque>))
+       ((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id head)
+          (decl_type
+           (Sized
+            (SArray
+             (SVector AoS
+              ((pattern (Lit Int 2))
+               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+             ((pattern (Lit Int 1))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+          (initialize Uninit)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable head) ()) (UArray UVector)
+          ((pattern
+            (FunApp (CompilerInternal FnMakeArray)
+             (((pattern
+                (Indexed
+                 ((pattern (Var x))
+                  (meta ((type_ (UArray UVector)) (loc <opaque>) (adlevel AutoDiffable))))
+                 ((Single
+                   ((pattern (Lit Int 1))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+           (meta ((type_ (UArray UVector)) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>))
+       ((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id tail)
+          (decl_type
+           (Sized
+            (SArray
+             (SVector AoS
+              ((pattern (Lit Int 2))
+               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+             ((pattern (Lit Int 2))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+          (initialize Uninit)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable tail) ()) (UArray UVector)
+          ((pattern
+            (FunApp (CompilerInternal FnMakeArray)
+             (((pattern
+                (Indexed
+                 ((pattern (Var x))
+                  (meta ((type_ (UArray UVector)) (loc <opaque>) (adlevel AutoDiffable))))
+                 ((Single
+                   ((pattern (Lit Int 2))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))
+              ((pattern
+                (Indexed
+                 ((pattern (Var x))
+                  (meta ((type_ (UArray UVector)) (loc <opaque>) (adlevel AutoDiffable))))
+                 ((Single
+                   ((pattern (Lit Int 3))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+           (meta ((type_ (UArray UVector)) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>))
+       ((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id joined)
+          (decl_type
+           (Sized
+            (SArray
+             (SVector AoS
+              ((pattern (Lit Int 2))
+               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+             ((pattern (Lit Int 3))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+          (initialize Uninit)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable joined) ()) (UArray UVector)
+          ((pattern
+            (FunApp (StanLib append_array FnPlain AoS)
+             (((pattern (Var head))
+               (meta ((type_ (UArray UVector)) (loc <opaque>) (adlevel AutoDiffable))))
+              ((pattern (Var tail))
+               (meta ((type_ (UArray UVector)) (loc <opaque>) (adlevel AutoDiffable)))))))
+           (meta ((type_ (UArray UVector)) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>))
+       ((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib fma FnPlain AoS)
+             (((pattern
+                (Promotion
+                 ((pattern (Lit Int 3))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                 UReal DataOnly))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+              ((pattern
+                (Indexed
+                 ((pattern
+                   (Indexed
+                    ((pattern (Var joined))
+                     (meta
+                      ((type_ (UArray UVector)) (loc <opaque>) (adlevel AutoDiffable))))
+                    ((Single
+                      ((pattern (Lit Int 3))
+                       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                  (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))
+                 ((Single
+                   ((pattern (Lit Int 1))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+              ((pattern
+                (FunApp (StanLib fma FnPlain AoS)
+                 (((pattern
+                    (Promotion
+                     ((pattern (Lit Int 2))
+                      (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                     UReal DataOnly))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+                  ((pattern
+                    (Indexed
+                     ((pattern
+                       (Indexed
+                        ((pattern (Var joined))
+                         (meta
+                          ((type_ (UArray UVector)) (loc <opaque>)
+                           (adlevel AutoDiffable))))
+                        ((Single
+                          ((pattern (Lit Int 2))
+                           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                      (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))
+                     ((Single
+                       ((pattern (Lit Int 2))
+                        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+                  ((pattern
+                    (Indexed
+                     ((pattern
+                       (Indexed
+                        ((pattern (Var joined))
+                         (meta
+                          ((type_ (UArray UVector)) (loc <opaque>)
+                           (adlevel AutoDiffable))))
+                        ((Single
+                          ((pattern (Lit Int 1))
+                           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                      (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))
+                     ((Single
+                       ((pattern (Lit Int 1))
+                        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
         (meta <opaque>)))))
     (meta <opaque>))))
  (reverse_mode_log_prob
   (((pattern
-     (Decl (decl_adtype AutoDiffable) (decl_id theta) (decl_type (Sized SReal))
+     (Decl (decl_adtype AutoDiffable) (decl_id x)
+      (decl_type
+       (Sized
+        (SArray
+         (SVector AoS
+          ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+         ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
       (initialize
        (Assign
         ((pattern
           (FunApp
            (CompilerInternal
-            (FnReadParam (constrain Identity) (dims ()) (mem_pattern SoA)))
+            (FnReadParam (constrain Identity)
+             (dims
+              (((pattern (Lit Int 3))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+               ((pattern (Lit Int 2))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern AoS)))
            ()))
-         (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))))
+         (meta ((type_ (UArray UVector)) (loc <opaque>) (adlevel AutoDiffable))))))))
     (meta <opaque>))
    ((pattern
      (Block
       (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id baseline)
+          (decl_type
+           (Sized
+            (SArray SInt
+             ((pattern (Lit Int 1))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+          (initialize Default)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable baseline) ()) (UArray UInt)
+          ((pattern
+            (FunApp (CompilerInternal FnMakeArray)
+             (((pattern (Lit Int 0))
+               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
          (Block
           (((pattern
              (Decl (decl_adtype DataOnly) (decl_id sym1__)
@@ -113,13 +358,11 @@
            ((pattern
              (Assignment ((LVariable sym1__) ()) (UArray UInt)
               ((pattern
-                (FunApp (CompilerInternal FnMakeArray)
-                 (((pattern (Lit Int 0))
-                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
-                  ((pattern (Lit Int 2))
-                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
-                  ((pattern (Lit Int 4))
-                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                (FunApp (StanLib append_array FnPlain AoS)
+                 (((pattern (Var baseline))
+                   (meta ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly))))
+                  ((pattern (Var selected))
+                   (meta ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly)))))))
                (meta ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly))))))
             (meta <opaque>))
            ((pattern
@@ -171,7 +414,25 @@
                                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
                                  UReal DataOnly))
                                (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
-                              ((pattern (Var theta))
+                              ((pattern
+                                (Indexed
+                                 ((pattern
+                                   (Indexed
+                                    ((pattern (Var x))
+                                     (meta
+                                      ((type_ (UArray UVector)) (loc <opaque>)
+                                       (adlevel AutoDiffable))))
+                                    ((Single
+                                      ((pattern (Lit Int 1))
+                                       (meta
+                                        ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                                  (meta
+                                   ((type_ UVector) (loc <opaque>)
+                                    (adlevel AutoDiffable))))
+                                 ((Single
+                                   ((pattern (Lit Int 1))
+                                    (meta
+                                     ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
                                (meta
                                 ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
                            (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
@@ -179,27 +440,225 @@
                     (meta <opaque>)))))
                 (meta <opaque>)))))
             (meta <opaque>)))))
+        (meta <opaque>))
+       ((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id head)
+          (decl_type
+           (Sized
+            (SArray
+             (SVector AoS
+              ((pattern (Lit Int 2))
+               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+             ((pattern (Lit Int 1))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+          (initialize Uninit)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable head) ()) (UArray UVector)
+          ((pattern
+            (FunApp (CompilerInternal FnMakeArray)
+             (((pattern
+                (Indexed
+                 ((pattern (Var x))
+                  (meta ((type_ (UArray UVector)) (loc <opaque>) (adlevel AutoDiffable))))
+                 ((Single
+                   ((pattern (Lit Int 1))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+           (meta ((type_ (UArray UVector)) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>))
+       ((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id tail)
+          (decl_type
+           (Sized
+            (SArray
+             (SVector AoS
+              ((pattern (Lit Int 2))
+               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+             ((pattern (Lit Int 2))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+          (initialize Uninit)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable tail) ()) (UArray UVector)
+          ((pattern
+            (FunApp (CompilerInternal FnMakeArray)
+             (((pattern
+                (Indexed
+                 ((pattern (Var x))
+                  (meta ((type_ (UArray UVector)) (loc <opaque>) (adlevel AutoDiffable))))
+                 ((Single
+                   ((pattern (Lit Int 2))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))
+              ((pattern
+                (Indexed
+                 ((pattern (Var x))
+                  (meta ((type_ (UArray UVector)) (loc <opaque>) (adlevel AutoDiffable))))
+                 ((Single
+                   ((pattern (Lit Int 3))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+           (meta ((type_ (UArray UVector)) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>))
+       ((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id joined)
+          (decl_type
+           (Sized
+            (SArray
+             (SVector AoS
+              ((pattern (Lit Int 2))
+               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+             ((pattern (Lit Int 3))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+          (initialize Uninit)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable joined) ()) (UArray UVector)
+          ((pattern
+            (FunApp (StanLib append_array FnPlain AoS)
+             (((pattern (Var head))
+               (meta ((type_ (UArray UVector)) (loc <opaque>) (adlevel AutoDiffable))))
+              ((pattern (Var tail))
+               (meta ((type_ (UArray UVector)) (loc <opaque>) (adlevel AutoDiffable)))))))
+           (meta ((type_ (UArray UVector)) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>))
+       ((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib fma FnPlain SoA)
+             (((pattern
+                (Promotion
+                 ((pattern (Lit Int 3))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                 UReal DataOnly))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+              ((pattern
+                (Indexed
+                 ((pattern
+                   (Indexed
+                    ((pattern (Var joined))
+                     (meta
+                      ((type_ (UArray UVector)) (loc <opaque>) (adlevel AutoDiffable))))
+                    ((Single
+                      ((pattern (Lit Int 3))
+                       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                  (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))
+                 ((Single
+                   ((pattern (Lit Int 1))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+              ((pattern
+                (FunApp (StanLib fma FnPlain SoA)
+                 (((pattern
+                    (Promotion
+                     ((pattern (Lit Int 2))
+                      (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                     UReal DataOnly))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+                  ((pattern
+                    (Indexed
+                     ((pattern
+                       (Indexed
+                        ((pattern (Var joined))
+                         (meta
+                          ((type_ (UArray UVector)) (loc <opaque>)
+                           (adlevel AutoDiffable))))
+                        ((Single
+                          ((pattern (Lit Int 2))
+                           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                      (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))
+                     ((Single
+                       ((pattern (Lit Int 2))
+                        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+                  ((pattern
+                    (Indexed
+                     ((pattern
+                       (Indexed
+                        ((pattern (Var joined))
+                         (meta
+                          ((type_ (UArray UVector)) (loc <opaque>)
+                           (adlevel AutoDiffable))))
+                        ((Single
+                          ((pattern (Lit Int 1))
+                           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                      (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))
+                     ((Single
+                       ((pattern (Lit Int 1))
+                        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
         (meta <opaque>)))))
     (meta <opaque>))))
  (generate_quantities
   (((pattern
-     (Decl (decl_adtype DataOnly) (decl_id theta) (decl_type (Sized SReal))
+     (Decl (decl_adtype DataOnly) (decl_id x)
+      (decl_type
+       (Sized
+        (SArray
+         (SVector AoS
+          ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+         ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
       (initialize
        (Assign
         ((pattern
           (FunApp
            (CompilerInternal
-            (FnReadParam (constrain Identity) (dims ()) (mem_pattern AoS)))
+            (FnReadParam (constrain Identity)
+             (dims
+              (((pattern (Lit Int 3))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+               ((pattern (Lit Int 2))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern AoS)))
            ()))
-         (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))))
+         (meta ((type_ (UArray UVector)) (loc <opaque>) (adlevel AutoDiffable))))))))
     (meta <opaque>))
    ((pattern
-     (NRFunApp
-      (CompilerInternal
-       (FnWriteParam (unconstrain_opt ())
-        (var
-         ((pattern (Var theta)) (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
-      ()))
+     (For (loopvar sym1__)
+      (lower
+       ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+      (upper
+       ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+      (body
+       ((pattern
+         (Block
+          (((pattern
+             (For (loopvar sym2__)
+              (lower
+               ((pattern (Lit Int 1))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+              (upper
+               ((pattern (Lit Int 3))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+              (body
+               ((pattern
+                 (Block
+                  (((pattern
+                     (NRFunApp
+                      (CompilerInternal
+                       (FnWriteParam (unconstrain_opt ())
+                        (var
+                         ((pattern
+                           (Indexed
+                            ((pattern (Var x))
+                             (meta
+                              ((type_ (UArray UVector)) (loc <opaque>)
+                               (adlevel DataOnly))))
+                            ((Single
+                              ((pattern (Var sym2__))
+                               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                             (Single
+                              ((pattern (Var sym1__))
+                               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                          (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+                      ()))
+                    (meta <opaque>)))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
     (meta <opaque>))
    ((pattern
      (IfElse
@@ -226,52 +685,172 @@
     (meta <opaque>))))
  (transform_inits
   (((pattern
-     (Decl (decl_adtype AutoDiffable) (decl_id theta) (decl_type (Sized SReal))
-      (initialize Uninit)))
+     (Decl (decl_adtype DataOnly) (decl_id pos__) (decl_type (Sized SInt))
+      (initialize Default)))
     (meta <opaque>))
    ((pattern
-     (Assignment ((LVariable theta) ()) UReal
-      ((pattern
-        (Indexed
-         ((pattern
-           (FunApp (CompilerInternal FnReadData)
-            (((pattern (Lit Str theta))
-              (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
-          (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))
-         ((Single
+     (Decl (decl_adtype AutoDiffable) (decl_id x)
+      (decl_type
+       (Sized
+        (SArray
+         (SVector AoS
+          ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+         ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id x_flat__)
+          (decl_type (Unsized (UArray UReal))) (initialize Uninit)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable x_flat__) ()) (UArray UReal)
+          ((pattern
+            (FunApp (CompilerInternal FnReadData)
+             (((pattern (Lit Str x))
+               (meta ((type_ (UArray UVector)) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable pos__) ()) UInt
+          ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar sym1__)
+          (lower
            ((pattern (Lit Int 1))
-            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
-       (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Lit Int 2))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (For (loopvar sym2__)
+                  (lower
+                   ((pattern (Lit Int 1))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (upper
+                   ((pattern (Lit Int 3))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (body
+                   ((pattern
+                     (Block
+                      (((pattern
+                         (Assignment
+                          ((LVariable x)
+                           ((Single
+                             ((pattern (Var sym2__))
+                              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                            (Single
+                             ((pattern (Var sym1__))
+                              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                          (UArray UVector)
+                          ((pattern
+                            (Indexed
+                             ((pattern (Var x_flat__))
+                              (meta
+                               ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))
+                             ((Single
+                               ((pattern (Var pos__))
+                                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                           (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+                        (meta <opaque>))
+                       ((pattern
+                         (Assignment ((LVariable pos__) ()) UInt
+                          ((pattern
+                            (FunApp (StanLib Plus__ FnPlain AoS)
+                             (((pattern (Var pos__))
+                               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                              ((pattern (Lit Int 1))
+                               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                        (meta <opaque>)))))
+                    (meta <opaque>)))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
     (meta <opaque>))
    ((pattern
      (NRFunApp
       (CompilerInternal
        (FnWriteParam (unconstrain_opt (Identity))
         (var
-         ((pattern (Var theta)) (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+         ((pattern (Var x))
+          (meta ((type_ (UArray UVector)) (loc <opaque>) (adlevel DataOnly)))))))
       ()))
     (meta <opaque>))))
  (unconstrain_array
   (((pattern
-     (Decl (decl_adtype AutoDiffable) (decl_id theta) (decl_type (Sized SReal))
-      (initialize Uninit)))
+     (Decl (decl_adtype AutoDiffable) (decl_id x)
+      (decl_type
+       (Sized
+        (SArray
+         (SVector AoS
+          ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+         ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Default)))
     (meta <opaque>))
    ((pattern
-     (Assignment ((LVariable theta) ()) UReal
-      ((pattern (FunApp (CompilerInternal FnReadDeserializer) ()))
-       (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+     (For (loopvar sym1__)
+      (lower
+       ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+      (upper
+       ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+      (body
+       ((pattern
+         (Block
+          (((pattern
+             (For (loopvar sym2__)
+              (lower
+               ((pattern (Lit Int 1))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+              (upper
+               ((pattern (Lit Int 3))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+              (body
+               ((pattern
+                 (Block
+                  (((pattern
+                     (Assignment
+                      ((LVariable x)
+                       ((Single
+                         ((pattern (Var sym2__))
+                          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                        (Single
+                         ((pattern (Var sym1__))
+                          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                      UVector
+                      ((pattern (FunApp (CompilerInternal FnReadDeserializer) ()))
+                       (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+                    (meta <opaque>)))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
     (meta <opaque>))
    ((pattern
      (NRFunApp
       (CompilerInternal
        (FnWriteParam (unconstrain_opt (Identity))
         (var
-         ((pattern (Var theta)) (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+         ((pattern (Var x))
+          (meta ((type_ (UArray UVector)) (loc <opaque>) (adlevel DataOnly)))))))
       ()))
     (meta <opaque>))))
  (output_vars
-  ((theta <opaque>
-    ((out_unconstrained_st SReal) (out_constrained_st SReal) (out_block Parameters)
-     (out_trans Identity)))))
+  ((x <opaque>
+    ((out_unconstrained_st
+      (SArray
+       (SVector AoS
+        ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+       ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+     (out_constrained_st
+      (SArray
+       (SVector AoS
+        ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+       ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+     (out_block Parameters) (out_trans Identity)))))
  (prog_name unsized_append_loop_model)
  (prog_path tests/fixtures/unsized_append_loop.stan))

--- a/tests/fixtures/unsized_append_loop.tmir.sexp
+++ b/tests/fixtures/unsized_append_loop.tmir.sexp
@@ -1,0 +1,277 @@
+((functions_block ()) (input_vars ()) (prepare_data ())
+ (log_prob
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id theta) (decl_type (Sized SReal))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity) (dims ()) (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Block
+          (((pattern
+             (Decl (decl_adtype DataOnly) (decl_id sym1__)
+              (decl_type (Unsized (UArray UInt))) (initialize Default)))
+            (meta <opaque>))
+           ((pattern
+             (Assignment ((LVariable sym1__) ()) (UArray UInt)
+              ((pattern
+                (FunApp (CompilerInternal FnMakeArray)
+                 (((pattern (Lit Int 0))
+                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                  ((pattern (Lit Int 2))
+                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                  ((pattern (Lit Int 4))
+                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+               (meta ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly))))))
+            (meta <opaque>))
+           ((pattern
+             (For (loopvar sym3__)
+              (lower
+               ((pattern (Lit Int 1))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+              (upper
+               ((pattern
+                 (FunApp (CompilerInternal FnLength)
+                  (((pattern (Var sym1__))
+                    (meta ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly)))))))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+              (body
+               ((pattern
+                 (Block
+                  (((pattern
+                     (Block
+                      (((pattern
+                         (Decl (decl_adtype DataOnly) (decl_id i)
+                          (decl_type (Unsized UInt)) (initialize Uninit)))
+                        (meta <opaque>))
+                       ((pattern
+                         (Assignment ((LVariable i) ()) UInt
+                          ((pattern
+                            (Indexed
+                             ((pattern (Var sym1__))
+                              (meta
+                               ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly))))
+                             ((Single
+                               ((pattern (Var sym3__))
+                                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                        (meta <opaque>))
+                       ((pattern
+                         (TargetPE
+                          ((pattern
+                            (FunApp (StanLib Times__ FnPlain AoS)
+                             (((pattern
+                                (Promotion
+                                 ((pattern
+                                   (FunApp (StanLib Plus__ FnPlain AoS)
+                                    (((pattern (Var i))
+                                      (meta
+                                       ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                                     ((pattern (Lit Int 1))
+                                      (meta
+                                       ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                                 UReal DataOnly))
+                               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+                              ((pattern (Var theta))
+                               (meta
+                                ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
+                           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+                        (meta <opaque>)))))
+                    (meta <opaque>)))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))))
+ (reverse_mode_log_prob
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id theta) (decl_type (Sized SReal))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity) (dims ()) (mem_pattern SoA)))
+           ()))
+         (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Block
+          (((pattern
+             (Decl (decl_adtype DataOnly) (decl_id sym1__)
+              (decl_type (Unsized (UArray UInt))) (initialize Default)))
+            (meta <opaque>))
+           ((pattern
+             (Assignment ((LVariable sym1__) ()) (UArray UInt)
+              ((pattern
+                (FunApp (CompilerInternal FnMakeArray)
+                 (((pattern (Lit Int 0))
+                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                  ((pattern (Lit Int 2))
+                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                  ((pattern (Lit Int 4))
+                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+               (meta ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly))))))
+            (meta <opaque>))
+           ((pattern
+             (For (loopvar sym3__)
+              (lower
+               ((pattern (Lit Int 1))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+              (upper
+               ((pattern
+                 (FunApp (CompilerInternal FnLength)
+                  (((pattern (Var sym1__))
+                    (meta ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly)))))))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+              (body
+               ((pattern
+                 (Block
+                  (((pattern
+                     (Block
+                      (((pattern
+                         (Decl (decl_adtype DataOnly) (decl_id i)
+                          (decl_type (Unsized UInt)) (initialize Uninit)))
+                        (meta <opaque>))
+                       ((pattern
+                         (Assignment ((LVariable i) ()) UInt
+                          ((pattern
+                            (Indexed
+                             ((pattern (Var sym1__))
+                              (meta
+                               ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly))))
+                             ((Single
+                               ((pattern (Var sym3__))
+                                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                        (meta <opaque>))
+                       ((pattern
+                         (TargetPE
+                          ((pattern
+                            (FunApp (StanLib Times__ FnPlain SoA)
+                             (((pattern
+                                (Promotion
+                                 ((pattern
+                                   (FunApp (StanLib Plus__ FnPlain SoA)
+                                    (((pattern (Var i))
+                                      (meta
+                                       ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                                     ((pattern (Lit Int 1))
+                                      (meta
+                                       ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                                 UReal DataOnly))
+                               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+                              ((pattern (Var theta))
+                               (meta
+                                ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
+                           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+                        (meta <opaque>)))))
+                    (meta <opaque>)))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))))
+ (generate_quantities
+  (((pattern
+     (Decl (decl_adtype DataOnly) (decl_id theta) (decl_type (Sized SReal))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity) (dims ()) (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt ())
+        (var
+         ((pattern (Var theta)) (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (IfElse
+      ((pattern
+        (FunApp (StanLib PNot__ FnPlain AoS)
+         (((pattern
+            (EOr
+             ((pattern (Var emit_transformed_parameters__))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+             ((pattern (Var emit_generated_quantities__))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+      ((pattern (Block (((pattern (Return ())) (meta <opaque>))))) (meta <opaque>)) ()))
+    (meta <opaque>))
+   ((pattern
+     (IfElse
+      ((pattern
+        (FunApp (StanLib PNot__ FnPlain AoS)
+         (((pattern (Var emit_generated_quantities__))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+      ((pattern (Block (((pattern (Return ())) (meta <opaque>))))) (meta <opaque>)) ()))
+    (meta <opaque>))))
+ (transform_inits
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id theta) (decl_type (Sized SReal))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable theta) ()) UReal
+      ((pattern
+        (Indexed
+         ((pattern
+           (FunApp (CompilerInternal FnReadData)
+            (((pattern (Lit Str theta))
+              (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+          (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))
+         ((Single
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+       (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var theta)) (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))))
+ (unconstrain_array
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id theta) (decl_type (Sized SReal))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable theta) ()) UReal
+      ((pattern (FunApp (CompilerInternal FnReadDeserializer) ()))
+       (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var theta)) (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))))
+ (output_vars
+  ((theta <opaque>
+    ((out_unconstrained_st SReal) (out_constrained_st SReal) (out_block Parameters)
+     (out_trans Identity)))))
+ (prog_name unsized_append_loop_model)
+ (prog_path tests/fixtures/unsized_append_loop.stan))

--- a/tests/test_lower.cpp
+++ b/tests/test_lower.cpp
@@ -4082,6 +4082,30 @@ int main() {
       expect_ulp("tcrossprod: g" + std::to_string(i), gradient[i], a(i).adj());
   }
 
+  // Two IndexMulti selectors on a matrix form their Cartesian submatrix.
+  // Different reordered row/column lists pin column-major gather order and
+  // route each gathered cell's adjoint back to the source matrix.
+  {
+    DataMap d;
+    d.set_int_array("row_indices", {3, 1});
+    d.set_int_array("column_indices", {2, 3});
+    CompiledModel gm =
+        compile_model(slurp("tests/fixtures/matrix_multi_multi.tmir.sexp"), d);
+    Executor gex(std::move(gm.graph));
+    gm.bind(gex);
+    const double q[9] = {0.2, -0.4, 0.7, 0.1, -0.3, 0.8, 0.5, 0.9, -0.6};
+    for (int i = 0; i < 9; ++i) gex.params_data()[i] = q[i];
+    double gradient[9] = {};
+    const double lp = gex.gradient(gradient);
+    const double want = 2.0 * q[5] + 2.0 * q[3] + 2.0 * q[8] + 2.0 * q[6];
+    expect_eq("matrix multi/multi: lp", lp, want);
+    for (int i = 0; i < 9; ++i) {
+      const bool selected = i == 3 || i == 5 || i == 6 || i == 8;
+      expect_eq("matrix multi/multi: g" + std::to_string(i), gradient[i],
+                selected ? 2.0 : 0.0);
+    }
+  }
+
   // A scalar replicated as a row vector uses the vector replication opcode,
   // but must retain its row-vector type for downstream expression lowering.
   {

--- a/tests/test_lower.cpp
+++ b/tests/test_lower.cpp
@@ -5215,6 +5215,58 @@ int main() {
     stan::math::recover_memory();
   }
 
+  // quad_form_sym at both overloads and both scalar types: a matrix B gives
+  // 0.5 * (C + C'), a vector B the scalar B' A B, and stan-math associates
+  // that scalar one way at double and the other at var. `a + a'` is exactly
+  // symmetric, so the symmetry check passes.
+  {
+    DataMap d;
+    const std::vector<double> dm = {1.5, 0.3,  -0.2, 0.3, 2.0,
+                                    0.7, -0.2, 0.7,  1.1};
+    const std::vector<double> dvv = {0.6, -1.2, 0.4};
+    d.set_real_array("d", dm);
+    d.set_real_array("dv", dvv);
+    CompiledModel mm =
+        compile_model(slurp("tests/fixtures/quad_form_sym.tmir.sexp"), d);
+    Executor mex(std::move(mm.graph));
+    mm.bind(mex);
+    const double q[18] = {0.2, -0.4, 0.7, -0.1, 0.9,  0.3, -0.6, 0.5,  0.8,
+                          1.1, -0.3, 0.2, 0.4,  -0.9, 0.6, 0.7,  -0.5, 0.15};
+    for (int i = 0; i < 18; ++i) mex.params_data()[i] = q[i];
+    double gradient[18] = {};
+    const double lp = mex.gradient(gradient);
+
+    using stan::math::var;
+    Eigen::Matrix<var, -1, -1> a(3, 3), b(3, 2);
+    Eigen::Matrix<var, -1, 1> v(3);
+    for (int i = 0; i < 9; ++i) a.data()[i] = q[i];
+    for (int i = 0; i < 6; ++i) b.data()[i] = q[9 + i];
+    for (int i = 0; i < 3; ++i) v.data()[i] = q[15 + i];
+    Eigen::MatrixXd dmat(3, 3);
+    Eigen::VectorXd dvec(3);
+    for (int i = 0; i < 9; ++i) dmat.data()[i] = dm[(size_t)i];
+    for (int i = 0; i < 3; ++i) dvec.data()[i] = dvv[(size_t)i];
+
+    const Eigen::Matrix<var, -1, -1> sym = a + a.transpose();
+    const Eigen::Matrix<var, -1, -1> qm = stan::math::quad_form_sym(sym, b);
+    var reference = qm(0, 0) - 0.7 * qm(1, 0) + 1.3 * qm(0, 1) + 0.4 * qm(1, 1);
+    reference += 0.9 * stan::math::quad_form_sym(sym, v);
+    reference += 1.7 * stan::math::quad_form_sym(dmat, dvec);
+    reference += 0.3 * stan::math::quad_form_sym(dmat, v);
+    reference.grad();
+    expect_eq("quad form sym lp", lp, reference.val());
+    for (int i = 0; i < 9; ++i)
+      expect_eq("quad form sym da " + std::to_string(i), gradient[i],
+                a.data()[i].adj());
+    for (int i = 0; i < 6; ++i)
+      expect_eq("quad form sym db " + std::to_string(i), gradient[9 + i],
+                b.data()[i].adj());
+    for (int i = 0; i < 3; ++i)
+      expect_eq("quad form sym dv " + std::to_string(i), gradient[15 + i],
+                v.data()[i].adj());
+    stan::math::recover_memory();
+  }
+
   if (failures == 0) std::printf("test_lower OK\n");
   return failures == 0 ? 0 : 1;
 }

--- a/tests/test_lower.cpp
+++ b/tests/test_lower.cpp
@@ -5189,6 +5189,32 @@ int main() {
                 want[i]);
   }
 
+  // matrix_exp retains the square matrix view and differentiates every output
+  // element through the full, nonsymmetric matrix exponential.
+  {
+    DataMap d;
+    CompiledModel mm =
+        compile_model(slurp("tests/fixtures/matrix_exp.tmir.sexp"), d);
+    Executor mex(std::move(mm.graph));
+    mm.bind(mex);
+    const double q[4] = {0.2, -0.4, 0.7, -0.1};
+    for (int i = 0; i < 4; ++i) mex.params_data()[i] = q[i];
+    double gradient[4] = {};
+    const double lp = mex.gradient(gradient);
+
+    using stan::math::var;
+    Eigen::Matrix<var, -1, -1> a(2, 2);
+    for (int i = 0; i < 4; ++i) a.data()[i] = q[i];
+    Eigen::Matrix<var, -1, -1> e = stan::math::matrix_exp(a);
+    var reference = e(0, 0) - 0.7 * e(1, 0) + 1.3 * e(0, 1) + 0.4 * e(1, 1);
+    reference.grad();
+    expect_eq("matrix exp lp", lp, reference.val());
+    for (int i = 0; i < 4; ++i)
+      expect_eq("matrix exp gradient " + std::to_string(i), gradient[i],
+                a.data()[i].adj());
+    stan::math::recover_memory();
+  }
+
   if (failures == 0) std::printf("test_lower OK\n");
   return failures == 0 ? 0 : 1;
 }

--- a/tests/test_lower.cpp
+++ b/tests/test_lower.cpp
@@ -5189,6 +5189,92 @@ int main() {
                 want[i]);
   }
 
+  // DataMap observations are first-index-fast, unlike the graph's outer-major
+  // array slots. A rank-two append used by constant indexing must preserve the
+  // former order. An empty operand also takes its suffix shape from the
+  // nonempty side, as stan-math does.
+  {
+    DataMap d = DataMap::from_json(R"({"a":[[1,2]],"b":[[10,20]]})");
+    CompiledModel am =
+        compile_model(slurp("tests/fixtures/append_regression.tmir.sexp"), d);
+    Executor aex(std::move(am.graph));
+    am.bind(aex);
+    const double q[4] = {0.1, 0.5, -0.7, 1.2};
+    for (int i = 0; i < 4; ++i) aex.params_data()[i] = q[i];
+    double gradient[4] = {};
+    expect_eq("rank-two append lp", aex.gradient(gradient), 6.0);
+    const double want[4] = {30.0, 3.0, 3.0, 3.0};
+    for (int i = 0; i < 4; ++i)
+      expect_eq("rank-two append gradient " + std::to_string(i), gradient[i],
+                want[i]);
+  }
+
+  // The same new MIR forms can occur inside parameter-dependent control.
+  // That route is compiled by ProgramCompiler rather than the main lowerer:
+  // it needs Cartesian matrix gathers, O1's empty Indexed wrapper, and
+  // deferred shape adoption for an unsized loop-sequence temporary.
+  {
+    DataMap d;
+    CompiledModel im =
+        compile_model(slurp("tests/fixtures/pr236_island.tmir.sexp"), d);
+    Executor iex(std::move(im.graph));
+    im.bind(iex);
+    const double positive[9] = {1, 2, 3, 4, 5, 6, 7, 8, 9};
+    std::copy(positive, positive + 9, iex.params_data());
+    double gradient[9] = {};
+    expect_eq("PR236 island positive lp", iex.gradient(gradient), 75.0);
+    const double positive_gradient[9] = {5, 0, 0, 2, 0, 2, 2, 0, 4};
+    for (int i = 0; i < 9; ++i)
+      expect_eq("PR236 island positive gradient " + std::to_string(i),
+                gradient[i], positive_gradient[i]);
+
+    std::copy(positive, positive + 9, iex.params_data());
+    iex.params_data()[0] = -1.0;
+    std::fill(gradient, gradient + 9, 0.0);
+    expect_eq("PR236 island negative lp", iex.gradient(gradient), -1.0);
+    for (int i = 0; i < 9; ++i)
+      expect_eq("PR236 island negative gradient " + std::to_string(i),
+                gradient[i], i == 0 ? 1.0 : 0.0);
+  }
+
+  // The non-O1 producer keeps this UDF call intact. Its data-only integer
+  // array formals must retain their compile-time values when ProgramCompiler
+  // enters the callee, or the matrix gather cannot resolve rows and columns.
+  {
+    DataMap d;
+    CompiledModel im =
+        compile_model(slurp("tests/fixtures/pr236_island_udf.tmir.sexp"), d);
+    Executor iex(std::move(im.graph));
+    im.bind(iex);
+    const double positive[9] = {1, 2, 3, 4, 5, 6, 7, 8, 9};
+    std::copy(positive, positive + 9, iex.params_data());
+    double gradient[9] = {};
+    expect_eq("PR236 island UDF lp", iex.gradient(gradient), 26.0);
+    const double want[9] = {0, 0, 0, 1, 0, 1, 1, 0, 1};
+    for (int i = 0; i < 9; ++i)
+      expect_eq("PR236 island UDF gradient " + std::to_string(i), gradient[i],
+                want[i]);
+  }
+
+  // O1 also uses deferred unsized temporaries for an appended integer loop
+  // sequence and for arrays of row-vector literals. Both values are built
+  // inside the runtime branch, then indexed by the unrolled source loop.
+  {
+    DataMap d;
+    d.set_int_array("d", {2});
+    CompiledModel im = compile_model(
+        slurp("tests/fixtures/pr236_unsized_island.tmir.sexp"), d);
+    Executor iex(std::move(im.graph));
+    im.bind(iex);
+    iex.params_data()[0] = 0.5;
+    double gradient[1] = {};
+    expect_eq("PR236 unsized island positive lp", iex.gradient(gradient), 6.5);
+    expect_eq("PR236 unsized island positive gradient", gradient[0], 13.0);
+    iex.params_data()[0] = -0.5;
+    expect_eq("PR236 unsized island negative lp", iex.gradient(gradient), 0.0);
+    expect_eq("PR236 unsized island negative gradient", gradient[0], 0.0);
+  }
+
   // matrix_exp retains the square matrix view and differentiates every output
   // element through the full, nonsymmetric matrix exponential.
   {
@@ -5213,6 +5299,61 @@ int main() {
       expect_eq("matrix exp gradient " + std::to_string(i), gradient[i],
                 a.data()[i].adj());
     stan::math::recover_memory();
+  }
+
+  // Transformed data and write_array recovery run MirInterp rather than the
+  // graph kernels. Both new functions must exist there as well. The test-only
+  // hook attaches the same interpreter used by ordinary late-truncation
+  // recovery beside this fixture's complete write_array graph.
+  {
+    DataMap d = DataMap::from_json(R"({"a":[7],"m":[[0,0],[0,0]]})");
+    check(test_setenv("STANLI_WA_FORCE_INTERP", "1", 1) == 0,
+          "enable new-functions write_array interpreter");
+    CompiledModel fm;
+    try {
+      fm = compile_model(slurp("tests/fixtures/interp_new_functions.tmir.sexp"),
+                         d);
+    } catch (...) {
+      test_unsetenv("STANLI_WA_FORCE_INTERP");
+      throw;
+    }
+    check(test_unsetenv("STANLI_WA_FORCE_INTERP") == 0,
+          "disable new-functions write_array interpreter");
+    Executor fex(std::move(fm.graph));
+    fm.bind(fex);
+    fex.params_data()[0] = 0.3;
+    double gradient[1] = {};
+    expect_eq("interpreter functions lp", fex.gradient(gradient), 3.3);
+    expect_eq("interpreter functions gradient", gradient[0], 11.0);
+
+    check(fm.write_array && fm.write_array->interp,
+          "new functions interpreted write_array selected");
+    if (fm.write_array && fm.write_array->interp) {
+      fex.params_data()[0] = 0.3;
+      fex.run_forward_only();
+      WaRng rng(1234);
+      const std::vector<double> row =
+          fm.write_array->interp->eval(fm.constrained_env(fex), rng);
+      const std::vector<std::string> names =
+          CompiledModel::csv_names(fm.write_array->interp->columns());
+      const auto expect_column = [&](const std::string& name, double want) {
+        const auto it = std::find(names.begin(), names.end(), name);
+        check(it != names.end(), "interpreted column " + name);
+        if (it != names.end())
+          expect_eq("interpreted value " + name,
+                    row.at((size_t)std::distance(names.begin(), it)), want);
+      };
+      expect_column("g_joined.1", 0.3);
+      expect_column("g_joined.2", 2.0);
+      Eigen::MatrixXd input = Eigen::MatrixXd::Zero(2, 2);
+      input(0, 0) = 0.3;
+      const Eigen::MatrixXd output = stan::math::matrix_exp(input);
+      expect_column("g_exp.1.1", output(0, 0));
+      expect_column("g_exp.2.1", output(1, 0));
+      expect_column("g_exp.1.2", output(0, 1));
+      expect_column("g_exp.2.2", output(1, 1));
+      expect_column("product", std::exp(0.3) * std::exp(2.0));
+    }
   }
 
   // quad_form_sym at both overloads and both scalar types: a matrix B gives
@@ -5265,6 +5406,25 @@ int main() {
       expect_eq("quad form sym dv " + std::to_string(i), gradient[15 + i],
                 v.data()[i].adj());
     stan::math::recover_memory();
+  }
+
+  // Stan Math's reverse-mode vector overload still evaluates 0.5 * (c + c)
+  // for the scalar result. Preserve that operation at overflow rather than
+  // returning the finite unsymmetrized c.
+  {
+    DataMap d;
+    d.set_real_array("d", std::vector<double>(9, 0.0));
+    d.set_real_array("dv", std::vector<double>(3, 0.0));
+    CompiledModel qm =
+        compile_model(slurp("tests/fixtures/quad_form_sym.tmir.sexp"), d);
+    Executor qex(std::move(qm.graph));
+    qm.bind(qex);
+    std::fill(qex.params_data(), qex.params_data() + 18, 0.0);
+    qex.params_data()[0] = 0.5;
+    qex.params_data()[15] = 1e154;
+    const double lp = qex.forward();
+    check(std::isinf(lp) && lp > 0.0,
+          "quad_form_sym active-vector scalar symmetrization overflow");
   }
 
   if (failures == 0) std::printf("test_lower OK\n");

--- a/tests/test_lower.cpp
+++ b/tests/test_lower.cpp
@@ -5168,19 +5168,25 @@ int main() {
     }
   }
 
-  // O1 materializes an array-valued loop sequence through an unsized integer
-  // array temporary. Its first assignment supplies the three-element shape
-  // used by both FnLength and subsequent indexing.
+  // append_array concatenates scalar-element and container-element arrays in
+  // outer-array order. O1 also materializes the loop sequence through an
+  // unsized integer-array temporary whose first assignment supplies its shape.
   {
     DataMap d;
+    d.set_int_array("selected", {2, 4});
     CompiledModel am =
         compile_model(slurp("tests/fixtures/unsized_append_loop.tmir.sexp"), d);
     Executor aex(std::move(am.graph));
     am.bind(aex);
-    aex.params_data()[0] = 0.5;
-    double gradient = 0.0;
-    expect_eq("unsized append loop lp", aex.gradient(&gradient), 4.5);
-    expect_eq("unsized append loop gradient", gradient, 9.0);
+    const double q[6] = {0.5, -0.7, 0.2, 1.1, -0.4, 0.8};
+    for (int i = 0; i < 6; ++i) aex.params_data()[i] = q[i];
+    double gradient[6] = {};
+    expect_eq("append array lp", aex.gradient(gradient),
+              10.0 * q[0] + 2.0 * q[3] + 3.0 * q[4]);
+    const double want[6] = {10.0, 0.0, 0.0, 2.0, 3.0, 0.0};
+    for (int i = 0; i < 6; ++i)
+      expect_eq("append array gradient " + std::to_string(i), gradient[i],
+                want[i]);
   }
 
   if (failures == 0) std::printf("test_lower OK\n");

--- a/tests/test_lower.cpp
+++ b/tests/test_lower.cpp
@@ -4106,6 +4106,26 @@ int main() {
     }
   }
 
+  // O1 composes a scalar UDF index through a two-axis gather as a nested
+  // Indexed node whose empty outer layer carries UReal. The selected cell is
+  // row_indices[1], column_indices[2] = source (3,3).
+  {
+    DataMap d;
+    d.set_int_array("row_indices", {3, 1});
+    d.set_int_array("column_indices", {2, 3});
+    CompiledModel gm = compile_model(
+        slurp("tests/fixtures/matrix_multi_multi_nested.tmir.sexp"), d);
+    Executor gex(std::move(gm.graph));
+    gm.bind(gex);
+    const double q[9] = {0.2, -0.4, 0.7, 0.1, -0.3, 0.8, 0.5, 0.9, -0.6};
+    for (int i = 0; i < 9; ++i) gex.params_data()[i] = q[i];
+    double gradient[9] = {};
+    expect_eq("matrix nested index: lp", gex.gradient(gradient), 2.0 * q[8]);
+    for (int i = 0; i < 9; ++i)
+      expect_eq("matrix nested index: g" + std::to_string(i), gradient[i],
+                i == 8 ? 2.0 : 0.0);
+  }
+
   // A scalar replicated as a row vector uses the vector replication opcode,
   // but must retain its row-vector type for downstream expression lowering.
   {

--- a/tests/test_lower.cpp
+++ b/tests/test_lower.cpp
@@ -5168,6 +5168,21 @@ int main() {
     }
   }
 
+  // O1 materializes an array-valued loop sequence through an unsized integer
+  // array temporary. Its first assignment supplies the three-element shape
+  // used by both FnLength and subsequent indexing.
+  {
+    DataMap d;
+    CompiledModel am =
+        compile_model(slurp("tests/fixtures/unsized_append_loop.tmir.sexp"), d);
+    Executor aex(std::move(am.graph));
+    am.bind(aex);
+    aex.params_data()[0] = 0.5;
+    double gradient = 0.0;
+    expect_eq("unsized append loop lp", aex.gradient(&gradient), 4.5);
+    expect_eq("unsized append loop gradient", gradient, 9.0);
+  }
+
   if (failures == 0) std::printf("test_lower OK\n");
   return failures == 0 ? 0 : 1;
 }

--- a/tests/test_mir_decode.cpp
+++ b/tests/test_mir_decode.cpp
@@ -497,7 +497,8 @@ json write_sized_type(const mir::SizedType& value) {
   return {{"base", value.base},
           {"dims", write_array(value.dims, write_expr)},
           {"elem_base", value.elem_base},
-          {"raw", value.raw}};
+          {"raw", value.raw},
+          {"unsized", write_unsized(value.unsized)}};
 }
 
 const char* write_stmt_kind(mir::Stmt::Kind value) {
@@ -1214,7 +1215,7 @@ void check_structural_rejections() {
                        "known function arity");
   for (const char* name :
        {"pow", "std_normal_qf", "trigamma", "is_nan", "tcrossprod", "diagonal",
-        "map_rect", "algebra_solver"}) {
+        "matrix_exp", "append_array", "map_rect", "algebra_solver"}) {
     bad_call.name = name;
     bad_call.args.clear();
     expect_error(write_v2(target_program(bad_call)),
@@ -1261,6 +1262,49 @@ void check_structural_rejections() {
   expect_error(write_v2(bad_binding),
                "variable type disagrees with its binding",
                "variable binding type mismatch");
+
+  mir::Program unsized_assignment;
+  mir::Stmt unsized_declaration;
+  unsized_declaration.kind = mir::Stmt::Decl;
+  unsized_declaration.decl_id = "tmp";
+  unsized_declaration.decl_type.raw = "(Unsized (UArray UReal))";
+  unsized_assignment.log_prob.push_back(std::move(unsized_declaration));
+  mir::Stmt first_assignment;
+  first_assignment.kind = mir::Stmt::Assignment;
+  first_assignment.lhs = "tmp";
+  first_assignment.rhs.kind = mir::Expr::Unsupported;
+  first_assignment.rhs.type_ = "UArray";
+  first_assignment.rhs.unsized = {1, mir::UnsizedLeaf::Real};
+  unsized_assignment.log_prob.push_back(std::move(first_assignment));
+  const mir::Program restored_unsized =
+      decode_program(write_v2(unsized_assignment));
+  check(restored_unsized.log_prob[0].decl_type.unsized.depth == 1 &&
+            restored_unsized.log_prob[0].decl_type.unsized.leaf ==
+                mir::UnsizedLeaf::Real,
+        "portable decoder restores unsized declaration metadata");
+
+  mir::Program wrong_unsized_leaf = unsized_assignment;
+  wrong_unsized_leaf.log_prob[1].rhs.unsized.leaf = mir::UnsizedLeaf::Int;
+  expect_error(write_v2(wrong_unsized_leaf),
+               "assignment type disagrees with its binding",
+               "unsized first assignment leaf mismatch");
+  mir::Program wrong_unsized_rank = unsized_assignment;
+  wrong_unsized_rank.log_prob[1].rhs.unsized.depth = 2;
+  expect_error(write_v2(wrong_unsized_rank),
+               "assignment type disagrees with its binding",
+               "unsized first assignment rank mismatch");
+  mir::Program wrong_unsized_initializer;
+  mir::Stmt initialized_unsized = unsized_assignment.log_prob[0];
+  initialized_unsized.has_init = true;
+  initialized_unsized.init = wrong_unsized_leaf.log_prob[1].rhs;
+  wrong_unsized_initializer.log_prob.push_back(std::move(initialized_unsized));
+  expect_error(write_v2(wrong_unsized_initializer),
+               "declaration initializer type disagrees with its binding",
+               "unsized declaration initializer mismatch");
+  mir::Program malformed_unsized = unsized_assignment;
+  malformed_unsized.log_prob[0].decl_type.raw = "(Unsized (UArray UFuture))";
+  expect_error(write_v2(malformed_unsized), "unsized declaration type",
+               "malformed unsized declaration spelling");
 
   mir::Program bad_function;
   mir::FunDef function;


### PR DESCRIPTION

- **Matrix multi-multi indexing** — two integer arrays on a matrix select the Cartesian submatrix, keeping each axis's order and duplicates rather than pairing corresponding indices.

  ```stan
  target += sum(computed[row_indices, column_indices]);
  ```

- **Nested indexing** — `--O1` index composition can leave an empty outer index node whose type is the final result. It's now collapsed rather than rejected on the stale intermediate type.

  ```stan
  real selected_cell(matrix x) { return x[1, 2]; }
  target += selected_cell(computed[row_indices, column_indices]);
  ```

- **Optimiser-generated container temporaries** — unsized container declarations take their shape from the first whole-variable assignment.

  ```stan
  for (i in {0, 2, 4})
    target += (i + 1) * theta;
  ```

- **`append_array`** — concatenation with element-shape and overflow checks, propagating data values so compile-time integer loops and index expressions still see exact contents.

  ```stan
  for (i in append_array(baseline, selected))
  array[3] vector[2] joined = append_array(head, tail);
  ```

- **`matrix_exp`** — differentiates through the full nonsymmetric exponential.

  ```stan
  matrix[2, 2] e = matrix_exp(a);
  ```

- **`quad_form_sym`** — both overloads, retaining stan-math's symmetry check on `A` and its two associations of the vector form (`B.dot(A * B)` at double, `B' * A * B` at var), which differ in the last bits.

  ```stan
  etacov = quad_form_sym(makesym(etacov, verbose, 1), eJAx');
  ```

