### PR TITLE
Path-gate the bounded MIR vectorization A/B check

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -72,6 +72,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       heavy: ${{ steps.scope.outputs.heavy }}
+      vectorize: ${{ steps.scope.outputs.vectorize }}
     steps:
       - uses: actions/checkout@v4
       - name: Select the validation scope
@@ -81,12 +82,14 @@ jobs:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
         run: |
           heavy=true
+          vectorize=true
           if [ "$GITHUB_EVENT_NAME" = pull_request ]; then
             git fetch --no-tags --depth=1 origin "$BASE_SHA"
             changed_files="$RUNNER_TEMP/stanli-changed-files"
             git diff --no-renames --name-only "$BASE_SHA" HEAD \
               > "$changed_files"
             heavy=false
+            vectorize=false
             while IFS= read -r path; do
               case "$path" in
                 README.md|TESTING.md|CHANGELOG.md|THIRD_PARTY_LICENSES.md|LICENSE|docs/*.md|web/index.html)
@@ -95,9 +98,18 @@ jobs:
                   heavy=true
                   ;;
               esac
+              # Gate the MIR vectorization A/B check on compiler/runtime/harness changes.
+              # It must run whenever anything that could affect lowering or the MIR
+              # output might have changed, to catch silent semantic drift.
+              case "$path" in
+                compiler/**|runtime/**|harnesses/vectorize_ab.py|tools/stanc_embed/**|tools/dev_setup.sh|CMakeLists.txt|deps/fetch.sh|.github/workflows/wheels.yml)
+                  vectorize=true
+                  ;;
+              esac
             done < "$changed_files"
           fi
           echo "heavy=$heavy" | tee -a "$GITHUB_OUTPUT"
+          echo "vectorize=$vectorize" | tee -a "$GITHUB_OUTPUT"
 
   # This is intentionally independent of the compiled runtime. In particular,
   # generated prose and the web index should not need a 30-minute C++ build to
@@ -451,8 +463,16 @@ jobs:
       # saved portable MIR directly so every point reuses the exact bytes.
       # Semantic/reference parity gates the job; graph sizes, re-roll
       # dispositions, and preparation timings are published as measurements.
+      #
+      # Gated on compiler/runtime/harness changes to avoid 79s overhead on every
+      # PR, especially docs-only ones. The check catches silent semantic drift
+      # from lowering and source-pass changes, so it must run on anything that
+      # could alter MIR or the compiled output; see changes.vectorize for paths.
       - name: Bounded MIR vectorization A/B
-        if: matrix.runtime == 'linux-x86_64'
+        if: >-
+          matrix.runtime == 'linux-x86_64' &&
+          (github.event_name != 'pull_request' ||
+           needs.changes.outputs.vectorize == 'true')
         timeout-minutes: 15
         shell: bash
         run: |


### PR DESCRIPTION
## What

The "Bounded MIR vectorization A/B" step runs `harnesses/vectorize_ab.py` over 7 posteriordb models and costs **78 s on every pull request**, including ones that touch no compiler code. It sits inside `build (manylinux_2_28_x86_64)`, which is the PR critical path, so that is 78 s of wall clock a developer waits for.

This gates it on a path filter, reusing the `scope` step in the existing `changes` job that already produces a `heavy` output — same mechanism, one more output.

## Trigger paths

The check exists to catch a source-pass or lowering change silently altering results, so the gate errs toward running:

- `compiler/**` — source passes and the OCaml pipeline
- `runtime/**` — the lowering target
- `harnesses/vectorize_ab.py` — the harness itself
- `tools/stanc_embed/**` — embedded compiler infrastructure
- `tools/dev_setup.sh` — pins `STANC3_SRC_SHA`
- `CMakeLists.txt` — carries `-ffp-contract=off` and the density tiers, either of which moves numerics
- `deps/fetch.sh` — pins stan-math and stan
- `.github/workflows/wheels.yml` — the invocation itself

It also runs unconditionally on every non-`pull_request` event (push, schedule, tag), and `vectorize` defaults to `true` so a failure to compute the diff fails open.

## Not in this PR

An earlier revision also tried to parallelize the `R package against the runtime` job, which adds ~120 s serialized after `build`. That has been dropped: the approach did not work and there is no cheap version.

Measured, that job is `setup-r` 40 s + `setup-r-dependencies` 38 s + `Build and check` 18 s. Splitting the setup into a parallel job and shipping it as an artifact fails outright — `setup-r` installs the R *interpreter*, so the consuming job has no `R` on PATH (`R: command not found`). And enabling dependency caching is a no-op: `setup-r-dependencies` already caches and already hits. What remains is apt system-requirement installation and the R install itself, so the only real fix is a prebuilt image with R baked in — the same approach #263 used for manylinux. Worth doing as its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)