### PR TITLE
Cache reference BridgeStan sources and per-model compiles in CI

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -621,10 +621,96 @@ jobs:
       # it looks for are in stanli's semantics, which do not vary by
       # platform; the numeric agreement that does vary is already covered
       # per-platform by the corpus oracle.
-      - name: Conformance against reference BridgeStan
+      #
+      # bridgestan is intentionally unpinned here (see below), so the two
+      # cache steps that follow key on the RESOLVED version captured by
+      # this step's output, never on a version string written in this
+      # file -- a hardcoded key would silently keep serving a stale cache
+      # after PyPI resolves a new bridgestan release.
+      - name: Install reference BridgeStan
+        id: bs-pkg
         if: matrix.plat == 'manylinux_2_28_x86_64'
         run: |
           /tmp/wheeltest/bin/pip install bridgestan
+          version=$(/tmp/wheeltest/bin/python \
+            -c 'import bridgestan; print(bridgestan.__version__)')
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      # bridgestan.download.get_bridgestan_src() always unpacks to
+      # ~/.bridgestan/bridgestan-<version> -- it ignores $BRIDGESTAN,
+      # which only steers where the *compiler* looks, not the download --
+      # so that is what gets cached. The directory holds the vendored
+      # stan-math source tree and, after the first model compile below,
+      # BridgeStan's own bridge objects and its built TBB/sundials
+      # libraries: infrastructure shared by all four models and rebuilt
+      # from scratch every run today. Keyed on the resolved version only
+      # -- this is BridgeStan's OWN vendored stan-math (a released
+      # tarball, pinned by BridgeStan, not by this repo), so it must never
+      # key on deps/math: the two stan-maths are unrelated checkouts, and
+      # a deps/math bump here would just evict a cache entry that was
+      # never invalidated in the first place.
+      - name: Restore BridgeStan sources and shared build objects
+        if: matrix.plat == 'manylinux_2_28_x86_64'
+        uses: actions/cache@v4
+        with:
+          path: ~/.bridgestan
+          key: >-
+            bridgestan-src-${{ runner.os }}-${{ steps.bs-pkg.outputs.version }}
+
+      # The per-model outputs of BridgeStan's own Makefile: the stanc-
+      # generated .hpp, the compiled .o, and the linked _model.so, all
+      # written next to the .stan file (see
+      # bridgestan.compile.generate_so_name). All three are gitignored
+      # (tests/fixtures/*.hpp, *.o, *_model.so) and all three need to
+      # land together, or `make` finds a prerequisite missing and rebuilds
+      # it -- and whatever depends on it -- right along with it. Keyed on
+      # the four fixtures' own contents plus the resolved version and
+      # platform; deps/math never enters this compile either, for the
+      # same reason as the cache above.
+      - name: Restore compiled BridgeStan conformance models
+        id: bs-models
+        if: matrix.plat == 'manylinux_2_28_x86_64'
+        uses: actions/cache@v4
+        with:
+          path: |
+            tests/fixtures/es.hpp
+            tests/fixtures/es.o
+            tests/fixtures/es_model.so
+            tests/fixtures/simp.hpp
+            tests/fixtures/simp.o
+            tests/fixtures/simp_model.so
+            tests/fixtures/newtrans.hpp
+            tests/fixtures/newtrans.o
+            tests/fixtures/newtrans_model.so
+            tests/fixtures/conj.hpp
+            tests/fixtures/conj.o
+            tests/fixtures/conj_model.so
+          key: >-
+            bridgestan-models-${{ matrix.plat }}-${{ steps.bs-pkg.outputs.version }}-${{ hashFiles('tests/fixtures/es.stan', 'tests/fixtures/simp.stan', 'tests/fixtures/newtrans.stan', 'tests/fixtures/conj.stan') }}
+
+      # actions/cache extracts with the mtimes the archive was saved with,
+      # not the extraction time -- so a restored .hpp/.o/.so trio carries
+      # LAST run's timestamps, while checkout just gave the .stan files
+      # THIS run's. Left alone, make sees the source as newer than
+      # everything downstream of it and rebuilds the whole per-model
+      # chain anyway: a cache that "hits" in the log and saves nothing,
+      # which is exactly the failure mode that looks identical to success
+      # on a single run. Touch the restored trio forward, oldest
+      # dependency first, only on an exact hit -- a bare touch on a miss
+      # would create empty files in place of the real build inputs.
+      - name: Advance restored model timestamps past their sources
+        if: matrix.plat == 'manylinux_2_28_x86_64' && steps.bs-models.outputs.cache-hit == 'true'
+        run: |
+          touch tests/fixtures/es.hpp tests/fixtures/simp.hpp \
+            tests/fixtures/newtrans.hpp tests/fixtures/conj.hpp
+          touch tests/fixtures/es.o tests/fixtures/simp.o \
+            tests/fixtures/newtrans.o tests/fixtures/conj.o
+          touch tests/fixtures/es_model.so tests/fixtures/simp_model.so \
+            tests/fixtures/newtrans_model.so tests/fixtures/conj_model.so
+
+      - name: Conformance against reference BridgeStan
+        if: matrix.plat == 'manylinux_2_28_x86_64'
+        run: |
           # bridgestan downloads its own C++ sources from github the first
           # time a model is compiled, inside the first conformance run. A
           # 503 from that download surfaces as a conformance failure, which
