### PR TITLE
Prebuild manylinux packages off the wheel path

### DIFF
--- a/.github/manylinux/Dockerfile
+++ b/.github/manylinux/Dockerfile
@@ -1,0 +1,20 @@
+# Keep the architecture in the build workflow: PyPA publishes separate
+# architecture-qualified images rather than one multi-architecture tag.
+ARG MANYLINUX_IMAGE=quay.io/pypa/manylinux_2_28_x86_64
+FROM ${MANYLINUX_IMAGE}
+
+# This label links the GHCR package to the repository before its first push,
+# which gives this repository's GITHUB_TOKEN pull access to the private image.
+LABEL org.opencontainers.image.source="https://github.com/seantalts/stanli"
+
+# These are build inputs, not workflow setup: putting them in one immutable
+# image removes two repository-metadata refreshes from every wheel build.
+RUN dnf install -y epel-release \
+    && dnf install -y \
+        unzip which diffutils patch rsync glibc-static ccache time \
+    && dnf clean all \
+    && rm -rf /var/cache/dnf
+
+# The upstream manylinux image deliberately keeps its interpreters out of
+# PATH. The wheel build uses 3.12 explicitly on every manylinux architecture.
+ENV PATH="/opt/python/cp312-cp312/bin:${PATH}"

--- a/.github/workflows/manylinux-images.yml
+++ b/.github/workflows/manylinux-images.yml
@@ -1,0 +1,83 @@
+# Publish the official PyPA manylinux environment with stanli's fixed build
+# packages already installed. Wheel jobs used to spend 26--37 seconds in dnf
+# on every run, in addition to the 30--41-second container initialization.
+name: manylinux build images
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - .github/manylinux/**
+      - .github/workflows/manylinux-images.yml
+  schedule:
+    # Refresh the mutable upstream image and RPMs monthly. This work is off the
+    # wheel critical path; package-list changes rebuild immediately on main.
+    - cron: '30 7 1 * *'
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: manylinux-build-images
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: publish (${{ matrix.tag }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-24.04
+            platform: linux/amd64
+            base: quay.io/pypa/manylinux_2_28_x86_64
+            tag: 2_28-x86_64
+          - os: ubuntu-24.04-arm
+            platform: linux/arm64
+            base: quay.io/pypa/manylinux_2_28_aarch64
+            tag: 2_28-aarch64
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: docker/setup-buildx-action@v4
+
+      # Native runners avoid QEMU and preserve the architecture-specific PyPA
+      # base exactly. pull/no-cache makes a scheduled run consume a new base
+      # digest and current RPMs even though the Dockerfile did not change.
+      - name: Build and publish
+        uses: docker/build-push-action@v7
+        with:
+          context: .github/manylinux
+          file: .github/manylinux/Dockerfile
+          build-args: MANYLINUX_IMAGE=${{ matrix.base }}
+          platforms: ${{ matrix.platform }}
+          pull: true
+          no-cache: true
+          push: true
+          tags: ghcr.io/seantalts/stanli-manylinux:${{ matrix.tag }}
+          labels: |
+            org.opencontainers.image.source=https://github.com/seantalts/stanli
+            org.opencontainers.image.description=PyPA manylinux_2_28 with stanli build packages
+
+      # Pull the registry copy rather than trusting BuildKit's local layers.
+      # This proves both that the job token can read the package and that the
+      # image exposes every tool the wheel job previously installed at runtime.
+      - name: Verify the published image
+        run: |
+          image=ghcr.io/seantalts/stanli-manylinux:${{ matrix.tag }}
+          docker run --rm "$image" sh -euc '
+            rpm -q unzip which diffutils patch rsync glibc-static ccache time
+            command -v ccache
+            command -v rsync
+            command -v python3
+            python3 -c "import sys; assert sys.version_info[:2] == (3, 12)"
+          '

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -35,6 +35,7 @@ on:
 
 permissions:
   contents: read
+  packages: read
 
 # One run per branch. Pushing twice to a pull request used to leave both
 # runs alive, competing for the same macOS runners, so the run that
@@ -146,7 +147,11 @@ jobs:
       github.event_name != 'pull_request' ||
       needs.changes.outputs.heavy == 'true'
     runs-on: ${{ matrix.os }}
-    container: ${{ matrix.container }}
+    container:
+      image: ${{ matrix.container }}
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
     env:
       # CMake reads this, so the library's minimum OS matches the version
       # the wheel tag promises. Without it the runner's own OS version
@@ -166,8 +171,8 @@ jobs:
       matrix:
         include: >-
           ${{ fromJSON(github.event_name == 'pull_request'
-              && '[{"os":"ubuntu-24.04","plat":"manylinux_2_28_x86_64","container":"quay.io/pypa/manylinux_2_28_x86_64","opam_arch":"x86_64-linux","build_jobs":2,"runtime":"linux-x86_64"}]'
-              || '[{"os":"macos-15","plat":"macosx_11_0_arm64","macos_target":"11.0","opam_arch":"arm64-macos","build_jobs":4,"runtime":"darwin-arm64"},{"os":"macos-15-intel","plat":"macosx_10_15_x86_64","macos_target":"10.15","opam_arch":"x86_64-macos","build_jobs":4,"runtime":"darwin-x86_64"},{"os":"ubuntu-24.04","plat":"manylinux_2_28_x86_64","container":"quay.io/pypa/manylinux_2_28_x86_64","opam_arch":"x86_64-linux","build_jobs":2,"runtime":"linux-x86_64"},{"os":"ubuntu-24.04-arm","plat":"manylinux_2_28_aarch64","container":"quay.io/pypa/manylinux_2_28_aarch64","opam_arch":"arm64-linux","build_jobs":2,"runtime":"linux-arm64"}]') }}
+              && '[{"os":"ubuntu-24.04","plat":"manylinux_2_28_x86_64","container":"ghcr.io/seantalts/stanli-manylinux:2_28-x86_64","opam_arch":"x86_64-linux","build_jobs":2,"runtime":"linux-x86_64"}]'
+              || '[{"os":"macos-15","plat":"macosx_11_0_arm64","macos_target":"11.0","opam_arch":"arm64-macos","build_jobs":4,"runtime":"darwin-arm64"},{"os":"macos-15-intel","plat":"macosx_10_15_x86_64","macos_target":"10.15","opam_arch":"x86_64-macos","build_jobs":4,"runtime":"darwin-x86_64"},{"os":"ubuntu-24.04","plat":"manylinux_2_28_x86_64","container":"ghcr.io/seantalts/stanli-manylinux:2_28-x86_64","opam_arch":"x86_64-linux","build_jobs":2,"runtime":"linux-x86_64"},{"os":"ubuntu-24.04-arm","plat":"manylinux_2_28_aarch64","container":"ghcr.io/seantalts/stanli-manylinux:2_28-aarch64","opam_arch":"arm64-linux","build_jobs":2,"runtime":"linux-arm64"}]') }}
     steps:
       - uses: actions/checkout@v4
 
@@ -193,17 +198,6 @@ jobs:
           key: >-
             ccache-${{ matrix.plat }}-release-v4-${{ steps.toolchain.outputs.id }}-${{ hashFiles('CMakeLists.txt', 'runtime/**', 'tests/**/*.cpp', 'tests/**/*.hpp', 'tools/**/*.cpp', 'tools/**/*.hpp', 'deps/fetch.sh') }}
           restore-keys: ccache-${{ matrix.plat }}-release-v4-${{ steps.toolchain.outputs.id }}-
