### PR TITLE
Use Clang for fast PR runtime tests

### DIFF
--- a/.github/workflows/stan-conformance-nightly.yml
+++ b/.github/workflows/stan-conformance-nightly.yml
@@ -34,8 +34,18 @@ jobs:
 
   inventory:
     runs-on: ubuntu-24.04
+    env:
+      # Use Clang's frontend with Ubuntu's GNU libstdc++/libgcc runtime.
+      # The conformance artifact must match the native release runtime ABI.
+      CC: clang
+      CXX: clang++
     steps:
       - uses: actions/checkout@v4
+
+      - name: Install the Clang C/C++ compiler
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang
 
       # dev_setup.sh is in the key: the stanc pin (STANC3_SRC_SHA)
       # lives there, so advancing it rolls this cache.
@@ -70,7 +80,8 @@ jobs:
 
       - name: Build the public stanli Python runtime
         run: |
-          cmake -B build-rel -DCMAKE_BUILD_TYPE=Release
+          cmake -B build-rel -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_C_COMPILER="$CC" -DCMAKE_CXX_COMPILER="$CXX"
           cmake --build build-rel --target stanli_shared -j2
           mkdir -p python/stanli/_bin
           cp build-rel/libstanli.so python/stanli/_bin/

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -1,9 +1,11 @@
 # Build the platform wheels, and publish them to PyPI on a version tag.
 #
-# Pull requests build the representative manylinux target, compile the runtime
-# for wasm32, run the full runtime and corpus tests, and gate the bounded Windows
-# compiler cross-build. Every release target also builds after merge, nightly,
-# and on version tags; publishing is gated on the tag and all of those builds.
+# Pull requests build the representative manylinux target with Clang, compile
+# the runtime for wasm32, run the full runtime and corpus tests, and gate the
+# bounded Windows compiler cross-build. Shipped Linux and Windows builds retain
+# their established GCC toolchains. Every release target also builds after
+# merge, nightly, and on version tags; publishing is gated on the tag and all
+# of those builds.
 #
 # Not cibuildwheel: it exists to build one wheel per CPython version, and
 # stanli ships a ctypes-loaded shared library with no extension module, so
@@ -157,10 +159,6 @@ jobs:
       # the wheel tag promises. Without it the runner's own OS version
       # becomes the floor and the tag quietly lies.
       MACOSX_DEPLOYMENT_TARGET: ${{ matrix.macos_target }}
-      # Native runtime builds use Clang explicitly. On Linux, Clang retains
-      # the manylinux image's GNU libstdc++/libgcc runtime libraries.
-      CC: clang
-      CXX: clang++
     strategy:
       fail-fast: false
       # A pull request builds one platform, and it is Linux x86_64. It
@@ -183,13 +181,15 @@ jobs:
       - name: System packages (manylinux)
         if: matrix.container != ''
         run: |
-          # Native runtime objects use Clang's frontends while retaining the
-          # manylinux image's GNU libstdc++/libgcc runtime libraries.
-          # Install it before the compiler fingerprint so the cache key names
-          # the compiler that CMake will actually invoke.
-          # Use the image's architecture-aware installer. Its Clang frontend
-          # is configured against this image's existing GNU toolchain/runtime.
-          manylinux-install-clang
+          # PR validation uses Clang's frontend with this image's existing GNU
+          # libstdc++/libgcc runtime. Release, scheduled, and manual builds keep
+          # the established GCC frontend so changing the validation compiler
+          # cannot change shipped runtime performance.
+          if [ "$GITHUB_EVENT_NAME" = pull_request ]; then
+            manylinux-install-clang
+            echo 'CC=clang' >> "$GITHUB_ENV"
+            echo 'CXX=clang++' >> "$GITHUB_ENV"
+          fi
           # OCaml's complete-object mode uses `ld -r`, which resolves its C
           # runtime dependencies from static archives during the partial link.
           dnf install -y unzip which diffutils patch rsync glibc-static
@@ -198,14 +198,15 @@ jobs:
           # explicitly rather than inheriting AlmaLinux's system python3.
           echo /opt/python/cp312-cp312/bin >> "$GITHUB_PATH"
 
-      - name: Fingerprint the selected Clang C++ compiler
+      - name: Fingerprint the selected C++ compiler
         id: toolchain
         shell: bash
         run: |
+          compiler="${CXX:-c++}"
           if command -v sha256sum >/dev/null; then
-            fingerprint=$("$CXX" --version | sha256sum | cut -d' ' -f1)
+            fingerprint=$("$compiler" --version | sha256sum | cut -d' ' -f1)
           else
-            fingerprint=$("$CXX" --version | shasum -a 256 | cut -d' ' -f1)
+            fingerprint=$("$compiler" --version | shasum -a 256 | cut -d' ' -f1)
           fi
           echo "id=$fingerprint" >> "$GITHUB_OUTPUT"
 
@@ -218,8 +219,8 @@ jobs:
         with:
           path: .ccache
           key: >-
-            ccache-${{ matrix.plat }}-release-clang-v5-${{ steps.toolchain.outputs.id }}-${{ hashFiles('CMakeLists.txt', 'runtime/**', 'tests/**/*.cpp', 'tests/**/*.hpp', 'tools/**/*.cpp', 'tools/**/*.hpp', 'deps/fetch.sh') }}
-          restore-keys: ccache-${{ matrix.plat }}-release-clang-v5-${{ steps.toolchain.outputs.id }}-
+            ccache-${{ matrix.plat }}-${{ github.event_name == 'pull_request' && 'release-clang-v5' || 'release-v4' }}-${{ steps.toolchain.outputs.id }}-${{ hashFiles('CMakeLists.txt', 'runtime/**', 'tests/**/*.cpp', 'tests/**/*.hpp', 'tools/**/*.cpp', 'tools/**/*.hpp', 'deps/fetch.sh') }}
+          restore-keys: ccache-${{ matrix.plat }}-${{ github.event_name == 'pull_request' && 'release-clang-v5' || 'release-v4' }}-${{ steps.toolchain.outputs.id }}-
 
       - name: System packages (macOS)
         if: matrix.container == ''
