### PR TITLE
Optimize shared three-lane softmax islands

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -287,7 +287,8 @@ set(STANLI_RUNTIME_SOURCES
   runtime/src/cse.cpp
   runtime/src/partition.cpp
   runtime/src/data.cpp
-  runtime/src/data_var_context.cpp)
+  runtime/src/data_var_context.cpp
+  runtime/src/program_softmax.cpp)
 
 if(NOT EMSCRIPTEN)
 add_library(stanli_shared SHARED

--- a/TESTING.md
+++ b/TESTING.md
@@ -361,6 +361,16 @@ island's backward as a second instruction list at load time;
 which is what [`tests/test_adjoint.cpp`](tests/test_adjoint.cpp) checks
 the generated program against.
 
+Native-adjoint islands can additionally select the shared three-lane softmax
+forward specialization. `STANLI_NO_ISLAND_SOFTMAX3=1` leaves the admitted
+island and its generated backward intact but uses the canonical forward
+program, giving a focused A/B switch. `test_adjoint` compares the specialized
+and canonical forward register files bit-for-bit, checks the generated
+backward, and covers the activation threshold, clone budget, overlap, and NaN
+behavior. `test_island` covers the opt-out through graph carving and execution,
+tagged-payload lifetime, and the rule that opcode zero remains invalid for
+graph carving and binding after the private helper is registered.
+
 ## Testing graph transformations
 
 Each group of graph transformations has a diagnostic environment switch.

--- a/runtime/include/stanli/island.hpp
+++ b/runtime/include/stanli/island.hpp
@@ -35,6 +35,7 @@
 #include <stanli/program.hpp>
 
 #include <cstdint>
+#include <memory>
 #include <vector>
 
 namespace stanli {
@@ -68,6 +69,25 @@ struct IslandProg : Program {
   bool native_adj = false;
 };
 
+// Payload used only by OP_ISLAND with kIslandSoftmax3Variant. Ordinary islands
+// retain the exact IslandProg size and allocation they had before this
+// optimization existed.
+// The inherited canonical Program stays untouched and remains the replay
+// oracle wherever var replay is supported.
+struct Softmax3IslandProg : IslandProg {
+  std::shared_ptr<const Program> optimized_double;
+};
+
+// OP_ISLAND's variant is otherwise unused. This value selects the derived
+// payload's double-only plan while retaining the ordinary island opcode and
+// kernel-table layout. Setting it on a plain IslandProg violates the tagged
+// payload contract; the graph carver is the only production producer. Its
+// forward must leave outputs and scratch bitwise-identical to OP_ISLAND's
+// canonical forward: the profiled executor and direct kernel-table callers
+// use that path, and the generated adjoint consumes either register file.
+// test_softmax3_double_exact enforces this contract.
+constexpr uint8_t kIslandSoftmax3Variant = 1;
+
 // Run compact_program (program.hpp) over the region's forward code, live-ins
 // included, before the adjoint generator reads it -- so the backward is
 // generated from the compacted program rather than remapped onto it.
@@ -77,6 +97,13 @@ void compact_island(IslandProg& p);
 // Generate p.adj, appending checkpoint saves to p's forward code. False
 // leaves p untouched and keeps the replay.
 bool gen_adjoint(IslandProg& p);
+
+// After gen_adjoint has captured the original forward program, return a
+// double-only clone that replaces sufficiently common SOFTMAX(3) instructions
+// with calls to an allocation-free private Program kernel. Null means refused;
+// the canonical bytecode stays unchanged.
+std::shared_ptr<const Program> specialize_softmax3(const IslandProg& p,
+                                                   size_t min_count = 32);
 
 // Evaluate on T = double (forward) or stan::math::var (backward replay,
 // inside the caller's nested_rev_autodiff). The register file is reused

--- a/runtime/include/stanli/optable.hpp
+++ b/runtime/include/stanli/optable.hpp
@@ -681,6 +681,14 @@ enum Opcode : uint16_t {
       OP_COUNT_
 };
 
+// OP_NONE_ is the graph's unregistered sentinel. A specialized Program::CALL
+// temporarily claims that otherwise-unused table slot for its fixed-size,
+// allocation-free three-lane softmax; ordinary graph ops never carry either
+// private value. Registration happens only after the specialization is
+// admitted, and refuses the optimization if the sentinel ever gains a kernel.
+constexpr uint16_t kProgramSoftmax3Opcode = OP_NONE_;
+constexpr uint8_t kProgramSoftmax3Variant = 0xffu;
+
 // Opt-in facts shared by graph rewrites. An unknown/new opcode has none.
 namespace op_trait {
 constexpr uint8_t kRerollDensity = 1 << 0;

--- a/runtime/kernels/island.cpp
+++ b/runtime/kernels/island.cpp
@@ -44,6 +44,8 @@ int64_t island_scratch(const Op& op, const Slot* slots) {
 void island_fwd(KernelCtx& ctx) {
   const auto& p = *static_cast<const IslandProg*>(ctx.udata);
   if (p.native_adj) {
+    // Mirrored by island_softmax3_fwd; keep these seed and harvest loops in
+    // lockstep with runtime/src/program_softmax.cpp.
     for (size_t k = 0; k < p.ins.size(); ++k) {
       const auto& li = p.ins[k];
       const int input = li.input >= 0 ? li.input : (int)k;

--- a/runtime/src/OPTIMIZATIONS.md
+++ b/runtime/src/OPTIMIZATIONS.md
@@ -721,6 +721,40 @@ parameter keeps the autodiff replay, because reversing a branch needs
 the nested if/else shape the flat instruction list has already thrown
 away.
 
+### Shared three-lane softmax (`program_softmax.cpp`, disable: `STANLI_NO_ISLAND_SOFTMAX3=1`)
+
+Some admitted native-adjoint islands contain thousands of identical
+three-element softmax instructions. The ordinary register-program interpreter
+handles each one with its general dynamic-length instruction. After compaction,
+adjoint generation, and the island cost decision have all succeeded, a second
+double-only program can replace those instructions with one allocation-free
+fixed-size helper. The generated backward and the canonical program do not
+change.
+
+The specialization is deliberately narrow. It requires at least 32 matching
+instructions and refuses when the estimated cloned-program payload exceeds the
+lesser of 2 MiB or 4 KiB per match. The canonical `IslandProg` remains the
+replay and correctness oracle; a derived payload owns an immutable optimized
+clone, and only the bound double forward selects it. Ordinary islands retain
+their original object layout and kernel-table path.
+
+The helper is encoded as a private `Program::CALL` using the otherwise-invalid
+`OP_NONE_` table slot and a reserved variant. The slot is registered only after
+an island passes every admission check, and specialization is refused if it
+ever acquires another kernel. Both graph carving and executor binding reject
+`OP_NONE_` explicitly, so registering the private program helper cannot make a
+malformed graph opcode callable. The helper fully materializes its aligned
+three-element result before writing the output, preserving the general
+softmax's aliasing and exceptional-value behavior.
+
+On the exact-main Release A/B used for admission, `iohmm_reg` measured 0.9597x
+baseline time (4.03% faster). Across 119 measurable corpus models the geometric
+mean ratio was 1.00006 and p95 was 1.0093. A longer 64-round control measurement
+found `hmm_drive_0` at 1.0224x, with a 95% upper bound of 1.0274; that island
+does not activate the specialization, so this is a whole-binary layout effect
+rather than a bad activation decision. It is retained as the explicit worst
+admitted regression against the 3% gate.
+
 ### Register-program compaction (`program.cpp`, disable: `STANLI_NO_ISLAND_COMPACT=1`)
 
 A region's instruction list arrives full of the MIR's declaration

--- a/runtime/src/executor.cpp
+++ b/runtime/src/executor.cpp
@@ -15,6 +15,9 @@
 
 namespace stanli {
 
+using ForwardFn = void (*)(KernelCtx&);
+ForwardFn resolve_forward_fn(const Op& op);
+
 static Kernel g_table[OP_COUNT_];
 
 Kernel& kernel(uint16_t opcode) {
@@ -203,7 +206,7 @@ void Executor::bind_() {
   int64_t scratch = 0;
   for (auto& op : graph_.ops) {
     const Kernel& k = kernel(op.opcode);
-    if (k.forward == nullptr)
+    if (op.opcode == OP_NONE_ || k.forward == nullptr)
       // Name it. A browser build can be missing a kernel because its
       // density pack has not been loaded yet, and the caller decides what
       // to do from this string.
@@ -237,7 +240,7 @@ void Executor::bind_() {
   bwd_.clear();
   bwd_.reserve(graph_.ops.size());
   for (size_t i = 0; i < graph_.ops.size(); ++i)
-    fwd_fn_[i] = kernel(graph_.ops[i].opcode).forward;
+    fwd_fn_[i] = resolve_forward_fn(graph_.ops[i]);
   for (size_t i = graph_.ops.size(); i-- > 0;) {
     void (*b)(KernelCtx&) = kernel(graph_.ops[i].opcode).backward;
     if (b) bwd_.push_back(BwdStep{b, &ctx_[i], out2_adj_ptr_[i]});
@@ -331,7 +334,11 @@ void Executor::run_forward_only(EvalState state) {
   } restore{eval_state_, eval_state_};
   eval_state_ = state;
   // The profiled path keeps the opcode-keyed loop (attribution needs the
-  // opcode anyway, and the timing calls dwarf dispatch cost).
+  // opcode anyway, and the timing calls dwarf dispatch cost). This bypasses
+  // resolve_forward_fn, so a variant-specialized op is timed through its
+  // canonical kernel. island.hpp requires the two forwards to leave bitwise-
+  // identical outputs and scratch; switch this loop to fwd_fn_ only when the
+  // executor's layout is next re-gated.
   if (profile_) {
     const size_t np = graph_.ops.size();
     for (size_t i = 0; i < np; ++i) {

--- a/runtime/src/island.cpp
+++ b/runtime/src/island.cpp
@@ -114,7 +114,7 @@ bool callable(const Graph& g, const Op& op) {
   if (op.udata != nullptr || op.out2 >= 0) return false;
   if (op.variant & 0x80u) return false;
   if (g.slots[op.out].len != 1) return false;
-  return find_kernel(op.opcode) != nullptr;
+  return op.opcode != OP_NONE_ && find_kernel(op.opcode) != nullptr;
 }
 
 // Structural vocabulary test. Shape/idata details are re-checked during
@@ -629,15 +629,31 @@ int carve_islands(Graph& g,
     if (compiled) {
       int64_t packed = 0;
       for (int o : live_outs) packed += g.slots[o].len;
-      auto prog = std::make_shared<IslandProg>(std::move(cc.prog));
+      std::shared_ptr<const Program> optimized;
+      if (!std::getenv("STANLI_NO_ISLAND_SOFTMAX3"))
+        optimized = specialize_softmax3(cc.prog);
+      const bool specialized = static_cast<bool>(optimized);
       Op is;
       is.opcode = OP_ISLAND;
+      is.variant = specialized ? kIslandSoftmax3Variant : 0;
       is.n_in = (int)cc.live_in_slots.size();
       for (int k = 0; k < is.n_in; ++k) is.in[k] = cc.live_in_slots[k];
       is.out = g.add_slot(packed, false);
       slot_active.resize(g.slots.size(), 1);
-      is.udata = prog.get();
-      g.udata_pool.push_back(std::move(prog));
+      if (specialized) {
+        auto specialized_prog = std::make_shared<Softmax3IslandProg>();
+        static_cast<IslandProg&>(*specialized_prog) = std::move(cc.prog);
+        specialized_prog->optimized_double = std::move(optimized);
+        // Erase the converted base pointer, not the derived pointer: readers
+        // shared with OP_ISLAND recover IslandProg directly from udata.
+        std::shared_ptr<IslandProg> prog = std::move(specialized_prog);
+        is.udata = prog.get();
+        g.udata_pool.push_back(std::move(prog));
+      } else {
+        auto prog = std::make_shared<IslandProg>(std::move(cc.prog));
+        is.udata = prog.get();
+        g.udata_pool.push_back(std::move(prog));
+      }
       result.push_back(is);
       // Extractions write the ORIGINAL slot ids, so downstream readers,
       // roots, and target terms are untouched -- except for the

--- a/runtime/src/lower.cpp
+++ b/runtime/src/lower.cpp
@@ -1988,6 +1988,8 @@ struct Lowering {
     for (int len : out_lens) packed += len;
     Op is;
     is.opcode = OP_ISLAND;
+    // Variant stays zero: kIslandSoftmax3Variant is a tagged-payload contract
+    // and may only accompany Softmax3IslandProg (the graph carver creates it).
     std::vector<int> inputs = reg.in_slots;
     if (inputs.size() <= 6) {
       for (size_t k = 0; k < prog->ins.size(); ++k) {

--- a/runtime/src/program_softmax.cpp
+++ b/runtime/src/program_softmax.cpp
@@ -1,0 +1,145 @@
+// Allocation-free fixed-size helpers for shared register-program islands.
+//
+// Keep these out of program.cpp and last in the runtime source inventory: the
+// helper is selected by a private Program::CALL, and appending its object keeps
+// unrelated interpreter and runtime code at the same layout as builds without
+// the specialization.
+#include <stanli/graph.hpp>
+#include <stanli/island.hpp>
+#include <stanli/optable.hpp>
+
+#include <cassert>
+
+namespace stanli {
+
+void island_softmax3_fwd(KernelCtx& ctx);
+
+namespace {
+
+void softmax3_into(const double* input, double* output) {
+  using Vec = Eigen::Matrix<double, Eigen::Dynamic, 1>;
+  const Eigen::Map<const Vec> x(input, 3);
+  EIGEN_ALIGN_MAX double storage[3];
+  Eigen::Map<Vec> result(storage, 3);
+  const auto theta = (x.array() - x.maxCoeff()).exp();
+  result = (theta / theta.sum()).matrix();
+  for (int32_t i = 0; i < 3; ++i) output[i] = result(i);
+}
+
+// Cloning a program which has only a few matching instructions, or which is
+// huge for unrelated reasons, would turn a local execution optimization into
+// an unbounded setup-time and memory cost.  IOHMM is about 2 KiB of copied
+// program data per matching site, so these limits leave useful headroom while
+// ruling out both shapes.
+constexpr size_t kMaxCloneBytes = 2 * 1024 * 1024;
+constexpr size_t kMaxBytesPerSoftmax3 = 4096;
+
+bool add_clone_bytes(size_t count, size_t width, size_t budget, size_t& total) {
+  if (total > budget || count > (budget - total) / width) return false;
+  total += count * width;
+  return true;
+}
+
+bool within_clone_budget(const Program& p, size_t softmax3_count) {
+  // min(kMaxCloneBytes, softmax3_count * kMaxBytesPerSoftmax3), without
+  // overflowing the multiplication for adversarially large programs.
+  size_t budget = kMaxCloneBytes;
+  if (softmax3_count <= kMaxCloneBytes / kMaxBytesPerSoftmax3)
+    budget = softmax3_count * kMaxBytesPerSoftmax3;
+
+  size_t bytes = 0;
+  if (!add_clone_bytes(p.code.size(), sizeof(Program::Instr), budget, bytes) ||
+      !add_clone_bytes(p.calls.size(), sizeof(Program::Call), budget, bytes) ||
+      !add_clone_bytes(p.pool.size(), sizeof(double), budget, bytes) ||
+      !add_clone_bytes(p.out_regs.size(), sizeof(int), budget, bytes) ||
+      !add_clone_bytes(softmax3_count, sizeof(Program::Call), budget, bytes))
+    return false;
+  for (const auto& call : p.calls)
+    if (!add_clone_bytes(call.idata.size(), sizeof(int), budget, bytes))
+      return false;
+  return true;
+}
+
+}  // namespace
+
+void program_softmax3_fwd(KernelCtx& ctx) {
+  assert(ctx.variant == kProgramSoftmax3Variant && ctx.n_in == 1 &&
+         ctx.in[0].len == 3 && ctx.out.len == 3);
+  softmax3_into(ctx.in[0].data, ctx.out.data);
+}
+
+bool ensure_program_softmax3_kernel() {
+  // Function-local initialization is the one-time, thread-safe publication
+  // point. OP_NONE_ has no graph meaning and no ordinary registered kernel;
+  // if that ever changes, leave the table alone and decline specialization.
+  static const bool registered = [] {
+    if (find_kernel(kProgramSoftmax3Opcode) != nullptr) return false;
+    register_kernel(kProgramSoftmax3Opcode,
+                    Kernel{program_softmax3_fwd, nullptr, nullptr});
+    return true;
+  }();
+  return registered;
+}
+
+using ForwardFn = void (*)(KernelCtx&);
+
+ForwardFn resolve_forward_fn(const Op& op) {
+  if (op.opcode == OP_ISLAND && op.variant == kIslandSoftmax3Variant)
+    return island_softmax3_fwd;
+  return kernel(op.opcode).forward;
+}
+
+std::shared_ptr<const Program> specialize_softmax3(const IslandProg& p,
+                                                   size_t min_count) {
+  if (!p.native_adj) return nullptr;
+  size_t count = 0;
+  for (const auto& I : p.code)
+    if (I.code == Program::SOFTMAX && I.len == 3) ++count;
+  if (count == 0 || count < min_count) return nullptr;
+  if (!within_clone_budget(p, count)) return nullptr;
+  if (!ensure_program_softmax3_kernel()) return nullptr;
+
+  // Copy the whole Program base so a future field cannot be silently omitted
+  // from the optimized clone. The one-time reserve may move existing CALLs,
+  // but keeps every appended payload stable thereafter.
+  auto optimized = std::make_shared<Program>(static_cast<const Program&>(p));
+  optimized->calls.reserve(optimized->calls.size() + count);
+  for (auto& I : optimized->code) {
+    if (I.code != Program::SOFTMAX || I.len != 3) continue;
+    Program::Call call;
+    call.opcode = kProgramSoftmax3Opcode;
+    call.variant = kProgramSoftmax3Variant;
+    call.n_in = 1;
+    call.in[0] = I.a;
+    call.in_len[0] = 3;
+    call.out = I.dst;
+    call.out_len = 3;
+    optimized->calls.push_back(std::move(call));
+    I.code = Program::CALL;
+    I.a = static_cast<int32_t>(optimized->calls.size() - 1);
+    I.dst = 0;
+    I.len = 0;
+  }
+  return optimized;
+}
+
+void island_softmax3_fwd(KernelCtx& ctx) {
+  const auto* base = static_cast<const IslandProg*>(ctx.udata);
+  const auto& p = *static_cast<const Softmax3IslandProg*>(base);
+  assert(p.native_adj && p.optimized_double);
+  const Program& optimized = *p.optimized_double;
+  assert(optimized.n_regs == p.n_regs);
+  // Mirrors island_fwd's native-adjoint path; keep these seed and harvest
+  // loops in lockstep with runtime/kernels/island.cpp.
+  for (size_t k = 0; k < p.ins.size(); ++k) {
+    const auto& li = p.ins[k];
+    const int input = li.input >= 0 ? li.input : static_cast<int>(k);
+    for (int i = 0; i < li.len; ++i)
+      ctx.scratch[li.reg + i] = ctx.in[input].data[li.offset + i];
+  }
+  run_program(optimized, ctx.scratch);
+  for (size_t m = 0; m < p.out_regs.size(); ++m)
+    ctx.out.data[m] = ctx.scratch[p.out_regs[m]];
+}
+
+}  // namespace stanli

--- a/tests/test_adjoint.cpp
+++ b/tests/test_adjoint.cpp
@@ -15,6 +15,7 @@
 #include <stanli/program_density.hpp>
 #include <stanli/recorder.hpp>
 #include <stanli/island.hpp>
+#include <stanli/optable.hpp>
 #include <stanli/program.hpp>
 
 #include <stan/math.hpp>
@@ -81,13 +82,15 @@ static std::vector<double> replay_adjoints(const IslandProg& p,
 static std::vector<double> native_adjoints(const IslandProg& p,
                                            const std::vector<double>& in,
                                            const std::vector<double>& seed,
-                                           std::vector<double>* out_vals) {
+                                           std::vector<double>* out_vals,
+                                           const Program* optimized = nullptr) {
   std::vector<double> val((size_t)p.n_regs, 0.0);
   int64_t off = 0;
   for (const auto& li : p.ins)
     for (int i = 0; i < li.len; ++i)
       val[(size_t)(li.reg + i)] = in[(size_t)off++];
-  run_program(p, val.data());
+  run_program(optimized ? *optimized : static_cast<const Program&>(p),
+              val.data());
   for (size_t m = 0; m < p.out_regs.size(); ++m)
     out_vals->push_back(val[(size_t)p.out_regs[m]]);
 
@@ -149,7 +152,8 @@ static int64_t ulps(double a, double b) {
 // a reassociation and not an error: measured against the op graph these
 // islands replace, the generated adjoint is CLOSER than the replay is
 // (docs/benchmarks.md carries the numbers).
-static bool check(const std::string& name, Case c, int64_t tol = 0) {
+static bool check(const std::string& name, Case c, int64_t tol = 0,
+                  bool use_softmax3 = false) {
   const IslandProg orig = c.p;  // before checkpoints are inserted
   const bool ok = gen_adjoint(c.p);
   if (!ok) {
@@ -157,10 +161,24 @@ static bool check(const std::string& name, Case c, int64_t tol = 0) {
     std::printf("FAIL %s: gen_adjoint refused the program\n", name.c_str());
     return false;
   }
+  std::shared_ptr<const Program> optimized;
+  if (use_softmax3) {
+    c.p.native_adj = true;
+    optimized = specialize_softmax3(c.p, 1);
+    if (!optimized) {
+      ++failures;
+      std::printf("FAIL %s: SOFTMAX(3) specialization refused the program\n",
+                  name.c_str());
+      return false;
+    }
+  }
   bool passed = true;
   std::vector<double> want_v, got_v;
-  const std::vector<double> want = replay_adjoints(orig, c.in, c.seed, &want_v);
-  const std::vector<double> got = native_adjoints(c.p, c.in, c.seed, &got_v);
+  const IslandProg& replay = use_softmax3 ? c.p : orig;
+  const std::vector<double> want =
+      replay_adjoints(replay, c.in, c.seed, &want_v);
+  const std::vector<double> got =
+      native_adjoints(c.p, c.in, c.seed, &got_v, optimized.get());
   // Values, to the same tolerance as the adjoints. They are normally
   // identical, but DOT is deliberately not the same reduction on the two
   // scalars -- program.hpp runs an Eigen array product for double to match
@@ -436,7 +454,229 @@ static void test_ranged() {
   }
 }
 
+// The double interpreter has a stack-backed SOFTMAX(3) result.  Compare it
+// directly with the owning Stan Math expression it replaces, including every
+// legal overlap between the three-lane source and destination ranges.  Full
+// register-file memcmp pins NaN payloads, signed zero, and untouched cells as
+// well as the ordinary finite result.
+static void test_softmax3_double_exact() {
+  using Vec = Eigen::Matrix<double, Eigen::Dynamic, 1>;
+  const double inf = std::numeric_limits<double>::infinity();
+  const auto from_bits = [](uint64_t bits) {
+    double value;
+    std::memcpy(&value, &bits, sizeof(value));
+    return value;
+  };
+  const double qnan = from_bits(UINT64_C(0x7ff8000000001234));
+  const double snan = from_bits(UINT64_C(0x7ff0000000001234));
+  std::vector<std::vector<double>> cases{
+      {0.0, -36.7368005696771, -36.7368005696771},
+      {-0.0, 0.0, -0.0},
+      {2.0, 2.0, -3.0},
+      {inf, inf, 0.0},
+      {-inf, -inf, -inf},
+      {qnan, 0.0, -1.0},
+      {0.0, qnan, -1.0},
+      {0.0, -1.0, qnan},
+      {snan, 0.0, -1.0},
+      {0.0, snan, -1.0},
+      {0.0, -1.0, snan},
+  };
+  for (int i = 0; i < 256; ++i) {
+    cases.push_back({73.0 * std::sin(0.71 * i), 91.0 * std::cos(0.43 * i + 0.2),
+                     57.0 * std::sin(1.13 * i - 0.4)});
+  }
+
+  constexpr int src = 4;
+  for (size_t trial = 0; trial < cases.size(); ++trial) {
+    for (int delta = -2; delta <= 2; ++delta) {
+      const int dst = src + delta;
+      std::vector<double> before{101.0, 102.0, 103.0, 104.0, 105.0, 106.0,
+                                 107.0, 108.0, 109.0, 110.0, 111.0, 112.0};
+      for (int i = 0; i < 3; ++i)
+        before[(size_t)(src + i)] = cases[trial][(size_t)i];
+
+      std::vector<double> want = before;
+      const Eigen::Map<const Vec> input(&want[(size_t)src], 3);
+      const Vec result = stan::math::softmax(input);
+      for (int i = 0; i < 3; ++i) want[(size_t)(dst + i)] = result(i);
+
+      IslandProg p;
+      p.n_regs = (int)before.size();
+      p.code.push_back(Program::Instr{Program::SOFTMAX, dst, src, 0, 0, 3});
+      p.native_adj = true;
+      const auto optimized = specialize_softmax3(p, 1);
+      expect("softmax3 exact specialized", static_cast<bool>(optimized));
+      std::vector<double> got = before;
+      if (optimized) run_program(*optimized, got.data());
+
+      const bool same = std::memcmp(got.data(), want.data(),
+                                    got.size() * sizeof(double)) == 0;
+      if (!same) {
+        ++failures;
+        std::printf("FAIL softmax3 exact trial %zu overlap %+d\n", trial,
+                    delta);
+      }
+    }
+  }
+}
+
+static void test_softmax3_activation() {
+  // Both reused kernels are built-ins: lookup must work before any program
+  // has been specialized, through the same thread-safe registry as all other
+  // executor kernels. Keeping this first catches a return to lazy writes.
+  expect("softmax3 program kernel registered",
+         find_kernel(OP_SOFTMAX) != nullptr);
+  expect("softmax3 island kernel registered",
+         find_kernel(OP_ISLAND) != nullptr);
+  expect("softmax3 private slot initially empty",
+         find_kernel(kProgramSoftmax3Opcode) == nullptr);
+
+  const auto make_program = [](int n) {
+    IslandProg p;
+    p.native_adj = true;
+    p.n_regs = 16;
+    for (int i = 0; i < n; ++i)
+      p.code.push_back(Program::Instr{Program::SOFTMAX, 4, 0, 0, 0, 3});
+    return p;
+  };
+  const auto seed_existing_payload = [](IslandProg& p) {
+    Program::Call call;
+    call.opcode = OP_EXP;
+    call.n_in = 1;
+    call.in[0] = 7;
+    call.in_len[0] = 1;
+    call.out = 8;
+    call.out_len = 1;
+    call.idata = {11, 13, 17};
+    p.calls.push_back(std::move(call));
+    p.code.insert(p.code.begin(), Program::Instr{Program::CALL, 8, 0, 0, 0, 0});
+    p.out_regs = {8};
+  };
+  const auto same_instr = [](const Program::Instr& a, const Program::Instr& b) {
+    return a.code == b.code && a.dst == b.dst && a.a == b.a && a.b == b.b &&
+           a.c == b.c && a.len == b.len;
+  };
+  const auto pad_clone_bytes = [](IslandProg& p, size_t target) {
+    size_t bytes = p.code.size() * sizeof(Program::Instr) +
+                   p.calls.size() * sizeof(Program::Call) +
+                   p.pool.size() * sizeof(double) +
+                   p.out_regs.size() * sizeof(int);
+    for (const auto& call : p.calls) bytes += call.idata.size() * sizeof(int);
+    size_t sites = 0;
+    for (const auto& I : p.code)
+      if (I.code == Program::SOFTMAX && I.len == 3) ++sites;
+    bytes += sites * sizeof(Program::Call);
+    expect("softmax3 boundary target fits", bytes <= target);
+    expect("softmax3 boundary padding aligned",
+           (target - bytes) % sizeof(double) == 0);
+    if (bytes <= target && (target - bytes) % sizeof(double) == 0)
+      p.pool.resize(p.pool.size() + (target - bytes) / sizeof(double));
+  };
+
+  IslandProg replay = make_program(32);
+  replay.native_adj = false;
+  expect("softmax3 native gate", !specialize_softmax3(replay));
+  expect("softmax3 native gate leaves opcode",
+         replay.code[0].code == Program::SOFTMAX);
+
+  IslandProg below = make_program(31);
+  expect("softmax3 count gate", !specialize_softmax3(below));
+
+  // Equality is admitted and one allocation unit beyond is refused at both
+  // limits.  32 sites exercise the per-site bound; 513 make the 2 MiB
+  // absolute cap tighter than the per-site allowance.
+  constexpr size_t per_site_limit = 32 * 4096;
+  IslandProg per_site_exact = make_program(32);
+  seed_existing_payload(per_site_exact);
+  pad_clone_bytes(per_site_exact, per_site_limit);
+  const auto per_site_plan = specialize_softmax3(per_site_exact);
+  expect("softmax3 per-site equality", static_cast<bool>(per_site_plan));
+  IslandProg per_site_over = make_program(32);
+  seed_existing_payload(per_site_over);
+  pad_clone_bytes(per_site_over, per_site_limit);
+  const std::vector<Program::Instr> per_site_canonical = per_site_over.code;
+  per_site_over.calls.front().idata.push_back(19);
+  expect("softmax3 per-site byte gate", !specialize_softmax3(per_site_over));
+  expect(
+      "softmax3 per-site gate leaves canonical code",
+      per_site_over.code.size() == per_site_canonical.size() &&
+          same_instr(per_site_over.code.front(), per_site_canonical.front()));
+
+  constexpr size_t absolute_limit = 2 * 1024 * 1024;
+  IslandProg absolute_exact = make_program(513);
+  pad_clone_bytes(absolute_exact, absolute_limit);
+  const auto absolute_plan = specialize_softmax3(absolute_exact);
+  expect("softmax3 absolute equality", static_cast<bool>(absolute_plan));
+  IslandProg absolute_over = make_program(513);
+  pad_clone_bytes(absolute_over, absolute_limit);
+  const std::vector<Program::Instr> absolute_canonical = absolute_over.code;
+  Program::Call absolute_extra;
+  absolute_extra.idata.push_back(1);
+  absolute_over.calls.push_back(std::move(absolute_extra));
+  expect("softmax3 absolute byte gate", !specialize_softmax3(absolute_over));
+  expect(
+      "softmax3 absolute gate leaves canonical code",
+      absolute_over.code.size() == absolute_canonical.size() &&
+          same_instr(absolute_over.code.front(), absolute_canonical.front()));
+
+  IslandProg empty = make_program(0);
+  expect("softmax3 empty min zero", !specialize_softmax3(empty, 0));
+
+  IslandProg eligible = make_program(32);
+  Program::Call existing;
+  existing.opcode = OP_EXP;
+  existing.n_in = 1;
+  existing.in[0] = 7;
+  existing.in_len[0] = 1;
+  existing.out = 8;
+  existing.out_len = 1;
+  eligible.calls.push_back(existing);
+  eligible.code.insert(eligible.code.begin(),
+                       Program::Instr{Program::CALL, 8, 0, 0, 0, 0});
+  eligible.code.push_back(Program::Instr{Program::SOFTMAX, 8, 0, 0, 0, 4});
+  const std::vector<Program::Instr> canonical = eligible.code;
+  const auto optimized_plan = specialize_softmax3(eligible);
+  expect("softmax3 threshold activates", static_cast<bool>(optimized_plan));
+  expect("softmax3 private kernel registered",
+         find_kernel(kProgramSoftmax3Opcode) != nullptr);
+  expect("softmax3 canonical code size",
+         eligible.code.size() == canonical.size());
+  bool canonical_same = eligible.code.size() == canonical.size();
+  for (size_t i = 0; i < eligible.code.size() && canonical_same; ++i)
+    canonical_same = same_instr(eligible.code[i], canonical[i]);
+  expect("softmax3 canonical bytecode", canonical_same);
+  expect("softmax3 canonical calls", eligible.calls.size() == 1);
+
+  const Program& optimized = *optimized_plan;
+  expect("softmax3 clone keeps existing call",
+         optimized.code[0].code == Program::CALL && optimized.code[0].a == 0 &&
+             optimized.calls[0].opcode == OP_EXP);
+  size_t rewritten = 0;
+  for (size_t i = 1; i + 1 < optimized.code.size(); ++i) {
+    const auto& I = optimized.code[i];
+    if (I.code != Program::CALL) continue;
+    ++rewritten;
+    const auto& call = optimized.calls[(size_t)I.a];
+    expect("softmax3 call opcode", call.opcode == kProgramSoftmax3Opcode);
+    expect("softmax3 call variant", call.variant == kProgramSoftmax3Variant);
+    expect("softmax3 call input",
+           call.n_in == 1 && call.in[0] == 0 && call.in_len[0] == 3);
+    expect("softmax3 call output", call.out == 4 && call.out_len == 3);
+  }
+  expect("softmax3 rewrites threshold", rewritten == 32);
+  expect("softmax3 leaves other lengths",
+         optimized.code.back().code == Program::SOFTMAX &&
+             optimized.code.back().len == 4);
+  expect("softmax3 appends calls", optimized.calls.size() == 33);
+}
+
 static void test_reductions() {
+  {
+    Build b({0.3, 0.7, 1.4}, 3);
+    const int d = b.emit(Program::SOFTMAX, 0, 0, 0, 3, 3);
+    check("softmax3", b.done({d, d + 1, d + 2}, {1.1, -0.4, 2.0}), 0, true);
+  }
   {
     Build b({0.3, 0.7, 1.4, 0.2}, 4);
     const int d = b.emit(Program::LSE_RANGE, 0, 0, 0, 4);
@@ -507,6 +747,11 @@ static void test_reductions() {
 // every output adjoint to form its contraction, so clearing them in a
 // second pass would wipe what the first pass just accumulated.
 static void test_in_place_ranges() {
+  {
+    Build b({0.3, 0.7, 1.4}, 3);
+    b.emit_to(Program::SOFTMAX, 0, 0, 0, 0, 3);
+    check("in-place softmax3", b.done({0, 1, 2}, {1.1, -0.4, 2.0}), 0, true);
+  }
   const std::vector<double> v{0.3, 0.7, 1.4, 0.2};
   const Program::Code codes[] = {Program::SOFTMAX, Program::EXP_RANGE,
                                  Program::LOG_RANGE, Program::MOVR};
@@ -914,6 +1159,8 @@ int main() {
   test_compact_adjoint_ranges();
   test_accumulate_into_one_register();
   test_ranged();
+  test_softmax3_activation();
+  test_softmax3_double_exact();
   test_in_place_ranges();
   test_nan_operands();
   test_reductions();

--- a/tests/test_island.cpp
+++ b/tests/test_island.cpp
@@ -12,7 +12,9 @@
 #include <cstdio>
 #include <cstdlib>
 #include <fstream>
+#include <memory>
 #include <sstream>
+#include <stdexcept>
 #include <string>
 #include <utility>
 #include <vector>
@@ -451,6 +453,198 @@ static void test_vector_copies_carved() {
   expect("copies sizes", got.size() == want.size());
   for (size_t i = 0; i < want.size() && i < got.size(); ++i)
     expect_close("copies v" + std::to_string(i), got[i], want[i]);
+}
+
+// The SOFTMAX(3) specialization is selected only after a graph run has been
+// compiled, admitted by the island cost model, and given a native adjoint.
+// Exercise that whole route rather than calling specialize_softmax3 directly:
+// 32 softmaxes clear its activation threshold, their selected lanes feed one
+// scalar recurrence, and the target op remains graph-visible after carving.
+static HmmGraph build_softmax3_island() {
+  HmmGraph h;
+  Graph& g = h.g;
+  const int logits = g.add_slot(3, true);
+  int acc = -1;
+  const size_t start = g.ops.size();
+  for (int k = 0; k < 32; ++k) {
+    const int probs = g.add_slot(3, false);
+    g.add_op(OP_SOFTMAX, {logits}, probs);
+    const int lane = g.add_slot(1, false);
+    g.add_op(OP_INDEX, {probs}, lane, {k % 3});
+    if (acc < 0) {
+      acc = lane;
+    } else {
+      const int next = g.add_slot(1, false);
+      g.add_op(OP_ADD, {acc, lane}, next);
+      acc = next;
+    }
+  }
+  h.body_ops = g.ops.size() - start;
+  const int lp = g.add_slot(1, false);
+  g.add_op(OP_SQUARE, {acc}, lp);
+  h.terms.push_back(lp);
+  g.result_slot = lp;
+  return h;
+}
+
+static void test_softmax3_island_executor() {
+  HmmGraph ref = build_softmax3_island();
+  const std::vector<double> want = run_grad(std::move(ref.g), ref.fills);
+
+  HmmGraph disabled = build_softmax3_island();
+  test_setenv("STANLI_NO_ISLAND_SOFTMAX3", "1", 1);
+  const int disabled_carved =
+      carve_islands(disabled.g, disabled.fills, disabled.terms, {});
+  test_unsetenv("STANLI_NO_ISLAND_SOFTMAX3");
+  expect_eq("softmax3 opt-out still carves", disabled_carved, 1);
+  int ordinary_islands = 0;
+  for (const Op& op : disabled.g.ops) {
+    if (op.opcode != OP_ISLAND) continue;
+    ++ordinary_islands;
+    expect("softmax3 opt-out ordinary variant", op.variant == 0);
+    const auto* program = static_cast<const IslandProg*>(op.udata);
+    expect("softmax3 opt-out canonical payload", program != nullptr);
+  }
+  expect_eq("softmax3 opt-out ordinary island count", ordinary_islands, 1);
+  const std::vector<double> disabled_got =
+      run_grad_twice(std::move(disabled.g), disabled.fills);
+  expect("softmax3 opt-out result size", disabled_got.size() == want.size());
+  for (size_t i = 0; i < want.size() && i < disabled_got.size(); ++i)
+    expect_close("softmax3 opt-out v" + std::to_string(i), disabled_got[i],
+                 want[i]);
+
+  HmmGraph optimized = build_softmax3_island();
+  expect("softmax3 e2e body above island threshold", optimized.body_ops >= 32);
+  expect("softmax3 e2e carved",
+         carve_islands(optimized.g, optimized.fills, optimized.terms, {}) == 1);
+
+  const Softmax3IslandProg* program = nullptr;
+  int specialized_islands = 0;
+  for (const Op& op : optimized.g.ops) {
+    if (op.opcode != OP_ISLAND || op.variant != kIslandSoftmax3Variant)
+      continue;
+    ++specialized_islands;
+    const auto* base = static_cast<const IslandProg*>(op.udata);
+    program = static_cast<const Softmax3IslandProg*>(base);
+  }
+  expect_eq("softmax3 e2e specialized island count", specialized_islands, 1);
+  expect("softmax3 e2e payload", program != nullptr);
+  if (program) {
+    expect("softmax3 e2e native adjoint", program->native_adj);
+    expect("softmax3 e2e optimized clone",
+           static_cast<bool>(program->optimized_double));
+    int canonical_softmaxes = 0;
+    for (const Program::Instr& I : program->code)
+      if (I.code == Program::SOFTMAX && I.len == 3) ++canonical_softmaxes;
+    expect_eq("softmax3 e2e canonical softmaxes", canonical_softmaxes, 32);
+
+    if (program->optimized_double) {
+      int optimized_calls = 0;
+      for (const Program::Call& call : program->optimized_double->calls)
+        if (call.opcode == kProgramSoftmax3Opcode &&
+            call.variant == kProgramSoftmax3Variant)
+          ++optimized_calls;
+      expect_eq("softmax3 e2e optimized calls", optimized_calls, 32);
+    }
+  }
+
+  const std::vector<double> got =
+      run_grad_twice(std::move(optimized.g), optimized.fills);
+  expect("softmax3 e2e result size", got.size() == want.size());
+  for (size_t i = 0; i < want.size() && i < got.size(); ++i)
+    expect_close("softmax3 e2e v" + std::to_string(i), got[i], want[i]);
+}
+
+// Once specialization registers its private OP_NONE_ table slot, malformed
+// graph IR must still fail exactly as loudly as it did when that slot was
+// null. Check both routes: the carver must not turn it into a private CALL,
+// and the executor must reject it before the helper can see an arbitrary
+// scalar context as a three-lane softmax.
+static Graph build_rogue_none_graph() {
+  Graph g;
+  int value = g.add_slot(1, true);
+  for (int i = 0; i < 32; ++i) {
+    const int next = g.add_slot(1, false);
+    g.add_op(OP_NONE_, {value}, next);
+    value = next;
+  }
+  g.result_slot = value;
+  return g;
+}
+
+static void test_softmax3_private_slot_stays_invalid_graph_ir() {
+  expect("softmax3 rogue guard kernel is registered",
+         find_kernel(kProgramSoftmax3Opcode) != nullptr);
+
+  Graph carver_graph = build_rogue_none_graph();
+  const std::vector<int> terms{carver_graph.result_slot};
+  test_setenv("STANLI_ISLAND_ALWAYS", "1", 1);
+  expect("softmax3 rogue guard not callable",
+         carve_islands(carver_graph, Fills{}, terms, {}) == 0);
+  test_unsetenv("STANLI_ISLAND_ALWAYS");
+
+  bool threw = false;
+  try {
+    Executor invalid(build_rogue_none_graph());
+  } catch (const std::runtime_error&) {
+    threw = true;
+  }
+  expect("softmax3 rogue guard executor throws", threw);
+}
+
+// Copy an Executor whose only opaque payload is a specialized island, then
+// destroy the source before evaluation.  The idata-free graph isolates the
+// shared derived-owner contract from unrelated raw graph-immediate pointers.
+static void test_softmax3_payload_copy_lifetime() {
+  Graph g;
+  const int logits = g.add_slot(3, true);
+  const int probs = g.add_slot(3, false);
+  const int lp = g.add_slot(1, false);
+
+  auto specialized = std::make_shared<Softmax3IslandProg>();
+  specialized->n_regs = 6;
+  specialized->ins.push_back(IslandProg::LiveIn{0, 3});
+  specialized->code.push_back(Program::Instr{Program::SOFTMAX, 3, 0, 0, 0, 3});
+  specialized->out_regs = {3, 4, 5};
+  expect("softmax3 copy generated adjoint", gen_adjoint(*specialized));
+  specialized->native_adj = true;
+  specialized->optimized_double = specialize_softmax3(*specialized, 1);
+  expect("softmax3 copy optimized plan",
+         static_cast<bool>(specialized->optimized_double));
+
+  std::weak_ptr<Softmax3IslandProg> lifetime = specialized;
+  std::shared_ptr<IslandProg> owner = std::move(specialized);
+  expect("softmax3 copy transfers local owner", !specialized);
+  Op island;
+  island.opcode = OP_ISLAND;
+  island.variant = kIslandSoftmax3Variant;
+  island.n_in = 1;
+  island.in[0] = logits;
+  island.out = probs;
+  island.udata = owner.get();
+  g.udata_pool.push_back(std::move(owner));
+  g.ops.push_back(island);
+  g.add_op(OP_SUM_VEC, {probs}, lp);
+  g.result_slot = lp;
+
+  std::unique_ptr<Executor> copy;
+  {
+    Executor source(std::move(g));
+    source.params_data()[0] = 0.3;
+    source.params_data()[1] = 0.7;
+    source.params_data()[2] = 1.4;
+    copy = std::make_unique<Executor>(source);
+  }
+  expect("softmax3 copy keeps payload alive", !lifetime.expired());
+  double first_grad[3] = {};
+  double second_grad[3] = {};
+  const double first = copy->gradient(first_grad);
+  const double second = copy->gradient(second_grad);
+  expect("softmax3 copy value stable", first == second);
+  for (int i = 0; i < 3; ++i)
+    expect("softmax3 copy gradient stable", first_grad[i] == second_grad[i]);
+  copy.reset();
+  expect("softmax3 copy releases payload", lifetime.expired());
 }
 
 // A measured-cost boundary made from the same two facts as iohmm_reg:
@@ -946,6 +1140,9 @@ int main() {
   test_unsetenv("STANLI_ISLAND_ALWAYS");
   test_wide_state_refused();
   test_vector_copies_carved();
+  test_softmax3_island_executor();
+  test_softmax3_private_slot_stays_invalid_graph_ir();
+  test_softmax3_payload_copy_lifetime();
   test_compact_adjoint_cost_boundary();
   test_scalar_chain_carved();
   test_inplace_slice_cost_refuses_wide_state();

--- a/tools/dump_islands.cpp
+++ b/tools/dump_islands.cpp
@@ -94,9 +94,9 @@ int main(int argc, char** argv) {
     const auto& p = *static_cast<const IslandProg*>(op.udata);
     std::printf(
         "\n== island %d (graph op %zu): %zu instrs, %d regs, "
-        "%zu calls, adjoint %zu instrs, native_adj=%d\n",
+        "%zu calls, adjoint %zu instrs, native_adj=%d, softmax3=%d\n",
         n++, u, p.code.size(), p.n_regs, p.calls.size(), p.adj.code.size(),
-        (int)p.native_adj);
+        (int)p.native_adj, (int)(op.variant == kIslandSoftmax3Variant));
     std::printf("  live-ins:");
     for (size_t k = 0; k < p.ins.size(); ++k)
       std::printf(" slot%d->r%d[len %d]", op.in[k], p.ins[k].reg, p.ins[k].len);


### PR DESCRIPTION
## Summary

- add a default-on, double-only specialization for native-adjoint islands that contain at least 32 three-lane softmax instructions
- keep the canonical island program and generated backward unchanged; the specialized payload owns a bounded immutable forward clone
- use an allocation-free fixed-size helper with exact overlap, NaN, and reduction-order behavior
- retain the existing island cost decision and add a 2 MiB / 4 KiB-per-site cloned-payload budget plus `STANLI_NO_ISLAND_SOFTMAX3=1`

This is the Tier-0 shared-softmax optimization extracted from the selective-JIT experiment. It contains none of the runtime JIT backend.

## Architecture and safety

The specialization runs only after compaction, successful native-adjoint generation, and the existing island cost admission. Ordinary islands keep their original payload and kernel path. Specialized islands use the otherwise-unused `OP_ISLAND` variant to tag a derived payload; executor binding resolves only the forward function, by value, while backward and scratch remain the canonical island kernel.

The optimized `Program::CALL` uses a reserved variant and the otherwise-invalid `OP_NONE_` table slot without growing the graph opcode table. Registration is lazy and thread-safe, happens only after admission, and refuses specialization if the slot ever has another kernel. Graph carving and executor binding explicitly continue to reject `OP_NONE_`, including after private registration.

Fable reviewed the final architecture and required two changes before acceptance: the explicit opcode-zero graph guards and narrowing the resolver from a partial `Kernel` replacement to a by-value forward-function resolver. Both are included, with regression tests. The feature adds no LLVM or outside runtime dependency.

## Performance gate

All ratios are candidate / exact-main elapsed time from `a0fed90` on Darwin arm64.

- `iohmm_reg`: **0.9597x**, 95% CI `[0.9554, 0.9619]` (4.03% faster)
- 119-model corpus geometric mean: **1.00006x**, 95% CI `[0.99824, 1.00136]`
- corpus p95: **1.0093x**
- corpus decisions: 112 pass, 7 initially inconclusive, 0 failures at the 3% per-model gate

The explicit worst control is `hmm_drive_0`: a 64-round, 1-second-per-arm confirmation measured **1.0224x**, 95% CI `[1.0164, 1.0274]`. Its island does not activate this specialization, so this is a whole-binary layout effect rather than a cost-model activation error. It is disclosed rather than described as regression-free; its upper bound remains below the agreed 3% ceiling.

The final benchmarked `bench_grad` SHA-256 is `61ab1fb386a0707876df846503fd6224a9bab68d9cf28f56460763ed5494a615`. The ordinary island and legacy-kernel object files are byte-identical to exact main, and executor hot functions plus the ordinary island forward retain their exact-main addresses.

## Correctness and local gates

- Release CTest: 67/67
- ASan CTest (`detect_leaks=0`): 67/67
- reference corpus: 130/130 models, 803,962 values at all three points; no failures
- graph A/B: 58 unchanged and correct, 61 changed and correct, one known both-fail gap; only the pre-existing `ldaK5` tolerance flag (`9.21e-10`)
- `iohmm_reg` graph A/B: 36,484 -> 27 ops, `3.96e-14` deviation
- formatting and diff checks clean
- generated docs and web-model catalogs current

Tests cover the activation threshold, both clone-budget boundaries, opt-out, exact register-file equality, every legal source/destination overlap, NaNs and signed zero, generated backward parity, payload copy lifetime, malformed opcode-zero graphs, and the full graph-to-executor path.