-
-      - name: System packages (manylinux)
-        if: matrix.container != ''
-        run: |
-          # OCaml's complete-object mode uses `ld -r`, which resolves its C
-          # runtime dependencies from static archives during the partial link.
-          dnf install -y unzip which diffutils patch rsync glibc-static
-          dnf install -y epel-release && dnf install -y ccache time
-          # The manylinux image keeps its interpreters out of PATH; pick one
-          # explicitly rather than inheriting AlmaLinux's system python3.
-          echo /opt/python/cp312-cp312/bin >> "$GITHUB_PATH"
 
       - name: System packages (macOS)
         if: matrix.container == ''


### PR DESCRIPTION
## Summary

- derive native x86_64 and aarch64 images from the official PyPA manylinux_2_28 bases
- publish them to GHCR monthly and whenever the image definition changes on main
- authenticate wheel-job pulls with the repository token, so package visibility is not a bootstrap dependency
- remove the per-run dnf step while retaining its complete package set and Python 3.12 PATH

## Measurements

Three recent successful PR builds spent 31--40 seconds initializing the official container and another 30--37 seconds in `System packages (manylinux)`, for 64, 70, and 70 seconds combined. A representative log shows about 25 seconds refreshing BaseOS/AppStream/PowerTools/EPEL metadata; the RPM payload was only 2.9 MB. The official base already contains epel-release, unzip, which, diffutils, and patch.

The bootstrap image run completed and smoke-tested the registry copies on both native architectures. Fresh image pulls took 29.7 seconds on x86_64 and 27.7 seconds on aarch64 in that run, before the package assertions.

The PR run and its identical targeted rerun measured `Initialize containers` at 42 and 41 seconds. `System packages (manylinux)` is gone, so the setup path is now 41--42 seconds versus the recent 64--70 seconds: a measured 22--29-second reduction. The larger image does add 1--11 seconds to initialization, but it removes the 30--37-second network-dependent package step.

## Verification

- `actionlint .github/workflows/*.yml`
- image build and registry smoke test: https://github.com/seantalts/stanli/actions/runs/33266866168
- full green PR workflow plus an identical targeted rerun: https://github.com/seantalts/stanli/actions/runs/33267001819
- verified unzip, which, diffutils, patch, rsync, glibc-static, ccache, GNU time, and Python 3.12 in both published images
- the x86_64 derived image passed the full wheel build, test suite, glibc 2.28 audit, Python package tests, corpus oracle, BridgeStan conformance, and R-package chain

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>