@@ -352,8 +353,12 @@ jobs:
           export CCACHE_DIR="$PWD/.ccache" CCACHE_COMPRESS=1 CCACHE_MAXSIZE=600M
           export CCACHE_SLOPPINESS=pch_defines,time_macros
           ccache -z
+          compiler_args=()
+          if [ -n "${CC:-}" ] && [ -n "${CXX:-}" ]; then
+            compiler_args+=("-DCMAKE_C_COMPILER=$CC" "-DCMAKE_CXX_COMPILER=$CXX")
+          fi
           cmake -B build-rel -DCMAKE_BUILD_TYPE=Release \
-            -DCMAKE_C_COMPILER="$CC" -DCMAKE_CXX_COMPILER="$CXX" \
+            "${compiler_args[@]}" \
             -DCMAKE_C_COMPILER_LAUNCHER=ccache \
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
             -DSTANLI_STANC_EMBED_OBJ="$PWD/deps/stanc3/stanc_embed.o" \

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -1148,12 +1148,6 @@ jobs:
     defaults:
       run:
         shell: msys2 {0}
-    env:
-      # UCRT64 Clang uses the UCRT64 GCC toolchain's GNU libstdc++/libgcc.
-      # Keep this environment in UCRT64; CLANG64 would select a different
-      # runtime (and libc++ is neither needed nor shipped by this wheel).
-      CC: clang
-      CXX: clang++
     steps:
       - uses: actions/checkout@v4
 
@@ -1162,7 +1156,6 @@ jobs:
           msystem: UCRT64
           update: false
           install: >-
-            mingw-w64-ucrt-x86_64-clang
             mingw-w64-ucrt-x86_64-gcc
             mingw-w64-ucrt-x86_64-cmake
             mingw-w64-ucrt-x86_64-ninja
@@ -1174,10 +1167,10 @@ jobs:
             unzip
             curl
 
-      - name: Fingerprint the Clang C++ compiler
+      - name: Fingerprint the C++ compiler
         id: toolchain
         run: |
-          fingerprint=$("$CXX" --version | sha256sum | cut -d' ' -f1)
+          fingerprint=$(c++ --version | sha256sum | cut -d' ' -f1)
           echo "id=$fingerprint" >> "$GITHUB_OUTPUT"
 
       - name: Restore the compiler cache
@@ -1185,8 +1178,8 @@ jobs:
         with:
           path: .ccache
           key: >-
-            ccache-win_amd64-ucrt64-clang-release-v3-${{ steps.toolchain.outputs.id }}-${{ hashFiles('CMakeLists.txt', 'runtime/**', 'tests/**/*.cpp', 'tests/**/*.hpp', 'tools/**/*.cpp', 'tools/**/*.hpp', 'deps/fetch.sh') }}
-          restore-keys: ccache-win_amd64-ucrt64-clang-release-v3-${{ steps.toolchain.outputs.id }}-
+            ccache-win_amd64-ucrt64-release-v2-${{ steps.toolchain.outputs.id }}-${{ hashFiles('CMakeLists.txt', 'runtime/**', 'tests/**/*.cpp', 'tests/**/*.hpp', 'tools/**/*.cpp', 'tools/**/*.hpp', 'deps/fetch.sh') }}
+          restore-keys: ccache-win_amd64-ucrt64-release-v2-${{ steps.toolchain.outputs.id }}-
 
       - name: Fetch pinned dependencies
         run: ./deps/fetch.sh
@@ -1218,10 +1211,8 @@ jobs:
       - name: Configure, build, test
         run: |
           export CCACHE_DIR="$PWD/.ccache" CCACHE_COMPRESS=1 CCACHE_MAXSIZE=600M
-          export CCACHE_SLOPPINESS=pch_defines,time_macros
           ccache -z
           cmake -B build-rel -G Ninja -DCMAKE_BUILD_TYPE=Release \
-            -DCMAKE_C_COMPILER="$CC" -DCMAKE_CXX_COMPILER="$CXX" \
             -DCMAKE_C_COMPILER_LAUNCHER=ccache \
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
           cmake --build build-rel -j4

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -351,7 +351,10 @@ jobs:
           # $PWD, not github.workspace: inside the manylinux containers the
           # workspace mounts at a different path than the expression gives.
           export CCACHE_DIR="$PWD/.ccache" CCACHE_COMPRESS=1 CCACHE_MAXSIZE=600M
-          export CCACHE_SLOPPINESS=pch_defines,time_macros
+          # The PCH is regenerated after every checkout. Ignore its file times
+          # while still hashing header contents, or every PCH consumer misses
+          # the restored cache even when its compile inputs are unchanged.
+          export CCACHE_SLOPPINESS=pch_defines,time_macros,include_file_mtime,include_file_ctime
           ccache -z
           compiler_args=()
           if [ -n "${CC:-}" ] && [ -n "${CXX:-}" ]; then
