### PR TITLE
Persist the emsdk download between runs

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -1476,8 +1476,24 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      # setup-emsdk re-downloads the whole SDK on every run (measured 39-40 s
+      # in both Emscripten jobs). Its actions-cache-folder input only chooses
+      # WHERE the download lands -- nothing persists that folder on its own,
+      # so the action logged "No cached files found at path .../emsdk-cache"
+      # every time. This is the step that makes the input mean something.
+      #
+      # Worth knowing for anyone touching the ccache below: this also has the
+      # side effect of pinning WHERE emsdk is unpacked. Without it the SDK
+      # lands in $RUNNER_TEMP/<uuid>/emsdk-main, a fresh uuid per run, and
+      # emcc bakes that path into the -isystem flags of every compile.
+      - name: Cache the emsdk download
+        uses: actions/cache@v4
+        with:
+          path: emsdk-cache
+          key: emsdk-${{ runner.os }}-${{ runner.arch }}-6.0.6-v1
       - uses: mymindstorm/setup-emsdk@v14
         with:
+          actions-cache-folder: emsdk-cache
           version: 6.0.6
       - name: Fingerprint the Emscripten compiler
         id: toolchain
@@ -1542,8 +1558,24 @@ jobs:
         with:
           name: browser-compilers
           path: browser-compilers
+      # setup-emsdk re-downloads the whole SDK on every run (measured 39-40 s
+      # in both Emscripten jobs). Its actions-cache-folder input only chooses
+      # WHERE the download lands -- nothing persists that folder on its own,
+      # so the action logged "No cached files found at path .../emsdk-cache"
+      # every time. This is the step that makes the input mean something.
+      #
+      # Worth knowing for anyone touching the ccache below: this also has the
+      # side effect of pinning WHERE emsdk is unpacked. Without it the SDK
+      # lands in $RUNNER_TEMP/<uuid>/emsdk-main, a fresh uuid per run, and
+      # emcc bakes that path into the -isystem flags of every compile.
+      - name: Cache the emsdk download
+        uses: actions/cache@v4
+        with:
+          path: emsdk-cache
+          key: emsdk-${{ runner.os }}-${{ runner.arch }}-4.0.8-v1
       - uses: mymindstorm/setup-emsdk@v14
         with:
+          actions-cache-folder: emsdk-cache
           version: 4.0.8
       - name: Fingerprint the Emscripten compiler
         id: toolchain


### PR DESCRIPTION
## What

Both Emscripten jobs re-download the whole SDK every run — **39–40 s** in `Run mymindstorm/setup-emsdk@v14`, on every push, PR and schedule.

`setup-emsdk` has an `actions-cache-folder` input, but it only chooses *where* the download lands. Nothing persists that folder on its own, so the action logged `No cached files found at path .../emsdk-cache` every run and re-downloaded anyway. Wrapping it in `actions/cache` is what makes the input mean anything.

## Measured

Two runs of one commit on the wasm job:

| | `setup-emsdk` |
| --- | --- |
| populating run | 40 s |
| next run | **1 s** |

The archive is 479 MB and restores in ~6 s, so the saving holds well clear of the transfer cost. Applies to `wasm (browser build)` and `webR runtime`.

The cache key carries each job's own pinned emsdk version — 6.0.6 for the browser build, 4.0.8 for the webR side module — so a version bump rotates the cache rather than serving a stale SDK.

## A note for whoever looks at the Emscripten ccache next

This also pins *where* emsdk is unpacked. Without it the SDK lands in `$RUNNER_TEMP/<uuid>/emsdk-main` with a fresh uuid every run, and emcc bakes that path into the `-isystem` flags of every compile.

That looked like an obvious explanation for those jobs' **0% ccache hit rate**. It is not: with the path provably pinned and `CCACHE_BASEDIR` covering it, the rate stays at 0/84 with a populated 32 MB cache restored. That investigation continues in #261 and is deliberately not bundled here, so this measured win doesn't wait on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)