### PR TITLE
Add sampling progress reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Unreleased
 
+### Sampling reports progress and problems
+
+The Python and R samplers now print CmdStan-style per-chain iteration updates,
+warmup/sampling timings, and warnings for divergent transitions or maximum
+treedepth saturation. A `refresh` argument controls the update interval and
+`refresh = 0` keeps sampling quiet. Progress events are marshalled back to the
+calling thread, so parallel R and Python console output is safe, and reporting
+does not change draws, sampler statistics, or RNG streams (#230).
+
 ### Complete indexed assignments lower everywhere
 
 Assignments such as `x[:] = rhs` now preserve the destination's declared

--- a/README.md
+++ b/README.md
@@ -216,6 +216,11 @@ print(fit.summary())      # stansummary's table
 print(fit.diagnose())     # the convergence checks, in words
 ```
 
+Sampling prints per-chain progress, elapsed warmup/sampling time, and any
+divergence or maximum-treedepth warnings. `refresh=100` is the default update
+interval; pass `refresh=0` for a quiet run. Reporting is observational and
+does not change draws or RNG streams.
+
 Four chains by default, run in parallel. Threading does not change the
 answer: each chain owns its executor and its RNG stream, so the draws
 are byte-identical to a sequential run. macOS and Linux release wheels compile
@@ -258,6 +263,10 @@ m <- stanli_model(file = "eight_schools.stan", data = list(J = 8L, y = y, sigma 
 fit <- sample_model(m, chains = 4, seed = 1)
 summary(fit)          # mean, MCSE, sd, quantiles, bulk/tail ESS, R-hat
 ```
+
+`sample_model()` reports the same progress, timing, and sampler problems as
+the Python binding. Set `refresh = 0` to suppress automatic output; doing so
+does not change the sampled result.
 
 The runtime is a separate release artifact so installing the R bridge never
 rebuilds stan-math. `stanli_install()` is explicit and pins the release the

--- a/python/README.md
+++ b/python/README.md
@@ -28,6 +28,29 @@ fit["mu"].mean()        # every draw of a column, chains concatenated
 fit.draws("mu")         # (chains, draws), for a trace plot
 ```
 
+Sampling reports CmdStan-shaped progress every 100 transitions by default,
+followed by per-chain warm-up, sampling, and total times:
+
+```text
+Chain [1] Iteration:    1 / 2000 [  0%]  (Warmup)
+Chain [1] Iteration: 1000 / 2000 [ 50%]  (Warmup)
+Chain [1] Iteration: 1001 / 2000 [ 50%]  (Sampling)
+Chain [1] Iteration: 2000 / 2000 [100%]  (Sampling)
+
+Chain [1] Elapsed Time: 0.821 seconds (Warm-up)
+                        0.169 seconds (Sampling)
+                        0.990 seconds (Total)
+```
+
+Set `refresh=0` for a completely quiet run, or another positive integer to
+change the update interval. Progress is written through Python's `sys.stdout`,
+so notebook output and `contextlib.redirect_stdout()` work normally. Reporting
+only observes completed transitions: changing `refresh` does not change draws,
+sampler statistics, generated-quantity RNG streams, or reproducibility. If any
+post-warmup transition diverges or saturates the maximum treedepth, the final
+output also reports the aggregate count. Those counts cover all transitions,
+including transitions omitted by thinning.
+
 ## Chains and convergence
 
 Four chains by default, run in parallel, because R-hat needs more than
@@ -181,7 +204,8 @@ model.constrained_names             # ['mu', 'tau', 'theta.1', ...]
 
 lp, grad = model.log_prob_grad(q)   # sampling log density and its gradient
 
-fit = model.sample(seed=1, warmup=1000, samples=1000, delta=0.8)
+fit = model.sample(seed=1, warmup=1000, samples=1000, delta=0.8,
+                   refresh=100)
 fit["theta.1"]                      # ndarray, chains concatenated
 ```
 

--- a/python/stanli/__init__.py
+++ b/python/stanli/__init__.py
@@ -8,6 +8,7 @@ compilation on this machine.
 import ctypes
 import json
 import math
+import operator
 import os
 import pathlib
 import subprocess
@@ -78,6 +79,21 @@ class _SampleOpts(ctypes.Structure):
     ]
 
 
+class _SampleReport(ctypes.Structure):
+    """Mirrors stanli_sample_report in runtime/include/stanli/capi.h."""
+    _fields_ = [
+        ("warmup_seconds", ctypes.c_double),
+        ("sampling_seconds", ctypes.c_double),
+        ("n_divergent", ctypes.c_int64),
+        ("n_max_treedepth", ctypes.c_int64),
+    ]
+
+
+_SampleProgressCallback = ctypes.CFUNCTYPE(
+    None, ctypes.c_int32, ctypes.c_int64, ctypes.c_int64, ctypes.c_int32,
+    ctypes.c_void_p)
+
+
 def _load_lib():
     names = {"darwin": "libstanli.dylib", "linux": "libstanli.so"}
     lib = ctypes.CDLL(str(_BIN / names.get(sys.platform, "stanli.dll")))
@@ -138,6 +154,12 @@ def _load_lib():
                                         ctypes.POINTER(ctypes.c_double),
                                         ctypes.POINTER(ctypes.c_double),
                                         ctypes.c_char_p, ctypes.c_size_t]
+    lib.stanli_sample_multi_progress.restype = ctypes.c_int
+    lib.stanli_sample_multi_progress.argtypes = [
+        ctypes.c_void_p, ctypes.POINTER(_SampleOpts), ctypes.c_int,
+        ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double),
+        _SampleProgressCallback, ctypes.c_void_p,
+        ctypes.POINTER(_SampleReport), ctypes.c_char_p, ctypes.c_size_t]
     lib.stanli_summary_stats.restype = ctypes.c_int
     lib.stanli_summary_stats.argtypes = [ctypes.POINTER(ctypes.c_double),
                                          ctypes.c_int64, ctypes.c_int64,
@@ -363,6 +385,41 @@ def _fmt(v, prec=4):
     return f"{v:.{prec}f}"
 
 
+def _print_sample_progress(chain_id, iteration, total, warmup):
+    """One CmdStan-shaped progress line, through Python's live stdout."""
+    width = max(1, len(str(total)))
+    percent = 100 if total == 0 else 100 * iteration // total
+    phase = "Warmup" if warmup else "Sampling"
+    print(f"Chain [{chain_id}] Iteration: {iteration:{width}d} / {total} "
+          f"[{percent:3d}%]  ({phase})", flush=True)
+
+
+def _print_sample_reports(reports, first_chain, samples, max_depth):
+    """Per-chain timing and aggregate post-warmup sampler problems."""
+    print()
+    for c, report in enumerate(reports):
+        label = f"Chain [{first_chain + c}] Elapsed Time: "
+        indent = " " * len(label)
+        total = report.warmup_seconds + report.sampling_seconds
+        print(f"{label}{report.warmup_seconds:.3f} seconds (Warm-up)")
+        print(f"{indent}{report.sampling_seconds:.3f} seconds (Sampling)")
+        print(f"{indent}{total:.3f} seconds (Total)")
+        print()
+
+    n_divergent = sum(r.n_divergent for r in reports)
+    n_max_depth = sum(r.n_max_treedepth for r in reports)
+    n_transitions = len(reports) * samples
+    if n_divergent:
+        percent = 100 * n_divergent / n_transitions if n_transitions else 0.0
+        print(f"Warning: {n_divergent} of {n_transitions} post-warmup "
+              f"transitions ({percent:.1f}%) ended with a divergence.")
+    if n_max_depth:
+        percent = 100 * n_max_depth / n_transitions if n_transitions else 0.0
+        print(f"Warning: {n_max_depth} of {n_transitions} post-warmup "
+              f"transitions ({percent:.1f}%) saturated the maximum "
+              f"treedepth of {max_depth}.")
+
+
 class Summary:
     """Per-parameter posterior summary: the columns stansummary prints.
 
@@ -424,12 +481,20 @@ class Fit:
     which is what a trace plot or a per-chain check wants.
     """
 
-    def __init__(self, names, draws, sampler_stats, max_depth, seed):
+    def __init__(self, names, draws, sampler_stats, max_depth, seed,
+                 reports=None):
         self.names = list(names)
         self._draws = draws               # (chains, draws, cols)
         self.sampler_stats = sampler_stats  # (chains, draws, 7)
         self.max_depth = max_depth
         self.seed = seed
+        self._divergence_counts = None
+        self._max_treedepth_counts = None
+        if reports is not None:
+            self._divergence_counts = np.array(
+                [r.n_divergent for r in reports], dtype=np.int64)
+            self._max_treedepth_counts = np.array(
+                [r.n_max_treedepth for r in reports], dtype=np.int64)
 
     @property
     def n_chains(self):
@@ -480,12 +545,16 @@ class Fit:
     @property
     def divergences(self):
         """Divergent transitions per chain."""
+        if self._divergence_counts is not None:
+            return self._divergence_counts.copy()
         col = SAMPLER_COLUMNS.index("divergent__")
         return self.sampler_stats[:, :, col].sum(axis=1).astype(np.int64)
 
     @property
     def max_treedepth_hits(self):
         """Transitions that saturated max_depth, per chain."""
+        if self._max_treedepth_counts is not None:
+            return self._max_treedepth_counts.copy()
         col = SAMPLER_COLUMNS.index("treedepth__")
         return (self.sampler_stats[:, :, col] >= self.max_depth) \
             .sum(axis=1).astype(np.int64)
@@ -698,7 +767,8 @@ class Model:
 
     def sample(self, *, chains=4, seed=1, warmup=1000, samples=1000,
                delta=0.8, max_depth=10, thin=1, save_warmup=False,
-               inits=None, init_radius=2.0, parallel_chains=None):
+               inits=None, init_radius=2.0, parallel_chains=None,
+               refresh=100):
         """NUTS draws as a Fit.
 
         Four chains by default, because R-hat needs more than one and a
@@ -719,11 +789,28 @@ class Model:
         so it is on by default. A build without thread support clamps it
         to 1 (see ``thread_safe()``).
 
+        `refresh` is the number of transitions between CmdStan-shaped
+        progress updates. The default is 100; zero disables all automatic
+        progress, timing, and sampler-problem output. Reporting only observes
+        the run and does not change draws, sampler statistics, or RNG streams.
+
         Columns are every column CmdStan's CSV would carry -- constrained
         parameters, transformed parameters, generated quantities, with RNG
         draws streamed per chain -- for models with a generate_quantities
         section, and the constrained parameters otherwise.
         """
