### PR TITLE
Cache cross-built Windows compilers

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -829,16 +829,42 @@ jobs:
       github.event_name != 'pull_request' ||
       needs.changes.outputs.heavy == 'true'
     runs-on: ubuntu-24.04
+    env:
+      WINDOWS_DUNE_VERSION: 3.24.2
     steps:
       - uses: actions/checkout@v4
 
+      - name: Check the Windows compiler source pin
+        run: |
+          setup_repo=$(sed -n 's/^STANC3_SRC_REPO=\([^ ]*\).*/\1/p' \
+                         tools/dev_setup.sh)
+          setup_pin=$(sed -n 's/^STANC3_SRC_SHA=\([0-9a-f]*\).*/\1/p' \
+                        tools/dev_setup.sh)
+          test "$setup_repo" = "$STANC3_SRC_REPO"
+          test "$setup_pin" = "$STANC3_SRC_SHA"
+
+      # On a warm setup-ocaml cache this job still spent 73 seconds in setup
+      # and 187 seconds cloning, installing 68 cross packages, and building.
+      # Cache the complete 20 MB product instead. The key deliberately covers
+      # every local input checked by the provenance stamp; the version prefix
+      # owns the fixed Windows target, Dune context, profile, and subst recipe.
+      - name: Restore the cross-built Windows compilers
+        id: windows-compilers-cache
+        uses: actions/cache@v4
+        with:
+          path: windows-compilers/
+          key: >-
+            windows-compilers-v1-${{ env.STANC3_SRC_REPO }}-${{ env.STANC3_SRC_SHA }}-ocaml${{ env.OCAML_VERSION }}-dune${{ env.WINDOWS_DUNE_VERSION }}-${{ hashFiles('.gitattributes', 'compiler/ocaml/**', 'compiler/js/**', 'tools/stanc_embed/**') }}
+
       - name: Cross-compiler
+        if: steps.windows-compilers-cache.outputs.cache-hit != 'true'
         run: |
           sudo apt-get update
           sudo apt-get install -y file gcc-mingw-w64-x86-64 \
             gcc-mingw-w64-i686
 
       - name: OCaml ${{ env.OCAML_VERSION }} for Windows
+        if: steps.windows-compilers-cache.outputs.cache-hit != 'true'
         uses: ocaml/setup-ocaml@v3
         with:
           cache-prefix: stanli-windows-${{ env.STANC3_SRC_SHA }}
@@ -848,14 +874,13 @@ jobs:
             windows: http://github.com/ocaml-cross/opam-cross-windows.git
             default: https://github.com/ocaml/opam-repository.git
 
+      - name: Dune ${{ env.WINDOWS_DUNE_VERSION }}
+        if: steps.windows-compilers-cache.outputs.cache-hit != 'true'
+        run: opam install -y "dune.$WINDOWS_DUNE_VERSION"
+
       - name: Build the pinned compilers
+        if: steps.windows-compilers-cache.outputs.cache-hit != 'true'
         run: |
-          setup_repo=$(sed -n 's/^STANC3_SRC_REPO=\([^ ]*\).*/\1/p' \
-                         tools/dev_setup.sh)
-          setup_pin=$(sed -n 's/^STANC3_SRC_SHA=\([0-9a-f]*\).*/\1/p' \
-                        tools/dev_setup.sh)
-          test "$setup_repo" = "$STANC3_SRC_REPO"
-          test "$setup_pin" = "$STANC3_SRC_SHA"
           bash tests/test_windows_provenance.sh
           git clone "$STANC3_SRC_REPO" deps/stanc3-src
           git -C deps/stanc3-src checkout -q --detach "$STANC3_SRC_SHA"
@@ -887,17 +912,33 @@ jobs:
           stanli_windows_cli_expected_stamp \
             "$STANC3_SRC_REPO" "$STANC3_SRC_SHA" \
             > windows-compilers/stanli-compile.stamp
+
+      # Validate a restored product just as strictly as a newly built one.
+      # On a cache hit there is no opam switch, so the helper checks every
+      # source-derived field plus the configured OCaml version and target.
+      - name: Validate the cross-built Windows compilers
+        run: |
+          test "$(cat windows-compilers/stanc.src)" = "$STANC3_SRC_SHA"
+          source tools/stanc_embed/provenance.sh
           stanli_windows_cli_artifact_matches \
             windows-compilers/stanli-compile \
             "$STANC3_SRC_REPO" "$STANC3_SRC_SHA"