@@ -1360,7 +1363,7 @@ jobs:
         run: |
           which ccache || sudo apt-get install -y ccache
           export CCACHE_DIR="$PWD/.ccache" CCACHE_COMPRESS=1 CCACHE_MAXSIZE=600M
-          export CCACHE_SLOPPINESS=pch_defines,time_macros
+          export CCACHE_SLOPPINESS=pch_defines,time_macros,include_file_mtime,include_file_ctime
           ccache -z
           # -O1 -g1, and every number here was read off a failed run's
           # log rather than guessed. -O1: ASan's checks do not depend on

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -157,6 +157,10 @@ jobs:
       # the wheel tag promises. Without it the runner's own OS version
       # becomes the floor and the tag quietly lies.
       MACOSX_DEPLOYMENT_TARGET: ${{ matrix.macos_target }}
+      # Native runtime builds use Clang explicitly. On Linux, Clang retains
+      # the manylinux image's GNU libstdc++/libgcc runtime libraries.
+      CC: clang
+      CXX: clang++
     strategy:
       fail-fast: false
       # A pull request builds one platform, and it is Linux x86_64. It
@@ -176,14 +180,32 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Fingerprint the C++ compiler
+      - name: System packages (manylinux)
+        if: matrix.container != ''
+        run: |
+          # Native runtime objects use Clang's frontends while retaining the
+          # manylinux image's GNU libstdc++/libgcc runtime libraries.
+          # Install it before the compiler fingerprint so the cache key names
+          # the compiler that CMake will actually invoke.
+          # Use the image's architecture-aware installer. Its Clang frontend
+          # is configured against this image's existing GNU toolchain/runtime.
+          manylinux-install-clang
+          # OCaml's complete-object mode uses `ld -r`, which resolves its C
+          # runtime dependencies from static archives during the partial link.
+          dnf install -y unzip which diffutils patch rsync glibc-static
+          dnf install -y epel-release && dnf install -y ccache time
+          # The manylinux image keeps its interpreters out of PATH; pick one
+          # explicitly rather than inheriting AlmaLinux's system python3.
+          echo /opt/python/cp312-cp312/bin >> "$GITHUB_PATH"
+
+      - name: Fingerprint the selected Clang C++ compiler
         id: toolchain
         shell: bash
         run: |
           if command -v sha256sum >/dev/null; then
-            fingerprint=$(c++ --version | sha256sum | cut -d' ' -f1)
+            fingerprint=$("$CXX" --version | sha256sum | cut -d' ' -f1)
           else
-            fingerprint=$(c++ --version | shasum -a 256 | cut -d' ' -f1)
+            fingerprint=$("$CXX" --version | shasum -a 256 | cut -d' ' -f1)
           fi
           echo "id=$fingerprint" >> "$GITHUB_OUTPUT"
 
@@ -196,8 +218,8 @@ jobs:
         with:
           path: .ccache
           key: >-
-            ccache-${{ matrix.plat }}-release-v4-${{ steps.toolchain.outputs.id }}-${{ hashFiles('CMakeLists.txt', 'runtime/**', 'tests/**/*.cpp', 'tests/**/*.hpp', 'tools/**/*.cpp', 'tools/**/*.hpp', 'deps/fetch.sh') }}
-          restore-keys: ccache-${{ matrix.plat }}-release-v4-${{ steps.toolchain.outputs.id }}-
+            ccache-${{ matrix.plat }}-release-clang-v5-${{ steps.toolchain.outputs.id }}-${{ hashFiles('CMakeLists.txt', 'runtime/**', 'tests/**/*.cpp', 'tests/**/*.hpp', 'tools/**/*.cpp', 'tools/**/*.hpp', 'deps/fetch.sh') }}
+          restore-keys: ccache-${{ matrix.plat }}-release-clang-v5-${{ steps.toolchain.outputs.id }}-
 
       - name: System packages (macOS)
         if: matrix.container == ''
@@ -328,8 +350,10 @@ jobs:
           # $PWD, not github.workspace: inside the manylinux containers the
           # workspace mounts at a different path than the expression gives.
           export CCACHE_DIR="$PWD/.ccache" CCACHE_COMPRESS=1 CCACHE_MAXSIZE=600M
+          export CCACHE_SLOPPINESS=pch_defines,time_macros
           ccache -z
           cmake -B build-rel -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_C_COMPILER="$CC" -DCMAKE_CXX_COMPILER="$CXX" \
             -DCMAKE_C_COMPILER_LAUNCHER=ccache \
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
             -DSTANLI_STANC_EMBED_OBJ="$PWD/deps/stanc3/stanc_embed.o" \
@@ -1124,6 +1148,12 @@ jobs:
     defaults:
       run:
         shell: msys2 {0}
+    env:
+      # UCRT64 Clang uses the UCRT64 GCC toolchain's GNU libstdc++/libgcc.
+      # Keep this environment in UCRT64; CLANG64 would select a different
+      # runtime (and libc++ is neither needed nor shipped by this wheel).
+      CC: clang
+      CXX: clang++
     steps:
       - uses: actions/checkout@v4
 
@@ -1132,6 +1162,7 @@ jobs:
           msystem: UCRT64
           update: false
           install: >-
+            mingw-w64-ucrt-x86_64-clang
             mingw-w64-ucrt-x86_64-gcc
             mingw-w64-ucrt-x86_64-cmake
             mingw-w64-ucrt-x86_64-ninja
@@ -1143,10 +1174,10 @@ jobs:
             unzip
             curl
 
-      - name: Fingerprint the C++ compiler
+      - name: Fingerprint the Clang C++ compiler
         id: toolchain
         run: |
