### PR TITLE
Fix handling of infinite bounds in constraints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+### Infinite declaration bounds are identities
+
+Parameter declarations whose lower bound is negative infinity or whose upper
+bound is positive infinity now pass those elements through unchanged and add no
+Jacobian term, matching Stan Math. This also works elementwise when a vector of
+bounds mixes finite and infinite entries (#250).
+
 ### More matrix selections and compile-time locals lower
 
 Two-axis matrix selections now accept any combination of `:`, single indices,

--- a/runtime/kernels/constrain.cpp
+++ b/runtime/kernels/constrain.cpp
@@ -91,16 +91,27 @@ inline double masked_sum(const double* x, const double* bound, int64_t n,
   return s;
 }
 
-// A bound adjoint lands per element when the bound varies and in one shared
-// lane when it does not -- the split add_bound_adj makes, reached one element
-// at a time because the mixed-infinity paths below build their terms inline.
+// A bound adjoint lands per element when the bound varies. A shared bound
+// first reduces all terms from zero and then adds that reduction once, which
+// preserves stan-math's `.sum()` callback rounding even when the lane already
+// has an adjoint from another use.
 struct BoundAdj {
   double* p;
   bool varies;
+  double lane = 0.0;
+  bool touched = false;
   BoundAdj(KernelCtx& ctx, int k)
       : p(ctx.in_adj[k].data), varies(Bound(ctx.in[k]).varies()) {}
-  void add(int64_t i, double v) const {
-    if (p) p[varies ? i : 0] += v;
+  void add(int64_t i, double v) {
+    if (!p) return;
+    touched = true;
+    if (varies)
+      p[i] += v;
+    else
+      lane += v;
+  }
+  void commit() {
+    if (p && !varies && touched) p[0] += lane;
   }
 };
 
@@ -160,9 +171,9 @@ void clower_bwd(KernelCtx& ctx) {
               lb[i] == kNegInf ? dout[i] : dout[i] * exp_x[i] + ctx.out2_adj;
     }
     if (lb.varies()) {
-      const BoundAdj lba(ctx, 1);
+      BoundAdj lba(ctx, 1);
       for (int64_t i = 0; i < n; ++i)
-        lba.add(i, lb[i] == kNegInf ? 0.0 : dout[i]);
+        if (lb[i] != kNegInf) lba.add(i, dout[i]);
     }
     return;
   }
@@ -225,9 +236,9 @@ void cupper_bwd(KernelCtx& ctx) {
               ub[i] == kPosInf ? dout[i] : -dout[i] * exp_x[i] + ctx.out2_adj;
     }
     if (ub.varies()) {
-      const BoundAdj uba(ctx, 1);
+      BoundAdj uba(ctx, 1);
       for (int64_t i = 0; i < n; ++i)
-        uba.add(i, ub[i] == kPosInf ? 0.0 : dout[i]);
+        if (ub[i] != kPosInf) uba.add(i, dout[i]);
     }
     return;
   }
@@ -291,23 +302,23 @@ void clu_bwd_inf(KernelCtx& ctx, int64_t n, const double* x, const double* il,
                  const Bound& lb, const Bound& ub) {
   const double* dout = ctx.out_adj_vec.data;
   const double lp_adj = ctx.out2_adj;
-  const BoundAdj lba(ctx, 1), uba(ctx, 2);
+  BoundAdj lba(ctx, 1), uba(ctx, 2);
   for (int64_t i = 0; i < n; ++i) {
     const bool li = lb[i] == kNegInf, ui = ub[i] == kPosInf;
     const double diff = ub[i] - lb[i];
     if (ctx.in_adj[0].data)
       ctx.in_adj[0].data[i] += li && ui ? dout[i]
                                : li     ? -dout[i] * std::exp(x[i]) + lp_adj
-                               : ui     ? dout[i] * std::exp(x[i]) + lp_adj
+                               : ui ? dout[i] * std::exp(x[i]) + lp_adj
                                     : dout[i] * diff * il[i] * (1.0 - il[i]) +
                                           lp_adj * (1.0 - 2.0 * il[i]);
-    lba.add(i, li   ? 0.0
-               : ui ? dout[i]
-                    : dout[i] * (1.0 - il[i]) - (1.0 / diff) * lp_adj);
-    uba.add(i, ui   ? 0.0
-               : li ? dout[i]
-                    : dout[i] * il[i] + (1.0 / diff) * lp_adj);
+    if (!li)
+      lba.add(i,
+              ui ? dout[i] : dout[i] * (1.0 - il[i]) - (1.0 / diff) * lp_adj);
+    if (!ui) uba.add(i, li ? dout[i] : dout[i] * il[i] + (1.0 / diff) * lp_adj);
   }
+  lba.commit();
+  uba.commit();
 }
 
 // rev lub_constrain(matrix, scalar, scalar, lp):

--- a/runtime/kernels/constrain.cpp
+++ b/runtime/kernels/constrain.cpp
@@ -63,6 +63,47 @@ inline void add_bound_adj(KernelCtx& ctx, int k, const double* terms,
     ctx.in_adj[k].data[0] += seq_sum(terms, n);
 }
 
+// An infinite bound is not a bound: every *_constrain overload short-circuits
+// it to the identity, so the element passes through untouched and contributes
+// no jacobian term. stan-math spells that as a `select` over an `is_inf` mask;
+// here it earns a branch of its own instead, because an infinite bound is rare
+// and the finite path has to stay the exact arithmetic the ULP calibration in
+// the header comment was measured against.
+constexpr double kNegInf = -std::numeric_limits<double>::infinity();
+constexpr double kPosInf = std::numeric_limits<double>::infinity();
+
+inline bool has_inf(const Bound& b, int64_t n, double inf) {
+  if (!b.varies()) return b[0] == inf;
+  for (int64_t i = 0; i < n; ++i)
+    if (b.p[i] == inf) return true;
+  return false;
+}
+
+// Jacobian for a per-element bound with identity elements masked to a literal
+// zero -- rev's `select(x, 0).sum()` -- reduced the way seq_sum reduces, so
+// the elements that do transform still land where they did.
+inline double masked_sum(const double* x, const double* bound, int64_t n,
+                         double inf) {
+  if (packet_math())
+    return (CMapA(bound, n) != inf).select(CMapA(x, n), 0.0).sum();
+  double s = 0.0;
+  for (int64_t i = 0; i < n; ++i) s += bound[i] == inf ? 0.0 : x[i];
+  return s;
+}
+
+// A bound adjoint lands per element when the bound varies and in one shared
+// lane when it does not -- the split add_bound_adj makes, reached one element
+// at a time because the mixed-infinity paths below build their terms inline.
+struct BoundAdj {
+  double* p;
+  bool varies;
+  BoundAdj(KernelCtx& ctx, int k)
+      : p(ctx.in_adj[k].data), varies(Bound(ctx.in[k]).varies()) {}
+  void add(int64_t i, double v) const {
+    if (p) p[varies ? i : 0] += v;
+  }
+};
+
 // rev lb_constrain(matrix, scalar, lp):
 //   exp_x = x.val().array().exp() (strided -> scalar std::exp);
 //   ret = exp_x + lb;  lp += x.val().sum() (sequential);