+          test "$(_stanc_embed_stamp_value \
+            windows-compilers/stanli-compile.stamp dune_version)" = \
+            "$WINDOWS_DUNE_VERSION"
           compiler_types=$(file \
             windows-compilers/stanc windows-compilers/stanli-compile)
           printf '%s\n' "$compiler_types"
           test "$(printf '%s\n' "$compiler_types" | \
             grep -c 'PE32+ executable.*x86-64')" -eq 2
-          x86_64-w64-mingw32-objdump -f \
-            windows-compilers/stanli-compile | \
-            grep -F 'file format pei-x86-64'
+          if command -v x86_64-w64-mingw32-objdump >/dev/null 2>&1; then
+            x86_64-w64-mingw32-objdump -f \
+              windows-compilers/stanli-compile | \
+              grep -E 'file format (pei|coff)-x86-64'
+          else
+            objdump -f windows-compilers/stanli-compile | \
+              grep -E 'file format (pei|coff)-x86-64'
+          fi
 
       - uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
## Summary

- cache the complete cross-built Windows compiler products under all source and toolchain provenance inputs
- skip MinGW, OCaml, and compiler builds on an exact cache hit
- validate cached and fresh products identically before uploading the run artifact
- pin and verify Dune 3.24.2 so its recorded provenance cannot drift outside the cache key

## Motivation

On successful main run 33264744926, `cross-build Windows compilers` took 5:00 even with warm setup-ocaml caches:

- `Cross-compiler`: 0:19
- `OCaml 5.5.0 for Windows`: 1:13
- `Build the pinned compilers`: 3:07
- artifact upload: 0:11

The restored Dune cache was only 424 bytes. The stanc3 installation script then installed 68 cross packages from scratch, accounting for most of the build step. The finished compiler directory is only 20 MB (6.7 MB in the Actions cache), making the complete output a much better cache boundary.

The cache key includes the stanc3 repository and SHA, OCaml and Dune versions, `.gitattributes`, and all files under `compiler/ocaml`, `compiler/js`, and `tools/stanc_embed`. Its version prefix owns the fixed Windows target, Dune context/profile, and `dune subst` recipe. The producer validates the restored provenance, PE architecture, source SHA, and pinned Dune version before uploading anything.

No cache-hit `touch` is needed: these executables are copied into a workflow artifact and later into the wheel; Make never consumes them as timestamped prerequisites.

## Measured result

Run [33266994967](https://github.com/seantalts/stanli/actions/runs/33266994967) used the identical commit `724937834d34ccc12955861c8d7885515f53d78b` for both attempts. Attempt 2 was started with `gh run rerun 33266994967`.

| Step | Populate | Exact rerun |
| --- | ---: | ---: |
| Entire cross-build job | 4:51 | 0:11 |
| Output-cache restore | 0:01 miss | 0:02 hit |
| MinGW install | 0:21 | skipped |
| OCaml setup | 1:12 | skipped |
| Dune pin | 0:01 | skipped |
| Build compilers | 3:02 | skipped |
| Validate products | 0:02 | <0:01 |
| Upload artifact | 0:02 | 0:02 |

The job improved by 4:40 (96%). Attempt 1 logged the cold miss and `Cache saved with key: windows-compilers-v1-…`; attempt 2 logged `Cache restored from key: windows-compilers-v1-…`. The restored products passed the provenance and PE checks and uploaded successfully.

## Dependency policy

This deliberately keeps `win_amd64` behind `Windows compiler parity`. Removing that edge would save the parity duration on green push/scheduled runs (about 0:54 in the supplied typical timing, 2:02 in the latest main run), but would spend the entire `win_amd64` job after a parity failure (about 2:54 on a warm run, and 20:55 in the latest changed-source main run). The current dependency encodes a reasonable fail-fast policy, so this PR does not change it.

## Verification

- [x] `bash tests/test_windows_provenance.sh`
- [x] workflow YAML parses locally
- [x] first GitHub run populated the output cache and passed all jobs
- [x] exact `gh run rerun` restored the key and cut the cross-build job to 11 seconds