-          fingerprint=$(c++ --version | sha256sum | cut -d' ' -f1)
+          fingerprint=$("$CXX" --version | sha256sum | cut -d' ' -f1)
           echo "id=$fingerprint" >> "$GITHUB_OUTPUT"
 
       - name: Restore the compiler cache
@@ -1154,8 +1185,8 @@ jobs:
         with:
           path: .ccache
           key: >-
-            ccache-win_amd64-ucrt64-release-v2-${{ steps.toolchain.outputs.id }}-${{ hashFiles('CMakeLists.txt', 'runtime/**', 'tests/**/*.cpp', 'tests/**/*.hpp', 'tools/**/*.cpp', 'tools/**/*.hpp', 'deps/fetch.sh') }}
-          restore-keys: ccache-win_amd64-ucrt64-release-v2-${{ steps.toolchain.outputs.id }}-
+            ccache-win_amd64-ucrt64-clang-release-v3-${{ steps.toolchain.outputs.id }}-${{ hashFiles('CMakeLists.txt', 'runtime/**', 'tests/**/*.cpp', 'tests/**/*.hpp', 'tools/**/*.cpp', 'tools/**/*.hpp', 'deps/fetch.sh') }}
+          restore-keys: ccache-win_amd64-ucrt64-clang-release-v3-${{ steps.toolchain.outputs.id }}-
 
       - name: Fetch pinned dependencies
         run: ./deps/fetch.sh
@@ -1187,8 +1218,10 @@ jobs:
       - name: Configure, build, test
         run: |
           export CCACHE_DIR="$PWD/.ccache" CCACHE_COMPRESS=1 CCACHE_MAXSIZE=600M
+          export CCACHE_SLOPPINESS=pch_defines,time_macros
           ccache -z
           cmake -B build-rel -G Ninja -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_C_COMPILER="$CC" -DCMAKE_CXX_COMPILER="$CXX" \
             -DCMAKE_C_COMPILER_LAUNCHER=ccache \
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
           cmake --build build-rel -j4
@@ -1266,19 +1299,28 @@ jobs:
       github.event_name != 'pull_request' &&
       startsWith(github.ref, 'refs/tags/') == false
     runs-on: ubuntu-24.04
+    env:
+      CC: clang
+      CXX: clang++
     # The first shipped configuration could not finish: gcc at
     # RelWithDebInfo (-O2 -g) with ASan took 8+ minutes per densities
     # shard -- 18% built after half an hour, runner reclaimed before the
     # end, and since the cache saved only on success, every subsequent
     # run started cold again. The ceiling exists so a stuck build fails
     # in bounded time instead of holding the concurrency queue.
+    # Clang is selected below, but its memory profile is not measured yet;
+    # retain these limits until a complete Clang run remeasures them.
     timeout-minutes: 90
     steps:
       - uses: actions/checkout@v4
-      - name: Fingerprint the C++ compiler
+      - name: Install the Clang C/C++ compiler
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang
+      - name: Fingerprint the Clang C++ compiler
         id: toolchain
         run: |
-          fingerprint=$(c++ --version | sha256sum | cut -d' ' -f1)
+          fingerprint=$("$CXX" --version | sha256sum | cut -d' ' -f1)
           echo "id=$fingerprint" >> "$GITHUB_OUTPUT"
       - name: Restore the compiler cache
         id: asan-cache
@@ -1288,8 +1330,8 @@ jobs:
           # never be handed to, or taken from, the wheel build's cache.
           path: .ccache
           key: >-
-            ccache-asan-gcc-o1-g1-v2-${{ steps.toolchain.outputs.id }}-${{ hashFiles('CMakeLists.txt', 'runtime/**', 'tests/**/*.cpp', 'tests/**/*.hpp', 'tools/**/*.cpp', 'tools/**/*.hpp', 'deps/fetch.sh') }}
-          restore-keys: ccache-asan-gcc-o1-g1-v2-${{ steps.toolchain.outputs.id }}-
+            ccache-asan-clang-o1-g1-v3-${{ steps.toolchain.outputs.id }}-${{ hashFiles('CMakeLists.txt', 'runtime/**', 'tests/**/*.cpp', 'tests/**/*.hpp', 'tools/**/*.cpp', 'tools/**/*.hpp', 'deps/fetch.sh') }}
+          restore-keys: ccache-asan-clang-o1-g1-v3-${{ steps.toolchain.outputs.id }}-
       - name: Fetch pinned dependencies
         run: ./deps/fetch.sh
       # Both fatal runs of this job died at the same place -- the density
@@ -1322,6 +1364,7 @@ jobs:
         run: |
           which ccache || sudo apt-get install -y ccache
           export CCACHE_DIR="$PWD/.ccache" CCACHE_COMPRESS=1 CCACHE_MAXSIZE=600M
+          export CCACHE_SLOPPINESS=pch_defines,time_macros
           ccache -z
           # -O1 -g1, and every number here was read off a failed run's
           # log rather than guessed. -O1: ASan's checks do not depend on
@@ -1339,6 +1382,7 @@ jobs:
           cmake -B build-asan -DCMAKE_BUILD_TYPE=None \
             -DCMAKE_C_FLAGS="-O1 -g1" -DCMAKE_CXX_FLAGS="-O1 -g1" \
             -DSTANLI_SANITIZE=address \
