### PR TITLE
Optimize program destinations without changing island activation

### DIFF
--- a/docs/superpowers/plans/2026-08-28-destination-forwarding-results.md
+++ b/docs/superpowers/plans/2026-08-28-destination-forwarding-results.md
@@ -1,0 +1,372 @@
+# Generic destination forwarding: implementation and results
+
+**Date:** 2026-08-28
+
+**Status:** PR candidate; implemented, rebased, performance-atomically
+squashed, validated locally, and ready for review; not merged; high-effort
+Fable review is a conditional GO with all local conditions satisfied;
+cross-platform CI remains a pre-merge gate
+
+**Branch:** `codex/destination-forwarding`
+
+**Atomic implementation commit:**
+`394e973a572e9821ac61f3b25e5851d760367384`
+
+**Full-corpus measured runtime commit:**
+`46e6b158310afc043b939bcaf388ba7e239288a8`. The final runtime source differs
+only by clang-format line wrapping, and its rebuilt `bench_grad` executable is
+byte-identical.
+
+## Decision
+
+Destination forwarding is worth preparing as a small, independently shippable
+feature. It is not a JIT and it contains no model-specific code. It is a
+model-blind register-program optimization that removes an adjacent temporary
+copy by making the producer write the copy's destination directly.
+
+On the final activation-preserving candidate it makes IOHMM 22.9% faster,
+two accelerator examples about 15% faster, two other HMMs 5-7% faster, and a
+third HMM 1.9% faster. The full timed corpus is about 0.8% faster
+geometrically. All 119 timed corpus models clear the 3% per-model regression
+policy after five noisy screen cases are rerun. The pass adds 211 production
+lines and removes 22; the remaining 298 added lines are safety and regression
+tests. This is a materially better payoff/complexity ratio than the dormant
+native-JIT prototype.
+
+The PR branch is based on current `origin/main`. Its implementation, activation
+gate, and tests are one performance-atomic commit; this report is separate. The
+intermediate research commit that exposed the ungated optimization remains
+only on the unpushed research branch and is not part of the proposed history.
+
+## What it does
+
+The program compiler commonly emits this form:
+
+```text
+producer temporary <- inputs
+MOV[/R] destination <- temporary
+```
+
+The pass rewrites it to:
+
+```text
+producer destination <- inputs
+```
+
+and deletes the copy. This works for scalar and ranged outputs and reduces the
+forward program, generated adjoint, and register file together.
+
+The legality checks are deliberately conservative:
+
+- the producer and copy must be adjacent;
+- branch-bearing programs are left unchanged;
+- the copy must consume exactly the producer's full output span, and its
+  temporary and destination spans may not overlap;
+- `MOV`, `MOVR`, `CALL`, no-output instructions, and instructions without a
+  generated adjoint are not treated as producers;
+- the temporary must be written once, read once by the copy, and not be a
+  seeded or live-out register;
+- the destination may not overlap a producer input, so an out-of-place
+  operation is never silently made in-place;
+- when a reverse rule saves the producer output, the destination may not be
+  overwritten later; and
+- after rewriting, the existing compactor and adjoint generator remain the
+  authorities for register mapping and reverse-code validity.
+
+`STANLI_NO_PROGRAM_DEST_FORWARD=1` is the A/B and emergency opt-out.
+
+## Activation and cost-model design
+
+The first implementation let its own instruction savings affect island
+admission. That activated a marginal island in `brmsmono`; the newly selected
+island measured 4.04% slower than the graph. The final design does not permit
+that feedback loop:
+
+1. Compile the raw candidate program.
+2. Compact and generate its adjoint with destination forwarding disabled.
+3. Make CALL eligibility and cost-model decisions from that established form.
+4. Only after the region is accepted, compact a retained raw copy with
+   destination forwarding enabled.
+5. Use the optimized copy only if adjoint generation still succeeds; otherwise
+   retain the priced program. Generator-refused replay-only regions are not
+   changed.
+
+A cheap syntax preflight avoids retaining a deep copy when the raw program has
+no adjacent producer/copy candidate. The old `compact_program` and
+`compact_island` entry points and symbols are preserved; explicitly gated
+helpers have distinct names, so source uses such as `auto f = &compact_program`
+remain unambiguous.
+
+This makes the activation rule exact rather than heuristic. A 147-entry
+PosteriorDB audit (120 unique models) compared feature-on with the opt-out and
+found identical:
+
+- graph op and slot counts;
+- island counts and exact graph positions;
+- every pre-forward cost-model diagnostic; and
+- every generated-adjoint refusal diagnostic.
+
+There were zero mismatches, timeouts, missing inputs, or stanc failures.
+`brmsmono` now remains a 43-op graph under both arms. Its 20-round runtime ratio
+is 1.0027, 95% CI [0.9973, 1.0063], replacing the former 1.0404 regression.
+
+Two non-island callers use the ordinary one-pass entry point: directly lowered
+runtime-control programs and ODE RHS programs. They do not need the island
+price/fallback protocol because the rewrite forbids every destination/input
+overlap (stricter than the adjoint generator's own overlap rule) and only
+removes a copy, so it cannot newly make adjoint generation fail. The semantic
+corpus replay corroborates output correctness for these paths; the activation
+audit's adjoint diagnostics apply only to regions considered by the island
+carver.
+
+## Performance results
+
+All ratios below are candidate / `STANLI_NO_PROGRAM_DEST_FORWARD=1`, so lower
+is better. Both arms use the same executable. Decision runs use fresh processes
+in alternating ABBA/BAAB order and report a stratified bootstrap interval over
+paired log ratios. All speed measurements were made on one macOS arm64 host;
+cross-platform performance remains unmeasured, while normal cross-platform
+correctness CI is a pre-merge gate.
+
+### Focused decision runs
+
+| Model | Candidate / baseline | 95% CI | Improvement |
+| --- | ---: | ---: | ---: |
+| `iohmm_reg` | 0.7714 | [0.7681, 0.7743] | 22.9% |
+| `accel_gp` | 0.8439 | [0.8402, 0.8483] | 15.6% |
+| `accel_splines` | 0.8520 | [0.8509, 0.8538] | 14.8% |
+| `hmm_drive_0` | 0.9345 | [0.9257, 0.9428] | 6.5% |
+| `hmm_gaussian` | 0.9419 | [0.9343, 0.9538] | 5.8% |
+| `soil_incubation` | 0.9551 | [0.9517, 0.9594] | 4.5% |
+| `hmm_drive_1` | 0.9814 | [0.9754, 0.9873] | 1.9% |
+| `brmsmono` activation guard | 1.0027 | [0.9973, 1.0063] | parity |
+
+The HMM run used 10 rounds x 0.5 seconds per measured gradient batch. The
+secondary run used the same protocol. `brmsmono` used 20 rounds and 700,000
+gradients per batch.
+
+### Rebased PR smoke
+
+The clean atomic implementation commit was rebuilt after rebasing and rerun
+for 8 rounds x 0.25 seconds. The executable has the same SHA-256 as the
+full-corpus executable, and all seven selected structurally active models
+passed both order cohorts:
+
+| Model | Candidate / baseline | 95% CI |
+| --- | ---: | ---: |
+| `iohmm_reg` | 0.7733 | [0.7679, 0.7744] |
+| `accel_gp` | 0.8403 | [0.8379, 0.8433] |
+| `accel_splines` | 0.8535 | [0.8472, 0.8560] |
+| `hmm_drive_0` | 0.9381 | [0.9243, 0.9385] |
+| `hmm_gaussian` | 0.9532 | [0.9477, 0.9614] |
+| `soil_incubation` | 0.9504 | [0.9419, 0.9538] |
+| `hmm_drive_1` | 0.9746 | [0.9640, 0.9809] |
+
+The `brmsmono` structural guard was also rerun on the atomic commit: both arms
+remain the same 43-op, 80-slot graph with no island.
+
+The structural reductions explain the HMM results:
+
+| Model | Forward instructions | Adjoint instructions | Registers |
+| --- | ---: | ---: | ---: |
+| `iohmm_reg`, opt-out | 31,968 | 30,472 | 43,488 |
+| `iohmm_reg`, enabled | 22,484 | 20,988 | 32,008 |
+| `hmm_gaussian`, opt-out | 26,956 | 25,460 | 25,479 |
+| `hmm_gaussian`, enabled | 21,467 | 19,971 | 19,990 |
+| `hmm_drive_0`, opt-out | 15,786 | 14,957 | 14,964 |
+| `hmm_drive_0`, enabled | 13,711 | 12,882 | 12,889 |
+
+Both accelerator models shrink an already-admitted island from 399 forward
+and 399 adjoint instructions/registers to 266 of each. `soil_incubation` is a
+directly lowered program rather than an island, showing that the pass is not
+an HMM recognizer.
+
+### Full corpus
+
+The 8-round x 0.1-second screen produced:
+
+- 120 models attempted;
+- 119 models timed;
+- zero performance failures;
+- 114 immediate passes and five inconclusive/noisy cases;
+- geometric mean 0.99227, 95% CI [0.99109, 0.99329];
+- median 0.99986;
+- p95 1.00503; and
+- worst screen point estimate 1.01782, already below the 3% policy.
+
+The five inconclusive models were rerun for 20 rounds x 0.5 seconds. All five
+then passed both order cohorts:
+
+| Model | Candidate / baseline | 95% CI |
+| --- | ---: | ---: |
+| `Rate_5_model` | 0.9991 | [0.9918, 1.0076] |
+| `arma11` | 0.9958 | [0.9895, 1.0046] |
+| `blr` | 0.9910 | [0.9719, 1.0030] |
+| `garch11` | 0.9977 | [0.9946, 1.0005] |
+| `logearn_logheight_male` | 1.0020 | [0.9948, 1.0097] |
+
+Replacing the five screen point estimates with their decision-run estimates
+gives a 0.99177 geometric mean, 0.99972 median, 1.0042 p95, and 1.00593 worst
+point estimate. This replacement summary does not have a recomputed aggregate
+confidence interval; the interval quoted above belongs to the original full
+screen.
+
+`sir` is the one untimed model: both arms reach its known invalid deterministic
+benchmark point. It is not counted as a regression. The semantic corpus replay
+includes it as the one identical both-fail case.
+
+Tiny-model noise can look like a large win even when the artifacts are
+identical (`dogs_hierarchical` is one example), so only the focused,
+structurally active results above should be treated as attributable payoff.
+
+## Preparation cost
+
+Fresh-process preparation was measured separately for 20 paired ABBA/BAAB
+rounds with `STANLI_PROFILE_PREP=1`. These are one-time file-to-bound-executor
+costs, not per-gradient overhead:
+
+| Model | Total preparation ratio | 95% CI |
+| --- | ---: | ---: |
+| `iohmm_reg` | 1.0062 | [1.0045, 1.0080] |
+| `hmm_gaussian` | 1.0060 | [1.0048, 1.0072] |
+| `hmm_drive_0` | 1.0155 | [1.0138, 1.0184] |
+| `accel_gp` | 1.0002 | [0.9965, 1.0098] |
+| `2pl_latent_reg_irt` | 1.0018 | [0.9978, 1.0042] |
+
+The largest measured preparation cost is 1.55%, below the 3% per-model policy.
+Using the median preparation delta and focused gradient saving, it amortizes in
+roughly 1-121 gradients across the four measured winning models, well within a
+normal warmup.
+
+## Correctness and safety
+
+- PosteriorDB semantic A/B: 119 runnable models, exact LP and all-gradient
+  equality at the harness's deterministic point, zero flags; `sir` is the one
+  identical known both-fail case.
+- Unit tests compare graph/island values and generated adjoints on synthetic
+  HMM, repeated-destination, and ranged-output fixtures.
+- Release suite: 67/67 tests pass after rebasing and atomically squashing the
+  candidate; the cross-path assertion is exactly the version on `main`.
+- ASan+UBSan: seven targeted suites pass after the rebase
+  (`test_pass_safety`, ODE program, MIR-program conformance, cross-path,
+  island, adjoint, and `brmsmono`).
+- Sanitized IOHMM feature-on/opt-out output is exactly identical.
+- A high-effort Fable review independently checked the op table, read/write
+  enumeration, generated-adjoint consume-and-zero behavior, activation path,
+  ABI, raw measurements, and retained hashes. Its conditional-GO code and
+  evidence conditions, including the atomic squash/rebase, are now satisfied
+  locally; cross-platform CI remains a pre-merge condition.
+
+Tests cover scalar and ranged forwarding, partial overlap, producer-input
+aliasing, extra temporary reads, seeded/live-out temporaries, later output
+overwrite, branch refusal, the profitable-island path, and the marginal
+`brmsmono` activation guard. Fable also identified an inherited relaxation of
+the cross-path island-switch floor; the original base assertion was restored
+and passes in both Release and ASan+UBSan builds.
+
+## Size and dependency constraints
+
+Relative to current `origin/main`, the atomic implementation changes seven
+files; the cross-path test is unchanged:
+
+- production: +211 / -22 lines (189 net);
+- tests: +298 / -5 lines; and
+- total: +509 / -27 lines (482 net).
+
+It adds no runtime dependency, no LLVM use, no executable-memory machinery,
+and no architecture-specific code. It satisfies the project constraint that
+LLVM may be used at build time but no outside library is required at runtime.
+
+## Evidence and provenance
+
+- Atomic implementation commit:
+  `394e973a572e9821ac61f3b25e5851d760367384`
+- Full-corpus measured production source commit:
+  `46e6b158310afc043b939bcaf388ba7e239288a8`
+- Release executable SHA-256:
+  `3099a1ff369c6b008e6d02aa23dfd54004907e6713462d3ac3a552441fdc6084`
+- Benchmark harness SHA-256:
+  `ee4fc13f6c0a8e2af5489b9a4ec7f89f7469aa15d809f33de44be85f18d0be95`
+- stanc executable SHA-256:
+  `5c1e1c10bdd8eab806fce67376cd3caaeb55d6f71839151c0a3511a2f86b95d3`
+- PosteriorDB commit:
+  `28f8d3d6e975315f42aa274a8399f21e07a43b30`
+- Targeted HMM results:
+  `/private/tmp/destination-forward-targeted-gated-46e6b15.jsonl`
+- Secondary focused results:
+  `/private/tmp/destination-forward-secondary-gated-46e6b15.jsonl`
+- Clean rebased-commit smoke results:
+  `/private/tmp/destination-forward-pr-smoke-45acde5.jsonl`
+- Full corpus and escalation results:
+  `/private/tmp/destination-forward-corpus-gated-46e6b15.jsonl` and
+  `/private/tmp/destination-forward-corpus-reruns-gated-46e6b15.jsonl`
+- Paired preparation results:
+  `/private/tmp/destination-forward-prep-gated-46e6b15.json`
+- Activation audit and reusable payload:
+  `/private/tmp/stanli-dest-activation-corpus.BUwU1Q/summary.json`
+  (SHA-256
+  `38dbaae0e0d89b4f547fa1b30025c4def2046d0bba60928284b61b9401acf1ce`)
+- `brmsmono` decision run:
+  `/private/tmp/brmsmono-destination-forward-gated-46e6b15.json`
+- Full semantic replay:
+  `/private/tmp/destination-forward-semantic-gated-46e6b15.txt`
+  (SHA-256
+  `36d556bd09af5f05eaaf190be5a7eb6b34d76fff8d492522fcfca4c23984ada8`)
+- Frozen-candidate Release test log:
+  `/private/tmp/destination-forward-release-tests-46e6b15.txt`
+  (SHA-256
+  `a02063f28f4d48f9ffb98347d8f6f7d34d9e01d562f4b8bf53a8fe80e419b602`)
+- Frozen-candidate ASan+UBSan test log:
+  `/private/tmp/destination-forward-sanitizer-tests-46e6b15.txt`
+  (SHA-256
+  `4f20e3dd819d16edf87415814163f2de20a902e9b50f749379272c2101656b5a`)
+- Post-rebase 67-test Release log:
+  `build-dest-forward/Testing/Temporary/LastTest.log`
+  (SHA-256
+  `be26c1b0697f6f474d8d52e343c7e24e3e942847939fc4a1a179019393c24ea6`)
+- Post-rebase seven-test ASan+UBSan log:
+  `build-dest-forward-san/Testing/Temporary/LastTest.log`
+  (SHA-256
+  `dbfa1de8bfccd36d8bb42ddca5a8cbe78d84c3c1e78c517631ab558895c65483`)
+- Sanitized IOHMM parity manifest:
+  `/private/tmp/destination-forward-iohmm-sanitized-parity-46e6b15.txt`
+  (SHA-256
+  `4845919e55987daa076e3fee0d6c1e06dd38248fa4fc3e8907a87cf99e07f7da`;
+  its on/off outputs both hash to
+  `6e9b8d79bd5796a302b7196d3ae214b68cf31c4e79ab9975055b4926cd8c985b`)
+- Reproduced structural counts:
+  `/private/tmp/destination-forward-structural-gated-46e6b15.txt`
+  (SHA-256
+  `54549904674ff4e325f1eb8e6c165e6200bf6d87fab4573cb1bdce978709f5e9`)
+- High-effort Fable review:
+  `/Users/xitrium/.claude/plans/act-as-a-skeptical-concurrent-squid.md`
+  (SHA-256
+  `a39d7c197987fac7610f7f07c8043689168485d0b2c8c96a42da2364090ff7d5`)
+
+The activation audit self-records the exact `dump_islands` binary it used
+(`825db7f8...`). That executable was subsequently rebuilt and now hashes to
+`be405140...`; the audit remains tied to its recorded binary, and the focused
+structural rows were reproduced after review with the retained inputs.
+
+The full-corpus manifests record a clean candidate source worktree at
+`46e6b15`; the rebased smoke manifest records a clean source worktree at
+`45acde5`. The final atomic commit, `394e973`, differs from the smoke source
+only by clang-format line wrapping, and all three produce the same
+`bench_grad` hash. The harness came from a separate dirty source worktree and
+the stanc source root was also dirty; their exact used files are content-hash
+pinned above, so this provenance is content-based rather than a claim that
+every source checkout was clean. The raw evidence paths are host-local
+research artifacts and should be copied to durable CI or review storage before
+the temporary workspace is removed. The atomic candidate is based directly on
+current `origin/main` (`13f8c19`).
+
+## PR and follow-on gates
+
+1. Require normal cross-platform correctness CI before merge; local performance
+   evidence is macOS arm64 only.
+2. Copy the host-local benchmark and semantic artifacts to durable review or
+   CI storage before removing the temporary workspace.
+3. Keep the generic recurrence/helper experiment separate. Destination
+   forwarding removes a large fraction of its motivating instruction traffic;
+   any helper should now be judged only on its *marginal* gain over this pass,
+   with the same 3% per-model corpus gate and a small implementation budget.

--- a/runtime/include/stanli/island.hpp
+++ b/runtime/include/stanli/island.hpp
@@ -94,6 +94,10 @@ constexpr uint8_t kIslandSoftmax3Variant = 1;
 // STANLI_NO_ISLAND_COMPACT=1 disables this pass only.
 void compact_island(IslandProg& p);
 
+// Explicitly gate producer-destination forwarding and report whether it
+// changed the program. The one-argument entry point remains the public default.
+bool compact_island_gated(IslandProg& p, bool enable_destination_forwarding);
+
 // Generate p.adj, appending checkpoint saves to p's forward code. False
 // leaves p untouched and keeps the replay.
 bool gen_adjoint(IslandProg& p);

--- a/runtime/include/stanli/program.hpp
+++ b/runtime/include/stanli/program.hpp
@@ -223,6 +223,13 @@ static_assert(program_code_count() == static_cast<size_t>(Program::CALL) + 1,
 // new numbering along with the program.
 void compact_program(Program& p, std::vector<std::pair<int, int>>& seeded);
 
+// Explicitly gate producer-destination forwarding and report whether it
+// changed the program. The original entry point above remains the public
+// default (and preserves its ABI); islands use this helper to price their
+// established compacted form before optimizing an accepted region.
+bool compact_program_gated(Program& p, std::vector<std::pair<int, int>>& seeded,
+                           bool enable_destination_forwarding);
+
 // Assemble the forward context for `call` over the register file `reg`.
 // Backward-only fields are left null; run_adjoint fills its own.
 KernelCtx call_fwd_ctx(const Program::Call& call, double* reg);

--- a/runtime/src/island.cpp
+++ b/runtime/src/island.cpp
@@ -442,15 +442,37 @@ struct Compiler {
   }
 };
 
+// Retaining the raw program lets an accepted island receive destination
+// forwarding after the legacy program has been priced, but copying every
+// candidate would add avoidable preparation work. Every legal rewrite has
+// this adjacent producer/copy syntax. The full pass remains the authority for
+// opcode, range, liveness, overlap, and branch safety, so false positives here
+// are harmless while this deliberately coarse probe cannot suppress a legal
+// rewrite.
+bool may_forward_adjacent_copy_destination(const Program& p) {
+  for (size_t i = 0; i + 1 < p.code.size(); ++i) {
+    const Program::Instr& producer = p.code[i];
+    const Program::Instr& copy = p.code[i + 1];
+    if ((copy.code == Program::MOV || copy.code == Program::MOVR) &&
+        copy.a == producer.dst)
+      return true;
+  }
+  return false;
+}
+
 }  // namespace
 
