### PR TITLE
Prepare v0.9.6 release

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -624,16 +624,16 @@ jobs:
       - name: Fetch the previous release and the legacy anchor
         run: |
           mkdir -p previous-release/runtime legacy-release
-          previous=https://github.com/seantalts/stanli/releases/download/v0.9.4
+          previous=https://github.com/seantalts/stanli/releases/download/v0.9.5
           legacy=https://github.com/seantalts/stanli/releases/download/v0.9.3
           curl -fsSL "$previous/stanli-runtime-linux-x86_64.tar.gz" \
             -o previous-release/runtime.tar.gz
-          curl -fsSL "$previous/stanli_0.9.4.tar.gz" \
-            -o previous-release/stanli_0.9.4.tar.gz
+          curl -fsSL "$previous/stanli_0.9.5.tar.gz" \
+            -o previous-release/stanli_0.9.5.tar.gz
           curl -fsSL "$legacy/stanli_0.9.3.tar.gz" \
             -o legacy-release/stanli_0.9.3.tar.gz
-          echo '5a7dd82af8c5bdcfa3798653e60b3c32347aa9d345b91d973250cc70d703c56f  previous-release/runtime.tar.gz' | sha256sum -c -
-          echo '83e4d1b9d2ccffba8b1f89b6ea6af05e7a75aaca178a0684715f6275636b19e6  previous-release/stanli_0.9.4.tar.gz' | sha256sum -c -
+          echo '6634d517be4a2938197f945cb2f86409f60c05045f512bd1f48a859a2e29cd21  previous-release/runtime.tar.gz' | sha256sum -c -
+          echo '5a67cb58d57b1dd0b465858d07d0a40d21da1802644c93ead89369efd82892cb  previous-release/stanli_0.9.5.tar.gz' | sha256sum -c -
           echo '1acbe821c58115678a69451c553a9b23c141d009f53c142492cee94599430495  legacy-release/stanli_0.9.3.tar.gz' | sha256sum -c -
           tar xzf previous-release/runtime.tar.gz \
             -C previous-release/runtime
@@ -685,7 +685,7 @@ jobs:
         working-directory: r
         run: |
           current_library="$PWD/../r-current-library"
-          previous_library="$PWD/../r-v0.9.4-library"
+          previous_library="$PWD/../r-v0.9.5-library"
           legacy_library="$PWD/../r-v0.9.3-library"
           previous_runtime="$PWD/../previous-release/runtime/libstanli.so"
           current_runtime="$STANLI_RUNTIME"
@@ -696,7 +696,7 @@ jobs:
 
           mkdir -p "$previous_library"
           R CMD INSTALL --library="$previous_library" \
-            ../previous-release/stanli_0.9.4.tar.gz
+            ../previous-release/stanli_0.9.5.tar.gz
           STANLI_RUNTIME="$current_runtime" \
             R_LIBS_USER="$previous_library${R_LIBS_USER:+:$R_LIBS_USER}" \
             Rscript ../tests/test_r_portable_compiler.R

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 0.9.6
+
 ### Sampling reports progress and problems
 
 The Python and R samplers now print CmdStan-style per-chain iteration updates,

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@seantalts/stanli",
-  "version": "0.9.5",
+  "version": "0.9.6",
   "description": "Full Stan in the browser: stanc3 compiles the model in JS, a WASM runtime lowers it to an op graph and runs NUTS. No server, no C++ toolchain.",
   "type": "module",
   "main": "index.mjs",

--- a/python/stanli/__init__.py
+++ b/python/stanli/__init__.py
@@ -22,7 +22,7 @@ __all__ = ["Model", "Fit", "Summary", "OptimizeResult",
            "SAMPLER_COLUMNS", "__version__"]
 # The one place the version lives. setup.py and the release workflow both
 # read it from here.
-__version__ = "0.9.5"
+__version__ = "0.9.6"
 
 _BIN = pathlib.Path(__file__).parent / "_bin"
 

--- a/r/DESCRIPTION
+++ b/r/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: stanli
 Type: Package
 Title: The Stan Language Interpreter
-Version: 0.9.5
+Version: 0.9.6
 Authors@R: person("Sean", "Talts", email = "xitrium@gmail.com",
                   role = c("aut", "cre"))
 Description: Compile and sample Stan models without a C++ toolchain. Stan

--- a/r/R/install.R
+++ b/r/R/install.R
@@ -14,7 +14,7 @@
 # and a default of "latest" would silently pair a pinned binding with a runtime
 # that has moved. The release workflow asserts this equals the tag being cut,
 # so bumping one without the other fails there rather than at a user's install.
-stanli_runtime_release <- "v0.9.5"
+stanli_runtime_release <- "v0.9.6"
 
 runtime_filename <- function() {
   switch(Sys.info()[["sysname"]],


### PR DESCRIPTION
## Summary

- bump Python, R, npm, and runtime pins to 0.9.6
- cut the current changelog entries as 0.9.6
- advance the cross-release compatibility pair to the verified v0.9.5 artifacts while retaining v0.9.3 as the legacy-format anchor

## Validation

- verified v0.9.5 runtime and R package SHA-256 digests against downloaded release assets
- parsed Python, R, npm, and workflow metadata
- `git diff --check`