+            -DCMAKE_C_COMPILER="$CC" -DCMAKE_CXX_COMPILER="$CXX" \
             -DCMAKE_C_COMPILER_LAUNCHER=ccache \
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
           # Peak of the largest single compile, the wheel build's own

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -178,25 +178,15 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: System packages (manylinux)
-        if: matrix.container != ''
+      - name: Clang frontend (pull requests)
+        if: matrix.container != '' && github.event_name == 'pull_request'
         run: |
-          # PR validation uses Clang's frontend with this image's existing GNU
-          # libstdc++/libgcc runtime. Release, scheduled, and manual builds keep
-          # the established GCC frontend so changing the validation compiler
-          # cannot change shipped runtime performance.
-          if [ "$GITHUB_EVENT_NAME" = pull_request ]; then
-            manylinux-install-clang
-            echo 'CC=clang' >> "$GITHUB_ENV"
-            echo 'CXX=clang++' >> "$GITHUB_ENV"
-          fi
-          # OCaml's complete-object mode uses `ld -r`, which resolves its C
-          # runtime dependencies from static archives during the partial link.
-          dnf install -y unzip which diffutils patch rsync glibc-static
-          dnf install -y epel-release && dnf install -y ccache time
-          # The manylinux image keeps its interpreters out of PATH; pick one
-          # explicitly rather than inheriting AlmaLinux's system python3.
-          echo /opt/python/cp312-cp312/bin >> "$GITHUB_PATH"
+          # The custom manylinux image already contains every fixed build
+          # package. Only PR validation adds Clang's frontend; release,
+          # scheduled, and manual builds retain the image's GCC frontend.
+          manylinux-install-clang
+          echo 'CC=clang' >> "$GITHUB_ENV"
+          echo 'CXX=clang++' >> "$GITHUB_ENV"
 
       - name: Fingerprint the selected C++ compiler
         id: toolchain

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,22 +20,6 @@ endif()
 
 project(stanli C CXX)
 
-# Clang is the supported frontend for native builds that gate pull requests.
-# Windows remains on the established UCRT64 GCC toolchain: that post-merge job
-# does not affect PR latency, and mixing Clang -O0 test objects with its GNU
-# runtime archive currently exposes MinGW COMDAT/linker failures. Keep that
-# unrelated migration out of the fast-test policy.
-foreach(_stanli_language IN ITEMS C CXX)
-  if(NOT WIN32 AND
-     NOT CMAKE_${_stanli_language}_COMPILER_ID MATCHES "^(AppleClang|Clang)$")
-    message(FATAL_ERROR
-      "stanli requires Clang for ${_stanli_language} on this platform; "
-      "got ${CMAKE_${_stanli_language}_COMPILER_ID} "
-      "(${CMAKE_${_stanli_language}_COMPILER}). "
-      "Configure with CC=clang and CXX=clang++.")
-  endif()
-endforeach()
-
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
@@ -536,6 +520,10 @@ endif()
 
 if(NOT EMSCRIPTEN)
 enable_testing()