-void compact_island(IslandProg& p) {
-  if (std::getenv("STANLI_NO_ISLAND_COMPACT")) return;
+void compact_island(IslandProg& p) { (void)compact_island_gated(p, true); }
+
+bool compact_island_gated(IslandProg& p, bool enable_destination_forwarding) {
+  if (std::getenv("STANLI_NO_ISLAND_COMPACT")) return false;
   std::vector<std::pair<int, int>> seeded;
   seeded.reserve(p.ins.size());
   for (const auto& li : p.ins) seeded.emplace_back(li.reg, li.len);
-  compact_program(p, seeded);
+  const bool destination_forwarded =
+      compact_program_gated(p, seeded, enable_destination_forwarding);
   for (size_t k = 0; k < p.ins.size(); ++k) p.ins[k].reg = seeded[k].first;
+  return destination_forwarded;
 }
 
 int carve_islands(Graph& g,
@@ -550,18 +572,24 @@ int carve_islands(Graph& g,
         for (int e = 0; e < (int)g.slots[o].len; ++e)
           cc.prog.out_regs.push_back(cc.reg_of.at(o) + e);
 
-    // Generate the backward before estimating, because generating it is
-    // what the estimate is about: it appends the checkpoint saves the
-    // adjoint needs, so both the register count and the instruction count
-    // below are the ones the island will actually run. STANLI_NO_NATIVE_ADJ
-    // does not skip this -- it only stops the kernel USING the result, so
-    // the two backwards can be compared over the same islands.
+    // Price the pre-destination-forwarding program. This deliberately keeps
+    // activation identical to the established cost model: copy coalescing may
+    // make an island that was already selected faster, but it cannot use its
+    // own savings to pull a new island across the line. A raw copy is retained
+    // only when the optimization is enabled, and is compacted after the cost
+    // decision below.
+    std::unique_ptr<IslandProg> destination_source;
+    bool priced_gen = false;
     if (compiled) {
       for (size_t k = 0; k < cc.prog.ins.size(); ++k)
         cc.prog.ins[k].active = slot_active[(size_t)cc.live_in_slots[k]] != 0;
-      compact_island(cc.prog);
-      const bool gen = gen_adjoint(cc.prog);
-      cc.prog.native_adj = gen && !std::getenv("STANLI_NO_NATIVE_ADJ");
+      if (!std::getenv("STANLI_NO_PROGRAM_DEST_FORWARD") &&
+          !std::getenv("STANLI_NO_ISLAND_COMPACT") &&
+          may_forward_adjacent_copy_destination(cc.prog))
+        destination_source = std::make_unique<IslandProg>(cc.prog);
+      compact_island_gated(cc.prog, false);
+      priced_gen = gen_adjoint(cc.prog);
+      cc.prog.native_adj = priced_gen && !std::getenv("STANLI_NO_NATIVE_ADJ");
       // The var replay cannot execute a CALL (kernels are double
       // machinery), so a CALL-bearing island exists only with its
       // generated adjoint; otherwise the run stays as ops, which is the
@@ -571,7 +599,7 @@ int carve_islands(Graph& g,
       // gradient -- but it is worth being able to see, because it is the
       // difference between a region that is fast and one that merely
       // works, and nothing else about the model would show it.
-      if (!gen && std::getenv("STANLI_DEBUG_ISLAND"))
+      if (!priced_gen && std::getenv("STANLI_DEBUG_ISLAND"))
         std::fprintf(stderr,
                      "island: no adjoint generated for a %zu-op region; "
                      "it will replay under var\n",
@@ -625,6 +653,26 @@ int carve_islands(Graph& g,
         std::fprintf(stderr, "island? ops=%zu graph=%lld island=%lld\n", j - i,
                      (long long)graph_cost, (long long)island_cost);
       if (graph_cost < island_cost) compiled = false;
+    }
+    if (compiled && destination_source && priced_gen) {
+      IslandProg optimized = std::move(*destination_source);
+      if (compact_island_gated(optimized, true)) {
+        const bool optimized_gen = gen_adjoint(optimized);
+        optimized.native_adj =
+            optimized_gen && !std::getenv("STANLI_NO_NATIVE_ADJ");
+        // Do not trade the existing generated backward for replay if
+        // forwarding exposes an unforeseen generator limitation. CALL cannot
+        // replay at all.
+        const bool usable =
+            optimized_gen && (optimized.calls.empty() || optimized.native_adj);
+        if (usable) {
+          cc.prog = std::move(optimized);
+        } else if (std::getenv("STANLI_DEBUG_ISLAND")) {
+          std::fprintf(stderr,
+                       "island: destination forwarding kept the priced "
+                       "program because its optimized adjoint was refused\n");
+        }
+      }
     }
     if (compiled) {
       int64_t packed = 0;

--- a/runtime/src/program.cpp
+++ b/runtime/src/program.cpp
@@ -20,6 +20,7 @@
 // renumbering only drops registers nothing names.
 #include <stanli/program.hpp>
 
+#include <cstdlib>
 #include <limits>
 #include <vector>
 
@@ -97,19 +98,138 @@ bool branches(Program::Code code) {
   return code == Program::JZ || code == Program::JMP;
 }
 
+bool overlaps(Span lhs, Span rhs) {
+  return lhs.reg < rhs.reg + rhs.len && rhs.reg < lhs.reg + lhs.len;
+}
+
+bool forwardable_producer(Program::Code code) {
+  // Copies already have a dedicated aliasing pass below. CALL payloads carry
+  // output and scratch ranges outside Instr. Instructions without a generated
+  // adjoint are outside this experiment as well: the important saving is the
+  // producer/copy pair in both the forward and generated reverse streams.
+  if (code == Program::MOV || code == Program::MOVR || code == Program::CALL)
+    return false;
+  const ProgramOpSpec& spec = program_code_spec(code);
+  return !spec.has(kProgramNoOutput) && !spec.has(kProgramNoAdjoint);
+}
+
+// Turn
+//
+//   producer temporary <- ...
+//   MOV[/R] destination <- temporary
+//
+// into a producer that writes destination directly. This is ordinary,
+// model-independent copy coalescing, but it complements the forward aliasing
+// pass below: that pass must keep copies into the interior of a ranged value,
+// while redirecting the producer preserves the range as a range.
+//
+// The producer and copy must be adjacent, the temporary must be private to
+// the pair, and the destination must not overlap any producer input. The last
+// condition keeps a previously out-of-place ranged operation out of place and
+// avoids relying on opcode-specific in-place semantics. Branch-bearing
+// programs retain the old path for now so erasing the copy cannot change a
+// jump target.
+bool forward_adjacent_copy_destinations(
+    Program& p, const std::vector<std::pair<int, int>>& seeded, bool enabled) {
+  if (!enabled || std::getenv("STANLI_NO_PROGRAM_DEST_FORWARD") ||
+      p.code.size() < 2)
+    return false;
+  for (const Program::Instr& I : p.code)
+    if (branches(I.code)) return false;
+
+  const size_t n_regs = static_cast<size_t>(p.n_regs);
+  std::vector<int> reads(n_regs, 0), writes(n_regs, 0);
+  std::vector<size_t> last_write(n_regs, p.code.size());
+  for (size_t i = 0; i < p.code.size(); ++i) {
+    const Program::Instr& I = p.code[i];
+    each_read(p, I, [&](Span span) {
+      for (int k = 0; k < span.len; ++k) ++reads[(size_t)(span.reg + k)];
+    });
+    each_write(p, I, [&](Span span) {
+      for (int k = 0; k < span.len; ++k) {
+        const size_t reg = (size_t)(span.reg + k);
+        ++writes[reg];
+        last_write[reg] = i;
+      }
+    });
+  }
+
+  std::vector<char> externally_named(n_regs, 0);
+  for (const auto& seed : seeded)
+    for (int k = 0; k < seed.second; ++k)
+      externally_named[(size_t)(seed.first + k)] = 1;
+  for (int reg : p.out_regs) externally_named[(size_t)reg] = 1;
+
+  std::vector<char> remove(p.code.size(), 0);
+  for (size_t i = 0; i + 1 < p.code.size(); ++i) {
+    Program::Instr& producer = p.code[i];
+    const Program::Instr& copy = p.code[i + 1];
+    if (!forwardable_producer(producer.code) ||
+        (copy.code != Program::MOV && copy.code != Program::MOVR))
+      continue;
+
+    const int output_len = program_output_len(producer);
+    const int copy_len = copy.code == Program::MOV ? 1 : copy.len;
+    if (output_len <= 0 || copy_len != output_len || copy.a != producer.dst)
+      continue;
+    const Span temporary{producer.dst, output_len};
+    const Span destination{copy.dst, copy_len};
+    if (overlaps(temporary, destination)) continue;
+
+    bool safe = true;
+    // When the reverse rule needs the producer's output value, it must survive
+    // in the destination until reverse. Earlier writes do not matter (the
+    // original copy overwrote them), but a later write would require a
+    // checkpoint copy and give the instruction straight back. Rules without
+    // SaveOut consume the destination adjoint directly and may forward into a
+    // repeatedly written state cell.
+    const bool saves_output =
+        program_code_spec(producer.code).has(kProgramSaveOut);
+    for (int k = 0; k < output_len && safe; ++k) {
+      const size_t src = (size_t)(temporary.reg + k);
+      const size_t dst = (size_t)(destination.reg + k);
+      safe = reads[src] == 1 && writes[src] == 1 && !externally_named[src] &&
+             (last_write[dst] == i + 1 || !saves_output);
+    }
+    each_read(p, producer, [&](Span input) {
+      if (overlaps(destination, input)) safe = false;
+    });
+    if (!safe) continue;
+
+    producer.dst = copy.dst;
+    remove[i + 1] = 1;
+    ++i;  // A copy cannot also begin another producer/copy pair.
+  }
+
+  size_t kept = 0;
+  for (char drop : remove)
+    if (!drop) ++kept;
+  if (kept == p.code.size()) return false;
+  std::vector<Program::Instr> code;
+  code.reserve(kept);
+  for (size_t i = 0; i < p.code.size(); ++i)
+    if (!remove[i]) code.push_back(p.code[i]);
+  p.code = std::move(code);
+  return true;
+}
+
 }  // namespace
 
 void compact_program(Program& p, std::vector<std::pair<int, int>>& seeded) {
+  (void)compact_program_gated(p, seeded, true);
+}
+
+bool compact_program_gated(Program& p, std::vector<std::pair<int, int>>& seeded,
+                           bool enable_destination_forwarding) {
   const int n_regs = p.n_regs;
-  const size_t n = p.code.size();
-  if (n_regs <= 0) return;
+  if (n_regs <= 0) return false;
   // DYN_INDEX's `c` is an offset into a run rather than a register.
   for (const auto& I : p.code) {
     if (I.code == Program::DYN_INDEX || I.code == Program::DIAG_PRE_MULTIPLY ||
         I.code == Program::DIAG_POST_MULTIPLY)
-      return;
+      return false;
     if (I.code == Program::CALL && (I.a < 0 || (size_t)I.a >= p.calls.size()))
-      return;
+      return false;
   }
 
   auto in_file = [&](Span s) { return s.reg >= 0 && s.reg + s.len <= n_regs; };
@@ -117,12 +237,16 @@ void compact_program(Program& p, std::vector<std::pair<int, int>>& seeded) {
     bool ok = true;
     each_write(p, I, [&](Span s) { ok = ok && in_file(s); });
     each_read(p, I, [&](Span s) { ok = ok && in_file(s); });
-    if (!ok) return;
+    if (!ok) return false;
   }
   for (const auto& s : seeded)
-    if (s.second > 0 && !in_file(Span{s.first, s.second})) return;
+    if (s.second > 0 && !in_file(Span{s.first, s.second})) return false;
   for (int reg : p.out_regs)
-    if (reg < 0 || reg >= n_regs) return;
+    if (reg < 0 || reg >= n_regs) return false;
+
+  const bool destination_forwarded = forward_adjacent_copy_destinations(
+      p, seeded, enable_destination_forwarding);
+  const size_t n = p.code.size();
 
   std::vector<char> pinned((size_t)n_regs, 0);
   std::vector<char> interior((size_t)n_regs + 1, 0);
@@ -272,7 +396,7 @@ void compact_program(Program& p, std::vector<std::pair<int, int>>& seeded) {
     each_read(p, p.code[i], check);
   }
   for (int reg : p.out_regs) used[(size_t)alias[(size_t)reg]] = 1;
-  if (!contiguous) return;
+  if (!contiguous) return destination_forwarded;
 
   std::vector<int> renumber((size_t)n_regs, -1);
   int at = 0;
@@ -304,6 +428,7 @@ void compact_program(Program& p, std::vector<std::pair<int, int>>& seeded) {
   for (auto& s : seeded)
     if (s.second > 0) s.first = map[(size_t)s.first];
   p.n_regs = at;
+  return destination_forwarded;
 }
 
 }  // namespace stanli

--- a/tests/test_adjoint.cpp
+++ b/tests/test_adjoint.cpp
@@ -424,6 +424,119 @@ static void test_compact_adjoint_ranges() {
   check("compact ranges parity", std::move(parity));
 }
 
+// The HMM shape writes one state cell repeatedly: a producer writes a private
+// temporary and MOV installs it into the state. Destination forwarding removes
+// both MOVs before adjoint generation; the direct ADD rules must still consume
+// and clear the state adjoint at each write in exactly the replay's order.
+static void test_forwarded_repeated_destination() {
+  Build b({0.31, 0.72, -0.45, 1.1});
+  const int state = b.alloc();
+  const int first_tmp = b.emit(Program::ADD, 0, 1);
+  b.emit_to(Program::MOV, state, first_tmp);
+  const int first_use = b.emit(Program::MUL, state, 2);
+  const int second_tmp = b.emit(Program::ADD, 2, 3);
+  b.emit_to(Program::MOV, state, second_tmp);
+  const int second_use = b.emit(Program::MUL, state, 0);
+  const int out = b.emit(Program::ADD, first_use, second_use);
+  Case c = b.done({out}, {0.83});
+  compact_island(c.p);
+  int moves = 0;
+  for (const Program::Instr& I : c.p.code)
+    if (I.code == Program::MOV || I.code == Program::MOVR) ++moves;
+  expect("forwarded repeated destination removes copies", moves == 0);
+  check("forwarded repeated destination", std::move(c));
+}
+
+static void test_forwarded_saveout_last_write() {
+  Build b({0.31, 0.72});
+  const int state = b.alloc();
+  b.emit_to(Program::MOV, state, 1);  // an earlier, overwritten initializer
+  const int temporary = b.emit(Program::EXP, 0);
+  b.emit_to(Program::MOV, state, temporary);
+  const int out = b.emit(Program::MUL, state, 1);
+  Case c = b.done({out}, {0.83});
+  compact_island(c.p);
+  bool exp_then_copy = false;
+  for (size_t i = 0; i + 1 < c.p.code.size(); ++i)
+    if (c.p.code[i].code == Program::EXP &&
+        (c.p.code[i + 1].code == Program::MOV ||
+         c.p.code[i + 1].code == Program::MOVR))
+      exp_then_copy = true;
+  expect("SaveOut final write forwards", !exp_then_copy);
+  check("forwarded SaveOut final write", std::move(c));
+}
+
+static void test_saveout_later_write_refuses_forwarding() {
+  Build b({0.31, 0.72});
+  const int state = b.alloc();
+  b.emit_to(Program::MOV, state, 1);
+  const int temporary = b.emit(Program::EXP, 0);
+  b.emit_to(Program::MOV, state, temporary);
+  const int first_use = b.emit(Program::MUL, state, 1);
+  b.emit_to(Program::MOV, state, 0);  // would overwrite EXP's saved output
+  const int out = b.emit(Program::ADD, first_use, state);
+  Case c = b.done({out}, {0.83});
+  compact_island(c.p);
+  bool exp_then_copy = false;
+  for (size_t i = 0; i + 1 < c.p.code.size(); ++i)
+    if (c.p.code[i].code == Program::EXP &&
+        (c.p.code[i + 1].code == Program::MOV ||
+         c.p.code[i + 1].code == Program::MOVR))
+      exp_then_copy = true;
+  expect("SaveOut later write keeps copy", exp_then_copy);
+  check("SaveOut later write", std::move(c));
+}
+
+static void test_forwarded_ranged_producers() {
+  for (Program::Code code : {Program::LOG_RANGE, Program::EXP_RANGE}) {
+    Build b({0.31, 0.72, 1.45}, 3);
+    const int left = b.alloc();
+    const int destination = b.alloc(3);
+    const int right = b.alloc();
+    const int temporary = b.emit(code, 0, 0, 0, 3, 3);
+    b.emit_to(Program::MOVR, destination, temporary, 0, 0, 3);
+    // Make the copy boundaries interior to a later ranged read. The ordinary
+    // source-alias pass must keep that MOVR, so its disappearance specifically
+    // exercises producer destination forwarding.
+    b.p.pool = {-0.45, 1.1};
+    b.emit_to(Program::CONST, left, 0);
+    b.emit_to(Program::CONST, right, 1);
+    const int out = b.emit(Program::LSE_RANGE, left, 0, 0, 5);
+    Case c = b.done({out}, {0.83});
+    compact_island(c.p);
+    bool producer_then_copy = false;
+    for (size_t i = 0; i + 1 < c.p.code.size(); ++i)
+      if (c.p.code[i].code == code && c.p.code[i + 1].code == Program::MOVR)
+        producer_then_copy = true;
+    expect(code == Program::LOG_RANGE ? "LOG_RANGE destination forwards"
+                                      : "EXP_RANGE destination forwards",
+           !producer_then_copy);
+    check(code == Program::LOG_RANGE ? "forwarded LOG_RANGE"
+                                     : "forwarded EXP_RANGE",
+          std::move(c));
+  }
+}
+
+static void test_ranged_saveout_partial_later_write_refuses() {
+  Build b({0.31, 0.72, 1.45, -0.45}, 4);
+  const int state = b.alloc(3);
+  const int temporary = b.emit(Program::EXP_RANGE, 0, 0, 0, 3, 3);
+  b.emit_to(Program::MOVR, state, temporary, 0, 0, 3);
+  const int before = b.emit(Program::LSE_RANGE, state, 0, 0, 3);
+  b.emit_to(Program::MOV, state + 1, 3);
+  const int after = b.emit(Program::LSE_RANGE, state, 0, 0, 3);
+  const int out = b.emit(Program::ADD, before, after);
+  Case c = b.done({out}, {0.83});
+  compact_island(c.p);
+  bool exp_then_copy = false;
+  for (size_t i = 0; i + 1 < c.p.code.size(); ++i)
+    if (c.p.code[i].code == Program::EXP_RANGE &&
+        c.p.code[i + 1].code == Program::MOVR)
+      exp_then_copy = true;
+  expect("ranged SaveOut one-lane later write keeps copy", exp_then_copy);
+  check("ranged SaveOut one-lane later write", std::move(c));
+}
+
 static void test_accumulate_into_one_register() {
   // OP_ADD_N lowers to a chain of ADD d,d,x -- pure routing, but the
   // adjoint has to keep the running register's adjoint alive across it.
@@ -1157,6 +1270,11 @@ int main() {
   test_live_copy_both_read();
   test_copy_then_modify_chain();
   test_compact_adjoint_ranges();
+  test_forwarded_repeated_destination();
+  test_forwarded_saveout_last_write();
+  test_saveout_later_write_refuses_forwarding();
+  test_forwarded_ranged_producers();
+  test_ranged_saveout_partial_later_write_refuses();
   test_accumulate_into_one_register();
   test_ranged();
   test_softmax3_activation();

--- a/tests/test_brmsmono.cpp
+++ b/tests/test_brmsmono.cpp
@@ -16,6 +16,10 @@
 // and folding the wrong dimension would still compile and still produce
 // a finite gradient.
 #include <stanli/compile.hpp>
+#include <stanli/island.hpp>
+#include <stanli/optable.hpp>
+
+#include "env_helpers.hpp"
 
 #include <cmath>
 #include <cstdio>
@@ -42,8 +46,38 @@ int main() {
   using namespace stanli;
 
   DataMap data = DataMap::from_json_file("tests/fixtures/brmsmono.json");
-  CompiledModel cm =
-      compile_model(slurp("tests/fixtures/brmsmono.tmir.sexp"), data);
+  const std::string mir = slurp("tests/fixtures/brmsmono.tmir.sexp");
+  CompiledModel cm = compile_model(mir, data);
+  auto island_count = [](const Graph& g) {
+    int n = 0;
+    for (const Op& op : g.ops)
+      if (op.opcode == OP_ISLAND) ++n;
+    return n;
+  };
+  // Destination forwarding makes this marginal program look cheaper but the
+  // resulting newly activated island measures slower than the graph. It may
+  // optimize an explicitly forced island, but must not change the default
+  // activation decision used to price the feature.
+  expect("destination forwarding does not activate a marginal island",
+         island_count(cm.graph) == 0);
+  test_setenv("STANLI_ISLAND_ALWAYS", "1", 1);
+  CompiledModel forced = compile_model(mir, data);
+  test_setenv("STANLI_NO_PROGRAM_DEST_FORWARD", "1", 1);
+  CompiledModel unforwarded = compile_model(mir, data);
+  test_unsetenv("STANLI_NO_PROGRAM_DEST_FORWARD");
+  test_unsetenv("STANLI_ISLAND_ALWAYS");
+  expect("marginal island remains available when forced",
+         island_count(forced.graph) == 1);
+  auto island_instructions = [](const Graph& g) {
+    size_t n = 0;
+    for (const Op& op : g.ops)
+      if (op.opcode == OP_ISLAND)
+        n += static_cast<const IslandProg*>(op.udata)->code.size();
+    return n;
+  };
+  expect("forced island still receives destination forwarding",
+         island_instructions(forced.graph) <
+             island_instructions(unforwarded.graph));
   Executor ex(std::move(cm.graph));
   cm.bind(ex);
 

--- a/tests/test_island.cpp
+++ b/tests/test_island.cpp
@@ -268,6 +268,112 @@ static void test_compact_range_copy() {
   expect_eq("range copy regs", p.n_regs, 5);
 }
 
+// A scalar producer per lane followed by three copies constructs one ranged
+// value. The ordinary source-alias pass must retain those copies because each
+// destination is an interior boundary; destination forwarding can instead
+// make the producers write the contiguous range directly.
+static void test_compact_forwards_producers_into_range() {
+  auto make = [] {
+    Program p;
+    p.n_regs = 13;
+    p.code = {{Program::ADD, 6, 0, 3},
+              {Program::MOV, 9, 6},
+              {Program::ADD, 7, 1, 4},
+              {Program::MOV, 10, 7},
+              {Program::ADD, 8, 2, 5},
+              {Program::MOV, 11, 8},
+              {Program::LSE_RANGE, 12, 9, 0, 0, 3}};
+    p.out_regs = {12};
+    return p;
+  };
+  std::vector<std::pair<int, int>> seeded{{0, 6}};
+
+  Program forwarded = make();
+  compact_program(forwarded, seeded);
+  expect_eq("destination forwarding code", opcodes(forwarded),
+            "ADD ADD ADD LSE_RANGE");
+
+  test_setenv("STANLI_NO_PROGRAM_DEST_FORWARD", "1", 1);
+  Program ordinary = make();
+  std::vector<std::pair<int, int>> ordinary_seeded{{0, 6}};
+  compact_program(ordinary, ordinary_seeded);
+  test_unsetenv("STANLI_NO_PROGRAM_DEST_FORWARD");
+  expect_eq("destination forwarding opt-out", opcodes(ordinary),
+            "ADD MOV ADD MOV ADD MOV LSE_RANGE");
+}
+
+static void test_compact_destination_forwarding_refuses_input_alias() {
+  Program p;
+  p.n_regs = 4;
+  p.code = {
+      {Program::ADD, 2, 0, 1}, {Program::MOV, 0, 2}, {Program::ADD, 3, 0, 1}};
+  p.out_regs = {3};
+  std::vector<std::pair<int, int>> seeded{{0, 2}};
+  compact_program(p, seeded);
+  expect_eq("destination forwarding input alias", opcodes(p), "ADD MOV ADD");
+}
+
+static void test_compact_destination_forwarding_refusals() {
+  {
+    Program p;
+    p.n_regs = 11;
+    p.code = {{Program::LOG_RANGE, 6, 0, 0, 0, 4},
+              {Program::MOVR, 2, 6, 0, 0, 4},
+              {Program::LSE_RANGE, 10, 2, 0, 0, 4}};
+    p.out_regs = {10};
+    std::vector<std::pair<int, int>> seeded{{0, 4}};
+    compact_program(p, seeded);
+    expect_eq("destination forwarding partial input overlap", opcodes(p),
+              "LOG_RANGE MOVR LSE_RANGE");
+  }
+  {
+    Program p;
+    p.n_regs = 6;
+    p.code = {
+        {Program::ADD, 4, 0, 1}, {Program::MOV, 2, 4}, {Program::ADD, 5, 4, 2}};
+    p.out_regs = {5};
+    std::vector<std::pair<int, int>> seeded{{0, 3}};
+    compact_program(p, seeded);
+    expect_eq("destination forwarding extra temporary read", opcodes(p),
+              "ADD MOV ADD");
+  }
+  {
+    Program p;
+    p.n_regs = 5;
+    p.code = {
+        {Program::ADD, 2, 0, 1}, {Program::MOV, 3, 2}, {Program::MUL, 4, 3, 1}};
+    p.out_regs = {4};
+    std::vector<std::pair<int, int>> seeded{{0, 4}};
+    compact_program(p, seeded);
+    expect_eq("destination forwarding seeded temporary", opcodes(p),
+              "ADD MOV MUL");
+  }
+  {
+    Program p;
+    p.n_regs = 6;
+    p.code = {
+        {Program::ADD, 4, 0, 1}, {Program::MOV, 2, 4}, {Program::MUL, 5, 2, 1}};
+    p.out_regs = {4, 5};
+    std::vector<std::pair<int, int>> seeded{{0, 3}};
+    compact_program(p, seeded);
+    expect_eq("destination forwarding live-out temporary", opcodes(p),
+              "ADD MOV MUL");
+  }
+  {
+    Program p;
+    p.n_regs = 6;
+    p.code = {{Program::ADD, 4, 0, 1},
+              {Program::MOV, 2, 4},
+              {Program::JZ, 3, 3},
+              {Program::ADD, 5, 2, 1}};
+    p.out_regs = {5};
+    std::vector<std::pair<int, int>> seeded{{0, 4}};
+    compact_program(p, seeded);
+    expect_eq("destination forwarding branch program", opcodes(p),
+              "ADD MOV JZ ADD");
+  }
+}
+
 // A read that spans two copies must not be split across their sources.
 static void test_compact_straddling_range_kept() {
   Program p;
@@ -412,9 +518,8 @@ static void test_unsupported_op_splits() {
 // the estimate still has to refuse once the backward stops building vars:
 // `bones_model` is it (36 ops behind 4,024 registers) and islands cost it
 // 19x replayed, 4x with a generated adjoint.
-static void test_wide_state_refused() {
+static Graph build_wide_state(Fills& fills, std::vector<int>& terms) {
   Graph g;
-  Fills fills;
   const int W = 64;
   int prev = g.add_slot(1, true);
   for (int t = 0; t < 12; ++t) {
@@ -431,11 +536,28 @@ static void test_wide_state_refused() {
   const int lp = g.add_slot(1, false);
   g.add_op(OP_ADD, {prev, prev}, lp);
   g.result_slot = lp;
-  std::vector<int> terms{lp};
+  terms = {lp};
+  return g;
+}
+
+static void test_wide_state_refused() {
+  Fills fills;
+  std::vector<int> terms;
+  Graph g = build_wide_state(fills, terms);
   const size_t before = g.ops.size();  // 36 in vocab, above kMinIslandOps
   const int carved = carve_islands(g, fills, terms, {});
   expect("wide none carved", carved == 0);
   expect("wide ops unchanged", g.ops.size() == before);
+
+  // Pin the override directly instead of relying on the cross-path fixture
+  // corpus to retain a model on exactly the losing side of the cost model.
+  Fills forced_fills;
+  std::vector<int> forced_terms;
+  Graph forced = build_wide_state(forced_fills, forced_terms);
+  test_setenv("STANLI_ISLAND_ALWAYS", "1", 1);
+  expect("wide forced carve",
+         carve_islands(forced, forced_fills, forced_terms, {}) == 1);
+  test_unsetenv("STANLI_ISLAND_ALWAYS");
 }
 
 // The cost estimate, on the two shapes it has to tell apart. A wide
@@ -445,10 +567,26 @@ static void test_vector_copies_carved() {
   HmmGraph ref = build_hmm(8, 128);
   const std::vector<double> want = run_grad(std::move(ref.g), ref.fills);
 
+  HmmGraph ordinary = build_hmm(8, 128);
+  test_setenv("STANLI_NO_PROGRAM_DEST_FORWARD", "1", 1);
+  const int ordinary_carved =
+      carve_islands(ordinary.g, ordinary.fills, ordinary.terms, {});
+  test_unsetenv("STANLI_NO_PROGRAM_DEST_FORWARD");
+
   HmmGraph isl = build_hmm(8, 128);
   const int carved = carve_islands(isl.g, isl.fills, isl.terms, {});
   expect("copies carved==1", carved == 1);
+  expect("copies opt-out also carved==1", ordinary_carved == 1);
   expect("copies ops==4", isl.g.ops.size() == 4);
+  auto island_instructions = [](const Graph& g) {
+    size_t n = 0;
+    for (const Op& op : g.ops)
+      if (op.opcode == OP_ISLAND)
+        n += static_cast<const IslandProg*>(op.udata)->code.size();
+    return n;
+  };
+  expect("copies forwarding shrinks an already profitable island",
+         island_instructions(isl.g) < island_instructions(ordinary.g));
   const std::vector<double> got = run_grad_twice(std::move(isl.g), isl.fills);
   expect("copies sizes", got.size() == want.size());
   for (size_t i = 0; i < want.size() && i < got.size(); ++i)
@@ -1117,6 +1255,9 @@ int main() {
   test_compact_rewritten_source_kept();
   test_compact_second_writer_kept();
   test_compact_range_copy();
+  test_compact_forwards_producers_into_range();
+  test_compact_destination_forwarding_refuses_input_alias();
+  test_compact_destination_forwarding_refusals();
   test_compact_straddling_range_kept();
   test_compact_call_ranges();
   test_compact_env_disable();


### PR DESCRIPTION
## Summary

- add a conservative, model-independent destination-forwarding pass for register programs
- rewrite adjacent `producer temporary; MOV[/R] destination <- temporary` pairs so the producer writes the destination directly
- preserve established island activation by pricing the unoptimized program first and applying forwarding only after admission
- retain the priced program if optimized adjoint generation fails, and provide `STANLI_NO_PROGRAM_DEST_FORWARD=1` as an A/B and emergency opt-out
- preserve the existing `compact_program` and `compact_island` entry points

This is an ordinary compiler optimization, not a model-specific recognizer or a native JIT. It adds no runtime dependency, LLVM use, executable-memory machinery, or architecture-specific code.

## Why activation is gated

The first research version let the instruction savings affect island admission. That activated a marginal `brmsmono` island and measured 4.04% slower. This PR deliberately makes admission from the pre-forward form, then optimizes only regions that were already accepted. On the final candidate, `brmsmono` remains the same 43-op, 80-slot graph in both arms; its 20-round runtime ratio was 1.0027, 95% CI [0.9973, 1.0063].

## Performance

Ratios are feature-on / `STANLI_NO_PROGRAM_DEST_FORWARD=1` in the same executable, so lower is better. Runs used fresh processes, alternating ABBA/BAAB order, and stratified bootstrap intervals.

Focused decision runs on macOS arm64:

| Model | Ratio | 95% CI | Improvement |
| --- | ---: | ---: | ---: |
| `iohmm_reg` | 0.7714 | [0.7681, 0.7743] | 22.9% |
| `accel_gp` | 0.8439 | [0.8402, 0.8483] | 15.6% |
| `accel_splines` | 0.8520 | [0.8509, 0.8538] | 14.8% |
| `hmm_drive_0` | 0.9345 | [0.9257, 0.9428] | 6.5% |
| `hmm_gaussian` | 0.9419 | [0.9343, 0.9538] | 5.8% |
| `soil_incubation` | 0.9551 | [0.9517, 0.9594] | 4.5% |
| `hmm_drive_1` | 0.9814 | [0.9754, 0.9873] | 1.9% |

The PosteriorDB screen attempted 120 models and timed 119. It had zero performance failures, with a 0.99227 geometric mean (95% CI [0.99109, 0.99329]). Five noisy/inconclusive screen cases were escalated to 20 rounds x 0.5 seconds and all passed both order cohorts. Replacing their screen estimates gives a 0.99177 geometric mean, 0.99972 median, 1.0042 p95, and 1.00593 worst point estimate.

One-time preparation cost was at most 1.55% in the five-model paired check. All performance evidence is from one macOS arm64 host; cross-platform performance is not claimed.

After rebasing and squashing, a clean-build 8-round smoke repeated all seven focused wins. The rebuilt `bench_grad` binary was byte-identical to the full-corpus binary (SHA-256 `3099a1ff369c6b008e6d02aa23dfd54004907e6713462d3ac3a552441fdc6084`).

## Correctness and validation

- 67/67 Release tests pass on this branch
- seven targeted ASan+UBSan suites pass, including ODE programs, MIR conformance, cross-path activation, island, adjoint, and `brmsmono`
- 147 PosteriorDB model/data pairs have identical graph shape, island positions, pre-forward pricing diagnostics, and island-carver adjoint-refusal diagnostics with the feature on/off
- 119 runnable PosteriorDB models have exact LP and all-gradient equality at the harness deterministic point; `sir` is the same known both-fail case in both arms
- sanitized IOHMM output is byte-identical with the feature on/off
- high-effort Fable review checked rewrite legality, opcode read/write enumeration, generated-adjoint behavior, activation architecture, ABI compatibility, and the retained benchmark artifacts; its local conditions are satisfied

Normal cross-platform correctness CI remains required before merge.

The full design, methodology, raw artifact paths, hashes, and caveats are in `docs/superpowers/plans/2026-08-28-destination-forwarding-results.md`.