@@ -74,6 +115,20 @@ void clower_fwd(KernelCtx& ctx) {
   const double* x = ctx.in[0].data;
   double* exp_x = ctx.scratch;
   const Bound lb(ctx.in[1]);
+  if (has_inf(lb, n, kNegInf)) {
+    if (!lb.varies()) {
+      // One shared -inf: the container is the identity end to end.
+      for (int64_t i = 0; i < n; ++i) ctx.out.data[i] = x[i];
+      ctx.out2.data[0] = 0.0;
+      return;
+    }
+    for (int64_t i = 0; i < n; ++i) {
+      exp_x[i] = std::exp(x[i]);
+      ctx.out.data[i] = lb[i] == kNegInf ? x[i] : exp_x[i] + lb[i];
+    }
+    ctx.out2.data[0] = masked_sum(x, lb.p, n, kNegInf);
+    return;
+  }
   if (packet_math() && n > 1) {
     MapA(exp_x, n) = CMapA(x, n).exp();
     if (lb.varies())
@@ -92,6 +147,25 @@ void clower_bwd(KernelCtx& ctx) {
   const int64_t n = ctx.in[0].len;
   const double* exp_x = ctx.scratch;
   const double* dout = ctx.out_adj_vec.data;
+  const Bound lb(ctx.in[1]);
+  if (has_inf(lb, n, kNegInf)) {
+    // Identity elements pass ret.adj straight through and take no jacobian
+    // share; their bound, having stayed out of the value, collects nothing.
+    if (ctx.in_adj[0].data) {
+      if (!lb.varies())
+        for (int64_t i = 0; i < n; ++i) ctx.in_adj[0].data[i] += dout[i];
+      else
+        for (int64_t i = 0; i < n; ++i)
+          ctx.in_adj[0].data[i] +=
+              lb[i] == kNegInf ? dout[i] : dout[i] * exp_x[i] + ctx.out2_adj;
+    }
+    if (lb.varies()) {
+      const BoundAdj lba(ctx, 1);
+      for (int64_t i = 0; i < n; ++i)
+        lba.add(i, lb[i] == kNegInf ? 0.0 : dout[i]);
+    }
+    return;
+  }
   if (ctx.in_adj[0].data) {
     for (int64_t i = 0; i < n; ++i)
       ctx.in_adj[0].data[i] += dout[i] * exp_x[i] + ctx.out2_adj;
@@ -109,6 +183,19 @@ void cupper_fwd(KernelCtx& ctx) {
   const double* x = ctx.in[0].data;
   double* exp_x = ctx.scratch;
   const Bound ub(ctx.in[1]);
+  if (has_inf(ub, n, kPosInf)) {
+    if (!ub.varies()) {
+      for (int64_t i = 0; i < n; ++i) ctx.out.data[i] = x[i];
+      ctx.out2.data[0] = 0.0;
+      return;
+    }
+    for (int64_t i = 0; i < n; ++i) {
+      exp_x[i] = std::exp(x[i]);
+      ctx.out.data[i] = ub[i] == kPosInf ? x[i] : ub[i] - exp_x[i];
+    }
+    ctx.out2.data[0] = masked_sum(x, ub.p, n, kPosInf);
+    return;
+  }
   if (packet_math() && n > 1) {
     MapA(exp_x, n) = CMapA(x, n).exp();
     if (ub.varies())
@@ -127,11 +214,100 @@ void cupper_bwd(KernelCtx& ctx) {
   const int64_t n = ctx.in[0].len;
   const double* exp_x = ctx.scratch;
   const double* dout = ctx.out_adj_vec.data;
+  const Bound ub(ctx.in[1]);
+  if (has_inf(ub, n, kPosInf)) {
+    if (ctx.in_adj[0].data) {
+      if (!ub.varies())
+        for (int64_t i = 0; i < n; ++i) ctx.in_adj[0].data[i] += dout[i];
+      else
+        for (int64_t i = 0; i < n; ++i)
+          ctx.in_adj[0].data[i] +=
+              ub[i] == kPosInf ? dout[i] : -dout[i] * exp_x[i] + ctx.out2_adj;
+    }
+    if (ub.varies()) {
+      const BoundAdj uba(ctx, 1);
+      for (int64_t i = 0; i < n; ++i)
+        uba.add(i, ub[i] == kPosInf ? 0.0 : dout[i]);
+    }
+    return;
+  }
   if (ctx.in_adj[0].data) {
     for (int64_t i = 0; i < n; ++i)
       ctx.in_adj[0].data[i] += -dout[i] * exp_x[i] + ctx.out2_adj;
   }
   add_bound_adj(ctx, 1, dout, n);
+}
+
+// The stored inv_logit, by whichever rev overload this slot's length selects.
+inline void clu_inv_logit(const double* x, double* il, int64_t n) {
+  if (n == 1) {
+    // Scalar rev overload: sign-branching stan::math::inv_logit.
+    il[0] = stan::math::inv_logit(x[0]);
+    return;
+  }
+  // Matrix rev overload: Eigen's scalar logistic functor over a strided
+  // .val() expression: e/(1+e) with an inf guard, no sign branch.
+  if (packet_math()) {
+    MapA(il, n) = CMapA(x, n).exp();
+    MapA(il, n) =
+        (MapA(il, n).isInf()).select(1.0, MapA(il, n) / (1.0 + MapA(il, n)));
+  } else {
+    for (int64_t i = 0; i < n; ++i) {
+      const double e = std::exp(x[i]);
+      il[i] = std::isinf(e) ? 1.0 : e / (1.0 + e);
+    }
+  }
+}
+
+// lub_constrain resolves each element by which of its bounds are infinite:
+// both -> identity, lower only -> the upper-bound transform, upper only ->
+// the lower-bound transform, neither -> the logit map. The jacobian follows,
+// contributing nothing, x, x, and log(diff) + logistic respectively.
+void clu_fwd_inf(KernelCtx& ctx, int64_t n, const double* x, double* il,
+                 const Bound& lb, const Bound& ub) {
+  double jac = 0.0;
+  for (int64_t i = 0; i < n; ++i) {
+    const bool li = lb[i] == kNegInf, ui = ub[i] == kPosInf;
+    if (li && ui) continue;
+    if (li || ui) {
+      jac += x[i];
+      continue;
+    }
+    const double nax = -std::abs(x[i]);
+    jac += std::log(ub[i] - lb[i]) + (nax - 2.0 * stan::math::log1p_exp(nax));
+  }
+  ctx.out2.data[0] = jac;
+  clu_inv_logit(x, il, n);
+  for (int64_t i = 0; i < n; ++i) {
+    const bool li = lb[i] == kNegInf, ui = ub[i] == kPosInf;
+    ctx.out.data[i] = li && ui ? x[i]
+                      : li     ? ub[i] - std::exp(x[i])
+                      : ui     ? std::exp(x[i]) + lb[i]
+                               : (ub[i] - lb[i]) * il[i] + lb[i];
+  }
+}
+
+void clu_bwd_inf(KernelCtx& ctx, int64_t n, const double* x, const double* il,
+                 const Bound& lb, const Bound& ub) {
+  const double* dout = ctx.out_adj_vec.data;
+  const double lp_adj = ctx.out2_adj;
+  const BoundAdj lba(ctx, 1), uba(ctx, 2);
+  for (int64_t i = 0; i < n; ++i) {
+    const bool li = lb[i] == kNegInf, ui = ub[i] == kPosInf;
+    const double diff = ub[i] - lb[i];
+    if (ctx.in_adj[0].data)
+      ctx.in_adj[0].data[i] += li && ui ? dout[i]
+                               : li     ? -dout[i] * std::exp(x[i]) + lp_adj
+                               : ui     ? dout[i] * std::exp(x[i]) + lp_adj
+                                    : dout[i] * diff * il[i] * (1.0 - il[i]) +
+                                          lp_adj * (1.0 - 2.0 * il[i]);
+    lba.add(i, li   ? 0.0
+               : ui ? dout[i]
+                    : dout[i] * (1.0 - il[i]) - (1.0 / diff) * lp_adj);
+    uba.add(i, ui   ? 0.0
+               : li ? dout[i]
+                    : dout[i] * il[i] + (1.0 / diff) * lp_adj);
+  }
 }
 
 // rev lub_constrain(matrix, scalar, scalar, lp):
@@ -144,6 +320,10 @@ void clu_fwd(KernelCtx& ctx) {
   const double* x = ctx.in[0].data;
   double* il = ctx.scratch;
   const Bound lb(ctx.in[1]), ub(ctx.in[2]);
+  if (has_inf(lb, n, kNegInf) || has_inf(ub, n, kPosInf)) {
+    clu_fwd_inf(ctx, n, x, il, lb, ub);
+    return;
+  }
   // Shared bounds make log(diff) loop-invariant, and std::log is opaque
   // enough that only hoisting it by hand keeps a parameter block at one
   // call rather than one per element.
@@ -157,23 +337,7 @@ void clu_fwd(KernelCtx& ctx) {
     jac += log_diff + (nax - 2.0 * stan::math::log1p_exp(nax));
   }
   ctx.out2.data[0] = jac;
-  if (n == 1) {
-    // Scalar rev overload: sign-branching stan::math::inv_logit.
-    il[0] = stan::math::inv_logit(x[0]);
-  } else {
-    // Matrix rev overload: Eigen's scalar logistic functor over a strided
-    // .val() expression: e/(1+e) with an inf guard, no sign branch.
-    if (packet_math()) {
-      MapA(il, n) = CMapA(x, n).exp();
-      MapA(il, n) =
-          (MapA(il, n).isInf()).select(1.0, MapA(il, n) / (1.0 + MapA(il, n)));
-    } else {
-      for (int64_t i = 0; i < n; ++i) {
-        const double e = std::exp(x[i]);
-        il[i] = std::isinf(e) ? 1.0 : e / (1.0 + e);
-      }
-    }
-  }
+  clu_inv_logit(x, il, n);
   for (int64_t i = 0; i < n; ++i)
     ctx.out.data[i] = (varies ? ub[i] - lb[i] : diff0) * il[i] + lb[i];
 }
@@ -182,6 +346,10 @@ void clu_bwd(KernelCtx& ctx) {
   const double* il = ctx.scratch;
   const double* dout = ctx.out_adj_vec.data;
   const Bound lb(ctx.in[1]), ub(ctx.in[2]);
+  if (has_inf(lb, n, kNegInf) || has_inf(ub, n, kPosInf)) {
+    clu_bwd_inf(ctx, n, ctx.in[0].data, il, lb, ub);
+    return;
+  }
   const bool varies = lb.varies() || ub.varies();
   const double diff0 = ub[0] - lb[0];
   if (ctx.in_adj[0].data) {

--- a/tests/fixtures/infbounds.stan
+++ b/tests/fixtures/infbounds.stan
@@ -1,0 +1,31 @@
+// Infinite declaration bounds. Every *_constrain overload reads an infinite
+// bound as no bound at all: the element passes through untouched and adds
+// no jacobian term. The kernels used to exponentiate through it, so a
+// declaration carrying one produced inf and an lp of -inf.
+//
+// The bound vectors mix infinite and finite entries, which is what makes
+// them worth testing -- the finite entries still have to transform. Their
+// four elements cover every branch lower_upper resolves per element:
+// lower-only infinite, upper-only infinite, both, and neither.
+//
+// Each parameter is summed into its own target term, so the reference in
+// tests/test_lower.cpp can reassociate the same way.
+transformed data {
+  vector[4] lo = [negative_infinity(), -0.5, negative_infinity(), 0.75]';
+  vector[4] hi = [3.25, positive_infinity(), positive_infinity(), 4.5]';
+}
+parameters {
+  vector<lower = lo>[4] a;
+  vector<upper = hi>[4] b;
+  vector<lower = lo, upper = hi>[4] c;
+  // The whole-container case: one shared bound that is itself infinite.
+  real<lower = negative_infinity()> d;
+  real<upper = positive_infinity()> e;
+}
+model {
+  target += sum(a);
+  target += sum(b);
+  target += sum(c);
+  target += d;
+  target += e;
+}

--- a/tests/fixtures/infbounds.tmir.sexp
+++ b/tests/fixtures/infbounds.tmir.sexp
@@ -1,0 +1,1108 @@
+((functions_block ()) (input_vars ())
+ (prepare_data
+  (((pattern
+     (Decl (decl_adtype DataOnly) (decl_id pos__) (decl_type (Sized SInt))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable pos__) ()) UInt
+      ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id lo)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Lit Int 4)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable lo) ()) UVector
+      ((pattern
+        (FunApp (StanLib Transpose__ FnPlain AoS)
+         (((pattern
+            (FunApp (CompilerInternal FnMakeRowVec)
+             (((pattern (FunApp (StanLib negative_infinity FnPlain AoS) ()))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+              ((pattern (Lit Real -0.5))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+              ((pattern (FunApp (StanLib negative_infinity FnPlain AoS) ()))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+              ((pattern (Lit Real 0.75))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ URowVector) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id hi)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Lit Int 4)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable hi) ()) UVector
+      ((pattern
+        (FunApp (StanLib Transpose__ FnPlain AoS)
+         (((pattern
+            (FunApp (CompilerInternal FnMakeRowVec)
+             (((pattern (Lit Real 3.25))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+              ((pattern (FunApp (StanLib positive_infinity FnPlain AoS) ()))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+              ((pattern (FunApp (StanLib positive_infinity FnPlain AoS) ()))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+              ((pattern (Lit Real 4.5))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ URowVector) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))))
+ (log_prob
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id a)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Lit Int 4)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam
+             (constrain
+              (Lower
+               ((pattern (Var lo))
+                (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly))))))
+             (dims
+              (((pattern (Lit Int 4))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp (StanLib check_matching_dims FnPlain AoS)
+      (((pattern (Lit Str constraint))
+        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+       ((pattern (Lit Str a)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+       ((pattern (Var a)) (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))
+       ((pattern (Lit Str lower))
+        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+       ((pattern (Var lo)) (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id b)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Lit Int 4)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam
+             (constrain
+              (Upper
+               ((pattern (Var hi))
+                (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly))))))
+             (dims
+              (((pattern (Lit Int 4))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp (StanLib check_matching_dims FnPlain AoS)
+      (((pattern (Lit Str constraint))
+        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+       ((pattern (Lit Str b)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+       ((pattern (Var b)) (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))
+       ((pattern (Lit Str upper))
+        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+       ((pattern (Var hi)) (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id c)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Lit Int 4)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam
+             (constrain
+              (LowerUpper
+               ((pattern (Var lo))
+                (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly))))
+               ((pattern (Var hi))
+                (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly))))))
+             (dims
+              (((pattern (Lit Int 4))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp (StanLib check_matching_dims FnPlain AoS)
+      (((pattern (Lit Str constraint))
+        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+       ((pattern (Lit Str c)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+       ((pattern (Var c)) (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))
+       ((pattern (Lit Str lower))
+        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+       ((pattern (Var lo)) (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp (StanLib check_matching_dims FnPlain AoS)
+      (((pattern (Lit Str constraint))
+        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+       ((pattern (Lit Str c)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+       ((pattern (Var c)) (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))
+       ((pattern (Lit Str upper))
+        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+       ((pattern (Var hi)) (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id d) (decl_type (Sized SReal))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam
+             (constrain
+              (Lower
+               ((pattern (FunApp (StanLib negative_infinity FnPlain AoS) ()))
+                (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+             (dims ()) (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id e) (decl_type (Sized SReal))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam
+             (constrain
+              (Upper
+               ((pattern (FunApp (StanLib positive_infinity FnPlain AoS) ()))
+                (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+             (dims ()) (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib sum FnPlain AoS)
+             (((pattern (Var a))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>))
+       ((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib sum FnPlain AoS)
+             (((pattern (Var b))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>))
+       ((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib sum FnPlain AoS)
+             (((pattern (Var c))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>))
+       ((pattern
+         (TargetPE
+          ((pattern (Var d))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>))
+       ((pattern
+         (TargetPE
+          ((pattern (Var e))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>)))))
+    (meta <opaque>))))
+ (reverse_mode_log_prob
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id a)
+      (decl_type
+       (Sized
+        (SVector SoA
+         ((pattern (Lit Int 4)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam
+             (constrain
+              (Lower
+               ((pattern (Var lo))
+                (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly))))))
+             (dims
+              (((pattern (Lit Int 4))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern SoA)))
+           ()))
+         (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp (StanLib check_matching_dims FnPlain AoS)
+      (((pattern (Lit Str constraint))
+        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+       ((pattern (Lit Str a)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+       ((pattern (Var a)) (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))
+       ((pattern (Lit Str lower))
+        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+       ((pattern (Var lo)) (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id b)
+      (decl_type
+       (Sized
+        (SVector SoA
+         ((pattern (Lit Int 4)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam
+             (constrain
+              (Upper
+               ((pattern (Var hi))
+                (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly))))))
+             (dims
+              (((pattern (Lit Int 4))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern SoA)))
+           ()))
+         (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp (StanLib check_matching_dims FnPlain AoS)
+      (((pattern (Lit Str constraint))
+        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+       ((pattern (Lit Str b)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+       ((pattern (Var b)) (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))
+       ((pattern (Lit Str upper))
+        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+       ((pattern (Var hi)) (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id c)
+      (decl_type
+       (Sized
+        (SVector SoA
+         ((pattern (Lit Int 4)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam
+             (constrain
+              (LowerUpper
+               ((pattern (Var lo))
+                (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly))))
+               ((pattern (Var hi))
+                (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly))))))
+             (dims
+              (((pattern (Lit Int 4))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern SoA)))
+           ()))
+         (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp (StanLib check_matching_dims FnPlain AoS)
+      (((pattern (Lit Str constraint))
+        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+       ((pattern (Lit Str c)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+       ((pattern (Var c)) (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))
+       ((pattern (Lit Str lower))
+        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+       ((pattern (Var lo)) (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp (StanLib check_matching_dims FnPlain AoS)
+      (((pattern (Lit Str constraint))
+        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+       ((pattern (Lit Str c)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+       ((pattern (Var c)) (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))
+       ((pattern (Lit Str upper))
+        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+       ((pattern (Var hi)) (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id d) (decl_type (Sized SReal))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam
+             (constrain
+              (Lower
+               ((pattern (FunApp (StanLib negative_infinity FnPlain AoS) ()))
+                (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+             (dims ()) (mem_pattern SoA)))
+           ()))
+         (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id e) (decl_type (Sized SReal))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam
+             (constrain
+              (Upper
+               ((pattern (FunApp (StanLib positive_infinity FnPlain AoS) ()))
+                (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+             (dims ()) (mem_pattern SoA)))
+           ()))
+         (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib sum FnPlain SoA)
+             (((pattern (Var a))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>))
+       ((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib sum FnPlain SoA)
+             (((pattern (Var b))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>))
+       ((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib sum FnPlain SoA)
+             (((pattern (Var c))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>))
+       ((pattern
+         (TargetPE
+          ((pattern (Var d))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>))
+       ((pattern
+         (TargetPE
+          ((pattern (Var e))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>)))))
+    (meta <opaque>))))
+ (generate_quantities
+  (((pattern
+     (Decl (decl_adtype DataOnly) (decl_id a)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Lit Int 4)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam
+             (constrain
+              (Lower
+               ((pattern (Var lo))
+                (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly))))))
+             (dims
+              (((pattern (Lit Int 4))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp (StanLib check_matching_dims FnPlain AoS)
+      (((pattern (Lit Str constraint))
+        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+       ((pattern (Lit Str a)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+       ((pattern (Var a)) (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly))))
+       ((pattern (Lit Str lower))
+        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+       ((pattern (Var lo)) (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id b)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Lit Int 4)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam
+             (constrain
+              (Upper
+               ((pattern (Var hi))
+                (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly))))))
+             (dims
+              (((pattern (Lit Int 4))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp (StanLib check_matching_dims FnPlain AoS)
+      (((pattern (Lit Str constraint))
+        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+       ((pattern (Lit Str b)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+       ((pattern (Var b)) (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly))))
+       ((pattern (Lit Str upper))
+        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+       ((pattern (Var hi)) (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id c)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Lit Int 4)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam
+             (constrain
+              (LowerUpper
+               ((pattern (Var lo))
+                (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly))))
+               ((pattern (Var hi))
+                (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly))))))
+             (dims
+              (((pattern (Lit Int 4))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp (StanLib check_matching_dims FnPlain AoS)
+      (((pattern (Lit Str constraint))
+        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+       ((pattern (Lit Str c)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+       ((pattern (Var c)) (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly))))
+       ((pattern (Lit Str lower))
+        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+       ((pattern (Var lo)) (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp (StanLib check_matching_dims FnPlain AoS)
+      (((pattern (Lit Str constraint))
+        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+       ((pattern (Lit Str c)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+       ((pattern (Var c)) (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly))))
+       ((pattern (Lit Str upper))
+        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+       ((pattern (Var hi)) (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id d) (decl_type (Sized SReal))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam
+             (constrain
+              (Lower
+               ((pattern (FunApp (StanLib negative_infinity FnPlain AoS) ()))
+                (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+             (dims ()) (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id e) (decl_type (Sized SReal))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam
+             (constrain
+              (Upper
+               ((pattern (FunApp (StanLib positive_infinity FnPlain AoS) ()))
+                (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+             (dims ()) (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt ())
+        (var
+         ((pattern (Var a)) (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt ())
+        (var
+         ((pattern (Var b)) (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt ())
+        (var
+         ((pattern (Var c)) (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt ())
+        (var
+         ((pattern (Var d)) (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt ())
+        (var
+         ((pattern (Var e)) (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (IfElse
+      ((pattern
+        (FunApp (StanLib PNot__ FnPlain AoS)
+         (((pattern
+            (EOr
+             ((pattern (Var emit_transformed_parameters__))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+             ((pattern (Var emit_generated_quantities__))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+      ((pattern (Block (((pattern (Return ())) (meta <opaque>))))) (meta <opaque>)) ()))
+    (meta <opaque>))
+   ((pattern
+     (IfElse
+      ((pattern
+        (FunApp (StanLib PNot__ FnPlain AoS)
+         (((pattern (Var emit_generated_quantities__))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+      ((pattern (Block (((pattern (Return ())) (meta <opaque>))))) (meta <opaque>)) ()))
+    (meta <opaque>))))
+ (transform_inits
+  (((pattern
+     (Decl (decl_adtype DataOnly) (decl_id pos__) (decl_type (Sized SInt))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable pos__) ()) UInt
+      ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id a)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Lit Int 4)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id a_flat__)
+          (decl_type (Unsized (UArray UReal))) (initialize Uninit)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable a_flat__) ()) (UArray UReal)
+          ((pattern
+            (FunApp (CompilerInternal FnReadData)
+             (((pattern (Lit Str a))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable pos__) ()) UInt
+          ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar sym1__)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Lit Int 4))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (Assignment
+                  ((LVariable a)
+                   ((Single
+                     ((pattern (Var sym1__))
+                      (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                  UVector
+                  ((pattern
+                    (Indexed
+                     ((pattern (Var a_flat__))
+                      (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))
+                     ((Single
+                       ((pattern (Var pos__))
+                        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+                (meta <opaque>))
+               ((pattern
+                 (Assignment ((LVariable pos__) ()) UInt
+                  ((pattern
+                    (FunApp (StanLib Plus__ FnPlain AoS)
+                     (((pattern (Var pos__))
+                       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                      ((pattern (Lit Int 1))
+                       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam
+        (unconstrain_opt
+         ((Lower
+           ((pattern (Var lo))
+            (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+        (var
+         ((pattern (Var a)) (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id b)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Lit Int 4)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id b_flat__)
+          (decl_type (Unsized (UArray UReal))) (initialize Uninit)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable b_flat__) ()) (UArray UReal)
+          ((pattern
+            (FunApp (CompilerInternal FnReadData)
+             (((pattern (Lit Str b))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable pos__) ()) UInt
+          ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar sym1__)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Lit Int 4))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (Assignment
+                  ((LVariable b)
+                   ((Single
+                     ((pattern (Var sym1__))
+                      (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                  UVector
+                  ((pattern
+                    (Indexed
+                     ((pattern (Var b_flat__))
+                      (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))
+                     ((Single
+                       ((pattern (Var pos__))
+                        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+                (meta <opaque>))
+               ((pattern
+                 (Assignment ((LVariable pos__) ()) UInt
+                  ((pattern
+                    (FunApp (StanLib Plus__ FnPlain AoS)
+                     (((pattern (Var pos__))
+                       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                      ((pattern (Lit Int 1))
+                       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam
+        (unconstrain_opt
+         ((Upper
+           ((pattern (Var hi))
+            (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+        (var
+         ((pattern (Var b)) (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id c)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Lit Int 4)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id c_flat__)
+          (decl_type (Unsized (UArray UReal))) (initialize Uninit)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable c_flat__) ()) (UArray UReal)
+          ((pattern
+            (FunApp (CompilerInternal FnReadData)
+             (((pattern (Lit Str c))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable pos__) ()) UInt
+          ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar sym1__)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Lit Int 4))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (Assignment
+                  ((LVariable c)
+                   ((Single
+                     ((pattern (Var sym1__))
+                      (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                  UVector
+                  ((pattern
+                    (Indexed
+                     ((pattern (Var c_flat__))
+                      (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))
+                     ((Single
+                       ((pattern (Var pos__))
+                        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+                (meta <opaque>))
+               ((pattern
+                 (Assignment ((LVariable pos__) ()) UInt
+                  ((pattern
+                    (FunApp (StanLib Plus__ FnPlain AoS)
+                     (((pattern (Var pos__))
+                       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                      ((pattern (Lit Int 1))
+                       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam
+        (unconstrain_opt
+         ((LowerUpper
+           ((pattern (Var lo))
+            (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly))))
+           ((pattern (Var hi))
+            (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+        (var
+         ((pattern (Var c)) (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id d) (decl_type (Sized SReal))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable d) ()) UReal
+      ((pattern
+        (Indexed
+         ((pattern
+           (FunApp (CompilerInternal FnReadData)
+            (((pattern (Lit Str d))
+              (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+          (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))
+         ((Single
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+       (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam
+        (unconstrain_opt
+         ((Lower
+           ((pattern (FunApp (StanLib negative_infinity FnPlain AoS) ()))
+            (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+        (var
+         ((pattern (Var d)) (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id e) (decl_type (Sized SReal))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable e) ()) UReal
+      ((pattern
+        (Indexed
+         ((pattern
+           (FunApp (CompilerInternal FnReadData)
+            (((pattern (Lit Str e))
+              (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+          (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))
+         ((Single
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+       (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam
+        (unconstrain_opt
+         ((Upper
+           ((pattern (FunApp (StanLib positive_infinity FnPlain AoS) ()))
+            (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+        (var
+         ((pattern (Var e)) (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))))
+ (unconstrain_array
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id a)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Lit Int 4)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable a) ()) UVector
+      ((pattern
+        (FunApp (CompilerInternal FnReadDeserializer)
+         (((pattern (Lit Int 4)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam
+        (unconstrain_opt
+         ((Lower
+           ((pattern (Var lo))
+            (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+        (var
+         ((pattern (Var a)) (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id b)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Lit Int 4)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable b) ()) UVector
+      ((pattern
+        (FunApp (CompilerInternal FnReadDeserializer)
+         (((pattern (Lit Int 4)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam
+        (unconstrain_opt
+         ((Upper
+           ((pattern (Var hi))
+            (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+        (var
+         ((pattern (Var b)) (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id c)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Lit Int 4)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable c) ()) UVector
+      ((pattern
+        (FunApp (CompilerInternal FnReadDeserializer)
+         (((pattern (Lit Int 4)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam
+        (unconstrain_opt
+         ((LowerUpper
+           ((pattern (Var lo))
+            (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly))))
+           ((pattern (Var hi))
+            (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+        (var
+         ((pattern (Var c)) (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id d) (decl_type (Sized SReal))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable d) ()) UReal
+      ((pattern (FunApp (CompilerInternal FnReadDeserializer) ()))
+       (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam
+        (unconstrain_opt
+         ((Lower
+           ((pattern (FunApp (StanLib negative_infinity FnPlain AoS) ()))
+            (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+        (var
+         ((pattern (Var d)) (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id e) (decl_type (Sized SReal))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable e) ()) UReal
+      ((pattern (FunApp (CompilerInternal FnReadDeserializer) ()))
+       (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam
+        (unconstrain_opt
+         ((Upper
+           ((pattern (FunApp (StanLib positive_infinity FnPlain AoS) ()))
+            (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+        (var
+         ((pattern (Var e)) (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))))
+ (output_vars
+  ((a <opaque>
+    ((out_unconstrained_st
+      (SVector AoS
+       ((pattern (Lit Int 4)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+     (out_constrained_st
+      (SVector AoS
+       ((pattern (Lit Int 4)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+     (out_block Parameters)
+     (out_trans
+      (Lower
+       ((pattern (Var lo)) (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly))))))))
+   (b <opaque>
+    ((out_unconstrained_st
+      (SVector AoS
+       ((pattern (Lit Int 4)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+     (out_constrained_st
+      (SVector AoS
+       ((pattern (Lit Int 4)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+     (out_block Parameters)
+     (out_trans
+      (Upper
+       ((pattern (Var hi)) (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly))))))))
+   (c <opaque>
+    ((out_unconstrained_st
+      (SVector AoS
+       ((pattern (Lit Int 4)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+     (out_constrained_st
+      (SVector AoS
+       ((pattern (Lit Int 4)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+     (out_block Parameters)
+     (out_trans
+      (LowerUpper
+       ((pattern (Var lo)) (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly))))
+       ((pattern (Var hi)) (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly))))))))
+   (d <opaque>
+    ((out_unconstrained_st SReal) (out_constrained_st SReal) (out_block Parameters)
+     (out_trans
+      (Lower
+       ((pattern (FunApp (StanLib negative_infinity FnPlain AoS) ()))
+        (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))))
+   (e <opaque>
+    ((out_unconstrained_st SReal) (out_constrained_st SReal) (out_block Parameters)
+     (out_trans
+      (Upper
+       ((pattern (FunApp (StanLib positive_infinity FnPlain AoS) ()))
+        (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))))))
+ (prog_name infbounds_model) (prog_path tests/fixtures/infbounds.stan))

--- a/tests/test_lower.cpp
+++ b/tests/test_lower.cpp
@@ -3617,6 +3617,99 @@ int main() {
     }
   }
 
+  // tests/fixtures/infbounds.stan: infinite bounds on the declarations
+  // themselves. An infinite bound is no bound -- the element is the
+  // identity and adds no jacobian term -- and the kernels used to
+  // exponentiate through it, so every one of these landed on inf and lp
+  // came out -inf. The vector bounds mix infinite and finite entries, so
+  // the elements that do transform are checked in the same pass.
+  {
+    CompiledModel im =
+        compile_model(slurp("tests/fixtures/infbounds.tmir.sexp"), DataMap());
+    Executor iex(std::move(im.graph));
+    im.bind(iex);
+    // Declaration order: a[4], b[4], c[4], d, e.
+    check(iex.n_params() == 14, "infbounds unconstrained size is 14");
+    const double pts[2][14] = {{0.4, -0.7, 1.25, -0.2, 0.9, -1.1, 0.35, 2.0,
+                                -0.45, 0.6, 1.8, -1.6, 0.7, -0.9},
+                               {-0.3, 0.9, -0.45, 1.4, 0.15, 0.5, -2.1, 0.8,
+                                1.05, -0.75, 0.25, 1.9, -0.55, 0.3}};
+    for (int c = 0; c < 2; ++c) {
+      for (int i = 0; i < 14; ++i) iex.params_data()[i] = pts[c][i];
+      double grad[14] = {0};
+      const double lp = iex.gradient(grad);
+
+      using stan::math::var;
+      using Vec = Eigen::Matrix<var, -1, 1>;
+      const double ninf = -std::numeric_limits<double>::infinity();
+      const double pinf = std::numeric_limits<double>::infinity();
+      Eigen::VectorXd lo(4), hi(4);
+      lo << ninf, -0.5, ninf, 0.75;
+      hi << 3.25, pinf, pinf, 4.5;
+      Vec a(4), b(4), cc(4);
+      for (int i = 0; i < 4; ++i) {
+        a(i) = pts[c][i];
+        b(i) = pts[c][4 + i];
+        cc(i) = pts[c][8 + i];
+      }
+      var d = pts[c][12], e = pts[c][13];
+      // Each `sum` is one ascending reduction over its own result, and
+      // OP_SUM_VEC accumulates the same way.
+      const auto vsum = [](const auto& v) {
+        var t = 0;
+        for (int i = 0; i < v.size(); ++i) t += v(i);
+        return t;
+      };
+      var jac = 0;
+      var acc = 0;
+      acc += vsum(stan::math::lb_constrain<true>(a, lo, jac));
+      acc += vsum(stan::math::ub_constrain<true>(b, hi, jac));
+      acc += vsum(stan::math::lub_constrain<true>(cc, lo, hi, jac));
+      acc += stan::math::lb_constrain<true>(d, ninf, jac);
+      acc += stan::math::ub_constrain<true>(e, pinf, jac);
+      acc += jac;
+      acc.grad();
+
+      check(std::isfinite(lp), "infbounds: lp is finite");
+      for (int i = 0; i < 4; ++i)
+        expect_ulp("infbounds a grad", grad[i], a(i).adj());
+      for (int i = 0; i < 4; ++i)
+        expect_ulp("infbounds b grad", grad[4 + i], b(i).adj());
+      for (int i = 0; i < 4; ++i)
+        expect_ulp("infbounds c grad", grad[8 + i], cc(i).adj());
+      expect_ulp("infbounds d grad", grad[12], d.adj());
+      expect_ulp("infbounds e grad", grad[13], e.adj());
+      const double tol = 8 * 2.220446049250313e-16 * std::abs(acc.val());
+      check(std::abs(lp - acc.val()) <= tol,
+            "infbounds: lp matches the var path");
+      stan::math::recover_memory();
+    }
+    // The identity elements have to reach write_array untransformed too:
+    // an unbounded declaration writes its unconstrained value straight out.
+    check(im.write_array && im.write_array->truncated.empty(),
+          "infbounds write_array compiled");
+    if (im.write_array && im.write_array->truncated.empty()) {
+      Executor wex(std::move(im.write_array->graph));
+      im.write_array->bind(wex);
+      for (int i = 0; i < 14; ++i) wex.params_data()[i] = pts[0][i];
+      wex.run_forward_only();
+      int found = 0;
+      for (const auto& col : im.write_array->columns) {
+        // a[1] and a[3] carry the -inf lower bound, d the shared one.
+        if (col.name == "a") {
+          ++found;
+          expect_ulp("infbounds wa a1", wex.value_ptr(col.slot)[0], pts[0][0]);
+          expect_ulp("infbounds wa a3", wex.value_ptr(col.slot)[2], pts[0][2]);
+        }
+        if (col.name == "d") {
+          ++found;
+          expect_ulp("infbounds wa d", *wex.value_ptr(col.slot), pts[0][12]);
+        }
+      }
+      check(found == 2, "infbounds write_array has a and d");
+    }
+  }
+
   // array[N] vector[K] data into a vectorized multivariate density. See
   // tests/fixtures/mnarr.stan: the data path stores this shape the way it
   // stores a matrix, and the kernel wants each element contiguous, so the

--- a/tests/test_transforms.cpp
+++ b/tests/test_transforms.cpp
@@ -6,6 +6,7 @@
 
 #include <stan/math.hpp>
 #include <cstdio>
+#include <limits>
 #include <string>
 
 static int failures = 0;
@@ -234,6 +235,58 @@ int main() {
                    b1_1, b2_1, jacobian);
     run_bound_case("lu scalar" + j, stanli::OP_CONSTRAIN_LU, 1, x1, 1, b1_1,
                    b2_1, jacobian);
+  }
+
+  // Infinite bounds. Every *_constrain overload reads one as no bound at
+  // all and hands the element back untouched, adding no jacobian term; the
+  // kernels used to exponentiate through it and return inf, which reached
+  // lp as -inf. A constant bound is the `real<lower=negative_infinity()>`
+  // and `vector<lower=lb>[N]` declaration shape.
+  const double ninf = -std::numeric_limits<double>::infinity();
+  const double pinf = std::numeric_limits<double>::infinity();
+  run_case("lower ninf vec", stanli::OP_CONSTRAIN_LOWER, 3, xs, ninf, 0.0);
+  run_case("lower ninf scalar", stanli::OP_CONSTRAIN_LOWER, 1, x1, ninf, 0.0);
+  run_case("upper pinf vec", stanli::OP_CONSTRAIN_UPPER, 3, xs, pinf, 0.0);
+  run_case("upper pinf scalar", stanli::OP_CONSTRAIN_UPPER, 1, x1, pinf, 0.0);
+  // lub resolves per element: lower infinite alone is the upper transform,
+  // upper infinite alone the lower one, and both together the identity.
+  run_case("lu ninf lower", stanli::OP_CONSTRAIN_LU, 3, xs, ninf, 2.0);
+  run_case("lu pinf upper", stanli::OP_CONSTRAIN_LU, 3, xs, -1.0, pinf);
+  run_case("lu both inf", stanli::OP_CONSTRAIN_LU, 3, xs, ninf, pinf);
+  run_case("lu both inf scalar", stanli::OP_CONSTRAIN_LU, 1, x1, ninf, pinf);
+
+  // The same through parameter-valued bounds, where an infinite bound also
+  // has an adjoint lane: having taken no part in the value, it must collect
+  // nothing. The per-element vectors mix infinite and finite entries, which
+  // is what a `vector<lower=lb>[N]` with one negative_infinity() declares --
+  // the finite entries still have to transform.
+  const double x4[4] = {0.3, -1.2, 2.0, 0.45};
+  const double ninf_1[1] = {ninf};
+  const double pinf_1[1] = {pinf};
+  const double lo_inf3[3] = {ninf, 0.75, -2.0};
+  const double hi_inf3[3] = {3.25, pinf, 1.5};
+  // Lower-only infinite, upper-only infinite, both, neither -- all four
+  // element branches of lub in one call.
+  const double lo_mix4[4] = {ninf, -0.5, ninf, 0.75};
+  const double hi_mix4[4] = {3.25, pinf, pinf, 4.5};
+  for (bool jacobian : {true, false}) {
+    const std::string j = jacobian ? " jac" : " nojac";
+    run_bound_case("lower ninf shared" + j, stanli::OP_CONSTRAIN_LOWER, 3, xs,
+                   1, ninf_1, b2_1, jacobian);
+    run_bound_case("lower ninf per-element" + j, stanli::OP_CONSTRAIN_LOWER, 3,
+                   xs, 3, lo_inf3, b2_3, jacobian);
+    run_bound_case("upper pinf shared" + j, stanli::OP_CONSTRAIN_UPPER, 3, xs,
+                   1, pinf_1, b1_1, jacobian);
+    run_bound_case("upper pinf per-element" + j, stanli::OP_CONSTRAIN_UPPER, 3,
+                   xs, 3, hi_inf3, b1_3, jacobian);
+    run_bound_case("lu ninf shared" + j, stanli::OP_CONSTRAIN_LU, 3, xs, 1,
+                   ninf_1, b2_1, jacobian);
+    run_bound_case("lu pinf shared" + j, stanli::OP_CONSTRAIN_LU, 3, xs, 1,
+                   b1_1, pinf_1, jacobian);
+    run_bound_case("lu both inf shared" + j, stanli::OP_CONSTRAIN_LU, 3, xs, 1,
+                   ninf_1, pinf_1, jacobian);
+    run_bound_case("lu mixed inf" + j, stanli::OP_CONSTRAIN_LU, 4, x4, 4,
+                   lo_mix4, hi_mix4, jacobian);
   }
 
   if (failures == 0) std::printf("test_transforms OK\n");

--- a/tests/test_transforms.cpp
+++ b/tests/test_transforms.cpp
@@ -176,6 +176,84 @@ static void run_bound_case(const std::string& tag, uint16_t opcode, int n,
   stan::math::recover_memory();
 }
 
+// lub with one shared and one per-element bound. Besides covering the two
+// mixed-shape overloads, `reuse_shared` gives the scalar bound an adjoint
+// before the constrain callback runs. Stan Math reduces the constrain terms
+// first and adds that reduction once; adding them directly to a nonzero lane
+// rounds differently at adversarial points.
+static void run_mixed_lu_case(const std::string& tag, int n, const double* x0,
+                              int nlb, const double* lbv, int nub,
+                              const double* ubv, bool jacobian,
+                              bool reuse_shared) {
+  using namespace stanli;
+  using stan::math::var;
+
+  Graph g;
+  const int x = g.add_slot(n, true);
+  const int lb = g.add_slot(nlb, true);
+  const int ub = g.add_slot(nub, true);
+  const int con = g.add_slot(n, false);
+  const int jac = g.add_slot(1, false);
+  const int s = g.add_slot(1, false);
+  const int lp = g.add_slot(1, false);
+  {
+    Op op;
+    op.opcode = OP_CONSTRAIN_LU;
+    op.out = con;
+    op.out2 = jac;
+    op.n_in = 3;
+    op.in[0] = x;
+    op.in[1] = lb;
+    op.in[2] = ub;
+    g.ops.push_back(op);
+  }
+  g.add_op(OP_SUM_VEC, {con}, s);
+  const int shared = nlb == 1 ? lb : ub;
+  if (jacobian && reuse_shared)
+    g.add_op(OP_ADD_N, {s, jac, shared}, lp);
+  else if (jacobian)
+    g.add_op(OP_ADD_N, {s, jac}, lp);
+  else if (reuse_shared)
+    g.add_op(OP_ADD_N, {s, shared}, lp);
+  else
+    g.add_op(OP_ADD_N, {s}, lp);
+  g.result_slot = lp;
+
+  Executor ex(std::move(g));
+  for (int i = 0; i < n; ++i) ex.param_ptr(x)[i] = x0[i];
+  for (int i = 0; i < nlb; ++i) ex.param_ptr(lb)[i] = lbv[i];
+  for (int i = 0; i < nub; ++i) ex.param_ptr(ub)[i] = ubv[i];
+  std::vector<double> grad(n + nlb + nub);
+  const double got = ex.gradient(grad.data());
+
+  Eigen::Matrix<var, -1, 1> vx(n), vlb(nlb), vub(nub);
+  for (int i = 0; i < n; ++i) vx(i) = x0[i];
+  for (int i = 0; i < nlb; ++i) vlb(i) = lbv[i];
+  for (int i = 0; i < nub; ++i) vub(i) = ubv[i];
+  var vjac = 0.0;
+  Eigen::Matrix<var, -1, 1> vcon;
+  if (nlb == 1)
+    vcon = jacobian ? stan::math::lub_constrain<true>(vx, vlb(0), vub, vjac)
+                    : stan::math::lub_constrain(vx, vlb(0), vub);
+  else
+    vcon = jacobian ? stan::math::lub_constrain<true>(vx, vlb, vub(0), vjac)
+                    : stan::math::lub_constrain(vx, vlb, vub(0));
+  var vlp = stan::math::sum(vcon);
+  if (jacobian) vlp += vjac;
+  if (reuse_shared) vlp += nlb == 1 ? vlb(0) : vub(0);
+  vlp.grad();
+
+  expect_eq(tag + " lp", got, vlp.val());
+  for (int i = 0; i < n; ++i)
+    expect_eq(tag + " gx" + std::to_string(i), grad[i], vx(i).adj());
+  for (int i = 0; i < nlb; ++i)
+    expect_eq(tag + " glb" + std::to_string(i), grad[n + i], vlb(i).adj());
+  for (int i = 0; i < nub; ++i)
+    expect_eq(tag + " gub" + std::to_string(i), grad[n + nlb + i],
+              vub(i).adj());
+  stan::math::recover_memory();
+}
+
 static void test_out2_is_result() {
   using namespace stanli;
   Graph g;
@@ -287,6 +365,24 @@ int main() {
                    ninf_1, pinf_1, jacobian);
     run_bound_case("lu mixed inf" + j, stanli::OP_CONSTRAIN_LU, 4, x4, 4,
                    lo_mix4, hi_mix4, jacobian);
+  }
+
+  // One scalar bound and one vector bound dispatch different Stan Math
+  // overloads from the both-scalar and both-vector cases above. Reusing the
+  // scalar in the objective makes its preexisting adjoint nonzero and pins
+  // the overload's reduce-then-add rounding order.
+  const double xr[3] = {-21.218105551082793, 7.4625322261737495,
+                        -24.25541517136952};
+  const double lo_shared[1] = {-0.5};
+  const double hi_mixed[3] = {pinf, 4.5, 1.5};
+  const double lo_mixed[3] = {ninf, 0.75, -2.0};
+  const double hi_shared[1] = {3.25};
+  for (bool jacobian : {true, false}) {
+    const std::string j = jacobian ? " jac" : " nojac";
+    run_mixed_lu_case("lu scalar lower mixed inf" + j, 3, xr, 1, lo_shared, 3,
+                      hi_mixed, jacobian, true);
+    run_mixed_lu_case("lu scalar upper mixed inf" + j, 3, xr, 3, lo_mixed, 1,
+                      hi_shared, jacobian, true);
   }
 
   if (failures == 0) std::printf("test_transforms OK\n");


### PR DESCRIPTION
## Fix handling of infinite bounds in constraints

The constrain kernels always applied the exp/logit transform, even when a
declared bound was infinite. stan-math treats an infinite bound as *no* bound —
the element passes through unchanged and adds no Jacobian term — so a
declaration carrying one produced `inf` values and an `lp` of `-inf`:

```stan
parameters {
  real<lower = negative_infinity()> d;
}