+# Pull-request validation uses Clang so its cheap test translation units can
+# link to the optimized runtime objects below. Shipped platform builds may use
+# their established compiler; this switch changes test scaffolding only when
+# the frontend supports the shared-PCH policy we validate in CI.
 set(STANLI_FAST_TEST_TUS OFF)
 if(NOT WIN32 AND CMAKE_CXX_COMPILER_ID MATCHES "^(AppleClang|Clang)$")
   set(STANLI_FAST_TEST_TUS ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,19 @@ endif()
 
 project(stanli C CXX)
 
+# Clang is the supported frontend for the stanli runtime and its tests. This
+# does not require replacing the platform C++ runtime: Linux and MSYS2 UCRT64
+# builds deliberately continue to use their GNU libraries and linkers.
+foreach(_stanli_language IN ITEMS C CXX)
+  if(NOT CMAKE_${_stanli_language}_COMPILER_ID MATCHES "^(AppleClang|Clang)$")
+    message(FATAL_ERROR
+      "stanli requires Clang for ${_stanli_language}; "
+      "got ${CMAKE_${_stanli_language}_COMPILER_ID} "
+      "(${CMAKE_${_stanli_language}_COMPILER}). "
+      "Configure with CC=clang and CXX=clang++.")
+  endif()
+endforeach()
+
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
@@ -520,11 +533,41 @@ endif()
 
 if(NOT EMSCRIPTEN)
 enable_testing()
+# One precompiled header for the test targets, built once and reused.
+#
+# The reason to care is CI, not an ordinary cached build. A change to a widely
+# included header invalidates most test objects, and roughly 3.6 seconds of
+# every test translation unit is otherwise spent re-reading <stan/math.hpp>.
+# CMake's default per-target PCH would build one copy for every executable, so
+# REUSE_FROM is essential here.
+#
+# recorder.hpp must come first. stan-math's prim value_of calls value_of
+# unqualified from inside a template, so stanli's rvar overload must be
+# declared before that template is defined.
+set(STANLI_TEST_PCH <stanli/recorder.hpp> <stan/math.hpp>)
+
+# REUSE_FROM requires identical compiler flags between the PCH owner and its
+# consumers. Both therefore compile at -O0. These flags affect only the test
+# scaffolding; the linked stanli runtime object library remains a Release build.
+function(stanli_configure_test_tu NAME)
+  target_compile_options(${NAME} PRIVATE -O0)
+  target_precompile_headers(${NAME} REUSE_FROM stanli_test_pch)
+endfunction()
+
+# The owner exists only to produce the shared PCH. Do not use tbb_stub.cpp as
+# its source: force-including stan-math would collide with the class definition
+# in the stub's non-Apple branch.
+add_library(stanli_test_pch OBJECT tests/pch_anchor.cpp)
+target_link_libraries(stanli_test_pch PRIVATE stanli)
+target_compile_options(stanli_test_pch PRIVATE -O0)
+target_precompile_headers(stanli_test_pch PRIVATE ${STANLI_TEST_PCH})
+
 # Single-threaded tests stub the one TBB symbol stan-math's rev core needs.
 function(stanli_add_test NAME)
   add_executable(${NAME} tests/${NAME}.cpp
     $<TARGET_OBJECTS:stanli_tbb_stub>)
   target_link_libraries(${NAME} PRIVATE stanli)
+  stanli_configure_test_tu(${NAME})
   # Tests run from the repo root so fixture paths are stable.
   add_test(NAME ${NAME} COMMAND ${NAME}
            WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
@@ -642,8 +685,12 @@ endforeach()
 
 # The C ABI lives only in the shared library. Test it through that shipped
 # boundary rather than compiling capi.cpp into the C++ unit-test library.
+# It still gets the test-only -O0 policy, but deliberately not the shared PCH:
+# force-including stan-math would pull TBB references across the C boundary this
+# executable is meant to verify in isolation.
 add_executable(test_capi tests/test_capi.cpp)
 target_link_libraries(test_capi PRIVATE stanli_shared)
+target_compile_options(test_capi PRIVATE -O0)
 add_test(NAME test_capi COMMAND test_capi
          WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,13 +20,16 @@ endif()
 
 project(stanli C CXX)
 
-# Clang is the supported frontend for the stanli runtime and its tests. This
-# does not require replacing the platform C++ runtime: Linux and MSYS2 UCRT64
-# builds deliberately continue to use their GNU libraries and linkers.
+# Clang is the supported frontend for native builds that gate pull requests.
+# Windows remains on the established UCRT64 GCC toolchain: that post-merge job
+# does not affect PR latency, and mixing Clang -O0 test objects with its GNU
+# runtime archive currently exposes MinGW COMDAT/linker failures. Keep that
+# unrelated migration out of the fast-test policy.
 foreach(_stanli_language IN ITEMS C CXX)
-  if(NOT CMAKE_${_stanli_language}_COMPILER_ID MATCHES "^(AppleClang|Clang)$")
+  if(NOT WIN32 AND
+     NOT CMAKE_${_stanli_language}_COMPILER_ID MATCHES "^(AppleClang|Clang)$")
     message(FATAL_ERROR
-      "stanli requires Clang for ${_stanli_language}; "
+      "stanli requires Clang for ${_stanli_language} on this platform; "
       "got ${CMAKE_${_stanli_language}_COMPILER_ID} "
       "(${CMAKE_${_stanli_language}_COMPILER}). "
       "Configure with CC=clang and CXX=clang++.")
@@ -533,6 +536,12 @@ endif()
 
 if(NOT EMSCRIPTEN)
 enable_testing()
+set(STANLI_FAST_TEST_TUS OFF)
+if(NOT WIN32 AND CMAKE_CXX_COMPILER_ID MATCHES "^(AppleClang|Clang)$")
+  set(STANLI_FAST_TEST_TUS ON)
+endif()
+
+if(STANLI_FAST_TEST_TUS)
 # One precompiled header for the test targets, built once and reused.
 #
 # The reason to care is CI, not an ordinary cached build. A change to a widely
@@ -561,13 +570,16 @@ add_library(stanli_test_pch OBJECT tests/pch_anchor.cpp)
 target_link_libraries(stanli_test_pch PRIVATE stanli)
 target_compile_options(stanli_test_pch PRIVATE -O0)
 target_precompile_headers(stanli_test_pch PRIVATE ${STANLI_TEST_PCH})
+endif()
 
 # Single-threaded tests stub the one TBB symbol stan-math's rev core needs.
 function(stanli_add_test NAME)
   add_executable(${NAME} tests/${NAME}.cpp
     $<TARGET_OBJECTS:stanli_tbb_stub>)
   target_link_libraries(${NAME} PRIVATE stanli)
-  stanli_configure_test_tu(${NAME})
+  if(STANLI_FAST_TEST_TUS)
+    stanli_configure_test_tu(${NAME})
+  endif()
   # Tests run from the repo root so fixture paths are stable.
   add_test(NAME ${NAME} COMMAND ${NAME}
            WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
@@ -685,12 +697,14 @@ endforeach()
 
 # The C ABI lives only in the shared library. Test it through that shipped
 # boundary rather than compiling capi.cpp into the C++ unit-test library.
-# It still gets the test-only -O0 policy, but deliberately not the shared PCH:
-# force-including stan-math would pull TBB references across the C boundary this
-# executable is meant to verify in isolation.
+# Under the fast-test policy it still gets -O0, but deliberately not the shared
+# PCH: force-including stan-math would pull TBB references across the C boundary
+# this executable is meant to verify in isolation.
 add_executable(test_capi tests/test_capi.cpp)
 target_link_libraries(test_capi PRIVATE stanli_shared)
-target_compile_options(test_capi PRIVATE -O0)
+if(STANLI_FAST_TEST_TUS)
+  target_compile_options(test_capi PRIVATE -O0)
+endif()
 add_test(NAME test_capi COMMAND test_capi
          WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 

--- a/README.md
+++ b/README.md
@@ -301,10 +301,11 @@ python3 -m http.server -d web     # then open http://localhost:8000
 
 ## Build
 
-Developer C/C++ builds require a C++17 Clang toolchain (`clang` and
-`clang++`). The Windows release wheel remains on its established MSYS2 UCRT64
-GCC toolchain; that post-merge packaging job is outside the PR-latency path.
-Other GNU libraries and tools may remain installed for auxiliary workflows.
+Developer C/C++ builds should use a C++17 Clang toolchain (`clang` and
+`clang++`) to match pull-request validation. The shipped Linux and Windows
+release wheels retain their established GCC toolchains, while macOS uses
+AppleClang. Other GNU libraries and tools may remain installed for auxiliary
+workflows.
 
 One-shot setup (fetches pinned deps, builds, runs tests):
 

--- a/README.md
+++ b/README.md
@@ -301,6 +301,10 @@ python3 -m http.server -d web     # then open http://localhost:8000
 
 ## Build
 
+Developer C/C++ builds require a C++17 Clang toolchain (`clang` and
+`clang++`). GCC and other GNU libraries/tools may remain installed for other
+workflows; they are not selected for the stanli C/C++ build.
+
 One-shot setup (fetches pinned deps, builds, runs tests):
 
 ```
@@ -320,14 +324,15 @@ Or manually:
 ```
 ./deps/fetch.sh
 build_jobs=$(tools/build_jobs.sh)
-cmake -B build
+cmake -B build -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++
 cmake --build build --parallel "$build_jobs"
 ctest --test-dir build --parallel "$build_jobs"
 ```
 
-The helper caps parallelism by both CPU count and usable RAM. It budgets 4 GiB
-per concurrent Stan Math compile on macOS/Windows and 6 GiB elsewhere; Linux
-needs the wider margin for GCC's largest shards and honors container limits.
+The helper caps parallelism by both CPU count and usable RAM. Its current
+starting-point budget is 4 GiB per concurrent Stan Math compile on macOS/Windows
+and 6 GiB elsewhere, with container limits honored; these figures should be
+remeasured for Clang as build workloads evolve.
 Override the result with `STANLI_JOBS=12 ./tools/dev_setup.sh`, or raise the
 per-job budget for a heavier toolchain with `STANLI_JOB_MEMORY_GIB` (the local
 AddressSanitizer recipe uses 12 GiB).

--- a/README.md
+++ b/README.md
@@ -302,8 +302,9 @@ python3 -m http.server -d web     # then open http://localhost:8000
 ## Build
 
 Developer C/C++ builds require a C++17 Clang toolchain (`clang` and
-`clang++`). GCC and other GNU libraries/tools may remain installed for other
-workflows; they are not selected for the stanli C/C++ build.
+`clang++`). The Windows release wheel remains on its established MSYS2 UCRT64
+GCC toolchain; that post-merge packaging job is outside the PR-latency path.
+Other GNU libraries and tools may remain installed for auxiliary workflows.
 
 One-shot setup (fetches pinned deps, builds, runs tests):
 

--- a/tests/pch_anchor.cpp
+++ b/tests/pch_anchor.cpp
@@ -1,0 +1,10 @@
+// Nothing but an anchor for the shared precompiled header.
+//
+// CMake's REUSE_FROM needs a real target and source file to build the PCH. This
+// must not be tests/tbb_stub.cpp: on non-Apple platforms that file defines a
+// TBB compatibility class which <stan/math.hpp> has already declared.
+namespace stanli {
+namespace {
+[[maybe_unused]] constexpr int kPchAnchor = 0;
+}  // namespace
+}  // namespace stanli

--- a/tools/build_jobs.sh
+++ b/tools/build_jobs.sh
@@ -173,9 +173,10 @@ stanli_detect_build_jobs() {
   fi
 
   memory_bytes=""
-  # Apple clang peaked at 2.75 GiB in the clean-build benchmark. Linux GCC's
-  # largest native shard has reached about 3.9 GiB, so Linux/unknown hosts get
-  # a wider safety margin. Windows CI has validated four jobs in 16 GiB.
+  # Apple clang peaked at 2.75 GiB in the clean-build benchmark. The wider
+  # Linux/unknown margin comes from the previous GCC build's 3.9 GiB peak;
+  # retain it until a Linux Clang cold build supplies a replacement number.
+  # Windows CI has validated four jobs in 16 GiB with the prior toolchain.
   bytes_per_job=6442450944
   case "$os" in
     Darwin)

--- a/tools/dev_setup.sh
+++ b/tools/dev_setup.sh
@@ -9,7 +9,7 @@
 #   tools/dev_setup.sh --all         everything
 #   tools/dev_setup.sh --no-build    stop before cmake (CI builds separately)
 #
-# Core needs: git, curl, cmake, a C++17 clang, python3.
+# Core needs: git, curl, cmake, C++17 clang and clang++, python3.
 # --embed and --corpus add opam (OCaml 5.5.0 switch built automatically).
 # --corpus adds: ~2 GB of checkouts under deps/ and a CmdStan build.
 # --conformance adds: opam, the pinned CmdStan/BridgeStan pair, and a venv
@@ -59,11 +59,32 @@ CONFORMANCE_VENV=${CONFORMANCE_VENV:-.venv-conformance}
 step() { printf '\n== %s\n' "$*"; }
 have() { command -v "$1" >/dev/null 2>&1; }
 
+# CMake must use Clang for the stanli C/C++ build. Allow callers to select a
+# versioned or otherwise explicitly located Clang, but do not silently accept
+# GCC through CC/CXX: that would leave a misleadingly configured build tree.
+is_clang() {
+  have "$1" && "$1" --version 2>/dev/null | grep -qi clang
+}
+
+if [ -n "${CC+x}" ] && ! is_clang "$CC"; then
+  echo "CC must name a Clang compiler (for example clang or clang-18)" >&2
+  exit 1
+fi
+if [ -n "${CXX+x}" ] && ! is_clang "$CXX"; then
+  echo "CXX must name a Clang compiler (for example clang++ or clang++-18)" >&2
+  exit 1
+fi
+CLANG_C=${CC:-clang}
+CLANG_CXX=${CXX:-clang++}
+
 # --- host prerequisites ----------------------------------------------------
 step "checking prerequisites"
 missing=()
-for tool in git curl cmake python3; do have "$tool" || missing+=("$tool"); done
-if ! have clang++ && ! have g++; then missing+=("clang++ (Xcode CLT or clang)"); fi
+for tool in git curl cmake python3; do
+  have "$tool" || missing+=("$tool")
+done
+is_clang "$CLANG_C" || missing+=("$CLANG_C (Clang C compiler)")
+is_clang "$CLANG_CXX" || missing+=("$CLANG_CXX (Clang C++ compiler)")
 if [ "$WANT_EMBED" = 1 ] || [ "$WANT_CORPUS" = 1 ] ||
    [ "$WANT_CONFORMANCE" = 1 ]; then
   have opam || missing+=(opam)
@@ -83,7 +104,11 @@ if [ ${#missing[@]} -gt 0 ]; then
     exit 1
   fi
 fi
-echo "ok: git curl cmake python3 and a C++ compiler present"
+if ! is_clang "$CLANG_C" || ! is_clang "$CLANG_CXX"; then
+  echo "clang and clang++ are required for stanli C/C++ builds" >&2
+  exit 1
+fi
+echo "ok: git curl cmake python3 and Clang C/C++ compilers present"
 
 # --- vendored headers -------------------------------------------------------
 step "fetching pinned deps (Stan Math and Stan)"
@@ -143,9 +168,11 @@ if [ "$WANT_BUILD" = 1 ]; then
     echo "ignoring embedded object with absent or mismatched provenance" >&2
   fi
   cmake -B build -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+    -DCMAKE_C_COMPILER="$CLANG_C" -DCMAKE_CXX_COMPILER="$CLANG_CXX" \
     ${EMBED_FLAGS[@]+"${EMBED_FLAGS[@]}"}
   cmake --build build --parallel "$BUILD_JOBS"
-  cmake -B build-rel -DCMAKE_BUILD_TYPE=Release
+  cmake -B build-rel -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_C_COMPILER="$CLANG_C" -DCMAKE_CXX_COMPILER="$CLANG_CXX"
   cmake --build build-rel --parallel "$BUILD_JOBS" \
     --target bench_grad stanli_run
 


### PR DESCRIPTION
## Summary

- build the representative manylinux pull-request runtime with Clang at Release `-O3`
- compile native test translation units at `-O0` and reuse one shared Stan Math PCH
- retain GCC for shipped manylinux and Windows UCRT64 wheels
- keep AppleClang for macOS and Clang for ASan and nightly conformance
- retain the existing GNU runtime libraries and auxiliary MinGW, OCaml, and Emscripten machinery
- use the prebuilt manylinux image and cached Windows compilers now present on `main`

## Why

#254 showed that the useful `-O0` test configuration was blocked by GCC code generation: GCC emitted an unused TBB `task_arena_base::internal_current_slot()` reference at `-O0`, while Clang did not emit it at either `-O0` or `-O3`. The runtime is compiled once as optimized `stanli_runtime_objects`, so target-local `-O0` flags affect only test scaffolding. The shared PCH avoids paying the Stan Math parse cost independently for every test executable.

This is a pull-request latency policy, not a GNU purge or a change to the shipped Linux runtime compiler. Linux Clang still links the manylinux GNU runtime libraries. Windows stays on MSYS2 UCRT64 GCC after the Clang frontend exposed MinGW GNU-ld COMDAT multiple-definition failures when linking mixed optimization levels.

## Runtime performance boundary

A one-off same-platform GitHub A/B compared GCC 14.2.1 and Clang 21.1.8 optimized runtimes. Across seven corpus benchmarks the geometric-mean Clang/GCC gradient-time ratio was 1.025, with six models between 0.931 and 1.057 but `normal_mixture` at 1.17-1.18. Therefore shipped manylinux wheels remain on GCC; this PR gets the Clang `-O0`/PCH test-latency benefit without changing shipped runtime performance.

## Final evidence

- local AppleClang Release build: 67/67 tests pass; runtime objects use `-O3`, test/PCH objects use `-O0`
- warm PR manylinux job: 7m02s end to end; configure/build 3m06s; 90.4% ccache hits
- the comparable #254 PR job took 13m09s, including a 7m22s configure/build with 60.3% cache hits
- PR Clang validation: 67/67 native tests; 130/130 corpus models at all three points, 803,962 values; parallel-chain bitwise test passes; vectorization A/B reports zero semantic failures
- full production-toolchain run: all jobs green on manylinux GCC, AppleClang, Windows UCRT64 GCC, wasm/webR, Python wheels, and R integration
- warm shipped manylinux x86_64 build identifies GNU 14.2.1, compiles with zero misses and 100% ccache hits, and passes the same 67 tests and corpus oracle
- Windows identifies GNU 16.1.0 and passes 66/66 native tests plus wheel installation tests
- ASan identifies Clang 18.1.3 and passes 67/67 tests; its first corrected-cache population peaked at 8.94 GB

The final manually dispatched full run is https://github.com/seantalts/stanli/actions/runs/33268791986 and the final PR run is https://github.com/seantalts/stanli/actions/runs/33268787711.
