### PR TITLE
Additional function support

### DIFF
--- a/runtime/include/stanli/mir_interp.hpp
+++ b/runtime/include/stanli/mir_interp.hpp
@@ -1727,12 +1727,32 @@ class MirInterp {
     }
     if (e.name == "sd") {
       Value a = eval(e.args[0]);
+      if (a.r.empty()) fail("sd: input must have a positive size", e.raw);
+      if (a.r.size() == 1) {
+        r.r = {T(0.0)};
+        return r;
+      }
       T m = T(0.0);
       for (const T& v : a.r) m += v;
       m /= (double)a.r.size();
       T s2 = T(0.0);
       for (const T& v : a.r) s2 += (v - m) * (v - m);
       r.r = {stan::math::sqrt(s2 / (double)(a.r.size() - 1))};
+      return r;
+    }
+    if (e.name == "variance") {
+      Value a = eval(e.args[0]);
+      if (a.r.empty()) fail("variance: input must have a positive size", e.raw);
+      if (a.r.size() == 1) {
+        r.r = {T(0.0)};
+        return r;
+      }
+      T m = T(0.0);
+      for (const T& v : a.r) m += v;
+      m /= (double)a.r.size();
+      T s2 = T(0.0);
+      for (const T& v : a.r) s2 += (v - m) * (v - m);
+      r.r = {s2 / (double)(a.r.size() - 1)};
       return r;
     }
     if (e.name == "sum") {

--- a/runtime/include/stanli/mir_interp.hpp
+++ b/runtime/include/stanli/mir_interp.hpp
@@ -1656,6 +1656,91 @@ class MirInterp {
         for (int64_t i = 0; i < n; ++i) o.r[(size_t)(j * n + i)] = c(i, j);
       return o;
     }
+    if ((e.name == "inverse" || e.name == "inverse_spd") &&
+        e.args.size() == 1) {
+      using Mat = Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>;
+      Value a = eval(e.args[0]);
+      if (a.dims.size() != 2 || a.dims[0] != a.dims[1])
+        fail(e.name + ": needs a square matrix", e.raw);
+      const int64_t n = a.dims[0];
+      Mat A(n, n);
+      for (int64_t j = 0; j < n; ++j)
+        for (int64_t i = 0; i < n; ++i) A(i, j) = a.r.at((size_t)(j * n + i));
+      const Mat c = e.name == "inverse" ? stan::math::inverse(A)
+                                        : stan::math::inverse_spd(A);
+      Value o;
+      o.dims = {n, n};
+      o.r.resize((size_t)(n * n));
+      for (int64_t j = 0; j < n; ++j)
+        for (int64_t i = 0; i < n; ++i) o.r[(size_t)(j * n + i)] = c(i, j);
+      return o;
+    }
+    if (e.name == "log_determinant" && e.args.size() == 1) {
+      using Mat = Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>;
+      Value a = eval(e.args[0]);
+      if (a.dims.size() != 2 || a.dims[0] != a.dims[1])
+        fail("log_determinant: needs a square matrix", e.raw);
+      const int64_t n = a.dims[0];
+      Mat A(n, n);
+      for (int64_t j = 0; j < n; ++j)
+        for (int64_t i = 0; i < n; ++i) A(i, j) = a.r.at((size_t)(j * n + i));
+      r.r = {stan::math::log_determinant(A)};
+      return r;
+    }
+    if (e.name == "quad_form" && e.args.size() == 2) {
+      using Mat = Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>;
+      Value a = eval(e.args[0]);
+      Value b = eval(e.args[1]);
+      if (a.dims.size() != 2 || a.dims[0] != a.dims[1])
+        fail("quad_form: needs a square matrix", e.raw);
+      const int64_t n = a.dims[0];
+      Mat A(n, n);
+      for (int64_t j = 0; j < n; ++j)
+        for (int64_t i = 0; i < n; ++i) A(i, j) = a.r.at((size_t)(j * n + i));
+      Value o;
+      if (b.dims.size() != 2) {
+        Eigen::Matrix<T, Eigen::Dynamic, 1> B((Eigen::Index)b.r.size());
+        for (size_t i = 0; i < b.r.size(); ++i) B((Eigen::Index)i) = b.r[i];
+        o.r = {stan::math::quad_form(A, B)};
+        return o;
+      }
+      const int64_t rb = b.dims[0], m = b.dims[1];
+      Mat B(rb, m);
+      for (int64_t j = 0; j < m; ++j)
+        for (int64_t i = 0; i < rb; ++i) B(i, j) = b.r.at((size_t)(j * rb + i));
+      const Mat c = stan::math::quad_form(A, B);
+      o.dims = {m, m};
+      o.r.resize((size_t)(m * m));
+      for (int64_t j = 0; j < m; ++j)
+        for (int64_t i = 0; i < m; ++i) o.r[(size_t)(j * m + i)] = c(i, j);
+      return o;
+    }
+    if (e.name == "add_diag" && e.args.size() == 2) {
+      using Mat = Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>;
+      Value a = eval(e.args[0]);
+      Value d = eval(e.args[1]);
+      if (a.dims.size() != 2) fail("add_diag: needs a matrix", e.raw);
+      const int64_t rows = a.dims[0], cols = a.dims[1];
+      Mat A(rows, cols);
+      for (int64_t j = 0; j < cols; ++j)
+        for (int64_t i = 0; i < rows; ++i)
+          A(i, j) = a.r.at((size_t)(j * rows + i));
+      Mat c;
+      if (d.r.size() == 1 && d.dims.empty()) {
+        c = stan::math::add_diag(A, d.r[0]);
+      } else {
+        Eigen::Matrix<T, Eigen::Dynamic, 1> D((Eigen::Index)d.r.size());
+        for (size_t i = 0; i < d.r.size(); ++i) D((Eigen::Index)i) = d.r[i];
+        c = stan::math::add_diag(A, D);
+      }
+      Value o;
+      o.dims = {rows, cols};
+      o.r.resize((size_t)(rows * cols));
+      for (int64_t j = 0; j < cols; ++j)
+        for (int64_t i = 0; i < rows; ++i)
+          o.r[(size_t)(j * rows + i)] = c(i, j);
+      return o;
+    }
     if (e.name == "quad_form_sym" && e.args.size() == 2) {
       // B' A B, symmetrised. Overload resolution on T reaches the same
       // stan-math call the graph kernel makes -- prim's B.dot(A * B) at

--- a/runtime/include/stanli/optable.hpp
+++ b/runtime/include/stanli/optable.hpp
@@ -28,6 +28,8 @@ namespace stanli {
   X(OP_BETA_BINOMIAL_LPMF)          \
   X(OP_LOGIT)                       \
   X(OP_MEAN)                        \
+  X(OP_SD)                          \
+  X(OP_VARIANCE)                    \
   X(OP_REP_VEC)                     \
   X(OP_INDEX)                       \
   X(OP_SET_INDEX)                   \

--- a/runtime/include/stanli/optable.hpp
+++ b/runtime/include/stanli/optable.hpp
@@ -161,7 +161,12 @@ namespace stanli {
   X(OP_EXTREMA_VEC)                 \
   X(OP_DYNAMIC_SLICE)               \
   X(OP_MATRIX_EXP)                  \
-  X(OP_QUAD_FORM_SYM)
+  X(OP_QUAD_FORM_SYM)               \
+  X(OP_INVERSE)                     \
+  X(OP_INVERSE_SPD)                 \
+  X(OP_LOG_DETERMINANT)             \
+  X(OP_QUAD_FORM)                   \
+  X(OP_ADD_DIAG)
 
 // Scalar densities, one line each: this list generates the opcode, the
 // name, the kernel, its registration, and the lowering table entry

--- a/runtime/kernels/elementwise.cpp
+++ b/runtime/kernels/elementwise.cpp
@@ -150,7 +150,9 @@ void sum_vec_bwd(KernelCtx& ctx) {
       ctx.in_adj[0].data[i] += ctx.out_adj;
 }
 
-// OP_PROD_VEC: generated-quantities-only product of a vector/row-vector.
+// OP_PROD_VEC: product of a vector/row-vector. The scratch stores one partial
+// per input coefficient for the model-block reverse pass; generated quantities
+// never execute the backward callback.
 // Variant 1 preserves the ascending scalar reduction selected by Eigen when
 // the source expression contains a strided matrix row.  The lowering records
 // that fact before the expression is materialized into a contiguous slot.
@@ -166,17 +168,34 @@ void prod_vec_fwd(KernelCtx& ctx) {
     double product = ctx.in[0].data[0];
     for (int64_t i = 1; i < ctx.in[0].len; ++i) product *= ctx.in[0].data[i];
     ctx.out.data[0] = product;
-    return;
+  } else {
+    assert(ctx.variant == 0);
+    using Vec = Eigen::Matrix<double, Eigen::Dynamic, 1>;
+    const Eigen::Map<const Vec> input(ctx.in[0].data, ctx.in[0].len);
+    ctx.out.data[0] = stan::math::prod(
+        input.unaryExpr(Eigen::internal::core_cast_op<double, double>()));
   }
-  assert(ctx.variant == 0);
-  using Vec = Eigen::Matrix<double, Eigen::Dynamic, 1>;
-  const Eigen::Map<const Vec> input(ctx.in[0].data, ctx.in[0].len);
-  ctx.out.data[0] = stan::math::prod(
-      input.unaryExpr(Eigen::internal::core_cast_op<double, double>()));
+
+  // Direct forward-only kernel probes do not provide scratch. Executors do,
+  // and only they can subsequently invoke the reverse pass.
+  if (ctx.scratch == nullptr) return;
+  ctx.scratch[0] = 1.0;
+  for (int64_t i = 1; i < ctx.in[0].len; ++i)
+    ctx.scratch[i] = ctx.scratch[i - 1] * ctx.in[0].data[i - 1];
+  double suffix = 1.0;
+  for (int64_t i = ctx.in[0].len; i-- > 0;) {
+    ctx.scratch[i] *= suffix;
+    suffix *= ctx.in[0].data[i];
+  }
+}
+void prod_vec_bwd(KernelCtx& ctx) {
+  if (!ctx.in_adj[0].data) return;
+  for (int64_t i = 0; i < ctx.in[0].len; ++i)
+    ctx.in_adj[0].data[i] += ctx.out_adj * ctx.scratch[i];
 }
 
-// OP_EXTREMA_VEC: generated-quantities-only min/max of a direct named
-// vector/row-vector (variant 0/1).  Stan Math defines extrema of an empty real
+// OP_EXTREMA_VEC: min/max of a direct named vector/row-vector (variant 0/1).
+// Stan Math defines extrema of an empty real
 // Eigen container as +/- infinity.  For nonempty inputs, the same-type unary
 // expression deliberately clears DirectAccessBit while retaining packet
 // access, so Eigen begins its packet reduction at lane zero just as it does
@@ -194,9 +213,27 @@ void extrema_vec_fwd(KernelCtx& ctx) {
   const Eigen::Map<const Vec> input(ctx.in[0].data, ctx.in[0].len);
   const auto owning_grouping =
       input.unaryExpr(Eigen::internal::core_cast_op<double, double>());
+  Eigen::Index selected = 0;
+  // Keep Stan Math's exact value path. Eigen's index-returning overload can
+  // select a different packet evaluator for NaNs and signed-zero ties, so it
+  // is used only to remember the reverse destination.
   ctx.out.data[0] = ctx.variant == 0 ? stan::math::min(owning_grouping)
                                      : stan::math::max(owning_grouping);
+  if (ctx.variant == 0)
+    (void)owning_grouping.minCoeff(&selected);
+  else
+    (void)owning_grouping.maxCoeff(&selected);
+  if (ctx.scratch != nullptr) ctx.scratch[0] = static_cast<double>(selected);
 }
+void extrema_vec_bwd(KernelCtx& ctx) {
+  if (!ctx.in_adj[0].data || ctx.in[0].len == 0) return;
+  ctx.in_adj[0].data[static_cast<int64_t>(ctx.scratch[0])] += ctx.out_adj;
+}
+
+int64_t input_len_scratch(const Op& op, const Slot* slots) {
+  return slots[op.in[0]].len;
+}
+int64_t scalar_scratch(const Op&, const Slot*) { return 1; }
 
 // OP_INDEX: scalar out = in[flat], idata = {flat}. Backward scatters.
 void index_fwd(KernelCtx& ctx) {
@@ -435,8 +472,10 @@ void register_elementwise_kernels() {
   register_kernel(OP_BCAST_FMA, Kernel{fma_fwd, fma_bwd, nullptr});
   register_kernel(OP_MATVEC, Kernel{matvec_fwd, matvec_bwd, nullptr});
   register_kernel(OP_SUM_VEC, Kernel{sum_vec_fwd, sum_vec_bwd, nullptr});
-  register_kernel(OP_PROD_VEC, Kernel{prod_vec_fwd, nullptr, nullptr});
-  register_kernel(OP_EXTREMA_VEC, Kernel{extrema_vec_fwd, nullptr, nullptr});
+  register_kernel(OP_PROD_VEC,
+                  Kernel{prod_vec_fwd, prod_vec_bwd, input_len_scratch});
+  register_kernel(OP_EXTREMA_VEC,
+                  Kernel{extrema_vec_fwd, extrema_vec_bwd, scalar_scratch});
   register_kernel(OP_INDEX, Kernel{index_fwd, index_bwd, nullptr});
   register_kernel(OP_SET_INDEX, Kernel{set_index_fwd, set_index_bwd, nullptr});
   register_kernel(OP_SET_INDEX_INPLACE, Kernel{set_index_inplace_fwd,

--- a/runtime/kernels/elementwise.cpp
+++ b/runtime/kernels/elementwise.cpp
@@ -5,6 +5,7 @@
 #include <stan/math/prim/fun/prod.hpp>
 #include <stan/math/prim/fun/max.hpp>
 #include <stan/math/prim/fun/min.hpp>
+#include <stan/math/rev/core.hpp>
 
 #include <cassert>
 #include <cmath>
@@ -150,12 +151,11 @@ void sum_vec_bwd(KernelCtx& ctx) {
       ctx.in_adj[0].data[i] += ctx.out_adj;
 }
 
-// OP_PROD_VEC: product of a vector/row-vector. The scratch stores one partial
-// per input coefficient for the model-block reverse pass; generated quantities
-// never execute the backward callback.
-// Variant 1 preserves the ascending scalar reduction selected by Eigen when
-// the source expression contains a strided matrix row.  The lowering records
-// that fact before the expression is materialized into a contiguous slot.
+// OP_PROD_VEC: product of a vector/row-vector.
+// Bit 0 preserves the ascending scalar reduction selected by Eigen when the
+// source expression contains a strided matrix row. Bit 1 marks an active
+// expression: Matrix<var> has no double packet reducer, so its value follows
+// the same ascending scalar order even for a contiguous named vector.
 // Eigen's redux normally chooses its packet boundary from the input address.
 // Graph slots share one arena, so that would make the arithmetic grouping
 // depend on every slot laid out before this one.  The explicit same-type
@@ -164,37 +164,39 @@ void sum_vec_bwd(KernelCtx& ctx) {
 // CmdStan passes to stan::math::prod without allocating a copy here.
 void prod_vec_fwd(KernelCtx& ctx) {
   assert(ctx.in[0].len > 0);
-  if (ctx.variant == 1) {
+  assert(ctx.variant <= 3);
+  if (ctx.variant != 0) {
     double product = ctx.in[0].data[0];
     for (int64_t i = 1; i < ctx.in[0].len; ++i) product *= ctx.in[0].data[i];
     ctx.out.data[0] = product;
   } else {
-    assert(ctx.variant == 0);
     using Vec = Eigen::Matrix<double, Eigen::Dynamic, 1>;
     const Eigen::Map<const Vec> input(ctx.in[0].data, ctx.in[0].len);
     ctx.out.data[0] = stan::math::prod(
         input.unaryExpr(Eigen::internal::core_cast_op<double, double>()));
   }
-
-  // Direct forward-only kernel probes do not provide scratch. Executors do,
-  // and only they can subsequently invoke the reverse pass.
-  if (ctx.scratch == nullptr) return;
-  ctx.scratch[0] = 1.0;
-  for (int64_t i = 1; i < ctx.in[0].len; ++i)
-    ctx.scratch[i] = ctx.scratch[i - 1] * ctx.in[0].data[i - 1];
-  double suffix = 1.0;
-  for (int64_t i = ctx.in[0].len; i-- > 0;) {
-    ctx.scratch[i] *= suffix;
-    suffix *= ctx.in[0].data[i];
-  }
 }
 void prod_vec_bwd(KernelCtx& ctx) {
   if (!ctx.in_adj[0].data) return;
+  stan::math::nested_rev_autodiff nested;
+  Eigen::Matrix<stan::math::var, Eigen::Dynamic, 1> input(ctx.in[0].len);
+  for (int64_t i = 0; i < ctx.in[0].len; ++i) input(i) = ctx.in[0].data[i];
+  stan::math::var product;
+  if (ctx.variant & 1u) {
+    // A strided row expression takes Eigen's ascending scalar reducer.
+    product = input(0);
+    for (int64_t i = 1; i < ctx.in[0].len; ++i) product *= input(i);
+  } else {
+    product = stan::math::prod(input);
+  }
+  stan::math::var seeded = product * ctx.out_adj;
+  stan::math::grad(seeded.vi_);
   for (int64_t i = 0; i < ctx.in[0].len; ++i)
-    ctx.in_adj[0].data[i] += ctx.out_adj * ctx.scratch[i];
+    ctx.in_adj[0].data[i] += input(i).adj();
 }
 
-// OP_EXTREMA_VEC: min/max of a direct named vector/row-vector (variant 0/1).
+// OP_EXTREMA_VEC: min/max of a direct named vector/row-vector. Bit 0 selects
+// max and bit 1 marks an active expression.
 // Stan Math defines extrema of an empty real
 // Eigen container as +/- infinity.  For nonempty inputs, the same-type unary
 // expression deliberately clears DirectAccessBit while retaining packet
@@ -202,11 +204,29 @@ void prod_vec_bwd(KernelCtx& ctx) {
 // for CmdStan's aligned owning VectorXd.  A direct Map would instead make
 // signed-zero/NaN tie grouping depend on this slot's arena address.
 void extrema_vec_fwd(KernelCtx& ctx) {
-  assert(ctx.variant <= 1);
+  assert(ctx.variant <= 3);
+  const bool maximum = ctx.variant & 1u;
   if (ctx.in[0].len == 0) {
-    ctx.out.data[0] = ctx.variant == 0
-                          ? std::numeric_limits<double>::infinity()
-                          : -std::numeric_limits<double>::infinity();
+    ctx.out.data[0] = maximum ? -std::numeric_limits<double>::infinity()
+                              : std::numeric_limits<double>::infinity();
+    return;
+  }
+  if (ctx.variant & 2u) {
+    // Matrix<var> has no packet extrema reducer. Eigen retains coefficient
+    // zero, then replaces it only on a strict comparison while scanning in
+    // order. This distinction controls signed-zero bits, interior NaNs, and
+    // which tied coefficient receives the adjoint.
+    int64_t selected = 0;
+    double value = ctx.in[0].data[0];
+    for (int64_t i = 1; i < ctx.in[0].len; ++i) {
+      const double candidate = ctx.in[0].data[i];
+      if (maximum ? value < candidate : candidate < value) {
+        value = candidate;
+        selected = i;
+      }
+    }
+    ctx.out.data[0] = value;
+    if (ctx.scratch != nullptr) ctx.scratch[0] = static_cast<double>(selected);
     return;
   }
   using Vec = Eigen::Matrix<double, Eigen::Dynamic, 1>;
@@ -217,9 +237,9 @@ void extrema_vec_fwd(KernelCtx& ctx) {
   // Keep Stan Math's exact value path. Eigen's index-returning overload can
   // select a different packet evaluator for NaNs and signed-zero ties, so it
   // is used only to remember the reverse destination.
-  ctx.out.data[0] = ctx.variant == 0 ? stan::math::min(owning_grouping)
-                                     : stan::math::max(owning_grouping);
-  if (ctx.variant == 0)
+  ctx.out.data[0] = maximum ? stan::math::max(owning_grouping)
+                            : stan::math::min(owning_grouping);
+  if (!maximum)
     (void)owning_grouping.minCoeff(&selected);
   else
     (void)owning_grouping.maxCoeff(&selected);
@@ -230,9 +250,6 @@ void extrema_vec_bwd(KernelCtx& ctx) {
   ctx.in_adj[0].data[static_cast<int64_t>(ctx.scratch[0])] += ctx.out_adj;
 }
 
-int64_t input_len_scratch(const Op& op, const Slot* slots) {
-  return slots[op.in[0]].len;
-}
 int64_t scalar_scratch(const Op&, const Slot*) { return 1; }
 
 // OP_INDEX: scalar out = in[flat], idata = {flat}. Backward scatters.
@@ -472,8 +489,7 @@ void register_elementwise_kernels() {
   register_kernel(OP_BCAST_FMA, Kernel{fma_fwd, fma_bwd, nullptr});
   register_kernel(OP_MATVEC, Kernel{matvec_fwd, matvec_bwd, nullptr});
   register_kernel(OP_SUM_VEC, Kernel{sum_vec_fwd, sum_vec_bwd, nullptr});
-  register_kernel(OP_PROD_VEC,
-                  Kernel{prod_vec_fwd, prod_vec_bwd, input_len_scratch});
+  register_kernel(OP_PROD_VEC, Kernel{prod_vec_fwd, prod_vec_bwd, nullptr});
   register_kernel(OP_EXTREMA_VEC,
                   Kernel{extrema_vec_fwd, extrema_vec_bwd, scalar_scratch});
   register_kernel(OP_INDEX, Kernel{index_fwd, index_bwd, nullptr});

--- a/runtime/kernels/eltwise_expr.cpp
+++ b/runtime/kernels/eltwise_expr.cpp
@@ -454,27 +454,26 @@ void dispersion_fwd(KernelCtx& ctx) {
   }
   using Vec = Eigen::Matrix<double, Eigen::Dynamic, 1>;
   const Eigen::Map<const Vec> input(ctx.in[0].data, n);
-  const auto owning_grouping =
-      input.unaryExpr(Eigen::internal::core_cast_op<double, double>());
-  const double mean = owning_grouping.mean();
-  double sum_of_squares = 0.0;
-  for (int64_t i = 0; i < n; ++i) {
-    ctx.scratch[i] = ctx.in[0].data[i] - mean;
-    sum_of_squares += ctx.scratch[i] * ctx.scratch[i];
-  }
-  const double variance = sum_of_squares / static_cast<double>(n - 1);
+  // The AoS rev overload first materializes values into an owning vector,
+  // then lets Eigen reduce both the mean and squared norm. Preserve those
+  // packet groupings rather than folding the squared differences by hand.
+  const Vec values = input;
+  const double mean = values.mean();
+  const Vec diff = values.array() - mean;
+  const double sum_of_squares = diff.squaredNorm();
+  const double size_m1 = static_cast<double>(n - 1);
+  const double variance = sum_of_squares / size_m1;
   ctx.out.data[0] = StdDev ? std::sqrt(variance) : variance;
   if constexpr (StdDev) {
     if (sum_of_squares < 1e-20) {
       const double partial = 1.0 / std::sqrt(static_cast<double>(n));
       for (int64_t i = 0; i < n; ++i) ctx.scratch[i] = partial;
     } else {
-      const double scale = 1.0 / (ctx.out.data[0] * (n - 1));
-      for (int64_t i = 0; i < n; ++i) ctx.scratch[i] *= scale;
+      const double denominator = ctx.out.data[0] * size_m1;
+      for (int64_t i = 0; i < n; ++i) ctx.scratch[i] = diff(i) / denominator;
     }
   } else {
-    const double scale = 2.0 / static_cast<double>(n - 1);
-    for (int64_t i = 0; i < n; ++i) ctx.scratch[i] *= scale;
+    for (int64_t i = 0; i < n; ++i) ctx.scratch[i] = 2.0 * diff(i) / size_m1;
   }
 }
 

--- a/runtime/kernels/eltwise_expr.cpp
+++ b/runtime/kernels/eltwise_expr.cpp
@@ -441,6 +441,55 @@ void mean_bwd(KernelCtx& ctx) {
   for (int64_t i = 0; i < ctx.in[0].len; ++i) ctx.in_adj[0].data[i] += d;
 }
 
+// Sample variance and standard deviation mirror the Stan Math rev overloads:
+// both use an owning-style Eigen reduction, and sd uses the same small-spread
+// derivative fallback instead of dividing by a nearly zero result.
+template <bool StdDev>
+void dispersion_fwd(KernelCtx& ctx) {
+  const int64_t n = ctx.in[0].len;
+  if (n == 1) {
+    ctx.out.data[0] = 0.0;
+    ctx.scratch[0] = 0.0;
+    return;
+  }
+  using Vec = Eigen::Matrix<double, Eigen::Dynamic, 1>;
+  const Eigen::Map<const Vec> input(ctx.in[0].data, n);
+  const auto owning_grouping =
+      input.unaryExpr(Eigen::internal::core_cast_op<double, double>());
+  const double mean = owning_grouping.mean();
+  double sum_of_squares = 0.0;
+  for (int64_t i = 0; i < n; ++i) {
+    ctx.scratch[i] = ctx.in[0].data[i] - mean;
+    sum_of_squares += ctx.scratch[i] * ctx.scratch[i];
+  }
+  const double variance = sum_of_squares / static_cast<double>(n - 1);
+  ctx.out.data[0] = StdDev ? std::sqrt(variance) : variance;
+  if constexpr (StdDev) {
+    if (sum_of_squares < 1e-20) {
+      const double partial = 1.0 / std::sqrt(static_cast<double>(n));
+      for (int64_t i = 0; i < n; ++i) ctx.scratch[i] = partial;
+    } else {
+      const double scale = 1.0 / (ctx.out.data[0] * (n - 1));
+      for (int64_t i = 0; i < n; ++i) ctx.scratch[i] *= scale;
+    }
+  } else {
+    const double scale = 2.0 / static_cast<double>(n - 1);
+    for (int64_t i = 0; i < n; ++i) ctx.scratch[i] *= scale;
+  }
+}
+
+void dispersion_bwd(KernelCtx& ctx) {
+  // Stan Math returns a disconnected constant for a singleton, so even an
+  // infinite upstream adjoint must not form inf * 0 and poison the input.
+  if (!ctx.in_adj[0].data || ctx.in[0].len == 1) return;
+  for (int64_t i = 0; i < ctx.in[0].len; ++i)
+    ctx.in_adj[0].data[i] += ctx.out_adj * ctx.scratch[i];
+}
+
+int64_t dispersion_scratch(const Op& op, const Slot* slots) {
+  return slots[op.in[0]].len;
+}
+
 // rep_vector(x, n): out[i] = x; scalar adjoint accumulates ascending.
 void repv_fwd(KernelCtx& ctx) {
   for (int64_t i = 0; i < ctx.out.len; ++i) ctx.out.data[i] = ctx.in[0].data[0];
@@ -502,6 +551,10 @@ void register_eltwise_kernels() {
   register_kernel(OP_LOG1M, Kernel{log1mv_fwd, log1mv_bwd, nullptr});
   register_kernel(OP_LOGIT, Kernel{logitv_fwd, logitv_bwd, nullptr});
   register_kernel(OP_MEAN, Kernel{mean_fwd, mean_bwd, nullptr});
+  register_kernel(
+      OP_SD, Kernel{dispersion_fwd<true>, dispersion_bwd, dispersion_scratch});
+  register_kernel(OP_VARIANCE, Kernel{dispersion_fwd<false>, dispersion_bwd,
+                                      dispersion_scratch});
   register_kernel(OP_REP_VEC, Kernel{repv_fwd, repv_bwd, nullptr});
 }
 

--- a/runtime/kernels/matrix_fns.cpp
+++ b/runtime/kernels/matrix_fns.cpp
@@ -251,9 +251,15 @@ void add_diag_bwd(KernelCtx& ctx) {
         CMapM(ctx.out_adj_vec.data, rows, cols);
   if (!ctx.in_adj[1].data) return;
   const int64_t n = std::min(rows, cols);
-  for (int64_t i = 0; i < n; ++i)
-    ctx.in_adj[1].data[ctx.variant == 1 ? 0 : i] +=
-        ctx.out_adj_vec.data[i * rows + i];
+  if (ctx.variant == 1) {
+    // Eigen creates the diagonal scalar additions in increasing coefficient
+    // order; Stan's tape replays them in reverse.
+    for (int64_t i = n; i-- > 0;)
+      ctx.in_adj[1].data[0] += ctx.out_adj_vec.data[i * rows + i];
+  } else {
+    for (int64_t i = 0; i < n; ++i)
+      ctx.in_adj[1].data[i] += ctx.out_adj_vec.data[i * rows + i];
+  }
 }
 
 // ---- quad_form_sym(A, B) --------------------------------------------------

--- a/runtime/kernels/matrix_fns.cpp
+++ b/runtime/kernels/matrix_fns.cpp
@@ -145,6 +145,117 @@ void matrix_exp_bwd(KernelCtx& ctx) {
   });
 }
 
+// ---- inverse / inverse_spd / log_determinant -----------------------------
+// All three use Stan Math itself in both sweeps. Inverse and log_determinant
+// have specialized rev overloads whose forward values are their double
+// implementations. inverse_spd is a scalar-templated LDLT, so its active
+// forward must run on Matrix<var> too: Eigen can otherwise choose different
+// packet arithmetic from the CmdStan expression.
+void inverse_fwd(KernelCtx& ctx) {
+  const int64_t n = ctx.idata[0];
+  MapM(ctx.out.data, n, n) = stan::math::inverse(CMapM(ctx.in[0].data, n, n));
+}
+void inverse_bwd(KernelCtx& ctx) {
+  const int64_t n = ctx.idata[0];
+  nary_bwd(ctx, [n](std::vector<VarV>& xs) {
+    Eigen::Map<VarM> a(xs[0].data(), n, n);
+    return stan::math::inverse(a);
+  });
+}
+
+void inverse_spd_fwd(KernelCtx& ctx) {
+  const int64_t n = ctx.idata[0];
+  if (ctx.variant == 0) {
+    MapM(ctx.out.data, n, n) =
+        stan::math::inverse_spd(CMapM(ctx.in[0].data, n, n));
+    return;
+  }
+  stan::math::nested_rev_autodiff nested;
+  VarM a(n, n);
+  for (int64_t i = 0; i < n * n; ++i) a.data()[i] = ctx.in[0].data[i];
+  MapM(ctx.out.data, n, n) = stan::math::value_of(stan::math::inverse_spd(a));
+}
+void inverse_spd_bwd(KernelCtx& ctx) {
+  const int64_t n = ctx.idata[0];
+  nary_bwd(ctx, [n](std::vector<VarV>& xs) {
+    Eigen::Map<VarM> a(xs[0].data(), n, n);
+    return stan::math::inverse_spd(a);
+  });
+}
+
+void log_det_fwd(KernelCtx& ctx) {
+  const int64_t n = ctx.idata[0];
+  ctx.out.data[0] = stan::math::log_determinant(CMapM(ctx.in[0].data, n, n));
+}
+void log_det_bwd(KernelCtx& ctx) {
+  const int64_t n = ctx.idata[0];
+  nary_bwd(ctx, [n](std::vector<VarV>& xs) {
+    Eigen::Map<VarM> a(xs[0].data(), n, n);
+    return stan::math::log_determinant(a);
+  });
+}
+
+// ---- quad_form(A, B) ------------------------------------------------------
+// in = {A (n x n), B (n x m)}; idata = {n, m}. Variant bits match the
+// quad_form_sym convention: bit 0 marks vector B and bit 1 marks an active
+// expression. The active vector overload associates B' * A * B, whereas the
+// primitive overload uses B.dot(A * B).
+void qf_fwd(KernelCtx& ctx) {
+  const int64_t n = ctx.idata[0], m = ctx.idata[1];
+  const CMapM a(ctx.in[0].data, n, n);
+  if (!(ctx.variant & 1u)) {
+    MapM(ctx.out.data, m, m) =
+        stan::math::quad_form(a, CMapM(ctx.in[1].data, n, m));
+    return;
+  }
+  const VecD b = CMapV(ctx.in[1].data, n);
+  if (!(ctx.variant & 2u)) {
+    ctx.out.data[0] = stan::math::quad_form(a, b);
+    return;
+  }
+  stan::math::check_square("quad_form", "A", a);
+  stan::math::check_multiplicable("quad_form", "A", a, "B", b);
+  const MatD c = b.transpose() * a * b;
+  ctx.out.data[0] = c(0, 0);
+}
+void qf_bwd(KernelCtx& ctx) {
+  const int64_t n = ctx.idata[0], m = ctx.idata[1];
+  if (ctx.variant & 1u) {
+    nary_bwd(ctx, [n](std::vector<VarV>& xs) {
+      Eigen::Map<VarM> a(xs[0].data(), n, n);
+      return stan::math::quad_form(a, xs[1]);
+    });
+    return;
+  }
+  nary_bwd(ctx, [n, m](std::vector<VarV>& xs) {
+    Eigen::Map<VarM> a(xs[0].data(), n, n);
+    Eigen::Map<VarM> b(xs[1].data(), n, m);
+    return stan::math::quad_form(a, b);
+  });
+}
+
+// ---- add_diag(A, d) -------------------------------------------------------
+// idata = {rows, cols}; variant 0 is a vector diagonal, 1 is a scalar.
+void add_diag_fwd(KernelCtx& ctx) {
+  const int64_t rows = ctx.idata[0], cols = ctx.idata[1];
+  MapM out(ctx.out.data, rows, cols);
+  out = CMapM(ctx.in[0].data, rows, cols);
+  const int64_t n = std::min(rows, cols);
+  for (int64_t i = 0; i < n; ++i)
+    out(i, i) += ctx.in[1].data[ctx.variant == 1 ? 0 : i];
+}
+void add_diag_bwd(KernelCtx& ctx) {
+  const int64_t rows = ctx.idata[0], cols = ctx.idata[1];
+  if (ctx.in_adj[0].data)
+    MapM(ctx.in_adj[0].data, rows, cols) +=
+        CMapM(ctx.out_adj_vec.data, rows, cols);
+  if (!ctx.in_adj[1].data) return;
+  const int64_t n = std::min(rows, cols);
+  for (int64_t i = 0; i < n; ++i)
+    ctx.in_adj[1].data[ctx.variant == 1 ? 0 : i] +=
+        ctx.out_adj_vec.data[i * rows + i];
+}
+
 // ---- quad_form_sym(A, B) --------------------------------------------------
 // in = {A (n x n), B (n x m)}; idata = {n, m}. The output is the m x m
 // matrix 0.5 * (C + C') with C = B' A B, or the single scalar extracted from
@@ -1305,6 +1416,13 @@ void register_matrix_kernels() {
   register_kernel(OP_CHOLESKY, Kernel{chol_fwd, chol_bwd, nullptr});
   register_kernel(OP_MATRIX_EXP,
                   Kernel{matrix_exp_fwd, matrix_exp_bwd, nullptr});
+  register_kernel(OP_INVERSE, Kernel{inverse_fwd, inverse_bwd, nullptr});
+  register_kernel(OP_INVERSE_SPD,
+                  Kernel{inverse_spd_fwd, inverse_spd_bwd, nullptr});
+  register_kernel(OP_LOG_DETERMINANT,
+                  Kernel{log_det_fwd, log_det_bwd, nullptr});
+  register_kernel(OP_QUAD_FORM, Kernel{qf_fwd, qf_bwd, nullptr});
+  register_kernel(OP_ADD_DIAG, Kernel{add_diag_fwd, add_diag_bwd, nullptr});
   register_kernel(OP_QUAD_FORM_SYM, Kernel{qfs_fwd, qfs_bwd, nullptr});
   register_kernel(OP_MULTI_NORMAL_CHOL_LPDF,
                   Kernel{mnc_fwd, mnc_bwd, mnc_scratch});

--- a/runtime/src/lower.cpp
+++ b/runtime/src/lower.cpp
@@ -4254,7 +4254,7 @@ struct Lowering {
       Val a = lower_expr(e.args[0]);
       return emit_value(OP_LOGIT, {a}, g.slots[a.slot].len, a.si);
     }
-    if ((e.name == "min" || e.name == "max") && in_write_array) {
+    if (e.name == "min" || e.name == "max") {
       // Preserve the construction-time path for well-formed data-only
       // extrema, including the scalar two-argument overload.  Dynamic
       // lowering is deliberately much narrower.
@@ -4267,7 +4267,7 @@ struct Lowering {
       if ((!is_vector(a.si) && !is_row_vector(a.si)) || g.slots[a.slot].len < 0)
         fail("min/max needs one vector or row-vector argument", e.raw);
       Val result = emit_value(OP_EXTREMA_VEC, {a}, 1);
-      result.autodiff = false;
+      if (in_write_array) result.autodiff = false;
       g.ops.back().variant = kind == mir::ExtremaKind::Max ? 1u : 0u;
       return result;
     }
@@ -4275,9 +4275,9 @@ struct Lowering {
       Val a = lower_expr(e.args[0]);
       return emit_value(OP_MEAN, {a}, 1);
     }
-    if (e.name == "prod" && in_write_array) {
+    if (e.name == "prod") {
       // Preserve the pre-existing construction-time behavior for data-only
-      // products.  OP_PROD_VEC is only the dynamic write_array tranche.
+      // products. Dynamic products use OP_PROD_VEC in either graph.
       if (auto v = fold_const(e)) return *v;
       if (e.args.size() != 1 || e.type_ != "UReal" ||
           e.unsized.leaf != mir::UnsizedLeaf::Real || e.unsized.depth != 0)
@@ -4304,6 +4304,14 @@ struct Lowering {
       Val result = emit_value(OP_PROD_VEC, {a}, 1);
       g.ops.back().variant = grouping == mir::ProdGrouping::Scalar ? 1u : 0u;
       return result;
+    }
+    if (e.name == "sd" || e.name == "variance") {
+      if (e.args.size() != 1)
+        fail(e.name + ": reduction needs exactly one argument", e.raw);
+      Val a = lower_expr(e.args[0]);
+      if (g.slots[a.slot].len <= 0)
+        fail(e.name + ": input must have a positive size", e.raw);
+      return emit_value(e.name == "sd" ? OP_SD : OP_VARIANCE, {a}, 1);
     }
     if (e.name == "rep_vector" || e.name == "rep_row_vector") {
       Val a = lower_expr(e.args[0]);

--- a/runtime/src/lower.cpp
+++ b/runtime/src/lower.cpp
@@ -4530,6 +4530,27 @@ struct Lowering {
       return emit_value(OP_MATRIX_EXP, {a}, g.slots[a.slot].len, a.si,
                         {checked_immediate(a.si.rows, "matrix_exp extent")});
     }
+    if ((e.name == "inverse" || e.name == "inverse_spd") &&
+        e.args.size() == 1) {
+      Val a = lower_expr(e.args[0]);
+      if (!is_matrix(a.si)) fail(e.name + ": needs a matrix", e.raw);
+      if (a.si.rows != a.si.cols)
+        fail(e.name + ": needs a square matrix", e.raw);
+      Val v = emit_value(e.name == "inverse" ? OP_INVERSE : OP_INVERSE_SPD, {a},
+                         g.slots[a.slot].len, a.si,
+                         {checked_immediate(a.si.rows, e.name + " extent")});
+      if (e.name == "inverse_spd") g.ops.back().variant = v.autodiff ? 1u : 0u;
+      return v;
+    }
+    if (e.name == "log_determinant" && e.args.size() == 1) {
+      Val a = lower_expr(e.args[0]);
+      if (!is_matrix(a.si)) fail("log_determinant: needs a matrix", e.raw);
+      if (a.si.rows != a.si.cols)
+        fail("log_determinant: needs a square matrix", e.raw);
+      return emit_value(
+          OP_LOG_DETERMINANT, {a}, 1, {},
+          {checked_immediate(a.si.rows, "log_determinant extent")});
+    }
 
     if ((e.name == "eigenvalues_sym" || e.name == "eigenvectors_sym") &&
         e.args.size() == 1) {
@@ -4591,6 +4612,48 @@ struct Lowering {
       // solves make, and for the same reason.
       g.ops.back().variant =
           (uint8_t)((b_matrix ? 0u : 1u) | (v.autodiff ? 2u : 0u));
+      return v;
+    }
+
+    if (e.name == "quad_form" && e.args.size() == 2) {
+      Val a = lower_expr(e.args[0]);
+      Val b = lower_expr(e.args[1]);
+      if (!is_matrix(a.si)) fail("quad_form: needs a matrix", e.raw);
+      if (a.si.rows != a.si.cols)
+        fail("quad_form: needs a square matrix", e.raw);
+      const bool b_matrix = is_matrix(b.si);
+      if (!b_matrix && !is_vector(b.si))
+        fail("quad_form: second argument is not a matrix or vector", e.raw);
+      const int64_t n = a.si.rows;
+      const int64_t rb = b_matrix ? b.si.rows : g.slots[b.slot].len;
+      const int64_t m = b_matrix ? b.si.cols : 1;
+      if (rb != n)
+        fail("quad_form: inner dimension mismatch (" + std::to_string(n) + "x" +
+                 std::to_string(n) + " against " + std::to_string(rb) + ")",
+             e.raw);
+      const SlotInfo si = b_matrix ? matrix_view(m, m) : SlotInfo{};
+      Val v = emit_value(OP_QUAD_FORM, {a, b}, m * m, si,
+                         {checked_immediate(n, "quad_form extent"),
+                          checked_immediate(m, "quad_form extent")});
+      g.ops.back().variant =
+          (uint8_t)((b_matrix ? 0u : 1u) | (v.autodiff ? 2u : 0u));
+      return v;
+    }
+
+    if (e.name == "add_diag" && e.args.size() == 2) {
+      Val a = lower_expr(e.args[0]);
+      Val d = lower_expr(e.args[1]);
+      if (!is_matrix(a.si)) fail("add_diag: needs a matrix", e.raw);
+      const bool scalar = is_scalar(d);
+      const int64_t n = std::min(a.si.rows, a.si.cols);
+      if (!scalar && !is_vector(d.si) && !is_row_vector(d.si))
+        fail("add_diag: diagonal must be a scalar or vector", e.raw);
+      if (!scalar && g.slots[d.slot].len != n)
+        fail("add_diag: diagonal length mismatch", e.raw);
+      Val v = emit_value(OP_ADD_DIAG, {a, d}, g.slots[a.slot].len, a.si,
+                         {checked_immediate(a.si.rows, "add_diag rows"),
+                          checked_immediate(a.si.cols, "add_diag cols")});
+      g.ops.back().variant = scalar ? 1u : 0u;
       return v;
     }
 

--- a/runtime/src/lower.cpp
+++ b/runtime/src/lower.cpp
@@ -4268,7 +4268,9 @@ struct Lowering {
         fail("min/max needs one vector or row-vector argument", e.raw);
       Val result = emit_value(OP_EXTREMA_VEC, {a}, 1);
       if (in_write_array) result.autodiff = false;
-      g.ops.back().variant = kind == mir::ExtremaKind::Max ? 1u : 0u;
+      g.ops.back().variant =
+          static_cast<uint8_t>((kind == mir::ExtremaKind::Max ? 1u : 0u) |
+                               (result.autodiff ? 2u : 0u));
       return result;
     }
     if (e.name == "mean") {
@@ -4302,7 +4304,9 @@ struct Lowering {
       if (grouping == mir::ProdGrouping::Legacy)
         fail("prod expression grouping is not native", e.raw);
       Val result = emit_value(OP_PROD_VEC, {a}, 1);
-      g.ops.back().variant = grouping == mir::ProdGrouping::Scalar ? 1u : 0u;
+      g.ops.back().variant = static_cast<uint8_t>(
+          (grouping == mir::ProdGrouping::Scalar ? 1u : 0u) |
+          (result.autodiff ? 2u : 0u));
       return result;
     }
     if (e.name == "sd" || e.name == "variance") {

--- a/tests/fixtures/a1_reductions.stan
+++ b/tests/fixtures/a1_reductions.stan
@@ -1,0 +1,10 @@
+parameters {
+  vector[3] y;
+  vector[1] singleton;
+}
+model {
+  y ~ std_normal();
+  singleton ~ std_normal();
+  target += prod(y) + min(y) + max(y) + sd(y) + variance(y);
+  target += sd(singleton) + variance(singleton);
+}

--- a/tests/fixtures/a1_reductions.tmir.sexp
+++ b/tests/fixtures/a1_reductions.tmir.sexp
@@ -1,0 +1,540 @@
+((functions_block ()) (input_vars ())
+ (prepare_data
+  (((pattern
+     (NRFunApp (CompilerInternal FnValidateSize)
+      (((pattern (Lit Str singleton))
+        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+       ((pattern (Lit Str 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+       ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+    (meta <opaque>))))
+ (log_prob
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id y)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity)
+             (dims
+              (((pattern (Lit Int 3))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id singleton)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity)
+             (dims
+              (((pattern (Lit Int 1))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib std_normal_lpdf (FnLpdf true) AoS)
+             (((pattern (Var y))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>))
+       ((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib std_normal_lpdf (FnLpdf true) AoS)
+             (((pattern (Var singleton))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>))
+       ((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib Plus__ FnPlain AoS)
+             (((pattern
+                (FunApp (StanLib Plus__ FnPlain AoS)
+                 (((pattern
+                    (FunApp (StanLib Plus__ FnPlain AoS)
+                     (((pattern
+                        (FunApp (StanLib Plus__ FnPlain AoS)
+                         (((pattern
+                            (FunApp (StanLib prod FnPlain AoS)
+                             (((pattern (Var y))
+                               (meta
+                                ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+                           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+                          ((pattern
+                            (FunApp (StanLib min FnPlain AoS)
+                             (((pattern (Var y))
+                               (meta
+                                ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+                           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
+                       (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+                      ((pattern
+                        (FunApp (StanLib max FnPlain AoS)
+                         (((pattern (Var y))
+                           (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+                       (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+                  ((pattern
+                    (FunApp (StanLib sd FnPlain AoS)
+                     (((pattern (Var y))
+                       (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+              ((pattern
+                (FunApp (StanLib variance FnPlain AoS)
+                 (((pattern (Var y))
+                   (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>))
+       ((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib Plus__ FnPlain AoS)
+             (((pattern
+                (FunApp (StanLib sd FnPlain AoS)
+                 (((pattern (Var singleton))
+                   (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+              ((pattern
+                (FunApp (StanLib variance FnPlain AoS)
+                 (((pattern (Var singleton))
+                   (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>)))))
+    (meta <opaque>))))
+ (reverse_mode_log_prob
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id y)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity)
+             (dims
+              (((pattern (Lit Int 3))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id singleton)
+      (decl_type
+       (Sized
+        (SVector SoA
+         ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity)
+             (dims
+              (((pattern (Lit Int 1))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern SoA)))
+           ()))
+         (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib std_normal_lpdf (FnLpdf true) AoS)
+             (((pattern (Var y))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>))
+       ((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib std_normal_lpdf (FnLpdf true) SoA)
+             (((pattern (Var singleton))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>))
+       ((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib Plus__ FnPlain SoA)
+             (((pattern
+                (FunApp (StanLib Plus__ FnPlain SoA)
+                 (((pattern
+                    (FunApp (StanLib Plus__ FnPlain SoA)
+                     (((pattern
+                        (FunApp (StanLib Plus__ FnPlain SoA)
+                         (((pattern
+                            (FunApp (StanLib prod FnPlain AoS)
+                             (((pattern (Var y))
+                               (meta
+                                ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+                           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+                          ((pattern
+                            (FunApp (StanLib min FnPlain AoS)
+                             (((pattern (Var y))
+                               (meta
+                                ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+                           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
+                       (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+                      ((pattern
+                        (FunApp (StanLib max FnPlain AoS)
+                         (((pattern (Var y))
+                           (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+                       (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+                  ((pattern
+                    (FunApp (StanLib sd FnPlain AoS)
+                     (((pattern (Var y))
+                       (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+              ((pattern
+                (FunApp (StanLib variance FnPlain AoS)
+                 (((pattern (Var y))
+                   (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>))
+       ((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib Plus__ FnPlain SoA)
+             (((pattern
+                (FunApp (StanLib sd FnPlain SoA)
+                 (((pattern (Var singleton))
+                   (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+              ((pattern
+                (FunApp (StanLib variance FnPlain SoA)
+                 (((pattern (Var singleton))
+                   (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>)))))
+    (meta <opaque>))))
+ (generate_quantities
+  (((pattern
+     (Decl (decl_adtype DataOnly) (decl_id y)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity)
+             (dims
+              (((pattern (Lit Int 3))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id singleton)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity)
+             (dims
+              (((pattern (Lit Int 1))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt ())
+        (var
+         ((pattern (Var y)) (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt ())
+        (var
+         ((pattern (Var singleton))
+          (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (IfElse
+      ((pattern
+        (FunApp (StanLib PNot__ FnPlain AoS)
+         (((pattern
+            (EOr
+             ((pattern (Var emit_transformed_parameters__))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+             ((pattern (Var emit_generated_quantities__))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+      ((pattern (Block (((pattern (Return ())) (meta <opaque>))))) (meta <opaque>)) ()))
+    (meta <opaque>))
+   ((pattern
+     (IfElse
+      ((pattern
+        (FunApp (StanLib PNot__ FnPlain AoS)
+         (((pattern (Var emit_generated_quantities__))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+      ((pattern (Block (((pattern (Return ())) (meta <opaque>))))) (meta <opaque>)) ()))
+    (meta <opaque>))))
+ (transform_inits
+  (((pattern
+     (Decl (decl_adtype DataOnly) (decl_id pos__) (decl_type (Sized SInt))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id y)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id y_flat__)
+          (decl_type (Unsized (UArray UReal))) (initialize Uninit)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable y_flat__) ()) (UArray UReal)
+          ((pattern
+            (FunApp (CompilerInternal FnReadData)
+             (((pattern (Lit Str y))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable pos__) ()) UInt
+          ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar sym1__)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Lit Int 3))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (Assignment
+                  ((LVariable y)
+                   ((Single
+                     ((pattern (Var sym1__))
+                      (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                  UVector
+                  ((pattern
+                    (Indexed
+                     ((pattern (Var y_flat__))
+                      (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))
+                     ((Single
+                       ((pattern (Var pos__))
+                        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+                (meta <opaque>))
+               ((pattern
+                 (Assignment ((LVariable pos__) ()) UInt
+                  ((pattern
+                    (FunApp (StanLib Plus__ FnPlain AoS)
+                     (((pattern (Var pos__))
+                       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                      ((pattern (Lit Int 1))
+                       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var y)) (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id singleton)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id singleton_flat__)
+          (decl_type (Unsized (UArray UReal))) (initialize Uninit)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable singleton_flat__) ()) (UArray UReal)
+          ((pattern
+            (FunApp (CompilerInternal FnReadData)
+             (((pattern (Lit Str singleton))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable pos__) ()) UInt
+          ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar sym1__)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (Assignment
+                  ((LVariable singleton)
+                   ((Single
+                     ((pattern (Var sym1__))
+                      (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                  UVector
+                  ((pattern
+                    (Indexed
+                     ((pattern (Var singleton_flat__))
+                      (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))
+                     ((Single
+                       ((pattern (Var pos__))
+                        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+                (meta <opaque>))
+               ((pattern
+                 (Assignment ((LVariable pos__) ()) UInt
+                  ((pattern
+                    (FunApp (StanLib Plus__ FnPlain AoS)
+                     (((pattern (Var pos__))
+                       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                      ((pattern (Lit Int 1))
+                       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var singleton))
+          (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))))
+ (unconstrain_array
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id y)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable y) ()) UVector
+      ((pattern
+        (FunApp (CompilerInternal FnReadDeserializer)
+         (((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var y)) (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id singleton)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable singleton) ()) UVector
+      ((pattern
+        (FunApp (CompilerInternal FnReadDeserializer)
+         (((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var singleton))
+          (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))))
+ (output_vars
+  ((y <opaque>
+    ((out_unconstrained_st
+      (SVector AoS
+       ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+     (out_constrained_st
+      (SVector AoS
+       ((pattern (Lit Int 3)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+     (out_block Parameters) (out_trans Identity)))
+   (singleton <opaque>
+    ((out_unconstrained_st
+      (SVector AoS
+       ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+     (out_constrained_st
+      (SVector AoS
+       ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+     (out_block Parameters) (out_trans Identity)))))
+ (prog_name a1_reductions_model) (prog_path tests/fixtures/a1_reductions.stan))

--- a/tests/fixtures/a2_matrix_functions.stan
+++ b/tests/fixtures/a2_matrix_functions.stan
@@ -1,0 +1,16 @@
+parameters {
+  vector[4] y;
+  vector[2] diagonal;
+}
+model {
+  matrix[2, 2] A = [[exp(y[1]), y[3]], [y[4], exp(y[2])]];
+  matrix[2, 2] S = diag_matrix(exp(y[1 : 2]));
+
+  y ~ std_normal();
+  diagonal ~ std_normal();
+  target += sum(inverse(A));
+  target += sum(inverse_spd(S));
+  target += log_determinant(A);
+  target += quad_form(A, [1.0, 2.0]');
+  target += sum(add_diag(A, diagonal));
+}

--- a/tests/fixtures/a2_matrix_functions.tmir.sexp
+++ b/tests/fixtures/a2_matrix_functions.tmir.sexp
@@ -1,0 +1,721 @@
+((functions_block ()) (input_vars ()) (prepare_data ())
+ (log_prob
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id y)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Lit Int 4)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity)
+             (dims
+              (((pattern (Lit Int 4))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id diagonal)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity)
+             (dims
+              (((pattern (Lit Int 2))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id A)
+          (decl_type
+           (Sized
+            (SMatrix AoS
+             ((pattern (Lit Int 2))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+             ((pattern (Lit Int 2))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+          (initialize Uninit)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable A) ()) UMatrix
+          ((pattern
+            (FunApp (CompilerInternal FnMakeRowVec)
+             (((pattern
+                (FunApp (CompilerInternal FnMakeRowVec)
+                 (((pattern
+                    (FunApp (StanLib exp FnPlain AoS)
+                     (((pattern
+                        (Indexed
+                         ((pattern (Var y))
+                          (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))
+                         ((Single
+                           ((pattern (Lit Int 1))
+                            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                       (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+                  ((pattern
+                    (Indexed
+                     ((pattern (Var y))
+                      (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))
+                     ((Single
+                       ((pattern (Lit Int 3))
+                        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
+               (meta ((type_ URowVector) (loc <opaque>) (adlevel AutoDiffable))))
+              ((pattern
+                (FunApp (CompilerInternal FnMakeRowVec)
+                 (((pattern
+                    (Indexed
+                     ((pattern (Var y))
+                      (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))
+                     ((Single
+                       ((pattern (Lit Int 4))
+                        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+                  ((pattern
+                    (FunApp (StanLib exp FnPlain AoS)
+                     (((pattern
+                        (Indexed
+                         ((pattern (Var y))
+                          (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))
+                         ((Single
+                           ((pattern (Lit Int 2))
+                            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                       (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
+               (meta ((type_ URowVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+           (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>))
+       ((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id S)
+          (decl_type
+           (Sized
+            (SMatrix AoS
+             ((pattern (Lit Int 2))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+             ((pattern (Lit Int 2))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+          (initialize Uninit)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable S) ()) UMatrix
+          ((pattern
+            (FunApp (StanLib diag_matrix FnPlain AoS)
+             (((pattern
+                (FunApp (StanLib exp FnPlain AoS)
+                 (((pattern
+                    (Indexed
+                     ((pattern (Var y))
+                      (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))
+                     ((Between
+                       ((pattern (Lit Int 1))
+                        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                       ((pattern (Lit Int 2))
+                        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                   (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+           (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>))
+       ((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib std_normal_lpdf (FnLpdf true) AoS)
+             (((pattern (Var y))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>))
+       ((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib std_normal_lpdf (FnLpdf true) AoS)
+             (((pattern (Var diagonal))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>))
+       ((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib sum FnPlain AoS)
+             (((pattern
+                (FunApp (StanLib inverse FnPlain AoS)
+                 (((pattern (Var A))
+                   (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable)))))))
+               (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>))
+       ((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib sum FnPlain AoS)
+             (((pattern
+                (FunApp (StanLib inverse_spd FnPlain AoS)
+                 (((pattern (Var S))
+                   (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable)))))))
+               (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>))
+       ((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib log_determinant FnPlain AoS)
+             (((pattern (Var A))
+               (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>))
+       ((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib quad_form FnPlain AoS)
+             (((pattern (Var A))
+               (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))
+              ((pattern
+                (FunApp (StanLib Transpose__ FnPlain AoS)
+                 (((pattern
+                    (FunApp (CompilerInternal FnMakeRowVec)
+                     (((pattern (Lit Real 1.0))
+                       (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+                      ((pattern (Lit Real 2.0))
+                       (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+                   (meta ((type_ URowVector) (loc <opaque>) (adlevel DataOnly)))))))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>))
+       ((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib sum FnPlain AoS)
+             (((pattern
+                (FunApp (StanLib add_diag FnPlain AoS)
+                 (((pattern (Var A))
+                   (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))
+                  ((pattern (Var diagonal))
+                   (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+               (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>)))))
+    (meta <opaque>))))
+ (reverse_mode_log_prob
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id y)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Lit Int 4)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity)
+             (dims
+              (((pattern (Lit Int 4))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id diagonal)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity)
+             (dims
+              (((pattern (Lit Int 2))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id A)
+          (decl_type
+           (Sized
+            (SMatrix AoS
+             ((pattern (Lit Int 2))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+             ((pattern (Lit Int 2))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+          (initialize Uninit)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable A) ()) UMatrix
+          ((pattern
+            (FunApp (CompilerInternal FnMakeRowVec)
+             (((pattern
+                (FunApp (CompilerInternal FnMakeRowVec)
+                 (((pattern
+                    (FunApp (StanLib exp FnPlain AoS)
+                     (((pattern
+                        (Indexed
+                         ((pattern (Var y))
+                          (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))
+                         ((Single
+                           ((pattern (Lit Int 1))
+                            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                       (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+                  ((pattern
+                    (Indexed
+                     ((pattern (Var y))
+                      (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))
+                     ((Single
+                       ((pattern (Lit Int 3))
+                        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
+               (meta ((type_ URowVector) (loc <opaque>) (adlevel AutoDiffable))))
+              ((pattern
+                (FunApp (CompilerInternal FnMakeRowVec)
+                 (((pattern
+                    (Indexed
+                     ((pattern (Var y))
+                      (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))
+                     ((Single
+                       ((pattern (Lit Int 4))
+                        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+                  ((pattern
+                    (FunApp (StanLib exp FnPlain AoS)
+                     (((pattern
+                        (Indexed
+                         ((pattern (Var y))
+                          (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))
+                         ((Single
+                           ((pattern (Lit Int 2))
+                            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                       (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
+               (meta ((type_ URowVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+           (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>))
+       ((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id S)
+          (decl_type
+           (Sized
+            (SMatrix AoS
+             ((pattern (Lit Int 2))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+             ((pattern (Lit Int 2))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+          (initialize Uninit)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable S) ()) UMatrix
+          ((pattern
+            (FunApp (StanLib diag_matrix FnPlain AoS)
+             (((pattern
+                (FunApp (StanLib exp FnPlain AoS)
+                 (((pattern
+                    (Indexed
+                     ((pattern (Var y))
+                      (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))
+                     ((Between
+                       ((pattern (Lit Int 1))
+                        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                       ((pattern (Lit Int 2))
+                        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                   (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+           (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>))
+       ((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib std_normal_lpdf (FnLpdf true) AoS)
+             (((pattern (Var y))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>))
+       ((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib std_normal_lpdf (FnLpdf true) AoS)
+             (((pattern (Var diagonal))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>))
+       ((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib sum FnPlain AoS)
+             (((pattern
+                (FunApp (StanLib inverse FnPlain AoS)
+                 (((pattern (Var A))
+                   (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable)))))))
+               (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>))
+       ((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib sum FnPlain AoS)
+             (((pattern
+                (FunApp (StanLib inverse_spd FnPlain AoS)
+                 (((pattern (Var S))
+                   (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable)))))))
+               (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>))
+       ((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib log_determinant FnPlain AoS)
+             (((pattern (Var A))
+               (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>))
+       ((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib quad_form FnPlain AoS)
+             (((pattern (Var A))
+               (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))
+              ((pattern
+                (FunApp (StanLib Transpose__ FnPlain AoS)
+                 (((pattern
+                    (FunApp (CompilerInternal FnMakeRowVec)
+                     (((pattern (Lit Real 1.0))
+                       (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+                      ((pattern (Lit Real 2.0))
+                       (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+                   (meta ((type_ URowVector) (loc <opaque>) (adlevel DataOnly)))))))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>))
+       ((pattern
+         (TargetPE
+          ((pattern
+            (FunApp (StanLib sum FnPlain AoS)
+             (((pattern
+                (FunApp (StanLib add_diag FnPlain AoS)
+                 (((pattern (Var A))
+                   (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))
+                  ((pattern (Var diagonal))
+                   (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+               (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable)))))))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+        (meta <opaque>)))))
+    (meta <opaque>))))
+ (generate_quantities
+  (((pattern
+     (Decl (decl_adtype DataOnly) (decl_id y)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Lit Int 4)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity)
+             (dims
+              (((pattern (Lit Int 4))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id diagonal)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize
+       (Assign
+        ((pattern
+          (FunApp
+           (CompilerInternal
+            (FnReadParam (constrain Identity)
+             (dims
+              (((pattern (Lit Int 2))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+             (mem_pattern AoS)))
+           ()))
+         (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt ())
+        (var
+         ((pattern (Var y)) (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt ())
+        (var
+         ((pattern (Var diagonal))
+          (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (IfElse
+      ((pattern
+        (FunApp (StanLib PNot__ FnPlain AoS)
+         (((pattern
+            (EOr
+             ((pattern (Var emit_transformed_parameters__))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+             ((pattern (Var emit_generated_quantities__))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+      ((pattern (Block (((pattern (Return ())) (meta <opaque>))))) (meta <opaque>)) ()))
+    (meta <opaque>))
+   ((pattern
+     (IfElse
+      ((pattern
+        (FunApp (StanLib PNot__ FnPlain AoS)
+         (((pattern (Var emit_generated_quantities__))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+      ((pattern (Block (((pattern (Return ())) (meta <opaque>))))) (meta <opaque>)) ()))
+    (meta <opaque>))))
+ (transform_inits
+  (((pattern
+     (Decl (decl_adtype DataOnly) (decl_id pos__) (decl_type (Sized SInt))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id y)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Lit Int 4)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id y_flat__)
+          (decl_type (Unsized (UArray UReal))) (initialize Uninit)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable y_flat__) ()) (UArray UReal)
+          ((pattern
+            (FunApp (CompilerInternal FnReadData)
+             (((pattern (Lit Str y))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable pos__) ()) UInt
+          ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar sym1__)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Lit Int 4))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (Assignment
+                  ((LVariable y)
+                   ((Single
+                     ((pattern (Var sym1__))
+                      (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                  UVector
+                  ((pattern
+                    (Indexed
+                     ((pattern (Var y_flat__))
+                      (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))
+                     ((Single
+                       ((pattern (Var pos__))
+                        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+                (meta <opaque>))
+               ((pattern
+                 (Assignment ((LVariable pos__) ()) UInt
+                  ((pattern
+                    (FunApp (StanLib Plus__ FnPlain AoS)
+                     (((pattern (Var pos__))
+                       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                      ((pattern (Lit Int 1))
+                       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var y)) (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id diagonal)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Default)))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id diagonal_flat__)
+          (decl_type (Unsized (UArray UReal))) (initialize Uninit)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable diagonal_flat__) ()) (UArray UReal)
+          ((pattern
+            (FunApp (CompilerInternal FnReadData)
+             (((pattern (Lit Str diagonal))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (Assignment ((LVariable pos__) ()) UInt
+          ((pattern (Lit Int 1)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar sym1__)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Lit Int 2))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (Assignment
+                  ((LVariable diagonal)
+                   ((Single
+                     ((pattern (Var sym1__))
+                      (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                  UVector
+                  ((pattern
+                    (Indexed
+                     ((pattern (Var diagonal_flat__))
+                      (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))
+                     ((Single
+                       ((pattern (Var pos__))
+                        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+                (meta <opaque>))
+               ((pattern
+                 (Assignment ((LVariable pos__) ()) UInt
+                  ((pattern
+                    (FunApp (StanLib Plus__ FnPlain AoS)
+                     (((pattern (Var pos__))
+                       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                      ((pattern (Lit Int 1))
+                       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var diagonal))
+          (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))))
+ (unconstrain_array
+  (((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id y)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Lit Int 4)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable y) ()) UVector
+      ((pattern
+        (FunApp (CompilerInternal FnReadDeserializer)
+         (((pattern (Lit Int 4)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var y)) (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id diagonal)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize Uninit)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment ((LVariable diagonal) ()) UVector
+      ((pattern
+        (FunApp (CompilerInternal FnReadDeserializer)
+         (((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var diagonal))
+          (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))))
+ (output_vars
+  ((y <opaque>
+    ((out_unconstrained_st
+      (SVector AoS
+       ((pattern (Lit Int 4)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+     (out_constrained_st
+      (SVector AoS
+       ((pattern (Lit Int 4)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+     (out_block Parameters) (out_trans Identity)))
+   (diagonal <opaque>
+    ((out_unconstrained_st
+      (SVector AoS
+       ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+     (out_constrained_st
+      (SVector AoS
+       ((pattern (Lit Int 2)) (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+     (out_block Parameters) (out_trans Identity)))))
+ (prog_name a2_matrix_functions_model)
+ (prog_path tests/fixtures/a2_matrix_functions.stan))

--- a/tests/test_eltwise.cpp
+++ b/tests/test_eltwise.cpp
@@ -3,7 +3,9 @@
 #include "graph_helpers.hpp"
 
 #include <stan/math.hpp>
+#include <algorithm>
 #include <cmath>
+#include <cstdint>
 #include <cstdio>
 #include <string>
 #include <vector>
@@ -201,6 +203,75 @@ int main() {
   // DOT
   check_case("dot", OP_DOT, 1, {A, B},
              [](auto& v) { return stan::math::dot_product(v[0], v[1]); });
+
+  // Reductions must preserve Stan Math's scalar/owning-Eigen grouping in the
+  // value sweep and its exact reverse expression. Short examples do not cross
+  // enough coefficients to distinguish prefix/suffix folds.
+  std::vector<double> product_values(62);
+  uint64_t reduction_state = 0x5052323535524544ULL;
+  for (size_t i = 0; i < product_values.size(); ++i) {
+    reduction_state =
+        reduction_state * 6364136223846793005ULL + 1442695040888963407ULL;
+    const double magnitude = 0.5 + static_cast<double>(reduction_state >> 11) /
+                                       static_cast<double>(uint64_t{1} << 53);
+    product_values[i] = i % 3 == 0 ? -magnitude : magnitude;
+  }
+  {
+    constexpr double seed = 0x1.4bc8f7f1101b4p-1;
+    Graph graph;
+    const int input = graph.add_slot((int64_t)product_values.size(), true);
+    const int product = graph.add_slot(1, false);
+    const int weight = graph.add_slot(1, false);
+    const int lp = graph.add_slot(1, false);
+    graph.add_op(OP_PROD_VEC, {input}, product);
+    graph.ops.back().variant = 2;
+    graph.add_op(OP_MUL, {product, weight}, lp);
+    graph.result_slot = lp;
+    Executor ex(std::move(graph));
+    std::copy(product_values.begin(), product_values.end(), ex.params_data());
+    ex.value_ptr(weight)[0] = seed;
+    std::vector<double> got(product_values.size());
+    const double got_lp = ex.gradient(got.data());
+
+    VecV reference((Eigen::Index)product_values.size());
+    for (size_t i = 0; i < product_values.size(); ++i)
+      reference((Eigen::Index)i) = product_values[i];
+    var want_lp = seed * stan::math::prod(reference);
+    want_lp.grad();
+    expect_eq("prod active reverse lp", got_lp, want_lp.val());
+    for (size_t i = 0; i < got.size(); ++i)
+      expect_eq("prod active reverse g" + std::to_string(i), got[i],
+                reference((Eigen::Index)i).adj());
+    stan::math::recover_memory();
+  }
+
+  const std::vector<double> dispersion_values = {
+      -0x1.eed17f1e56cfap-1, 0x1.d7236aa8481ap-3,   -0x1.5739d23914f38p-3,
+      0x1.f9947b4a8e84cp+0,  -0x1.939f5dd3c17fcp-2, 0x1.ac1c7d9bca5ap-3,
+      -0x1.bdaa1148dc42p-5,  -0x1.878a0e048d69ap-1, 0x1.cde266be7caf8p+0,
+      0x1.a516e5df7c134p-1,  0x1.fda3afe2a467p-3,   0x1.95f599d080ap-2,
+      -0x1.8c365ff5309e8p-2, -0x1.6cc56196b8368p-1};
+  check_case("sd packet reduction", OP_SD, 1, {dispersion_values},
+             [](auto& v) { return stan::math::sd(v[0]); });
+
+  const std::vector<double> variance_values = {
+      -0x1.a1113046c0eb4p+0, 0x1.2b06fc967f838p-1,  -0x1.f1da834a6269p-4,
+      0x1.1aff6118016c4p-1,  -0x1.0b5282797d2ep-1,  -0x1.4a8a06f6f264ap+0,
+      -0x1.4c8ac5f162b16p-1, 0x1.de0b55a45268p-3,   -0x1.cf3f6d897a2dcp-2,
+      -0x1.5e092e1d37172p+0, -0x1.481cade96bbd8p-1, -0x1.16dd852648f3cp-2,
+      -0x1.183b2f928f00bp+0, 0x1.74ea191bb084ap+0,  -0x1.524fc26f53946p+0,
+      0x1.2f60c1bb19678p-1,  -0x1.ea2fe6af70cbcp-1, 0x1.2ebd281cf3754p-1,
+      -0x1.b24b43e8d3206p-1, -0x1.444a2d87e964cp+0, 0x1.cda5412561c6cp-1,
+      0x1.367d5c0e9ebfap+0,  -0x1.07431f46256f8p+0, -0x1.99787f870601cp-1,
+      0x1.f2244bd31308p-1,   0x1.4b5c2aebb7fap+0,   0x1.1862475d31d1p-3,
+      -0x1.eb96cd19916d8p-3, 0x1.057f0309d7d18p-2,  -0x1.3c78760cc3ecp-4,
+      -0x1.baf4364aba14dp+0, -0x1.210b1a49ba46p-1,  -0x1.9ad3b4faaf06cp-1,
+      0x1.e59fc5c9cabb4p+0,  0x1.94c0e00da58fp-2,   -0x1.1c02689124baap-1,
+      -0x1.abb727a329779p+0, 0x1.da16b74b11b6p-3,   -0x1.2cee8b6a8b83p-4,
+      -0x1.6c530bf63304ep-1, 0x1.f20db2973a4fp-3,   0x1.6e9b7964687ecp-1,
+      -0x1.5464a2a1801ap-4,  0x1.5ee91b82af3a8p-1,  -0x1.1875cb52a1ab3p+0};
+  check_case("variance packet reduction", OP_VARIANCE, 1, {variance_values},
+             [](auto& v) { return stan::math::variance(v[0]); });
 
   if (failures == 0) std::printf("test_eltwise OK\n");
   return failures == 0 ? 0 : 1;

--- a/tests/test_lower.cpp
+++ b/tests/test_lower.cpp
@@ -268,6 +268,9 @@ int main() {
         compile_model(slurp("tests/fixtures/a1_reductions.tmir.sexp"), d);
     check(count_opcode(reductions, OP_PROD_VEC) == 1,
           "A1 product opcode census");
+    for (const Op& op : reductions.graph.ops)
+      if (op.opcode == OP_PROD_VEC)
+        check(op.variant == 2, "A1 active product scalar grouping");
     check(count_opcode(reductions, OP_EXTREMA_VEC) == 2,
           "A1 extrema opcode census");
     check(count_opcode(reductions, OP_SD) == 2, "A1 sd opcode census");
@@ -355,6 +358,53 @@ int main() {
       expect_ulp("A2 matrix functions d" + std::to_string(i), gradient[4 + i],
                  diagonal(i).adj());
     stan::math::recover_memory();
+  }
+
+  // A scalar add_diag argument receives one contribution per diagonal entry.
+  // The additions are created from the first coefficient to the last, so the
+  // reverse tape accumulates a deliberately cancellation-sensitive seed in
+  // the opposite order.
+  {
+    const Kernel* add_diag = find_kernel(OP_ADD_DIAG);
+    check(add_diag && add_diag->forward && add_diag->backward,
+          "add_diag scalar kernel registration");
+    if (add_diag && add_diag->forward && add_diag->backward) {
+      constexpr int n = 3;
+      double a[n * n] = {};
+      double diagonal = 0.0;
+      double out[n * n] = {};
+      double out_adj[n * n] = {};
+      out_adj[0] = 1e16;
+      out_adj[4] = -1e16;
+      out_adj[8] = 1.0;
+      double diagonal_adj = 0.0;
+      const int dims[] = {n, n};
+      KernelCtx ctx;
+      ctx.in[0] = Desc{a, n * n};
+      ctx.in[1] = Desc{&diagonal, 1};
+      ctx.n_in = 2;
+      ctx.out = Desc{out, n * n};
+      ctx.variant = 1;
+      ctx.idata = dims;
+      ctx.n_idata = 2;
+      add_diag->forward(ctx);
+      ctx.in_adj[0] = Desc{nullptr, n * n};
+      ctx.in_adj[1] = Desc{&diagonal_adj, 1};
+      ctx.out_adj_vec = Desc{out_adj, n * n};
+      add_diag->backward(ctx);
+
+      Eigen::MatrixXd matrix = Eigen::MatrixXd::Zero(n, n);
+      Eigen::MatrixXd seed = Eigen::MatrixXd::Zero(n, n);
+      seed(0, 0) = 1e16;
+      seed(1, 1) = -1e16;
+      seed(2, 2) = 1.0;
+      stan::math::var d_ref = 0.0;
+      stan::math::var reference = stan::math::sum(
+          stan::math::elt_multiply(stan::math::add_diag(matrix, d_ref), seed));
+      reference.grad();
+      expect_eq("add_diag scalar reverse order", diagonal_adj, d_ref.adj());
+      stan::math::recover_memory();
+    }
   }
 
   // Direct input preload must be an exact replacement for stanc's generated

--- a/tests/test_lower.cpp
+++ b/tests/test_lower.cpp
@@ -300,6 +300,63 @@ int main() {
     stan::math::recover_memory();
   }
 
+  // Section A2's matrix functions share shapes but not implementations:
+  // inverse_spd uses an LDLT, log_determinant a pivoted QR, and quad_form is
+  // deliberately not the symmetrising quad_form_sym operation. Pin all five
+  // as native opcodes and compare their composed reverse pass to Stan Math.
+  {
+    DataMap d;
+    CompiledModel matrix_functions =
+        compile_model(slurp("tests/fixtures/a2_matrix_functions.tmir.sexp"), d);
+    check(count_opcode(matrix_functions, OP_INVERSE) == 1,
+          "A2 inverse opcode census");
+    check(count_opcode(matrix_functions, OP_INVERSE_SPD) == 1,
+          "A2 inverse_spd opcode census");
+    check(count_opcode(matrix_functions, OP_LOG_DETERMINANT) == 1,
+          "A2 log determinant opcode census");
+    check(count_opcode(matrix_functions, OP_QUAD_FORM) == 1,
+          "A2 quad form opcode census");
+    check(count_opcode(matrix_functions, OP_ADD_DIAG) == 1,
+          "A2 add diag opcode census");
+
+    Executor matrix_ex(std::move(matrix_functions.graph));
+    matrix_functions.bind(matrix_ex);
+    const double q[] = {0.2, -0.3, 0.1, -0.2, 0.4, -0.1};
+    std::copy(q, q + 6, matrix_ex.params_data());
+    double gradient[6];
+    const double lp = matrix_ex.gradient(gradient);
+
+    using stan::math::var;
+    Eigen::Matrix<var, -1, 1> y(4), diagonal(2);
+    for (int i = 0; i < 4; ++i) y(i) = q[i];
+    for (int i = 0; i < 2; ++i) diagonal(i) = q[4 + i];
+    Eigen::Matrix<var, -1, -1> A(2, 2), S(2, 2);
+    A << stan::math::exp(y(0)), y(2), y(3), stan::math::exp(y(1));
+    S.setZero();
+    S(0, 0) = stan::math::exp(y(0));
+    S(1, 1) = stan::math::exp(y(1));
+    Eigen::VectorXd b(2);
+    b << 1.0, 2.0;
+
+    var reference = stan::math::std_normal_lpdf<true>(y);
+    reference += stan::math::std_normal_lpdf<true>(diagonal);
+    reference += stan::math::sum(stan::math::inverse(A));
+    reference += stan::math::sum(stan::math::inverse_spd(S));
+    reference += stan::math::log_determinant(A);
+    reference += stan::math::quad_form(A, b);
+    reference += stan::math::sum(stan::math::add_diag(A, diagonal));
+    reference.grad();
+
+    expect_ulp("A2 matrix functions lp", lp, reference.val());
+    for (int i = 0; i < 4; ++i)
+      expect_ulp("A2 matrix functions y" + std::to_string(i), gradient[i],
+                 y(i).adj());
+    for (int i = 0; i < 2; ++i)
+      expect_ulp("A2 matrix functions d" + std::to_string(i), gradient[4 + i],
+                 diagonal(i).adj());
+    stan::math::recover_memory();
+  }
+
   // Direct input preload must be an exact replacement for stanc's generated
   // FnReadData reconstruction.  This one fixture covers a vector, a matrix,
   // and two array-of-vector inputs; y is deliberately written with integer

--- a/tests/test_lower.cpp
+++ b/tests/test_lower.cpp
@@ -258,6 +258,48 @@ int main() {
   stanli::set_packet_math(false);
   using namespace stanli;
 
+  // Section A1's five reductions must lower in the autodiff model graph, not
+  // merely in the generated-quantities graph. A zero product and tied maximum
+  // pin the non-generic reverse cases; singleton dispersion must remain a
+  // disconnected constant just as it is in Stan Math.
+  {
+    DataMap d;
+    CompiledModel reductions =
+        compile_model(slurp("tests/fixtures/a1_reductions.tmir.sexp"), d);
+    check(count_opcode(reductions, OP_PROD_VEC) == 1,
+          "A1 product opcode census");
+    check(count_opcode(reductions, OP_EXTREMA_VEC) == 2,
+          "A1 extrema opcode census");
+    check(count_opcode(reductions, OP_SD) == 2, "A1 sd opcode census");
+    check(count_opcode(reductions, OP_VARIANCE) == 2,
+          "A1 variance opcode census");
+
+    Executor reduction_ex(std::move(reductions.graph));
+    reductions.bind(reduction_ex);
+    const double q[] = {0.25, 0.25, 0.0, 0.4};
+    std::copy(q, q + 4, reduction_ex.params_data());
+    double gradient[4];
+    const double lp = reduction_ex.gradient(gradient);
+
+    using stan::math::var;
+    Eigen::Matrix<var, -1, 1> y(3), singleton(1);
+    for (int i = 0; i < 3; ++i) y(i) = q[i];
+    singleton(0) = q[3];
+    var reference = stan::math::std_normal_lpdf<true>(y);
+    reference += stan::math::std_normal_lpdf<true>(singleton);
+    reference += stan::math::prod(y) + stan::math::min(y) + stan::math::max(y) +
+                 stan::math::sd(y) + stan::math::variance(y);
+    reference += stan::math::sd(singleton) + stan::math::variance(singleton);
+    reference.grad();
+
+    expect_ulp("A1 reductions lp", lp, reference.val());
+    for (int i = 0; i < 3; ++i)
+      expect_ulp("A1 reductions y" + std::to_string(i), gradient[i],
+                 y(i).adj());
+    expect_eq("A1 singleton gradient", gradient[3], singleton(0).adj());
+    stan::math::recover_memory();
+  }
+
   // Direct input preload must be an exact replacement for stanc's generated
   // FnReadData reconstruction.  This one fixture covers a vector, a matrix,
   // and two array-of-vector inputs; y is deliberately written with integer

--- a/tests/test_pass_safety.cpp
+++ b/tests/test_pass_safety.cpp
@@ -416,7 +416,7 @@ static void test_rng_is_an_effect_barrier() {
          got_rng.gen()() == want_rng.gen()());
 }
 
-static void test_product_is_forward_only_pass_barrier() {
+static void test_product_pass_barrier() {
   Graph g;
   Fills fills;
   const int input = g.add_slot(5, true);
@@ -446,9 +446,10 @@ static void test_product_is_forward_only_pass_barrier() {
     stores += op.opcode == OP_SET_INDEX_INPLACE;
     island_ops += op.opcode == OP_ISLAND;
   }
-  expect("product has no backward kernel",
+  expect("product has a backward kernel",
          find_kernel(OP_PROD_VEC) != nullptr &&
-             kernel(OP_PROD_VEC).backward == nullptr);
+             kernel(OP_PROD_VEC).backward != nullptr &&
+             kernel(OP_PROD_VEC).scratch_size != nullptr);
   expect("product is absent from value-free backward traits",
          !backward_ignores_values(OP_PROD_VEC));
   expect("product survives constfold with parameter input",
@@ -472,7 +473,7 @@ static void test_product_is_forward_only_pass_barrier() {
   expect("standalone products keep pinned Stan Math grouping", exact);
 }
 
-static void test_extrema_is_forward_only_pass_barrier() {
+static void test_extrema_pass_barrier() {
   Graph g;
   Fills fills;
   const int input = g.add_slot(7, true);
@@ -505,9 +506,9 @@ static void test_extrema_is_forward_only_pass_barrier() {
     island_ops += op.opcode == OP_ISLAND;
   }
   const Kernel* extrema = find_kernel(OP_EXTREMA_VEC);
-  expect("extrema has a forward-only no-scratch kernel",
-         extrema != nullptr && extrema->backward == nullptr &&
-             extrema->scratch_size == nullptr);
+  expect("extrema has a backward kernel", extrema != nullptr &&
+                                              extrema->backward != nullptr &&
+                                              extrema->scratch_size != nullptr);
   expect("extrema is absent from value-free backward traits",
          !backward_ignores_values(OP_EXTREMA_VEC));
   expect("extrema survives constfold with parameter input",
@@ -573,8 +574,8 @@ int main() {
   test_setenv("STANLI_ISLAND_ALWAYS", "1", 1);  // see the fuzz loop
   test_whitelist_backwards_ignore_values();
   test_rng_is_an_effect_barrier();
-  test_product_is_forward_only_pass_barrier();
-  test_extrema_is_forward_only_pass_barrier();
+  test_product_pass_barrier();
+  test_extrema_pass_barrier();
   test_random_graphs_preserve_gradients();
   if (failures) {
     std::printf("%d failures\n", failures);

--- a/tests/test_pass_safety.cpp
+++ b/tests/test_pass_safety.cpp
@@ -449,7 +449,7 @@ static void test_product_pass_barrier() {
   expect("product has a backward kernel",
          find_kernel(OP_PROD_VEC) != nullptr &&
              kernel(OP_PROD_VEC).backward != nullptr &&
-             kernel(OP_PROD_VEC).scratch_size != nullptr);
+             kernel(OP_PROD_VEC).scratch_size == nullptr);
   expect("product is absent from value-free backward traits",
          !backward_ignores_values(OP_PROD_VEC));
   expect("product survives constfold with parameter input",

--- a/tests/test_write_array.cpp
+++ b/tests/test_write_array.cpp
@@ -2095,7 +2095,7 @@ void test_product_exact_grouping() {
   }
 
   const Kernel& product = kernel(OP_PROD_VEC);
-  if (product.backward == nullptr || product.scratch_size == nullptr) {
+  if (product.backward == nullptr || product.scratch_size != nullptr) {
     ++failures;
     std::printf("FAIL product kernel has no differentiable implementation\n");
   }
@@ -2396,6 +2396,42 @@ void test_extrema_exact_grouping() {
               static_cast<unsigned long long>(reduction_bits(wants[variant])));
         }
       }
+
+      std::vector<double> active_values = values;
+      Eigen::Matrix<stan::math::var, -1, 1> active(
+          static_cast<Eigen::Index>(values.size()));
+      for (size_t i = 0; i < values.size(); ++i)
+        active(static_cast<Eigen::Index>(i)) = values[i];
+      stan::math::var want_active =
+          variant == 0 ? stan::math::min(active) : stan::math::max(active);
+      double got_active = 0.0;
+      double selected = 0.0;
+      std::vector<double> adj(values.size(), 0.0);
+      KernelCtx active_ctx;
+      active_ctx.n_in = 1;
+      active_ctx.in[0] =
+          Desc{active_values.data(), static_cast<int64_t>(values.size())};
+      active_ctx.out = Desc{&got_active, 1};
+      active_ctx.scratch = &selected;
+      active_ctx.variant = static_cast<uint8_t>(variant | 2);
+      extrema.forward(active_ctx);
+      active_ctx.in_adj[0] = Desc{adj.data(), static_cast<int64_t>(adj.size())};
+      active_ctx.out_adj = 1.0;
+      extrema.backward(active_ctx);
+      want_active.grad();
+      if (!same_reduction_value(got_active, want_active.val())) {
+        ++failures;
+        std::printf("FAIL active extrema value case %zu variant %d\n", c,
+                    variant);
+      }
+      for (size_t i = 0; i < adj.size(); ++i) {
+        if (adj[i] == active(static_cast<Eigen::Index>(i)).adj()) continue;
+        ++failures;
+        std::printf(
+            "FAIL active extrema adjoint case %zu variant %d index %zu\n", c,
+            variant, i);
+      }
+      stan::math::recover_memory();
     }
   }
 

--- a/tests/test_write_array.cpp
+++ b/tests/test_write_array.cpp
@@ -2095,9 +2095,9 @@ void test_product_exact_grouping() {
   }
 
   const Kernel& product = kernel(OP_PROD_VEC);
-  if (product.backward != nullptr) {
+  if (product.backward == nullptr || product.scratch_size == nullptr) {
     ++failures;
-    std::printf("FAIL product kernel has a backward implementation\n");
+    std::printf("FAIL product kernel has no differentiable implementation\n");
   }
 
   const double denorm = std::numeric_limits<double>::denorm_min();
@@ -2331,9 +2331,9 @@ void test_product_exact_grouping() {
 void test_extrema_exact_grouping() {
   using namespace stanli;
   const Kernel& extrema = kernel(OP_EXTREMA_VEC);
-  if (extrema.backward != nullptr || extrema.scratch_size != nullptr) {
+  if (extrema.backward == nullptr || extrema.scratch_size == nullptr) {
     ++failures;
-    std::printf("FAIL extrema kernel is not forward-only/no-scratch\n");
+    std::printf("FAIL extrema kernel has no differentiable implementation\n");
   }
 
   const double inf = std::numeric_limits<double>::infinity();
@@ -2696,20 +2696,21 @@ void test_gq_extrema_lowering_guards() {
     expect_extrema_interp(udf, "dynamic UDF extrema stays interpreted");
   }
 
-  // The opcode is generated-quantities-only: an active log_prob reduction
-  // must still be refused rather than acquiring a forward-only reverse path.
-  bool reverse_refused = false;
+  // The same opcode now serves active log_prob reductions through its stored
+  // selected coefficient.
+  bool reverse_compiled = false;
   try {
     DataMap no_data;
-    (void)compile_model(slurp("tests/fixtures/gq_extrema_reverse.tmir.sexp"),
-                        no_data);
-  } catch (const CompileError& e) {
-    reverse_refused = std::string(e.what()).find("unsupported function min") !=
-                      std::string::npos;
+    CompiledModel reverse = compile_model(
+        slurp("tests/fixtures/gq_extrema_reverse.tmir.sexp"), no_data);
+    reverse_compiled =
+        std::any_of(reverse.graph.ops.begin(), reverse.graph.ops.end(),
+                    [](const Op& op) { return op.opcode == OP_EXTREMA_VEC; });
+  } catch (const CompileError&) {
   }
-  if (!reverse_refused) {
+  if (!reverse_compiled) {
     ++failures;
-    std::printf("FAIL dynamic log_prob extrema was not refused\n");
+    std::printf("FAIL dynamic log_prob extrema was not compiled\n");
   }
 }
 
@@ -2728,7 +2729,7 @@ void test_compiled_gq_reductions() {
   }
 
   // The same fixture pins both legacy seams in log_prob: data-only prod is
-  // folded rather than becoming the forward-only opcode, and pure-data int
+  // folded rather than becoming a runtime opcode, and pure-data int
   // sum still compiles/evaluates outside the runtime GQ specialization.
   int log_products = 0;
   for (const Op& op : cm.graph.ops)
@@ -3274,8 +3275,7 @@ void test_gq_reduction_lowering_guards() {
     expect_reduction_interp(nested_math, "expression surface",
                             "prod(1-exp(x)) stays interpreted");
 
-  // A dynamic product in log_prob must retain the old unsupported/fallback
-  // behavior; the forward-only opcode is never admitted to reverse mode.
+  // A dynamic product in log_prob uses the same opcode with stored partials.
   std::string reverse = base;
   const size_t log_prod = reverse.find("(FunApp (StanLib prod");
   const std::string data_node =
@@ -3288,16 +3288,17 @@ void test_gq_reduction_lowering_guards() {
       "AutoDiffable))))";
   if (replace_reduction_after(reverse, log_prod, data_node, active_node,
                               "reverse-mode product")) {
-    bool refused = false;
+    bool compiled = false;
     try {
-      (void)compile_model(reverse, reduction_data());
-    } catch (const CompileError& e) {
-      refused = std::string(e.what()).find("unsupported function prod") !=
-                std::string::npos;
+      CompiledModel model = compile_model(reverse, reduction_data());
+      compiled =
+          std::any_of(model.graph.ops.begin(), model.graph.ops.end(),
+                      [](const Op& op) { return op.opcode == OP_PROD_VEC; });
+    } catch (const CompileError&) {
     }
-    if (!refused) {
+    if (!compiled) {
       ++failures;
-      std::printf("FAIL dynamic log_prob product was not refused\n");
+      std::printf("FAIL dynamic log_prob product was not compiled\n");
     }
   }
 


### PR DESCRIPTION
## Additional reductions

**New functions:** `sd(x)`, `variance(x)` — new opcodes `OP_SD` / `OP_VARIANCE`, sharing one
templated kernel. Partials are cached in scratch during the forward pass; the singleton and
near-zero-spread cases follow Stan Math's fallbacks rather than dividing by ~0.

**Wider compatibility:** `prod`, `min`, and `max` were generated-quantities-only. They now work
in the model block too — the `in_write_array` gate is gone and both opcodes gained reverse
passes (`prod` via prefix/suffix products, `min`/`max` by recording the selected index).

## Additional matrix functions

**New functions:** `inverse`, `inverse_spd`, `log_determinant`, `quad_form`, and `add_diag` —
each with a new opcode, kernel, lowering path, and MIR-interpreter path.

- `quad_form` accepts a matrix or vector second argument (m×m or scalar output).
- `add_diag` accepts a scalar or vector diagonal.
- `inverse_spd` runs its forward pass on `Matrix<var>` when active, so Eigen matches CmdStan.

All paths validate squareness, dimensions, and diagonal length with descriptive errors.