+        if isinstance(refresh, (bool, np.bool_)):
+            raise TypeError("refresh must be a nonnegative integer")
+        try:
+            refresh = operator.index(refresh)
+        except TypeError:
+            raise TypeError("refresh must be a nonnegative integer") from None
+        if refresh < 0:
+            raise ValueError("refresh must be nonnegative")
+        int_max = 2 ** (8 * ctypes.sizeof(ctypes.c_int) - 1) - 1
+        if refresh > int_max:
+            raise OverflowError("refresh does not fit in a C int")
+
         opts = _SampleOpts()
         _lib.stanli_sample_opts_init(ctypes.byref(opts))
         opts.seed = seed
@@ -759,15 +846,37 @@ class Model:
         n_stored = _lib.stanli_n_stored_draws(ctypes.byref(opts))
         raw = np.empty((opts.chains, n_stored, self.n_unconstrained))
         stats = np.empty((opts.chains, n_stored, _N_SAMPLER_COLS))
+        reports = (_SampleReport * opts.chains)()
         err = ctypes.create_string_buffer(4096)
-        failed = _lib.stanli_sample_multi(self._m, ctypes.byref(opts),
-                                          _dptr(raw), _dptr(stats),
-                                          err, len(err))
+        callback_errors = []
+        # A typed null function pointer: ctypes does not accept Python None for
+        # a CFUNCTYPE argtype, even though both represent a null C callback.
+        progress_cb = _SampleProgressCallback()
+        if refresh:
+            def progress(chain_id, iteration, total, is_warmup, _user):
+                if callback_errors:
+                    return
+                try:
+                    _print_sample_progress(chain_id, iteration, total,
+                                           is_warmup)
+                except BaseException as exc:  # ctypes cannot propagate it
+                    callback_errors.append(exc)
+
+            # Keep this object in a local until the native call returns. ctypes
+            # callbacks are raw function pointers; collecting it early would
+            # leave the sampler calling freed memory.
+            progress_cb = _SampleProgressCallback(progress)
+
+        failed = _lib.stanli_sample_multi_progress(
+            self._m, ctypes.byref(opts), refresh, _dptr(raw), _dptr(stats),
+            progress_cb, None, reports, err, len(err))
         del init_arr
         if failed:
             raise RuntimeError(
                 f"{failed} of {opts.chains} chains failed; first: "
                 f"{err.value.decode()}")
+        if callback_errors:
+            raise callback_errors[0]
 
         names, have_wa = self._column_names()
         out = np.empty((opts.chains, n_stored, len(names)))
@@ -789,4 +898,8 @@ class Model:
                 else:
                     _lib.stanli_constrain(self._m, _dptr(q), _dptr(row))
                 out[c, s] = row
-        return Fit(names, out, stats, opts.max_depth, seed)
+        fit = Fit(names, out, stats, opts.max_depth, seed, reports)
+        if refresh:
+            _print_sample_reports(reports, first_chain, opts.samples,
+                                  opts.max_depth)
+        return fit

--- a/r/R/stanli.R
+++ b/r/R/stanli.R
@@ -117,12 +117,25 @@ log_prob_grad <- function(model, q) {
 #' @param init_radius Random inits are drawn uniform(-r, r); 0 starts at
 #'   the origin.
 #' @param parallel_chains Chains to run at once. Defaults to all of them.
-#' @return An object of class `stanli_fit`.
+#' @param refresh Print a progress update every `refresh` transitions within
+#'   each phase, plus the first and last transition of the phase. Set to 0 to
+#'   suppress all automatic sampling output.
+#' @return An object of class `stanli_fit`. Its `report` element contains
+#'   per-chain warmup and sampling times plus exact divergence and
+#'   maximum-treedepth counts. With a compatible older runtime that predates
+#'   progress reporting, `report$available` is `FALSE` and those values are
+#'   `NA`.
 #' @export
 sample_model <- function(model, chains = 4, seed = 1, warmup = 1000,
                          samples = 1000, thin = 1, delta = 0.8,
                          max_depth = 10, save_warmup = FALSE, init = NULL,
-                         init_radius = 2, parallel_chains = NULL) {
+                         init_radius = 2, parallel_chains = NULL,
+                         refresh = 100) {
+  if (length(refresh) != 1L || !is.numeric(refresh) || is.na(refresh) ||
+      !is.finite(refresh) || refresh < 0 || refresh != floor(refresh) ||
+      refresh > .Machine$integer.max)
+    stop("refresh must be a single nonnegative integer", call. = FALSE)
+  refresh <- as.integer(refresh)
   load_runtime()
   if (is.null(parallel_chains)) parallel_chains <- chains
   init_vec <- numeric(0)
@@ -140,7 +153,7 @@ sample_model <- function(model, chains = 4, seed = 1, warmup = 1000,
                as.integer(samples), as.integer(thin), as.double(delta),
                as.integer(max_depth), isTRUE(save_warmup),
                as.double(init_radius), as.integer(parallel_chains))
-  res <- .Call("stanli_r_sample", model$ptr, opts, init_vec)
+  res <- .Call("stanli_r_sample", model$ptr, opts, init_vec, refresh)
 
   nchain <- res$chains
   ndraw <- res$draws
@@ -157,9 +170,14 @@ sample_model <- function(model, chains = 4, seed = 1, warmup = 1000,
                       dim = c(model$n_unconstrained, ndraw, nchain)),
                 c(2, 3, 1))
 
+  report <- list(available = res$report_available,
+                 warmup_seconds = res$warmup_seconds,
+                 sampling_seconds = res$sampling_seconds,
+                 n_divergent = res$n_divergent,
+                 n_max_treedepth = res$n_max_treedepth)
   structure(list(draws = arr, sampler = sarr, unconstrained = uarr,
                  columns = model$columns, max_depth = max_depth, seed = seed,
-                 model = model),
+                 model = model, report = report),
             class = "stanli_fit")
 }
 

