### PR TITLE
Speed up compiled RK ODE sensitivities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## Unreleased
 
+### Compiled RK sensitivities avoid nested autodiff
+
+Eligible `ode_rk45` and `ode_ckrk` calls now integrate values and coupled
+sensitivities directly from the compiled RHS value and Jacobian program. The
+existing Stan Math path remains the exact fallback for unsupported RHS
+instructions and can be selected with `STANLI_NO_ODE_DIRECT_RK=1` for
+differential testing. This removes nested reverse-mode autodiff from the hot
+callback while preserving the pinned Stan Math tableau, controller, error
+norm, output layout, validation, and exception behavior.
+
 ### Infinite declaration bounds are identities
 
 Parameter declarations whose lower bound is negative infinity or whose upper

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -585,6 +585,18 @@ set_tests_properties(test_prep_profile_reroll_dispositions PROPERTIES
 add_executable(bench_opcost tools/bench_opcost.cpp
   $<TARGET_OBJECTS:stanli_tbb_stub>)
 target_link_libraries(bench_opcost PRIVATE stanli)
+# Developer-only ODE RHS generated-adjoint spike.  Not a test and not installed.
+add_executable(bench_rhs_adjoint EXCLUDE_FROM_ALL
+  tools/bench_rhs_adjoint.cpp tests/tbb_stub.cpp)
+target_link_libraries(bench_rhs_adjoint PRIVATE stanli)
+# Developer-only complete-solve sensitivity ceilings.  They retain the merged
+# runtime as the oracle and install no experimental path in libstanli.
+add_executable(bench_ode_ceiling EXCLUDE_FROM_ALL
+  tools/bench_ode_ceiling.cpp tests/tbb_stub.cpp)
+target_link_libraries(bench_ode_ceiling PRIVATE stanli)
+add_executable(bench_ode_cvodes_ceiling EXCLUDE_FROM_ALL
+  tools/bench_ode_cvodes_ceiling.cpp tests/tbb_stub.cpp)
+target_link_libraries(bench_ode_cvodes_ceiling PRIVATE stanli)
 add_executable(bench_dispatch tools/bench_dispatch.cpp)
 add_executable(dump_ops tools/dump_ops.cpp
   $<TARGET_OBJECTS:stanli_tbb_stub>)

--- a/TESTING.md
+++ b/TESTING.md
@@ -327,9 +327,12 @@ interpreter but missing from graph lowering.
 [`tests/cross_path.hpp`](tests/cross_path.hpp) compiles one model several
 times, once per configuration, and compares the results. The
 configurations are `STANLI_NO_ISLAND`, `STANLI_ISLAND_ALWAYS`,
-`STANLI_NO_NATIVE_ADJ`, rerolling/in-place updates/constant folding off, and
-the shipped pipeline with `STANLI_WA_FORCE_INTERP` attaching `WaInterp` beside
-a complete `write_array` graph so both engines produce the same output row.
+`STANLI_NO_NATIVE_ADJ`, `STANLI_NO_ODE_DIRECT_RK`,
+rerolling/in-place updates/constant folding off, and the shipped pipeline with
+`STANLI_WA_FORCE_INTERP` attaching `WaInterp` beside a complete `write_array`
+graph so both engines produce the same output row. The ODE configuration
+retains the generated direct-RK payload but selects the canonical Stan Math
+solve, so the comparison isolates execution rather than preparation.
 
 The cross-path result excludes stochastic `write_array` columns from its
 bitwise count. It identifies them by running the interpreter with two seeds
@@ -370,6 +373,30 @@ backward, and covers the activation threshold, clone budget, overlap, and NaN
 behavior. `test_island` covers the opt-out through graph carving and execution,
 tagged-payload lifetime, and the rule that opcode zero remains invalid for
 graph carving and binding after the private helper is registered.
+
+The direct RK path has two additional focused gates. `test_ode_prog` checks
+that derivative construction leaves the canonical RHS bytecode unchanged,
+requires bitwise local RHS values and `J_y`/`J_theta` entries for admitted
+programs, and pins structural refusals including runtime jumps, `DOT`, and
+signed-zero-sensitive `FMAX`/`FMIN`. `test_odevariadic` compares the default
+path against a separately lowered `STANLI_NO_ODE_DIRECT_RK=1` oracle for RK45,
+CKRK, and legacy RK45. It compares solution bits, the complete Jacobian
+scratch matrix, both input pullbacks, whole-model log density and gradient,
+all scalar-activity masks, shared-spec multithreaded execution, and exception
+type and text. Data-only, BDF/Adams, ineligible RHS programs, and
+`forward_value_only` remain on their established paths.
+
+The direct/oracle gate is bitwise; it has no ledger tolerance. The integrated
+macOS arm64 Release A/B admitted the default path with 1.8615x
+[1.8380x, 1.8853x] oracle/direct on `lotka_volterra` and 1.8035x
+[1.7578x, 1.8505x] on `soil_incubation`, while the ineligible branched BDF
+control was unchanged. Linux x86-64 must run both default and
+`STANLI_NO_ODE_DIRECT_RK=1`, the focused ODE tests, and the ODE interface sweep
+before merge. Any architecture-specific disagreement narrows eligibility or
+keeps the oracle; it does not relax the exact gate. This testing contract is
+for the all-double coupled-sensitivity path. The slower Phase 0
+precomputed-gradient callback bridge remains stopped and is not selected by
+either arm.
 
 ## Testing graph transformations
 

--- a/docs/hacking.md
+++ b/docs/hacking.md
@@ -175,8 +175,8 @@ ones through every stage, op list and register programs included.
 | [`runtime/src/mir_decode.cpp`](../runtime/src/mir_decode.cpp), [`portable_mir_v2_reader.cpp`](../runtime/src/portable_mir_v2_reader.cpp), [`mir_reader.cpp`](../runtime/src/mir_reader.cpp) | Dispatches compact portable MIR or legacy s-expressions into one MIR representation and runs their shared finalization. |
 | [`runtime/src/inplace.cpp`](../runtime/src/inplace.cpp), [`constfold.cpp`](../runtime/src/constfold.cpp), [`reroll.cpp`](../runtime/src/reroll.cpp), [`island.cpp`](../runtime/src/island.cpp) | The graph passes, in pipeline order. |
 | [`runtime/src/executor.cpp`](../runtime/src/executor.cpp) | Runs the op list. `STANLI_PROFILE=1` prints per-opcode time accounting. |
-| [`runtime/kernels/`](../runtime/kernels/) | The kernels: [`densities.cpp`](../runtime/kernels/densities.cpp), [`elementwise.cpp`](../runtime/kernels/elementwise.cpp), [`constrain.cpp`](../runtime/kernels/constrain.cpp), and friends. [`matrix_fns.cpp`](../runtime/kernels/matrix_fns.cpp) and [`legacy_fns.cpp`](../runtime/kernels/legacy_fns.cpp) wrap stan-math functions that have no native kernel yet. |
-| [`runtime/include/stanli/mir_interp.hpp`](../runtime/include/stanli/mir_interp.hpp) | The MIR interpreter: runs MIR directly, without lowering to ops. Used where the op graph cannot go: transformed data at load time, ODE right-hand sides, interpreted `write_array`. |
+| [`runtime/kernels/`](../runtime/kernels/) | The kernels: [`densities.cpp`](../runtime/kernels/densities.cpp), [`elementwise.cpp`](../runtime/kernels/elementwise.cpp), [`constrain.cpp`](../runtime/kernels/constrain.cpp), and friends. [`ode.cpp`](../runtime/kernels/ode.cpp) owns the canonical Stan Math solves and the direct all-double coupled RK path. [`matrix_fns.cpp`](../runtime/kernels/matrix_fns.cpp) and [`legacy_fns.cpp`](../runtime/kernels/legacy_fns.cpp) wrap stan-math functions that have no native kernel yet. |
+| [`runtime/include/stanli/mir_interp.hpp`](../runtime/include/stanli/mir_interp.hpp) | The MIR interpreter: runs MIR directly, without lowering to ops. Used where the op graph cannot go: transformed data at load time, unsupported ODE right-hand-side fallbacks, interpreted `write_array`. |
 | [`runtime/src/wa_interp.cpp`](../runtime/src/wa_interp.cpp) | Interpreted per-draw generated quantities for unsupported/container-result RNGs and dynamic geometry. Fixed-shape draw-dependent branches, checked one-level runtime indexing, and Viterbi backtracking compile; all 119 compiling corpus models currently have graph-backed write arrays. |
 | [`runtime/include/stanli/program.hpp`](../runtime/include/stanli/program.hpp), [`mir_prog.hpp`](../runtime/include/stanli/mir_prog.hpp) | The register machine and its MIR front end. Its `DENSITY` instruction covers the 27 scalar continuous densities through [`program_density.hpp`](../runtime/include/stanli/program_density.hpp), one table shared with the MIR interpreter; its `CALL` instruction runs a graph kernel over a range of registers. |
 | [`runtime/src/adjoint.cpp`](../runtime/src/adjoint.cpp) | `gen_adjoint`: differentiates a register program into a second register program, so an island's backward is a second cheap pass rather than a replay under stan-math's `var`. Owns the checkpoint analysis (save a register before a later write destroys a value a derivative rule needs). `STANLI_NO_NATIVE_ADJ=1` restores the replay, which is the oracle it is tested against ([`test_adjoint.cpp`](../tests/test_adjoint.cpp)). |
@@ -339,9 +339,8 @@ runs the graph's own kernel over a range of registers. A register
 program can therefore say anything the graph can say about scalars,
 and one unsupported function no longer splits a region in half.
 
-Derivatives come in two ways. Parameter-dependent control flow and ODE
-right-hand sides use the `var` replay described above. Islands instead
-get a *generated* backward: `gen_adjoint`
+Parameter-dependent control flow uses the `var` replay described above.
+Islands instead get a *generated* backward: `gen_adjoint`
 ([`adjoint.cpp`](../runtime/src/adjoint.cpp)) reads the forward
 instruction list once, at load, and writes a second instruction list
 that computes the derivatives directly, on plain doubles, allocating
@@ -353,6 +352,39 @@ against ([`test_adjoint.cpp`](../tests/test_adjoint.cpp)). One
 exception: an island that branches on a parameter keeps the replay,
 because reversing a branch needs the if/else shape the flat
 instruction list has already thrown away.
+
+ODE right-hand sides use both mechanisms. For active sensitivities, the
+canonical path still replays the compiled RHS under stan-math's `var`, and its
+Stan Math solve remains the oracle for every solver and shape. A narrower,
+default-on RK45/CKRK path clones a branchless compiled RHS and generates a
+backward for that clone. At each solver callback
+it computes `f`, `J_y`, and `J_theta` on doubles, then advances one coupled
+state containing the primal system and the active initial-state and parameter
+sensitivity lanes. The coupled vector uses the same Boost tableau, controller,
+error norm, observation schedule, and scalar accumulation order as the pinned
+Stan Math implementation. Its observer writes values and the complete solution
+Jacobian directly into the ODE op's output and scratch; the graph backward is
+unchanged.
+
+This ODE path fails closed. Only an explicit exact-grouping opcode whitelist is
+eligible; runtime branches, `DOT`, signed-zero-sensitive `FMAX`/`FMIN`, calls,
+and any unfamiliar instruction retain the canonical solve. BDF, Adams,
+data-only solves, and malformed runtime shapes do too. The canonical program
+is not modified when the derivative clone receives checkpoint saves.
+`STANLI_NO_ODE_DIRECT_RK=1`, set before the model is loaded, selects the oracle
+without suppressing payload construction or eligibility diagnostics. Selection
+is recorded in the ODE specification at lowering, so gradient evaluation does
+not read the environment.
+
+Do not confuse this with the rejected Phase 0 callback bridge. That experiment
+wrapped generated rows in `precomputed_gradients_vari` callback results and
+failed its speed gate. The direct RK path creates no callback vars or
+precomputed-gradient nodes: generated reverse is only a local-Jacobian provider
+inside an all-double coupled solve. The bridge remains stopped. Admission was
+based on exact macOS arm64 model and synthetic results plus integrated 1.86x
+and 1.80x oracle/direct gains on Lotka--Volterra and soil. Linux x86-64 exact
+default/oracle agreement and the focused ODE tests remain a merge gate; do not
+turn an architecture disagreement into a tolerance.
 
 ## The sampler
 

--- a/docs/superpowers/plans/2026-08-28-ode-rhs-generated-adjoint-results.md
+++ b/docs/superpowers/plans/2026-08-28-ode-rhs-generated-adjoint-results.md
@@ -1,0 +1,258 @@
+# ODE RHS generated-adjoint experiment: Phase 0 result
+
+## Outcome
+
+**STOP after Phase 0. Do not build or ship the production feature.**
+
+The best compliant generated-callback prototype is slower than the current
+`run_rhs<stan::math::var>` callback on both eligible real RK45 targets:
+
+| stanc-generated optimized MIR | old median | generated median | paired old/generated |
+|---|---:|---:|---:|
+| `lotka_volterra::dz_dt` | 94.1 ns | 110.8 ns | 0.853x |
+| `soil_incubation::two_pool_feedback` | 109.6 ns | 118.0 ns | 0.930x |
+
+Seven independent Release runs per target, each containing 51 alternating
+paired batches of 100,000 callbacks, put the Lotka ratios between 0.834x and
+0.855x and the soil ratios between 0.916x and 0.935x. The generated path was
+about 17% to 20% slower on Lotka and 7% to 9% slower on soil. The plan required
+at least 2.0x at this gate, so production refactoring, integration, corpus
+timing, and a PR are intentionally not attempted.
+
+This is the result the plan's stop rule is for: the source transformation is
+viable, but the complete callback lifecycle does not leave enough work to
+amortize generated reverse rows and precomputed-gradient nodes on a small ODE.
+
+## Provenance
+
+- Base: `a018ab76b378d587211ac746a75a86684f72a232`, latest `origin/main` when
+  the experiment began, merging PR #243.
+- Candidate commit: none. The experiment remains an uncommitted developer
+  benchmark and report.
+- Host: Apple M3 Ultra, 32 physical/logical cores, 96 GiB RAM.
+- OS: macOS 26.4 (`25E246`), arm64.
+- Compiler: Apple clang 21.0.0, `-ffp-contract=off` through the project target.
+- CMake: 4.3.3.
+- Stan Math: `8f326d14599d3030c626c46532d8e8534c1cdbec`.
+- Stan: `c96d04115d35cb04f42e45c5a69a82f9704798f1`.
+- stanc3: `5b824ee48c590fa229dcebf6b57457b2fd212aa8`
+  (`v2.39.0-142-g5b824ee`).
+- PosteriorDB: `28f8d3d6e975315f42aa274a8399f21e07a43b30`.
+- CmdStan: `11cb052d3e1fc8c799e0fec559e2ee5452b38d27`
+  (v2.39.0, TBB built).
+
+The pinned corpus setup completed and an immediate second invocation was
+idempotent.
+
+## What Phase 0 measured
+
+`tools/bench_rhs_adjoint.cpp` accepts any stanc-generated optimized TMIR
+function and uses its finalized, post-compaction `RhsProgram`. It was first
+validated on `tests/fixtures/odefns.tmir.sexp::f_lin`, then measured on the
+pinned PosteriorDB/CmdStan models' actual optimized MIR. The Lotka RHS is:
+
+```text
+du = (theta[1] - theta[2] * v) * u
+dv = (-theta[3] + theta[4] * u) * v
+```
+
+The old arm measures the actual callback lifecycle:
+
+1. Open the per-callback nested reverse-mode scope.
+2. Construct the evolving state vars.
+3. Execute the canonical compacted program on vars.
+4. Sweep RHS outputs in ascending order.
+5. Harvest state and persistent deep-copied-theta adjoints.
+6. Clear nested adjoints between rows and theta adjoints after every row.
+
+The generated arm uses only existing production primitives and measures:
+
+1. Copy the canonical `Program` into an `IslandProg` prototype.
+2. Mark time and `x_r` inactive, state and theta active.
+3. Generate the checkpointed forward and reverse with existing
+   `gen_adjoint`.
+4. Clear and seed a reusable double register file; execute one double forward.
+5. Clear the complete adjoint file for each output, seed through `adj_reg`,
+   execute `run_adjoint`, and harvest a row.
+6. Allocate one shared operand-pointer array and one contiguous Jacobian on
+   Stan Math's current arena.
+7. Construct each output with the low-level
+   `precomputed_gradients_vari(value, size, operands, row)` constructor.
+8. Perform the same ascending Stan sweeps and harvests as the old arm.
+
+The active theta vars are created outside each callback's nested scope, as
+`coupled_ode_system` does with `deep_copy_vars`. Only the evolving state and
+RHS graph/nodes are per-callback. The benchmark alternates arm order, warms
+both paths, consumes values and every harvested derivative through a volatile
+sink, and performs no ordinary heap allocation after workspace warm-up except
+the returned/output containers already present in the callback contract.
+
+The actual Lotka RHS has 6 instructions and 13 registers; the generated
+sibling has 6 forward and 6 reverse instructions. The actual soil RHS has 8
+instructions and 15 registers; its sibling has 8 forward and 8 reverse
+instructions. Neither needs checkpoints. These are favorable cases for
+generated adjoints: straight-line scalar arithmetic, no branch refusal, no
+checkpoint expansion, and only two output rows.
+
+## Correctness checks performed before timing
+
+The prototype requires bitwise equality for:
+
+- RHS output values.
+- Every generated local Jacobian entry versus the current var replay.
+- Every derivative harvested after the precomputed-gradient output sweeps.
+- A second consecutive callback through each arm.
+
+It also verifies that persistent theta adjoints return to positive zero after
+each callback. The focused clean-baseline test set passed before the spike:
+
+```text
+test_adjoint
+test_ode_prog
+test_odevariadic
+test_algebra
+test_mir_unary_fallback
+test_cross_path
+```
+
+After adding the developer benchmark, the same focused set was rebuilt and
+remained green. No production runtime behavior changed.
+
+## Repeated timing results
+
+Command:
+
+```sh
+cmake -S . -B build-rel -DCMAKE_BUILD_TYPE=Release
+cmake --build build-rel -j8 --target bench_rhs_adjoint
+./build-rel/bench_rhs_adjoint 100000 51 /tmp/stanli_rhs_bench.Zo4JJw/lotka_volterra.tmir.sexp dz_dt 2 4 0
+./build-rel/bench_rhs_adjoint 100000 51 /tmp/stanli_rhs_bench.Zo4JJw/soil_incubation.tmir.sexp two_pool_feedback 2 4 0
+```
+
+Lotka--Volterra:
+
+| run | old var ns | generated ns | paired old/generated |
+|---:|---:|---:|---:|
+| 1 | 94.1 | 113.1 | 0.834x |
+| 2 | 94.3 | 110.7 | 0.854x |
+| 3 | 93.8 | 111.7 | 0.843x |
+| 4 | 93.8 | 111.5 | 0.838x |
+| 5 | 94.7 | 110.8 | 0.853x |
+| 6 | 94.1 | 110.6 | 0.855x |
+| 7 | 94.6 | 110.4 | 0.853x |
+| median | **94.1** | **110.8** | **0.853x** |
+
+Soil incubation:
+
+| run | old var ns | generated ns | paired old/generated |
+|---:|---:|---:|---:|
+| 1 | 108.8 | 118.6 | 0.919x |
+| 2 | 109.6 | 117.6 | 0.930x |
+| 3 | 110.3 | 118.8 | 0.926x |
+| 4 | 109.0 | 116.5 | 0.933x |
+| 5 | 108.9 | 118.7 | 0.916x |
+| 6 | 110.4 | 118.0 | 0.935x |
+| 7 | 109.7 | 117.3 | 0.932x |
+| median | **109.6** | **118.0** | **0.930x** |
+
+As a supplementary check, five runs of the local `f_lin` fixture produced a
+0.950x median ratio (range 0.939x--0.965x), also slower than var replay.
+
+The result is not close to the 2.0x threshold; it is on the wrong side of
+parity. Confidence intervals are unnecessary to classify this gate because
+all fourteen real-model runs agree on the direction and the required effect
+is far outside the observed noise bands.
+
+## Gate evaluation
+
+| required gate | result | decision |
+|---|---|---|
+| Complete generated callback at least 2x faster on representative eligible RK45 RHS | 0.853x on actual Lotka; 0.930x on actual soil | **FAIL** |
+| Credible measured path to at least 10% whole-gradient improvement on Lotka | actual callback regresses by about 17% | **FAIL / not credible** |
+| A second ODE has at least a 3% whole-gradient ceiling | not run after mandatory first-gate failure | **NOT REACHED** |
+
+Per the original instructions, later phases stop here. In particular, there is
+no default-on path, environment selector, cost model, sanitizer candidate,
+CmdStan ODE sweep, full corpus performance run, or PR. Running those after the
+mandatory callback gate failed would turn a bounded spike into the ODE
+subsystem rewrite the plan explicitly forbids.
+
+## Target eligibility at the stop point
+
+The following records prototype generation/refusal, not a claim that a
+production sibling was installed:
+
+| target | solver/path | classification |
+|---|---|---|
+| `lotka_volterra::dz_dt` | RK45, two states, four theta | generated and verified bitwise; 6 forward/6 reverse instructions |
+| `soil_incubation::two_pool_feedback` | RK45, two states, four theta | generated and verified bitwise; 8 forward/8 reverse instructions |
+| `one_comp_mm_elim_abs` | BDF, one state, three theta, two `x_r` | structurally refused on `JZ`; 19 instructions/23 registers |
+| `odevariadic` BDF fixture | CVODES/BDF | structurally eligible branchless fixture |
+
+`one_comp_mm_elim_abs` would therefore retain the exact canonical var callback
+even if later phases existed. The BDF audit also confirmed that CVODES invokes
+both a var-state/data-theta state-Jacobian callback and, for active solves, the
+coupled sensitivity callback. Selection must use actual callback scalar types,
+not the original ODE op's activity mask.
+
+## Independent Fable review
+
+Claude Fable 5 reviewed the plan at high effort against this checkout before
+the stop decision. Its verdict was that the architecture is feasible with
+amendments, and its explicit stop criterion was: **stop on any Phase 0 miss**.
+It recommended tightening any future revival in these ways:
+
+- Require bitwise local-Jacobian equality and either bitwise forward-value
+  parity or structural refusal for opcodes whose double and var reductions
+  differ (`DOT` is already deliberately split).
+- Zero the complete adjoint file per output and seed via `adj_reg`; use `+=`
+  for the seed so an output aliased with a live-in retains its identity
+  contribution.
+- Generate against a copy and attach the immutable sibling only at ODE
+  lowering, keeping algebra and the canonical fallback pristine.
+- Read the environment gate once at lowering while still generating the
+  sibling, so fresh-process A/B arms have identical preparation.
+- Prove BDF activation for both theta-active and theta-inactive callback
+  instantiations, not merely numerical agreement.
+- Use a 2% investigation threshold and 3% hard regression stop consistently.
+
+The Stan Math audit independently confirmed the core lifetime rule: output
+nodes may share one arena-owned operand array and contiguous Jacobian, but they
+must never retain pointers into reusable thread-local Jacobian storage.
+
+A parallel ODE change has now completed explicit legacy RK45/BDF/Adams
+dispatch and replaced `VarRhs`'s vector marshalling with `run_rhs_into` and
+direct Eigen output. That work reports clean paired speedups of 1.265x on
+Lotka, 1.243x on soil, and 1.104x on `one_comp`, with six live solver-dispatch
+cases passing CmdStan. It has no overlapping hunks to reconcile with this
+developer-only spike. If generated adjoints are ever reconsidered, their
+selector must be a compiled-RHS helper callable from the direct `VarRhs` seam;
+placing it only in the former vector-returning `MirRhs::eval` would be bypassed.
+The remaining opportunity indicated by these combined results is BDF/CVODES
+sensitivity cost, not the generated callback bridge measured here.
+
+## Preparation, memory, and line counts
+
+- Production preparation overhead: none (no production payload exists).
+- Production retained memory: none.
+- Prototype structural payload: copied 6-instruction/13-register and
+  8-instruction/15-register forwards, with equal-length reverse programs, for
+  the two measured cases.
+- Production lines changed: 0.
+- Runtime/test lines changed: 0.
+- Developer benchmark: one 564-line standalone source file plus a three-line
+  CMake target; it is not installed and is not a CTest test.
+
+## Reconsideration boundary
+
+Do not restart this design because the refactor is easy. Reconsider only if a
+material premise changes, for example:
+
+- Stan Math exposes a callback Jacobian interface that avoids constructing and
+  sweeping precomputed-gradient nodes; or
+- profiling finds a structurally different, common eligible RHS whose complete
+  callback is at least 2x faster *and* a conservative structural rule excludes
+  the small Lotka-shaped regression.
+
+Any revival starts again at Phase 0 and must include the stricter parity and
+CVODES activation checks above.

--- a/docs/superpowers/plans/2026-08-28-ode-sensitivity-ceiling-results.md
+++ b/docs/superpowers/plans/2026-08-28-ode-sensitivity-ceiling-results.md
@@ -1,0 +1,566 @@
+# ODE sensitivity ceilings after Phase 1
+
+**Status:** developer-only attribution and ceiling experiment complete on
+2026-08-28. No experimental solver path is installed in the runtime.
+
+The recommended branchless RK path was subsequently implemented and admitted;
+see `2026-08-29-ode-direct-rk-results.md`. The CVODES experiments in this
+report remain developer-only.
+
+## Outcome
+
+The merged Phase 1 implementation is a sound baseline, and both solver
+families retain substantial headroom.
+
+1. A stanli-owned all-double coupled RK solve, using the pinned Boost RK45 or
+   Cash--Karp tableau directly, is an exact and compelling follow-up for
+   branchless compiled RHS programs. Complete-solve geometric-mean speedups
+   are `1.800x` on Lotka--Volterra and `1.796x` on soil under RK45. CKRK gives
+   `1.821x` and `1.860x`. Values, every solution-Jacobian bit, and callback
+   counts match the current Stan Math oracle; candidate step totals are
+   recorded separately.
+2. A three-operation CVODES derivative-provider seam is technically small
+   and worthwhile for narrow active widths. On the real branched
+   `one_comp_mm_elim_abs` RHS, the bounded BDF prototype is `1.210x` faster at
+   complete-solve level and the forced Adams arm is `1.144x` faster.
+3. The CVODES timing arm is not production-admissible yet. Its branch-aware
+   `fvar<double>` Jacobian follows `JZ/JMP`, but arithmetic grouping differs
+   from current reverse mode. Complete one-compartment errors remain tiny
+   (`4.87e-14` worst absolute Jacobian error over three points), yet they are
+   not bitwise exact.
+4. One forward tangent replay per input direction is not a general strategy.
+   A retained BDF confirmation loses at active width 16 (`0.857x`), and the
+   screen collapses at width 64; the same mechanism loses on RK branches even
+   at the small baseline shape (`0.773x`). The production
+   follow-up needs an exact executed-instruction trace/reverse provider, not a
+   general fvar-column path.
+5. The failed Phase 0 generated-reverse/precomputed-gradient callback bridge
+   remains stopped. None of these prototypes constructs precomputed-gradient
+   callback nodes or installs that path. The RK experiment reuses the raw
+   register adjoint only as a double-space `J_y/J_theta` provider inside a
+   separately owned coupled solve.
+
+Recommended PR sequence:
+
+- pursue an exact, branchless RK45/CKRK coupled-sensitivity path first;
+- build an exact branch-aware register derivative provider next;
+- then expose the three-operation provider policy at the pinned CVODES seam;
+- do not merge either current benchmark implementation as production code.
+
+## Scope and terminology
+
+The candidate/oracle ratios in this report are complete ODE solve ratios. They
+include solver setup, integration, output materialization, and dense solution
+Jacobian extraction. They do not include the surrounding graph or the final
+`OP_ODE` matrix-vector pullback. The reported full-gradient numbers are
+Amdahl projections from independently measured OP shares, not integrated
+candidate timings.
+
+The direct RK arm is deliberately a hard ceiling. It mirrors the pinned Stan
+Math loop's Boost tableau, controller, full-coupled-state error norm, initial
+step, observation schedule, tolerances, and step checker, but bypasses the
+ordinary all-double RHS container adapter and repeated high-level validation.
+A production implementation must preserve error semantics without putting
+those checks back in the callback loop.
+
+The CVODES arm is a proximity ceiling. It reproduces the pinned lifecycle and
+official CVODES configuration, but uses fvar Jacobian columns whose arithmetic
+grouping is not an exact replacement for the oracle.
+
+All decision ratios below come from uninstrumented, sequential runs with no
+other benchmark process active. The runner retains every batch, computes the
+geometric mean and two-sided Student-t 95% interval in log-ratio space, and
+writes a provenance sidecar. Earlier overlapping exploratory runs are retained
+only as discarded diagnostics and are not quoted here.
+
+## Provenance
+
+- Base and `origin/main`:
+  `0c89544b695e22eaf788eb88aa8622377e8921fc` (`Speed up builds and CI
+  (#244)`), a descendant of `bdfc9e2867a9f2561b7890d19200e0676f020015`,
+  which merged PR #245. All decision runs were repeated after the fast-forward.
+- Candidate commit: none; all artifacts are uncommitted developer tools and
+  this report.
+- Host: Apple M3 Ultra, 32 cores, 96 GiB RAM.
+- OS: macOS 26.4 (`25E246`), arm64.
+- Compiler: Apple clang 21.0.0.
+- Build: Release, `-O3 -DNDEBUG -ffp-contract=off`.
+- CMake: 4.3.3.
+- Stan Math: `8f326d14599d3030c626c46532d8e8534c1cdbec`.
+- Stan: `c96d04115d35cb04f42e45c5a69a82f9704798f1`.
+- stanc3: `5b824ee48c590fa229dcebf6b57457b2fd212aa8`
+  (`v2.39.0-142-g5b824ee`).
+- PosteriorDB: `28f8d3d6e975315f42aa274a8399f21e07a43b30`.
+- CmdStan: `11cb052d3e1fc8c799e0fec559e2ee5452b38d27`.
+
+The tools compile against the merged runtime, retain that solve as their
+oracle, and do not modify `runtime/` or `deps/`. Their CMake targets are
+`EXCLUDE_FROM_ALL`, so normal Release builds neither compile nor link the
+diagnostic programs.
+
+Every retained JSONL row includes SHA-256 hashes of its MIR, data, and selected
+benchmark binary. Each run sidecar records the exact Git status, host, Python,
+CMake cache, target compile flags/definitions, compiler versions, commands,
+artifact hashes, and hashes for the uncommitted benchmark/generator sources.
+The prepared manifests also record the source Stan/archive and pinned stanc
+paths and hashes.
+
+## Phase 1 baseline and whole-gradient attribution
+
+Ten uninstrumented Release `bench_grad` runs gave these merged-baseline
+medians:
+
+| model | warmed gradient |
+|---|---:|
+| `lotka_volterra` | 40.477 us |
+| `soil_incubation` | 56.084 us |
+| `one_comp_mm_elim_abs` | 485.588 us |
+
+Existing executor profiling separates the graph-level ODE forward and
+backward work:
+
+| model | OP_ODE forward / gradient | OP_ODE backward / gradient | profiled total | forward share | total OP share |
+|---|---:|---:|---:|---:|---:|
+| Lotka | 40.159 us | 0.143 us | 41.779 us | 96.12% | 96.47% |
+| soil | 54.306 us | 0.118 us | 58.100 us | 93.47% | 93.67% |
+| one-compartment | 483.939 us | 0.022 us | 484.614 us | 99.86% | 99.87% |
+
+`OP_ODE` backward is therefore not a useful optimization target: it costs
+roughly 22--143 ns per gradient. The work is in forward sensitivity solving.
+
+The Phase 1 callback/marshalling result remains relevant context. Relative to
+the pre-PR checkout, its direct Eigen output and legacy `_tol_impl` dispatch
+improved complete gradients by `1.265x` on Lotka, `1.243x` on soil, and
+`1.104x` on one-compartment. This experiment starts after those copies have
+already been removed.
+
+### Complete-solve work attribution
+
+The standalone tools keep profiling as a separate template instantiation.
+The paired arms contain no phase clocks, counters, statistics calls, or
+runtime profiling branches. Component timers are perturbative and are used
+only to locate work.
+
+For one-compartment BDF at point 0, the oracle and candidate callback roles
+match exactly:
+
+| work | oracle | compiled CVODES arm |
+|---|---:|---:|
+| primal RHS calls | 1,066 | 1,066 |
+| derivative callbacks | 572 | 9 `J_y` + 563 full `J_y/J_theta` |
+| accepted steps | not externally exposed | 516 |
+| CVODES primal RHS statistic | not externally exposed | 1,066 |
+| CVODES Jacobian statistic | not externally exposed | 9 |
+| CVODES sensitivity RHS statistic | not externally exposed | 563 |
+| nonlinear iterations | not externally exposed | 539 |
+| sensitivity nonlinear iterations | not externally exposed | 558 |
+
+The corresponding Adams arm has 364 primal calls and 194 derivative calls on
+both sides; the candidate reports 176 accepted steps, four state Jacobians,
+and 190 sensitivity RHS evaluations.
+
+A representative instrumented BDF candidate attributes approximately 63 us
+to register seeding, 122 us to register-program bodies, 47 us to output
+extraction, and 8 us to sensitivity products across the solve. These fields
+overlap the callback totals and must not be summed. Constructor/allocation,
+CVODES setup, `CVodeGetSens`, output packing, and final oracle harvest are each
+low-single-digit microseconds or less. The dominant removable work is repeated
+derivative construction inside the integration, not final Jacobian harvesting
+or graph backward.
+
+The candidate-only RK diagnostic shows the same shape. Times in the last five
+columns are per callback and intentionally include clock perturbation:
+
+| model | callbacks | instrumented solver | final packing | seed | body | output extraction | local Jacobian | sensitivity propagation |
+|---|---:|---:|---:|---:|---:|---:|---:|---:|
+| Lotka | 260 | 61.2 us | 0.5 us | 16.2 ns | 16.7 ns | 13.2 ns | 55.1 ns | 19.3 ns |
+| soil | 326 | 76.2 us | 0.5 us | 14.1 ns | 16.4 ns | 12.9 ns | 54.3 ns | 17.9 ns |
+
+The oracle callback phase labels are not directly comparable: its register
+timer excludes Stan Math's reverse sweeps and sensitivity products. Only the
+uninstrumented complete-solve ratios are used for decisions.
+
+The perturbative RK breakdown is retained separately in the diagnostic
+runner artifact listed below; it is not inferred from the decision timings.
+
+Allocation semantics are also bounded:
+
+- the merged callback writes directly into caller-owned Eigen output;
+- RK candidate register, value, Jacobian, and sensitivity buffers live for one
+  solve and are reused by every callback;
+- the direct RK callback fills Odeint-owned `std::vector<double>` storage and
+  performs no vector-to-Eigen-to-vector coupled-state round trip;
+- CVODES candidate state, sensitivity lanes, dense matrix, linear solver,
+  `N_Vector` shells, register files, `J_y`, and `J_theta` are allocated once per
+  solve;
+- no tangent direction allocates inside a timed callback;
+- normal Release runtime code contains none of this diagnostic machinery.
+
+## RK45 and CKRK hard ceiling
+
+### Prototype
+
+The candidate state is
+
+```text
+z = [y,
+     S_y0 lane 0, ..., S_y0 lane Ny-1,
+     S_theta lane 0, ..., S_theta lane P-1]
+```
+
+with one contiguous state-sized block per active input. Its callback evaluates
+compiled `f`, `J_y`, and `J_theta`, then uses the oracle's scalar order:
+
+```text
+y'          = f
+S_y0'       = J_y * S_y0
+S_theta'    = J_theta + J_y * S_theta
+```
+
+The complete coupled vector enters the adaptive error norm. A state-only solve
+followed by a separate sensitivity integration is not used.
+
+The raw generated register reverse is eligible only for instructions already
+supported by `gen_adjoint`. It runs one double forward and one reverse sweep
+per RHS output. It creates no `var`, `vari`, arena operand array, or
+precomputed-gradient node. Unsupported control flow selects the fvar
+experimental arm in this tool; production must instead select the current
+oracle until an exact trace reverse exists.
+
+### Real-model results
+
+Each row uses 200 ms warmup per arm followed by 15 alternating paired batches;
+each timed arm lasts at least 0.5 seconds per batch. The estimate is the
+geometric mean of paired oracle/candidate ratios with a paired-log t interval.
+
+| solver | model | oracle median | candidate median | speedup | paired 95% CI | callbacks | candidate accepted / attempted / rejected |
+|---|---|---:|---:|---:|---:|---:|---:|
+| RK45 | Lotka | 42.065 us | 23.396 us | **1.800x** | [1.769x, 1.830x] | 260 / 260 | 32 / 43 / 11 |
+| RK45 | soil | 57.503 us | 32.196 us | **1.796x** | [1.772x, 1.820x] | 326 / 326 | 47 / 54 / 7 |
+| CKRK | Lotka | 41.299 us | 22.569 us | **1.821x** | [1.803x, 1.839x] | 258 / 258 | 36 / 43 / 7 |
+| CKRK | soil | 54.068 us | 28.958 us | **1.860x** | [1.849x, 1.871x] | 288 / 288 | 48 / 48 / 0 |
+
+RK attempt counts are derived from the pinned six-stage tableau callback count;
+accepted steps are returned by `integrate_times`. The derivation is reported
+as such in tool output. The current high-level oracle does not expose its
+accepted/rejected counters, so only total callback-work parity is asserted.
+
+At point 0, Lotka compares all 40 solution values and 240 Jacobian entries;
+soil compares 50 and 300. All bits match. Points 1 and 2 are also exact for
+both tableaux:
+
+| solver / model / point | callbacks | accepted steps | result |
+|---|---:|---:|---|
+| RK45 / Lotka / 1 | 152 / 152 | 23 | 40 / 40 values and 240 / 240 J bits exact |
+| RK45 / Lotka / 2 | 134 / 134 | 22 | 40 / 40 values and 240 / 240 J bits exact |
+| RK45 / soil / 1 | 302 / 302 | 44 | 50 / 50 values and 300 / 300 J bits exact |
+| RK45 / soil / 2 | 308 / 308 | 45 | 50 / 50 values and 300 / 300 J bits exact |
+| CKRK / Lotka / 1 | 132 / 132 | 22 | 40 / 40 values and 240 / 240 J bits exact |
+| CKRK / Lotka / 2 | 132 / 132 | 22 | 40 / 40 values and 240 / 240 J bits exact |
+| CKRK / soil / 1 | 258 / 258 | 43 | 50 / 50 values and 300 / 300 J bits exact |
+| CKRK / soil / 2 | 258 / 258 | 43 | 50 / 50 values and 300 / 300 J bits exact |
+
+Using only the separately measured `OP_ODE` forward shares, the RK45 solve
+ceilings project to `1.745x` for the complete Lotka gradient and `1.707x` for
+soil. CKRK projects to `1.765x` and `1.761x`. Transforming the solve intervals
+through the same forward-only Amdahl calculation gives `[1.718x,1.773x]`,
+`[1.687x,1.727x]`, `[1.748x,1.781x]`, and `[1.752x,1.771x]`, respectively.
+`OP_ODE` backward and all other graph work remain unaccelerated in this
+calculation. These are projections, not production A/B results.
+
+## BDF and Adams CVODES proximity ceiling
+
+### Smallest seam
+
+Pinned Stan Math currently owns static callbacks and the `cvodes_mem` lifetime.
+There is no standalone `J_theta` setter. The smallest useful policy is:
+
+```text
+rhs(t, y)               -> f
+jacobian_states(t, y)   -> J_y
+jacobians(t, y)         -> J_y, J_theta
+```
+
+The existing CVODES trampolines can use those operations for `CVRhsFn`,
+`CVLsJacFn`, and `CVSensRhsFn`. The sensitivity callback computes
+`J_y*S_y0` or `J_theta + J_y*S_theta` lane by lane. BDF and Adams share this
+seam; the linear multistep method remains a CVODES choice.
+
+The bounded local adapter preserves the pinned order:
+
+1. create CVODES memory and initialize the primal state;
+2. install user data before Jacobian and sensitivity callbacks;
+3. apply Stan Math's max-step and tolerance configuration;
+4. install the dense matrix and linear solver;
+5. install `J_y`, then staggered sensitivity callbacks and sensitivity error
+   control;
+6. advance and harvest every requested output time;
+7. query official statistics before `CVodeFree`;
+8. destroy sensitivity shells, solver, matrix, state vector, and context in
+   ownership order.
+
+### Branch-aware one-compartment proof
+
+The optimized one-compartment RHS is 19 instructions / 23 registers and has a
+`JZ` around the dose arm. `run_program<fvar<double>>` evaluates comparisons on
+the primal and differentiates only the selected arm.
+
+At corpus point 0 and `-0.0`, `+0.0`, `nextafter(0,-infinity)`, and
+`nextafter(0,+infinity)`, all four local `J_y/J_theta` entries and the RHS value
+match reverse mode bit for bit. The positive adjacent value takes the dose arm
+(`f = 16.577563771134717`); the other three return zero. This proves the actual
+`t > 0` control flow is supported rather than structurally refused.
+
+Fvar and reverse derivative grouping can still differ on the same selected
+arm. At point 1, for example, one boundary-probe derivative differs by one ULP.
+The three complete-solve checks are:
+
+| solver | point | max value abs error | max full-J abs error | exact J entries |
+|---|---:|---:|---:|---:|
+| BDF | 0 | 1.78e-14 | 1.40e-14 | 20 / 80 |
+| BDF | 1 | 1.78e-14 | 4.86e-14 | 21 / 80 |
+| BDF | 2 | 2.49e-14 | 5.66e-15 | 21 / 80 |
+| Adams | 0 | 1.60e-14 | 1.91e-14 | 21 / 80 |
+| Adams | 1 | 7.11e-15 | 2.66e-14 | 27 / 80 |
+| Adams | 2 | 1.07e-14 | 9.33e-15 | 23 / 80 |
+
+Callback-role counts match at all timed points. Comparable internal CVODES
+statistics are unavailable from the current oracle because pinned Stan Math
+frees its private memory before returning; the tool explicitly reports that
+solver-work parity is unknown beyond callback counts.
+
+### Real-model timing
+
+| solver | oracle median | candidate median | speedup | paired 95% CI | range |
+|---|---:|---:|---:|---:|---:|
+| BDF | 517.760 us | 418.811 us | **1.210x** | [1.195x, 1.225x] | 1.152x--1.248x |
+| Adams | 241.633 us | 214.405 us | **1.144x** | [1.125x, 1.163x] | 1.098x--1.231x |
+
+The forward-only BDF ceiling projects to `1.210x` for the complete
+one-compartment gradient with a transformed interval of `[1.195x,1.225x]`.
+The forced Adams result projects to `1.144x` with `[1.125x,1.163x]`. Neither
+projection admits the current fvar provider.
+
+## Synthetic shape sweep
+
+`gen_ode_ceiling_sweep.py` emits 21 runnable cases for each solver, 84 total.
+The one-factor axes around
+`(S=2,P=4,T=8,branch=false,y0=active,theta=active)` are:
+
+- `S = 1, 2, 4, 8, 16`;
+- active theta width `P = 0, 1, 4, 16, 64`;
+- output-time count `T = 1, 4, 8, 32, 128`;
+- branch absent/present;
+- initial state data/active;
+- theta data/active;
+- five interaction/edge cases.
+
+The runnable matrix covers type masks `0x3` (active `y0` and theta), `0x2`
+(data `y0`, active theta), and `0x1` (active `y0`, data theta). Four additional
+genuine `0x0` models are recorded in `compile_only.json`. The optimized MIR
+still contains those calls; Stanli's constant folder evaluates them outside
+the repeated log-density graph. There is consequently no runtime
+`OP_ODE` to benchmark. This documents the fourth activity combination without
+faking activity merely to keep an operation alive. All four compiled inputs
+were checked directly; both ceiling binaries report `compiled model has no
+OP_ODE` as expected.
+
+Every `S > 1` RHS has dense state coupling through
+`0.02 * sum(y) / rows(y)`. Its off-diagonal `J_y` entries are `0.02 / S`, so
+the sweep exercises a non-diagonal multi-state CVODES Jacobian rather than a
+collection of independent scalar equations.
+
+Every case runs in a fresh process. The retained screen uses three paired
+batches of one solve with no duration warmup; it locates structural crossovers
+and is not an admission benchmark. Ratios below are the median and range of
+the 21 per-case paired geometric means.
+
+| solver | median case ratio | range | correctness |
+|---|---:|---:|---|
+| RK45 | 1.577x | 0.156x--3.420x | 3,075 / 3,075 values, 54,693 / 54,693 solution-J entries, and 4,740 / 4,740 local entries exact; all callback counts equal |
+| CKRK | 1.533x | 0.143x--3.363x | 3,075 / 3,075 values, 54,693 / 54,693 solution-J entries, and 4,740 / 4,740 local entries exact; all callback counts equal |
+| BDF | 1.167x | 0.637x--1.559x | 3,075 / 3,075 values and 54,693 / 54,693 J entries exact |
+| Adams | 1.188x | 0.481x--1.544x | 3,075 / 3,075 values and 54,693 / 54,693 J entries exact |
+
+The synthetic algebra happens to be grouping-stable, so CV fvar is exact
+there. Every synthetic row explicitly requests and passes the bitwise timing
+gate; none is admitted under the proximity rule. That does not override the
+real one-compartment counterexample.
+
+Structural findings:
+
+- generated-reverse RK wins all 18 branchless cases for both tableaux;
+- the three currently fvar-backed RK branch cases lose for both tableaux;
+- CV fvar wins 15 / 18 branchless shapes and 1 / 3 branch shapes for both BDF
+  and Adams in the low-iteration screen;
+- CV fvar is profitable at narrow `P`, loses in the retained `P=16`
+  confirmation, and loses decisively at `P=64` in the screen;
+- data `y0` and data theta exercise different coupled widths, so eligibility
+  cannot be inferred from the source parameter count alone;
+- the exact synthetic CV results demonstrate dense-`J_y` mechanics, but do
+  not override the real one-compartment fvar/reverse grouping counterexample.
+
+Long confirmation runs with the admission warmup/sampling protocol show:
+
+| solver / shape | provider | speedup | paired 95% CI | verdict |
+|---|---|---:|---:|---|
+| RK45 `S16/P4/T8`, straight | generated reverse | 1.253x | [1.239x, 1.267x] | bitwise-exact win |
+| RK45 `S2/P4/T8`, branch | fvar columns | 0.773x | [0.765x, 0.782x] | bitwise exact here, reject on cost |
+| BDF `S2/P16/T8`, straight | fvar columns | 0.857x | [0.843x, 0.871x] | bitwise exact here, reject on cost |
+| BDF `S2/P4/T8`, branch | fvar columns | 1.123x | [1.111x, 1.135x] | bitwise exact here; proximity algorithm only |
+
+All four confirmation rows use 200 ms warmup and 15 paired batches; the
+shortest timed arm in any batch is 0.542 seconds.
+
+These rows show why eligibility cannot be only “compiled RHS available.” The
+derivative algorithm and active width matter.
+
+## Recommendation matrix
+
+| family / proposed path | evidence | production prerequisite | decision |
+|---|---|---|---|
+| RK45/CKRK, branchless direct coupled solve | exact 1.80x--1.86x real-model solve ceilings; all 18 branchless synthetic cases win | retain Phase 1 `run_rhs_into` seam, immutable generated derivative payload, exact checks, fallback selector, error-semantic tests | **Follow-up PR merits immediate work** |
+| RK45/CKRK, current fvar branch path | 0.773x at the small branch; worse when wide | exact executed-trace reverse or another reverse-cost provider | **Stop; do not integrate** |
+| BDF/Adams, three-operation CVODES provider seam | real P=3 branch wins 1.210x / 1.144x; P=4 synthetic branch wins 1.123x BDF | exact branch-aware reverse provider; oracle CVODES work-stat hook; same-binary full-gradient A/B | **Follow-up seam/prototype merits work** |
+| BDF/Adams, fvar column provider | loses by P=16 and is non-bitwise on one-compartment | none; replace the algorithm | **Do not ship** |
+| Phase 0 precomputed-gradient callback bridge | mandatory gate failed at 0.853x / 0.930x | material premise change | **Remain stopped** |
+
+The first RK PR should be deliberately narrow:
+
+- support only branchless compiled programs whose generated local values and
+  full Jacobian are bitwise exact;
+- retain the exact current solve as a runtime-selectable oracle/fallback;
+- preserve the complete coupled error norm and tableau;
+- preserve high-level input and error semantics outside the callback loop;
+- compare accepted/attempted/rejected steps and callback counts;
+- use PR #245's direct-Eigen `run_rhs_into` structure rather than restoring a
+  vector-returning adapter;
+- measure integrated `bench_grad`, default CmdStan, and `stanc --O1` CmdStan
+  before enabling by default.
+
+The CVODES follow-up should begin with the derivative payload, not a copied
+solver:
+
+- generate an executed-instruction trace that records the chosen `JZ/JMP`
+  path and applies reverse rules in the oracle's grouping;
+- validate signed zero, adjacent branch values, nonfinite behavior, and every
+  supported opcode;
+- expose `f`, `J_y`, and `J_y/J_theta` behind the smallest policy extension
+  possible;
+- if an upstream/pinned-header policy is unavailable, keep a repository-owned
+  lifecycle adapter bounded to the audited initialization order;
+- select by measured structural cost, with the current path as fallback.
+
+## Correctness and admission gates still required
+
+Before any production integration:
+
+1. require bitwise local RHS and complete `J_y/J_theta` equality for every
+   selected derivative program;
+2. reject nonfinite comparison inputs even when both sides have the same bit
+   pattern; both benchmark gates now do this before any timing begins. The CV
+   proximity gate also requires each finite difference to meet either
+   `1e-12` absolute or `1e-9` relative tolerance, while grouping-stable
+   synthetic rows explicitly require bitwise equality;
+3. require same-binary complete solution values, full scratch Jacobian,
+   callback counts, and RK step history;
+4. expose or copy diagnostic CVODES glue so oracle/candidate step, nonlinear,
+   Jacobian, and sensitivity statistics can be compared;
+5. run all three deterministic corpus points, the complete 84-case runtime
+   matrix, and confirm the four compiler-eliminated data/data dispositions;
+6. run the merged CmdStan differential oracle and error-behavior tests;
+7. run 200 ms warmup per arm and at least 15 paired batches of at least 0.5 s
+   per arm with profiling compiled out;
+8. run integrated complete-gradient A/B measurements rather than admitting
+   from the projections in this report;
+9. confirm on Linux x86-64 as well as macOS arm64.
+
+The runner additionally refuses input/output path collisions, rehashes MIR,
+data, and the selected binary before and after every case, requires the
+explicit pre-timing gate, and rejects missing, duplicate, nonfinite, or
+nonpositive batch samples rather than computing a partial interval.
+
+The merged Phase 1 baseline already has three-point CmdStan parity: 94 values,
+worst relative error `1.57e-13`, plus six discriminating legacy solver cases.
+On the final `0c89544` base, the broader repository sweep also passed all 16
+ODE interfaces against CmdStan, covering every modern default/tolerance
+solver, vector and mixed arguments, and all six legacy cases; its worst
+reported relative error was `2.40e-14`. This experiment changes no runtime
+code, so those oracles remain applicable.
+
+## Artifacts and reproduction
+
+Repository artifacts:
+
+- `tools/bench_ode_ceiling.cpp`: exact oracle plus direct all-double RK45/CKRK
+  ceiling, local/full checks, step/callback counts, diagnostic attribution, and
+  paired timing;
+- `tools/bench_ode_cvodes_ceiling.cpp`: exact oracle plus local BDF/Adams
+  CVODES proximity arm, branch proof, official statistics, attribution, and
+  paired timing;
+- `tools/gen_ode_ceiling_sweep.py`: 84-case modern-interface generator plus
+  four genuine compiler-eliminated data/data dispositions;
+- `tools/prepare_ode_ceiling_models.py`: reproducible pinned PosteriorDB/stanc
+  preparation of all three real inputs and six solver rows;
+- `tools/run_ode_ceiling_sweep.py`: fresh-process runner, exact case filters,
+  parser, JSONL/raw-log writer, paired-log statistics, hashes, provenance,
+  safe owned replacement, and timeout/failure continuation;
+- `tools/bench_rhs_adjoint.cpp`: retained failed Phase 0 callback benchmark;
+- `docs/superpowers/plans/2026-08-28-ode-rhs-generated-adjoint-results.md`:
+  Phase 0 stop report.
+
+Ephemeral retained artifacts for this run:
+
+- `/tmp/stanli_ode_ceiling_final_0c89544/manifest.json`: reproducibly prepared real
+  inputs and six solver rows;
+- `/tmp/stanli_ode_ceiling_final_0c89544/real_rk_15x26000_final_0c89544.jsonl`,
+  `real_bdf_15x1300_final_0c89544.jsonl`, and
+  `real_adams_15x2500_final_0c89544.jsonl`: idle sequential decision runs;
+- `/tmp/stanli_ode_ceiling_final_0c89544/parity_rk_point{1,2}_1x3_final_0c89544.jsonl`
+  and `parity_cv_point{1,2}_1x3_final_0c89544.jsonl`: retained nonzero-point checks;
+- `/tmp/stanli_ode_ceiling_final_0c89544/diagnostic_rk_1x1_final_0c89544.jsonl`:
+  retained perturbative RK attribution and raw logs;
+- `/tmp/stanli_ode_synthetic_v6_0c89544/manifest.json` and
+  `compile_only.json`: 84 runnable rows and four all-data dispositions;
+- `/tmp/stanli_ode_synthetic_v6_0c89544/screen_1x3_final_0c89544.jsonl`: complete
+  screening results;
+- `/tmp/stanli_ode_synthetic_v6_0c89544/long_*_final_0c89544.jsonl`: four
+  sequential long confirmations;
+- every JSONL above has a sibling `.logs/` directory and
+  `.provenance.json` sidecar with raw output and reproduction metadata.
+
+Representative commands:
+
+```sh
+cmake -S . -B build-rel -DCMAKE_BUILD_TYPE=Release
+cmake --build build-rel -j8 \
+  --target bench_rhs_adjoint bench_ode_ceiling bench_ode_cvodes_ceiling
+
+python3 tools/prepare_ode_ceiling_models.py \
+  /tmp/stanli_ode_ceiling_final_0c89544
+
+python3 tools/run_ode_ceiling_sweep.py \
+  /tmp/stanli_ode_ceiling_final_0c89544/manifest.json \
+  --output /tmp/stanli_ode_ceiling_final_0c89544/real_rk.jsonl \
+  --solvers rk45,ckrk --iterations 26000 --batches 15 --warmup-ms 200
+
+python3 tools/gen_ode_ceiling_sweep.py \
+  /tmp/stanli_ode_synthetic_v6_0c89544 \
+  --stanc deps/stanc3/stanc
+
+python3 tools/run_ode_ceiling_sweep.py \
+  /tmp/stanli_ode_synthetic_v6_0c89544/manifest.json \
+  --output /tmp/stanli_ode_synthetic_v6_0c89544/screen.jsonl \
+  --iterations 1 --batches 3 --warmup-ms 0
+```
+
+## Final boundary
+
+The result supports owning coupled sensitivity execution where the evidence is
+exact and large enough. It does not support installing a general derivative
+provider merely because it avoids autodiff.
+
+The next production experiment should be the exact branchless RK path. In
+parallel, the useful BDF/Adams research task is an exact branch-aware trace
+reverse plus the three-operation CVODES seam. The Phase 0 precomputed callback
+bridge and the current fvar-column production path should remain out.

--- a/docs/superpowers/plans/2026-08-29-ode-direct-rk-results.md
+++ b/docs/superpowers/plans/2026-08-29-ode-direct-rk-results.md
@@ -1,0 +1,126 @@
+# Direct compiled RK sensitivities: production result
+
+**Status:** the RK45/CKRK implementation is complete and default-on for
+eligible compiled RHS programs. It is rebased onto `origin/main` at
+`d40e8a35b50ce8bc7ece3c402da0060f944a7844`. macOS arm64 admission evidence
+is complete; Linux x86-64 Release CI remains the merge gate.
+
+## Outcome
+
+The bounded ceiling prototype translated cleanly into the runtime and retained
+nearly all of its measured gain. For an eligible RK call, stanli now integrates
+the primal state and every active sensitivity together in double precision.
+Each RHS callback runs one compiled double forward and generated register
+reverse sweeps to obtain exact `f`, `J_y`, and `J_theta`; it creates no nested
+Stan Math autodiff graph.
+
+The current Stan Math implementation remains the exact oracle and fallback.
+Selection is fail-closed at lowering: unsupported instructions, control flow,
+an unavailable compiled RHS, non-RK solvers, or a shape mismatch retain the
+old path. `STANLI_NO_ODE_DIRECT_RK=1` selects the oracle when a model is
+lowered, which supports fresh-process differential and performance tests
+without a branch in the callback.
+
+This is not a revival of the stopped Phase 0 callback bridge. That prototype
+constructed precomputed-gradient Stan Math nodes and failed its mandatory
+callback-level speed gate. The admitted path instead owns the complete coupled
+RK solve in double space and uses generated reverse only as a local Jacobian
+provider.
+
+## Retained end-to-end performance
+
+The retained run used 200 ms warmup per arm, calibrated every timed arm to at
+least 0.5 seconds, then ran 15 alternating ABBA/BAAB fresh-process paired
+batches. Estimates are geometric means of paired ratios; intervals are
+two-sided Student-t 95% intervals in log-ratio space.
+
+| model | comparison | speedup | paired 95% CI |
+|---|---|---:|---:|
+| Lotka--Volterra | stanli oracle / direct RK | **1.968x** | [1.951x, 1.985x] |
+| Lotka--Volterra | CmdStan default / direct RK | **2.157x** | [2.094x, 2.221x] |
+| Lotka--Volterra | CmdStan `--O1` / direct RK | **2.201x** | [2.184x, 2.218x] |
+| soil incubation | stanli oracle / direct RK | **1.958x** | [1.944x, 1.971x] |
+| soil incubation | CmdStan default / direct RK | **2.266x** | [2.241x, 2.291x] |
+| soil incubation | CmdStan `--O1` / direct RK | **2.207x** | [2.179x, 2.235x] |
+| one-compartment BDF | stanli oracle / current | 0.997x | [0.988x, 1.006x] |
+| one-compartment BDF | CmdStan default / current | **1.068x** | [1.061x, 1.075x] |
+| one-compartment BDF | CmdStan `--O1` / current | **1.082x** | [1.068x, 1.097x] |
+
+The BDF row is deliberately neutral for the stanli A/B comparison: the new
+selector does not admit BDF, so both arms execute the same current runtime.
+It confirms that the inverse selector itself does not perturb ineligible
+models. Relative to CmdStan, the earlier Phase 1 direct-output work remains
+visible.
+
+The earlier synthetic ceiling screen covered state count, active-parameter
+width, output-time count, solver, activity masks, and branch presence. Every
+admitted branchless case won: 18/18 RK45 cases had median `1.588x` speedup
+(range `1.227x`--`2.615x`) and 18/18 CKRK cases had median `1.545x`
+(range `1.160x`--`2.035x`). Branched programs retained the oracle.
+
+## Exactness and behavior evidence
+
+- A local hand-built RHS containing every admitted opcode matches the
+  canonical var program bitwise for values and the complete `J_y/J_theta`.
+- Opcode admission defaults to refusal. `DOT`, reductions, calls, jumps, and
+  `FMAX/FMIN` are refused; the last pair is excluded because signed-zero ties
+  do not reproduce Stan Math var semantics exactly.
+- All RK45 and CKRK activity masks, legacy RK45, direct and oracle full
+  Jacobians, scratch layout, and pullbacks match in the focused runtime test.
+- Separately lowered default-on and `STANLI_NO_ODE_DIRECT_RK=1` models match
+  exactly for complete output, gradient, stderr, and return behavior.
+- Invalid tolerance, empty/unordered/nonfinite time and data inputs, maximum
+  step exhaustion, and solver failure retain the exact exception type and
+  message.
+- Four threads sharing one immutable `OdeSpec` completed six repeated exact
+  comparisons each, exercising the thread-local reusable workspace.
+- The cross-path corpus reports one live direct-RK fixture and verifies that
+  the inverse selector returns it to the oracle.
+- Three real models at three parameter points matched exactly between stanli
+  direct and oracle paths (9/9). A live CmdStan differential covered 16
+  interfaces with a worst absolute difference of `2.40e-14`, below `1e-9`.
+- The production synthetic manifest covered 84 configurations at three
+  parameter points (252 exact default/oracle comparisons).
+
+## Implementation boundary
+
+The direct path deliberately mirrors the pinned Stan Math integration
+contract: Boost RK45 or Cash--Karp tableau, initial step, controller, complete
+coupled-state error norm, output schedule, step checker, validation order,
+exception translation, and row-major harvested Jacobian. State, sensitivity,
+register, value, and local-Jacobian buffers are reused for the solve through a
+thread-local workspace. The graph-level `OP_ODE` backward pass is unchanged.
+
+Normal Release builds contain no attribution timers or benchmark counters.
+The ceiling and production benchmark targets are `EXCLUDE_FROM_ALL`; the
+production runner checkpoints results atomically after every comparison and
+records hashes for the benchmark binary, MIR, data, and CmdStan executables.
+
+## Provenance and retained artifacts
+
+- Source base for the retained timing run:
+  `4f697ae40d55b8647d290d72774beecf174d859e`.
+- Final rebase and correctness base:
+  `d40e8a35b50ce8bc7ece3c402da0060f944a7844`.
+- Host: Apple M3 Ultra, macOS 26.4 arm64; Apple clang 21.0.0; Release
+  `-O3 -DNDEBUG -ffp-contract=off`.
+- CmdStan: `11cb052d3e1fc8c799e0fec559e2ee5452b38d27`.
+- Retained production JSON:
+  `/private/tmp/stanli_ode_production_isolated_20260829.json`.
+- Benchmark binary SHA-256:
+  `81e9938c34b80fddc0878c94932542b0d044b19eb62f66d3189a82a9b3d1f2f2`.
+- Synthetic manifest:
+  `/private/tmp/stanli_ode_synthetic_v6_0c89544/manifest.json`.
+
+Older files named `stanli_ode_production_4f697ae.json` and
+`stanli_ode_production_final_4f697ae.json` were overlapping or interrupted
+diagnostics and are not evidence for this decision.
+
+## Recommendation
+
+Merge the direct RK45/CKRK path after Linux x86-64 Release CI repeats the
+correctness suite and paired regression gate. Continue BDF/Adams work in a
+separate change: the branch-aware CVODES provider seam remains promising, but
+the measured fvar prototype was not bitwise exact and must not be promoted.
+Do not revive the Phase 0 precomputed-gradient callback bridge or use one
+forward-tangent replay per active input as the general derivative provider.

--- a/runtime/include/stanli/ode.hpp
+++ b/runtime/include/stanli/ode.hpp
@@ -9,6 +9,7 @@
 #include <stanli/ode_prog.hpp>
 
 #include <map>
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -67,6 +68,15 @@ struct OdeSpec {
   // The right-hand side, compiled. Falls back to the MIR interpreter when
   // `prog.ok` is false; `prog.why` says what stopped it.
   RhsProgram prog;
+  // Branchless double-forward/generated-reverse derivative payload for the
+  // direct coupled RK45/CKRK path. Null is an ordinary structural refusal;
+  // `prog` remains the exact nested-autodiff oracle and fallback.
+  std::shared_ptr<const IslandProg> direct_rk;
+  std::string direct_rk_why;
+  // Selection is fixed at lowering so the repeated kernel does no environment
+  // lookup. STANLI_NO_ODE_DIRECT_RK leaves the payload present for a clean
+  // same-binary oracle comparison while disabling its use.
+  bool direct_rk_enabled = false;
 };
 
 }  // namespace stanli

--- a/runtime/include/stanli/ode_prog.hpp
+++ b/runtime/include/stanli/ode_prog.hpp
@@ -26,10 +26,13 @@
 
 #include <cstdint>
 #include <map>
+#include <memory>
 #include <string>
 #include <vector>
 
 namespace stanli {
+
+struct IslandProg;
 
 struct RhsProgram : Program {
   // Where run_rhs deposits the call arguments.
@@ -69,6 +72,14 @@ RhsProgram compile_rhs(const mir::FunDef& f,
                        int n_y, int n_theta, int n_x_r,
                        const std::vector<int>& x_i);
 
+// Build an immutable double-forward/generated-reverse derivative payload from
+// a compiled RHS. The canonical RhsProgram is copied before checkpoint saves
+// are inserted, so callers always retain it as the exact var-replay oracle.
+// Programs with runtime control flow or another unsupported derivative opcode
+// return null and keep that oracle path.
+std::shared_ptr<const IslandProg> make_rhs_adjoint_program(
+    const RhsProgram& rhs, std::string* refusal = nullptr);
+
 // Evaluate. The register file is reused between calls (one per result scalar
 // type), which keeps the register-machine body allocation-free after first
 // use; the compiler guarantees every register is written before it is read,
@@ -90,10 +101,9 @@ std::vector<T>& rhs_regs() {
 namespace detail {
 
 template <typename T, typename T_time, typename T_y, typename T_theta>
-std::vector<T>& eval_rhs_regs(const RhsProgram& p, const T_time& t,
-                              const T_y* y, const T_theta* th,
-                              size_t n_th_source, const double* xr) {
-  std::vector<T>& reg = rhs_regs<T>();
+void seed_rhs_regs(const RhsProgram& p, const T_time& t, const T_y* y,
+                   const T_theta* th, size_t n_th_source, const double* xr,
+                   std::vector<T>& reg) {
   if ((int)reg.size() < p.n_regs) reg.resize((size_t)p.n_regs);
   for (int i = 0; i < p.n_y; ++i) reg[(size_t)(p.y0 + i)] = T(y[i]);
   for (int i = 0; i < p.n_th; ++i) reg[(size_t)(p.th0 + i)] = T(th[i]);
@@ -102,6 +112,14 @@ std::vector<T>& eval_rhs_regs(const RhsProgram& p, const T_time& t,
   }
   reg[(size_t)p.t_reg] = T(t);
   for (int i = 0; i < p.n_xr; ++i) reg[(size_t)(p.xr0 + i)] = T(xr[i]);
+}
+
+template <typename T, typename T_time, typename T_y, typename T_theta>
+std::vector<T>& eval_rhs_regs(const RhsProgram& p, const T_time& t,
+                              const T_y* y, const T_theta* th,
+                              size_t n_th_source, const double* xr) {
+  std::vector<T>& reg = rhs_regs<T>();
+  seed_rhs_regs<T>(p, t, y, th, n_th_source, xr, reg);
 
   run_program(p, reg);
   return reg;

--- a/runtime/kernels/ode.cpp
+++ b/runtime/kernels/ode.cpp
@@ -23,6 +23,7 @@
 // initial tape reset, only that output and those inputs need clearing between
 // rows; the graph backward later applies the rows in Stan's reverse order.
 #include <stanli/graph.hpp>
+#include <stanli/island.hpp>
 #include <stanli/packet.hpp>
 #include <stanli/mir_interp.hpp>
 #include <stanli/ode.hpp>
@@ -30,6 +31,11 @@
 
 #include <stan/math.hpp>
 
+#include <algorithm>
+#include <boost/numeric/odeint.hpp>
+#include <functional>
+#include <limits>
+#include <stdexcept>
 #include <type_traits>
 #include <vector>
 
@@ -207,6 +213,297 @@ std::vector<std::vector<stan::return_type_t<T_y0, T_theta>>> solve(
   return out;
 }
 
+// Mutable storage for the direct RK callback. It is deliberately per thread,
+// not part of OdeSpec: executors share the immutable spec and may run in
+// parallel. An ODE RHS cannot itself solve an ODE, so the same non-reentrant
+// contract as rhs_regs<T>() lets successive solves reuse every allocation.
+struct DirectRkWorkspace {
+  std::vector<double> values;
+  std::vector<double> adjoints;
+  std::vector<double> f;
+  std::vector<double> J_y;
+  std::vector<double> J_theta;
+  std::vector<double> state;
+  std::vector<double> times;
+};
+
+DirectRkWorkspace& direct_rk_workspace() {
+  static thread_local DirectRkWorkspace workspace;
+  return workspace;
+}
+
+// Evaluate f, J_y and (when needed) J_theta without constructing a nested
+// autodiff tape. The immutable payload is a clone of the canonical RHS with
+// checkpoint saves for its generated reverse; the exact canonical program
+// remains available to solve() as the oracle.
+class DirectRkDerivative {
+ public:
+  DirectRkDerivative(const OdeSpec& spec, size_t theta_source,
+                     DirectRkWorkspace& workspace)
+      : rhs_(spec.prog),
+        generated_(*spec.direct_rk),
+        theta_source_(theta_source),
+        workspace_(workspace) {}
+
+  template <bool ThetaAutodiff>
+  void evaluate(double t, const double* y, const double* theta,
+                const double* x_r) {
+    workspace_.values.resize((size_t)generated_.n_regs);
+    workspace_.adjoints.resize((size_t)generated_.adj.n_regs);
+    workspace_.f.resize((size_t)rhs_.n_y);
+    workspace_.J_y.resize((size_t)rhs_.n_y * (size_t)rhs_.n_y);
+    if constexpr (ThetaAutodiff) {
+      workspace_.J_theta.resize((size_t)rhs_.n_y * theta_source_);
+      std::fill(workspace_.J_theta.begin(), workspace_.J_theta.end(), 0.0);
+    }
+
+    detail::seed_rhs_regs<double>(rhs_, t, y, theta, theta_source_, x_r,
+                                  workspace_.values);
+
+    run_program(static_cast<const Program&>(generated_), workspace_.values);
+    for (size_t i = 0; i < generated_.out_regs.size(); ++i)
+      workspace_.f[i] = workspace_.values[(size_t)generated_.out_regs[i]];
+
+    const AdjProgram& reverse = generated_.adj;
+    for (size_t output = 0; output < generated_.out_regs.size(); ++output) {
+      std::fill(workspace_.adjoints.begin(), workspace_.adjoints.end(), 0.0);
+      const int output_reg = generated_.out_regs[output];
+      workspace_.adjoints[(size_t)reverse.adj_reg[(size_t)output_reg]] = 1.0;
+      run_adjoint(generated_, reverse, workspace_.values.data(),
+                  workspace_.adjoints.data());
+      for (int input = 0; input < rhs_.n_y; ++input) {
+        const int reg = rhs_.y0 + input;
+        workspace_.J_y[output * (size_t)rhs_.n_y + (size_t)input] =
+            workspace_.adjoints[(size_t)reverse.adj_reg[(size_t)reg]];
+      }
+      if constexpr (ThetaAutodiff) {
+        for (int input = 0; input < rhs_.n_th; ++input) {
+          const int reg = rhs_.th0 + input;
+          workspace_.J_theta[output * theta_source_ + (size_t)input] =
+              workspace_.adjoints[(size_t)reverse.adj_reg[(size_t)reg]];
+        }
+      }
+    }
+  }
+
+ private:
+  const RhsProgram& rhs_;
+  const IslandProg& generated_;
+  size_t theta_source_;
+  DirectRkWorkspace& workspace_;
+};
+
+// The state layout and arithmetic grouping are the pinned Stan Math coupled
+// system's: base states, one S-vector per active y0 lane, then one per active
+// theta lane. In particular the parameter lane starts with J_theta and adds
+// the J_y product left-to-right, which is observable in the last bit.
+template <bool YAutodiff, bool ThetaAutodiff>
+class DirectRkSystem {
+ public:
+  DirectRkSystem(const OdeSpec& spec, size_t states, size_t theta_source,
+                 const double* theta, DirectRkWorkspace& workspace)
+      : derivative_(spec, theta_source, workspace),
+        states_(states),
+        theta_source_(theta_source),
+        theta_(theta),
+        x_r_(spec.x_r.data()),
+        workspace_(workspace) {}
+
+  void operator()(const std::vector<double>& z, std::vector<double>& dz,
+                  double t) const {
+    const size_t y_lanes = YAutodiff ? states_ : 0;
+    const size_t theta_lanes = ThetaAutodiff ? theta_source_ : 0;
+    const size_t expected = states_ * (1 + y_lanes + theta_lanes);
+    if (z.size() != expected)
+      throw std::runtime_error("coupled RK state has unexpected size");
+    dz.resize(expected);
+
+    derivative_.template evaluate<ThetaAutodiff>(t, z.data(), theta_, x_r_);
+    for (size_t output = 0; output < states_; ++output) {
+      dz[output] = workspace_.f[output];
+      if constexpr (YAutodiff) {
+        for (size_t lane = 0; lane < states_; ++lane) {
+          double derivative = 0.0;
+          for (size_t input = 0; input < states_; ++input)
+            derivative += z[states_ + states_ * lane + input] *
+                          workspace_.J_y[output * states_ + input];
+          dz[states_ + states_ * lane + output] = derivative;
+        }
+      }
+      if constexpr (ThetaAutodiff) {
+        for (size_t lane = 0; lane < theta_source_; ++lane) {
+          double derivative = workspace_.J_theta[output * theta_source_ + lane];
+          for (size_t input = 0; input < states_; ++input)
+            derivative +=
+                z[states_ + states_ * y_lanes + states_ * lane + input] *
+                workspace_.J_y[output * states_ + input];
+          dz[states_ + states_ * y_lanes + states_ * lane + output] =
+              derivative;
+        }
+      }
+    }
+  }
+
+ private:
+  mutable DirectRkDerivative derivative_;
+  size_t states_;
+  size_t theta_source_;
+  const double* theta_;
+  const double* x_r_;
+  DirectRkWorkspace& workspace_;
+};
+
+const char* direct_rk_function_name(const OdeSpec& spec) {
+  if (spec.legacy) return "integrate_ode_rk45";
+  return spec.solver == OdeSpec::CKRK ? "ode_ckrk_tol" : "ode_rk45_tol";
+}
+
+void validate_direct_rk(const char* function_name, const OdeSpec& spec,
+                        const double* y0, size_t states, const double* theta,
+                        size_t theta_source) {
+  const Eigen::Map<const Eigen::VectorXd> y0_map(y0, (Eigen::Index)states);
+  const Eigen::Map<const Eigen::VectorXd> theta_map(theta,
+                                                    (Eigen::Index)theta_source);
+  stan::math::check_finite(function_name, "initial state", y0_map);
+  stan::math::check_finite(function_name, "initial time", spec.t0);
+  stan::math::check_finite(function_name, "times", spec.ts);
+  stan::math::check_finite(function_name, "ode parameters and data", theta_map);
+  stan::math::check_finite(function_name, "ode parameters and data", spec.x_r);
+  stan::math::check_finite(function_name, "ode parameters and data", spec.x_i);
+  stan::math::check_nonzero_size(function_name, "initial state", y0_map);
+  stan::math::check_nonzero_size(function_name, "times", spec.ts);
+  stan::math::check_sorted(function_name, "times", spec.ts);
+  stan::math::check_less(function_name, "initial time", spec.t0, spec.ts[0]);
+  stan::math::check_positive_finite(function_name, "relative_tolerance",
+                                    spec.rtol);
+  stan::math::check_positive_finite(function_name, "absolute_tolerance",
+                                    spec.atol);
+  stan::math::check_positive(function_name, "max_num_steps", spec.max_steps);
+}
+
+template <bool YAutodiff, bool ThetaAutodiff>
+bool direct_rk_shape_ok(const KernelCtx& ctx, const OdeSpec& spec) {
+  if (ctx.in[0].len <= 0 || ctx.in[1].len < 0 || ctx.out.len < 0 ||
+      spec.prog.n_y < 0 || spec.prog.n_th < 0 || spec.prog.n_xr < 0 ||
+      spec.direct_rk->n_regs < 0 || spec.direct_rk->adj.n_regs < 0)
+    return false;
+  const size_t states = (size_t)ctx.in[0].len;
+  const size_t theta_source = (size_t)ctx.in[1].len;
+  const size_t max = std::numeric_limits<size_t>::max();
+  if ((size_t)spec.prog.n_y != states ||
+      (size_t)spec.prog.n_th > theta_source ||
+      (size_t)spec.prog.n_xr != spec.x_r.size() ||
+      spec.prog.out_regs.size() != states ||
+      spec.direct_rk->out_regs.size() != states ||
+      (spec.ts.size() != 0 && states > max / spec.ts.size()) ||
+      (size_t)ctx.out.len != spec.ts.size() * states ||
+      states > max - theta_source)
+    return false;
+  const size_t width = states + theta_source;
+  const size_t y_lanes = YAutodiff ? states : 0;
+  const size_t theta_lanes = ThetaAutodiff ? theta_source : 0;
+  if (y_lanes > max - theta_lanes || 1 > max - y_lanes - theta_lanes)
+    return false;
+  const size_t lane_count = 1 + y_lanes + theta_lanes;
+  if (states > max / states || states > max / lane_count ||
+      (theta_source != 0 && states > max / theta_source) ||
+      (size_t)ctx.out.len > max / std::max<size_t>(1, width))
+    return false;
+  return true;
+}
+
+template <bool YAutodiff, bool ThetaAutodiff>
+void solve_direct_rk(KernelCtx& ctx, const OdeSpec& spec) {
+  using boost::numeric::odeint::integrate_times;
+  using boost::numeric::odeint::make_controlled;
+  using boost::numeric::odeint::make_dense_output;
+  using boost::numeric::odeint::max_step_checker;
+  using boost::numeric::odeint::no_progress_error;
+  using boost::numeric::odeint::runge_kutta_cash_karp54;
+  using boost::numeric::odeint::runge_kutta_dopri5;
+
+  const size_t states = (size_t)ctx.in[0].len;
+  const size_t theta_source = (size_t)ctx.in[1].len;
+  const size_t width = states + theta_source;
+  const size_t y_lanes = YAutodiff ? states : 0;
+  const size_t theta_lanes = ThetaAutodiff ? theta_source : 0;
+  const size_t coupled_size = states * (1 + y_lanes + theta_lanes);
+  const char* function_name = direct_rk_function_name(spec);
+
+  validate_direct_rk(function_name, spec, ctx.in[0].data, states,
+                     ctx.in[1].data, theta_source);
+  if ((size_t)ctx.out.len != spec.ts.size() * states)
+    throw std::runtime_error("OP_ODE output shape does not match solve times");
+
+  DirectRkWorkspace& workspace = direct_rk_workspace();
+  workspace.state.assign(coupled_size, 0.0);
+  for (size_t i = 0; i < states; ++i) workspace.state[i] = ctx.in[0].data[i];
+  if constexpr (YAutodiff)
+    for (size_t i = 0; i < states; ++i)
+      workspace.state[states + states * i + i] = 1.0;
+
+  // Inactive columns are observable scratch, even though ode_bwd will not
+  // scatter them. Zeroing the complete matrix keeps the established contract.
+  std::fill(ctx.scratch, ctx.scratch + (size_t)ctx.out.len * width, 0.0);
+
+  workspace.times.resize(spec.ts.size() + 1);
+  workspace.times[0] = spec.t0;
+  std::copy(spec.ts.begin(), spec.ts.end(), workspace.times.begin() + 1);
+  DirectRkSystem<YAutodiff, ThetaAutodiff> system(spec, states, theta_source,
+                                                  ctx.in[1].data, workspace);
+  bool initial_observed = false;
+  size_t time_index = 0;
+  auto observer = [&](const std::vector<double>& state, double) {
+    if (!initial_observed) {
+      initial_observed = true;
+      return;
+    }
+    if (time_index >= spec.ts.size())
+      throw std::runtime_error("direct RK observer produced too many states");
+    for (size_t output_state = 0; output_state < states; ++output_state) {
+      const size_t output = time_index * states + output_state;
+      ctx.out.data[output] = state[output_state];
+      if constexpr (YAutodiff)
+        for (size_t lane = 0; lane < states; ++lane)
+          ctx.scratch[output * width + lane] =
+              state[states + states * lane + output_state];
+      if constexpr (ThetaAutodiff)
+        for (size_t lane = 0; lane < theta_source; ++lane)
+          ctx.scratch[output * width + states + lane] =
+              state[states + states * y_lanes + states * lane + output_state];
+    }
+    ++time_index;
+  };
+
+  try {
+    if (spec.solver == OdeSpec::RK45) {
+      integrate_times(
+          make_dense_output(spec.atol, spec.rtol,
+                            runge_kutta_dopri5<std::vector<double>, double,
+                                               std::vector<double>, double>()),
+          std::ref(system), workspace.state, workspace.times.begin(),
+          workspace.times.end(), 0.1, observer,
+          max_step_checker(spec.max_steps));
+    } else {
+      integrate_times(
+          make_controlled(
+              spec.atol, spec.rtol,
+              runge_kutta_cash_karp54<std::vector<double>, double,
+                                      std::vector<double>, double>()),
+          std::ref(system), workspace.state, workspace.times.begin(),
+          workspace.times.end(), 0.1, observer,
+          max_step_checker(spec.max_steps));
+    }
+  } catch (const no_progress_error&) {
+    stan::math::throw_domain_error(function_name, "",
+                                   workspace.times[time_index + 1],
+                                   "Failed to integrate to next output time (",
+                                   ") in less than max_num_steps steps");
+  }
+  if (time_index != spec.ts.size())
+    throw std::runtime_error("direct RK observer produced too few states");
+}
+
 // Solve with the scalar types selected at lowering. OP_ODE variant bit 2 marks
 // an explicit type mask: low bit y0, next bit theta (1 = var). Variant zero is
 // the compatibility encoding for hand-built graphs and means the former
@@ -231,6 +528,15 @@ void ode_fwd_typed(KernelCtx& ctx, const OdeSpec& s) {
         ctx.out.data[(int64_t)n * S + k] = solv[n][k];
     for (int64_t i = 0; i < ctx.out.len * W; ++i) J[i] = 0.0;
   } else {
+    // The lowering-time switch keeps the exact current solve as a same-binary
+    // oracle without an environment lookup in this repeated kernel. A payload
+    // is present only when generated differentiation refused no opcode.
+    if (s.direct_rk_enabled && s.direct_rk &&
+        (s.solver == OdeSpec::RK45 || s.solver == OdeSpec::CKRK) &&
+        direct_rk_shape_ok<YAutodiff, ThetaAutodiff>(ctx, s)) {
+      solve_direct_rk<YAutodiff, ThetaAutodiff>(ctx, s);
+      return;
+    }
     stan::math::nested_rev_autodiff nested;
     std::vector<T_y0> z0(ctx.in[0].data, ctx.in[0].data + S);
     std::vector<T_theta> th(ctx.in[1].data, ctx.in[1].data + P);

--- a/runtime/src/OPTIMIZATIONS.md
+++ b/runtime/src/OPTIMIZATIONS.md
@@ -914,6 +914,80 @@ three evaluation points for all three models (63/63 scalars). This is a
 targeted mechanism A/B; it does not replace the full-corpus warmed means or
 CmdStan columns in `docs/corpus-bench.tsv`.
 
+### Direct coupled RK sensitivities (`ode.cpp`, disable: `STANLI_NO_ODE_DIRECT_RK=1`)
+
+An eligible RK45 or Cash--Karp solve now keeps the entire sensitivity system
+in plain doubles. Its coupled state has the same layout and evolution as Stan
+Math's pinned RK implementation:
+
+```text
+z              = [y, S_y0 lane 0, ..., S_theta lane P-1]
+y'             = f(t, y, theta)
+S_y0'          = J_y S_y0
+S_theta'       = J_theta + J_y S_theta
+```
+
+The complete coupled vector still enters the adaptive error norm. The runtime
+uses the pinned Dopri5 or Cash--Karp Boost tableau, controller, initial step,
+output schedule, tolerances, and maximum-step checker. For each callback it
+runs the compiled RHS once on doubles, runs its generated reverse once per RHS
+output to obtain `J_y` and `J_theta`, and propagates the active sensitivity
+lanes in Stan Math's scalar order. Thread-local register, adjoint, Jacobian,
+state, and time buffers are reused across callbacks. The observer writes
+solution values and the dense solution Jacobian directly into the `OP_ODE`
+output and scratch regions; the existing `OP_ODE` backward remains the same
+matrix-vector pullback.
+
+Eligibility is deliberately narrower than either the RHS register compiler or
+`gen_adjoint`. The RHS must compile, use RK45 or CKRK, contain no runtime
+control flow, and consist entirely of an explicit exact-grouping opcode
+whitelist. A newly added opcode therefore fails closed. Jumps, `DOT` (whose
+double packet reduction can group differently from the `var` replay),
+`FMAX`/`FMIN` (whose signed-zero tie choice differs), kernel calls, densities,
+and other unproved operations keep the current Stan Math solve. BDF and Adams
+also keep that solve. Data-only ODEs retain their cheaper ordinary double
+solve because they have no sensitivity lanes to accelerate.
+
+The generated payload is made from a clone of the canonical RHS. The
+canonical program is never checkpoint-mutated and remains the exact nested
+autodiff oracle and structural fallback. `STANLI_NO_ODE_DIRECT_RK=1`, read when
+the model is lowered, selects that oracle while still building the same
+payload and recording the same eligibility/refusal result. This makes the
+switch both an emergency escape hatch and a same-binary A/B control. Runtime
+shape inconsistencies also fail closed to the oracle. On the direct path,
+validation order, public function labels, and the translation of Boost's
+no-progress failure reproduce the corresponding Stan Math exception type and
+message.
+
+This is not the stopped Phase 0 generated-callback experiment. Phase 0 put
+generated Jacobian rows behind the existing Stan callback by constructing
+`precomputed_gradients_vari` outputs, and its complete callback measured only
+0.853x and 0.930x as fast as the canonical callback. The admitted path creates
+no callback `var`, arena operand array, or precomputed-gradient node. It uses
+the generated reverse only as a double-space local-Jacobian provider inside a
+separately owned coupled RK solve; the Phase 0 bridge remains unimplemented.
+
+On 2026-08-28, an uninstrumented Release build on an Apple M3 Ultra
+(`-O3 -ffp-contract=off`) ran 15 alternating paired batches of at least 0.5 s
+per arm through the integrated implementation:
+
+| model | current oracle / direct RK | paired 95% CI | pinned CmdStan default / direct RK | pinned CmdStan `--O1` / direct RK |
+| --- | ---: | ---: | ---: | ---: |
+| `lotka_volterra` | 1.8615x | [1.8380x, 1.8853x] | 2.1158x | 2.1241x |
+| `soil_incubation` | 1.8035x | [1.7578x, 1.8505x] | 2.2124x | 2.1454x |
+
+The ineligible branched BDF control, `one_comp_mm_elim_abs`, was unchanged at
+1.0050x [0.9995x, 1.0106x]. Before integration, the complete-solve ceiling
+prototype measured RK45 at 1.800x/1.796x and CKRK at 1.821x/1.860x on the two
+eligible real models. At all three evaluation points, each eligible model
+matched every solution and Jacobian bit and every callback count; all 18
+branchless synthetic shapes won under both RK tableaux. These macOS arm64
+results admit the default-on policy, but they are not cross-architecture
+evidence. Exact default-versus-oracle
+parity and the focused ODE suite on Linux x86-64 are a merge gate. A Linux
+failure must narrow the whitelist or retain the oracle, not weaken the bitwise
+gate.
+
 ## Executor details (`executor.cpp`)
 
 - Each op's context (the pointers telling the kernel where its inputs,
@@ -1009,10 +1083,10 @@ silently. Three layers:
 
 The env switches (`STANLI_NO_DATA_PRELOAD`, `STANLI_NO_INPLACE`,
 `STANLI_NO_CONSTFOLD`, `STANLI_NO_REROLL`, `STANLI_NO_ISLAND`,
-`STANLI_NO_ISLAND_COMPACT`) exist so a wrong
-result can be attributed to one optimization quickly, and they are how each
-one is measured: every speed number is the same build with one variable set
-and unset.
+`STANLI_NO_ISLAND_COMPACT`, `STANLI_NO_ODE_DIRECT_RK`) exist so a wrong result
+can be attributed to one optimization quickly, and they are how each one is
+measured: every speed number is the same build with one variable set and
+unset.
 
 ## Historical targeted measurements
 

--- a/runtime/src/lower.cpp
+++ b/runtime/src/lower.cpp
@@ -4670,6 +4670,26 @@ struct Lowering {
                    "stanli: ODE right-hand side %s falls back to the "
                    "interpreter: %s\n",
                    spec->rhs_name.c_str(), spec->prog.why.c_str());
+    if (spec->prog.ok &&
+        (spec->solver == OdeSpec::RK45 || spec->solver == OdeSpec::CKRK)) {
+      spec->direct_rk =
+          make_rhs_adjoint_program(spec->prog, &spec->direct_rk_why);
+      spec->direct_rk_enabled =
+          spec->direct_rk && !std::getenv("STANLI_NO_ODE_DIRECT_RK");
+    }
+    if (spec->prog.ok &&
+        (spec->solver == OdeSpec::RK45 || spec->solver == OdeSpec::CKRK) &&
+        std::getenv("STANLI_DEBUG_ODE")) {
+      if (spec->direct_rk)
+        std::fprintf(stderr,
+                     "stanli: ODE right-hand side %s is direct-RK eligible%s\n",
+                     spec->rhs_name.c_str(),
+                     spec->direct_rk_enabled ? "" : " (oracle selected)");
+      else
+        std::fprintf(stderr,
+                     "stanli: ODE right-hand side %s keeps the RK oracle: %s\n",
+                     spec->rhs_name.c_str(), spec->direct_rk_why.c_str());
+    }
     Val v = emit_value(OP_ODE, {z0, theta}, N * S, result_si, {(int)N, (int)S});
     // Bit 2 says the low bits explicitly describe the C++ scalar types
     // selected by stanc's adlevels: bit 0 for y0, bit 1 for theta. Runtime

--- a/runtime/src/ode_prog.cpp
+++ b/runtime/src/ode_prog.cpp
@@ -5,6 +5,7 @@
 // body can contain is the shared compiler's problem.
 #include <stanli/ode_prog.hpp>
 
+#include <stanli/island.hpp>
 #include <stanli/mir_prog.hpp>
 
 #include <stdexcept>
@@ -34,6 +35,50 @@ bool supported_rhs_view(const mir::UnsizedView& view) {
          view.leaf == mir::UnsizedLeaf::Int ||
          view.leaf == mir::UnsizedLeaf::Vector ||
          view.leaf == mir::UnsizedLeaf::RowVector;
+}
+
+// The direct RK path compares against a var replay, so admitting a derivative
+// rule is not enough: its double forward must also preserve the replay's exact
+// value grouping. Keep this an explicit whitelist so a new Program opcode
+// fails closed. In particular DOT uses Eigen packet reduction for double and
+// Stan's scalar dot_product for var; one ULP can change adaptive step history.
+bool exact_ode_adjoint_opcode(Program::Code code) {
+  switch (code) {
+    case Program::CONST:
+    case Program::CONSTR:
+    case Program::MOV:
+    case Program::MOVR:
+    case Program::ADD:
+    case Program::SUB:
+    case Program::MUL:
+    case Program::DIV:
+    case Program::POW:
+    case Program::NEG:
+    case Program::EXP:
+    case Program::LOG:
+    case Program::SQRT:
+    case Program::SQUARE:
+    case Program::INV:
+    case Program::FABS:
+    case Program::INV_LOGIT:
+    case Program::LOG1M:
+    case Program::LOG1P_EXP:
+    case Program::TANH:
+    case Program::GT:
+    case Program::GE:
+    case Program::LT:
+    case Program::LE:
+    case Program::EQ:
+    case Program::NE:
+    case Program::LOG_RANGE:
+    case Program::EXP_RANGE:
+    case Program::LSE2:
+    case Program::LOG_MIX:
+    case Program::FMA:
+      return true;
+    default:
+      return false;
+  }
 }
 
 void stamp_rhs_view(Range* range, const mir::UnsizedView& view) {
@@ -150,6 +195,34 @@ RhsProgram compile_rhs(const mir::FunDef& f,
   args[2].is_int = true;
   args[2].ints = x_i;
   return compile_rhs_args(f, funs, n_y, args);
+}
+
+std::shared_ptr<const IslandProg> make_rhs_adjoint_program(
+    const RhsProgram& rhs, std::string* refusal) {
+  if (refusal) refusal->clear();
+  if (!rhs.ok) {
+    if (refusal) *refusal = "compiled RHS unavailable: " + rhs.why;
+    return nullptr;
+  }
+  for (const Program::Instr& instruction : rhs.code) {
+    if (exact_ode_adjoint_opcode(instruction.code)) continue;
+    if (refusal)
+      *refusal = std::string("opcode ") +
+                 program_code_spec(instruction.code).name +
+                 " is not in the exact direct-RK whitelist";
+    return nullptr;
+  }
+  auto candidate = std::make_shared<IslandProg>();
+  static_cast<Program&>(*candidate) = static_cast<const Program&>(rhs);
+  candidate->ins.push_back(IslandProg::LiveIn{rhs.t_reg, 1, -1, 0, false});
+  candidate->ins.push_back(IslandProg::LiveIn{rhs.y0, rhs.n_y, -1, 0, true});
+  candidate->ins.push_back(IslandProg::LiveIn{rhs.th0, rhs.n_th, -1, 0, true});
+  candidate->ins.push_back(IslandProg::LiveIn{rhs.xr0, rhs.n_xr, -1, 0, false});
+  if (!gen_adjoint(*candidate)) {
+    if (refusal) *refusal = "generated adjoint refused the compiled RHS";
+    return nullptr;
+  }
+  return candidate;
 }
 
 }  // namespace stanli

--- a/tests/cross_path.hpp
+++ b/tests/cross_path.hpp
@@ -16,6 +16,7 @@
 //   no_island      STANLI_NO_ISLAND: carver off, graph ops stay
 //   island_always  STANLI_ISLAND_ALWAYS: carve past the cost estimate
 //   no_native_adj  STANLI_NO_NATIVE_ADJ: islands replay under var
+//   no_ode_direct_rk STANLI_NO_ODE_DIRECT_RK: RK45/CKRK use their exact oracle
 //   passes_off     STANLI_NO_REROLL, STANLI_NO_INPLACE, STANLI_NO_CONSTFOLD
 //
 // The default compile also sets STANLI_WA_FORCE_INTERP, the one new switch:
@@ -126,9 +127,10 @@ struct Config {
 // previous config would silently make the next comparison vacuous.
 inline const std::vector<std::string>& harness_vars() {
   static const std::vector<std::string> v = {
-      "STANLI_NO_ISLAND",      "STANLI_ISLAND_ALWAYS", "STANLI_NO_NATIVE_ADJ",
-      "STANLI_NO_REROLL",      "STANLI_NO_INPLACE",    "STANLI_NO_CONSTFOLD",
-      "STANLI_WA_FORCE_INTERP"};
+      "STANLI_NO_ISLAND",       "STANLI_ISLAND_ALWAYS",
+      "STANLI_NO_NATIVE_ADJ",   "STANLI_NO_REROLL",
+      "STANLI_NO_INPLACE",      "STANLI_NO_CONSTFOLD",
+      "STANLI_WA_FORCE_INTERP", "STANLI_NO_ODE_DIRECT_RK"};
   return v;
 }
 
@@ -154,6 +156,7 @@ inline const std::vector<Config>& configs() {
       {"no_island", {"STANLI_NO_ISLAND"}},
       {"island_always", {"STANLI_ISLAND_ALWAYS"}},
       {"no_native_adj", {"STANLI_NO_NATIVE_ADJ"}},
+      {"no_ode_direct_rk", {"STANLI_NO_ODE_DIRECT_RK"}},
       {"passes_off",
        {"STANLI_NO_REROLL", "STANLI_NO_INPLACE", "STANLI_NO_CONSTFOLD"}},
   };
@@ -183,6 +186,7 @@ struct Paths {
   int native_adj = 0;  // islands running their generated backward
   int ode = 0;
   int ode_prog = 0;         // right-hand side compiled
+  int ode_direct_rk = 0;    // eligible and enabled coupled RK45/CKRK path
   int ode_interp = 0;       // right-hand side falls back to MirInterp under var
   std::string wa = "none";  // none | graph | interp | truncated+interp
   size_t wa_columns = 0;
@@ -191,9 +195,9 @@ struct Paths {
     char buf[256];
     std::snprintf(buf, sizeof(buf),
                   "islands %d (%d necessity, %d carved), native_adj %d/%d, "
-                  "wa %s, ode %d (%d program, %d interp)",
+                  "wa %s, ode %d (%d program, %d direct RK, %d interp)",
                   islands, necessity, carved, native_adj, islands, wa.c_str(),
-                  ode, ode_prog, ode_interp);
+                  ode, ode_prog, ode_direct_rk, ode_interp);
     return buf;
   }
 };
@@ -206,10 +210,12 @@ inline void scan_graph(const Graph& g, Paths* p) {
       if (static_cast<const IslandProg*>(op.udata)->native_adj) ++p->native_adj;
     } else if (op.opcode == OP_ODE) {
       ++p->ode;
-      if (static_cast<const OdeSpec*>(op.udata)->prog.ok)
+      const auto* spec = static_cast<const OdeSpec*>(op.udata);
+      if (spec->prog.ok)
         ++p->ode_prog;
       else
         ++p->ode_interp;
+      if (spec->direct_rk && spec->direct_rk_enabled) ++p->ode_direct_rk;
     }
   }
 }

--- a/tests/test_cross_path.cpp
+++ b/tests/test_cross_path.cpp
@@ -71,9 +71,11 @@ int main() {
   int driven = 0, skipped = 0, comparisons = 0, declared = 0;
   int with_islands = 0, with_carved = 0, with_necessity = 0;
   int with_native_adj = 0, with_replay_adj = 0;
-  int with_wa_graph = 0, with_wa_interp = 0, with_ode = 0, with_ode_interp = 0;
+  int with_wa_graph = 0, with_wa_interp = 0, with_ode = 0;
+  int with_ode_direct_rk = 0, with_ode_interp = 0;
   int wa_columns_compared = 0, wa_rng_excluded = 0;
   int island_always_gained = 0, no_island_dropped = 0;
+  int no_ode_direct_rk_dropped = 0;
   std::vector<std::string> skips;
 
   for (const std::string& name : names) {
@@ -124,6 +126,7 @@ int main() {
     if (any(&cross::Paths::native_adj) > 0) ++with_native_adj;
     if (r.paths.islands > r.paths.native_adj) ++with_replay_adj;
     if (any(&cross::Paths::ode) > 0) ++with_ode;
+    if (r.paths.ode_direct_rk > 0) ++with_ode_direct_rk;
     if (any(&cross::Paths::ode_interp) > 0) ++with_ode_interp;
     if (r.paths.wa == "graph+interp") ++with_wa_graph;
     if (r.paths.wa == "truncated+interp") ++with_wa_interp;
@@ -136,6 +139,12 @@ int main() {
     };
     if (islands_of("no_island") < r.paths.islands) ++no_island_dropped;
     if (islands_of("island_always") > r.paths.islands) ++island_always_gained;
+    const auto direct_rk_of = [&r](const char* cfg) {
+      auto it = r.by_config.find(cfg);
+      return it == r.by_config.end() ? 0 : it->second.ode_direct_rk;
+    };
+    if (direct_rk_of("no_ode_direct_rk") < r.paths.ode_direct_rk)
+      ++no_ode_direct_rk_dropped;
   }
 
   std::printf(
@@ -144,17 +153,18 @@ int main() {
       driven, skipped, comparisons, declared);
   std::printf(
       "  engines: %d with islands (%d necessity, %d carved), %d with a "
-      "generated adjoint, %d with a var replay, %d with an ODE (%d falling "
-      "back to the interpreter)\n",
+      "generated adjoint, %d with a var replay, %d with an ODE (%d direct "
+      "RK, %d falling back to the interpreter)\n",
       with_islands, with_necessity, with_carved, with_native_adj,
-      with_replay_adj, with_ode, with_ode_interp);
+      with_replay_adj, with_ode, with_ode_direct_rk, with_ode_interp);
   std::printf(
       "  write_array: %d complete graphs, %d truncated, %d columns "
       "compared against the interpreter, %d excluded as RNG-tainted\n",
       with_wa_graph, with_wa_interp, wa_columns_compared, wa_rng_excluded);
   std::printf(
-      "  switches: NO_ISLAND drops islands on %d, ISLAND_ALWAYS adds on %d\n",
-      no_island_dropped, island_always_gained);
+      "  switches: NO_ISLAND drops islands on %d, ISLAND_ALWAYS adds on %d, "
+      "NO_ODE_DIRECT_RK drops direct RK on %d\n",
+      no_island_dropped, island_always_gained, no_ode_direct_rk_dropped);
   // Engine-coverage floors. These are measured values, not aspirations:
   // each is what the corpus reaches today, so a vocabulary regression that
   // moves work off a path (a carve that stops carving, an ODE right-hand
@@ -174,6 +184,9 @@ int main() {
              std::to_string(with_native_adj));
   expect(with_ode >= 1, "at least 1 fixture reaches the ODE integrator, got " +
                             std::to_string(with_ode));
+  expect(with_ode_direct_rk >= 1,
+         "at least 1 fixture reaches the direct RK path, got " +
+             std::to_string(with_ode_direct_rk));
   expect(with_wa_graph >= 80,
          "at least 80 fixtures lower their whole write_array section, got " +
              std::to_string(with_wa_graph));
@@ -194,6 +207,9 @@ int main() {
   expect(island_always_gained >= 1,
          "STANLI_ISLAND_ALWAYS adds islands somewhere, got " +
              std::to_string(island_always_gained));
+  expect(no_ode_direct_rk_dropped >= 1,
+         "STANLI_NO_ODE_DIRECT_RK disables a direct RK path somewhere, got " +
+             std::to_string(no_ode_direct_rk_dropped));
 
   // Only on a failure, and last: the skip list is the first thing anyone
   // asks for when a floor drops, and 80-odd lines of it on a green run is

--- a/tests/test_ode_prog.cpp
+++ b/tests/test_ode_prog.cpp
@@ -12,6 +12,7 @@
 // still produce the right answer.
 #include <stanli/mir.hpp>
 #include <stanli/mir_interp.hpp>
+#include <stanli/island.hpp>
 #include <stanli/ode_prog.hpp>
 #include <stanli/sexp.hpp>
 
@@ -56,10 +57,135 @@ std::string slurp(const std::string& path) {
 // Deterministic, and spread over both sides of the branch condition.
 double probe(int i) { return 0.35 + 0.21 * std::sin(1.7 * i) + 0.05 * (i % 3); }
 
+void check_generated_local(const std::string& name, const stanli::RhsProgram& p,
+                           const stanli::IslandProg& generated, double t,
+                           const std::vector<double>& y,
+                           const std::vector<double>& theta,
+                           const std::vector<double>& x_r) {
+  using namespace stanli;
+  const size_t width = y.size() + theta.size();
+  std::vector<double> want_values(p.out_regs.size());
+  std::vector<double> want_jacobian(p.out_regs.size() * width);
+  {
+    stan::math::nested_rev_autodiff nested;
+    std::vector<stan::math::var> y_vars(y.begin(), y.end());
+    std::vector<stan::math::var> theta_vars(theta.begin(), theta.end());
+    std::vector<stan::math::var> outputs(p.out_regs.size());
+    run_rhs_into<stan::math::var>(p, t, y_vars.data(), theta_vars.data(),
+                                  theta_vars.size(), x_r.data(),
+                                  outputs.data());
+    for (size_t output = 0; output < outputs.size(); ++output)
+      want_values[output] = outputs[output].val();
+    for (size_t output = 0; output < outputs.size(); ++output) {
+      stan::math::grad(outputs[output].vi_);
+      for (size_t input = 0; input < y.size(); ++input)
+        want_jacobian[output * width + input] = y_vars[input].adj();
+      for (size_t input = 0; input < theta.size(); ++input)
+        want_jacobian[output * width + y.size() + input] =
+            theta_vars[input].adj();
+      if (output + 1 < outputs.size()) nested.set_zero_all_adjoints();
+    }
+  }
+
+  std::vector<double> values((size_t)generated.n_regs);
+  for (int i = 0; i < p.n_y; ++i) values[(size_t)(p.y0 + i)] = y[(size_t)i];
+  for (int i = 0; i < p.n_th; ++i)
+    values[(size_t)(p.th0 + i)] = theta[(size_t)i];
+  values[(size_t)p.t_reg] = t;
+  for (int i = 0; i < p.n_xr; ++i) values[(size_t)(p.xr0 + i)] = x_r[(size_t)i];
+  run_program(generated, values);
+
+  std::vector<double> got_values(p.out_regs.size());
+  std::vector<double> got_jacobian(p.out_regs.size() * width);
+  std::vector<double> adjoints((size_t)generated.adj.n_regs);
+  for (size_t output = 0; output < p.out_regs.size(); ++output) {
+    const int output_reg = generated.out_regs[output];
+    got_values[output] = values[(size_t)output_reg];
+    std::fill(adjoints.begin(), adjoints.end(), 0.0);
+    adjoints[(size_t)generated.adj.adj_reg[(size_t)output_reg]] = 1.0;
+    run_adjoint(generated, generated.adj, values.data(), adjoints.data());
+    for (int input = 0; input < p.n_y; ++input) {
+      const int reg = p.y0 + input;
+      got_jacobian[output * width + (size_t)input] =
+          adjoints[(size_t)generated.adj.adj_reg[(size_t)reg]];
+    }
+    for (int input = 0; input < p.n_th; ++input) {
+      const int reg = p.th0 + input;
+      got_jacobian[output * width + y.size() + (size_t)input] =
+          adjoints[(size_t)generated.adj.adj_reg[(size_t)reg]];
+    }
+  }
+
+  bool values_exact = got_values.size() == want_values.size();
+  for (size_t i = 0; i < got_values.size() && values_exact; ++i)
+    values_exact = bits(got_values[i]) == bits(want_values[i]);
+  bool jacobian_exact = got_jacobian.size() == want_jacobian.size();
+  for (size_t i = 0; i < got_jacobian.size() && jacobian_exact; ++i)
+    jacobian_exact = bits(got_jacobian[i]) == bits(want_jacobian[i]);
+  expect(name + ": generated local values are bitwise exact", values_exact);
+  expect(name + ": generated local Jacobian is bitwise exact", jacobian_exact);
+}
+
+void check_exact_opcode_contract() {
+  using namespace stanli;
+  RhsProgram p;
+  p.ok = true;
+  p.t_reg = 0;
+  p.y0 = 1;
+  p.n_y = 2;
+  p.th0 = 3;
+  p.n_th = 3;
+  p.xr0 = 6;
+  p.n_xr = 2;
+  p.n_regs = 8;
+  auto alloc = [&](int len = 1) {
+    const int reg = p.n_regs;
+    p.n_regs += len;
+    return reg;
+  };
+  auto emit = [&](Program::Code code, int a, int b = 0, int c = 0, int len = 0,
+                  int out_len = 1) {
+    const int dst = alloc(out_len);
+    p.code.push_back(Program::Instr{code, dst, a, b, c, len});
+    for (int i = 0; i < out_len; ++i) p.out_regs.push_back(dst + i);
+  };
+
+  p.pool = {0.375, -0.25, 1.5};
+  emit(Program::CONST, 0);
+  emit(Program::CONSTR, 1, 0, 0, 2, 2);
+  emit(Program::MOV, p.y0);
+  emit(Program::MOVR, p.y0, 0, 0, 2, 2);
+  for (Program::Code code :
+       {Program::ADD, Program::SUB, Program::MUL, Program::DIV, Program::POW})
+    emit(code, p.y0, p.th0);
+  for (Program::Code code :
+       {Program::NEG, Program::EXP, Program::LOG, Program::SQRT,
+        Program::SQUARE, Program::INV, Program::FABS, Program::INV_LOGIT,
+        Program::LOG1M, Program::LOG1P_EXP, Program::TANH})
+    emit(code, code == Program::LOG1M ? p.th0 : p.y0);
+  for (Program::Code code : {Program::GT, Program::GE, Program::LT, Program::LE,
+                             Program::EQ, Program::NE})
+    emit(code, p.y0, p.th0);
+  emit(Program::LOG_RANGE, p.y0, 0, 0, 2, 2);
+  emit(Program::EXP_RANGE, p.y0, 0, 0, 2, 2);
+  emit(Program::LSE2, p.y0, p.y0 + 1);
+  emit(Program::LOG_MIX, p.th0, p.y0, p.y0 + 1);
+  emit(Program::FMA, p.y0, p.th0, p.xr0);
+
+  std::string refusal;
+  const std::shared_ptr<const IslandProg> generated =
+      make_rhs_adjoint_program(p, &refusal);
+  expect("exact opcode contract is eligible", (bool)generated);
+  expect("exact opcode contract has no refusal", refusal.empty());
+  if (generated)
+    check_generated_local("exact opcode contract", p, *generated, 0.25,
+                          {0.7, 1.2}, {0.3, 0.8, 1.1}, {0.4, 0.6});
+}
+
 void check(const std::string& name, const stanli::mir::FunDef& f,
            const std::map<std::string, const stanli::mir::FunDef*>& funs,
            int n_y, int n_th, const std::vector<double>& x_r,
-           const std::vector<int>& x_i, bool want_ok) {
+           const std::vector<int>& x_i, bool want_ok, bool want_generated) {
   using namespace stanli;
   RhsProgram p = compile_rhs(f, funs, n_y, n_th, (int)x_r.size(), x_i);
   if (p.ok != want_ok) {
@@ -68,13 +194,39 @@ void check(const std::string& name, const stanli::mir::FunDef& f,
                 (int)p.ok, (int)want_ok, p.why.c_str());
     return;
   }
+  const int canonical_n_regs = p.n_regs;
+  const std::vector<Program::Instr> canonical_code = p.code;
+  std::string refusal;
+  const std::shared_ptr<const IslandProg> generated =
+      make_rhs_adjoint_program(p, &refusal);
+  bool canonical_unchanged =
+      p.n_regs == canonical_n_regs && p.code.size() == canonical_code.size();
+  for (size_t i = 0; i < p.code.size() && canonical_unchanged; ++i) {
+    const Program::Instr& got = p.code[i];
+    const Program::Instr& want = canonical_code[i];
+    canonical_unchanged = got.code == want.code && got.dst == want.dst &&
+                          got.a == want.a && got.b == want.b &&
+                          got.c == want.c && got.len == want.len;
+  }
+  expect(name + ": derivative builder preserves canonical bytecode",
+         canonical_unchanged);
   if (!want_ok) {
     if (p.why.empty()) {
       ++failures;
       std::printf("FAIL %s: refused without saying why\n", name.c_str());
     }
+    expect(name + ": compiler refusal has no derivative payload", !generated);
+    expect(name + ": compiler refusal is observable", !refusal.empty());
     return;  // the interpreter still serves it; the ODE kernel falls back
   }
+  expect(name + ": generated derivative eligibility",
+         (bool)generated == want_generated);
+  expect(name + ": generated derivative disposition is observable",
+         generated ? refusal.empty() : !refusal.empty());
+  if (!generated && (name == "f_branch" || name == "f_udf"))
+    expect(name + ": runtime control-flow refusal names JZ/JMP",
+           refusal.find("JZ") != std::string::npos ||
+               refusal.find("JMP") != std::string::npos);
 
   for (int trial = 0; trial < 12; ++trial) {
     const double t = probe(trial) * 2.0;  // straddles the t > 0.5 branch
@@ -111,6 +263,7 @@ void check(const std::string& name, const stanli::mir::FunDef& f,
         return;
       }
     }
+    if (generated) check_generated_local(name, p, *generated, t, y, th, x_r);
   }
 }
 
@@ -251,12 +404,13 @@ int main() {
     const char* name;
     int n_y, n_th;
     bool want_ok;
+    bool want_generated;
   };
   const Case cases[] = {
-      {"f_lin", 2, 4, true},
-      {"f_branch", 2, 4, true},
-      {"f_udf", 2, 4, true},
-      {"f_early", 2, 4, false},  // return out of a runtime branch
+      {"f_lin", 2, 4, true, true},
+      {"f_branch", 2, 4, true, false},  // JZ/JMP fail closed
+      {"f_udf", 2, 4, true, false},     // runtime ternary emits JZ/JMP
+      {"f_early", 2, 4, false, false},  // return from a runtime branch
   };
   for (const Case& c : cases) {
     auto it = funs.find(c.name);
@@ -265,8 +419,10 @@ int main() {
       std::printf("FAIL fixture has no function %s\n", c.name);
       continue;
     }
-    check(c.name, *it->second, funs, c.n_y, c.n_th, x_r, x_i, c.want_ok);
+    check(c.name, *it->second, funs, c.n_y, c.n_th, x_r, x_i, c.want_ok,
+          c.want_generated);
   }
+  check_exact_opcode_contract();
 
   // stan-math instantiates a var state whenever either side is active. The
   // data-y/active-theta case is included too: run_rhs is a generic boundary,
@@ -292,6 +448,37 @@ int main() {
       check_mixed_seed<false, true>(p, "double/var");
       check_mixed_seed<true, true>(p, "var/var");
       check_mixed_seed<false, false>(p, "double/double");
+
+      // gen_adjoint can differentiate DOT, but its double packet reduction is
+      // not the var replay's scalar grouping. The ODE-specific exact whitelist
+      // must refuse it before generated-adjoint construction.
+      RhsProgram with_dot = p;
+      with_dot.code.push_back(Program::Instr{Program::DOT, with_dot.n_regs,
+                                             with_dot.y0, with_dot.y0, 0, 2});
+      ++with_dot.n_regs;
+      std::string refusal;
+      expect("direct RK refuses DOT value grouping",
+             !make_rhs_adjoint_program(with_dot, &refusal));
+      expect("direct RK DOT refusal is observable",
+             refusal.find("DOT") != std::string::npos);
+
+      // C99 fmax/fmin and Stan Math's var overload choose different operands
+      // for signed-zero ties. Even an otherwise unused occurrence makes the
+      // program ineligible until the double forward can mirror var exactly.
+      for (const Program::Code opcode : {Program::FMAX, Program::FMIN}) {
+        RhsProgram with_signed_zero_tie = p;
+        with_signed_zero_tie.code.push_back(Program::Instr{
+            opcode, with_signed_zero_tie.n_regs, with_signed_zero_tie.y0,
+            with_signed_zero_tie.y0 + 1, 0, 0});
+        ++with_signed_zero_tie.n_regs;
+        refusal.clear();
+        const char* name = program_code_spec(opcode).name;
+        expect(
+            std::string("direct RK refuses ") + name + " signed-zero grouping",
+            !make_rhs_adjoint_program(with_signed_zero_tie, &refusal));
+        expect(std::string("direct RK ") + name + " refusal is observable",
+               refusal.find(name) != std::string::npos);
+      }
     }
   }
 

--- a/tests/test_odevariadic.cpp
+++ b/tests/test_odevariadic.cpp
@@ -19,6 +19,8 @@
 //      loudly.
 //   3. _tol at a tighter tolerance must sit closer to the others, not
 //      further away.
+#include "env_helpers.hpp"
+
 #include <stanli/compile.hpp>
 #include <stanli/ode.hpp>
 #include <stanli/optable.hpp>
@@ -26,12 +28,16 @@
 #include <stan/math.hpp>
 
 #include <algorithm>
+#include <atomic>
 #include <cmath>
+#include <cstdint>
 #include <cstdio>
+#include <cstring>
 #include <fstream>
 #include <limits>
 #include <sstream>
 #include <string>
+#include <thread>
 #include <type_traits>
 #include <vector>
 
@@ -47,6 +53,20 @@ static std::string slurp(const std::string& p) {
   std::ostringstream ss;
   ss << f.rdbuf();
   return ss.str();
+}
+
+static uint64_t bits(double value) {
+  uint64_t result;
+  std::memcpy(&result, &value, sizeof(result));
+  return result;
+}
+
+static bool bitwise_equal(const std::vector<double>& lhs,
+                          const std::vector<double>& rhs) {
+  if (lhs.size() != rhs.size()) return false;
+  for (size_t i = 0; i < lhs.size(); ++i)
+    if (bits(lhs[i]) != bits(rhs[i])) return false;
+  return true;
 }
 
 static void expect_close(const std::string& what, double got, double want,
@@ -99,9 +119,14 @@ OdeActivityRun direct_activity_run(const stanli::OdeSpec& spec) {
     Eigen::VectorXd y0((Eigen::Index)test_y0.size());
     for (size_t i = 0; i < test_y0.size(); ++i)
       y0((Eigen::Index)i) = test_y0[i];
-    const auto solved = stan::math::ode_rk45_tol(
-        DirectRhs{}, y0, spec.t0, spec.ts, spec.rtol, spec.atol, spec.max_steps,
-        nullptr, test_theta, spec.x_r, spec.x_i);
+    const auto solved =
+        spec.solver == stanli::OdeSpec::CKRK
+            ? stan::math::ode_ckrk_tol(DirectRhs{}, y0, spec.t0, spec.ts,
+                                       spec.rtol, spec.atol, spec.max_steps,
+                                       nullptr, test_theta, spec.x_r, spec.x_i)
+            : stan::math::ode_rk45_tol(DirectRhs{}, y0, spec.t0, spec.ts,
+                                       spec.rtol, spec.atol, spec.max_steps,
+                                       nullptr, test_theta, spec.x_r, spec.x_i);
     for (const auto& state : solved)
       for (Eigen::Index k = 0; k < state.size(); ++k)
         out.value.push_back(state(k));
@@ -111,9 +136,14 @@ OdeActivityRun direct_activity_run(const stanli::OdeSpec& spec) {
     for (size_t i = 0; i < test_y0.size(); ++i)
       y0((Eigen::Index)i) = test_y0[i];
     std::vector<T_theta> theta(test_theta.begin(), test_theta.end());
-    const auto solved = stan::math::ode_rk45_tol(
-        DirectRhs{}, y0, spec.t0, spec.ts, spec.rtol, spec.atol, spec.max_steps,
-        nullptr, theta, spec.x_r, spec.x_i);
+    const auto solved =
+        spec.solver == stanli::OdeSpec::CKRK
+            ? stan::math::ode_ckrk_tol(DirectRhs{}, y0, spec.t0, spec.ts,
+                                       spec.rtol, spec.atol, spec.max_steps,
+                                       nullptr, theta, spec.x_r, spec.x_i)
+            : stan::math::ode_rk45_tol(DirectRhs{}, y0, spec.t0, spec.ts,
+                                       spec.rtol, spec.atol, spec.max_steps,
+                                       nullptr, theta, spec.x_r, spec.x_i);
     stan::math::var weighted = 0.0;
     size_t o = 0;
     for (const auto& state : solved)
@@ -133,21 +163,24 @@ OdeActivityRun direct_activity_run(const stanli::OdeSpec& spec) {
 }
 
 template <bool YAutodiff, bool ThetaAutodiff>
-OdeActivityRun kernel_activity_run(const stanli::OdeSpec& spec) {
+OdeActivityRun kernel_activity_run(
+    const stanli::OdeSpec& spec, const std::vector<double>& y0_values = test_y0,
+    const std::vector<double>& theta_values = test_theta) {
   using namespace stanli;
   OdeActivityRun out;
-  out.value.assign(spec.ts.size() * test_y0.size(), 0.0);
-  out.y_grad.assign(test_y0.size(), 0.0);
-  out.theta_grad.assign(test_theta.size(), 0.0);
-  out.jacobian.assign(out.value.size() * (test_y0.size() + test_theta.size()),
-                      std::numeric_limits<double>::quiet_NaN());
+  out.value.assign(spec.ts.size() * y0_values.size(), 0.0);
+  out.y_grad.assign(y0_values.size(), 0.0);
+  out.theta_grad.assign(theta_values.size(), 0.0);
+  out.jacobian.assign(
+      out.value.size() * (y0_values.size() + theta_values.size()),
+      std::numeric_limits<double>::quiet_NaN());
 
   KernelCtx ctx;
   ctx.n_in = 2;
   ctx.in[0] =
-      Desc{const_cast<double*>(test_y0.data()), (int64_t)test_y0.size()};
-  ctx.in[1] =
-      Desc{const_cast<double*>(test_theta.data()), (int64_t)test_theta.size()};
+      Desc{const_cast<double*>(y0_values.data()), (int64_t)y0_values.size()};
+  ctx.in[1] = Desc{const_cast<double*>(theta_values.data()),
+                   (int64_t)theta_values.size()};
   ctx.out = Desc{out.value.data(), (int64_t)out.value.size()};
   ctx.scratch = out.jacobian.data();
   ctx.udata = &spec;
@@ -167,14 +200,14 @@ OdeActivityRun kernel_activity_run(const stanli::OdeSpec& spec) {
   // backward must not rely on 0 * adjoint being harmless: a stale/poisoned
   // column can contain NaN. Poison those columns after checking forward and
   // require the type mask, rather than mere buffer presence, to gate scatter.
-  const size_t width = test_y0.size() + test_theta.size();
+  const size_t width = y0_values.size() + theta_values.size();
   for (size_t o = 0; o < out.value.size(); ++o) {
     if constexpr (!YAutodiff)
-      for (size_t i = 0; i < test_y0.size(); ++i)
+      for (size_t i = 0; i < y0_values.size(); ++i)
         out.jacobian[o * width + i] = std::numeric_limits<double>::quiet_NaN();
     if constexpr (!ThetaAutodiff)
-      for (size_t i = 0; i < test_theta.size(); ++i)
-        out.jacobian[o * width + test_y0.size() + i] =
+      for (size_t i = 0; i < theta_values.size(); ++i)
+        out.jacobian[o * width + y0_values.size() + i] =
             std::numeric_limits<double>::quiet_NaN();
   }
   ode->backward(ctx);
@@ -184,10 +217,23 @@ OdeActivityRun kernel_activity_run(const stanli::OdeSpec& spec) {
 
 template <bool YAutodiff, bool ThetaAutodiff>
 void check_activity_case(const stanli::OdeSpec& spec, const char* label) {
+  stanli::OdeSpec oracle_spec = spec;
+  oracle_spec.direct_rk_enabled = false;
+  const OdeActivityRun oracle =
+      kernel_activity_run<YAutodiff, ThetaAutodiff>(oracle_spec);
+  stanli::OdeSpec direct_spec = spec;
+  direct_spec.direct_rk_enabled = true;
   const OdeActivityRun got =
-      kernel_activity_run<YAutodiff, ThetaAutodiff>(spec);
+      kernel_activity_run<YAutodiff, ThetaAutodiff>(direct_spec);
   const OdeActivityRun want =
       direct_activity_run<YAutodiff, ThetaAutodiff>(spec);
+  const std::string prefix = std::string(label) + ": direct/oracle ";
+  expect(prefix + "solution bits", bitwise_equal(got.value, oracle.value));
+  expect(prefix + "full scratch bits",
+         bitwise_equal(got.jacobian, oracle.jacobian));
+  expect(prefix + "y pullback bits", bitwise_equal(got.y_grad, oracle.y_grad));
+  expect(prefix + "theta pullback bits",
+         bitwise_equal(got.theta_grad, oracle.theta_grad));
   expect(std::string(label) + " output shape",
          got.value.size() == want.value.size());
   for (size_t i = 0; i < got.value.size() && i < want.value.size(); ++i)
@@ -205,12 +251,111 @@ void check_activity_case(const stanli::OdeSpec& spec, const char* label) {
     if constexpr (!YAutodiff)
       for (size_t i = 0; i < test_y0.size(); ++i)
         expect(std::string(label) + " zero y Jacobian column",
-               got.jacobian[o * width + i] == 0.0);
+               bits(got.jacobian[o * width + i]) == bits(0.0));
     if constexpr (!ThetaAutodiff)
       for (size_t i = 0; i < test_theta.size(); ++i)
         expect(std::string(label) + " zero theta Jacobian column",
-               got.jacobian[o * width + test_y0.size() + i] == 0.0);
+               bits(got.jacobian[o * width + test_y0.size() + i]) == bits(0.0));
   }
+}
+
+struct OdeError {
+  bool threw = false;
+  std::string type;
+  std::string message;
+};
+
+static OdeError capture_ode_error(
+    const stanli::OdeSpec& spec, bool use_direct,
+    const std::vector<double>& y0_values = test_y0,
+    const std::vector<double>& theta_values = test_theta) {
+  stanli::OdeSpec selected_spec = spec;
+  selected_spec.direct_rk_enabled = use_direct;
+  OdeError result;
+  try {
+    (void)kernel_activity_run<true, true>(selected_spec, y0_values,
+                                          theta_values);
+  } catch (const std::exception& error) {
+    result.threw = true;
+    result.type = typeid(error).name();
+    result.message = error.what();
+  }
+  return result;
+}
+
+static void check_error_parity(
+    const stanli::OdeSpec& spec, const std::string& label,
+    const std::vector<double>& y0_values = test_y0,
+    const std::vector<double>& theta_values = test_theta) {
+  const OdeError oracle =
+      capture_ode_error(spec, false, y0_values, theta_values);
+  const OdeError direct =
+      capture_ode_error(spec, true, y0_values, theta_values);
+  expect(label + ": oracle throws", oracle.threw);
+  expect(label + ": direct throws", direct.threw);
+  expect(label + ": exception type", direct.type == oracle.type);
+  expect(label + ": exception message", direct.message == oracle.message);
+}
+
+// OdeSpec and its generated derivative payload are graph-owned and shared by
+// executor copies. The mutable direct-RK register/Jacobian buffers must remain
+// thread-local: otherwise two chains can agree in a serial test and corrupt
+// each other as soon as multiple chains evaluate the same model concurrently.
+static void check_shared_spec_threads(const stanli::OdeSpec& spec) {
+  stanli::OdeSpec direct_spec = spec;
+  direct_spec.direct_rk_enabled = true;
+
+  constexpr int kThreads = 4;
+  constexpr int kRepeats = 6;
+  std::vector<std::vector<double>> y0(kThreads, test_y0);
+  std::vector<std::vector<double>> theta(kThreads, test_theta);
+  std::vector<OdeActivityRun> expected;
+  expected.reserve(kThreads);
+  for (int thread = 0; thread < kThreads; ++thread) {
+    y0[(size_t)thread][0] += 0.07 * thread;
+    y0[(size_t)thread][1] -= 0.04 * thread;
+    theta[(size_t)thread][0] += 0.03 * thread;
+    theta[(size_t)thread][1] += 0.02 * thread;
+    expected.push_back(kernel_activity_run<true, true>(
+        direct_spec, y0[(size_t)thread], theta[(size_t)thread]));
+  }
+
+  std::atomic<int> ready{0};
+  std::atomic<bool> start{false};
+  std::vector<std::string> errors(kThreads);
+  std::vector<std::thread> threads;
+  threads.reserve(kThreads);
+  for (int thread = 0; thread < kThreads; ++thread) {
+    threads.emplace_back([&, thread] {
+      ready.fetch_add(1, std::memory_order_release);
+      while (!start.load(std::memory_order_acquire)) std::this_thread::yield();
+      try {
+        for (int repeat = 0; repeat < kRepeats; ++repeat) {
+          const OdeActivityRun got = kernel_activity_run<true, true>(
+              direct_spec, y0[(size_t)thread], theta[(size_t)thread]);
+          const OdeActivityRun& want = expected[(size_t)thread];
+          if (!bitwise_equal(got.value, want.value) ||
+              !bitwise_equal(got.jacobian, want.jacobian) ||
+              !bitwise_equal(got.y_grad, want.y_grad) ||
+              !bitwise_equal(got.theta_grad, want.theta_grad)) {
+            errors[(size_t)thread] =
+                "direct result differs from the serial shared-spec result";
+            break;
+          }
+        }
+      } catch (const std::exception& error) {
+        errors[(size_t)thread] = error.what();
+      }
+    });
+  }
+  while (ready.load(std::memory_order_acquire) != kThreads)
+    std::this_thread::yield();
+  start.store(true, std::memory_order_release);
+  for (auto& thread : threads) thread.join();
+
+  for (int thread = 0; thread < kThreads; ++thread)
+    expect("shared OdeSpec thread " + std::to_string(thread),
+           errors[(size_t)thread].empty());
 }
 
 static void check_precomputed_jacobian_harvest() {
@@ -246,26 +391,55 @@ static void check_precomputed_jacobian_harvest() {
   }
 }
 
-static const stanli::OdeSpec* fixture_rk45_spec(const stanli::Graph& graph) {
+static const stanli::OdeSpec* fixture_spec(
+    const stanli::Graph& graph, stanli::OdeSpec::Solver solver,
+    const std::string& rhs_name = "rhs") {
   using namespace stanli;
   for (const Op& op : graph.ops)
     if (op.opcode == OP_ODE) {
       const auto* spec = static_cast<const OdeSpec*>(op.udata);
-      if (!spec->legacy && spec->solver == OdeSpec::RK45 &&
-          spec->rhs_name == "rhs")
+      if (!spec->legacy && spec->solver == solver && spec->rhs_name == rhs_name)
         return spec;
     }
   return nullptr;
+}
+
+static stanli::CompiledModel compile_ode_fixture(const std::string& mir_text,
+                                                 const stanli::DataMap& data,
+                                                 bool disable_direct_rk) {
+  const char* selector = "STANLI_NO_ODE_DIRECT_RK";
+  disable_direct_rk ? test_setenv(selector, "1", 1) : test_unsetenv(selector);
+  try {
+    stanli::CompiledModel cm = stanli::compile_model(mir_text, data);
+    test_unsetenv(selector);
+    return cm;
+  } catch (...) {
+    test_unsetenv(selector);
+    throw;
+  }
 }
 
 int main() {
   using namespace stanli;
 
   DataMap data = DataMap::from_json_file("tests/fixtures/odevariadic.json");
-  CompiledModel cm =
-      compile_model(slurp("tests/fixtures/odevariadic.tmir.sexp"), data);
-  const OdeSpec* rk45_spec = fixture_rk45_spec(cm.graph);
+  const std::string mir_text = slurp("tests/fixtures/odevariadic.tmir.sexp");
+  CompiledModel cm = compile_ode_fixture(mir_text, data, false);
+  CompiledModel oracle_cm = compile_ode_fixture(mir_text, data, true);
+  const OdeSpec* rk45_spec = fixture_spec(cm.graph, OdeSpec::RK45);
+  const OdeSpec* ckrk_spec = fixture_spec(cm.graph, OdeSpec::CKRK);
+  const OdeSpec* mixed_rk45_spec =
+      fixture_spec(cm.graph, OdeSpec::RK45, "rhs_mixed");
   expect("fixture exposes a modern rk45 rhs", rk45_spec != nullptr);
+  expect("fixture exposes a modern ckrk rhs", ckrk_spec != nullptr);
+  expect("fixture exposes a mixed-data rk45 rhs", mixed_rk45_spec != nullptr);
+  const OdeSpec* oracle_rk45_spec =
+      fixture_spec(oracle_cm.graph, OdeSpec::RK45);
+  expect("oracle fixture exposes a modern rk45 rhs",
+         oracle_rk45_spec != nullptr);
+  if (oracle_rk45_spec)
+    expect("inverse selector disables direct RK at lowering",
+           !oracle_rk45_spec->direct_rk_enabled);
 
   bool log_has_vv = false, log_has_vd = false, log_has_dv = false;
   for (const Op& op : cm.graph.ops)
@@ -293,14 +467,83 @@ int main() {
   check_precomputed_jacobian_harvest();
 
   if (rk45_spec) {
+    expect("branchless RK45 has a direct derivative payload",
+           (bool)rk45_spec->direct_rk && rk45_spec->direct_rk_why.empty() &&
+               rk45_spec->direct_rk_enabled);
     check_activity_case<true, false>(*rk45_spec, "active y/data theta");
     check_activity_case<false, true>(*rk45_spec, "data y/active theta");
     check_activity_case<true, true>(*rk45_spec, "active y/active theta");
     check_activity_case<false, false>(*rk45_spec, "data y/data theta");
+    check_shared_spec_threads(*rk45_spec);
+
+    OdeSpec invalid = *rk45_spec;
+    invalid.rtol = 0.0;
+    check_error_parity(invalid, "RK45 invalid relative tolerance");
+    invalid = *rk45_spec;
+    invalid.ts.clear();
+    check_error_parity(invalid, "RK45 empty times");
+    invalid = *rk45_spec;
+    invalid.ts[0] = invalid.t0;
+    check_error_parity(invalid, "RK45 time equals initial time");
+    invalid = *rk45_spec;
+    invalid.max_steps = 0;
+    check_error_parity(invalid, "RK45 invalid max steps");
+    std::vector<double> invalid_y0 = test_y0;
+    invalid_y0[0] = std::numeric_limits<double>::quiet_NaN();
+    check_error_parity(*rk45_spec, "RK45 nonfinite initial state", invalid_y0);
+    std::vector<double> invalid_theta = test_theta;
+    invalid_theta[1] = std::numeric_limits<double>::infinity();
+    check_error_parity(*rk45_spec, "RK45 nonfinite parameter", test_y0,
+                       invalid_theta);
+    invalid = *rk45_spec;
+    invalid.t0 = std::numeric_limits<double>::quiet_NaN();
+    check_error_parity(invalid, "RK45 nonfinite initial time");
+    invalid = *rk45_spec;
+    invalid.ts[1] = std::numeric_limits<double>::infinity();
+    check_error_parity(invalid, "RK45 nonfinite output time");
+    invalid = *rk45_spec;
+    std::swap(invalid.ts[0], invalid.ts[1]);
+    check_error_parity(invalid, "RK45 unordered output times");
+    invalid = *rk45_spec;
+    invalid.max_steps = 1;
+    check_error_parity(invalid, "RK45 integration step limit");
+
+    OdeSpec legacy = *rk45_spec;
+    legacy.legacy = true;
+    check_activity_case<true, true>(legacy, "legacy RK45 active y/theta");
+    legacy.rtol = 0.0;
+    check_error_parity(legacy, "legacy RK45 invalid relative tolerance");
+  }
+  if (mixed_rk45_spec) {
+    expect("mixed-data RK45 has a direct derivative payload",
+           (bool)mixed_rk45_spec->direct_rk &&
+               mixed_rk45_spec->direct_rk_why.empty() &&
+               mixed_rk45_spec->direct_rk_enabled);
+    expect("mixed-data RK45 exposes one real datum and three parameters",
+           mixed_rk45_spec->x_r.size() == 1 &&
+               mixed_rk45_spec->prog.n_xr == 1 &&
+               mixed_rk45_spec->prog.n_th == 3);
+    if (mixed_rk45_spec->x_r.size() == 1 && mixed_rk45_spec->prog.n_xr == 1 &&
+        mixed_rk45_spec->prog.n_th == 3) {
+      OdeSpec invalid = *mixed_rk45_spec;
+      invalid.x_r[0] = std::numeric_limits<double>::quiet_NaN();
+      check_error_parity(invalid, "RK45 nonfinite real data", test_y0,
+                         {0.2, 0.35, 0.4});
+    }
+  }
+  if (ckrk_spec) {
+    expect("branchless CKRK has a direct derivative payload",
+           (bool)ckrk_spec->direct_rk && ckrk_spec->direct_rk_why.empty() &&
+               ckrk_spec->direct_rk_enabled);
+    check_activity_case<true, false>(*ckrk_spec, "CKRK active y/data theta");
+    check_activity_case<false, true>(*ckrk_spec, "CKRK data y/active theta");
+    check_activity_case<true, true>(*ckrk_spec, "CKRK active y/theta");
   }
 
   Executor ex(std::move(cm.graph));
   cm.bind(ex);
+  Executor oracle_ex(std::move(oracle_cm.graph));
+  oracle_cm.bind(oracle_ex);
 
   // a, b, p[2], y0[2]
   const int64_t n = ex.n_params();
@@ -310,10 +553,19 @@ int main() {
   std::vector<double> q((size_t)n);
   for (int64_t i = 0; i < n; ++i) q[(size_t)i] = -0.3 + 0.11 * (double)i;
 
-  std::vector<double> grad((size_t)n);
-  for (int64_t i = 0; i < n; ++i) ex.params_data()[i] = q[(size_t)i];
+  std::vector<double> grad((size_t)n), oracle_grad((size_t)n);
+  expect("oracle model has the same parameter count",
+         oracle_ex.n_params() == n);
+  for (int64_t i = 0; i < n; ++i) {
+    ex.params_data()[i] = q[(size_t)i];
+    oracle_ex.params_data()[i] = q[(size_t)i];
+  }
+  const double oracle_lp = oracle_ex.gradient(oracle_grad.data());
   const double lp = ex.gradient(grad.data());
   expect("lp is finite", std::isfinite(lp));
+  expect("whole-model direct/oracle lp bits", bits(lp) == bits(oracle_lp));
+  expect("whole-model direct/oracle gradient bits",
+         bitwise_equal(grad, oracle_grad));
 
   // ---- the value-only forward ------------------------------------------
   // ode_fwd is the only kernel that skips work under forward_value_only:

--- a/tools/bench_cmdstan_grad.cpp
+++ b/tools/bench_cmdstan_grad.cpp
@@ -43,7 +43,16 @@ int main(int argc, char** argv) {
     stan::math::recover_memory();
   };
 
-  for (int i = 0; i < 200; ++i) one();
+  // Warm by elapsed time, as bench_grad does.  A fixed count is much too
+  // short for small ODE systems and makes fresh-process paired measurements
+  // depend on which arm happened to run first on a cold core.
+  {
+    auto warmup_start = std::chrono::steady_clock::now();
+    do {
+      one();
+    } while (std::chrono::steady_clock::now() - warmup_start <
+             std::chrono::milliseconds(200));
+  }
   auto t0 = std::chrono::steady_clock::now();
   for (int i = 0; i < N; ++i) one();
   auto t1 = std::chrono::steady_clock::now();

--- a/tools/bench_ode_ceiling.cpp
+++ b/tools/bench_ode_ceiling.cpp
@@ -1,0 +1,1256 @@
+// Developer-only ceiling benchmark for direct coupled RK sensitivities.
+//
+// The production ODE path asks Stan Math to discover RHS Jacobians with a
+// nested reverse-mode callback.  This tool keeps the same pinned RK45/CKRK
+// implementation's Boost tableau, coupled-state error control, tolerances,
+// step checker, and output observer, but presents a manually assembled
+// all-double coupled system directly to integrate_times. It thereby measures
+// the ceiling from removing nested autodiff and the ordinary-RHS adapter
+// without changing the numerical solver.
+//
+// Two developer-only Jacobian providers are available:
+//
+//   generated  a double forward plus the existing generated register adjoint;
+//   fvar       one branch-aware fvar<double> column replay per input.
+//
+// The generated provider is deliberately *not* the failed Phase 0 bridge: it
+// constructs no precomputed-gradient callback nodes and is never installed in
+// the runtime.  Generation happens against a copy, leaving OdeSpec::prog as
+// the pristine value/oracle program.
+//
+// Usage:
+//   bench_ode_ceiling MODEL.tmir.sexp DATA.json [options]
+//
+// Options:
+//   --provider auto|generated|fvar   (default: auto)
+//   --solver model|rk45|ckrk         (default: model)
+//   --point 0|1|2                    deterministic unconstrained point
+//   --iterations N                   solves per timing batch (default: 200)
+//   --batches N                      alternating paired batches (default: 15)
+//   --warmup-ms N                    warmup duration per arm (default: 200)
+//   --diagnostic                     print perturbative component timers
+#include <stan/math/fwd.hpp>
+
+#include <stanli/compile.hpp>
+#include <stanli/graph.hpp>
+#include <stanli/island.hpp>
+#include <stanli/ode.hpp>
+#include <stanli/ode_prog.hpp>
+#include <stanli/optable.hpp>
+#include <stanli/program.hpp>
+
+#include <stan/math.hpp>
+
+#include <algorithm>
+#include <chrono>
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <fstream>
+#include <limits>
+#include <numeric>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+namespace stanli {
+
+// ODE RHS programs do not contain log-density instructions.  Supplying this
+// developer-tool-only specialization lets the generic register interpreter be
+// instantiated for fvar without adding an fvar density ABI to libstanli.  A
+// surprising density remains an explicit refusal, not silently differentiated.
+template <>
+stan::math::fvar<double> program_density<stan::math::fvar<double>>(
+    int, const stan::math::fvar<double>*) {
+  throw std::logic_error("density instruction in ODE fvar replay");
+}
+
+}  // namespace stanli
+
+namespace {
+
+using Clock = std::chrono::steady_clock;
+using TimePoint = Clock::time_point;
+using stan::math::fvar;
+using stan::math::var;
+using stanli::AdjProgram;
+using stanli::IslandProg;
+using stanli::OdeSpec;
+using stanli::Program;
+using stanli::RhsProgram;
+
+volatile double benchmark_sink = 0.0;
+
+std::string slurp(const std::string& path) {
+  std::ifstream in(path, std::ios::binary);
+  if (!in) throw std::runtime_error("cannot open " + path);
+  std::ostringstream out;
+  out << in.rdbuf();
+  if (in.bad()) throw std::runtime_error("cannot read " + path);
+  return out.str();
+}
+
+uint64_t bits(double x) {
+  uint64_t result;
+  std::memcpy(&result, &x, sizeof(result));
+  return result;
+}
+
+int positive_int(const std::string& text, const char* name) {
+  char* end = nullptr;
+  const long value = std::strtol(text.c_str(), &end, 10);
+  if (text.empty() || !end || *end != '\0' || value <= 0 || value > 100000000L)
+    throw std::runtime_error(std::string(name) + " must be a positive integer");
+  return static_cast<int>(value);
+}
+
+int nonnegative_int(const std::string& text, const char* name) {
+  char* end = nullptr;
+  const long value = std::strtol(text.c_str(), &end, 10);
+  if (text.empty() || !end || *end != '\0' || value < 0 || value > 2)
+    throw std::runtime_error(std::string(name) + " must be 0, 1, or 2");
+  return static_cast<int>(value);
+}
+
+int nonnegative_duration(const std::string& text, const char* name) {
+  char* end = nullptr;
+  const long value = std::strtol(text.c_str(), &end, 10);
+  if (text.empty() || !end || *end != '\0' || value < 0 || value > 60000)
+    throw std::runtime_error(std::string(name) +
+                             " must be between 0 and 60000");
+  return static_cast<int>(value);
+}
+
+double eval_point(int64_t i, int variant) {
+  switch (variant) {
+    case 1:
+      return 0.02 * static_cast<double>((i % 5) - 2);
+    case 2:
+      return 0.0;
+    default:
+      return 0.1 + 0.05 * static_cast<double>(i % 7) -
+             0.15 * static_cast<double>(i % 3);
+  }
+}
+
+int64_t elapsed_ns(TimePoint begin) {
+  return std::chrono::duration_cast<std::chrono::nanoseconds>(Clock::now() -
+                                                              begin)
+      .count();
+}
+
+struct Options {
+  std::string mir;
+  std::string data;
+  std::string provider = "auto";
+  std::string solver = "model";
+  int point = 0;
+  int iterations = 200;
+  int batches = 15;
+  int warmup_ms = 200;
+  bool diagnostic = false;
+  bool require_exact = false;
+};
+
+void usage() {
+  std::fprintf(stderr,
+               "usage: bench_ode_ceiling MODEL.tmir.sexp DATA.json "
+               "[--provider auto|generated|fvar] [--solver model|rk45|ckrk] "
+               "[--point 0|1|2] [--iterations N] [--batches N] "
+               "[--warmup-ms N] [--diagnostic] [--require-exact]\n");
+}
+
+Options parse_options(int argc, char** argv) {
+  if (argc == 2 &&
+      (std::string(argv[1]) == "--help" || std::string(argv[1]) == "-h")) {
+    usage();
+    std::exit(0);
+  }
+  if (argc < 3) {
+    usage();
+    throw std::runtime_error("missing MIR or data path");
+  }
+  Options out;
+  out.mir = argv[1];
+  out.data = argv[2];
+  for (int i = 3; i < argc; ++i) {
+    const std::string arg = argv[i];
+    auto value = [&](const char* flag) -> std::string {
+      if (i + 1 >= argc)
+        throw std::runtime_error(std::string(flag) + " needs a value");
+      return argv[++i];
+    };
+    if (arg == "--provider")
+      out.provider = value("--provider");
+    else if (arg == "--solver")
+      out.solver = value("--solver");
+    else if (arg == "--point")
+      out.point = nonnegative_int(value("--point"), "--point");
+    else if (arg == "--iterations")
+      out.iterations = positive_int(value("--iterations"), "--iterations");
+    else if (arg == "--batches")
+      out.batches = positive_int(value("--batches"), "--batches");
+    else if (arg == "--warmup-ms")
+      out.warmup_ms = nonnegative_duration(value("--warmup-ms"), "--warmup-ms");
+    else if (arg == "--diagnostic")
+      out.diagnostic = true;
+    else if (arg == "--require-exact")
+      out.require_exact = true;
+    else if (arg == "--help" || arg == "-h") {
+      usage();
+      std::exit(0);
+    } else {
+      throw std::runtime_error("unknown option " + arg);
+    }
+  }
+  if (out.provider != "auto" && out.provider != "generated" &&
+      out.provider != "fvar")
+    throw std::runtime_error("--provider must be auto, generated, or fvar");
+  if (out.solver != "model" && out.solver != "rk45" && out.solver != "ckrk")
+    throw std::runtime_error("--solver must be model, rk45, or ckrk");
+  return out;
+}
+
+enum class RkSolver { RK45, CKRK };
+
+const char* solver_name(RkSolver solver) {
+  return solver == RkSolver::RK45 ? "rk45" : "ckrk";
+}
+
+const char* spec_solver_name(OdeSpec::Solver solver) {
+  switch (solver) {
+    case OdeSpec::RK45:
+      return "rk45";
+    case OdeSpec::BDF:
+      return "bdf";
+    case OdeSpec::ADAMS:
+      return "adams";
+    case OdeSpec::CKRK:
+      return "ckrk";
+  }
+  return "unknown";
+}
+
+RkSolver select_solver(const Options& options, const OdeSpec& spec) {
+  if (options.solver == "rk45") return RkSolver::RK45;
+  if (options.solver == "ckrk") return RkSolver::CKRK;
+  if (spec.solver == OdeSpec::RK45) return RkSolver::RK45;
+  if (spec.solver == OdeSpec::CKRK) return RkSolver::CKRK;
+  throw std::runtime_error("model's first ODE uses " +
+                           std::string(spec_solver_name(spec.solver)) +
+                           "; pass --solver rk45 or --solver ckrk for the "
+                           "developer RK ceiling experiment");
+}
+
+struct Breakdown {
+  uint64_t callbacks = 0;
+  size_t accepted_steps = 0;
+  int64_t callback_ns = 0;
+  int64_t seed_ns = 0;
+  int64_t body_ns = 0;
+  int64_t output_ns = 0;
+  int64_t jacobian_ns = 0;
+  int64_t propagation_ns = 0;
+  int64_t solver_ns = 0;
+  int64_t final_ns = 0;
+};
+
+struct SolveResult {
+  std::vector<double> values;
+  std::vector<double> jacobian;
+};
+
+struct CompareResult {
+  size_t total = 0;
+  size_t bitwise = 0;
+  double max_relative = 0.0;
+  size_t worst = 0;
+};
+
+CompareResult compare(const std::vector<double>& got,
+                      const std::vector<double>& want) {
+  if (got.size() != want.size())
+    throw std::runtime_error(
+        "comparison size mismatch: " + std::to_string(got.size()) + " versus " +
+        std::to_string(want.size()));
+  CompareResult result;
+  result.total = got.size();
+  for (size_t i = 0; i < got.size(); ++i) {
+    const bool exact = bits(got[i]) == bits(want[i]);
+    if (exact) ++result.bitwise;
+    if (!std::isfinite(got[i]) || !std::isfinite(want[i])) {
+      result.max_relative = std::numeric_limits<double>::infinity();
+      result.worst = i;
+      continue;
+    }
+    if (exact) continue;
+    double relative = std::numeric_limits<double>::infinity();
+    const double scale =
+        std::max({1e-12, std::fabs(got[i]), std::fabs(want[i])});
+    relative = std::fabs(got[i] - want[i]) / scale;
+    if (relative > result.max_relative) {
+      result.max_relative = relative;
+      result.worst = i;
+    }
+  }
+  return result;
+}
+
+void print_compare(const char* label, const CompareResult& result) {
+  std::printf("%s bitwise=%zu/%zu max_relative=%.9g worst=%zu\n", label,
+              result.bitwise, result.total, result.max_relative, result.worst);
+}
+
+std::string structural_refusal(const Program& program) {
+  std::vector<std::string> names;
+  for (const auto& instruction : program.code) {
+    const auto& spec = stanli::program_code_spec(instruction.code);
+    if (!spec.has(stanli::kProgramNoAdjoint)) continue;
+    if (std::find(names.begin(), names.end(), spec.name) == names.end())
+      names.emplace_back(spec.name);
+  }
+  std::string result;
+  for (const auto& name : names) {
+    if (!result.empty()) result += ", ";
+    result += name;
+  }
+  return result;
+}
+
+// The exact Phase 1 callback, copied into the developer target so the current
+// solve can be timed without changing runtime/kernels/ode.cpp.
+template <bool Diagnostic>
+struct OracleRhs {
+  const OdeSpec* spec;
+  Breakdown* breakdown;
+
+  template <typename T_y, typename T_param>
+  Eigen::Matrix<stan::return_type_t<T_y, T_param>, Eigen::Dynamic, 1>
+  operator()(const double& t, const Eigen::Matrix<T_y, Eigen::Dynamic, 1>& y,
+             std::ostream*, const std::vector<T_param>& theta,
+             const std::vector<double>& x_r, const std::vector<int>&) const {
+    using T = stan::return_type_t<T_y, T_param>;
+    TimePoint callback_start;
+    if constexpr (Diagnostic) {
+      ++breakdown->callbacks;
+      callback_start = Clock::now();
+    }
+
+    Eigen::Matrix<T, Eigen::Dynamic, 1> out(
+        static_cast<Eigen::Index>(spec->prog.out_regs.size()));
+    std::vector<T>& registers = stanli::rhs_regs<T>();
+
+    TimePoint phase;
+    if constexpr (Diagnostic) phase = Clock::now();
+    if (static_cast<int>(registers.size()) < spec->prog.n_regs)
+      registers.resize(static_cast<size_t>(spec->prog.n_regs));
+    for (int i = 0; i < spec->prog.n_y; ++i)
+      registers[static_cast<size_t>(spec->prog.y0 + i)] = T(y(i));
+    for (int i = 0; i < spec->prog.n_th; ++i)
+      registers[static_cast<size_t>(spec->prog.th0 + i)] = T(theta[i]);
+    // Retain Phase 1's promotion of an unread variadic placeholder.
+    for (size_t i = static_cast<size_t>(spec->prog.n_th); i < theta.size();
+         ++i) {
+      [[maybe_unused]] const T promoted(theta[i]);
+    }
+    registers[static_cast<size_t>(spec->prog.t_reg)] = T(t);
+    for (int i = 0; i < spec->prog.n_xr; ++i)
+      registers[static_cast<size_t>(spec->prog.xr0 + i)] = T(x_r[i]);
+    if constexpr (Diagnostic) {
+      breakdown->seed_ns += elapsed_ns(phase);
+      phase = Clock::now();
+    }
+
+    stanli::run_program(spec->prog, registers);
+    if constexpr (Diagnostic) {
+      breakdown->body_ns += elapsed_ns(phase);
+      phase = Clock::now();
+    }
+    for (size_t i = 0; i < spec->prog.out_regs.size(); ++i)
+      out(static_cast<Eigen::Index>(i)) =
+          registers[static_cast<size_t>(spec->prog.out_regs[i])];
+    if constexpr (Diagnostic) {
+      breakdown->output_ns += elapsed_ns(phase);
+      breakdown->callback_ns += elapsed_ns(callback_start);
+    }
+    return out;
+  }
+};
+
+template <typename Rhs, typename T_y0, typename T_theta>
+auto call_rk_solver(RkSolver solver, const OdeSpec& spec, const Rhs& rhs,
+                    const Eigen::Matrix<T_y0, Eigen::Dynamic, 1>& y0,
+                    const std::vector<T_theta>& theta) {
+  if (solver == RkSolver::RK45) {
+    return stan::math::ode_rk45_tol_impl(
+        spec.legacy ? "integrate_ode_rk45" : "ode_rk45_tol", rhs, y0, spec.t0,
+        spec.ts, spec.rtol, spec.atol, spec.max_steps, nullptr, theta, spec.x_r,
+        spec.x_i);
+  }
+  return stan::math::ode_ckrk_tol_impl(
+      "ode_ckrk_tol", rhs, y0, spec.t0, spec.ts, spec.rtol, spec.atol,
+      spec.max_steps, nullptr, theta, spec.x_r, spec.x_i);
+}
+
+template <bool YAutodiff, bool ThetaAutodiff, bool Diagnostic>
+SolveResult run_oracle_typed(RkSolver solver, const OdeSpec& spec,
+                             const std::vector<double>& y0_values,
+                             const std::vector<double>& theta_values,
+                             Breakdown* breakdown) {
+  using T_y0 = std::conditional_t<YAutodiff, var, double>;
+  using T_theta = std::conditional_t<ThetaAutodiff, var, double>;
+  const size_t S = y0_values.size();
+  const size_t P = theta_values.size();
+  const size_t W = S + P;
+  SolveResult result;
+  result.values.resize(spec.ts.size() * S);
+  result.jacobian.assign(result.values.size() * W, 0.0);
+
+  if constexpr (!YAutodiff && !ThetaAutodiff) {
+    Eigen::Matrix<T_y0, Eigen::Dynamic, 1> y0(S);
+    for (size_t i = 0; i < S; ++i)
+      y0(static_cast<Eigen::Index>(i)) = y0_values[i];
+    std::vector<T_theta> theta(theta_values.begin(), theta_values.end());
+    OracleRhs<Diagnostic> rhs{&spec, breakdown};
+    TimePoint phase;
+    if constexpr (Diagnostic) phase = Clock::now();
+    const auto solution = call_rk_solver(solver, spec, rhs, y0, theta);
+    if constexpr (Diagnostic) {
+      breakdown->solver_ns = elapsed_ns(phase);
+      phase = Clock::now();
+    }
+    for (size_t n = 0; n < solution.size(); ++n)
+      for (size_t i = 0; i < S; ++i)
+        result.values[n * S + i] = solution[n](static_cast<Eigen::Index>(i));
+    if constexpr (Diagnostic) breakdown->final_ns = elapsed_ns(phase);
+    return result;
+  } else {
+    stan::math::nested_rev_autodiff nested;
+    Eigen::Matrix<T_y0, Eigen::Dynamic, 1> y0(S);
+    for (size_t i = 0; i < S; ++i)
+      y0(static_cast<Eigen::Index>(i)) = y0_values[i];
+    std::vector<T_theta> theta(theta_values.begin(), theta_values.end());
+    OracleRhs<Diagnostic> rhs{&spec, breakdown};
+    TimePoint phase;
+    if constexpr (Diagnostic) phase = Clock::now();
+    const auto solution = call_rk_solver(solver, spec, rhs, y0, theta);
+    if constexpr (Diagnostic) {
+      breakdown->solver_ns = elapsed_ns(phase);
+      phase = Clock::now();
+    }
+
+    for (size_t n = 0; n < solution.size(); ++n)
+      for (size_t i = 0; i < S; ++i)
+        result.values[n * S + i] =
+            solution[n](static_cast<Eigen::Index>(i)).val();
+
+    stan::math::set_zero_all_adjoints_nested();
+    for (size_t o = result.values.size(); o-- > 0;) {
+      auto* output = solution[o / S](static_cast<Eigen::Index>(o % S)).vi_;
+      output->adj_ = 1.0;
+      output->chain();
+      if constexpr (YAutodiff) {
+        for (size_t i = 0; i < S; ++i) {
+          result.jacobian[o * W + i] = y0(static_cast<Eigen::Index>(i)).adj();
+          y0(static_cast<Eigen::Index>(i)).vi_->adj_ = 0.0;
+        }
+      }
+      if constexpr (ThetaAutodiff) {
+        for (size_t i = 0; i < P; ++i) {
+          result.jacobian[o * W + S + i] = theta[i].adj();
+          theta[i].vi_->adj_ = 0.0;
+        }
+      }
+      output->adj_ = 0.0;
+    }
+    if constexpr (Diagnostic) breakdown->final_ns = elapsed_ns(phase);
+    return result;
+  }
+}
+
+template <bool Diagnostic>
+SolveResult run_oracle(RkSolver solver, const OdeSpec& spec,
+                       const std::vector<double>& y0,
+                       const std::vector<double>& theta, uint8_t type_mask,
+                       Breakdown* breakdown) {
+  if (type_mask == 0x3u)
+    return run_oracle_typed<true, true, Diagnostic>(solver, spec, y0, theta,
+                                                    breakdown);
+  if (type_mask == 0x1u)
+    return run_oracle_typed<true, false, Diagnostic>(solver, spec, y0, theta,
+                                                     breakdown);
+  if (type_mask == 0x2u)
+    return run_oracle_typed<false, true, Diagnostic>(solver, spec, y0, theta,
+                                                     breakdown);
+  return run_oracle_typed<false, false, Diagnostic>(solver, spec, y0, theta,
+                                                    breakdown);
+}
+
+enum class ProviderKind { Generated, Fvar };
+
+class DerivativeProvider {
+ public:
+  DerivativeProvider(const RhsProgram& rhs, size_t theta_source,
+                     const std::string& requested)
+      : rhs_(rhs), theta_source_(theta_source) {
+    // Developer-only direct-coupled machinery.  The clone absorbs any
+    // checkpoint MOVs; OdeSpec::prog remains canonical and untouched.
+    static_cast<Program&>(generated_) = static_cast<const Program&>(rhs_);
+    generated_.ins.push_back(IslandProg::LiveIn{rhs_.t_reg, 1, -1, 0, false});
+    generated_.ins.push_back(
+        IslandProg::LiveIn{rhs_.y0, rhs_.n_y, -1, 0, true});
+    generated_.ins.push_back(
+        IslandProg::LiveIn{rhs_.th0, rhs_.n_th, -1, 0, true});
+    generated_.ins.push_back(
+        IslandProg::LiveIn{rhs_.xr0, rhs_.n_xr, -1, 0, false});
+    generated_ok_ = stanli::gen_adjoint(generated_);
+    if (!generated_ok_) {
+      refusal_ = structural_refusal(rhs_);
+      if (refusal_.empty()) refusal_ = "adjoint generation failed";
+    }
+
+    if (requested == "generated") {
+      if (!generated_ok_)
+        throw std::runtime_error("generated provider refused: " + refusal_);
+      kind_ = ProviderKind::Generated;
+    } else if (requested == "fvar") {
+      kind_ = ProviderKind::Fvar;
+    } else {
+      kind_ = generated_ok_ ? ProviderKind::Generated : ProviderKind::Fvar;
+    }
+
+    if (generated_ok_) {
+      generated_values_.resize(static_cast<size_t>(generated_.n_regs));
+      generated_adjoints_.resize(static_cast<size_t>(generated_.adj.n_regs));
+    }
+    primal_values_.resize(static_cast<size_t>(rhs_.n_regs));
+    fvar_values_.resize(static_cast<size_t>(rhs_.n_regs));
+  }
+
+  ProviderKind kind() const { return kind_; }
+  bool generated_ok() const { return generated_ok_; }
+  const std::string& refusal() const { return refusal_; }
+
+  const char* name() const {
+    return kind_ == ProviderKind::Generated ? "generated" : "fvar";
+  }
+
+  size_t generated_forward_instructions() const {
+    return generated_ok_ ? generated_.code.size() : 0;
+  }
+
+  size_t generated_reverse_instructions() const {
+    return generated_ok_ ? generated_.adj.code.size() : 0;
+  }
+
+  template <bool Diagnostic>
+  void evaluate(double t, const double* y, const std::vector<double>& theta,
+                const double* x_r, bool theta_derivatives, double* f,
+                double* J_y, double* J_theta, Breakdown* breakdown) {
+    std::fill(J_y, J_y + static_cast<size_t>(rhs_.n_y * rhs_.n_y), 0.0);
+    if (theta_source_ != 0)
+      std::fill(J_theta,
+                J_theta + static_cast<size_t>(rhs_.n_y) * theta_source_, 0.0);
+    if (kind_ == ProviderKind::Generated) {
+      evaluate_generated<Diagnostic>(t, y, theta, x_r, theta_derivatives, f,
+                                     J_y, J_theta, breakdown);
+    } else {
+      evaluate_fvar<Diagnostic>(t, y, theta, x_r, theta_derivatives, f, J_y,
+                                J_theta, breakdown);
+    }
+  }
+
+  template <bool Diagnostic>
+  void evaluate_values(double t, const double* y,
+                       const std::vector<double>& theta, const double* x_r,
+                       double* f, Breakdown* breakdown) {
+    TimePoint phase;
+    if constexpr (Diagnostic) phase = Clock::now();
+    std::vector<double>* registers = &primal_values_;
+    const Program* program = &rhs_;
+    if (kind_ == ProviderKind::Generated) {
+      std::fill(generated_values_.begin(), generated_values_.end(), 0.0);
+      registers = &generated_values_;
+      program = &generated_;
+    }
+    seed(*program, *registers, t, y, theta, x_r, -1);
+    if constexpr (Diagnostic) {
+      breakdown->seed_ns += elapsed_ns(phase);
+      phase = Clock::now();
+    }
+    stanli::run_program(*program, *registers);
+    if constexpr (Diagnostic) {
+      breakdown->body_ns += elapsed_ns(phase);
+      phase = Clock::now();
+    }
+    for (size_t i = 0; i < rhs_.out_regs.size(); ++i)
+      f[i] = (*registers)[static_cast<size_t>(rhs_.out_regs[i])];
+    if constexpr (Diagnostic) breakdown->output_ns += elapsed_ns(phase);
+  }
+
+ private:
+  template <typename T>
+  void seed(const Program& program, std::vector<T>& registers, double t,
+            const double* y, const std::vector<double>& theta,
+            const double* x_r, int derivative_column) {
+    (void)program;
+    for (int i = 0; i < rhs_.n_y; ++i) {
+      if constexpr (std::is_same_v<T, fvar<double>>)
+        registers[static_cast<size_t>(rhs_.y0 + i)] =
+            T(y[i], derivative_column == i ? 1.0 : 0.0);
+      else
+        registers[static_cast<size_t>(rhs_.y0 + i)] = T(y[i]);
+    }
+    for (int i = 0; i < rhs_.n_th; ++i) {
+      if constexpr (std::is_same_v<T, fvar<double>>)
+        registers[static_cast<size_t>(rhs_.th0 + i)] =
+            T(theta[static_cast<size_t>(i)],
+              derivative_column == rhs_.n_y + i ? 1.0 : 0.0);
+      else
+        registers[static_cast<size_t>(rhs_.th0 + i)] =
+            T(theta[static_cast<size_t>(i)]);
+    }
+    registers[static_cast<size_t>(rhs_.t_reg)] = T(t);
+    for (int i = 0; i < rhs_.n_xr; ++i)
+      registers[static_cast<size_t>(rhs_.xr0 + i)] = T(x_r[i]);
+  }
+
+  template <bool Diagnostic>
+  void evaluate_generated(double t, const double* y,
+                          const std::vector<double>& theta, const double* x_r,
+                          bool theta_derivatives, double* f, double* J_y,
+                          double* J_theta, Breakdown* breakdown) {
+    TimePoint phase;
+    if constexpr (Diagnostic) phase = Clock::now();
+    std::fill(generated_values_.begin(), generated_values_.end(), 0.0);
+    seed(generated_, generated_values_, t, y, theta, x_r, -1);
+    if constexpr (Diagnostic) {
+      breakdown->seed_ns += elapsed_ns(phase);
+      phase = Clock::now();
+    }
+    stanli::run_program(static_cast<const Program&>(generated_),
+                        generated_values_);
+    if constexpr (Diagnostic) {
+      breakdown->body_ns += elapsed_ns(phase);
+      phase = Clock::now();
+    }
+    for (size_t i = 0; i < generated_.out_regs.size(); ++i)
+      f[i] = generated_values_[static_cast<size_t>(generated_.out_regs[i])];
+    if constexpr (Diagnostic) {
+      breakdown->output_ns += elapsed_ns(phase);
+      phase = Clock::now();
+    }
+
+    const AdjProgram& reverse = generated_.adj;
+    for (size_t output = 0; output < generated_.out_regs.size(); ++output) {
+      std::fill(generated_adjoints_.begin(), generated_adjoints_.end(), 0.0);
+      const int output_reg = generated_.out_regs[output];
+      generated_adjoints_[static_cast<size_t>(
+          reverse.adj_reg[static_cast<size_t>(output_reg)])] += 1.0;
+      stanli::run_adjoint(generated_, reverse, generated_values_.data(),
+                          generated_adjoints_.data());
+      for (int i = 0; i < rhs_.n_y; ++i) {
+        const int reg = rhs_.y0 + i;
+        J_y[output * static_cast<size_t>(rhs_.n_y) + static_cast<size_t>(i)] =
+            generated_adjoints_[static_cast<size_t>(
+                reverse.adj_reg[static_cast<size_t>(reg)])];
+      }
+      if (theta_derivatives) {
+        for (int i = 0; i < rhs_.n_th; ++i) {
+          const int reg = rhs_.th0 + i;
+          J_theta[output * theta_source_ + static_cast<size_t>(i)] =
+              generated_adjoints_[static_cast<size_t>(
+                  reverse.adj_reg[static_cast<size_t>(reg)])];
+        }
+      }
+    }
+    if constexpr (Diagnostic) breakdown->jacobian_ns += elapsed_ns(phase);
+  }
+
+  template <bool Diagnostic>
+  void evaluate_fvar(double t, const double* y,
+                     const std::vector<double>& theta, const double* x_r,
+                     bool theta_derivatives, double* f, double* J_y,
+                     double* J_theta, Breakdown* breakdown) {
+    TimePoint phase;
+    if constexpr (Diagnostic) phase = Clock::now();
+    seed(rhs_, primal_values_, t, y, theta, x_r, -1);
+    if constexpr (Diagnostic) {
+      breakdown->seed_ns += elapsed_ns(phase);
+      phase = Clock::now();
+    }
+    stanli::run_program(rhs_, primal_values_);
+    if constexpr (Diagnostic) {
+      breakdown->body_ns += elapsed_ns(phase);
+      phase = Clock::now();
+    }
+    for (size_t i = 0; i < rhs_.out_regs.size(); ++i)
+      f[i] = primal_values_[static_cast<size_t>(rhs_.out_regs[i])];
+    if constexpr (Diagnostic) {
+      breakdown->output_ns += elapsed_ns(phase);
+      phase = Clock::now();
+    }
+
+    const int columns = rhs_.n_y + (theta_derivatives ? rhs_.n_th : 0);
+    for (int column = 0; column < columns; ++column) {
+      seed(rhs_, fvar_values_, t, y, theta, x_r, column);
+      stanli::run_program(rhs_, fvar_values_);
+      for (size_t output = 0; output < rhs_.out_regs.size(); ++output) {
+        const double derivative =
+            fvar_values_[static_cast<size_t>(rhs_.out_regs[output])].d_;
+        if (column < rhs_.n_y)
+          J_y[output * static_cast<size_t>(rhs_.n_y) +
+              static_cast<size_t>(column)] = derivative;
+        else
+          J_theta[output * theta_source_ +
+                  static_cast<size_t>(column - rhs_.n_y)] = derivative;
+      }
+    }
+    if constexpr (Diagnostic) breakdown->jacobian_ns += elapsed_ns(phase);
+  }
+
+  const RhsProgram& rhs_;
+  size_t theta_source_;
+  ProviderKind kind_ = ProviderKind::Fvar;
+  IslandProg generated_;
+  bool generated_ok_ = false;
+  std::string refusal_;
+  std::vector<double> generated_values_;
+  std::vector<double> generated_adjoints_;
+  std::vector<double> primal_values_;
+  std::vector<fvar<double>> fvar_values_;
+};
+
+template <bool Diagnostic>
+struct DoubleCoupledSystem {
+  DerivativeProvider* provider;
+  size_t S;
+  size_t P;
+  size_t N_y0;
+  size_t N_theta;
+  const std::vector<double>& theta;
+  const std::vector<double>& x_r;
+  Breakdown* breakdown;
+  mutable std::vector<double> f;
+  mutable std::vector<double> J_y;
+  mutable std::vector<double> J_theta;
+
+  DoubleCoupledSystem(DerivativeProvider* provider_in, size_t S_in, size_t P_in,
+                      bool y0_active, bool theta_active,
+                      const std::vector<double>& theta_in,
+                      const std::vector<double>& x_r_in,
+                      Breakdown* breakdown_in)
+      : provider(provider_in),
+        S(S_in),
+        P(P_in),
+        N_y0(y0_active ? S_in : 0),
+        N_theta(theta_active ? P_in : 0),
+        theta(theta_in),
+        x_r(x_r_in),
+        breakdown(breakdown_in),
+        f(S_in),
+        J_y(S_in * S_in),
+        J_theta(S_in * P_in) {}
+
+  void operator()(const std::vector<double>& z, std::vector<double>& dz,
+                  double t) const {
+    TimePoint callback_start;
+    if constexpr (Diagnostic) {
+      ++breakdown->callbacks;
+      callback_start = Clock::now();
+    }
+    const size_t expected = S * (1 + N_y0 + N_theta);
+    if (z.size() != expected)
+      throw std::runtime_error("coupled RK state has unexpected size");
+
+    dz.resize(expected);
+    if (N_y0 == 0 && N_theta == 0) {
+      provider->template evaluate_values<Diagnostic>(
+          t, z.data(), theta, x_r.data(), f.data(), breakdown);
+    } else {
+      provider->template evaluate<Diagnostic>(
+          t, z.data(), theta, x_r.data(), N_theta != 0, f.data(), J_y.data(),
+          J_theta.data(), breakdown);
+    }
+
+    TimePoint phase;
+    if constexpr (Diagnostic) phase = Clock::now();
+    for (size_t i = 0; i < S; ++i) {
+      dz[i] = f[i];
+      for (size_t j = 0; j < N_y0; ++j) {
+        double derivative = 0.0;
+        for (size_t k = 0; k < S; ++k)
+          derivative += z[S + S * j + k] * J_y[i * S + k];
+        dz[S + S * j + i] = derivative;
+      }
+      for (size_t j = 0; j < N_theta; ++j) {
+        double derivative = J_theta[i * P + j];
+        for (size_t k = 0; k < S; ++k)
+          derivative += z[S + S * N_y0 + S * j + k] * J_y[i * S + k];
+        dz[S + S * N_y0 + S * j + i] = derivative;
+      }
+    }
+    if constexpr (Diagnostic) {
+      breakdown->propagation_ns += elapsed_ns(phase);
+      breakdown->callback_ns += elapsed_ns(callback_start);
+    }
+  }
+};
+
+template <bool Diagnostic>
+std::vector<std::vector<double>> integrate_direct_rk(
+    RkSolver solver, const OdeSpec& spec,
+    DoubleCoupledSystem<Diagnostic>* system, std::vector<double> initial,
+    Breakdown* breakdown) {
+  using boost::numeric::odeint::integrate_times;
+  using boost::numeric::odeint::make_controlled;
+  using boost::numeric::odeint::make_dense_output;
+  using boost::numeric::odeint::max_step_checker;
+  using boost::numeric::odeint::no_progress_error;
+  using boost::numeric::odeint::runge_kutta_cash_karp54;
+  using boost::numeric::odeint::runge_kutta_dopri5;
+
+  std::vector<double> times(spec.ts.size() + 1);
+  times[0] = spec.t0;
+  std::copy(spec.ts.begin(), spec.ts.end(), times.begin() + 1);
+  std::vector<std::vector<double>> solution;
+  solution.reserve(spec.ts.size());
+  bool initial_observed = false;
+  auto observer = [&](const std::vector<double>& state, double) {
+    if (!initial_observed) {
+      initial_observed = true;
+      return;
+    }
+    solution.push_back(state);
+  };
+
+  size_t accepted_steps = 0;
+  try {
+    if (solver == RkSolver::RK45) {
+      accepted_steps = integrate_times(
+          make_dense_output(spec.atol, spec.rtol,
+                            runge_kutta_dopri5<std::vector<double>, double,
+                                               std::vector<double>, double>()),
+          std::ref(*system), initial, times.begin(), times.end(), 0.1, observer,
+          max_step_checker(spec.max_steps));
+    } else {
+      accepted_steps = integrate_times(
+          make_controlled(
+              spec.atol, spec.rtol,
+              runge_kutta_cash_karp54<std::vector<double>, double,
+                                      std::vector<double>, double>()),
+          std::ref(*system), initial, times.begin(), times.end(), 0.1, observer,
+          max_step_checker(spec.max_steps));
+    }
+  } catch (const no_progress_error&) {
+    throw std::domain_error("direct RK ceiling exceeded max_steps");
+  }
+  if constexpr (Diagnostic) breakdown->accepted_steps = accepted_steps;
+  return solution;
+}
+
+template <bool Diagnostic>
+SolveResult run_candidate(RkSolver solver, const OdeSpec& spec,
+                          const std::vector<double>& y0,
+                          const std::vector<double>& theta, uint8_t type_mask,
+                          DerivativeProvider* provider, Breakdown* breakdown) {
+  const size_t S = y0.size();
+  const size_t P = theta.size();
+  const size_t W = S + P;
+  const bool y0_active = (type_mask & 0x1u) != 0;
+  const bool theta_active = (type_mask & 0x2u) != 0;
+  const size_t N_y0 = y0_active ? S : 0;
+  const size_t N_theta = theta_active ? P : 0;
+  const size_t coupled_size = S * (1 + N_y0 + N_theta);
+
+  std::vector<double> initial(coupled_size, 0.0);
+  for (size_t i = 0; i < S; ++i) initial[i] = y0[i];
+  for (size_t i = 0; i < N_y0; ++i) initial[S + S * i + i] = 1.0;
+
+  DoubleCoupledSystem<Diagnostic> rhs(provider, S, P, y0_active, theta_active,
+                                      theta, spec.x_r, breakdown);
+  TimePoint phase;
+  if constexpr (Diagnostic) phase = Clock::now();
+  const auto solution =
+      integrate_direct_rk(solver, spec, &rhs, std::move(initial), breakdown);
+  if constexpr (Diagnostic) {
+    breakdown->solver_ns = elapsed_ns(phase);
+    phase = Clock::now();
+  }
+
+  SolveResult result;
+  result.values.resize(spec.ts.size() * S);
+  result.jacobian.assign(result.values.size() * W, 0.0);
+  for (size_t n = 0; n < solution.size(); ++n) {
+    for (size_t i = 0; i < S; ++i) {
+      const size_t output = n * S + i;
+      result.values[output] = solution[n][i];
+      if (y0_active)
+        for (size_t j = 0; j < S; ++j)
+          result.jacobian[output * W + j] = solution[n][S + S * j + i];
+      if (theta_active)
+        for (size_t j = 0; j < P; ++j)
+          result.jacobian[output * W + S + j] =
+              solution[n][S + S * N_y0 + S * j + i];
+    }
+  }
+  if constexpr (Diagnostic) breakdown->final_ns = elapsed_ns(phase);
+  return result;
+}
+
+struct LocalResult {
+  std::vector<double> values;
+  std::vector<double> jacobian;
+};
+
+LocalResult local_oracle(const RhsProgram& rhs, double t,
+                         const std::vector<double>& y_values,
+                         const std::vector<double>& theta_values,
+                         const std::vector<double>& x_r) {
+  stan::math::nested_rev_autodiff nested;
+  std::vector<var> y;
+  std::vector<var> theta;
+  y.reserve(y_values.size());
+  theta.reserve(theta_values.size());
+  for (double value : y_values) y.emplace_back(value);
+  for (double value : theta_values) theta.emplace_back(value);
+  std::vector<var> outputs(rhs.out_regs.size());
+  stanli::run_rhs_into<var>(rhs, t, y.data(), theta.data(), theta.size(),
+                            x_r.data(), outputs.data());
+
+  LocalResult result;
+  result.values.resize(outputs.size());
+  result.jacobian.resize(outputs.size() * (y.size() + theta.size()));
+  for (size_t i = 0; i < outputs.size(); ++i)
+    result.values[i] = outputs[i].val();
+  for (size_t output = 0; output < outputs.size(); ++output) {
+    stan::math::grad(outputs[output].vi_);
+    const size_t width = y.size() + theta.size();
+    for (size_t i = 0; i < y.size(); ++i)
+      result.jacobian[output * width + i] = y[i].adj();
+    for (size_t i = 0; i < theta.size(); ++i)
+      result.jacobian[output * width + y.size() + i] = theta[i].adj();
+    if (output + 1 < outputs.size()) nested.set_zero_all_adjoints();
+  }
+  return result;
+}
+
+LocalResult local_candidate(DerivativeProvider* provider, const RhsProgram& rhs,
+                            double t, const std::vector<double>& y,
+                            const std::vector<double>& theta,
+                            const std::vector<double>& x_r) {
+  LocalResult result;
+  result.values.resize(static_cast<size_t>(rhs.n_y));
+  std::vector<double> J_y(static_cast<size_t>(rhs.n_y * rhs.n_y));
+  std::vector<double> J_theta(static_cast<size_t>(rhs.n_y) * theta.size());
+  provider->evaluate<false>(t, y.data(), theta, x_r.data(), true,
+                            result.values.data(), J_y.data(), J_theta.data(),
+                            nullptr);
+  result.jacobian.resize(static_cast<size_t>(rhs.n_y) *
+                         (static_cast<size_t>(rhs.n_y) + theta.size()));
+  for (int output = 0; output < rhs.n_y; ++output) {
+    const size_t width = static_cast<size_t>(rhs.n_y) + theta.size();
+    for (int i = 0; i < rhs.n_y; ++i)
+      result.jacobian[static_cast<size_t>(output) * width +
+                      static_cast<size_t>(i)] =
+          J_y[static_cast<size_t>(output * rhs.n_y + i)];
+    for (size_t i = 0; i < theta.size(); ++i)
+      result.jacobian[static_cast<size_t>(output) * width +
+                      static_cast<size_t>(rhs.n_y) + i] =
+          J_theta[static_cast<size_t>(output) * theta.size() + i];
+  }
+  return result;
+}
+
+double checksum(const SolveResult& result) {
+  double value = 0.0;
+  if (!result.values.empty()) {
+    value += result.values.front();
+    value += 0.5 * result.values.back();
+  }
+  if (!result.jacobian.empty()) {
+    value += 0.25 * result.jacobian.front();
+    value += 0.125 * result.jacobian[result.jacobian.size() / 2];
+    value += 0.0625 * result.jacobian.back();
+  }
+  return value;
+}
+
+template <typename F>
+double time_solves(int iterations, F&& solve) {
+  double sink = 0.0;
+  const auto begin = Clock::now();
+  for (int i = 0; i < iterations; ++i) sink += checksum(solve());
+  const auto end = Clock::now();
+  benchmark_sink += sink;
+  return std::chrono::duration<double, std::nano>(end - begin).count() /
+         static_cast<double>(iterations);
+}
+
+double median(std::vector<double> values) {
+  std::sort(values.begin(), values.end());
+  const size_t middle = values.size() / 2;
+  if (values.size() % 2 != 0) return values[middle];
+  return 0.5 * (values[middle - 1] + values[middle]);
+}
+
+void print_breakdown(const char* label, const Breakdown& stats) {
+  const double callbacks =
+      static_cast<double>(std::max<uint64_t>(1, stats.callbacks));
+  std::printf(
+      "%s diagnostic callbacks=%llu solver=%.3f us final=%.3f us "
+      "callback=%.3f ns/cb seed=%.3f body=%.3f output=%.3f "
+      "jacobian=%.3f propagation=%.3f ns/cb\n",
+      label, static_cast<unsigned long long>(stats.callbacks),
+      stats.solver_ns / 1000.0, stats.final_ns / 1000.0,
+      stats.callback_ns / callbacks, stats.seed_ns / callbacks,
+      stats.body_ns / callbacks, stats.output_ns / callbacks,
+      stats.jacobian_ns / callbacks, stats.propagation_ns / callbacks);
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+  try {
+    const Options options = parse_options(argc, argv);
+    const stanli::DataMap data =
+        stanli::DataMap::from_json(slurp(options.data));
+    stanli::CompiledModel model =
+        stanli::compile_model(slurp(options.mir), data);
+    stanli::Executor executor(std::move(model.graph));
+    model.bind(executor);
+    for (int64_t i = 0; i < executor.n_params(); ++i)
+      executor.params_data()[i] = eval_point(i, options.point);
+
+    // One ordinary evaluation materializes transformed ODE inputs in their
+    // bound slots.  It is preparation, outside every solve timing below.
+    std::vector<double> model_gradient(
+        static_cast<size_t>(executor.n_params()));
+    const double model_lp = executor.gradient(model_gradient.data());
+
+    const stanli::Op* ode_op = nullptr;
+    for (const auto& op : executor.graph().ops) {
+      if (op.opcode == stanli::OP_ODE) {
+        ode_op = &op;
+        break;
+      }
+    }
+    if (!ode_op) throw std::runtime_error("compiled model has no OP_ODE");
+    const auto* spec = static_cast<const OdeSpec*>(ode_op->udata);
+    if (!spec) throw std::runtime_error("OP_ODE has no OdeSpec");
+    if (!spec->prog.ok)
+      throw std::runtime_error("first ODE uses the interpreter fallback: " +
+                               spec->prog.why);
+
+    const auto& graph = executor.graph();
+    const size_t S = static_cast<size_t>(graph.slots[ode_op->in[0]].len);
+    const size_t P = static_cast<size_t>(graph.slots[ode_op->in[1]].len);
+    const size_t output_size =
+        static_cast<size_t>(graph.slots[ode_op->out].len);
+    if (S == 0 || output_size % S != 0 || output_size / S != spec->ts.size())
+      throw std::runtime_error("OP_ODE shape does not match OdeSpec times");
+    if (spec->prog.out_regs.size() != S)
+      throw std::runtime_error(
+          "compiled RHS output width does not match state");
+    const double* y0_data = executor.value_ptr(ode_op->in[0]);
+    const double* theta_data = executor.value_ptr(ode_op->in[1]);
+    const std::vector<double> y0(y0_data, y0_data + S);
+    const std::vector<double> theta(theta_data, theta_data + P);
+    const uint8_t type_mask =
+        (ode_op->variant & 0x4u) != 0 ? (ode_op->variant & 0x3u) : 0x3u;
+    const RkSolver solver = select_solver(options, *spec);
+
+    DerivativeProvider provider(spec->prog, P, options.provider);
+    const size_t N_y0 = (type_mask & 0x1u) != 0 ? S : 0;
+    const size_t N_theta = (type_mask & 0x2u) != 0 ? P : 0;
+    const size_t coupled_size = S * (1 + N_y0 + N_theta);
+
+    std::printf(
+        "model_lp=%.17g rhs=%s original_solver=%s benchmark_solver=%s "
+        "legacy=%d point=%d\n",
+        model_lp, spec->rhs_name.c_str(), spec_solver_name(spec->solver),
+        solver_name(solver), spec->legacy ? 1 : 0, options.point);
+    std::printf(
+        "shape states=%zu theta_source=%zu outputs=%zu times=%zu "
+        "type_mask=0x%x coupled=%zu rhs_instructions=%zu rhs_registers=%d\n",
+        S, P, output_size, spec->ts.size(), static_cast<unsigned>(type_mask),
+        coupled_size, spec->prog.code.size(), spec->prog.n_regs);
+    std::printf(
+        "provider requested=%s selected=%s generated_eligible=%d "
+        "generated_forward=%zu generated_reverse=%zu",
+        options.provider.c_str(), provider.name(),
+        provider.generated_ok() ? 1 : 0,
+        provider.generated_forward_instructions(),
+        provider.generated_reverse_instructions());
+    if (!provider.generated_ok())
+      std::printf(" refusal=\"%s\"", provider.refusal().c_str());
+    std::printf("\n");
+
+    // Check both sides of time-dependent branches when the first observation
+    // lies after t0, plus a late point.  The state is held fixed so this is a
+    // local RHS/Jacobian proof rather than another numerical integration.
+    std::vector<double> local_times{spec->t0};
+    if (!spec->ts.empty()) {
+      local_times.push_back(spec->t0 + 0.5 * (spec->ts.front() - spec->t0));
+      if (bits(spec->ts.back()) != bits(local_times.back()))
+        local_times.push_back(spec->ts.back());
+    }
+    bool local_exact = true;
+    bool local_numerical = true;
+    for (size_t k = 0; k < local_times.size(); ++k) {
+      const LocalResult old_local =
+          local_oracle(spec->prog, local_times[k], y0, theta, spec->x_r);
+      const LocalResult new_local = local_candidate(
+          &provider, spec->prog, local_times[k], y0, theta, spec->x_r);
+      const std::string value_label = "local[" + std::to_string(k) + "].values";
+      const std::string jacobian_label =
+          "local[" + std::to_string(k) + "].jacobian";
+      const CompareResult value_comparison =
+          compare(new_local.values, old_local.values);
+      const CompareResult jacobian_comparison =
+          compare(new_local.jacobian, old_local.jacobian);
+      std::printf("local[%zu] t=%.17g\n", k, local_times[k]);
+      print_compare(value_label.c_str(), value_comparison);
+      print_compare(jacobian_label.c_str(), jacobian_comparison);
+      local_exact &= value_comparison.bitwise == value_comparison.total &&
+                     jacobian_comparison.bitwise == jacobian_comparison.total;
+      local_numerical &= value_comparison.max_relative <= 1e-9 &&
+                         jacobian_comparison.max_relative <= 1e-9;
+    }
+
+    Breakdown old_diagnostic;
+    Breakdown new_diagnostic;
+    const SolveResult old_result =
+        run_oracle<true>(solver, *spec, y0, theta, type_mask, &old_diagnostic);
+    const SolveResult new_result = run_candidate<true>(
+        solver, *spec, y0, theta, type_mask, &provider, &new_diagnostic);
+    std::printf("callbacks oracle=%llu candidate=%llu equal=%d\n",
+                static_cast<unsigned long long>(old_diagnostic.callbacks),
+                static_cast<unsigned long long>(new_diagnostic.callbacks),
+                old_diagnostic.callbacks == new_diagnostic.callbacks ? 1 : 0);
+    // Both pinned tableaux use six RHS evaluations per attempt. Cash--Karp
+    // has no FSAL initialization calls; Dopri5's dense wrapper evaluates the
+    // initial derivative and may reinitialize for the exact final endpoint.
+    // Keep this explicitly labelled as a stage-count derivation.
+    const size_t initialization_rhs =
+        solver == RkSolver::RK45 ? new_diagnostic.callbacks % 6u : 0u;
+    const size_t attempted_steps =
+        (new_diagnostic.callbacks - initialization_rhs) / 6u;
+    if (attempted_steps < new_diagnostic.accepted_steps)
+      throw std::runtime_error("derived RK attempt count is inconsistent");
+    std::printf(
+        "steps candidate_accepted=%zu attempted_derived=%zu "
+        "rejected_derived=%zu initialization_rhs=%zu\n",
+        new_diagnostic.accepted_steps, attempted_steps,
+        attempted_steps - new_diagnostic.accepted_steps, initialization_rhs);
+    const CompareResult solution_values =
+        compare(new_result.values, old_result.values);
+    const CompareResult solution_jacobian =
+        compare(new_result.jacobian, old_result.jacobian);
+    print_compare("solution.values", solution_values);
+    print_compare("solution.jacobian", solution_jacobian);
+    const bool callback_equal =
+        old_diagnostic.callbacks == new_diagnostic.callbacks;
+    const bool solution_exact =
+        solution_values.bitwise == solution_values.total &&
+        solution_jacobian.bitwise == solution_jacobian.total;
+    const bool solution_numerical = solution_values.max_relative <= 1e-9 &&
+                                    solution_jacobian.max_relative <= 1e-9;
+    const bool exact_required =
+        options.require_exact || provider.kind() == ProviderKind::Generated;
+    if (!callback_equal || !local_numerical || !solution_numerical ||
+        (exact_required && (!local_exact || !solution_exact)))
+      throw std::runtime_error(
+          "candidate failed the pre-timing correctness gate");
+    std::printf("timing_gate=%s pass=1 work_parity=callback_count\n",
+                exact_required ? "exact" : "proximity");
+    if (options.diagnostic) {
+      print_breakdown("oracle", old_diagnostic);
+      print_breakdown("candidate", new_diagnostic);
+      std::printf(
+          "diagnostic note: component clocks perturb callbacks; the paired "
+          "timings below instantiate clock-free solve arms\n");
+    }
+
+    // Warm the clock-free template instantiations independently so each arm
+    // reaches the requested duration even when their costs differ greatly.
+    const int64_t warmup_target_ns =
+        static_cast<int64_t>(options.warmup_ms) * 1000000;
+    int64_t old_warmup_ns = 0, new_warmup_ns = 0;
+    size_t old_warmup_solves = 0, new_warmup_solves = 0;
+    while (old_warmup_ns < warmup_target_ns ||
+           new_warmup_ns < warmup_target_ns) {
+      if (old_warmup_ns < warmup_target_ns) {
+        const TimePoint begin = Clock::now();
+        benchmark_sink += checksum(
+            run_oracle<false>(solver, *spec, y0, theta, type_mask, nullptr));
+        old_warmup_ns += elapsed_ns(begin);
+        ++old_warmup_solves;
+      }
+      if (new_warmup_ns < warmup_target_ns) {
+        const TimePoint begin = Clock::now();
+        benchmark_sink += checksum(run_candidate<false>(
+            solver, *spec, y0, theta, type_mask, &provider, nullptr));
+        new_warmup_ns += elapsed_ns(begin);
+        ++new_warmup_solves;
+      }
+    }
+    std::printf(
+        "warmup oracle_ms=%.3f candidate_ms=%.3f oracle_solves=%zu "
+        "candidate_solves=%zu\n",
+        old_warmup_ns / 1e6, new_warmup_ns / 1e6, old_warmup_solves,
+        new_warmup_solves);
+
+    std::vector<double> old_ns;
+    std::vector<double> new_ns;
+    std::vector<double> paired;
+    old_ns.reserve(static_cast<size_t>(options.batches));
+    new_ns.reserve(static_cast<size_t>(options.batches));
+    paired.reserve(static_cast<size_t>(options.batches));
+    for (int batch = 0; batch < options.batches; ++batch) {
+      double old_time;
+      double new_time;
+      if (batch % 2 == 0) {
+        old_time = time_solves(options.iterations, [&] {
+          return run_oracle<false>(solver, *spec, y0, theta, type_mask,
+                                   nullptr);
+        });
+        new_time = time_solves(options.iterations, [&] {
+          return run_candidate<false>(solver, *spec, y0, theta, type_mask,
+                                      &provider, nullptr);
+        });
+      } else {
+        new_time = time_solves(options.iterations, [&] {
+          return run_candidate<false>(solver, *spec, y0, theta, type_mask,
+                                      &provider, nullptr);
+        });
+        old_time = time_solves(options.iterations, [&] {
+          return run_oracle<false>(solver, *spec, y0, theta, type_mask,
+                                   nullptr);
+        });
+      }
+      old_ns.push_back(old_time);
+      new_ns.push_back(new_time);
+      paired.push_back(old_time / new_time);
+      std::printf("batch=%d oracle_ns=%.1f candidate_ns=%.1f speedup=%.6fx\n",
+                  batch + 1, old_time, new_time, old_time / new_time);
+    }
+    const auto [ratio_min, ratio_max] =
+        std::minmax_element(paired.begin(), paired.end());
+    std::printf(
+        "median oracle_ns=%.1f candidate_ns=%.1f paired_speedup=%.6fx "
+        "range=[%.6fx,%.6fx] iterations=%d batches=%d sink=%.9g\n",
+        median(old_ns), median(new_ns), median(paired), *ratio_min, *ratio_max,
+        options.iterations, options.batches,
+        static_cast<double>(benchmark_sink));
+    return 0;
+  } catch (const std::exception& error) {
+    std::fprintf(stderr, "bench_ode_ceiling: %s\n", error.what());
+    return 1;
+  }
+}

--- a/tools/bench_ode_cvodes_ceiling.cpp
+++ b/tools/bench_ode_cvodes_ceiling.cpp
@@ -1,0 +1,1272 @@
+// Developer-only ceiling experiment for the CVODES ODE paths.
+//
+// This is an uninstalled developer benchmark, not a test or runtime hook. It
+// keeps the merged PR #245 Stan Math solve as the oracle, then compares it with
+// a local CVODES driver whose primal, state-Jacobian, and sensitivity callbacks
+// evaluate an RhsProgram without reverse-mode autodiff. The experimental
+// Jacobian uses one stackless fvar<double> replay per input direction,
+// including the canonical program's JZ/JMP control flow.
+//
+// The fvar arm is a ceiling/proximity experiment, not an exact replacement:
+// forward and reverse accumulation group some derivatives differently.  In
+// particular one_comp_mm_elim_abs has normal finite points where the two local
+// Jacobians differ by two ulp.  The program therefore always reports exact-bit
+// counts and numerical deltas against the current solve; it never silently
+// promotes the experimental path to an oracle.
+//
+// A representative manual build (from the repository root) is:
+//
+//   c++ -O3 -DNDEBUG -std=c++17 -ffp-contract=off \
+//     -DBOOST_DISABLE_ASSERTS -DBRIDGESTAN_EXPORT=1 -DSTAN_THREADS=1 \
+//     -D_REENTRANT -Iruntime/include -Ideps/math -Ideps/stan/src \
+//     -Ideps/math/lib/eigen_5.0.1 -Ideps/math/lib/boost_1.87.0 \
+//     -Ideps/math/lib/sundials_6.1.1/include \
+//     -Ideps/math/lib/tbb_2020.3/include \
+//     tools/bench_ode_cvodes_ceiling.cpp tests/tbb_stub.cpp \
+//     build-rel/libstanli.a build-rel/libsundials.a \
+//     -o build-rel/bench_ode_cvodes_ceiling
+//
+// Include fwd before the register-program header: run_program's qualified Stan
+// Math calls need the fvar overloads in their overload set at definition time.
+#include <stan/math/fwd.hpp>
+
+#include <stanli/compile.hpp>
+#include <stanli/graph.hpp>
+#include <stanli/ode.hpp>
+#include <stanli/ode_prog.hpp>
+#include <stanli/optable.hpp>
+#include <stanli/program.hpp>
+
+#include <stan/math.hpp>
+#include <stan/math/rev/functor/cvodes_utils.hpp>
+
+#include <cvodes/cvodes.h>
+#include <cvodes/cvodes_ls.h>
+#include <nvector/nvector_serial.h>
+#include <sunlinsol/sunlinsol_dense.h>
+
+#include <algorithm>
+#include <chrono>
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <fstream>
+#include <limits>
+#include <numeric>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+// RhsPrograms never contain densities.  run_program<T>'s closed switch still
+// references program_density<T>, while the shared library explicitly
+// instantiates only double and var.  Supply a benchmark-local rejecting
+// specialization so fvar replay links without compiling the complete density
+// catalogue for a path that structurally refuses it.
+namespace stanli {
+template <>
+stan::math::fvar<double> program_density<stan::math::fvar<double>>(
+    int, const stan::math::fvar<double>*) {
+  throw std::logic_error("density instruction in ODE RHS tangent replay");
+}
+}  // namespace stanli
+
+namespace {
+
+using Clock = std::chrono::steady_clock;
+using Fvar = stan::math::fvar<double>;
+using stan::math::cvodes_check;
+using stan::math::var;
+using stanli::OdeSpec;
+using stanli::Program;
+using stanli::RhsProgram;
+
+volatile double benchmark_sink = 0.0;
+
+int64_t elapsed_ns(Clock::time_point begin) {
+  return std::chrono::duration_cast<std::chrono::nanoseconds>(Clock::now() -
+                                                              begin)
+      .count();
+}
+
+int64_t duration_ns(Clock::time_point begin, Clock::time_point end) {
+  return std::chrono::duration_cast<std::chrono::nanoseconds>(end - begin)
+      .count();
+}
+
+std::string slurp(const std::string& path) {
+  std::ifstream in(path);
+  if (!in) throw std::runtime_error("cannot open " + path);
+  std::ostringstream out;
+  out << in.rdbuf();
+  return out.str();
+}
+
+int integer_arg(const char* text, const char* name, int minimum = 0) {
+  char* end = nullptr;
+  const long value = std::strtol(text, &end, 10);
+  if (!text[0] || !end || *end != '\0' || value < minimum || value > 100000000L)
+    throw std::runtime_error(std::string(name) + " is out of range");
+  return static_cast<int>(value);
+}
+
+struct Options {
+  std::string mir;
+  std::string data;
+  std::string solver = "model";
+  int point = 0;
+  int iterations = 200;
+  int batches = 9;
+  int warmup_ms = 200;
+  bool require_exact = false;
+};
+
+void usage() {
+  std::fprintf(stderr,
+               "usage: bench_ode_cvodes_ceiling MODEL.tmir.sexp DATA.json "
+               "[--solver model|bdf|adams] [--point 0|1|2] "
+               "[--iterations N] [--batches N] [--warmup-ms N] "
+               "[--require-exact]\n");
+}
+
+Options parse_options(int argc, char** argv) {
+  if (argc == 2 &&
+      (std::string(argv[1]) == "--help" || std::string(argv[1]) == "-h")) {
+    usage();
+    std::exit(0);
+  }
+  if (argc < 3) {
+    usage();
+    throw std::runtime_error("missing MIR or data path");
+  }
+  Options out;
+  out.mir = argv[1];
+  out.data = argv[2];
+  for (int i = 3; i < argc; ++i) {
+    const std::string flag = argv[i];
+    auto value = [&](const char* name) -> const char* {
+      if (i + 1 >= argc)
+        throw std::runtime_error(std::string(name) + " needs a value");
+      return argv[++i];
+    };
+    if (flag == "--solver") {
+      out.solver = value("--solver");
+    } else if (flag == "--point") {
+      out.point = integer_arg(value("--point"), "--point");
+      if (out.point > 2) throw std::runtime_error("--point must be 0, 1, or 2");
+    } else if (flag == "--iterations") {
+      out.iterations = integer_arg(value("--iterations"), "--iterations", 1);
+    } else if (flag == "--batches") {
+      out.batches = integer_arg(value("--batches"), "--batches", 1);
+    } else if (flag == "--warmup-ms") {
+      out.warmup_ms = integer_arg(value("--warmup-ms"), "--warmup-ms");
+    } else if (flag == "--require-exact") {
+      out.require_exact = true;
+    } else if (flag == "--help" || flag == "-h") {
+      usage();
+      std::exit(0);
+    } else {
+      throw std::runtime_error("unknown option " + flag);
+    }
+  }
+  if (out.solver != "model" && out.solver != "bdf" && out.solver != "adams")
+    throw std::runtime_error("--solver must be model, bdf, or adams");
+  return out;
+}
+
+double eval_point(int64_t index, int point) {
+  switch (point) {
+    case 1:
+      return 0.02 * static_cast<double>((index % 5) - 2);
+    case 2:
+      return 0.0;
+    default:
+      return 0.1 + 0.05 * static_cast<double>(index % 7) -
+             0.15 * static_cast<double>(index % 3);
+  }
+}
+
+const char* solver_name(OdeSpec::Solver solver) {
+  switch (solver) {
+    case OdeSpec::RK45:
+      return "rk45";
+    case OdeSpec::BDF:
+      return "bdf";
+    case OdeSpec::ADAMS:
+      return "adams";
+    case OdeSpec::CKRK:
+      return "ckrk";
+  }
+  return "unknown";
+}
+
+OdeSpec::Solver select_solver(const Options& options, const OdeSpec& spec) {
+  if (options.solver == "bdf") return OdeSpec::BDF;
+  if (options.solver == "adams") return OdeSpec::ADAMS;
+  if (spec.solver == OdeSpec::BDF || spec.solver == OdeSpec::ADAMS)
+    return spec.solver;
+  throw std::runtime_error("model's first ODE uses " +
+                           std::string(solver_name(spec.solver)) +
+                           "; pass --solver bdf or --solver adams for the "
+                           "developer CVODES ceiling experiment");
+}
+
+uint64_t bits(double value) {
+  uint64_t out;
+  std::memcpy(&out, &value, sizeof(out));
+  return out;
+}
+
+uint64_t ordered_bits(double value) {
+  const uint64_t raw = bits(value);
+  return (raw >> 63) ? ~raw : (raw | (uint64_t{1} << 63));
+}
+
+uint64_t ulp_distance(double a, double b) {
+  const uint64_t x = ordered_bits(a), y = ordered_bits(b);
+  return x > y ? x - y : y - x;
+}
+
+double median(std::vector<double> values) {
+  if (values.empty()) return 0.0;
+  std::sort(values.begin(), values.end());
+  const size_t middle = values.size() / 2;
+  if (values.size() & 1u) return values[middle];
+  return 0.5 * (values[middle - 1] + values[middle]);
+}
+
+struct CallbackProfile {
+  int64_t value_calls = 0;
+  int64_t jacobian_calls = 0;
+  int64_t full_jacobian_calls = 0;
+  int64_t tangent_directions = 0;
+  int64_t seed_ns = 0;
+  int64_t body_ns = 0;
+  int64_t extract_ns = 0;
+  int64_t value_callback_ns = 0;
+  int64_t jacobian_callback_ns = 0;
+  int64_t sensitivity_callback_ns = 0;
+  int64_t sensitivity_product_ns = 0;
+};
+
+struct CvodesStats {
+  long int steps = 0;
+  long int rhs_evals = 0;
+  long int linear_setups = 0;
+  long int error_test_fails = 0;
+  long int nonlinear_iters = 0;
+  long int nonlinear_fails = 0;
+  long int jacobian_evals = 0;
+  long int linear_rhs_evals = 0;
+  long int linear_iters = 0;
+  long int linear_fails = 0;
+  long int sens_rhs_evals = 0;
+  long int sens_extra_rhs_evals = 0;
+  long int sens_error_test_fails = 0;
+  long int sens_linear_setups = 0;
+  long int sens_nonlinear_iters = 0;
+  long int sens_nonlinear_fails = 0;
+};
+
+struct SolveProfile {
+  int64_t total_ns = 0;
+  int64_t allocation_ns = 0;
+  int64_t setup_ns = 0;
+  int64_t integrate_ns = 0;
+  int64_t get_sens_ns = 0;
+  int64_t output_ns = 0;
+  int64_t final_harvest_ns = 0;
+  int64_t oracle_double_callbacks = 0;
+  int64_t oracle_var_callbacks = 0;
+  int64_t oracle_double_callback_ns = 0;
+  int64_t oracle_var_callback_ns = 0;
+  CallbackProfile callback;
+  CvodesStats cvodes;
+};
+
+struct SolveResult {
+  std::vector<double> values;
+  // Row-major by flattened solution output, then [y0, theta].
+  std::vector<double> jacobian;
+  SolveProfile profile;
+};
+
+struct BenchCase {
+  OdeSpec ode;
+  std::vector<double> y0;
+  std::vector<double> theta;
+};
+
+BenchCase materialize_case(const OdeSpec& spec, const double* y0, size_t n_y,
+                           const double* theta, size_t n_theta,
+                           OdeSpec::Solver solver) {
+  BenchCase out;
+  out.ode = spec;
+  // OdeSpec's default copy leaves the non-owning lookup map pointing into the
+  // source.  The compiled path below does not consult it, but repair it so the
+  // benchmark copy is independently well-formed.
+  out.ode.funs_map.clear();
+  for (const auto& [name, definition] : out.ode.owned)
+    out.ode.funs_map[name] = &definition;
+  out.ode.solver = solver;
+  out.y0.assign(y0, y0 + n_y);
+  out.theta.assign(theta, theta + n_theta);
+
+  if (!out.ode.prog.ok)
+    throw std::runtime_error("first ODE uses the interpreter fallback: " +
+                             out.ode.prog.why);
+  if (out.ode.prog.n_y != static_cast<int>(n_y))
+    throw std::runtime_error("OP_ODE state width disagrees with RHS program");
+  if (out.ode.prog.n_th < 0 || out.ode.prog.n_th > static_cast<int>(n_theta))
+    throw std::runtime_error(
+        "OP_ODE theta source is narrower than the RHS program input");
+  for (const Program::Instr& instruction : out.ode.prog.code) {
+    if (instruction.code == Program::CALL ||
+        instruction.code == Program::DENSITY)
+      throw std::runtime_error(
+          "fvar ceiling refuses CALL and DENSITY instructions");
+  }
+
+  return out;
+}
+
+// Values and dense RHS Jacobians with no reverse-mode tape.  A full Jacobian
+// call runs N + P directions; a primal-Jacobian call runs only the N state
+// directions.  Buffers belong to one solve and therefore outlive every
+// synchronous SUNDIALS callback without relying on global thread-local state.
+template <bool Profile>
+class TangentProvider {
+ public:
+  TangentProvider(const RhsProgram& program, const std::vector<double>& theta,
+                  const std::vector<double>& xr)
+      : p_(program),
+        theta_(theta),
+        xr_(xr),
+        dreg_(static_cast<size_t>(program.n_regs)),
+        freg_(static_cast<size_t>(program.n_regs)) {}
+
+  void values(double t, const double* y, double* out) {
+    Clock::time_point callback_begin;
+    Clock::time_point part;
+    if constexpr (Profile) {
+      ++profile_.value_calls;
+      callback_begin = Clock::now();
+      part = callback_begin;
+    }
+    seed_double(t, y);
+    if constexpr (Profile) {
+      profile_.seed_ns += elapsed_ns(part);
+      part = Clock::now();
+    }
+    stanli::run_program(p_, dreg_);
+    if constexpr (Profile) {
+      profile_.body_ns += elapsed_ns(part);
+      part = Clock::now();
+    }
+    for (size_t i = 0; i < p_.out_regs.size(); ++i)
+      out[i] = dreg_[static_cast<size_t>(p_.out_regs[i])];
+    if constexpr (Profile) profile_.extract_ns += elapsed_ns(part);
+    if constexpr (Profile)
+      profile_.value_callback_ns += elapsed_ns(callback_begin);
+  }
+
+  void jacobian(double t, const double* y, bool include_theta, double* values,
+                double* jy, double* jtheta) {
+    const int width = p_.n_y + (include_theta ? p_.n_th : 0);
+    if (include_theta && jtheta)
+      std::fill(jtheta, jtheta + p_.out_regs.size() * theta_.size(), 0.0);
+    Clock::time_point callback_begin;
+    if constexpr (Profile) {
+      if (include_theta)
+        ++profile_.full_jacobian_calls;
+      else
+        ++profile_.jacobian_calls;
+      profile_.tangent_directions += width;
+      callback_begin = Clock::now();
+    }
+
+    for (int direction = 0; direction < width; ++direction) {
+      Clock::time_point part;
+      if constexpr (Profile) part = Clock::now();
+      seed_fvar(t, y, direction, include_theta);
+      if constexpr (Profile) {
+        profile_.seed_ns += elapsed_ns(part);
+        part = Clock::now();
+      }
+      stanli::run_program(p_, freg_);
+      if constexpr (Profile) {
+        profile_.body_ns += elapsed_ns(part);
+        part = Clock::now();
+      }
+      for (size_t output = 0; output < p_.out_regs.size(); ++output) {
+        const Fvar& result = freg_[static_cast<size_t>(p_.out_regs[output])];
+        if (direction == 0 && values) values[output] = result.val_;
+        if (direction < p_.n_y) {
+          jy[output * static_cast<size_t>(p_.n_y) +
+             static_cast<size_t>(direction)] = result.d_;
+        } else if (jtheta) {
+          const int column = direction - p_.n_y;
+          jtheta[output * theta_.size() + static_cast<size_t>(column)] =
+              result.d_;
+        }
+      }
+      if constexpr (Profile) profile_.extract_ns += elapsed_ns(part);
+    }
+    if constexpr (Profile) {
+      const int64_t elapsed = elapsed_ns(callback_begin);
+      if (include_theta)
+        profile_.sensitivity_callback_ns += elapsed;
+      else
+        profile_.jacobian_callback_ns += elapsed;
+    }
+  }
+
+  CallbackProfile& profile() { return profile_; }
+  const CallbackProfile& profile() const { return profile_; }
+
+ private:
+  const RhsProgram& p_;
+  const std::vector<double>& theta_;
+  const std::vector<double>& xr_;
+  std::vector<double> dreg_;
+  std::vector<Fvar> freg_;
+  CallbackProfile profile_;
+
+  void seed_double(double t, const double* y) {
+    for (int i = 0; i < p_.n_y; ++i)
+      dreg_[static_cast<size_t>(p_.y0 + i)] = y[i];
+    for (int i = 0; i < p_.n_th; ++i)
+      dreg_[static_cast<size_t>(p_.th0 + i)] = theta_[static_cast<size_t>(i)];
+    dreg_[static_cast<size_t>(p_.t_reg)] = t;
+    for (int i = 0; i < p_.n_xr; ++i)
+      dreg_[static_cast<size_t>(p_.xr0 + i)] = xr_[static_cast<size_t>(i)];
+  }
+
+  void seed_fvar(double t, const double* y, int direction, bool include_theta) {
+    for (int i = 0; i < p_.n_y; ++i)
+      freg_[static_cast<size_t>(p_.y0 + i)] =
+          Fvar(y[i], direction == i ? 1.0 : 0.0);
+    for (int i = 0; i < p_.n_th; ++i) {
+      const bool active = include_theta && direction == p_.n_y + i;
+      freg_[static_cast<size_t>(p_.th0 + i)] =
+          Fvar(theta_[static_cast<size_t>(i)], active ? 1.0 : 0.0);
+    }
+    freg_[static_cast<size_t>(p_.t_reg)] = Fvar(t, 0.0);
+    for (int i = 0; i < p_.n_xr; ++i)
+      freg_[static_cast<size_t>(p_.xr0 + i)] =
+          Fvar(xr_[static_cast<size_t>(i)], 0.0);
+  }
+};
+
+template <int Lmm, bool Profile>
+class LocalCvodesIntegrator {
+ public:
+  LocalCvodesIntegrator(const BenchCase& benchmark, bool y_active,
+                        bool theta_active)
+      : benchmark_(benchmark),
+        n_(benchmark.y0.size()),
+        p_(benchmark.theta.size()),
+        n_y_sens_(y_active ? n_ : 0),
+        n_theta_sens_(theta_active ? p_ : 0),
+        n_sens_(n_y_sens_ + n_theta_sens_),
+        state_(n_ * (1 + n_sens_), 0.0),
+        provider_(benchmark.ode.prog, benchmark.theta, benchmark.ode.x_r),
+        jy_(n_ * n_),
+        jtheta_(n_ * p_) {
+    for (size_t i = 0; i < n_; ++i) state_[i] = benchmark.y0[i];
+    for (size_t i = 0; i < n_y_sens_; ++i) state_[n_ + i * n_ + i] = 1.0;
+
+    try {
+      nv_state_ = N_VMake_Serial(n_, state_.data(), context_);
+      if (!nv_state_) throw std::runtime_error("N_VMake_Serial failed");
+      matrix_ = SUNDenseMatrix(n_, n_, context_);
+      if (!matrix_) throw std::runtime_error("SUNDenseMatrix failed");
+      linear_solver_ = SUNLinSol_Dense(nv_state_, matrix_, context_);
+      if (!linear_solver_) throw std::runtime_error("SUNLinSol_Dense failed");
+      if (n_sens_ != 0) {
+        nv_sens_ =
+            N_VCloneEmptyVectorArray(static_cast<int>(n_sens_), nv_state_);
+        if (!nv_sens_)
+          throw std::runtime_error("N_VCloneEmptyVectorArray failed");
+        for (size_t s = 0; s < n_sens_; ++s)
+          NV_DATA_S(nv_sens_[s]) = state_.data() + n_ + s * n_;
+      }
+    } catch (...) {
+      release();
+      throw;
+    }
+  }
+
+  LocalCvodesIntegrator(const LocalCvodesIntegrator&) = delete;
+  LocalCvodesIntegrator& operator=(const LocalCvodesIntegrator&) = delete;
+
+  ~LocalCvodesIntegrator() { release(); }
+
+  SolveResult solve() {
+    SolveResult result;
+    Clock::time_point total_begin;
+    if constexpr (Profile) total_begin = Clock::now();
+    void* memory = nullptr;
+    try {
+      Clock::time_point setup_begin;
+      if constexpr (Profile) setup_begin = Clock::now();
+      memory = CVodeCreate(Lmm, context_);
+      if (!memory) throw std::runtime_error("CVodeCreate failed");
+      CHECK_CVODES_CALL(CVodeInit(memory, &LocalCvodesIntegrator::cv_rhs,
+                                  benchmark_.ode.t0, nv_state_));
+      // CVodeSetJacFn and CVodeSensInit capture the current user-data pointer.
+      // Preserve Stan Math's order: install it before either callback.
+      CHECK_CVODES_CALL(CVodeSetUserData(memory, this));
+      stan::math::cvodes_set_options(memory, benchmark_.ode.max_steps);
+      CHECK_CVODES_CALL(
+          CVodeSStolerances(memory, benchmark_.ode.rtol, benchmark_.ode.atol));
+      CHECK_CVODES_CALL(CVodeSetLinearSolver(memory, linear_solver_, matrix_));
+      CHECK_CVODES_CALL(
+          CVodeSetJacFn(memory, &LocalCvodesIntegrator::cv_jacobian_states));
+      if (n_sens_ != 0) {
+        CHECK_CVODES_CALL(
+            CVodeSensInit(memory, static_cast<int>(n_sens_), CV_STAGGERED,
+                          &LocalCvodesIntegrator::cv_rhs_sens, nv_sens_));
+        CHECK_CVODES_CALL(CVodeSetSensErrCon(memory, SUNTRUE));
+        CHECK_CVODES_CALL(CVodeSensEEtolerances(memory));
+      }
+      if constexpr (Profile) result.profile.setup_ns = elapsed_ns(setup_begin);
+
+      result.values.reserve(benchmark_.ode.ts.size() * n_);
+      result.jacobian.assign(benchmark_.ode.ts.size() * n_ * (n_ + p_), 0.0);
+      double current_time = benchmark_.ode.t0;
+      for (size_t output_time = 0; output_time < benchmark_.ode.ts.size();
+           ++output_time) {
+        const double final_time = benchmark_.ode.ts[output_time];
+        if (final_time != current_time) {
+          Clock::time_point integrate_begin;
+          if constexpr (Profile) integrate_begin = Clock::now();
+          CHECK_CVODES_CALL(
+              CVode(memory, final_time, nv_state_, &current_time, CV_NORMAL));
+          if constexpr (Profile)
+            result.profile.integrate_ns += elapsed_ns(integrate_begin);
+          if (n_sens_ != 0) {
+            Clock::time_point get_begin;
+            if constexpr (Profile) get_begin = Clock::now();
+            CHECK_CVODES_CALL(CVodeGetSens(memory, &current_time, nv_sens_));
+            if constexpr (Profile)
+              result.profile.get_sens_ns += elapsed_ns(get_begin);
+          }
+        }
+
+        Clock::time_point output_begin;
+        if constexpr (Profile) output_begin = Clock::now();
+        for (size_t row = 0; row < n_; ++row) {
+          result.values.push_back(state_[row]);
+          const size_t flat_output = output_time * n_ + row;
+          double* jac = result.jacobian.data() + flat_output * (n_ + p_);
+          for (size_t column = 0; column < n_y_sens_; ++column)
+            jac[column] = state_[n_ + column * n_ + row];
+          for (size_t column = 0; column < n_theta_sens_; ++column) {
+            const size_t sensitivity = n_y_sens_ + column;
+            jac[n_ + column] = state_[n_ + sensitivity * n_ + row];
+          }
+        }
+        if constexpr (Profile)
+          result.profile.output_ns += elapsed_ns(output_begin);
+        current_time = final_time;
+      }
+
+      if constexpr (Profile) collect_stats(memory, &result.profile.cvodes);
+      CVodeFree(&memory);
+      result.profile.callback = provider_.profile();
+      if constexpr (Profile) result.profile.total_ns = elapsed_ns(total_begin);
+      return result;
+    } catch (...) {
+      if (memory) CVodeFree(&memory);
+      throw;
+    }
+  }
+
+ private:
+  const BenchCase& benchmark_;
+  size_t n_;
+  size_t p_;
+  size_t n_y_sens_;
+  size_t n_theta_sens_;
+  size_t n_sens_;
+  sundials::Context context_;
+  std::vector<double> state_;
+  N_Vector nv_state_ = nullptr;
+  N_Vector* nv_sens_ = nullptr;
+  SUNMatrix matrix_ = nullptr;
+  SUNLinearSolver linear_solver_ = nullptr;
+  TangentProvider<Profile> provider_;
+  std::vector<double> jy_;
+  std::vector<double> jtheta_;
+
+  void release() noexcept {
+    if (nv_sens_) {
+      N_VDestroyVectorArray(nv_sens_, static_cast<int>(n_sens_));
+      nv_sens_ = nullptr;
+    }
+    if (linear_solver_) {
+      SUNLinSolFree(linear_solver_);
+      linear_solver_ = nullptr;
+    }
+    if (matrix_) {
+      SUNMatDestroy(matrix_);
+      matrix_ = nullptr;
+    }
+    if (nv_state_) {
+      N_VDestroy_Serial(nv_state_);
+      nv_state_ = nullptr;
+    }
+  }
+
+  static int cv_rhs(realtype t, N_Vector y, N_Vector ydot, void* user_data) {
+    auto* self = static_cast<LocalCvodesIntegrator*>(user_data);
+    self->provider_.values(t, NV_DATA_S(y), NV_DATA_S(ydot));
+    return 0;
+  }
+
+  static int cv_jacobian_states(realtype t, N_Vector y, N_Vector,
+                                SUNMatrix jacobian, void* user_data, N_Vector,
+                                N_Vector, N_Vector) {
+    auto* self = static_cast<LocalCvodesIntegrator*>(user_data);
+    self->provider_.jacobian(t, NV_DATA_S(y), false, nullptr, self->jy_.data(),
+                             nullptr);
+    for (size_t column = 0; column < self->n_; ++column)
+      for (size_t row = 0; row < self->n_; ++row)
+        SM_ELEMENT_D(jacobian, row, column) =
+            self->jy_[row * self->n_ + column];
+    return 0;
+  }
+
+  static int cv_rhs_sens(int, realtype t, N_Vector y, N_Vector,
+                         N_Vector* y_sens, N_Vector* y_sens_dot,
+                         void* user_data, N_Vector, N_Vector) {
+    auto* self = static_cast<LocalCvodesIntegrator*>(user_data);
+    self->provider_.jacobian(
+        t, NV_DATA_S(y), self->n_theta_sens_ != 0, nullptr, self->jy_.data(),
+        self->n_theta_sens_ ? self->jtheta_.data() : nullptr);
+    Clock::time_point product_begin;
+    if constexpr (Profile) product_begin = Clock::now();
+    // Match coupled_ode_system's scalar grouping: output row outermost;
+    // initial-state lanes start at +0, parameter lanes start at J_theta, and
+    // each dot product accumulates state columns in ascending order.
+    for (size_t row = 0; row < self->n_; ++row) {
+      for (size_t sensitivity = 0; sensitivity < self->n_y_sens_;
+           ++sensitivity) {
+        double derivative = 0.0;
+        for (size_t state = 0; state < self->n_; ++state)
+          derivative += NV_DATA_S(y_sens[sensitivity])[state] *
+                        self->jy_[row * self->n_ + state];
+        NV_DATA_S(y_sens_dot[sensitivity])[row] = derivative;
+      }
+      for (size_t parameter = 0; parameter < self->n_theta_sens_; ++parameter) {
+        const size_t sensitivity = self->n_y_sens_ + parameter;
+        double derivative = self->jtheta_[row * self->p_ + parameter];
+        for (size_t state = 0; state < self->n_; ++state)
+          derivative += NV_DATA_S(y_sens[sensitivity])[state] *
+                        self->jy_[row * self->n_ + state];
+        NV_DATA_S(y_sens_dot[sensitivity])[row] = derivative;
+      }
+    }
+    if constexpr (Profile)
+      self->provider_.profile().sensitivity_product_ns +=
+          elapsed_ns(product_begin);
+    return 0;
+  }
+
+  void collect_stats(void* memory, CvodesStats* stats) {
+    CHECK_CVODES_CALL(CVodeGetNumSteps(memory, &stats->steps));
+    CHECK_CVODES_CALL(CVodeGetNumRhsEvals(memory, &stats->rhs_evals));
+    CHECK_CVODES_CALL(CVodeGetNumLinSolvSetups(memory, &stats->linear_setups));
+    CHECK_CVODES_CALL(
+        CVodeGetNumErrTestFails(memory, &stats->error_test_fails));
+    CHECK_CVODES_CALL(
+        CVodeGetNumNonlinSolvIters(memory, &stats->nonlinear_iters));
+    CHECK_CVODES_CALL(
+        CVodeGetNumNonlinSolvConvFails(memory, &stats->nonlinear_fails));
+    CHECK_CVODES_CALL(CVodeGetNumJacEvals(memory, &stats->jacobian_evals));
+    CHECK_CVODES_CALL(CVodeGetNumLinRhsEvals(memory, &stats->linear_rhs_evals));
+    CHECK_CVODES_CALL(CVodeGetNumLinIters(memory, &stats->linear_iters));
+    CHECK_CVODES_CALL(CVodeGetNumLinConvFails(memory, &stats->linear_fails));
+    if (n_sens_ != 0) {
+      CHECK_CVODES_CALL(
+          CVodeGetSensNumRhsEvals(memory, &stats->sens_rhs_evals));
+      CHECK_CVODES_CALL(
+          CVodeGetNumRhsEvalsSens(memory, &stats->sens_extra_rhs_evals));
+      CHECK_CVODES_CALL(
+          CVodeGetSensNumErrTestFails(memory, &stats->sens_error_test_fails));
+      CHECK_CVODES_CALL(
+          CVodeGetSensNumLinSolvSetups(memory, &stats->sens_linear_setups));
+      CHECK_CVODES_CALL(
+          CVodeGetSensNumNonlinSolvIters(memory, &stats->sens_nonlinear_iters));
+      CHECK_CVODES_CALL(CVodeGetSensNumNonlinSolvConvFails(
+          memory, &stats->sens_nonlinear_fails));
+    }
+  }
+};
+
+struct OracleCallbackProfile {
+  int64_t double_calls = 0;
+  int64_t var_calls = 0;
+  int64_t double_ns = 0;
+  int64_t var_ns = 0;
+};
+
+// The merged PR #245 callback shape: caller-owned Eigen output and direct
+// run_rhs_into, with no legacy public std::vector adapter.
+template <bool Profile>
+struct OracleRhs {
+  const BenchCase* benchmark;
+  OracleCallbackProfile* profile;
+
+  template <typename T_y, typename T_theta>
+  Eigen::Matrix<stan::return_type_t<T_y, T_theta>, Eigen::Dynamic, 1>
+  operator()(const double& t, const Eigen::Matrix<T_y, Eigen::Dynamic, 1>& y,
+             std::ostream*, const std::vector<T_theta>& theta,
+             const std::vector<double>& x_r, const std::vector<int>&) const {
+    using T = stan::return_type_t<T_y, T_theta>;
+    Clock::time_point begin;
+    if constexpr (Profile) begin = Clock::now();
+    Eigen::Matrix<T, Eigen::Dynamic, 1> out(
+        static_cast<Eigen::Index>(benchmark->ode.prog.out_regs.size()));
+    stanli::run_rhs_into<T>(benchmark->ode.prog, t, y.data(), theta.data(),
+                            theta.size(), x_r.data(), out.data());
+    if constexpr (Profile) {
+      if constexpr (std::is_same_v<T, double>) {
+        ++profile->double_calls;
+        profile->double_ns += elapsed_ns(begin);
+      } else {
+        ++profile->var_calls;
+        profile->var_ns += elapsed_ns(begin);
+      }
+    }
+    return out;
+  }
+};
+
+struct NoNestedAutodiff {};
+
+template <int Lmm, bool YActive, bool ThetaActive, bool Profile>
+SolveResult run_oracle_typed(const BenchCase& benchmark) {
+  using T_y = std::conditional_t<YActive, var, double>;
+  using T_theta = std::conditional_t<ThetaActive, var, double>;
+  using T_out = stan::return_type_t<T_y, T_theta>;
+
+  SolveResult result;
+  Clock::time_point total_begin;
+  if constexpr (Profile) total_begin = Clock::now();
+  OracleCallbackProfile callback;
+  using Nested =
+      std::conditional_t<YActive || ThetaActive,
+                         stan::math::nested_rev_autodiff, NoNestedAutodiff>;
+  Nested nested;
+
+  // Retain ode_fwd_typed's construction order: y0, then theta, then the
+  // Eigen-state handle copies made by solve().
+  std::vector<T_y> y0(benchmark.y0.begin(), benchmark.y0.end());
+  std::vector<T_theta> theta(benchmark.theta.begin(), benchmark.theta.end());
+  Eigen::Matrix<T_y, Eigen::Dynamic, 1> eigen_y0(
+      static_cast<Eigen::Index>(y0.size()));
+  for (size_t i = 0; i < y0.size(); ++i)
+    eigen_y0(static_cast<Eigen::Index>(i)) = y0[i];
+
+  OracleRhs<Profile> rhs{&benchmark, &callback};
+  std::vector<Eigen::Matrix<T_out, Eigen::Dynamic, 1>> solution;
+  Clock::time_point solve_begin;
+  if constexpr (Profile) solve_begin = Clock::now();
+  if constexpr (Lmm == CV_BDF) {
+    solution = stan::math::ode_bdf_tol_impl(
+        "integrate_ode_bdf", rhs, eigen_y0, benchmark.ode.t0, benchmark.ode.ts,
+        benchmark.ode.rtol, benchmark.ode.atol, benchmark.ode.max_steps,
+        nullptr, theta, benchmark.ode.x_r, benchmark.ode.x_i);
+  } else {
+    solution = stan::math::ode_adams_tol_impl(
+        "integrate_ode_adams", rhs, eigen_y0, benchmark.ode.t0,
+        benchmark.ode.ts, benchmark.ode.rtol, benchmark.ode.atol,
+        benchmark.ode.max_steps, nullptr, theta, benchmark.ode.x_r,
+        benchmark.ode.x_i);
+  }
+
+  const size_t n = benchmark.y0.size(), p = benchmark.theta.size();
+  const size_t output_count = solution.size() * n;
+  result.values.resize(output_count);
+  result.jacobian.assign(output_count * (n + p), 0.0);
+  for (size_t time = 0; time < solution.size(); ++time)
+    for (size_t state = 0; state < n; ++state) {
+      const size_t output = time * n + state;
+      if constexpr (std::is_same_v<T_out, double>)
+        result.values[output] = solution[time](state);
+      else
+        result.values[output] = solution[time](state).val();
+    }
+
+  if constexpr (!std::is_same_v<T_out, double>) {
+    Clock::time_point harvest_begin;
+    if constexpr (Profile) harvest_begin = Clock::now();
+    stan::math::set_zero_all_adjoints_nested();
+    for (size_t output = output_count; output-- > 0;) {
+      var value = solution[output / n](output % n);
+      value.vi_->adj_ = 1.0;
+      value.vi_->chain();
+      double* row = result.jacobian.data() + output * (n + p);
+      if constexpr (YActive) {
+        for (size_t i = 0; i < n; ++i) {
+          row[i] = y0[i].adj();
+          y0[i].vi_->adj_ = 0.0;
+        }
+      }
+      if constexpr (ThetaActive) {
+        for (size_t i = 0; i < p; ++i) {
+          row[n + i] = theta[i].adj();
+          theta[i].vi_->adj_ = 0.0;
+        }
+      }
+      value.vi_->adj_ = 0.0;
+    }
+    if constexpr (Profile)
+      result.profile.final_harvest_ns = elapsed_ns(harvest_begin);
+  }
+
+  if constexpr (Profile) {
+    result.profile.total_ns = elapsed_ns(total_begin);
+    result.profile.allocation_ns = duration_ns(total_begin, solve_begin);
+    result.profile.oracle_double_callbacks = callback.double_calls;
+    result.profile.oracle_var_callbacks = callback.var_calls;
+    result.profile.oracle_double_callback_ns = callback.double_ns;
+    result.profile.oracle_var_callback_ns = callback.var_ns;
+  }
+  return result;
+}
+
+template <int Lmm, bool Profile>
+SolveResult run_oracle(const BenchCase& benchmark, bool y_active,
+                       bool theta_active) {
+  if (y_active && theta_active)
+    return run_oracle_typed<Lmm, true, true, Profile>(benchmark);
+  if (y_active) return run_oracle_typed<Lmm, true, false, Profile>(benchmark);
+  if (theta_active)
+    return run_oracle_typed<Lmm, false, true, Profile>(benchmark);
+  return run_oracle_typed<Lmm, false, false, Profile>(benchmark);
+}
+
+template <int Lmm, bool Profile>
+SolveResult run_local(const BenchCase& benchmark, bool y_active,
+                      bool theta_active) {
+  Clock::time_point begin;
+  Clock::time_point constructed;
+  if constexpr (Profile) begin = Clock::now();
+  SolveResult result;
+  {
+    LocalCvodesIntegrator<Lmm, Profile> integrator(benchmark, y_active,
+                                                   theta_active);
+    if constexpr (Profile) constructed = Clock::now();
+    result = integrator.solve();
+    if constexpr (Profile)
+      result.profile.allocation_ns = duration_ns(begin, constructed);
+  }
+  if constexpr (Profile) result.profile.total_ns = elapsed_ns(begin);
+  return result;
+}
+
+struct Comparison {
+  size_t count = 0;
+  size_t exact = 0;
+  double max_abs = 0.0;
+  double max_rel = 0.0;
+  uint64_t max_ulp = 0;
+  size_t worst = 0;
+  bool numerical = true;
+};
+
+Comparison compare(const std::vector<double>& candidate,
+                   const std::vector<double>& oracle) {
+  if (candidate.size() != oracle.size())
+    throw std::runtime_error("comparison size mismatch");
+  Comparison out;
+  out.count = candidate.size();
+  for (size_t i = 0; i < candidate.size(); ++i) {
+    const bool exact = bits(candidate[i]) == bits(oracle[i]);
+    if (exact) ++out.exact;
+    if (!std::isfinite(candidate[i]) || !std::isfinite(oracle[i])) {
+      out.max_abs = std::numeric_limits<double>::infinity();
+      out.max_rel = std::numeric_limits<double>::infinity();
+      out.max_ulp = std::numeric_limits<uint64_t>::max();
+      out.worst = i;
+      out.numerical = false;
+      continue;
+    }
+    const double absolute = std::abs(candidate[i] - oracle[i]);
+    const double scale =
+        std::max({1e-12, std::abs(candidate[i]), std::abs(oracle[i])});
+    const double relative = absolute / scale;
+    if (absolute > 1e-12 && relative > 1e-9) out.numerical = false;
+    const uint64_t ulps = ulp_distance(candidate[i], oracle[i]);
+    if (relative > out.max_rel ||
+        (relative == out.max_rel && absolute > out.max_abs))
+      out.worst = i;
+    out.max_abs = std::max(out.max_abs, absolute);
+    out.max_rel = std::max(out.max_rel, relative);
+    out.max_ulp = std::max(out.max_ulp, ulps);
+  }
+  return out;
+}
+
+void print_comparison(const char* label, const Comparison& comparison,
+                      const std::vector<double>& candidate,
+                      const std::vector<double>& oracle) {
+  std::printf(
+      "%s: exact=%zu/%zu max_abs=%.17g max_rel=%.17g max_ulp=%llu "
+      "worst[%zu]=%.17g oracle=%.17g\n",
+      label, comparison.exact, comparison.count, comparison.max_abs,
+      comparison.max_rel, static_cast<unsigned long long>(comparison.max_ulp),
+      comparison.worst, comparison.count ? candidate[comparison.worst] : 0.0,
+      comparison.count ? oracle[comparison.worst] : 0.0);
+}
+
+struct LocalRhsResult {
+  std::vector<double> values;
+  std::vector<double> jacobian;
+};
+
+LocalRhsResult local_reverse_result(const BenchCase& benchmark, double t) {
+  stan::math::nested_rev_autodiff nested;
+  std::vector<var> y;
+  std::vector<var> theta;
+  y.reserve(benchmark.y0.size());
+  theta.reserve(benchmark.theta.size());
+  for (double value : benchmark.y0) y.emplace_back(value);
+  for (double value : benchmark.theta) theta.emplace_back(value);
+
+  std::vector<var> output(benchmark.ode.prog.out_regs.size());
+  stanli::run_rhs_into<var>(benchmark.ode.prog, t, y.data(), theta.data(),
+                            theta.size(), benchmark.ode.x_r.data(),
+                            output.data());
+  LocalRhsResult result;
+  result.values.resize(output.size());
+  const size_t width = y.size() + theta.size();
+  result.jacobian.resize(output.size() * width);
+  for (size_t row = 0; row < output.size(); ++row) {
+    result.values[row] = output[row].val();
+    stan::math::grad(output[row].vi_);
+    for (size_t column = 0; column < y.size(); ++column)
+      result.jacobian[row * width + column] = y[column].adj();
+    for (size_t column = 0; column < theta.size(); ++column)
+      result.jacobian[row * width + y.size() + column] = theta[column].adj();
+    if (row + 1 < output.size()) nested.set_zero_all_adjoints();
+  }
+  return result;
+}
+
+LocalRhsResult local_tangent_result(const BenchCase& benchmark, double t) {
+  TangentProvider<false> provider(benchmark.ode.prog, benchmark.theta,
+                                  benchmark.ode.x_r);
+  const size_t n = benchmark.y0.size();
+  const size_t p = benchmark.theta.size();
+  std::vector<double> jy(n * n);
+  std::vector<double> jtheta(n * p);
+  LocalRhsResult result;
+  result.values.resize(n);
+  result.jacobian.resize(n * (n + p));
+  provider.jacobian(t, benchmark.y0.data(), true, result.values.data(),
+                    jy.data(), jtheta.data());
+  for (size_t row = 0; row < n; ++row) {
+    std::copy_n(jy.data() + row * n, n, result.jacobian.data() + row * (n + p));
+    std::copy_n(jtheta.data() + row * p, p,
+                result.jacobian.data() + row * (n + p) + n);
+  }
+  return result;
+}
+
+void print_local_branch_proof(const BenchCase& benchmark, bool require_exact) {
+  const double infinity = std::numeric_limits<double>::infinity();
+  const double midpoint =
+      benchmark.ode.ts.empty()
+          ? benchmark.ode.t0
+          : benchmark.ode.t0 +
+                0.5 * (benchmark.ode.ts.back() - benchmark.ode.t0);
+  std::vector<double> candidates{benchmark.ode.t0};
+  if (benchmark.ode.rhs_name == "one_comp_mm_elim_abs") {
+    candidates.insert(candidates.end(),
+                      {-0.0, 0.0, std::nextafter(benchmark.ode.t0, -infinity),
+                       std::nextafter(benchmark.ode.t0, infinity)});
+  } else if (benchmark.ode.rhs_name == "synthetic_rhs") {
+    candidates.insert(candidates.end(),
+                      {std::nextafter(midpoint, -infinity), midpoint,
+                       std::nextafter(midpoint, infinity)});
+  }
+  std::vector<double> probes;
+  for (double candidate : candidates) {
+    const bool seen = std::any_of(
+        probes.begin(), probes.end(),
+        [&](double prior) { return bits(prior) == bits(candidate); });
+    if (!seen) probes.push_back(candidate);
+  }
+
+  std::printf("local branch-aware tangent proof: probes=%zu\n", probes.size());
+  for (size_t i = 0; i < probes.size(); ++i) {
+    const LocalRhsResult oracle = local_reverse_result(benchmark, probes[i]);
+    const LocalRhsResult tangent = local_tangent_result(benchmark, probes[i]);
+    const Comparison values = compare(tangent.values, oracle.values);
+    const Comparison jacobian = compare(tangent.jacobian, oracle.jacobian);
+    std::printf("local probe[%zu] t=%.17g signbit=%d\n", i, probes[i],
+                std::signbit(probes[i]) ? 1 : 0);
+    print_comparison("  rhs values", values, tangent.values, oracle.values);
+    print_comparison("  rhs Jacobian", jacobian, tangent.jacobian,
+                     oracle.jacobian);
+    const bool exact =
+        values.exact == values.count && jacobian.exact == jacobian.count;
+    if (!values.numerical || !jacobian.numerical || (require_exact && !exact))
+      throw std::runtime_error("local tangent failed the numerical gate");
+  }
+}
+
+void print_profile(const SolveResult& oracle, const SolveResult& local) {
+  const SolveProfile& old = oracle.profile;
+  const SolveProfile& now = local.profile;
+  const CallbackProfile& callback = now.callback;
+  const CvodesStats& stats = now.cvodes;
+  std::printf(
+      "oracle profile ns: total=%lld allocation=%lld callback_double=%lld/%lld "
+      "callback_var=%lld/%lld final_harvest=%lld\n",
+      static_cast<long long>(old.total_ns),
+      static_cast<long long>(old.allocation_ns),
+      static_cast<long long>(old.oracle_double_callback_ns),
+      static_cast<long long>(old.oracle_double_callbacks),
+      static_cast<long long>(old.oracle_var_callback_ns),
+      static_cast<long long>(old.oracle_var_callbacks),
+      static_cast<long long>(old.final_harvest_ns));
+  std::printf(
+      "local profile ns: total=%lld allocation=%lld setup=%lld integrate=%lld "
+      "get_sens=%lld "
+      "output=%lld seed=%lld body=%lld extract=%lld sens_product=%lld\n",
+      static_cast<long long>(now.total_ns),
+      static_cast<long long>(now.allocation_ns),
+      static_cast<long long>(now.setup_ns),
+      static_cast<long long>(now.integrate_ns),
+      static_cast<long long>(now.get_sens_ns),
+      static_cast<long long>(now.output_ns),
+      static_cast<long long>(callback.seed_ns),
+      static_cast<long long>(callback.body_ns),
+      static_cast<long long>(callback.extract_ns),
+      static_cast<long long>(callback.sensitivity_product_ns));
+  std::printf(
+      "local callbacks: values=%lld jy=%lld full_j=%lld directions=%lld "
+      "value_ns=%lld jy_ns=%lld full_j_ns=%lld\n",
+      static_cast<long long>(callback.value_calls),
+      static_cast<long long>(callback.jacobian_calls),
+      static_cast<long long>(callback.full_jacobian_calls),
+      static_cast<long long>(callback.tangent_directions),
+      static_cast<long long>(callback.value_callback_ns),
+      static_cast<long long>(callback.jacobian_callback_ns),
+      static_cast<long long>(callback.sensitivity_callback_ns));
+  std::printf(
+      "CVODES stats: steps=%ld rhs=%ld jac=%ld lin_setup=%ld err_fail=%ld "
+      "nlin_iter=%ld nlin_fail=%ld lin_rhs=%ld lin_iter=%ld lin_fail=%ld\n",
+      stats.steps, stats.rhs_evals, stats.jacobian_evals, stats.linear_setups,
+      stats.error_test_fails, stats.nonlinear_iters, stats.nonlinear_fails,
+      stats.linear_rhs_evals, stats.linear_iters, stats.linear_fails);
+  std::printf(
+      "CVODES sensitivity stats: rhs=%ld extra_primal_rhs=%ld err_fail=%ld "
+      "lin_setup=%ld nlin_iter=%ld nlin_fail=%ld\n",
+      stats.sens_rhs_evals, stats.sens_extra_rhs_evals,
+      stats.sens_error_test_fails, stats.sens_linear_setups,
+      stats.sens_nonlinear_iters, stats.sens_nonlinear_fails);
+}
+
+template <typename F>
+double time_solves(int iterations, F&& solve) {
+  const auto begin = Clock::now();
+  for (int i = 0; i < iterations; ++i) {
+    SolveResult result = solve();
+    if (!result.values.empty()) benchmark_sink += result.values.back();
+    if (!result.jacobian.empty()) benchmark_sink += result.jacobian.back();
+  }
+  return static_cast<double>(elapsed_ns(begin)) /
+         static_cast<double>(iterations);
+}
+
+template <int Lmm>
+void run_benchmark(const BenchCase& benchmark, bool y_active, bool theta_active,
+                   int iterations, int batches, int warmup_ms,
+                   bool require_exact) {
+  const SolveResult oracle_profile =
+      run_oracle<Lmm, true>(benchmark, y_active, theta_active);
+  const SolveResult local_profile =
+      run_local<Lmm, true>(benchmark, y_active, theta_active);
+  const Comparison values =
+      compare(local_profile.values, oracle_profile.values);
+  const Comparison jacobian =
+      compare(local_profile.jacobian, oracle_profile.jacobian);
+  print_comparison("solution values (fvar ceiling vs current oracle)", values,
+                   local_profile.values, oracle_profile.values);
+  print_comparison("solution Jacobian (fvar ceiling vs current oracle)",
+                   jacobian, local_profile.jacobian, oracle_profile.jacobian);
+  const int64_t oracle_derivative_callbacks =
+      oracle_profile.profile.oracle_var_callbacks;
+  const int64_t local_derivative_callbacks =
+      local_profile.profile.callback.jacobian_calls +
+      local_profile.profile.callback.full_jacobian_calls;
+  const bool callback_equal =
+      oracle_profile.profile.oracle_double_callbacks ==
+          local_profile.profile.callback.value_calls &&
+      oracle_derivative_callbacks == local_derivative_callbacks;
+  const bool solution_exact =
+      values.exact == values.count && jacobian.exact == jacobian.count;
+  const bool correctness_pass = values.numerical && jacobian.numerical &&
+                                (!require_exact || solution_exact);
+  std::printf(
+      "timing_gate=%s pass=%d work_parity=callback_count "
+      "oracle_cvodes_stats=unavailable\n",
+      require_exact ? "exact" : "proximity",
+      callback_equal && correctness_pass ? 1 : 0);
+  if (!callback_equal || !correctness_pass)
+    throw std::runtime_error(
+        "candidate failed the pre-timing correctness gate");
+  print_profile(oracle_profile, local_profile);
+
+  // Warm the compile-time-uninstrumented arms independently so each reaches
+  // the requested duration even when their costs differ materially.
+  const double warmup_target_ns = static_cast<double>(warmup_ms) * 1e6;
+  double oracle_warmup_ns = 0.0, local_warmup_ns = 0.0;
+  size_t oracle_warmup_solves = 0, local_warmup_solves = 0;
+  while (oracle_warmup_ns < warmup_target_ns ||
+         local_warmup_ns < warmup_target_ns) {
+    if (oracle_warmup_ns < warmup_target_ns) {
+      oracle_warmup_ns += time_solves(1, [&] {
+        return run_oracle<Lmm, false>(benchmark, y_active, theta_active);
+      });
+      ++oracle_warmup_solves;
+    }
+    if (local_warmup_ns < warmup_target_ns) {
+      local_warmup_ns += time_solves(1, [&] {
+        return run_local<Lmm, false>(benchmark, y_active, theta_active);
+      });
+      ++local_warmup_solves;
+    }
+  }
+  std::printf(
+      "warmup oracle_ms=%.3f local_ms=%.3f oracle_solves=%zu "
+      "local_solves=%zu\n",
+      oracle_warmup_ns / 1e6, local_warmup_ns / 1e6, oracle_warmup_solves,
+      local_warmup_solves);
+
+  std::vector<double> oracle_ns, local_ns, speedups;
+  oracle_ns.reserve(static_cast<size_t>(batches));
+  local_ns.reserve(static_cast<size_t>(batches));
+  speedups.reserve(static_cast<size_t>(batches));
+  for (int batch = 0; batch < batches; ++batch) {
+    double old_time = 0.0, new_time = 0.0;
+    if ((batch & 1) == 0) {
+      old_time = time_solves(iterations, [&] {
+        return run_oracle<Lmm, false>(benchmark, y_active, theta_active);
+      });
+      new_time = time_solves(iterations, [&] {
+        return run_local<Lmm, false>(benchmark, y_active, theta_active);
+      });
+    } else {
+      new_time = time_solves(iterations, [&] {
+        return run_local<Lmm, false>(benchmark, y_active, theta_active);
+      });
+      old_time = time_solves(iterations, [&] {
+        return run_oracle<Lmm, false>(benchmark, y_active, theta_active);
+      });
+    }
+    oracle_ns.push_back(old_time);
+    local_ns.push_back(new_time);
+    speedups.push_back(old_time / new_time);
+    std::printf("batch %02d: oracle=%.1f ns local=%.1f ns speedup=%.6fx\n",
+                batch + 1, old_time, new_time, old_time / new_time);
+  }
+  std::printf(
+      "uninstrumented medians: oracle=%.1f ns local=%.1f ns paired "
+      "speedup=%.6fx (range %.6fx..%.6fx) sink=%.17g\n",
+      median(oracle_ns), median(local_ns), median(speedups),
+      *std::min_element(speedups.begin(), speedups.end()),
+      *std::max_element(speedups.begin(), speedups.end()), benchmark_sink);
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+  try {
+    const Options options = parse_options(argc, argv);
+    const stanli::DataMap data =
+        stanli::DataMap::from_json(slurp(options.data));
+    stanli::CompiledModel model =
+        stanli::compile_model(slurp(options.mir), data);
+    stanli::Executor executor(std::move(model.graph));
+    model.bind(executor);
+    for (int64_t i = 0; i < executor.n_params(); ++i)
+      executor.params_data()[i] = eval_point(i, options.point);
+
+    // One normal graph evaluation materializes transformed y0/theta slots.
+    // This preparation is outside all component and paired solve timings.
+    std::vector<double> model_gradient(
+        static_cast<size_t>(executor.n_params()));
+    const double model_lp = executor.gradient(model_gradient.data());
+
+    const stanli::Op* ode_op = nullptr;
+    for (const auto& op : executor.graph().ops) {
+      if (op.opcode == stanli::OP_ODE) {
+        ode_op = &op;
+        break;
+      }
+    }
+    if (!ode_op) throw std::runtime_error("compiled model has no OP_ODE");
+    const auto* spec = static_cast<const OdeSpec*>(ode_op->udata);
+    if (!spec) throw std::runtime_error("OP_ODE has no OdeSpec");
+
+    const auto& graph = executor.graph();
+    const size_t n_y = static_cast<size_t>(graph.slots[ode_op->in[0]].len);
+    const size_t n_theta = static_cast<size_t>(graph.slots[ode_op->in[1]].len);
+    const size_t output_size =
+        static_cast<size_t>(graph.slots[ode_op->out].len);
+    if (n_y == 0 || output_size % n_y != 0 ||
+        output_size / n_y != spec->ts.size())
+      throw std::runtime_error("OP_ODE shape does not match OdeSpec times");
+    if (spec->prog.out_regs.size() != n_y)
+      throw std::runtime_error(
+          "compiled RHS output width does not match state");
+    const uint8_t type_mask =
+        (ode_op->variant & 0x4u) != 0 ? (ode_op->variant & 0x3u) : 0x3u;
+    const bool y_active = (type_mask & 0x1u) != 0;
+    const bool theta_active = (type_mask & 0x2u) != 0;
+    const OdeSpec::Solver selected_solver = select_solver(options, *spec);
+    BenchCase benchmark = materialize_case(
+        *spec, executor.value_ptr(ode_op->in[0]), n_y,
+        executor.value_ptr(ode_op->in[1]), n_theta, selected_solver);
+
+    std::printf(
+        "CVODES fvar ceiling/proximity experiment: model_lp=%.17g rhs=%s "
+        "original_solver=%s solver=%s legacy=%d point=%d\n",
+        model_lp, benchmark.ode.rhs_name.c_str(), solver_name(spec->solver),
+        solver_name(selected_solver), benchmark.ode.legacy ? 1 : 0,
+        options.point);
+    std::printf(
+        "shape states=%zu theta_source=%zu theta_program=%d xr=%zu times=%zu "
+        "outputs=%zu type_mask=0x%x activity=%d/%d code=%zu regs=%d "
+        "rtol=%.17g atol=%.17g max_steps=%ld\n",
+        n_y, n_theta, benchmark.ode.prog.n_th, benchmark.ode.x_r.size(),
+        benchmark.ode.ts.size(), output_size, static_cast<unsigned>(type_mask),
+        y_active ? 1 : 0, theta_active ? 1 : 0, benchmark.ode.prog.code.size(),
+        benchmark.ode.prog.n_regs, benchmark.ode.rtol, benchmark.ode.atol,
+        benchmark.ode.max_steps);
+    print_local_branch_proof(benchmark, options.require_exact);
+    if (selected_solver == OdeSpec::BDF)
+      run_benchmark<CV_BDF>(benchmark, y_active, theta_active,
+                            options.iterations, options.batches,
+                            options.warmup_ms, options.require_exact);
+    else
+      run_benchmark<CV_ADAMS>(benchmark, y_active, theta_active,
+                              options.iterations, options.batches,
+                              options.warmup_ms, options.require_exact);
+    return 0;
+  } catch (const std::exception& error) {
+    std::fprintf(stderr, "bench_ode_cvodes_ceiling: %s\n", error.what());
+    return 1;
+  }
+}

--- a/tools/bench_ode_production.py
+++ b/tools/bench_ode_production.py
@@ -1,0 +1,312 @@
+#!/usr/bin/env python3
+"""Paired complete-gradient admission benchmark for the ODE runtime path.
+
+Builds pinned CmdStan gradient drivers from both default and ``stanc --O1``
+generated C++, then compares them with the same Release ``bench_grad`` binary
+running the current ODE oracle and the direct RK candidate.  Every sample is a
+fresh process with a 200 ms in-process warmup.  Batches alternate ABBA/BAAB
+order and each measured arm is calibrated to the requested minimum duration.
+
+Usage:
+  tools/bench_ode_production.py deps/cmdstan --build build-rel
+"""
+
+import argparse
+import hashlib
+import json
+import math
+import os
+import pathlib
+import platform
+import statistics
+import subprocess
+import sys
+import tempfile
+import zipfile
+
+
+REPO = pathlib.Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "tools"))
+from cmdstan_ref import compile_cmd  # noqa: E402
+
+
+MODELS = (
+    ("lotka_volterra", "hudson_lynx_hare"),
+    ("soil_incubation", "soil_carbon"),
+    ("one_comp_mm_elim_abs", "one_comp_mm_elim_abs"),
+)
+
+# Two-sided 95% Student-t critical values, indexed by degrees of freedom.
+T95 = {
+    1: 12.706, 2: 4.303, 3: 3.182, 4: 2.776, 5: 2.571,
+    6: 2.447, 7: 2.365, 8: 2.306, 9: 2.262, 10: 2.228,
+    11: 2.201, 12: 2.179, 13: 2.160, 14: 2.145, 15: 2.131,
+    16: 2.120, 17: 2.110, 18: 2.101, 19: 2.093, 20: 2.086,
+    21: 2.080, 22: 2.074, 23: 2.069, 24: 2.064, 25: 2.060,
+    26: 2.056, 27: 2.052, 28: 2.048, 29: 2.045, 30: 2.042,
+}
+
+
+def run(command, *, env=None):
+    result = subprocess.run(
+        [str(part) for part in command], capture_output=True, text=True,
+        cwd=REPO, env=env,
+    )
+    if result.returncode != 0:
+        rendered = " ".join(str(part) for part in command)
+        raise RuntimeError(
+            f"command failed ({result.returncode}): {rendered}\n"
+            f"{result.stderr[-4000:]}"
+        )
+    return result
+
+
+def extract_data(archive, destination):
+    with zipfile.ZipFile(archive) as source:
+        members = [
+            name for name in source.namelist()
+            if name.endswith(".json") and not name.endswith("/")
+        ]
+        if len(members) != 1:
+            raise RuntimeError(
+                f"expected one JSON member in {archive}, found {len(members)}"
+            )
+        destination.write_bytes(source.read(members[0]))
+
+
+def sha256_file(path):
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def prepare_model(name, data_name, cmdstan, stanc, posteriordb, work):
+    model_dir = work / name
+    model_dir.mkdir()
+    stan = posteriordb / "models/stan" / f"{name}.stan"
+    archive = posteriordb / "data/data" / f"{data_name}.json.zip"
+    data = model_dir / "data.json"
+    mir = model_dir / "model.tmir.sexp"
+    extract_data(archive, data)
+    mir.write_text(run([stanc, "--O1", "--debug-optimized-mir", stan]).stdout)
+
+    executables = {}
+    for variant, stanc_flags in (("default", ()), ("o1", ("--O1",))):
+        header = model_dir / f"{variant}.hpp"
+        run([stanc, *stanc_flags, stan, f"--o={header}"])
+        executable = model_dir / f"cmdstan_{variant}"
+        run(compile_cmd(
+            cmdstan, header, REPO / "tools/bench_cmdstan_grad.cpp",
+            executable, opt="-O3",
+        ))
+        executables[variant] = executable
+    return data, mir, executables
+
+
+def reuse_model(name, work):
+    model_dir = work / name
+    data = model_dir / "data.json"
+    mir = model_dir / "model.tmir.sexp"
+    executables = {
+        "default": model_dir / "cmdstan_default",
+        "o1": model_dir / "cmdstan_o1",
+    }
+    for required in (data, mir, *executables.values()):
+        if not required.is_file():
+            raise FileNotFoundError(required)
+    return data, mir, executables
+
+
+def arm_environment(direct):
+    env = os.environ.copy()
+    if direct:
+        env.pop("STANLI_NO_ODE_DIRECT_RK", None)
+    else:
+        env["STANLI_NO_ODE_DIRECT_RK"] = "1"
+    env.pop("STANLI_ODE_DIRECT_RK", None)
+    return env
+
+
+def sample(command, count, env=None):
+    fields = run([*command, str(count)], env=env).stdout.split()
+    if not fields:
+        raise RuntimeError(f"benchmark emitted no result: {command}")
+    value = float(fields[0])
+    if not math.isfinite(value) or value <= 0:
+        raise RuntimeError(f"invalid benchmark time {value}: {command}")
+    return value
+
+
+def calibrate(command, env, minimum_seconds):
+    probe_count = 100
+    ns = sample(command, probe_count, env)
+    count = max(1, math.ceil(minimum_seconds * 1e9 / ns))
+    # Leave a little margin so normal timing noise cannot dip under the gate.
+    return max(probe_count, math.ceil(count * 1.10))
+
+
+def interval(ratios):
+    logs = [math.log(value) for value in ratios]
+    center = statistics.mean(logs)
+    if len(logs) == 1:
+        return math.exp(center), math.nan, math.nan
+    error = statistics.stdev(logs) / math.sqrt(len(logs))
+    critical = T95.get(len(logs) - 1, 1.96)
+    return (
+        math.exp(center),
+        math.exp(center - critical * error),
+        math.exp(center + critical * error),
+    )
+
+
+def paired_batches(arm_a, arm_b, counts, rounds):
+    ratios = []
+    raw = []
+    for batch in range(rounds):
+        order = ("a", "b", "b", "a") if batch % 2 == 0 else (
+            "b", "a", "a", "b"
+        )
+        values = {"a": [], "b": []}
+        for side in order:
+            command, env = arm_a if side == "a" else arm_b
+            values[side].append(sample(command, counts[side], env))
+        a_ns = statistics.mean(values["a"])
+        b_ns = statistics.mean(values["b"])
+        ratio = a_ns / b_ns
+        ratios.append(ratio)
+        raw.append({"batch": batch + 1, "a_ns": a_ns, "b_ns": b_ns,
+                    "ratio": ratio})
+    return ratios, raw
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("cmdstan", type=pathlib.Path)
+    parser.add_argument("--build", type=pathlib.Path, default="build-rel")
+    parser.add_argument("--posteriordb", type=pathlib.Path,
+                        default="deps/posteriordb/posterior_database")
+    parser.add_argument("--stanc", type=pathlib.Path,
+                        default="deps/stanc3/stanc")
+    parser.add_argument("--rounds", type=int, default=15)
+    parser.add_argument("--min-seconds", type=float, default=0.5)
+    parser.add_argument("--output", type=pathlib.Path)
+    parser.add_argument("--keep", action="store_true")
+    parser.add_argument(
+        "--reuse-work", type=pathlib.Path,
+        help="reuse a prior --keep directory instead of rebuilding CmdStan",
+    )
+    args = parser.parse_args()
+    if args.rounds < 2 or not math.isfinite(args.min_seconds) or \
+            args.min_seconds <= 0:
+        parser.error("--rounds must be at least 2 and --min-seconds positive")
+
+    output = args.output.resolve() if args.output else None
+    output_tmp = (output.with_name(output.name + ".tmp") if output else None)
+    for destination in (output, output_tmp):
+        if destination and (destination.exists() or destination.is_symlink()):
+            raise FileExistsError(destination)
+
+    cmdstan = args.cmdstan.resolve()
+    build = (REPO / args.build).resolve()
+    posteriordb = (REPO / args.posteriordb).resolve()
+    stanc = (REPO / args.stanc).resolve()
+    bench_grad = build / "bench_grad"
+    for required in (bench_grad, stanc):
+        if not required.is_file():
+            raise FileNotFoundError(required)
+
+    work = (args.reuse_work.resolve() if args.reuse_work else
+            pathlib.Path(tempfile.mkdtemp(prefix="stanli_ode_production_")))
+    results = {
+        "git_head": run(["git", "rev-parse", "HEAD"]).stdout.strip(),
+        "cmdstan_head": run(
+            ["git", "-C", cmdstan, "rev-parse", "HEAD"]
+        ).stdout.strip(),
+        "platform": platform.platform(),
+        "bench_grad_sha256": sha256_file(bench_grad),
+        "rounds": args.rounds,
+        "minimum_seconds": args.min_seconds,
+        "work": str(work),
+        "complete": False,
+        "models": [],
+    }
+
+    def save_results():
+        if not output:
+            return
+        output_tmp.write_text(json.dumps(results, indent=2) + "\n")
+        output_tmp.replace(output)
+    comparisons = (
+        ("oracle/direct", "oracle", "direct"),
+        ("cmdstan_default/direct", "cmdstan_default", "direct"),
+        ("cmdstan_o1/direct", "cmdstan_o1", "direct"),
+    )
+
+    for name, data_name in MODELS:
+        print(f"preparing {name}", flush=True)
+        if args.reuse_work:
+            data, mir, executables = reuse_model(name, work)
+        else:
+            data, mir, executables = prepare_model(
+                name, data_name, cmdstan, stanc, posteriordb, work
+            )
+        arms = {
+            "oracle": ([bench_grad, mir, data], arm_environment(False)),
+            "direct": ([bench_grad, mir, data], arm_environment(True)),
+            "cmdstan_default": ([executables["default"], data], None),
+            "cmdstan_o1": ([executables["o1"], data], None),
+        }
+        counts = {
+            arm: calibrate(command, env, args.min_seconds)
+            for arm, (command, env) in arms.items()
+        }
+        model_result = {
+            "model": name,
+            "counts": counts,
+            "artifacts": {
+                "mir_sha256": sha256_file(mir),
+                "data_sha256": sha256_file(data),
+                "cmdstan_default_sha256": sha256_file(executables["default"]),
+                "cmdstan_o1_sha256": sha256_file(executables["o1"]),
+            },
+            "comparisons": [],
+        }
+        results["models"].append(model_result)
+        for label, a_name, b_name in comparisons:
+            ratios, raw = paired_batches(
+                arms[a_name], arms[b_name],
+                {"a": counts[a_name], "b": counts[b_name]}, args.rounds,
+            )
+            estimate, low, high = interval(ratios)
+            model_result["comparisons"].append({
+                "name": label, "estimate": estimate, "low": low,
+                "high": high, "batches": raw,
+            })
+            print(
+                f"{name} {label}: {estimate:.6f}x "
+                f"[{low:.6f}, {high:.6f}]", flush=True
+            )
+            save_results()
+
+    print("\n| model | comparison | geometric mean | paired 95% CI |")
+    print("|---|---|---:|---:|")
+    for model in results["models"]:
+        for comparison in model["comparisons"]:
+            print(
+                f"| `{model['model']}` | {comparison['name']} | "
+                f"{comparison['estimate']:.3f}x | "
+                f"[{comparison['low']:.3f}x, {comparison['high']:.3f}x] |"
+            )
+
+    if output:
+        results["complete"] = True
+        save_results()
+        print(f"results: {output}")
+    if args.keep:
+        print(f"artifacts: {work}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/bench_rhs_adjoint.cpp
+++ b/tools/bench_rhs_adjoint.cpp
@@ -1,0 +1,564 @@
+// Developer-only Phase 0 spike for generated ODE RHS adjoints.
+//
+// This deliberately uses only existing production primitives.  The generated
+// path copies a compacted RhsProgram into an IslandProg, asks gen_adjoint to
+// add checkpoints and build the reverse program, then measures the complete
+// callback lifecycle proposed for ODEs:
+//
+//   * seed and execute the checkpointed forward once on doubles;
+//   * run one generated reverse sweep per RHS output;
+//   * construct precomputed-gradient output vars; and
+//   * run the subsequent Stan reverse sweeps and harvest their Jacobian rows.
+//
+// The comparison path is today's callback lifecycle: reuse the solver's
+// deep-copied theta vars, create current-state vars, run the RHS register
+// program on vars, and run/harvest one Stan reverse sweep per output.
+// Correctness and consecutive-call behavior are checked bitwise before any
+// timing.  This target is neither a test nor installed; it is an experiment
+// kept beside the other developer benchmarks.
+#include <stanli/adjoint.hpp>
+#include <stanli/island.hpp>
+#include <stanli/mir.hpp>
+#include <stanli/ode_prog.hpp>
+#include <stanli/program.hpp>
+#include <stanli/sexp.hpp>
+
+#include <stan/math.hpp>
+
+#include <algorithm>
+#include <chrono>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <fstream>
+#include <map>
+#include <numeric>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace {
+
+using stan::math::var;
+using stanli::AdjProgram;
+using stanli::IslandProg;
+using stanli::Program;
+using stanli::RhsProgram;
+
+volatile double benchmark_sink = 0.0;
+
+std::string slurp(const std::string& path) {
+  std::ifstream in(path);
+  if (!in) throw std::runtime_error("cannot open " + path);
+  std::ostringstream out;
+  out << in.rdbuf();
+  return out.str();
+}
+
+int positive_arg(const char* text, const char* name) {
+  char* end = nullptr;
+  const long value = std::strtol(text, &end, 10);
+  if (!text[0] || !end || *end != '\0' || value <= 0 || value > 100000000L)
+    throw std::runtime_error(std::string(name) + " must be a positive integer");
+  return static_cast<int>(value);
+}
+
+int nonnegative_arg(const char* text, const char* name) {
+  char* end = nullptr;
+  const long value = std::strtol(text, &end, 10);
+  if (!text[0] || !end || *end != '\0' || value < 0 || value > 100000000L)
+    throw std::runtime_error(std::string(name) +
+                             " must be a nonnegative integer");
+  return static_cast<int>(value);
+}
+
+uint64_t bits(double value) {
+  uint64_t out;
+  std::memcpy(&out, &value, sizeof(out));
+  return out;
+}
+
+bool same_vector(const char* label, const std::vector<double>& got,
+                 const std::vector<double>& want) {
+  if (got.size() != want.size()) {
+    std::fprintf(stderr, "%s size: got %zu, want %zu\n", label, got.size(),
+                 want.size());
+    return false;
+  }
+  for (size_t i = 0; i < got.size(); ++i) {
+    if (bits(got[i]) == bits(want[i])) continue;
+    std::fprintf(stderr,
+                 "%s[%zu]: got %.17g (0x%016llx), want %.17g "
+                 "(0x%016llx)\n",
+                 label, i, got[i], (unsigned long long)bits(got[i]), want[i],
+                 (unsigned long long)bits(want[i]));
+    return false;
+  }
+  return true;
+}
+
+bool adjoints_are_positive_zero(const char* label,
+                                const std::vector<var>& vars) {
+  for (size_t i = 0; i < vars.size(); ++i) {
+    if (bits(vars[i].adj()) == bits(0.0)) continue;
+    std::fprintf(stderr, "%s[%zu]: got %.17g (0x%016llx), want +0\n", label, i,
+                 vars[i].adj(), (unsigned long long)bits(vars[i].adj()));
+    return false;
+  }
+  return true;
+}
+
+struct Prototype {
+  RhsProgram rhs;
+  IslandProg generated;
+  bool generated_ok = false;
+  std::string refusal;
+};
+
+std::string structural_refusal(const Program& p) {
+  std::vector<std::string> opcodes;
+  for (const auto& instruction : p.code) {
+    const auto& spec = stanli::program_code_spec(instruction.code);
+    if (!spec.has(stanli::kProgramNoAdjoint)) continue;
+    const std::string name(spec.name);
+    if (std::find(opcodes.begin(), opcodes.end(), name) == opcodes.end())
+      opcodes.push_back(name);
+  }
+  std::string out;
+  for (size_t i = 0; i < opcodes.size(); ++i) {
+    if (i) out += ", ";
+    out += opcodes[i];
+  }
+  return out;
+}
+
+Prototype make_prototype(const std::string& fixture,
+                         const std::string& rhs_name, int n_y, int n_theta,
+                         int n_x_r) {
+  stanli::mir::Program mir =
+      stanli::mir::read_program(stanli::sexp::parse(slurp(fixture)));
+  std::map<std::string, const stanli::mir::FunDef*> funs;
+  for (const auto& f : mir.fun_defs) funs[f.name] = &f;
+  const auto it = funs.find(rhs_name);
+  if (it == funs.end())
+    throw std::runtime_error("fixture has no " + rhs_name + " RHS");
+
+  Prototype out;
+  out.rhs = stanli::compile_rhs(*it->second, funs, n_y, n_theta, n_x_r, {3});
+  if (!out.rhs.ok)
+    throw std::runtime_error(rhs_name +
+                             " register compilation failed: " + out.rhs.why);
+
+  // Slice only the canonical compacted Program.  gen_adjoint is allowed to
+  // mutate this copy with checkpoints; the RhsProgram remains the exact old
+  // var replay used by the comparison path.
+  static_cast<Program&>(out.generated) = static_cast<const Program&>(out.rhs);
+  out.generated.ins.push_back(
+      IslandProg::LiveIn{out.rhs.t_reg, 1, -1, 0, false});
+  out.generated.ins.push_back(
+      IslandProg::LiveIn{out.rhs.y0, out.rhs.n_y, -1, 0, true});
+  out.generated.ins.push_back(
+      IslandProg::LiveIn{out.rhs.th0, out.rhs.n_th, -1, 0, true});
+  out.generated.ins.push_back(
+      IslandProg::LiveIn{out.rhs.xr0, out.rhs.n_xr, -1, 0, false});
+  out.generated_ok = stanli::gen_adjoint(out.generated);
+  if (!out.generated_ok) {
+    const std::string opcodes = structural_refusal(out.rhs);
+    out.refusal = opcodes.empty() ? "adjoint generation failed"
+                                  : "unsupported opcodes: " + opcodes;
+  }
+  return out;
+}
+
+std::vector<double> deterministic_values(int count, double base, double step) {
+  std::vector<double> out((size_t)count);
+  for (int i = 0; i < count; ++i)
+    out[(size_t)i] = base + step * (double)(i + 1);
+  return out;
+}
+
+struct Observation {
+  std::vector<double> values;
+  std::vector<double> local_jacobian;
+  std::vector<double> harvested_jacobian;
+};
+
+struct OldWorkspace {
+  std::vector<var> y;
+  std::vector<var> outputs;
+  std::vector<double> harvested;
+
+  OldWorkspace(size_t n_y, size_t n_theta, size_t n_out)
+      : harvested(n_out * (n_y + n_theta)) {
+    y.reserve(n_y);
+    outputs.reserve(n_out);
+  }
+};
+
+struct GeneratedWorkspace {
+  std::vector<var> y;
+  std::vector<var> outputs;
+  std::vector<double> values;
+  std::vector<double> adjoints;
+  std::vector<double> harvested;
+
+  GeneratedWorkspace(const Prototype& p)
+      : values((size_t)p.generated.n_regs),
+        adjoints((size_t)p.generated.adj.n_regs),
+        harvested(p.generated.out_regs.size() *
+                  (size_t)(p.rhs.n_y + p.rhs.n_th)) {
+    y.reserve((size_t)p.rhs.n_y);
+    outputs.reserve(p.generated.out_regs.size());
+  }
+};
+
+template <typename Vars>
+void refill_vars(Vars& vars, const std::vector<double>& values) {
+  vars.clear();
+  for (double value : values) vars.emplace_back(value);
+}
+
+// Match coupled_ode_system's callback lifecycle exactly.  The state vars and
+// outputs live on the per-callback nested tape, while the deep-copied theta
+// vars live outside it.  Rows are swept in output order; nested adjoints only
+// need clearing between rows, and the persistent theta adjoints must be
+// cleared after every row (including the last one).
+void sweep_and_harvest(const std::vector<var>& outputs,
+                       const std::vector<var>& y, const std::vector<var>& theta,
+                       stan::math::nested_rev_autodiff& nested,
+                       std::vector<double>& harvested) {
+  const size_t width = y.size() + theta.size();
+  harvested.resize(outputs.size() * width);
+  for (size_t o = 0; o < outputs.size(); ++o) {
+    stan::math::grad(outputs[o].vi_);
+    for (size_t i = 0; i < y.size(); ++i) harvested[o * width + i] = y[i].adj();
+    for (size_t i = 0; i < theta.size(); ++i) {
+      harvested[o * width + y.size() + i] = theta[i].adj();
+      theta[i].adj() = 0.0;
+    }
+    if (o + 1 < outputs.size()) nested.set_zero_all_adjoints();
+  }
+}
+
+double checksum(const std::vector<var>& outputs,
+                const std::vector<double>& harvested) {
+  double out = 0.0;
+  for (size_t o = 0; o < outputs.size(); ++o)
+    out += (double)(o + 1) * outputs[o].val();
+  for (size_t i = 0; i < harvested.size(); ++i)
+    out += (0.03125 + (double)(i + 1) * 0.0078125) * harvested[i];
+  return out;
+}
+
+double old_callback(const Prototype& p, double t,
+                    const std::vector<double>& y_values,
+                    const std::vector<var>& theta,
+                    const std::vector<double>& x_r, OldWorkspace& ws,
+                    Observation* observation = nullptr) {
+  // Clear stale handles before opening the next nested arena; their pointed-to
+  // varis belonged to the preceding callback and have already been recovered.
+  ws.y.clear();
+  ws.outputs.clear();
+  stan::math::nested_rev_autodiff nested;
+  refill_vars(ws.y, y_values);
+
+  stanli::run_rhs<var>(p.rhs, t, ws.y.data(), theta.data(), theta.size(),
+                       x_r.data(), ws.outputs);
+  const size_t n_out = ws.outputs.size();
+  sweep_and_harvest(ws.outputs, ws.y, theta, nested, ws.harvested);
+
+  if (observation) {
+    observation->values.resize(n_out);
+    for (size_t o = 0; o < n_out; ++o)
+      observation->values[o] = ws.outputs[o].val();
+    observation->local_jacobian.clear();
+    observation->harvested_jacobian = ws.harvested;
+  }
+  return checksum(ws.outputs, ws.harvested);
+}
+
+double generated_callback(const Prototype& p, double t,
+                          const std::vector<double>& y_values,
+                          const std::vector<var>& theta,
+                          const std::vector<double>& x_r,
+                          GeneratedWorkspace& ws,
+                          Observation* observation = nullptr) {
+  ws.y.clear();
+  ws.outputs.clear();
+  stan::math::nested_rev_autodiff nested;
+  refill_vars(ws.y, y_values);
+
+  const size_t n_out = p.generated.out_regs.size();
+  const size_t width = ws.y.size() + theta.size();
+  auto& arena = stan::math::ChainableStack::instance_->memalloc_;
+  stan::math::vari** operands = arena.alloc_array<stan::math::vari*>(width);
+  double* local_jacobian = arena.alloc_array<double>(n_out * width);
+  for (size_t i = 0; i < ws.y.size(); ++i) operands[i] = ws.y[i].vi_;
+  for (size_t i = 0; i < theta.size(); ++i)
+    operands[ws.y.size() + i] = theta[i].vi_;
+
+  // Seed the checkpoint-capable forward's original live-in registers.  The
+  // appended checkpoint registers are written by the generated forward.  The
+  // whole reusable file is cleared so unwritten or newly appended cells can
+  // never retain data from a preceding callback.
+  std::fill(ws.values.begin(), ws.values.end(), 0.0);
+  ws.values[(size_t)p.rhs.t_reg] = t;
+  for (int i = 0; i < p.rhs.n_y; ++i)
+    ws.values[(size_t)(p.rhs.y0 + i)] = y_values[(size_t)i];
+  for (int i = 0; i < p.rhs.n_th; ++i)
+    ws.values[(size_t)(p.rhs.th0 + i)] = theta[(size_t)i].val();
+  for (int i = 0; i < p.rhs.n_xr; ++i)
+    ws.values[(size_t)(p.rhs.xr0 + i)] = x_r[(size_t)i];
+  stanli::run_program(static_cast<const Program&>(p.generated),
+                      ws.values.data());
+
+  const AdjProgram& reverse = p.generated.adj;
+  for (size_t o = 0; o < n_out; ++o) {
+    const int out_reg = p.generated.out_regs[o];
+    std::fill(ws.adjoints.begin(), ws.adjoints.end(), 0.0);
+    // Add the seed through adj_reg: if an output aliases an active live-in,
+    // this preserves the identity contribution instead of overwriting it.
+    ws.adjoints[(size_t)reverse.adj_reg[(size_t)out_reg]] += 1.0;
+    stanli::run_adjoint(p.generated, reverse, ws.values.data(),
+                        ws.adjoints.data());
+    double* row = local_jacobian + o * width;
+    for (int i = 0; i < p.rhs.n_y; ++i) {
+      const int reg = p.rhs.y0 + i;
+      row[(size_t)i] = ws.adjoints[(size_t)reverse.adj_reg[(size_t)reg]];
+    }
+    for (int i = 0; i < p.rhs.n_th; ++i) {
+      const int reg = p.rhs.th0 + i;
+      row[(size_t)p.rhs.n_y + (size_t)i] =
+          ws.adjoints[(size_t)reverse.adj_reg[(size_t)reg]];
+    }
+  }
+
+  // Match ode_store_sensitivities' low-level layout: every output node shares
+  // one arena operand array and points at its row in one contiguous arena
+  // Jacobian.  This avoids the public helper's per-output pointer and gradient
+  // copies while retaining Stan Math's ordinary precomputed-gradient nodes.
+  for (size_t o = 0; o < n_out; ++o) {
+    const int out_reg = p.generated.out_regs[o];
+    ws.outputs.emplace_back(new stan::math::precomputed_gradients_vari(
+        ws.values[(size_t)out_reg], width, operands,
+        local_jacobian + o * width));
+  }
+
+  // Account for the sweeps the surrounding Stan Jacobian machinery performs
+  // after the callback returns its precomputed-gradient vars.
+  sweep_and_harvest(ws.outputs, ws.y, theta, nested, ws.harvested);
+
+  if (observation) {
+    observation->values.resize(n_out);
+    for (size_t o = 0; o < n_out; ++o)
+      observation->values[o] = ws.outputs[o].val();
+    observation->local_jacobian.assign(local_jacobian,
+                                       local_jacobian + n_out * width);
+    observation->harvested_jacobian = ws.harvested;
+  }
+  return checksum(ws.outputs, ws.harvested);
+}
+
+template <typename F>
+double time_callbacks(int iterations, F&& callback) {
+  double local_sink = 0.0;
+  const auto begin = std::chrono::steady_clock::now();
+  for (int i = 0; i < iterations; ++i) local_sink += callback();
+  const auto end = std::chrono::steady_clock::now();
+  benchmark_sink += local_sink;
+  return std::chrono::duration<double, std::nano>(end - begin).count() /
+         (double)iterations;
+}
+
+double median(std::vector<double> values) {
+  std::sort(values.begin(), values.end());
+  const size_t middle = values.size() / 2;
+  if (values.size() % 2) return values[middle];
+  return 0.5 * (values[middle - 1] + values[middle]);
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+  try {
+    if (argc > 8) {
+      std::fprintf(stderr,
+                   "usage: %s [iterations-per-batch] [batches] [fixture] "
+                   "[rhs-name] [n-y] [n-theta] [n-x-r]\n",
+                   argv[0]);
+      return 2;
+    }
+    const int iterations =
+        argc > 1 ? positive_arg(argv[1], "iterations") : 5000;
+    const int batches = argc > 2 ? positive_arg(argv[2], "batches") : 21;
+    const std::string fixture =
+        argc > 3 ? argv[3] : "tests/fixtures/odefns.tmir.sexp";
+    const std::string rhs_name = argc > 4 ? argv[4] : "f_lin";
+    const int n_y = argc > 5 ? positive_arg(argv[5], "n-y") : 2;
+    const int n_theta = argc > 6 ? nonnegative_arg(argv[6], "n-theta") : 4;
+    const int n_x_r = argc > 7 ? nonnegative_arg(argv[7], "n-x-r") : 2;
+
+    const Prototype prototype =
+        make_prototype(fixture, rhs_name, n_y, n_theta, n_x_r);
+    if (!prototype.generated_ok) {
+      const bool structural =
+          prototype.refusal.rfind("unsupported opcodes:", 0) == 0;
+      std::printf("%s generated-adjoint %s: %s\n", rhs_name.c_str(),
+                  structural ? "structurally refused" : "refused",
+                  prototype.refusal.c_str());
+      std::printf(
+          "forward instructions: canonical=%zu checkpointed=refused; "
+          "reverse=refused\n",
+          prototype.rhs.code.size());
+      std::printf("registers: canonical=%d; outputs=%zu inputs=%d\n",
+                  prototype.rhs.n_regs, prototype.rhs.out_regs.size(),
+                  prototype.rhs.n_y + prototype.rhs.n_th);
+      return 0;
+    }
+
+    const std::vector<double> y = deterministic_values(n_y, 0.7, 0.2);
+    const std::vector<double> theta_values =
+        deterministic_values(n_theta, 0.11, 0.07);
+    const std::vector<double> x_r = deterministic_values(n_x_r, 1.0, 0.5);
+    constexpr double t = 0.73;
+    // coupled_ode_system deep-copies active arguments once when the solver is
+    // constructed.  Keep that copy on the outer tape; only state vars are
+    // created inside each callback's nested scope.
+    std::vector<var> old_theta;
+    std::vector<var> generated_theta;
+    old_theta.reserve(theta_values.size());
+    generated_theta.reserve(theta_values.size());
+    for (double value : theta_values) {
+      old_theta.emplace_back(value);
+      generated_theta.emplace_back(value);
+    }
+
+    OldWorkspace old_ws(y.size(), old_theta.size(),
+                        prototype.rhs.out_regs.size());
+    GeneratedWorkspace generated_ws(prototype);
+
+    Observation old_observation, generated_observation;
+    (void)old_callback(prototype, t, y, old_theta, x_r, old_ws,
+                       &old_observation);
+    (void)generated_callback(prototype, t, y, generated_theta, x_r,
+                             generated_ws, &generated_observation);
+    bool verified = true;
+    verified &= same_vector("RHS values", generated_observation.values,
+                            old_observation.values);
+    verified &= same_vector("generated local Jacobian",
+                            generated_observation.local_jacobian,
+                            old_observation.harvested_jacobian);
+    verified &= same_vector("precomputed-gradient harvest",
+                            generated_observation.harvested_jacobian,
+                            old_observation.harvested_jacobian);
+    verified &= adjoints_are_positive_zero("old theta adjoint", old_theta);
+    verified &=
+        adjoints_are_positive_zero("generated theta adjoint", generated_theta);
+
+    Observation old_repeat, generated_repeat;
+    (void)old_callback(prototype, t, y, old_theta, x_r, old_ws, &old_repeat);
+    (void)generated_callback(prototype, t, y, generated_theta, x_r,
+                             generated_ws, &generated_repeat);
+    verified &= same_vector("repeated old RHS values", old_repeat.values,
+                            old_observation.values);
+    verified &=
+        same_vector("repeated old Jacobian", old_repeat.harvested_jacobian,
+                    old_observation.harvested_jacobian);
+    verified &=
+        same_vector("repeated generated RHS values", generated_repeat.values,
+                    generated_observation.values);
+    verified &= same_vector("repeated generated local Jacobian",
+                            generated_repeat.local_jacobian,
+                            generated_observation.local_jacobian);
+    verified &= same_vector("repeated precomputed-gradient harvest",
+                            generated_repeat.harvested_jacobian,
+                            generated_observation.harvested_jacobian);
+    verified &=
+        adjoints_are_positive_zero("repeated old theta adjoint", old_theta);
+    verified &= adjoints_are_positive_zero("repeated generated theta adjoint",
+                                           generated_theta);
+    if (!verified) return 1;
+
+    const int warmups = std::max(2000, iterations / 2);
+    double warm_sink = 0.0;
+    for (int i = 0; i < warmups; ++i) {
+      if (i & 1) {
+        warm_sink += generated_callback(prototype, t, y, generated_theta, x_r,
+                                        generated_ws);
+        warm_sink += old_callback(prototype, t, y, old_theta, x_r, old_ws);
+      } else {
+        warm_sink += old_callback(prototype, t, y, old_theta, x_r, old_ws);
+        warm_sink += generated_callback(prototype, t, y, generated_theta, x_r,
+                                        generated_ws);
+      }
+    }
+    benchmark_sink += warm_sink;
+
+    std::vector<double> old_samples, generated_samples, ratios;
+    old_samples.reserve((size_t)batches);
+    generated_samples.reserve((size_t)batches);
+    ratios.reserve((size_t)batches);
+    for (int batch = 0; batch < batches; ++batch) {
+      double old_ns, generated_ns;
+      if (batch & 1) {
+        generated_ns = time_callbacks(iterations, [&] {
+          return generated_callback(prototype, t, y, generated_theta, x_r,
+                                    generated_ws);
+        });
+        old_ns = time_callbacks(iterations, [&] {
+          return old_callback(prototype, t, y, old_theta, x_r, old_ws);
+        });
+      } else {
+        old_ns = time_callbacks(iterations, [&] {
+          return old_callback(prototype, t, y, old_theta, x_r, old_ws);
+        });
+        generated_ns = time_callbacks(iterations, [&] {
+          return generated_callback(prototype, t, y, generated_theta, x_r,
+                                    generated_ws);
+        });
+      }
+      old_samples.push_back(old_ns);
+      generated_samples.push_back(generated_ns);
+      ratios.push_back(old_ns / generated_ns);
+    }
+
+    const double old_median = median(old_samples);
+    const double generated_median = median(generated_samples);
+    const double paired_median = median(ratios);
+    const double aggregate_ratio =
+        std::accumulate(old_samples.begin(), old_samples.end(), 0.0) /
+        std::accumulate(generated_samples.begin(), generated_samples.end(),
+                        0.0);
+
+    std::printf("%s generated-adjoint prototype verified bitwise\n",
+                rhs_name.c_str());
+    std::printf(
+        "forward instructions: canonical=%zu checkpointed=%zu; "
+        "reverse=%zu\n",
+        prototype.rhs.code.size(), prototype.generated.code.size(),
+        prototype.generated.adj.code.size());
+    std::printf(
+        "registers: canonical=%d checkpointed=%d adjoint=%d; "
+        "outputs=%zu inputs=%d\n",
+        prototype.rhs.n_regs, prototype.generated.n_regs,
+        prototype.generated.adj.n_regs, prototype.generated.out_regs.size(),
+        prototype.rhs.n_y + prototype.rhs.n_th);
+    std::printf("warmups=%d batches=%d iterations/batch=%d\n", warmups, batches,
+                iterations);
+    std::printf("old var callback       median %9.1f ns/callback\n",
+                old_median);
+    std::printf("generated + precomputed median %9.1f ns/callback\n",
+                generated_median);
+    std::printf(
+        "speedup: %.3fx paired median, %.3fx aggregate "
+        "(generated %.1f%% of old)\n",
+        paired_median, aggregate_ratio, 100.0 * generated_median / old_median);
+    std::printf("sink=%.17g\n", (double)benchmark_sink);
+    return 0;
+  } catch (const std::exception& e) {
+    std::fprintf(stderr, "bench_rhs_adjoint: %s\n", e.what());
+    return 1;
+  }
+}

--- a/tools/gen_ode_ceiling_sweep.py
+++ b/tools/gen_ode_ceiling_sweep.py
@@ -1,0 +1,350 @@
+#!/usr/bin/env python3
+"""Generate the synthetic ODE sensitivity-ceiling matrix.
+
+The generated models deliberately use the public modern ODE interfaces. State
+count, active parameter width, and output-time count remain data dimensions so
+one optimized MIR file per (solver, branch, initial-state activity, parameter
+activity) tuple covers the whole shape sweep; stanli specializes those
+dimensions while compiling against each JSON file. The runnable manifest has
+84 rows spanning the three activity masks that survive in the log-density
+graph. Four genuine data/data rows live in compile_only.json: their ODEs are
+correctly precomputed out of that graph, documenting the fourth mask without
+mislabeling a parameter-dependent input as data.
+
+This is developer measurement infrastructure, not a corpus or production
+eligibility policy. It writes a manifest consumed by bench_ode_ceiling.
+"""
+
+import argparse
+import hashlib
+import json
+import pathlib
+import re
+import subprocess
+
+
+SOLVERS = ("rk45", "ckrk", "bdf", "adams")
+SENTINEL = ".stanli-ode-ceiling-generator"
+SENTINEL_TEXT = "stanli synthetic ODE ceiling generator v1\n"
+
+SOURCE_NAME = re.compile(
+    r"synthetic_(?:rk45|ckrk|bdf|adams)_"
+    r"(?:branch|straight)_(?:yactive|ydata)_(?:thetaactive|thetadata)"
+    r"\.(?:stan|hpp|tmir\.sexp)"
+)
+DATA_NAME = re.compile(
+    r"synthetic_(?:rk45|ckrk|bdf|adams)_"
+    r"(?:branch|straight)_(?:yactive|ydata)_(?:thetaactive|thetadata)_"
+    r"s\d+_p\d+_n\d+\.json"
+)
+
+
+def sha256_file(path: pathlib.Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def model_source(
+    solver: str, branched: bool, active_y0: bool, active_theta: bool
+) -> str:
+    branch_body = """
+      if (t > 1.0) {
+        dy[i] = base + 0.001 * y[i];
+      } else {
+        dy[i] = base - 0.0015 * y[i];
+      }
+""" if branched else "      dy[i] = base;\n"
+    y0_data = "" if active_y0 else "  vector[S] y0_data;\n"
+    y0_param = "  vector[S] y0;\n" if active_y0 else ""
+    y0_name = "y0" if active_y0 else "y0_data"
+    y0_prior = "  y0 ~ normal(0.2, 0.5);\n" if active_y0 else ""
+    theta_data = "" if active_theta else "  vector[P] theta_data;\n"
+    theta_param = "  vector[P] theta;\n" if active_theta else ""
+    theta_name = "theta" if active_theta else "theta_data"
+    theta_prior = "  theta ~ normal(0, 0.5);\n" if active_theta else ""
+    return f"""functions {{
+  vector synthetic_rhs(real t, vector y, vector theta, real theta_scale) {{
+    vector[rows(y)] dy;
+    real forcing = sum(theta) * theta_scale;
+    real coupling = 0.02 * sum(y) / rows(y);
+    for (i in 1:rows(y)) {{
+      real base = -0.12 * y[i] + coupling + 0.01 * forcing;
+{branch_body}    }}
+    return dy;
+  }}
+}}
+data {{
+  int<lower=1> S;
+  int<lower=0> P;
+  int<lower=1> N;
+  array[N] real<lower=0> ts;
+  real<lower=0> rel_tol;
+  real<lower=0> abs_tol;
+  real<lower=0> theta_scale;
+{y0_data}{theta_data}}}
+parameters {{
+{y0_param}{theta_param}
+  real nuisance;
+}}
+transformed parameters {{
+  array[N] vector[S] z = ode_{solver}_tol(
+      synthetic_rhs, {y0_name}, 0.0, ts, rel_tol, abs_tol, 1000000,
+      {theta_name}, theta_scale);
+}}
+model {{
+{y0_prior}  nuisance ~ normal(0, 1);
+{theta_prior}
+  for (n in 1:N) target += 0.01 * sum(z[n]);
+}}
+"""
+
+
+def cases():
+    """Twenty-one runnable cases per solver across masks 0x3, 0x2, 0x1."""
+    baseline = (2, 4, 8, False, True, True)
+    rows = {baseline: "baseline"}
+    for states in (1, 2, 4, 8, 16):
+        rows.setdefault((states, 4, 8, False, True, True), "states")
+    for params in (0, 1, 4, 16, 64):
+        rows.setdefault((2, params, 8, False, True, True), "parameters")
+    for times in (1, 4, 8, 32, 128):
+        rows.setdefault((2, 4, times, False, True, True), "output_times")
+    rows.setdefault((2, 4, 8, True, True, True), "branch")
+    rows.setdefault((2, 4, 8, False, False, True), "y0_activity")
+    rows.setdefault((2, 4, 8, False, True, False), "theta_activity")
+
+    interactions = (
+        (1, 64, 1, False, False, True),
+        (16, 0, 128, False, True, True),
+        (8, 32, 32, True, True, True),
+        (2, 64, 32, True, False, True),
+        (2, 0, 8, False, False, True),
+    )
+    for row in interactions:
+        rows[row] = "interaction"
+    return [(s, p, n, branch, active_y0, active_theta, axis)
+            for (s, p, n, branch, active_y0, active_theta), axis
+            in rows.items()]
+
+
+def known_generated_file(path: pathlib.Path) -> bool:
+    """Whether path names a regular file this generator may have created."""
+    if path.is_symlink() or not path.is_file():
+        return False
+    return (path.name in ("manifest.json", "compile_only.json")
+            or SOURCE_NAME.fullmatch(path.name) is not None
+            or DATA_NAME.fullmatch(path.name) is not None)
+
+
+def prepare_output(output: pathlib.Path, force: bool) -> None:
+    """Create output or safely clear a directory owned by this generator."""
+    if output.is_symlink():
+        raise ValueError(f"refusing symlink output directory: {output}")
+    if output.exists() and not output.is_dir():
+        raise NotADirectoryError(output)
+
+    if not output.exists():
+        output.mkdir(parents=True)
+    else:
+        entries = list(output.iterdir())
+        if entries:
+            marker = output / SENTINEL
+            marker_valid = (
+                not marker.is_symlink()
+                and marker.is_file()
+                and marker.read_text(encoding="utf-8") == SENTINEL_TEXT
+            )
+            if not marker_valid:
+                raise FileExistsError(
+                    f"refusing nonempty directory not owned by this "
+                    f"generator: {output}"
+                )
+            if not force:
+                raise FileExistsError(
+                    f"refusing to replace generated directory {output}; "
+                    "pass --force"
+                )
+            unknown = [
+                child for child in entries
+                if child.name != SENTINEL and not known_generated_file(child)
+            ]
+            if unknown:
+                names = ", ".join(sorted(child.name for child in unknown))
+                raise FileExistsError(
+                    f"refusing to clean unknown or non-regular entries in "
+                    f"{output}: {names}"
+                )
+            for child in entries:
+                if child.name != SENTINEL:
+                    child.unlink()
+
+    marker = output / SENTINEL
+    if marker.is_symlink():
+        raise ValueError(f"refusing symlink sentinel: {marker}")
+    marker.write_text(SENTINEL_TEXT, encoding="utf-8")
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("output", type=pathlib.Path)
+    parser.add_argument("--stanc", type=pathlib.Path,
+                        default=pathlib.Path("deps/stanc3/stanc"))
+    parser.add_argument(
+        "--force", action="store_true",
+        help="replace only a sentinel-marked directory of generated files",
+    )
+    args = parser.parse_args()
+
+    output = args.output.expanduser().absolute()
+    stanc = args.stanc.expanduser().resolve()
+    if not stanc.is_file():
+        raise FileNotFoundError(stanc)
+    stanc_sha256 = sha256_file(stanc)
+    prepare_output(output, args.force)
+    manifest = []
+    compile_only = []
+
+    sources = {}
+    for solver in SOLVERS:
+        for (states, params, times, branched, active_y0, active_theta,
+             axis) in cases():
+            source_key = (solver, branched, active_y0, active_theta)
+            y_activity = "yactive" if active_y0 else "ydata"
+            theta_activity = "thetaactive" if active_theta else "thetadata"
+            stem = (f"synthetic_{solver}_"
+                    f"{'branch' if branched else 'straight'}_{y_activity}_"
+                    f"{theta_activity}")
+            stan = output / f"{stem}.stan"
+            mir = output / f"{stem}.tmir.sexp"
+            if source_key not in sources:
+                stan.write_text(
+                    model_source(solver, branched, active_y0, active_theta),
+                    encoding="utf-8",
+                )
+                generated = subprocess.run(
+                    [str(stanc), "--O1", "--debug-optimized-mir",
+                     str(stan)], check=True, capture_output=True, text=True)
+                mir.write_text(generated.stdout, encoding="utf-8")
+                sources[source_key] = (stan, mir)
+            else:
+                stan, mir = sources[source_key]
+
+            case = f"{stem}_s{states}_p{params}_n{times}"
+            data = output / f"{case}.json"
+            values = {
+                "S": states,
+                "P": params,
+                "N": times,
+                "ts": [2.0 * (i + 1) / times for i in range(times)],
+                "rel_tol": 1e-8,
+                "abs_tol": 1e-8,
+                "theta_scale": 1.0 / (params + 1.0),
+            }
+            if not active_y0:
+                values["y0_data"] = [0.2 + 0.01 * i for i in range(states)]
+            if not active_theta:
+                values["theta_data"] = [
+                    0.05 * (i + 1) / (params + 1.0)
+                    for i in range(params)
+                ]
+            data.write_text(
+                json.dumps(values, separators=(",", ":")), encoding="utf-8"
+            )
+            manifest.append({
+                "case": case,
+                "solver": solver,
+                "branched": branched,
+                "active_y0": active_y0,
+                "active_theta": active_theta,
+                "states": states,
+                "parameters": params,
+                "output_times": times,
+                "axis": axis,
+                "require_exact": True,
+                "mir": str(mir),
+                "data": str(data),
+                "stan": str(stan),
+                "stan_sha256": sha256_file(stan),
+                "stanc": str(stanc),
+                "stanc_sha256": stanc_sha256,
+            })
+
+    # With both ODE scalar inputs data, Stanli evaluates the solve in its
+    # write/preparation path and removes it from the repeated log-density
+    # graph. Preserve one real source/MIR/data row per solver as an explicit
+    # compile-only disposition instead of feeding a no-OP model to the timing
+    # binaries or manufacturing a false activity bit with a control input.
+    for solver in SOLVERS:
+        stem = f"synthetic_{solver}_straight_ydata_thetadata"
+        stan = output / f"{stem}.stan"
+        mir = output / f"{stem}.tmir.sexp"
+        stan.write_text(
+            model_source(solver, False, False, False), encoding="utf-8"
+        )
+        generated = subprocess.run(
+            [str(stanc), "--O1", "--debug-optimized-mir", str(stan)],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        mir.write_text(generated.stdout, encoding="utf-8")
+        case = f"{stem}_s2_p4_n8"
+        data = output / f"{case}.json"
+        data.write_text(
+            json.dumps({
+                "S": 2,
+                "P": 4,
+                "N": 8,
+                "ts": [0.25 * (i + 1) for i in range(8)],
+                "rel_tol": 1e-8,
+                "abs_tol": 1e-8,
+                "theta_scale": 0.2,
+                "y0_data": [0.2, 0.21],
+                "theta_data": [0.01, 0.02, 0.03, 0.04],
+            }, separators=(",", ":")),
+            encoding="utf-8",
+        )
+        compile_only.append({
+            "case": case,
+            "solver": solver,
+            "branched": False,
+            "active_y0": False,
+            "active_theta": False,
+            "type_mask": "0x0",
+            "states": 2,
+            "parameters": 4,
+            "output_times": 8,
+            "log_density_graph_op_ode": False,
+            "disposition": (
+                "constant-folded by Stanli outside the repeated "
+                "log-density graph"
+            ),
+            "mir": str(mir),
+            "data": str(data),
+            "stan": str(stan),
+            "stan_sha256": sha256_file(stan),
+            "stanc": str(stanc),
+            "stanc_sha256": stanc_sha256,
+        })
+
+    manifest_path = output / "manifest.json"
+    manifest_path.write_text(
+        json.dumps(manifest, indent=2) + "\n", encoding="utf-8"
+    )
+    compile_only_path = output / "compile_only.json"
+    compile_only_path.write_text(
+        json.dumps(compile_only, indent=2) + "\n", encoding="utf-8"
+    )
+    print(
+        f"generated {len(manifest)} runnable cases and "
+        f"{len(compile_only)} compile-only cases in {output}"
+    )
+    print(manifest_path)
+    print(compile_only_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/prepare_ode_ceiling_models.py
+++ b/tools/prepare_ode_ceiling_models.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+"""Prepare the three real ODE ceiling inputs and a benchmark manifest.
+
+The script extracts pinned PosteriorDB data, asks the pinned stanc executable
+for optimized MIR, and emits rows for RK45/CKRK and BDF/Adams.  It never
+overwrites an unowned directory.
+"""
+
+import argparse
+import hashlib
+import json
+import pathlib
+import subprocess
+import zipfile
+
+
+REPO = pathlib.Path(__file__).resolve().parent.parent
+SENTINEL = ".stanli-ode-ceiling-models-owned"
+SENTINEL_TEXT = "owned by prepare_ode_ceiling_models.py v1\n"
+MODELS = (
+    ("lotka_volterra", "hudson_lynx_hare", ("rk45", "ckrk")),
+    ("soil_incubation", "soil_carbon", ("rk45", "ckrk")),
+    ("one_comp_mm_elim_abs", "one_comp_mm_elim_abs", ("bdf", "adams")),
+)
+
+
+def sha256_file(path: pathlib.Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def prepare_output(path: pathlib.Path, force: bool) -> None:
+    if path.is_symlink():
+        raise RuntimeError(f"refusing symlink output directory: {path}")
+    if path.exists() and not path.is_dir():
+        raise RuntimeError(f"output exists and is not a directory: {path}")
+    if not path.exists():
+        path.mkdir(parents=True)
+        (path / SENTINEL).write_text(SENTINEL_TEXT)
+        return
+
+    sentinel = path / SENTINEL
+    children = list(path.iterdir())
+    generated = [child for child in children if child.name != SENTINEL]
+    if not generated:
+        sentinel_present = sentinel.exists() or sentinel.is_symlink()
+        if sentinel_present:
+            if sentinel.is_symlink() or not sentinel.is_file():
+                raise RuntimeError(f"invalid ownership sentinel: {sentinel}")
+            if sentinel.read_text() != SENTINEL_TEXT:
+                raise RuntimeError(
+                    f"invalid ownership sentinel contents: {sentinel}"
+                )
+        else:
+            sentinel.write_text(SENTINEL_TEXT)
+        return
+    if not force:
+        raise FileExistsError(f"refusing nonempty output directory: {path}")
+    if sentinel.is_symlink() or not sentinel.is_file():
+        raise RuntimeError(f"refusing to clean unowned output directory: {path}")
+    if sentinel.read_text() != SENTINEL_TEXT:
+        raise RuntimeError(f"refusing invalid ownership sentinel: {sentinel}")
+    for child in generated:
+        allowed = (
+            child.name == "manifest.json"
+            or child.name.endswith(".tmir.sexp")
+            or child.name.endswith(".data.json")
+        )
+        if child.is_symlink() or not child.is_file() or not allowed:
+            raise RuntimeError(f"refusing unexpected output entry: {child}")
+    for child in generated:
+        child.unlink()
+
+
+def extract_json(archive: pathlib.Path) -> bytes:
+    with zipfile.ZipFile(archive) as source:
+        members = [
+            name for name in source.namelist()
+            if name.endswith(".json") and not name.endswith("/")
+        ]
+        if len(members) != 1:
+            raise RuntimeError(
+                f"expected one JSON member in {archive}, found {len(members)}"
+            )
+        return source.read(members[0])
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("output", type=pathlib.Path)
+    parser.add_argument(
+        "--stanc", type=pathlib.Path, default=REPO / "deps/stanc3/stanc"
+    )
+    parser.add_argument(
+        "--posteriordb",
+        type=pathlib.Path,
+        default=REPO / "deps/posteriordb/posterior_database",
+    )
+    parser.add_argument("--force", action="store_true")
+    args = parser.parse_args()
+
+    output = args.output.expanduser().absolute()
+    stanc = args.stanc.expanduser().resolve()
+    posteriordb = args.posteriordb.expanduser().resolve()
+    if not stanc.is_file():
+        raise FileNotFoundError(stanc)
+    prepare_output(output, args.force)
+    stanc_sha256 = sha256_file(stanc)
+
+    manifest = []
+    for model, data_name, solvers in MODELS:
+        stan = posteriordb / "models/stan" / f"{model}.stan"
+        archive = posteriordb / "data/data" / f"{data_name}.json.zip"
+        if not stan.is_file():
+            raise FileNotFoundError(stan)
+        if not archive.is_file():
+            raise FileNotFoundError(archive)
+        stan_sha256 = sha256_file(stan)
+        archive_sha256 = sha256_file(archive)
+
+        data = output / f"{model}.data.json"
+        mir = output / f"{model}.tmir.sexp"
+        data.write_bytes(extract_json(archive))
+        try:
+            stan_arg = stan.relative_to(REPO)
+        except ValueError:
+            stan_arg = stan
+        generated = subprocess.run(
+            [str(stanc), "--O1", "--debug-optimized-mir", str(stan_arg)],
+            check=True,
+            capture_output=True,
+            text=True,
+            cwd=REPO,
+        )
+        mir.write_text(generated.stdout)
+        for solver in solvers:
+            manifest.append(
+                {
+                    "case": f"{model}_{solver}",
+                    "model": model,
+                    "solver": solver,
+                    "mir": str(mir),
+                    "data": str(data),
+                    "stan": str(stan.resolve()),
+                    "stan_sha256": stan_sha256,
+                    "source_archive": str(archive.resolve()),
+                    "source_archive_sha256": archive_sha256,
+                    "stanc": str(stanc),
+                    "stanc_sha256": stanc_sha256,
+                }
+            )
+
+    manifest_path = output / "manifest.json"
+    manifest_path.write_text(json.dumps(manifest, indent=2) + "\n")
+    print(f"prepared {len(MODELS)} models and {len(manifest)} solver rows")
+    print(manifest_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/run_ode_ceiling_sweep.py
+++ b/tools/run_ode_ceiling_sweep.py
@@ -1,0 +1,1189 @@
+#!/usr/bin/env python3
+"""Run the developer-only ODE ceiling matrix in isolated processes.
+
+Each manifest row gets a fresh benchmark process so executor capacities and
+Stan Math arena state cannot leak between shapes.  Results are appended to
+JSONL as they finish; a timeout or malformed benchmark result is recorded and
+does not stop the remaining cases.
+
+This is screening infrastructure.  Low-iteration results locate crossovers;
+admission decisions still require longer paired runs of the selected cases.
+"""
+
+import argparse
+import datetime
+import hashlib
+import json
+import math
+import os
+import pathlib
+import platform
+import re
+import shlex
+import shutil
+import socket
+import stat
+import subprocess
+import sys
+import tempfile
+import time
+
+
+SOLVERS = ("rk45", "ckrk", "bdf", "adams")
+RK_SOLVERS = frozenset(("rk45", "ckrk"))
+KV_RE = re.compile(r"([A-Za-z_][A-Za-z0-9_]*)=(?:\"([^\"]*)\"|(\S+))")
+LOG_SENTINEL = ".stanli-ode-ceiling-logs-v1"
+LOG_SENTINEL_CONTENT = "stanli ODE ceiling sweep log directory v1\n"
+PROVENANCE_SUFFIX = ".provenance.json"
+CMAKE_CACHE_KEYS = frozenset(
+    (
+        "CMAKE_BUILD_TYPE",
+        "CMAKE_C_COMPILER",
+        "CMAKE_C_COMPILER_LAUNCHER",
+        "CMAKE_C_FLAGS",
+        "CMAKE_CXX_COMPILER",
+        "CMAKE_CXX_COMPILER_LAUNCHER",
+        "CMAKE_CXX_EXTENSIONS",
+        "CMAKE_CXX_FLAGS",
+        "CMAKE_CXX_STANDARD",
+        "CMAKE_EXE_LINKER_FLAGS",
+        "CMAKE_INTERPROCEDURAL_OPTIMIZATION",
+        "CMAKE_SHARED_LINKER_FLAGS",
+        "CMAKE_STATIC_LINKER_FLAGS",
+    )
+)
+
+
+def absolute_path(path):
+    """Make a path absolute without hiding a symlink at the leaf."""
+    return pathlib.Path(os.path.abspath(os.fspath(path.expanduser())))
+
+
+def canonical_path(path):
+    """Resolve parent symlinks for collision checks without opening a file."""
+    return pathlib.Path(os.path.realpath(os.fspath(path)))
+
+
+def reject_output_collisions(output, log_dir, provenance_path, protected):
+    destinations = {
+        canonical_path(output): "output",
+        canonical_path(provenance_path): "provenance sidecar",
+    }
+    canonical_log_dir = canonical_path(log_dir)
+    for source in protected:
+        canonical_source = canonical_path(source)
+        if canonical_source in destinations:
+            raise ValueError(
+                f"refusing {destinations[canonical_source]} collision with "
+                f"benchmark input: {source}"
+            )
+        if (canonical_source == canonical_log_dir or
+                canonical_log_dir in canonical_source.parents):
+            raise ValueError(
+                f"refusing log directory containing benchmark input: "
+                f"{source}"
+            )
+
+
+def path_exists(path):
+    """Like lexists(3): broken symlinks count as existing paths."""
+    return path.exists() or path.is_symlink()
+
+
+def require_regular_file(path, label):
+    if path.is_symlink():
+        raise ValueError(f"refusing symlink {label}: {path}")
+    if not stat.S_ISREG(path.lstat().st_mode):
+        raise ValueError(f"expected regular {label}: {path}")
+
+
+def owned_log_files(log_dir):
+    """Validate an existing log directory before --force removes it."""
+    if log_dir.is_symlink():
+        raise ValueError(f"refusing symlink log directory: {log_dir}")
+    if not log_dir.is_dir():
+        raise ValueError(f"expected log directory: {log_dir}")
+    sentinel = log_dir / LOG_SENTINEL
+    if not path_exists(sentinel):
+        raise ValueError(
+            f"refusing to clean unowned log directory without {LOG_SENTINEL}: "
+            f"{log_dir}"
+        )
+    require_regular_file(sentinel, "log-directory sentinel")
+    if sentinel.read_text() != LOG_SENTINEL_CONTENT:
+        raise ValueError(f"refusing log directory with invalid sentinel: {log_dir}")
+    logs = []
+    for child in log_dir.iterdir():
+        if child == sentinel:
+            continue
+        if child.is_symlink() or child.suffix != ".log":
+            raise ValueError(
+                f"refusing log directory with unexpected entry: {child}"
+            )
+        require_regular_file(child, "log file")
+        logs.append(child)
+    return sentinel, logs
+
+
+def prepare_output_paths(output, log_dir, provenance_path, force):
+    """Create an empty, owned output area without broad deletion."""
+    for path, label in (
+        (output, "output"),
+        (log_dir, "log directory"),
+        (provenance_path, "provenance sidecar"),
+    ):
+        if path.is_symlink():
+            raise ValueError(f"refusing symlink {label}: {path}")
+
+    existing = [
+        path for path in (output, log_dir, provenance_path) if path_exists(path)
+    ]
+    if existing and not force:
+        raise FileExistsError(
+            "refusing to replace existing artifact(s): "
+            + ", ".join(str(path) for path in existing)
+            + "; pass --force"
+        )
+
+    log_cleanup = None
+    if path_exists(log_dir):
+        log_cleanup = owned_log_files(log_dir)
+    for path, label in (
+        (output, "output"),
+        (provenance_path, "provenance sidecar"),
+    ):
+        if path_exists(path):
+            require_regular_file(path, label)
+
+    # All existing artifacts have been validated before removing any of them.
+    if force:
+        for path in (output, provenance_path):
+            if path_exists(path):
+                path.unlink()
+        if log_cleanup is not None:
+            sentinel, logs = log_cleanup
+            for child in logs:
+                child.unlink()
+            sentinel.unlink()
+            log_dir.rmdir()
+
+    output.parent.mkdir(parents=True, exist_ok=True)
+    log_dir.mkdir()
+    with (log_dir / LOG_SENTINEL).open("x") as stream:
+        stream.write(LOG_SENTINEL_CONTENT)
+
+
+def sha256_file(path, cache=None):
+    key = str(path)
+    if cache is not None and key in cache:
+        return cache[key]
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    value = digest.hexdigest()
+    if cache is not None:
+        cache[key] = value
+    return value
+
+
+def current_case_hashes(case_record, executable):
+    return {
+        "mir": sha256_file(case_record["mir"]),
+        "data": sha256_file(case_record["data"]),
+        "selected_binary": sha256_file(executable),
+    }
+
+
+def case_hash_error(case_record, executable, expected):
+    try:
+        observed = current_case_hashes(case_record, executable)
+    except OSError as error:
+        return f"benchmark input became unreadable: {error}"
+    changed = [
+        name for name, digest in expected.items()
+        if observed.get(name) != digest
+    ]
+    if changed:
+        return "benchmark input hash changed: " + ", ".join(changed)
+    return None
+
+
+def command_output(command, cwd=None, timeout=10.0):
+    try:
+        completed = subprocess.run(
+            command,
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired) as error:
+        return {"ok": False, "error": str(error)}
+    output = (completed.stdout or completed.stderr).strip()
+    return {
+        "ok": completed.returncode == 0,
+        "returncode": completed.returncode,
+        "output": output,
+    }
+
+
+def git_provenance(cwd):
+    root_result = command_output(
+        ["git", "rev-parse", "--show-toplevel"], cwd=cwd
+    )
+    if not root_result["ok"]:
+        return {
+            "available": False,
+            "error": root_result.get("error") or root_result.get("output", ""),
+        }
+    root = pathlib.Path(root_result["output"])
+    head = command_output(["git", "rev-parse", "HEAD"], cwd=root)
+    branch = command_output(
+        ["git", "branch", "--show-current"], cwd=root
+    )
+    status_result = command_output(
+        ["git", "status", "--porcelain=v1", "--untracked-files=normal"],
+        cwd=root,
+    )
+    status_lines = (
+        status_result.get("output", "").splitlines()
+        if status_result["ok"] else []
+    )
+    return {
+        "available": True,
+        "root": str(root),
+        "head": head.get("output") if head["ok"] else None,
+        "branch": branch.get("output") if branch["ok"] else None,
+        "dirty": bool(status_lines) if status_result["ok"] else None,
+        "status_entry_count": len(status_lines) if status_result["ok"] else None,
+        "status": status_lines if status_result["ok"] else None,
+        "status_error": None if status_result["ok"] else status_result,
+    }
+
+
+def find_cmake_cache(executable):
+    for directory in (executable.parent, *executable.parents):
+        candidate = directory / "CMakeCache.txt"
+        if candidate.is_file() and not candidate.is_symlink():
+            return candidate
+    return None
+
+
+def relevant_cmake_cache(cache_path):
+    entries = {}
+    for line in cache_path.read_text(errors="replace").splitlines():
+        if not line or line.startswith(("#", "//")) or "=" not in line:
+            continue
+        declaration, value = line.split("=", 1)
+        key = declaration.split(":", 1)[0]
+        if (
+            key in CMAKE_CACHE_KEYS
+            or key.startswith("CMAKE_C_FLAGS_")
+            or key.startswith("CMAKE_CXX_FLAGS_")
+            or key.startswith("CMAKE_EXE_LINKER_FLAGS_")
+            or key.startswith("CMAKE_SHARED_LINKER_FLAGS_")
+            or key.startswith("CMAKE_STATIC_LINKER_FLAGS_")
+        ):
+            entries[key] = value
+    return entries
+
+
+def target_compile_flags(executable):
+    cache_path = find_cmake_cache(executable)
+    if cache_path is None:
+        return None
+    flags_path = (
+        cache_path.parent / "CMakeFiles" / f"{executable.name}.dir" / "flags.make"
+    )
+    if flags_path.is_symlink() or not flags_path.is_file():
+        return None
+    assignments = {}
+    for line in flags_path.read_text(errors="replace").splitlines():
+        if "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        key = key.strip()
+        if key.startswith(("CXX_FLAGS", "CXX_DEFINES")):
+            assignments[key] = value.strip()
+    return {
+        "path": str(flags_path),
+        "sha256": sha256_file(flags_path),
+        "assignments": assignments,
+    }
+
+
+def compiler_provenance(cmake_records):
+    candidates = []
+    for record in cmake_records:
+        entries = record["entries"]
+        for key in ("CMAKE_CXX_COMPILER", "CMAKE_C_COMPILER"):
+            if entries.get(key):
+                candidates.append(entries[key])
+    if not candidates:
+        fallback = shutil.which("c++")
+        if fallback:
+            candidates.append(fallback)
+    compilers = []
+    for compiler in dict.fromkeys(candidates):
+        resolved = shutil.which(compiler) or compiler
+        version = command_output([resolved, "--version"])
+        compilers.append(
+            {
+                "path": resolved,
+                "version": version.get("output"),
+                "version_ok": version["ok"],
+            }
+        )
+    return compilers
+
+
+def host_provenance():
+    return {
+        "hostname": socket.gethostname(),
+        "platform": platform.platform(),
+        "system": platform.system(),
+        "release": platform.release(),
+        "machine": platform.machine(),
+        "processor": platform.processor(),
+        "python": {
+            "version": platform.python_version(),
+            "implementation": platform.python_implementation(),
+            "executable": sys.executable,
+            "full_version": sys.version,
+        },
+    }
+
+
+def build_provenance(manifest_path, executables, executable_hashes, args):
+    runner_path = pathlib.Path(__file__).resolve()
+    git_record = git_provenance(runner_path.parent)
+    repository_root = (
+        pathlib.Path(git_record["root"])
+        if git_record.get("available") else runner_path.parent.parent
+    )
+    source_candidates = [
+        repository_root / "CMakeLists.txt",
+        repository_root / "tools" / "run_ode_ceiling_sweep.py",
+        repository_root / "tools" / "prepare_ode_ceiling_models.py",
+        repository_root / "tools" / "gen_ode_ceiling_sweep.py",
+    ]
+    if "rk" in executables:
+        source_candidates.append(
+            repository_root / "tools" / "bench_ode_ceiling.cpp"
+        )
+    if "cvodes" in executables:
+        source_candidates.append(
+            repository_root / "tools" / "bench_ode_cvodes_ceiling.cpp"
+        )
+    source_hashes = [
+        {"path": str(path), "sha256": sha256_file(path)}
+        for path in source_candidates
+        if path.is_file() and not path.is_symlink()
+    ]
+    cache_records = []
+    by_cache = {}
+    for kind, executable in executables.items():
+        cache_path = find_cmake_cache(executable)
+        if cache_path is None:
+            continue
+        key = str(cache_path)
+        if key not in by_cache:
+            by_cache[key] = {
+                "path": key,
+                "sha256": sha256_file(cache_path),
+                "entries": relevant_cmake_cache(cache_path),
+                "benchmarks": [],
+            }
+            cache_records.append(by_cache[key])
+        by_cache[key]["benchmarks"].append(kind)
+    return {
+        "schema": "stanli.ode-ceiling-sweep.provenance.v1",
+        "created_utc": datetime.datetime.now(
+            datetime.timezone.utc
+        ).isoformat(),
+        "completed": False,
+        "argv": sys.argv,
+        "manifest": {
+            "path": str(manifest_path),
+            "sha256": sha256_file(manifest_path),
+        },
+        "runner": {
+            "path": str(runner_path),
+            "sha256": sha256_file(runner_path),
+        },
+        "git": git_record,
+        "sources": source_hashes,
+        "host": host_provenance(),
+        "benchmarks": {
+            kind: {
+                "path": str(path),
+                "sha256": executable_hashes[kind],
+                "compile_flags": target_compile_flags(path),
+            }
+            for kind, path in executables.items()
+        },
+        "cmake_caches": cache_records,
+        "compilers": compiler_provenance(cache_records),
+        "selection": {
+            "solvers": args.solvers,
+            "case_names": args.case_names,
+            "case_substrings": args.case_substrings,
+            "point": args.point,
+            "iterations": args.iterations,
+            "batches": args.batches,
+            "warmup_ms": args.warmup_ms,
+            "timeout_seconds": args.timeout,
+            "diagnostic": args.diagnostic,
+        },
+    }
+
+
+def atomic_write_json(path, payload, exclusive=False):
+    if exclusive:
+        with path.open("x") as stream:
+            json.dump(payload, stream, indent=2, sort_keys=True)
+            stream.write("\n")
+        return
+    descriptor, temporary_name = tempfile.mkstemp(
+        dir=path.parent, prefix=f".{path.name}.", suffix=".tmp"
+    )
+    temporary_path = pathlib.Path(temporary_name)
+    try:
+        with os.fdopen(descriptor, "w") as stream:
+            json.dump(payload, stream, indent=2, sort_keys=True)
+            stream.write("\n")
+        os.replace(temporary_path, path)
+    finally:
+        if path_exists(temporary_path):
+            temporary_path.unlink()
+
+
+def _beta_continued_fraction(a, b, x):
+    """Continued fraction used by the regularized incomplete beta."""
+    maximum_iterations = 200
+    epsilon = 3.0e-14
+    minimum = 1.0e-300
+    qab = a + b
+    qap = a + 1.0
+    qam = a - 1.0
+    c = 1.0
+    d = 1.0 - qab * x / qap
+    if abs(d) < minimum:
+        d = minimum
+    d = 1.0 / d
+    result = d
+    for iteration in range(1, maximum_iterations + 1):
+        even = 2 * iteration
+        coefficient = (
+            iteration * (b - iteration) * x
+            / ((qam + even) * (a + even))
+        )
+        d = 1.0 + coefficient * d
+        if abs(d) < minimum:
+            d = minimum
+        c = 1.0 + coefficient / c
+        if abs(c) < minimum:
+            c = minimum
+        d = 1.0 / d
+        result *= d * c
+        coefficient = -(
+            (a + iteration) * (qab + iteration) * x
+            / ((a + even) * (qap + even))
+        )
+        d = 1.0 + coefficient * d
+        if abs(d) < minimum:
+            d = minimum
+        c = 1.0 + coefficient / c
+        if abs(c) < minimum:
+            c = minimum
+        d = 1.0 / d
+        delta = d * c
+        result *= delta
+        if abs(delta - 1.0) <= epsilon:
+            return result
+    raise ArithmeticError("incomplete-beta continued fraction did not converge")
+
+
+def regularized_incomplete_beta(a, b, x):
+    if x <= 0.0:
+        return 0.0
+    if x >= 1.0:
+        return 1.0
+    front = math.exp(
+        math.lgamma(a + b) - math.lgamma(a) - math.lgamma(b)
+        + a * math.log(x) + b * math.log1p(-x)
+    )
+    if x < (a + 1.0) / (a + b + 2.0):
+        return front * _beta_continued_fraction(a, b, x) / a
+    return 1.0 - (
+        front * _beta_continued_fraction(b, a, 1.0 - x) / b
+    )
+
+
+def student_t_cdf(value, degrees_freedom):
+    if value == 0.0:
+        return 0.5
+    x = degrees_freedom / (degrees_freedom + value * value)
+    tail = 0.5 * regularized_incomplete_beta(
+        0.5 * degrees_freedom, 0.5, x
+    )
+    return 1.0 - tail if value > 0.0 else tail
+
+
+def student_t_critical_95(degrees_freedom):
+    low = 0.0
+    high = 1.0
+    while student_t_cdf(high, degrees_freedom) < 0.975:
+        high *= 2.0
+    for _ in range(80):
+        middle = 0.5 * (low + high)
+        if student_t_cdf(middle, degrees_freedom) < 0.975:
+            low = middle
+        else:
+            high = middle
+    return 0.5 * (low + high)
+
+
+def paired_log_statistics(batches):
+    samples = []
+    for batch in batches:
+        value = batch.get("speedup")
+        if (
+            isinstance(value, (int, float))
+            and not isinstance(value, bool)
+            and math.isfinite(value)
+            and value > 0.0
+        ):
+            samples.append(float(value))
+    logs = [math.log(value) for value in samples]
+    result = {
+        "method": "two-sided 95% Student-t interval on log(speedup)",
+        "sample_count": len(samples),
+        "geometric_mean": math.exp(sum(logs) / len(logs)) if logs else None,
+        "confidence_level": 0.95,
+        "degrees_freedom": len(logs) - 1 if len(logs) >= 2 else None,
+        "ci_low": None,
+        "ci_high": None,
+    }
+    if len(logs) < 2:
+        return result
+    mean = sum(logs) / len(logs)
+    variance = sum((value - mean) ** 2 for value in logs) / (len(logs) - 1)
+    standard_error = math.sqrt(variance / len(logs))
+    critical = student_t_critical_95(len(logs) - 1)
+    margin = critical * standard_error
+    result.update(
+        {
+            "log_mean": mean,
+            "log_sample_standard_deviation": math.sqrt(variance),
+            "log_standard_error": standard_error,
+            "t_critical": critical,
+            "ci_low": math.exp(mean - margin),
+            "ci_high": math.exp(mean + margin),
+        }
+    )
+    return result
+
+
+def case_name(row, manifest_index):
+    return str(row.get("case", f"case_{manifest_index + 1}"))
+
+
+def case_matches(name, exact_names, substrings):
+    if not exact_names and not substrings:
+        return True
+    return name in exact_names or any(value in name for value in substrings)
+
+
+def log_filename(case_index, name):
+    slug = re.sub(r"[^A-Za-z0-9_.-]+", "_", name).strip("._") or "case"
+    digest = hashlib.sha256(name.encode()).hexdigest()[:8]
+    return f"{case_index:03d}_{slug[:80]}_{digest}.log"
+
+
+def scalar(text):
+    """Convert an unambiguous benchmark scalar, preserving opaque strings."""
+    if text in ("true", "false"):
+        return text == "true"
+    try:
+        return int(text, 0)
+    except ValueError:
+        pass
+    try:
+        value = float(text)
+        return value if math.isfinite(value) else text
+    except ValueError:
+        return text
+
+
+def key_values(line):
+    return {
+        match.group(1): scalar(match.group(2) or match.group(3))
+        for match in KV_RE.finditer(line)
+    }
+
+
+def parse_rk_output(stdout):
+    parsed = {
+        "header": {},
+        "shape": {},
+        "provider": {},
+        "correctness": {},
+        "batches": [],
+    }
+    local = []
+    compare_re = re.compile(
+        r"^(?P<label>.+) bitwise=(?P<exact>\d+)/(?P<total>\d+) "
+        r"max_relative=(?P<relative>\S+) worst=(?P<worst>\d+)$"
+    )
+    callbacks_re = re.compile(
+        r"^callbacks oracle=(\d+) candidate=(\d+) equal=(\d+)$"
+    )
+    steps_re = re.compile(
+        r"^steps candidate_accepted=(\d+) attempted_derived=(\d+) "
+        r"rejected_derived=(\d+) initialization_rhs=(\d+)$"
+    )
+    batch_re = re.compile(
+        r"^batch=(\d+) oracle_ns=(\S+) candidate_ns=(\S+) "
+        r"speedup=(\S+)x$"
+    )
+    summary_re = re.compile(
+        r"^median oracle_ns=(\S+) candidate_ns=(\S+) "
+        r"paired_speedup=(\S+)x range=\[(\S+)x,(\S+)x\] "
+        r"iterations=(\d+) batches=(\d+) sink=(\S+)$"
+    )
+    for line in stdout.splitlines():
+        if line.startswith("model_lp="):
+            parsed["header"] = key_values(line)
+        elif line.startswith("shape "):
+            parsed["shape"] = key_values(line)
+        elif line.startswith("provider "):
+            parsed["provider"] = key_values(line)
+        elif line.startswith("timing_gate="):
+            parsed["timing_gate"] = key_values(line)
+        else:
+            match = compare_re.match(line)
+            if match:
+                item = {
+                    "label": match.group("label"),
+                    "exact": int(match.group("exact")),
+                    "total": int(match.group("total")),
+                    "max_relative": scalar(match.group("relative")),
+                    "worst": int(match.group("worst")),
+                }
+                if item["label"].startswith("local["):
+                    local.append(item)
+                else:
+                    parsed["correctness"][item["label"]] = item
+                continue
+            match = callbacks_re.match(line)
+            if match:
+                parsed["callbacks"] = {
+                    "oracle": int(match.group(1)),
+                    "candidate": int(match.group(2)),
+                    "equal": bool(int(match.group(3))),
+                }
+                continue
+            match = steps_re.match(line)
+            if match:
+                parsed["steps"] = {
+                    "accepted": int(match.group(1)),
+                    "attempted_derived": int(match.group(2)),
+                    "rejected_derived": int(match.group(3)),
+                    "initialization_rhs": int(match.group(4)),
+                }
+                continue
+            match = batch_re.match(line)
+            if match:
+                parsed["batches"].append(
+                    {
+                        "batch": int(match.group(1)),
+                        "oracle_ns": scalar(match.group(2)),
+                        "candidate_ns": scalar(match.group(3)),
+                        "speedup": scalar(match.group(4)),
+                    }
+                )
+                continue
+            match = summary_re.match(line)
+            if match:
+                parsed["timing"] = {
+                    "oracle_ns": scalar(match.group(1)),
+                    "candidate_ns": scalar(match.group(2)),
+                    "paired_speedup": scalar(match.group(3)),
+                    "range_min": scalar(match.group(4)),
+                    "range_max": scalar(match.group(5)),
+                    "iterations": int(match.group(6)),
+                    "batches": int(match.group(7)),
+                }
+    parsed["correctness"]["local"] = local
+    return parsed
+
+
+def parse_cvodes_output(stdout):
+    parsed = {
+        "header": {},
+        "shape": {},
+        "correctness": {},
+        "profiles": {},
+        "stats": {},
+        "batches": [],
+    }
+    compare_re = re.compile(
+        r"^(?P<label>solution (?:values|Jacobian)).*: "
+        r"exact=(?P<exact>\d+)/(?P<total>\d+) "
+        r"max_abs=(?P<absolute>\S+) max_rel=(?P<relative>\S+) "
+        r"max_ulp=(?P<ulp>\d+) worst\[(?P<worst>\d+)\]="
+        r"(?P<value>\S+) oracle=(?P<oracle>\S+)$"
+    )
+    batch_re = re.compile(
+        r"^batch (\d+): oracle=(\S+) ns local=(\S+) ns speedup=(\S+)x$"
+    )
+    summary_re = re.compile(
+        r"^uninstrumented medians: oracle=(\S+) ns local=(\S+) ns paired "
+        r"speedup=(\S+)x \(range (\S+)x\.\.(\S+)x\) sink=(\S+)$"
+    )
+    for line in stdout.splitlines():
+        if line.startswith("CVODES fvar ceiling/proximity experiment:"):
+            parsed["header"] = key_values(line)
+        elif line.startswith("shape "):
+            parsed["shape"] = key_values(line)
+        elif line.startswith("oracle profile ns:"):
+            parsed["profiles"]["oracle"] = key_values(line)
+        elif line.startswith("local profile ns:"):
+            parsed["profiles"]["local"] = key_values(line)
+        elif line.startswith("local callbacks:"):
+            parsed["profiles"]["callbacks"] = key_values(line)
+        elif line.startswith("CVODES stats:"):
+            parsed["stats"]["solver"] = key_values(line)
+        elif line.startswith("CVODES sensitivity stats:"):
+            parsed["stats"]["sensitivity"] = key_values(line)
+        elif line.startswith("timing_gate="):
+            parsed["timing_gate"] = key_values(line)
+        else:
+            match = compare_re.match(line)
+            if match:
+                parsed["correctness"][match.group("label")] = {
+                    "exact": int(match.group("exact")),
+                    "total": int(match.group("total")),
+                    "max_abs": scalar(match.group("absolute")),
+                    "max_relative": scalar(match.group("relative")),
+                    "max_ulp": int(match.group("ulp")),
+                    "worst": int(match.group("worst")),
+                    "candidate_value": scalar(match.group("value")),
+                    "oracle_value": scalar(match.group("oracle")),
+                }
+                continue
+            match = batch_re.match(line)
+            if match:
+                parsed["batches"].append(
+                    {
+                        "batch": int(match.group(1)),
+                        "oracle_ns": scalar(match.group(2)),
+                        "candidate_ns": scalar(match.group(3)),
+                        "speedup": scalar(match.group(4)),
+                    }
+                )
+                continue
+            match = summary_re.match(line)
+            if match:
+                parsed["timing"] = {
+                    "oracle_ns": scalar(match.group(1)),
+                    "candidate_ns": scalar(match.group(2)),
+                    "paired_speedup": scalar(match.group(3)),
+                    "range_min": scalar(match.group(4)),
+                    "range_max": scalar(match.group(5)),
+                }
+    return parsed
+
+
+def validate_parsed_result(parsed, expected_batches, expected_iterations):
+    """Return a reason when stdout is incomplete or numerically invalid."""
+    timing_gate = parsed.get("timing_gate")
+    if not isinstance(timing_gate, dict) or timing_gate.get("pass") != 1:
+        return "missing or failed pre-timing correctness gate"
+
+    batches = parsed.get("batches")
+    if not isinstance(batches, list) or len(batches) != expected_batches:
+        return (
+            f"expected {expected_batches} complete batches, found "
+            f"{len(batches) if isinstance(batches, list) else 0}"
+        )
+    if [batch.get("batch") for batch in batches] != list(
+        range(1, expected_batches + 1)
+    ):
+        return "batch identifiers are missing, duplicated, or out of order"
+    for batch in batches:
+        for field in ("oracle_ns", "candidate_ns", "speedup"):
+            value = batch.get(field)
+            if (
+                not isinstance(value, (int, float))
+                or isinstance(value, bool)
+                or not math.isfinite(value)
+                or value <= 0.0
+            ):
+                return f"batch {batch.get('batch')} has invalid {field}"
+
+    timing = parsed.get("timing")
+    if not isinstance(timing, dict):
+        return "timing summary not found"
+    for field in (
+        "oracle_ns", "candidate_ns", "paired_speedup", "range_min",
+        "range_max",
+    ):
+        value = timing.get(field)
+        if (
+            not isinstance(value, (int, float))
+            or isinstance(value, bool)
+            or not math.isfinite(value)
+            or value <= 0.0
+        ):
+            return f"timing summary has invalid {field}"
+    if "batches" in timing and timing["batches"] != expected_batches:
+        return "timing summary batch count does not match the request"
+    if "iterations" in timing and timing["iterations"] != expected_iterations:
+        return "timing summary iteration count does not match the request"
+    return None
+
+
+def selected_solvers(text):
+    values = [value.strip().lower() for value in text.split(",") if value.strip()]
+    if not values:
+        raise argparse.ArgumentTypeError("select at least one solver")
+    unknown = sorted(set(values) - set(SOLVERS))
+    if unknown:
+        raise argparse.ArgumentTypeError(
+            "unknown solver(s): " + ", ".join(unknown)
+        )
+    return tuple(dict.fromkeys(values))
+
+
+def arguments():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("manifest", type=pathlib.Path)
+    parser.add_argument("--output", type=pathlib.Path, required=True)
+    parser.add_argument(
+        "--rk-benchmark", type=pathlib.Path,
+        default=pathlib.Path("build-rel/bench_ode_ceiling"),
+    )
+    parser.add_argument(
+        "--cvodes-benchmark", type=pathlib.Path,
+        default=pathlib.Path("build-rel/bench_ode_cvodes_ceiling"),
+    )
+    parser.add_argument(
+        "--solvers", type=selected_solvers, default=SOLVERS,
+        help="comma-separated subset of rk45,ckrk,bdf,adams",
+    )
+    parser.add_argument(
+        "--case", "--case-name", dest="case_names", action="append",
+        default=[], metavar="NAME",
+        help="run an exact, case-sensitive manifest case name (repeatable)",
+    )
+    parser.add_argument(
+        "--case-substr", dest="case_substrings", action="append",
+        default=[], metavar="TEXT",
+        help=(
+            "run case names containing this case-sensitive text (repeatable; "
+            "combined with --case by OR)"
+        ),
+    )
+    parser.add_argument("--point", type=int, choices=(0, 1, 2), default=0)
+    parser.add_argument("--iterations", type=int, default=1)
+    parser.add_argument("--batches", type=int, default=3)
+    parser.add_argument("--warmup-ms", type=int, default=0)
+    parser.add_argument(
+        "--diagnostic", action="store_true",
+        help="ask RK benchmarks to emit perturbative component timings",
+    )
+    parser.add_argument("--timeout", type=float, default=120.0)
+    parser.add_argument(
+        "--force", action="store_true",
+        help=(
+            "replace regular output/sidecar files and a sentinel-owned log "
+            "directory"
+        ),
+    )
+    args = parser.parse_args()
+    if (args.iterations < 1 or args.batches < 1 or args.warmup_ms < 0
+            or args.timeout <= 0):
+        parser.error(
+            "iterations, batches, and timeout must be positive; "
+            "warmup-ms must be nonnegative"
+        )
+    if any(not value for value in (*args.case_names, *args.case_substrings)):
+        parser.error("case filters must not be empty")
+    return args
+
+
+def resolved_executable(path):
+    path = path.expanduser().resolve()
+    if not path.is_file():
+        raise FileNotFoundError(path)
+    return path
+
+
+def main():
+    args = arguments()
+    manifest_path = args.manifest.expanduser().resolve()
+    rows = json.loads(manifest_path.read_text())
+    if not isinstance(rows, list):
+        raise ValueError("manifest root must be a JSON array")
+    cases = []
+    hash_cache = {}
+    for manifest_index, row in enumerate(rows):
+        if not isinstance(row, dict):
+            raise ValueError(f"manifest row {manifest_index} must be an object")
+        solver = row.get("solver")
+        name = case_name(row, manifest_index)
+        if solver not in args.solvers or not case_matches(
+            name, args.case_names, args.case_substrings
+        ):
+            continue
+        if solver not in SOLVERS:
+            raise ValueError(
+                f"manifest row {manifest_index} has unknown solver {solver!r}"
+            )
+        try:
+            mir_path = pathlib.Path(row["mir"]).expanduser().resolve()
+            data_path = pathlib.Path(row["data"]).expanduser().resolve()
+        except KeyError as error:
+            raise ValueError(
+                f"manifest row {manifest_index} is missing {error.args[0]!r}"
+            ) from error
+        if not mir_path.is_file():
+            raise FileNotFoundError(mir_path)
+        if not data_path.is_file():
+            raise FileNotFoundError(data_path)
+        cases.append(
+            {
+                "manifest_index": manifest_index,
+                "row": row,
+                "name": name,
+                "solver": solver,
+                "kind": "rk" if solver in RK_SOLVERS else "cvodes",
+                "mir": mir_path,
+                "data": data_path,
+                "mir_sha256": sha256_file(mir_path, hash_cache),
+                "data_sha256": sha256_file(data_path, hash_cache),
+            }
+        )
+    if not cases:
+        raise ValueError("no manifest cases matched the solver and case filters")
+
+    benchmark_arguments = {
+        "rk": args.rk_benchmark,
+        "cvodes": args.cvodes_benchmark,
+    }
+    needed_kinds = {case["kind"] for case in cases}
+    executables = {
+        kind: resolved_executable(benchmark_arguments[kind])
+        for kind in sorted(needed_kinds)
+    }
+    executable_hashes = {
+        kind: sha256_file(path, hash_cache)
+        for kind, path in executables.items()
+    }
+
+    # Capture repository state before output artifacts can affect dirty status.
+    provenance = build_provenance(
+        manifest_path, executables, executable_hashes, args
+    )
+    provenance["case_count"] = len(cases)
+
+    output = absolute_path(args.output)
+    log_dir = pathlib.Path(str(output) + ".logs")
+    provenance_path = pathlib.Path(str(output) + PROVENANCE_SUFFIX)
+    protected_paths = {
+        manifest_path,
+        pathlib.Path(__file__).resolve(),
+        *executables.values(),
+        *(case["mir"] for case in cases),
+        *(case["data"] for case in cases),
+    }
+    for source in provenance.get("sources", []):
+        protected_paths.add(pathlib.Path(source["path"]))
+    for cache in provenance.get("cmake_caches", []):
+        protected_paths.add(pathlib.Path(cache["path"]))
+    for benchmark in provenance.get("benchmarks", {}).values():
+        flags = benchmark.get("compile_flags")
+        if flags is not None:
+            protected_paths.add(pathlib.Path(flags["path"]))
+    for row in rows:
+        for key in ("stan", "stanc", "source_archive"):
+            value = row.get(key) if isinstance(row, dict) else None
+            if isinstance(value, str):
+                protected_paths.add(pathlib.Path(value).expanduser().resolve())
+        for key in ("mir", "data"):
+            value = row.get(key) if isinstance(row, dict) else None
+            if isinstance(value, str):
+                protected_paths.add(pathlib.Path(value).expanduser().resolve())
+    reject_output_collisions(
+        output, log_dir, provenance_path, protected_paths
+    )
+    prepare_output_paths(
+        output, log_dir, provenance_path, force=args.force
+    )
+    atomic_write_json(provenance_path, provenance, exclusive=True)
+
+    started = time.monotonic()
+    counts = {"ok": 0, "failed": 0, "timeout": 0, "parse_error": 0}
+    with output.open("x") as stream:
+        for index, case_record in enumerate(cases, 1):
+            manifest_index = case_record["manifest_index"]
+            row = case_record["row"]
+            case = case_record["name"]
+            solver = case_record["solver"]
+            kind = case_record["kind"]
+            command = [
+                str(executables[kind]),
+                str(case_record["mir"]),
+                str(case_record["data"]),
+                "--solver", str(solver),
+                "--point", str(args.point),
+                "--iterations", str(args.iterations),
+                "--batches", str(args.batches),
+                "--warmup-ms", str(args.warmup_ms),
+            ]
+            if row.get("require_exact") is True:
+                command.append("--require-exact")
+            if args.diagnostic and kind == "rk":
+                command.append("--diagnostic")
+            case_started = time.monotonic()
+            stdout = ""
+            stderr = ""
+            returncode = None
+            status = "failed"
+            expected_hashes = {
+                "mir": case_record["mir_sha256"],
+                "data": case_record["data_sha256"],
+                "selected_binary": executable_hashes[kind],
+            }
+            integrity_error = case_hash_error(
+                case_record, executables[kind], expected_hashes
+            )
+            if integrity_error is not None:
+                stderr = integrity_error
+            else:
+                try:
+                    completed = subprocess.run(
+                        command,
+                        capture_output=True,
+                        text=True,
+                        timeout=args.timeout,
+                        check=False,
+                    )
+                    stdout = completed.stdout
+                    stderr = completed.stderr
+                    returncode = completed.returncode
+                    status = "ok" if returncode == 0 else "failed"
+                except subprocess.TimeoutExpired as error:
+                    stdout = error.stdout or ""
+                    stderr = error.stderr or ""
+                    if isinstance(stdout, bytes):
+                        stdout = stdout.decode(errors="replace")
+                    if isinstance(stderr, bytes):
+                        stderr = stderr.decode(errors="replace")
+                    status = "timeout"
+                integrity_error = case_hash_error(
+                    case_record, executables[kind], expected_hashes
+                )
+                if integrity_error is not None:
+                    status = "failed"
+                    stderr = (stderr.rstrip() + "\n" + integrity_error).lstrip()
+
+            log_path = log_dir / log_filename(index, case)
+            with log_path.open("x") as log_stream:
+                log_stream.write(
+                    "$ " + shlex.join(command) + "\n\n[stdout]\n" + stdout
+                    + "\n[stderr]\n" + stderr
+                )
+            result = {
+                "manifest_index": manifest_index,
+                "case_index": index,
+                "case_count": len(cases),
+                "case": row,
+                "status": status,
+                "returncode": returncode,
+                "elapsed_seconds": time.monotonic() - case_started,
+                "command": command,
+                "log": str(log_path),
+                "stderr": stderr.strip(),
+                "sha256": {
+                    "mir": case_record["mir_sha256"],
+                    "data": case_record["data_sha256"],
+                    "selected_binary": executable_hashes[kind],
+                },
+                "mir_sha256": case_record["mir_sha256"],
+                "data_sha256": case_record["data_sha256"],
+                "selected_binary_sha256": executable_hashes[kind],
+                "provenance": str(provenance_path),
+            }
+            if status == "ok":
+                result["result"] = (
+                    parse_rk_output(stdout)
+                    if kind == "rk" else parse_cvodes_output(stdout)
+                )
+                validation_error = validate_parsed_result(
+                    result["result"], args.batches, args.iterations
+                )
+                if validation_error is not None:
+                    result["status"] = "parse_error"
+                    result["parse_error"] = validation_error
+                else:
+                    paired_statistics = paired_log_statistics(
+                        result["result"]["batches"]
+                    )
+                    result["result"]["paired_log_statistics"] = (
+                        paired_statistics
+                    )
+                    if paired_statistics["sample_count"] != args.batches:
+                        result["status"] = "parse_error"
+                        result["parse_error"] = (
+                            "paired statistics did not consume every batch"
+                        )
+            counts[result["status"]] += 1
+            stream.write(json.dumps(result, sort_keys=True) + "\n")
+            stream.flush()
+            timing = result.get("result", {}).get("timing", {})
+            ratio = timing.get("paired_speedup")
+            ratio_text = f" {ratio:.3f}x" if isinstance(ratio, (int, float)) else ""
+            print(
+                f"[{index:02d}/{len(cases):02d}] {case}: "
+                f"{result['status']}{ratio_text}",
+                file=sys.stderr,
+                flush=True,
+            )
+
+    summary = {
+        "output": str(output),
+        "logs": str(log_dir),
+        "provenance": str(provenance_path),
+        "cases": len(cases),
+        "counts": counts,
+        "elapsed_seconds": time.monotonic() - started,
+        "iterations": args.iterations,
+        "batches": args.batches,
+        "warmup_ms": args.warmup_ms,
+        "diagnostic": args.diagnostic,
+        "point": args.point,
+        "solvers": args.solvers,
+        "case_names": args.case_names,
+        "case_substrings": args.case_substrings,
+    }
+    provenance.update(
+        {
+            "completed": True,
+            "completed_utc": datetime.datetime.now(
+                datetime.timezone.utc
+            ).isoformat(),
+            "summary": summary,
+        }
+    )
+    atomic_write_json(provenance_path, provenance)
+    print(json.dumps(summary, indent=2))
+    return 0 if counts["failed"] + counts["timeout"] + counts["parse_error"] == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- integrate eligible RK45 and CKRK values plus coupled sensitivities directly in double space using compiled RHS values and generated register Jacobians
- retain the current Stan Math nested-autodiff solve as a fail-closed oracle and fallback, selectable with `STANLI_NO_ODE_DIRECT_RK=1`
- preserve the pinned RK tableaux, controller, coupled error norm, validation order, exceptions, output layout, and graph backward contract
- add exact opcode admission, activity-mask, error-parity, concurrency, cross-path, and oracle-selector coverage
- include the Phase 0 stop report, solver-family ceiling study, retained production benchmark report, and reproducible benchmark tools

This does not revive the losing Phase 0 precomputed-gradient callback bridge. Generated reverse is used only as a local double-space `J_y`/`J_theta` provider inside a separately owned coupled RK solve.

## Performance

Retained macOS arm64 fresh-process paired results, 15 batches per comparison with 200 ms warmup and at least 0.5 seconds per timed arm:

| model | comparison | speedup | paired 95% CI |
|---|---|---:|---:|
| Lotka--Volterra | stanli oracle / direct RK | 1.968x | [1.951x, 1.985x] |
| soil incubation | stanli oracle / direct RK | 1.958x | [1.944x, 1.971x] |
| Lotka--Volterra | CmdStan default / direct RK | 2.157x | [2.094x, 2.221x] |
| soil incubation | CmdStan default / direct RK | 2.266x | [2.241x, 2.291x] |

The one-compartment BDF model is intentionally ineligible and neutral under the stanli oracle/direct selector: 0.997x [0.988x, 1.006x].

## Validation

- `ctest --test-dir build-rel --output-on-failure -j 6`: 67/67 passed
- focused ODE program, variadic, and cross-path tests passed
- 252/252 synthetic default/oracle comparisons were exact
- 9/9 three-model, three-point default/oracle comparisons were exact
- `python3 harnesses/ode_sweep.py deps/cmdstan --build build-rel`: 16/16 interfaces within `1e-9`, worst `2.40e-14`
- changed C++ sources pass `clang-format --dry-run --Werror`
- `git diff --check` passes

## Merge gate

macOS arm64 evidence is complete. Linux x86-64 Release CI should repeat the correctness suite before merge; platform-specific numerical behavior remains the explicit final gate.