@@ -634,10 +720,23 @@ jobs:
           # real outage says so in its own words. bridgestan retries the
           # download itself, but only a URLError: it calls every HTTPError
           # unrecoverable, and a 503 is an HTTPError.
+          #
+          # get_bridgestan_src() re-downloads and re-extracts unconditionally
+          # -- it has no idea the cache step above may have just restored
+          # the exact same tree -- so verify what it would unpack first,
+          # the same way bridgestan's own compile_model() does, and only
+          # call it when that verification fails. The retry loop still
+          # wraps the real download: a cache miss (a bridgestan release, a
+          # first run, a cold cache scope) still takes that path.
           for try in 1 2 3 4 5; do
-            /tmp/wheeltest/bin/python \
-              -c 'import bridgestan.download as d; d.get_bridgestan_src()' &&
-              break
+            /tmp/wheeltest/bin/python <<'PY' && break
+          import bridgestan.compile as c
+          import bridgestan.download as d
+          try:
+              c.verify_bridgestan_path(str(d.CURRENT_BRIDGESTAN))
+          except ValueError:
+              d.get_bridgestan_src()
+          PY
             echo "bridgestan source download failed (attempt $try of 5)"
             [ "$try" = 5 ] && exit 1
             sleep $((try * 20))

--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,7 @@ __pycache__/
 *.py[cod]
 tests/fixtures/*_model.so
 tests/fixtures/*.hpp
+tests/fixtures/*.o
 conformance-cache/
 
 # harnesses/model_census.py run artifacts: the invented data and CmdStan


### PR DESCRIPTION
## The measured problem

The "Conformance against reference BridgeStan" step (`.github/workflows/wheels.yml`, gated to `manylinux_2_28_x86_64`) took 128-161s on **every** run, measured from run 33254943950:

| Step | Time |
|---|---|
| `pip install bridgestan` | 1 s |
| `es.stan` (includes the one-time source download) | 88 s |
| `simp.stan` | 14 s |
| `newtrans.stan` | 26 s |
| `conj.stan` | 13 s |

`tools/bs_conformance.py` calls `bridgestan.StanModel.from_stan_file(...)`, which shells out to BridgeStan's own `make` to transpile each `.stan` fixture to C++ and compile it against BridgeStan's own vendored stan-math into a `.so`. The four fixtures are tiny (9-39 lines); essentially all of the ~80s of `make` time and ~60s of the ~88s on `es.stan` is stan-math source download + compilation, none of it cached.

## What this PR does (CI latency only, no runtime/C++ behaviour change)

1. **Caches the downloaded BridgeStan source tree** (`~/.bridgestan`, where `bridgestan.download.get_bridgestan_src()` always unpacks regardless of `$BRIDGESTAN`), keyed on the *resolved* bridgestan version. This also accumulates BridgeStan's own bridge/TBB/sundials build objects, shared across all four models, after the first compile.
2. **Caches the compiled per-model outputs** (`tests/fixtures/{es,simp,newtrans,conj}.{hpp,o,so}`, where BridgeStan's Makefile writes them next to each `.stan` file), keyed on the resolved version, platform, and a hash of the four fixtures.
3. Keeps the existing 5-attempt retry loop around the source download (a 503 from the mirror once surfaced as a spurious conformance failure and turned `main` red), but first verifies the unpacked tree the same way `bridgestan.compile.compile_model()` does, and skips the download outright on a hit.
4. Adds a step that advances the restored `.hpp/.o/.so` mtimes forward (oldest dependency first) on an exact cache hit, since `actions/cache` restores files with the mtimes they were saved with, while `git checkout` gives the `.stan` fixtures today's mtime — left alone, `make` would see the freshly checked-out source as newer than the cached outputs and rebuild the whole chain anyway, silently defeating the cache.
5. Adds `tests/fixtures/*.o` to `.gitignore` — BridgeStan already produced this file every run, it just was never persisted before.

**Neither cache key includes `deps/math`'s SHA.** BridgeStan compiles against its own vendored stan-math (bundled inside its release tarball), never this repo's `deps/math` checkout — verified directly against the BridgeStan release tarball's `stan/lib/stan_math` and its Makefile's `MATH ?= $(STAN)lib/stan_math/`.

**Note:** `pip install bridgestan` is intentionally left unpinned (pre-existing behavior). That means the reference implementation's version can drift between runs — a pre-existing oracle-drift concern this PR does not attempt to fix. The cache keys are built from the *resolved* version captured at runtime (`bridgestan.__version__`), not a hardcoded string, so a version bump correctly misses cache rather than serving a stale reference.

## Verification

A cache change can't be validated from a single run — a cache that looks configured but never actually hits reads identical to success on run 1. This PR was verified with two runs of the same commit (first populates the cache, second should hit it); see the follow-up comment on this PR for the measured before/after durations and the "Cache restored from key: ..." confirmation from the logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)