--- a/r/README.md
+++ b/r/README.md
@@ -51,6 +51,13 @@ stanli_diagnose(fit)  # divergences, treedepth, E-BFMI, R-hat, ESS
 as_draws_array(fit)   # a posterior::draws_array
 ```
 
+Sampling prints periodic per-chain progress, elapsed warmup and sampling
+times, and any divergent-transition or maximum-treedepth warnings. Set
+`refresh = 0` for a quiet run. Exact per-chain times and problem counts are
+also available in `fit$report`. When the package is deliberately paired with
+a compatible older runtime, sampling still works but these new report fields
+are `NA` and `fit$report$available` is `FALSE`.
+
 Four chains of eight schools (8000 draws, full summary and diagnostics)
 take about 70 ms, because the model is lowered to a graph over
 precompiled kernels rather than translated to C++ and compiled.

--- a/r/man/sample_model.Rd
+++ b/r/man/sample_model.Rd
@@ -16,7 +16,8 @@ sample_model(
   save_warmup = FALSE,
   init = NULL,
   init_radius = 2,
-  parallel_chains = NULL
+  parallel_chains = NULL,
+  refresh = 100
 )
 }
 \arguments{
@@ -40,9 +41,16 @@ exist.}
 the origin.}
 
 \item{parallel_chains}{Chains to run at once. Defaults to all of them.}
+
+\item{refresh}{Print a progress update every `refresh` transitions within
+each phase, plus the first and last transition of the phase. Set to 0 to
+suppress all automatic sampling output.}
 }
 \value{
-An object of class `stanli_fit`.
+An object of class `stanli_fit`. Its `report` element contains per-chain
+warmup and sampling times plus exact divergence and maximum-treedepth counts.
+With a compatible older runtime that predates progress reporting,
+`report$available` is `FALSE` and those values are `NA`.
 }
 \description{
 Four chains by default, run in parallel: R-hat needs more than one

--- a/r/src/bridge.c
+++ b/r/src/bridge.c
@@ -80,6 +80,19 @@ typedef struct {
   int num_threads;
 } stanli_sample_opts;
 
+/* Mirrors the result-only struct used by stanli_sample_multi_progress. It is
+ * part of that new entry point rather than stanli_sample_opts, so adding it
+ * does not change the version-1 options layout above. */
+typedef struct {
+  double warmup_seconds;
+  double sampling_seconds;
+  int64_t n_divergent;
+  int64_t n_max_treedepth;
+} stanli_sample_report;
+
+typedef void (*stanli_sample_progress_cb)(int32_t, int64_t, int64_t, int32_t,
+                                          void*);
+
 typedef struct {
   uint32_t seed;
   int chain_id;
@@ -115,6 +128,10 @@ static void (*p_sample_opts_init)(stanli_sample_opts*);
 static int64_t (*p_n_stored_draws)(const stanli_sample_opts*);
 static int (*p_sample_multi)(void*, const stanli_sample_opts*, double*, double*,
                              char*, size_t);
+static int (*p_sample_multi_progress)(void*, const stanli_sample_opts*, int,
+                                      double*, double*,
+                                      stanli_sample_progress_cb, void*,
+                                      stanli_sample_report*, char*, size_t);
 static const char* (*p_sampler_column_name)(int);
 static int (*p_summary_stats)(const double*, int64_t, int64_t, int64_t,
                               double*);
@@ -185,6 +202,11 @@ SEXP stanli_bridge_load(SEXP path) {
   BIND("stanli_sample_opts_init", p_sample_opts_init);
   BIND("stanli_n_stored_draws", p_n_stored_draws);
   BIND("stanli_sample_multi", p_sample_multi);
+  /* Added without an ABI bump: a version-1 runtime may legitimately predate
+   * progress reporting. Keep the old sampler as the compatibility path rather
+   * than making an optional feature prevent the library loading. */
+  *(void**)(&p_sample_multi_progress) =
+      dl_sym(g_lib, "stanli_sample_multi_progress");
   BIND("stanli_sampler_column_name", p_sampler_column_name);
   BIND("stanli_summary_stats", p_summary_stats);
   BIND("stanli_diagnose_text", p_diagnose_text);
@@ -321,28 +343,92 @@ static void fill_sample_opts(stanli_sample_opts* o, SEXP l) {
   o->num_threads = asInteger(VECTOR_ELT(l, 9));
 }
 
-SEXP stanli_r_sample(SEXP m, SEXP optlist, SEXP inits) {
+/* The runtime guarantees this is called on the thread that entered
+ * stanli_r_sample, even when chains themselves run on worker threads. R's
+ * console API is not thread-safe, so keep this callback deliberately tiny and
+ * never call user R code from it. */
+static void sample_progress(int32_t chain_id, int64_t iteration, int64_t total,
+                            int32_t warmup, void* user) {
+  (void)user;
+  const int pct = total > 0 ? (int)(100 * iteration / total) : 100;
+  Rprintf("Chain [%d] Iteration: %4lld / %lld [%3d%%]  (%s)\n", chain_id,
+          (long long)iteration, (long long)total, pct,
+          warmup ? "Warmup" : "Sampling");
+  R_FlushConsole();
+}
+
+static void print_sample_reports(const stanli_sample_opts* o, int64_t nchain,
+                                 const stanli_sample_report* reports) {
+  int64_t n_divergent = 0;
+  int64_t n_max_treedepth = 0;
+  const int first_chain = o->chain_id > 0 ? o->chain_id : 1;
+  for (int64_t c = 0; c < nchain; ++c) {
+    const stanli_sample_report* r = reports + c;
+    Rprintf("\nChain [%d] Elapsed Time: %.3f seconds (Warm-up)\n",
+            first_chain + (int)c, r->warmup_seconds);
+    Rprintf("                  %.3f seconds (Sampling)\n", r->sampling_seconds);
+    Rprintf("                  %.3f seconds (Total)\n",
+            r->warmup_seconds + r->sampling_seconds);
+    n_divergent += r->n_divergent;
+    n_max_treedepth += r->n_max_treedepth;
+  }
+
+  const int64_t transitions = nchain * (int64_t)o->samples;
+  if (n_divergent > 0)
+    Rprintf(
+        "\nWarning: %lld of %lld post-warmup transitions diverged. "
+        "Raise delta or reparameterize.\n",
+        (long long)n_divergent, (long long)transitions);
+  if (n_max_treedepth > 0)
+    Rprintf(
+        "\nWarning: %lld of %lld post-warmup transitions saturated the "
+        "maximum treedepth of %d. Raise max_depth to allow deeper "
+        "trajectories.\n",
+        (long long)n_max_treedepth, (long long)transitions,
+        o->max_depth > 0 ? o->max_depth : 10);
+  R_FlushConsole();
+}
+
+SEXP stanli_r_sample(SEXP m, SEXP optlist, SEXP inits, SEXP refresh) {
   require_loaded();
   void* mm = model_ptr(m);
   stanli_sample_opts o;
   fill_sample_opts(&o, optlist);
   if (XLENGTH(inits) > 0) o.inits = REAL(inits);
+  const int refresh_rate = asInteger(refresh);
 
   const int64_t n = p_n_unconstrained(mm);
   const int64_t rows = p_n_stored_draws(&o);
   const int64_t nchain = o.chains > 0 ? o.chains : 1;
+  stanli_sample_report* reports =
+      (stanli_sample_report*)R_alloc((size_t)nchain, sizeof(*reports));
 
   SEXP raw = PROTECT(allocVector(REALSXP, (R_xlen_t)(nchain * rows * n)));
   SEXP stats = PROTECT(allocVector(REALSXP, (R_xlen_t)(nchain * rows * 7)));
   char err[4096];
   err[0] = '\0';
+  const int have_reports = p_sample_multi_progress != NULL;
+  if (!have_reports && refresh_rate > 0) {
+    Rprintf(
+        "Sampling progress is unavailable with this older stanli runtime; "
+        "sampling will continue without automatic output. Run "
+        "stanli_install(overwrite = TRUE) to update.\n");
+    R_FlushConsole();
+  }
   const int failed =
-      p_sample_multi(mm, &o, REAL(raw), REAL(stats), err, sizeof err);
+      have_reports
+          ? p_sample_multi_progress(mm, &o, refresh_rate, REAL(raw),
+                                    REAL(stats),
+                                    refresh_rate > 0 ? sample_progress : NULL,
+                                    NULL, reports, err, sizeof err)
+          : p_sample_multi(mm, &o, REAL(raw), REAL(stats), err, sizeof err);
   if (failed) {
     UNPROTECT(2);
     error("%d of %d chains failed; first: %s", failed, (int)nchain,
           err[0] ? err : "(no message)");
   }
+  if (have_reports && refresh_rate > 0)
+    print_sample_reports(&o, nchain, reports);
 
   /* Constrain every stored draw into the CSV columns, per chain, so the
    * RNG stream in generated quantities differs by chain the way CmdStan's
@@ -369,20 +455,46 @@ SEXP stanli_r_sample(SEXP m, SEXP optlist, SEXP inits) {
     }
   }
 
-  SEXP out = PROTECT(allocVector(VECSXP, 5));
+  SEXP warmup_seconds = PROTECT(allocVector(REALSXP, (R_xlen_t)nchain));
+  SEXP sampling_seconds = PROTECT(allocVector(REALSXP, (R_xlen_t)nchain));
+  SEXP n_divergent = PROTECT(allocVector(REALSXP, (R_xlen_t)nchain));
+  SEXP n_max_treedepth = PROTECT(allocVector(REALSXP, (R_xlen_t)nchain));
+  double* warmup_out = REAL(warmup_seconds);
+  double* sampling_out = REAL(sampling_seconds);
+  double* divergent_out = REAL(n_divergent);
+  double* treedepth_out = REAL(n_max_treedepth);
+  for (int64_t c = 0; c < nchain; ++c) {
+    warmup_out[c] = have_reports ? reports[c].warmup_seconds : NA_REAL;
+    sampling_out[c] = have_reports ? reports[c].sampling_seconds : NA_REAL;
+    divergent_out[c] = have_reports ? (double)reports[c].n_divergent : NA_REAL;
+    treedepth_out[c] =
+        have_reports ? (double)reports[c].n_max_treedepth : NA_REAL;
+  }
+
+  SEXP out = PROTECT(allocVector(VECSXP, 10));
   SET_VECTOR_ELT(out, 0, vals);
   SET_VECTOR_ELT(out, 1, stats);
   SET_VECTOR_ELT(out, 2, ScalarInteger((int)nchain));
   SET_VECTOR_ELT(out, 3, ScalarInteger((int)rows));
   SET_VECTOR_ELT(out, 4, raw);
-  SEXP nm = PROTECT(allocVector(STRSXP, 5));
+  SET_VECTOR_ELT(out, 5, warmup_seconds);
+  SET_VECTOR_ELT(out, 6, sampling_seconds);
+  SET_VECTOR_ELT(out, 7, n_divergent);
+  SET_VECTOR_ELT(out, 8, n_max_treedepth);
+  SET_VECTOR_ELT(out, 9, ScalarLogical(have_reports));
+  SEXP nm = PROTECT(allocVector(STRSXP, 10));
   SET_STRING_ELT(nm, 0, mkChar("values"));
   SET_STRING_ELT(nm, 1, mkChar("stats"));
   SET_STRING_ELT(nm, 2, mkChar("chains"));
   SET_STRING_ELT(nm, 3, mkChar("draws"));
   SET_STRING_ELT(nm, 4, mkChar("unconstrained"));
+  SET_STRING_ELT(nm, 5, mkChar("warmup_seconds"));
+  SET_STRING_ELT(nm, 6, mkChar("sampling_seconds"));
+  SET_STRING_ELT(nm, 7, mkChar("n_divergent"));
+  SET_STRING_ELT(nm, 8, mkChar("n_max_treedepth"));
+  SET_STRING_ELT(nm, 9, mkChar("report_available"));
   setAttrib(out, R_NamesSymbol, nm);
-  UNPROTECT(5);
+  UNPROTECT(9);
   return out;
 }
 

--- a/r/src/init.c
+++ b/r/src/init.c
@@ -13,7 +13,7 @@ extern SEXP stanli_r_thread_safe(void);
 extern SEXP stanli_r_n_unconstrained(SEXP);
 extern SEXP stanli_r_column_names(SEXP);
 extern SEXP stanli_r_grad(SEXP, SEXP);
-extern SEXP stanli_r_sample(SEXP, SEXP, SEXP);
+extern SEXP stanli_r_sample(SEXP, SEXP, SEXP, SEXP);
 extern SEXP stanli_r_sampler_columns(void);
 extern SEXP stanli_r_summary(SEXP, SEXP);
 extern SEXP stanli_r_diagnose(SEXP, SEXP, SEXP, SEXP, SEXP);
@@ -29,7 +29,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"stanli_r_n_unconstrained", (DL_FUNC)&stanli_r_n_unconstrained, 1},
     {"stanli_r_column_names", (DL_FUNC)&stanli_r_column_names, 1},
     {"stanli_r_grad", (DL_FUNC)&stanli_r_grad, 2},
-    {"stanli_r_sample", (DL_FUNC)&stanli_r_sample, 3},
+    {"stanli_r_sample", (DL_FUNC)&stanli_r_sample, 4},
     {"stanli_r_sampler_columns", (DL_FUNC)&stanli_r_sampler_columns, 0},
     {"stanli_r_summary", (DL_FUNC)&stanli_r_summary, 2},
     {"stanli_r_diagnose", (DL_FUNC)&stanli_r_diagnose, 5},

--- a/r/tests/testthat/test-sampling.R
+++ b/r/tests/testthat/test-sampling.R
@@ -19,6 +19,12 @@ es_model <- function() {
     sigma = c(15, 10, 16, 11, 9, 11, 10, 18)))
 }
 
+progress_model <- function() {
+  stanli_model(code = "
+    parameters { real x; }
+    model { x ~ normal(0, 1); }")
+}
+
 test_that("a model compiles and reports its shape", {
   skip_without_runtime()
   m <- es_model()
@@ -35,10 +41,94 @@ test_that("log_prob_grad returns lp and a gradient of the right length", {
   expect_length(g$grad, m$n_unconstrained)
 })
 
+test_that("refresh is a single nonnegative integer", {
+  bad <- list(-1, 1.5, NA_real_, NaN, Inf, c(1, 2), "1", TRUE, NULL)
+  for (value in bad)
+    expect_error(sample_model(NULL, refresh = value),
+                 "single nonnegative integer", fixed = TRUE)
+})
+
+test_that("sampling progress is informative and observational", {
+  skip_without_runtime()
+  m <- progress_model()
+  loud <- NULL
+  text <- capture.output({
+    loud <- sample_model(m, chains = 1, seed = 9182, warmup = 3, samples = 4,
+                         init = 0, init_radius = 0, parallel_chains = 1,
+                         refresh = 2)
+  })
+
+  progress <- grep("^Chain \\[1\\] Iteration:", text, value = TRUE)
+  iterations <- as.integer(sub("^.*Iteration: +([0-9]+) /.*$", "\\1",
+                               progress))
+  expect_identical(iterations, c(1L, 2L, 3L, 4L, 5L, 7L))
+  expect_true(all(grepl("\\(Warmup\\)$", progress[1:3])))
+  expect_true(all(grepl("\\(Sampling\\)$", progress[4:6])))
+  expect_equal(sum(grepl("^Chain \\[1\\] Elapsed Time:", text)), 1)
+  expect_true(loud$report$available)
+  expect_length(loud$report$warmup_seconds, 1)
+  expect_gte(loud$report$warmup_seconds, 0)
+  expect_gte(loud$report$sampling_seconds, 0)
+  expect_gte(loud$report$n_divergent, 0)
+  expect_gte(loud$report$n_max_treedepth, 0)
+  expect_identical(names(loud)[seq_len(7)],
+                   c("draws", "sampler", "unconstrained", "columns",
+                     "max_depth", "seed", "model"))
+
+  quiet <- NULL
+  quiet_text <- capture.output({
+    quiet <- sample_model(m, chains = 1, seed = 9182, warmup = 3, samples = 4,
+                          init = 0, init_radius = 0, parallel_chains = 1,
+                          refresh = 0)
+  })
+  expect_length(quiet_text, 0)
+  expect_identical(loud$draws, quiet$draws)
+  expect_identical(loud$sampler, quiet$sampler)
+  expect_identical(loud$unconstrained, quiet$unconstrained)
+  expect_identical(loud$report$n_divergent, quiet$report$n_divergent)
+  expect_identical(loud$report$n_max_treedepth,
+                   quiet$report$n_max_treedepth)
+})
+
+test_that("problem output uses exact unthinned report counts", {
+  skip_without_runtime()
+  m <- progress_model()
+  fit <- NULL
+  text <- capture.output({
+    fit <- sample_model(m, chains = 1, seed = 7, warmup = 10, samples = 20,
+                        thin = 3, max_depth = 1, init = 0, init_radius = 0,
+                        parallel_chains = 1, refresh = 100)
+  })
+
+  expect_gt(fit$report$n_max_treedepth, dim(fit$sampler)[1])
+  expect_true(any(grepl(
+    paste0("Warning: ", fit$report$n_max_treedepth,
+           " of 20 post-warmup transitions saturated"),
+    text, fixed = TRUE)))
+})
+
+test_that("parallel chains report through the R console", {
+  skip_without_runtime()
+  m <- progress_model()
+  text <- capture.output(
+    sample_model(m, chains = 2, seed = 7, warmup = 2, samples = 2,
+                 init = 0, init_radius = 0, parallel_chains = 2, refresh = 1))
+
+  for (chain in 1:2) {
+    progress <- grep(paste0("^Chain \\[", chain, "\\] Iteration:"), text,
+                     value = TRUE)
+    iterations <- as.integer(sub("^.*Iteration: +([0-9]+) /.*$", "\\1",
+                                 progress))
+    expect_identical(iterations, 1:4)
+    expect_equal(sum(grepl(paste0("^Chain \\[", chain,
+                                  "\\] Elapsed Time:"), text)), 1)
+  }
+})
+
 test_that("sampling recovers the eight schools posterior", {
   skip_without_runtime()
   fit <- sample_model(es_model(), chains = 4, seed = 1, warmup = 1000,
-                      samples = 1000)
+                      samples = 1000, refresh = 0)
   expect_equal(dim(fit$draws)[1:2], c(1000L, 4L))
   s <- summary(fit)
   mu <- s[s$variable == "mu", ]
@@ -52,9 +142,9 @@ test_that("threading does not change the answer", {
   skip_without_runtime()
   m <- es_model()
   a <- sample_model(m, chains = 4, seed = 7, warmup = 300, samples = 300,
-                    parallel_chains = 1)
+                    parallel_chains = 1, refresh = 0)
   b <- sample_model(m, chains = 4, seed = 7, warmup = 300, samples = 300,
-                    parallel_chains = 4)
+                    parallel_chains = 4, refresh = 0)
   # Each chain owns its executor and its RNG stream, so a parallel run is
   # byte-identical. This holds on a single-threaded build too, which is
   # the point: turning threads on cannot quietly change a result.
@@ -64,8 +154,10 @@ test_that("threading does not change the answer", {
 test_that("chains are different streams of the same seed", {
   skip_without_runtime()
   m <- es_model()
-  a <- sample_model(m, chains = 2, seed = 3, warmup = 200, samples = 200)
-  b <- sample_model(m, chains = 2, seed = 3, warmup = 200, samples = 200)
+  a <- sample_model(m, chains = 2, seed = 3, warmup = 200, samples = 200,
+                    refresh = 0)
+  b <- sample_model(m, chains = 2, seed = 3, warmup = 200, samples = 200,
+                    refresh = 0)
   expect_identical(a$draws, b$draws)
   # Identical chains would mean the chain id never reached the RNG, and
   # R-hat of two identical chains is a clean 1.0 -- nothing would show it.
@@ -75,7 +167,7 @@ test_that("chains are different streams of the same seed", {
 test_that("the draws array is posterior-shaped and keeps its names", {
   skip_without_runtime()
   fit <- sample_model(es_model(), chains = 2, seed = 4, warmup = 200,
-                      samples = 200)
+                      samples = 200, refresh = 0)
   a <- as_draws_array(fit)
   # The dims carry names (iteration, chain, variable), which is what
   # posterior expects, so compare the values rather than the vector.
@@ -88,7 +180,7 @@ test_that("the draws array is posterior-shaped and keeps its names", {
 test_that("diagnostics report on a converged fit", {
   skip_without_runtime()
   fit <- sample_model(es_model(), chains = 4, seed = 5, warmup = 1000,
-                      samples = 1000)
+                      samples = 1000, refresh = 0)
   txt <- capture.output(stanli_diagnose(fit))
   expect_true(any(grepl("R-hat is below", txt)))
   expect_true(any(grepl("E-BFMI is above", txt)))
@@ -103,7 +195,7 @@ test_that("optimize finds a mode the sampler can start from", {
   # optimizer minimizes.
   expect_equal(o$lp, log_prob_grad(m, o$unconstrained)$lp, tolerance = 1e-8)
   fit <- sample_model(m, chains = 1, seed = 2, warmup = 200, samples = 200,
-                      init = o$unconstrained)
+                      init = o$unconstrained, refresh = 0)
   expect_equal(dim(fit$draws)[1], 200L)
 })
 

--- a/runtime/include/stanli/capi.h
+++ b/runtime/include/stanli/capi.h
@@ -155,6 +155,35 @@ int stanli_sample_multi(stanli_model* m, const stanli_sample_opts* opts,
                         double* draws, double* stats, char* err,
                         size_t err_len);
 
+/* Per-chain facts that are not properties of one stored draw. Counts cover
+ * every post-warmup transition even when thinning drops rows. */
+typedef struct {
+  double warmup_seconds;
+  double sampling_seconds;
+  int64_t n_divergent;
+  int64_t n_max_treedepth;
+} stanli_sample_report;
+
+/* A completed transition selected by `refresh`. The iteration is one-based
+ * across warmup and sampling together, `total` is warmup + samples, and
+ * warmup is nonzero for the warmup phase. Callbacks are serialized on the
+ * thread that called stanli_sample_multi_progress, never a sampler worker, so
+ * language bindings may safely write to their own consoles. */
+typedef void (*stanli_sample_progress_cb)(int32_t chain_id, int64_t iteration,
+                                          int64_t total, int32_t warmup,
+                                          void* user);
+
+/* Progress-capable form of stanli_sample_multi. `refresh` follows CmdStan's
+ * convention: in each phase, report the first transition, every refresh-th
+ * transition, and the phase's final transition.
+ * Zero disables callbacks; negative values are rejected. `reports`, when
+ * non-null, holds opts->chains entries. This is an additive entry point, so
+ * stanli_sample_opts and STANLI_ABI_VERSION remain unchanged. */
+int stanli_sample_multi_progress(
+    stanli_model* m, const stanli_sample_opts* opts, int refresh, double* draws,
+    double* stats, stanli_sample_progress_cb progress, void* progress_user,
+    stanli_sample_report* reports, char* err, size_t err_len);
+
 /* The seven sampler columns, in order: lp__, accept_stat__, stepsize__,
  * treedepth__, n_leapfrog__, divergent__, energy__. */
 #define STANLI_N_SAMPLER_COLS 7

--- a/runtime/include/stanli/nuts.hpp
+++ b/runtime/include/stanli/nuts.hpp
@@ -57,29 +57,60 @@ struct SamplerStats {
   std::vector<std::array<double, 7>> rows;
 };
 
+// Per-chain information that belongs to the run rather than to one stored
+// draw. Diagnostic counts cover every post-warmup transition, including the
+// ones thinning drops, and the two times are measured independently so a
+// parallel multi-chain caller can report each chain honestly.
+struct SamplingReport {
+  double warmup_seconds = 0;
+  double sampling_seconds = 0;
+  int64_t n_divergent = 0;
+  int64_t n_max_treedepth = 0;
+};
+
 // Optional per-transition observer for streaming consumers (the browser
 // worker's live plots): called after every transition with the phase and
 // the current unconstrained point.
 using DrawObserver =
     std::function<void(int64_t i, bool warmup, const double* q)>;
 
+// Optional lightweight observer for console progress. Unlike DrawObserver it
+// does not expose the position, so multi-chain execution can queue the small
+// event and dispatch it on the calling thread. `i` is zero-based within the
+// current phase and the callback runs after that transition completes.
+using ProgressObserver = std::function<void(int64_t i, bool warmup)>;
+
 // Adaptive diagonal-metric NUTS (stan::mcmc::adapt_diag_e_nuts) over the
 // executor's log_prob_grad. Returns one unconstrained parameter vector per
 // stored draw. `stats`, when non-null, receives one row per stored draw.
 std::vector<std::vector<double>> run_nuts(Executor& ex, const NutsConfig& cfg,
                                           SamplerStats* stats = nullptr,
-                                          const DrawObserver& observe = {});
+                                          const DrawObserver& observe = {},
+                                          const ProgressObserver& progress = {},
+                                          SamplingReport* report = nullptr);
 
 // ---- multi-chain -----------------------------------------------------------
 
 struct ChainResult {
   std::vector<std::vector<double>> draws;
   SamplerStats stats;
+  SamplingReport report;
   // Empty on success. A chain that fails does not take the run down with
   // it -- CmdStan reports a failed chain and keeps the others -- so the
   // caller decides what a partial run is worth.
   std::string error;
 };
+
+// Called on the thread that invoked run_nuts_chains, never on a sampler
+// worker. `chain` is the zero-based index into the supplied executor list.
+using ChainProgressObserver =
+    std::function<void(int chain, int64_t i, bool warmup)>;
+
+// CmdStan-style refresh selection. `i` is zero-based within the phase. The
+// first transition, every `refresh`-th transition within the phase, and the
+// phase's final transition are reported.
+bool should_report_progress(const NutsConfig& cfg, int64_t i, bool warmup,
+                            int refresh);
 
 // True when this build can run chains in real threads. stan-math's
 // autodiff stack is a plain static unless STAN_THREADS is defined, in
@@ -97,10 +128,10 @@ bool thread_safe_build();
 // n_threads <= 1 runs sequentially. Larger values are honoured only on a
 // thread_safe_build(); elsewhere they are clamped to 1, because the
 // alternative is a wrong answer rather than a slow one.
-std::vector<ChainResult> run_nuts_chains(const std::vector<Executor*>& execs,
-                                         const NutsConfig& cfg,
-                                         int n_threads = 1,
-                                         const DrawObserver& observe = {});
+std::vector<ChainResult> run_nuts_chains(
+    const std::vector<Executor*>& execs, const NutsConfig& cfg,
+    int n_threads = 1, const DrawObserver& observe = {},
+    const ChainProgressObserver& progress = {}, int progress_refresh = 1);
 
 // Build `n` executors over the same compiled graph, copying it out of an
 // already-bound one. The caller keeps ownership; `src` is not modified.

--- a/runtime/src/capi.cpp
+++ b/runtime/src/capi.cpp
@@ -352,14 +352,28 @@ const char* stanli_sampler_column_name(int i) {
 int stanli_sample_multi(stanli_model* m, const stanli_sample_opts* opts,
                         double* draws, double* stats, char* err,
                         size_t err_len) {
+  return stanli_sample_multi_progress(m, opts, 0, draws, stats, nullptr,
+                                      nullptr, nullptr, err, err_len);
+}
+
+int stanli_sample_multi_progress(
+    stanli_model* m, const stanli_sample_opts* opts, int refresh, double* draws,
+    double* stats, stanli_sample_progress_cb progress, void* progress_user,
+    stanli_sample_report* reports, char* err, size_t err_len) {
   try {
     if (opts == nullptr) {
       put_err(err, err_len, "null options");
       return 1;
     }
+    if (refresh < 0) {
+      put_err(err, err_len, "refresh must be nonnegative");
+      return 1;
+    }
     const int n_chains = opts->chains > 0 ? opts->chains : 1;
     const int64_t n = m->ex->n_params();
     const int64_t n_stored = stanli_n_stored_draws(opts);
+    if (reports != nullptr)
+      for (int c = 0; c < n_chains; ++c) reports[c] = stanli_sample_report{};
 
     stanli::NutsConfig cfg;
     cfg.seed = opts->seed;
@@ -380,9 +394,20 @@ int stanli_sample_multi(stanli_model* m, const stanli_sample_opts* opts,
     execs.push_back(m->ex.get());
     for (auto& c : clones) execs.push_back(c.get());
 
+    stanli::ChainProgressObserver progress_observer;
+    if (progress != nullptr && refresh > 0) {
+      progress_observer = [&](int chain, int64_t i, bool warmup) {
+        const int64_t completed = warmup ? i + 1 : (int64_t)cfg.warmup + i + 1;
+        progress(cfg.chain_id + chain, completed,
+                 (int64_t)cfg.warmup + cfg.samples, warmup ? 1 : 0,
+                 progress_user);
+      };
+    }
+
     std::vector<stanli::ChainResult> res;
     if (opts->inits == nullptr) {
-      res = stanli::run_nuts_chains(execs, cfg, opts->num_threads);
+      res = stanli::run_nuts_chains(execs, cfg, opts->num_threads, {},
+                                    progress_observer, refresh);
     } else {
       // Per-chain inits mean per-chain configs, which run_nuts_chains
       // does not take (it varies only the chain id). Run them one at a
@@ -394,8 +419,15 @@ int stanli_sample_multi(stanli_model* m, const stanli_sample_opts* opts,
         cc.chain_id = cfg.chain_id + c;
         cc.init = opts->inits + (int64_t)c * n;
         try {
+          stanli::ProgressObserver one_progress;
+          if (progress_observer)
+            one_progress = [&, c, cc](int64_t i, bool warmup) {
+              if (stanli::should_report_progress(cc, i, warmup, refresh))
+                progress_observer(c, i, warmup);
+            };
           res[(size_t)c].draws =
-              stanli::run_nuts(*execs[(size_t)c], cc, &res[(size_t)c].stats);
+              stanli::run_nuts(*execs[(size_t)c], cc, &res[(size_t)c].stats, {},
+                               one_progress, &res[(size_t)c].report);
         } catch (const std::exception& e) {
           res[(size_t)c].error = e.what();
         }
@@ -406,6 +438,12 @@ int stanli_sample_multi(stanli_model* m, const stanli_sample_opts* opts,
     std::string first_error;
     for (int c = 0; c < n_chains; ++c) {
       const auto& r = res[(size_t)c];
+      if (reports != nullptr) {
+        reports[c].warmup_seconds = r.report.warmup_seconds;
+        reports[c].sampling_seconds = r.report.sampling_seconds;
+        reports[c].n_divergent = r.report.n_divergent;
+        reports[c].n_max_treedepth = r.report.n_max_treedepth;
+      }
       if (!r.error.empty()) {
         if (failed++ == 0)
           first_error =

--- a/runtime/src/nuts.cpp
+++ b/runtime/src/nuts.cpp
@@ -10,16 +10,25 @@
 #include <stan/services/util/create_rng.hpp>
 
 #include <atomic>
+#include <chrono>
 #include <cmath>
+#include <condition_variable>
 #include <cstdio>
 #include <cstdlib>
+#include <deque>
+#include <exception>
+#include <mutex>
 #include <thread>
 
 namespace stanli {
 
 std::vector<std::vector<double>> run_nuts(Executor& ex, const NutsConfig& cfg,
                                           SamplerStats* stats,
-                                          const DrawObserver& observe) {
+                                          const DrawObserver& observe,
+                                          const ProgressObserver& progress,
+                                          SamplingReport* report) {
+  using Clock = std::chrono::steady_clock;
+  if (report) *report = SamplingReport{};
   // CmdStan's generator, seeded CmdStan's way: same engine (mixmax in this
   // Stan version, ecuyer1988 in older ones -- create_rng is what tracks
   // that), same (0, 1, seed, chain) construction, chain 1 as the default
@@ -79,26 +88,50 @@ std::vector<std::vector<double>> run_nuts(Executor& ex, const NutsConfig& cfg,
   const auto step = [&](int64_t i, bool warmup, bool keep) {
     s = sampler.transition(s, logger);
     s.cont_params(qd);
+    // A report covers every post-warmup transition even when thinning drops
+    // the row. Fetch the sampler parameters once when either consumer needs
+    // them; this is observational and does not touch the sampler RNG.
+    const bool inspect = (keep && stats) || (!warmup && report);
+    if (inspect) {
+      sp.clear();
+      sampler.get_sampler_params(sp);
+    }
     if (keep) {
       draws.emplace_back(qd.data(), qd.data() + n);
       if (stats) {
         // get_sampler_params yields stepsize__, treedepth__, n_leapfrog__,
         // divergent__, energy__ in that order (stan::mcmc::base_nuts).
-        sp.clear();
-        sampler.get_sampler_params(sp);
         stats->rows.push_back(
             {s.log_prob(), s.accept_stat(), sp.size() > 0 ? sp[0] : 0.0,
              sp.size() > 1 ? sp[1] : 0.0, sp.size() > 2 ? sp[2] : 0.0,
              sp.size() > 3 ? sp[3] : 0.0, sp.size() > 4 ? sp[4] : 0.0});
       }
     }
+    if (!warmup && report) {
+      if (sp.size() > 3 && sp[3] != 0.0) ++report->n_divergent;
+      if (sp.size() > 1 && (int)sp[1] >= cfg.max_depth)
+        ++report->n_max_treedepth;
+    }
     if (observe) observe(i, warmup, qd.data());
+    if (progress) progress(i, warmup);
   };
 
+  // Match Stan's timing boundary: initialization and stepsize search are
+  // setup, not warmup transitions. In particular, warmup=0 should not report
+  // model initialization as warmup time.
+  const auto warmup_started = Clock::now();
   for (int i = 0; i < cfg.warmup; ++i)
     step(i, true, cfg.save_warmup && (i % thin == 0));
+  const auto warmup_finished = Clock::now();
+  if (report)
+    report->warmup_seconds =
+        std::chrono::duration<double>(warmup_finished - warmup_started).count();
   sampler.disengage_adaptation();
+  const auto sampling_started = Clock::now();
   for (int i = 0; i < cfg.samples; ++i) step(i, false, i % thin == 0);
+  if (report)
+    report->sampling_seconds =
+        std::chrono::duration<double>(Clock::now() - sampling_started).count();
   return draws;
 }
 
@@ -120,6 +153,14 @@ bool thread_safe_build() {
 #endif
 }
 
+bool should_report_progress(const NutsConfig& cfg, int64_t i, bool warmup,
+                            int refresh) {
+  if (refresh <= 0) return false;
+  const int64_t completed = i + 1;
+  const int64_t phase_total = warmup ? cfg.warmup : cfg.samples;
+  return completed == 1 || completed == phase_total || completed % refresh == 0;
+}
+
 std::vector<std::unique_ptr<Executor>> clone_executors(const Executor& src,
                                                        int n) {
   std::vector<std::unique_ptr<Executor>> out;
@@ -130,7 +171,9 @@ std::vector<std::unique_ptr<Executor>> clone_executors(const Executor& src,
 
 std::vector<ChainResult> run_nuts_chains(const std::vector<Executor*>& execs,
                                          const NutsConfig& cfg, int n_threads,
-                                         const DrawObserver& observe) {
+                                         const DrawObserver& observe,
+                                         const ChainProgressObserver& progress,
+                                         int progress_refresh) {
   const size_t n_chains = execs.size();
   std::vector<ChainResult> out(n_chains);
 
@@ -138,12 +181,13 @@ std::vector<ChainResult> run_nuts_chains(const std::vector<Executor*>& execs,
   // and leaves its draws empty rather than taking the run down: CmdStan
   // reports a failed chain and keeps the others, and a three-of-four run
   // is something the caller can decide about.
-  const auto run_one = [&](size_t c) {
+  const auto run_one = [&](size_t c, const ProgressObserver& one_progress) {
     NutsConfig cc = cfg;
     cc.chain_id = cfg.chain_id + (int)c;
     try {
       out[c].draws = run_nuts(*execs[c], cc, &out[c].stats,
-                              n_chains == 1 ? observe : DrawObserver{});
+                              n_chains == 1 ? observe : DrawObserver{},
+                              one_progress, &out[c].report);
     } catch (const std::exception& e) {
       out[c].error = e.what();
     }
@@ -158,7 +202,23 @@ std::vector<ChainResult> run_nuts_chains(const std::vector<Executor*>& execs,
   if (!thread_safe_build()) threads = 1;
 
   if (threads <= 1) {
-    for (size_t c = 0; c < n_chains; ++c) run_one(c);
+    std::exception_ptr progress_error;
+    for (size_t c = 0; c < n_chains; ++c) {
+      ProgressObserver one_progress;
+      if (progress)
+        one_progress = [&, c](int64_t i, bool warmup) {
+          if (!should_report_progress(cfg, i, warmup, progress_refresh) ||
+              progress_error)
+            return;
+          try {
+            progress((int)c, i, warmup);
+          } catch (...) {
+            progress_error = std::current_exception();
+          }
+        };
+      run_one(c, one_progress);
+    }
+    if (progress_error) std::rethrow_exception(progress_error);
     return out;
   }
 
@@ -168,6 +228,20 @@ std::vector<ChainResult> run_nuts_chains(const std::vector<Executor*>& execs,
   std::atomic<size_t> next{0};
   std::vector<std::thread> pool;
   pool.reserve((size_t)threads);
+
+  // R's console API is main-thread-only, and a Python callback from a new
+  // native thread has avoidable interpreter overhead. Workers therefore
+  // enqueue only the three small fields; this calling thread drains them and
+  // invokes the public observer while the pool runs.
+  struct ProgressEvent {
+    int chain;
+    int64_t i;
+    bool warmup;
+  };
+  std::mutex progress_mutex;
+  std::condition_variable progress_ready;
+  std::deque<ProgressEvent> progress_events;
+  int live_workers = threads;
   for (int t = 0; t < threads; ++t)
     pool.emplace_back([&] {
       // stan-math REQUIRES this. Under STAN_THREADS its autodiff stack
@@ -180,9 +254,58 @@ std::vector<ChainResult> run_nuts_chains(const std::vector<Executor*>& execs,
       // first nested_rev_autodiff on a worker dereferences null inside
       // start_nested(), which is a segfault, not a wrong number.
       stan::math::ChainableStack ad_tape_for_this_thread;
-      for (size_t c = next++; c < n_chains; c = next++) run_one(c);
+      for (size_t c = next++; c < n_chains; c = next++) {
+        ProgressObserver one_progress;
+        if (progress)
+          one_progress = [&, c](int64_t i, bool warmup) {
+            if (!should_report_progress(cfg, i, warmup, progress_refresh))
+              return;
+            {
+              std::lock_guard<std::mutex> lock(progress_mutex);
+              progress_events.push_back({(int)c, i, warmup});
+            }
+            progress_ready.notify_one();
+          };
+        run_one(c, one_progress);
+      }
+      {
+        // Completion is part of the condition-variable predicate, so mutate
+        // it under the same mutex. Otherwise the final notify can race
+        // between the caller's predicate check and its wait and be lost.
+        std::lock_guard<std::mutex> lock(progress_mutex);
+        --live_workers;
+      }
+      progress_ready.notify_one();
     });
+
+  std::exception_ptr progress_error;
+  if (progress) {
+    for (;;) {
+      ProgressEvent event{};
+      {
+        std::unique_lock<std::mutex> lock(progress_mutex);
+        progress_ready.wait(lock, [&] {
+          return !progress_events.empty() || live_workers == 0;
+        });
+        if (progress_events.empty()) break;
+        event = progress_events.front();
+        progress_events.pop_front();
+      }
+      // A public C++ observer is allowed to throw. Keep draining so workers
+      // cannot block behind an abandoned queue, join every thread, and only
+      // then let the exception escape; destroying a joinable std::thread
+      // during unwinding would terminate the process.
+      if (!progress_error) {
+        try {
+          progress(event.chain, event.i, event.warmup);
+        } catch (...) {
+          progress_error = std::current_exception();
+        }
+      }
+    }
+  }
   for (auto& th : pool) th.join();
+  if (progress_error) std::rethrow_exception(progress_error);
   return out;
 }
 

--- a/tests/test_capi.cpp
+++ b/tests/test_capi.cpp
@@ -10,13 +10,15 @@
 #include <stanli/capi.h>
 
 #include <algorithm>
+#include <array>
 #include <cmath>
 #include <cstdio>
 #include <fstream>
 #include <limits>
 #include <sstream>
-#include <utility>
 #include <string>
+#include <thread>
+#include <utility>
 #include <vector>
 
 namespace {
@@ -37,6 +39,12 @@ void expect_eq(const char* what, const std::string& got,
   ++failures;
   std::printf("FAIL %s\n  got  %s\n  want %s\n", what, got.c_str(),
               want.c_str());
+}
+
+void expect_true(const std::string& what, bool ok) {
+  if (ok) return;
+  ++failures;
+  std::printf("FAIL %s\n", what.c_str());
 }
 
 void expect_near(const std::string& what, double got, double want) {
@@ -448,6 +456,104 @@ void expect_pathfinder() {
   stanli_model_free(model);
 }
 
+struct ProgressCapture {
+  std::thread::id caller;
+  bool caller_thread = true;
+  std::vector<std::array<int64_t, 4>> events;
+};
+
+void capture_progress(int32_t chain_id, int64_t iteration, int64_t total,
+                      int32_t warmup, void* user) {
+  auto* capture = static_cast<ProgressCapture*>(user);
+  capture->caller_thread =
+      capture->caller_thread && std::this_thread::get_id() == capture->caller;
+  capture->events.push_back({chain_id, iteration, total, warmup});
+}
+
+// The additive progress entry point must be the old sampler plus observation:
+// same bytes, caller-thread callbacks, exact refresh schedule and reports.
+void expect_sampling_progress() {
+  const std::string mir = slurp("tests/fixtures/gqconst.tmir.sexp");
+  const char* data = R"({"rectangular":[[1,4],[2,5],[3,6]]})";
+  char err[8192]{};
+  stanli_model* quiet = stanli_model_new(mir.c_str(), data, err, sizeof err);
+  stanli_model* observed = stanli_model_new(mir.c_str(), data, err, sizeof err);
+  if (quiet == nullptr || observed == nullptr) {
+    ++failures;
+    std::printf("FAIL C API progress model construction: %s\n", err);
+    if (quiet) stanli_model_free(quiet);
+    if (observed) stanli_model_free(observed);
+    return;
+  }
+
+  stanli_sample_opts opts;
+  stanli_sample_opts_init(&opts);
+  opts.seed = 230;
+  opts.chains = 2;
+  opts.warmup = 4;
+  opts.samples = 3;
+  opts.init_radius = 0.0;
+  opts.num_threads = 2;
+  const int64_t n = stanli_n_unconstrained(quiet);
+  const int64_t rows = stanli_n_stored_draws(&opts);
+  std::vector<double> quiet_draws((size_t)(opts.chains * rows * n));
+  std::vector<double> quiet_stats(
+      (size_t)(opts.chains * rows * STANLI_N_SAMPLER_COLS));
+  std::vector<double> observed_draws(quiet_draws.size());
+  std::vector<double> observed_stats(quiet_stats.size());
+
+  const int quiet_failed = stanli_sample_multi(
+      quiet, &opts, quiet_draws.data(), quiet_stats.data(), err, sizeof err);
+  ProgressCapture capture{std::this_thread::get_id()};
+  std::vector<stanli_sample_report> reports((size_t)opts.chains);
+  const int observed_failed = stanli_sample_multi_progress(
+      observed, &opts, 2, observed_draws.data(), observed_stats.data(),
+      capture_progress, &capture, reports.data(), err, sizeof err);
+  expect_true("C API progress runs succeed",
+              quiet_failed == 0 && observed_failed == 0);
+  expect_true("C API progress leaves draws bitwise unchanged",
+              quiet_draws == observed_draws);
+  expect_true("C API progress leaves stats bitwise unchanged",
+              quiet_stats == observed_stats);
+  expect_true("C API progress callback uses the caller thread",
+              capture.caller_thread);
+
+  const std::vector<int64_t> wanted{1, 2, 4, 5, 6, 7};
+  for (int chain = 1; chain <= opts.chains; ++chain) {
+    std::vector<int64_t> got;
+    for (const auto& event : capture.events) {
+      if (event[0] != chain) continue;
+      got.push_back(event[1]);
+      expect_true("C API progress total is stable", event[2] == 7);
+      expect_true("C API progress phase matches the boundary",
+                  (event[1] <= opts.warmup) == (event[3] != 0));
+    }
+    expect_true(
+        "C API progress refresh sequence for chain " + std::to_string(chain),
+        got == wanted);
+    const auto& report = reports[(size_t)(chain - 1)];
+    expect_true("C API reports nonnegative timings",
+                report.warmup_seconds >= 0.0 && report.sampling_seconds >= 0.0);
+    expect_true("C API reports bounded problem counts",
+                report.n_divergent >= 0 && report.n_divergent <= opts.samples &&
+                    report.n_max_treedepth >= 0 &&
+                    report.n_max_treedepth <= opts.samples);
+  }
+
+  ProgressCapture rejected{std::this_thread::get_id()};
+  err[0] = '\0';
+  const int negative = stanli_sample_multi_progress(
+      observed, &opts, -1, observed_draws.data(), observed_stats.data(),
+      capture_progress, &rejected, reports.data(), err, sizeof err);
+  expect_true("C API rejects negative refresh",
+              negative != 0 &&
+                  std::string(err).find("refresh") != std::string::npos &&
+                  rejected.events.empty());
+
+  stanli_model_free(quiet);
+  stanli_model_free(observed);
+}
+
 }  // namespace
 
 int main() {
@@ -488,6 +594,7 @@ int main() {
   expect_compiled_scalar_rng();
   expect_necessity_effects_refused();
   expect_pathfinder();
+  expect_sampling_progress();
 
   if (failures == 0) std::printf("test_capi OK\n");
   return failures == 0 ? 0 : 1;

--- a/tests/test_multichain.cpp
+++ b/tests/test_multichain.cpp
@@ -13,9 +13,12 @@
 #include <stanli/diagnose.hpp>
 #include <stanli/nuts.hpp>
 
+#include <algorithm>
 #include <cmath>
 #include <cstdio>
+#include <stdexcept>
 #include <string>
+#include <thread>
 #include <vector>
 
 static int failures = 0;
@@ -191,6 +194,154 @@ int main() {
       same = same && seq[c].draws == par[c].draws;
     }
     expect("threaded chains are bitwise the sequential chains", same);
+  }
+
+  // ---- progress is rate-limited, caller-threaded, and observational ----
+  {
+    NutsConfig schedule;
+    schedule.warmup = 4;
+    schedule.samples = 3;
+    std::vector<int64_t> selected;
+    for (int i = 0; i < schedule.warmup; ++i)
+      if (should_report_progress(schedule, i, true, 2))
+        selected.push_back(i + 1);
+    for (int i = 0; i < schedule.samples; ++i)
+      if (should_report_progress(schedule, i, false, 2))
+        selected.push_back(schedule.warmup + i + 1);
+    expect("refresh selects first, boundary, multiples, and final",
+           selected == std::vector<int64_t>({1, 2, 4, 5, 6, 7}));
+    NutsConfig nonmultiple;
+    nonmultiple.warmup = 3;
+    nonmultiple.samples = 4;
+    selected.clear();
+    for (int i = 0; i < nonmultiple.warmup; ++i)
+      if (should_report_progress(nonmultiple, i, true, 2))
+        selected.push_back(i + 1);
+    for (int i = 0; i < nonmultiple.samples; ++i)
+      if (should_report_progress(nonmultiple, i, false, 2))
+        selected.push_back(nonmultiple.warmup + i + 1);
+    expect("refresh intervals restart at the sampling phase",
+           selected == std::vector<int64_t>({1, 2, 3, 4, 5, 7}));
+    expect("refresh zero selects no transitions",
+           !should_report_progress(schedule, 0, true, 0) &&
+               !should_report_progress(schedule, 2, false, 0));
+
+    const int C = 2;
+    Executor quiet_base(normal_graph(3));
+    quiet_base.value_ptr(2)[0] = 1.0;
+    auto quiet_clones = clone_executors(quiet_base, C - 1);
+    std::vector<Executor*> quiet_execs{&quiet_base};
+    for (auto& c : quiet_clones) quiet_execs.push_back(c.get());
+
+    Executor observed_base(normal_graph(3));
+    observed_base.value_ptr(2)[0] = 1.0;
+    auto observed_clones = clone_executors(observed_base, C - 1);
+    std::vector<Executor*> observed_execs{&observed_base};
+    for (auto& c : observed_clones) observed_execs.push_back(c.get());
+
+    NutsConfig cfg;
+    cfg.seed = 8181;
+    cfg.warmup = 50;
+    cfg.samples = 30;
+    const auto quiet = run_nuts_chains(quiet_execs, cfg, C);
+
+    const std::thread::id caller = std::this_thread::get_id();
+    bool caller_thread = true;
+    std::vector<std::vector<int64_t>> events(C);
+    const auto observed = run_nuts_chains(
+        observed_execs, cfg, C, {},
+        [&](int chain, int64_t i, bool warmup) {
+          caller_thread = caller_thread && std::this_thread::get_id() == caller;
+          events[(size_t)chain].push_back(warmup ? i + 1 : cfg.warmup + i + 1);
+        },
+        7);
+    bool same = quiet.size() == observed.size();
+    for (int c = 0; same && c < C; ++c) {
+      same = quiet[(size_t)c].draws == observed[(size_t)c].draws &&
+             quiet[(size_t)c].stats.rows == observed[(size_t)c].stats.rows;
+      expect(
+          "progress events are monotone within a chain",
+          std::is_sorted(events[(size_t)c].begin(), events[(size_t)c].end()));
+      expect("progress includes each chain's final transition",
+             !events[(size_t)c].empty() &&
+                 events[(size_t)c].back() == cfg.warmup + cfg.samples);
+      expect("sampling timings are nonnegative",
+             observed[(size_t)c].report.warmup_seconds >= 0.0 &&
+                 observed[(size_t)c].report.sampling_seconds >= 0.0);
+    }
+    expect("progress callbacks run on the caller thread", caller_thread);
+    expect("progress does not change draws or sampler stats", same);
+
+    Executor throwing_base(normal_graph(3));
+    throwing_base.value_ptr(2)[0] = 1.0;
+    auto throwing_clones = clone_executors(throwing_base, C - 1);
+    std::vector<Executor*> throwing_execs{&throwing_base};
+    for (auto& c : throwing_clones) throwing_execs.push_back(c.get());
+    bool callback_error_rethrown = false;
+    try {
+      (void)run_nuts_chains(
+          throwing_execs, cfg, C, {},
+          [](int, int64_t, bool) {
+            throw std::runtime_error("progress callback failed");
+          },
+          7);
+    } catch (const std::runtime_error& e) {
+      callback_error_rethrown =
+          std::string(e.what()) == "progress callback failed";
+    }
+    expect("throwing progress callback finishes safely and rethrows",
+           callback_error_rethrown);
+
+    NutsConfig empty_cfg = cfg;
+    empty_cfg.warmup = 0;
+    empty_cfg.samples = 0;
+    Executor empty_base(normal_graph(3));
+    empty_base.value_ptr(2)[0] = 1.0;
+    auto empty_clones = clone_executors(empty_base, C - 1);
+    std::vector<Executor*> empty_execs{&empty_base};
+    for (auto& c : empty_clones) empty_execs.push_back(c.get());
+    int empty_events = 0;
+    const auto empty = run_nuts_chains(
+        empty_execs, empty_cfg, C, {},
+        [&](int, int64_t, bool) { ++empty_events; }, 1);
+    expect("zero-transition chains complete without callbacks",
+           empty.size() == C && empty_events == 0);
+  }
+
+  // ---- reports cover transitions that thinning does not store -----------
+  {
+    Executor full_ex(normal_graph(2));
+    full_ex.value_ptr(2)[0] = 1.0;
+    Executor thin_ex(normal_graph(2));
+    thin_ex.value_ptr(2)[0] = 1.0;
+    NutsConfig full_cfg;
+    full_cfg.seed = 9191;
+    full_cfg.warmup = 30;
+    full_cfg.samples = 40;
+    full_cfg.max_depth = 1;
+    SamplerStats full_stats;
+    SamplingReport full_report;
+    (void)run_nuts(full_ex, full_cfg, &full_stats, {}, {}, &full_report);
+
+    int64_t full_depth_hits = 0;
+    for (const auto& row : full_stats.rows)
+      if ((int)row[3] >= full_cfg.max_depth) ++full_depth_hits;
+    expect("report agrees with unthinned sampler stats",
+           full_report.n_max_treedepth == full_depth_hits);
+    expect("depth-one run exercises saturation reporting", full_depth_hits > 0);
+
+    NutsConfig thin_cfg = full_cfg;
+    thin_cfg.thin = 7;
+    thin_cfg.save_warmup = true;
+    SamplingReport thin_report;
+    SamplerStats thin_stats;
+    (void)run_nuts(thin_ex, thin_cfg, &thin_stats, {}, {}, &thin_report);
+    expect("thinned report keeps every post-warmup diagnostic",
+           thin_report.n_divergent == full_report.n_divergent &&
+               thin_report.n_max_treedepth == full_report.n_max_treedepth);
+    expect(
+        "thinned stats really omit transitions",
+        thin_stats.rows.size() < (size_t)(thin_cfg.warmup + thin_cfg.samples));
   }
 
   // ---- thinning and saved warmup change the row count -------------------

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -7,7 +7,10 @@ Run against an installed wheel (CI does) or a local build:
 """
 import base64
 import concurrent.futures
+import contextlib
+import io
 import pathlib
+import re
 import shutil
 import subprocess
 import sys
@@ -30,7 +33,7 @@ def _portable_payload(mir):
 def test_sample_eight_schools():
     m = stanli.Model(stan_file=FIXTURES / "es.stan",
                      data=FIXTURES / "eight_schools.json")
-    d = m.sample(seed=1, warmup=1000, samples=1000)
+    d = m.sample(seed=1, warmup=1000, samples=1000, refresh=0)
     mu = d["mu"].mean()
     assert 3.0 < mu < 6.0, mu
 
@@ -62,7 +65,7 @@ def test_sample_returns_transformed_parameters():
     # write_array path must surface it alongside the declared parameters.
     m = stanli.Model(stan_file=FIXTURES / "es.stan",
                      data=FIXTURES / "eight_schools.json")
-    d = m.sample(seed=1, warmup=200, samples=100)
+    d = m.sample(seed=1, warmup=200, samples=100, refresh=0)
     for col in ("mu", "tau", "theta.1", "theta.8"):
         assert col in d, sorted(d)[:12]
     assert abs(d["theta.1"].mean()) < 30.0
@@ -73,21 +76,137 @@ def test_sample_returns_generated_quantities():
     # columns and seeded RNG stream must both reach Python.
     code = (FIXTURES / "gqrng.stan").read_text()
     m = stanli.Model(stan_code=code, data={"N": 5})
-    d = m.sample(seed=7, warmup=200, samples=50)
+    d = m.sample(seed=7, warmup=200, samples=50, refresh=0)
     for col in ("sigma", "yrep", "crep", "branchy", "p"):
         assert col in d, sorted(d)
     crep = d["crep"]
     assert ((crep == np.floor(crep)) & (crep >= 0) & (crep <= 5)).all()
     assert (d["p"] == 6.0).all()
     assert d["yrep"].std() > 0.0
-    d2 = stanli.Model(stan_code=code, data={"N": 5}).sample(
-        seed=7, warmup=200, samples=50)
-    assert (d["yrep"] == d2["yrep"]).all(), "same seed, different GQ draws"
+    progress = io.StringIO()
+    with contextlib.redirect_stdout(progress):
+        d2 = stanli.Model(stan_code=code, data={"N": 5}).sample(
+            seed=7, warmup=200, samples=50, refresh=1)
+    assert "Iteration:" in progress.getvalue()
+    assert np.array_equal(d.draws(), d2.draws()), \
+        "progress changed parameter or generated-quantity draws"
+    assert np.array_equal(d.sampler_stats, d2.sampler_stats), \
+        "progress changed sampler statistics"
 
 
 def _es():
     return stanli.Model(stan_file=FIXTURES / "es.stan",
                         data=FIXTURES / "eight_schools.json")
+
+
+def _normal():
+    return stanli.Model(
+        stan_code="parameters { real x; } model { x ~ normal(0, 1); }")
+
+
+def test_sample_progress_output_and_refresh_zero():
+    # The formatter is Python-side so redirect_stdout works in notebooks and
+    # test runners rather than only at the process file-descriptor level.
+    exact = io.StringIO()
+    with contextlib.redirect_stdout(exact):
+        stanli._print_sample_progress(1, 1, 2000, True)
+    assert exact.getvalue() == (
+        "Chain [1] Iteration:    1 / 2000 [  0%]  (Warmup)\n")
+
+    shown = io.StringIO()
+    with contextlib.redirect_stdout(shown):
+        fit = _normal().sample(chains=1, warmup=4, samples=3,
+                               parallel_chains=1, refresh=2)
+    assert fit.n_draws == 3
+    text = shown.getvalue()
+    lines = [line for line in text.splitlines() if "Iteration:" in line]
+    iterations = [int(re.search(r"Iteration:\s+(\d+)", line).group(1))
+                  for line in lines]
+    assert iterations == [1, 2, 4, 5, 6, 7], lines
+    assert all("(Warmup)" in line for line in lines[:3])
+    assert all("(Sampling)" in line for line in lines[3:])
+    assert "Elapsed Time:" in text
+    assert "seconds (Warm-up)" in text
+    assert "seconds (Sampling)" in text
+    assert "seconds (Total)" in text
+
+    quiet = io.StringIO()
+    with contextlib.redirect_stdout(quiet):
+        _normal().sample(chains=1, warmup=4, samples=3,
+                         parallel_chains=1, refresh=0)
+    assert quiet.getvalue() == ""
+
+
+def test_sample_progress_callback_runs_on_the_calling_thread():
+    owner = threading.get_ident()
+
+    class SameThreadStream(io.StringIO):
+        def write(self, text):
+            assert threading.get_ident() == owner, \
+                "Python progress callback ran on a sampler worker"
+            return super().write(text)
+
+    stream = SameThreadStream()
+    with contextlib.redirect_stdout(stream):
+        _normal().sample(chains=2, warmup=20, samples=10,
+                         parallel_chains=2, refresh=7)
+
+    seen = {1: [], 2: []}
+    for line in stream.getvalue().splitlines():
+        match = re.search(r"Chain \[(\d+)\] Iteration:\s+(\d+)", line)
+        if match:
+            seen[int(match.group(1))].append(int(match.group(2)))
+    assert all(seen.values()), seen
+    assert all(values == sorted(values) for values in seen.values()), seen
+
+
+def test_sample_refresh_validation():
+    m = _normal()
+    for bad, error in [(-1, ValueError), (1.5, TypeError), ("2", TypeError),
+                       (True, TypeError), (np.bool_(False), TypeError),
+                       (None, TypeError), (2 ** 31, OverflowError)]:
+        try:
+            m.sample(chains=1, warmup=0, samples=1, refresh=bad)
+        except error:
+            pass
+        else:
+            raise AssertionError(f"refresh={bad!r} did not raise {error.__name__}")
+
+    # numpy integer scalars are useful in programmatic configurations and
+    # satisfy Python's integer-index protocol.
+    with contextlib.redirect_stdout(io.StringIO()):
+        fit = m.sample(chains=1, warmup=0, samples=1,
+                       refresh=np.int64(0))
+    assert fit.n_draws == 1
+
+
+def test_fit_uses_full_transition_report_counts():
+    # Stored sampler rows can be thinned and can include saved warmup rows.
+    # Fit's headline counts must therefore use the run report, not recount the
+    # retained stats array.
+    reports = (stanli._SampleReport * 2)()
+    reports[0].warmup_seconds = 0.25
+    reports[0].sampling_seconds = 0.50
+    reports[0].n_divergent = 3
+    reports[0].n_max_treedepth = 4
+    reports[1].warmup_seconds = 0.75
+    reports[1].sampling_seconds = 1.00
+    reports[1].n_divergent = 5
+    reports[1].n_max_treedepth = 6
+    fit = stanli.Fit(["x"], np.zeros((2, 1, 1)), np.zeros((2, 1, 7)),
+                     10, 1, reports)
+    assert fit.divergences.tolist() == [3, 5]
+    assert fit.max_treedepth_hits.tolist() == [4, 6]
+
+    output = io.StringIO()
+    with contextlib.redirect_stdout(output):
+        stanli._print_sample_reports(reports, first_chain=1, samples=10,
+                                     max_depth=12)
+    text = output.getvalue()
+    assert "8 of 20 post-warmup transitions (40.0%)" in text
+    assert "10 of 20 post-warmup transitions (50.0%)" in text
+    assert "maximum treedepth of 12" in text
+    assert text.count("Elapsed Time:") == 2
 
 
 def test_sample_opts_defaults_match_the_header():
@@ -108,7 +227,7 @@ def test_sample_opts_defaults_match_the_header():
 
 def test_multichain_shapes_and_dict_protocol():
     m = _es()
-    fit = m.sample(chains=3, seed=2, warmup=300, samples=200)
+    fit = m.sample(chains=3, seed=2, warmup=300, samples=200, refresh=0)
     assert fit.n_chains == 3 and fit.n_draws == 200
     assert fit.draws().shape == (3, 200, len(fit.names))
     assert fit.draws("mu").shape == (3, 200)
@@ -125,8 +244,8 @@ def test_multichain_shapes_and_dict_protocol():
 
 def test_chains_are_different_streams_and_seeds_reproduce():
     m = _es()
-    a = m.sample(chains=2, seed=3, warmup=200, samples=100)
-    b = m.sample(chains=2, seed=3, warmup=200, samples=100)
+    a = m.sample(chains=2, seed=3, warmup=200, samples=100, refresh=0)
+    b = m.sample(chains=2, seed=3, warmup=200, samples=100, refresh=0)
     assert (a.draws("mu") == b.draws("mu")).all(), "same seed must reproduce"
     # Chain 2 uses a different stream of the same seed, so its draws must
     # not be chain 1's. Identical chains would mean the chain id never
@@ -137,7 +256,7 @@ def test_chains_are_different_streams_and_seeds_reproduce():
 
 def test_summary_and_diagnostics():
     m = _es()
-    fit = m.sample(chains=4, seed=4, warmup=1000, samples=1000)
+    fit = m.sample(chains=4, seed=4, warmup=1000, samples=1000, refresh=0)
     s = fit.summary()
     assert len(s) == len(fit.names)
     assert 3.0 < s["mu"]["mean"] < 6.0, s["mu"]
@@ -177,7 +296,8 @@ def test_diagnostics_report_a_broken_fit():
         parameters { real log_tau; vector[9] z; }
         model { log_tau ~ normal(0, 3); z ~ normal(0, exp(log_tau)); }
     """)
-    fit = m.sample(chains=2, seed=5, warmup=150, samples=300, delta=0.5)
+    fit = m.sample(chains=2, seed=5, warmup=150, samples=300, delta=0.5,
+                   refresh=0)
     text = fit.diagnose()
     assert ("diverged" in text or "R-hat reaches" in text
             or "ESS falls" in text or "E-BFMI is below" in text), text
@@ -192,9 +312,9 @@ def test_parallel_chains_match_sequential_bitwise():
     # assertion cannot be weakened by the build.
     m = _es()
     seq = m.sample(chains=4, seed=11, warmup=300, samples=300,
-                   parallel_chains=1)
+                   parallel_chains=1, refresh=0)
     par = m.sample(chains=4, seed=11, warmup=300, samples=300,
-                   parallel_chains=4)
+                   parallel_chains=4, refresh=0)
     assert (seq.draws() == par.draws()).all(), "threading changed the draws"
     assert (seq.sampler_stats == par.sampler_stats).all()
 
@@ -202,9 +322,9 @@ def test_parallel_chains_match_sequential_bitwise():
 def test_thin_and_save_warmup_change_the_row_count():
     m = _es()
     assert m.sample(chains=1, seed=6, warmup=100, samples=100,
-                    thin=4).n_draws == 25
+                    thin=4, refresh=0).n_draws == 25
     assert m.sample(chains=1, seed=6, warmup=100, samples=100,
-                    save_warmup=True).n_draws == 200
+                    save_warmup=True, refresh=0).n_draws == 200
 
 
 def test_explicit_inits():
@@ -213,12 +333,12 @@ def test_explicit_inits():
     # One vector is broadcast to every chain; a per-chain matrix is taken
     # as given. Both must sample.
     assert m.sample(chains=2, seed=8, warmup=50, samples=50,
-                    inits=np.zeros(n)).n_draws == 50
+                    inits=np.zeros(n), refresh=0).n_draws == 50
     assert m.sample(chains=2, seed=8, warmup=50, samples=50,
-                    inits=np.zeros((2, n))).n_draws == 50
+                    inits=np.zeros((2, n)), refresh=0).n_draws == 50
     # init_radius=0 is CmdStan's `init=0`.
     assert m.sample(chains=1, seed=8, warmup=50, samples=50,
-                    init_radius=0.0).n_draws == 50
+                    init_radius=0.0, refresh=0).n_draws == 50
     try:
         m.sample(chains=2, seed=8, warmup=10, samples=10,
                  inits=np.zeros((3, n)))
@@ -233,7 +353,7 @@ def test_generated_quantities_differ_across_chains():
     # same posterior-predictive draws and the predictive check is a lie.
     code = (FIXTURES / "gqrng.stan").read_text()
     fit = stanli.Model(stan_code=code, data={"N": 5}).sample(
-        chains=2, seed=9, warmup=200, samples=50)
+        chains=2, seed=9, warmup=200, samples=50, refresh=0)
     assert not (fit.draws("yrep")[0] == fit.draws("yrep")[1]).all()
 
 
@@ -255,7 +375,7 @@ def test_optimize_finds_a_mode_and_feeds_sample():
 
     # Starting the sampler from the mode is the point of having it.
     fit = m.sample(chains=1, seed=2, warmup=200, samples=200,
-                   inits=r.unconstrained)
+                   inits=r.unconstrained, refresh=0)
     assert fit.n_draws == 200
 
 

--- a/tests/test_webr.mjs
+++ b/tests/test_webr.mjs
@@ -39,7 +39,8 @@ await webR.FS.writeFile('/tmp/libstanli.so',
 const res = await webR.evalR(`
   dyn.load('/tmp/libstanli.so')
   syms <- c('stanli_abi_version', 'stanli_model_new', 'stanli_exact_lp',
-            'stanli_grad', 'stanli_sample_multi', 'stanli_optimize',
+            'stanli_grad', 'stanli_sample_multi',
+            'stanli_sample_multi_progress', 'stanli_optimize',
             'stanli_diagnose_text', 'stanli_wa_row')
   syms[!vapply(syms, is.loaded, logical(1))]
 `);

--- a/tools/exported_symbols.def
+++ b/tools/exported_symbols.def
@@ -35,6 +35,7 @@ EXPORTS
   stanli_n_stored_draws
   stanli_thread_safe
   stanli_sample_multi
+  stanli_sample_multi_progress
   stanli_sampler_column_name
   stanli_summary_stats
   stanli_diagnose_text


### PR DESCRIPTION
Closes #230.

Adds CmdStan-style sampling progress, elapsed warmup/sampling timings, and exact divergence/maximum-treedepth reporting to the Python and R bindings. `refresh = 0` keeps runs quiet, reporting remains observational, and the R bridge retains compatibility with the previous ABI-v1 runtime.

Validation:
- 67/67 native tests
- 30 Python tests
- 55 R sampling expectations and R CMD check
- STANLI_THREADS on/off coverage
- previous R runtime compatibility test