### PR TITLE
Fix the issue 257 runtime gaps

### DIFF
--- a/runtime/include/stanli/mir_interp.hpp
+++ b/runtime/include/stanli/mir_interp.hpp
@@ -675,6 +675,16 @@ class MirInterp {
             st.fn_name == "FnValidateSizePositive" ||
             st.fn_name == "check_greater_or_equal")
           return;
+        if (st.fn_name == "FnValidateSizeUnitVector") {
+          if (st.fn_args.size() != 3 ||
+              st.fn_args[0].kind != mir::Expr::LitStr ||
+              st.fn_args[1].kind != mir::Expr::LitStr)
+            fail("malformed FnValidateSizeUnitVector", st.raw);
+          stan::math::validate_unit_vector_index(
+              st.fn_args[0].lit_s.c_str(), st.fn_args[1].lit_s.c_str(),
+              static_cast<int>(as_int(st.fn_args[2])));
+          return;
+        }
         fail("unsupported statement function " + st.fn_name, st.raw);
       case mir::Stmt::Skip:
         return;  // constraint checks are not executed here
@@ -1337,6 +1347,18 @@ class MirInterp {
         const int64_t Rb = b_mat ? b.dims[0] : (int64_t)b.r.size();
         const int64_t Cb = b_mat ? b.dims[1] : 1;
         if (Ca != Rb) fail(e.name + ": inner dimension mismatch", e.raw);
+        // Matrix * matrix must use Eigen's product evaluator, just as the
+        // graph GEMM and generated Stan do. A hand-written scalar loop has
+        // a measurably different association for a one-column product.
+        if (a_mat && b_mat) {
+          using Mat = Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>;
+          r.r.resize((size_t)(Ra * Cb));
+          Eigen::Map<const Mat> am(a.r.data(), Ra, Ca);
+          Eigen::Map<const Mat> bm(b.r.data(), Rb, Cb);
+          Eigen::Map<Mat>(r.r.data(), Ra, Cb) = am * bm;
+          r.dims = {Ra, Cb};
+          return r;
+        }
         // Col-major storage on both sides.
         r.r.assign((size_t)(Ra * Cb), T(0.0));
         for (int64_t j = 0; j < Cb; ++j)
@@ -1934,9 +1956,17 @@ class MirInterp {
     }
     if (e.name == "sum") {
       Value a = eval(e.args[0]);
-      T m = T(0.0);
-      for (const T& v : a.r) m += v;
-      r.r = {m};
+      if (a.is_int && a.i.size() == a.r.size()) {
+        int total = 0;
+        for (int x : a.i) total += x;
+        r.is_int = true;
+        r.i = {total};
+        r.r = {T((double)total)};
+      } else {
+        T total = T(0.0);
+        for (const T& x : a.r) total += x;
+        r.r = {total};
+      }
       return r;
     }
     // The matrix slice family, all on col-major storage.
@@ -2139,6 +2169,42 @@ class MirInterp {
       const Eigen::Map<const Vec> input(a.r.data(), a.r.size());
       r.r = {stan::math::prod(
           input.unaryExpr(Eigen::internal::core_cast_op<T, T>()))};
+      return r;
+    }
+    if ((e.name == "columns_dot_product" || e.name == "rows_dot_product") &&
+        e.args.size() == 2) {
+      Value a = eval(e.args[0]), b = eval(e.args[1]);
+      if (a.dims.size() != 2 || a.dims != b.dims || a.r.size() != b.r.size())
+        fail(e.name + ": arguments must be matrices of the same size", e.raw);
+      const int64_t rows = a.dims[0], cols = a.dims[1];
+      const bool by_columns = e.name == "columns_dot_product";
+      const int64_t groups = by_columns ? cols : rows;
+      const int64_t width = by_columns ? rows : cols;
+      r.dims = {groups};
+      r.r.assign((size_t)groups, T(0.0));
+      for (int64_t group = 0; group < groups; ++group)
+        for (int64_t k = 0; k < width; ++k) {
+          const int64_t at = by_columns ? group * rows + k : k * rows + group;
+          r.r[(size_t)group] += a.r.at((size_t)at) * b.r.at((size_t)at);
+        }
+      return r;
+    }
+    if ((e.name == "columns_dot_self" || e.name == "rows_dot_self") &&
+        e.args.size() == 1) {
+      Value a = eval(e.args[0]);
+      if (a.dims.size() != 2)
+        fail(e.name + ": argument must be a matrix", e.raw);
+      const int64_t rows = a.dims[0], cols = a.dims[1];
+      const bool by_columns = e.name == "columns_dot_self";
+      const int64_t groups = by_columns ? cols : rows;
+      const int64_t width = by_columns ? rows : cols;
+      r.dims = {groups};
+      r.r.assign((size_t)groups, T(0.0));
+      for (int64_t group = 0; group < groups; ++group)
+        for (int64_t k = 0; k < width; ++k) {
+          const int64_t at = by_columns ? group * rows + k : k * rows + group;
+          r.r[(size_t)group] += a.r.at((size_t)at) * a.r.at((size_t)at);
+        }
       return r;
     }
     // Two arguments is the elementwise form, which Stan vectorizes over
@@ -2651,8 +2717,8 @@ class MirInterp {
       for (size_t i = 0; i < n; ++i) {
         // The continuous ones go through the shared dispatch, so this
         // cannot be narrower than what the register machine accepts and
-        // costs one instantiation of 27 densities rather than one per
-        // translation unit that interprets MIR.
+        // costs one shared set of probability-function instantiations rather
+        // than one set per translation unit that interprets MIR.
         if (shared_id >= 0) {
           T argbuf[kMaxDensityArgs];
           const int arity = program_density_arity(shared_id);
@@ -2693,6 +2759,18 @@ class MirInterp {
       r.dims = {n};
       r.r.assign(n, v.r.at(0));
       if (v.is_int) r.i.assign(n, v.i.at(0));
+      return r;
+    }
+    if (e.name == "csr_extract_w" && e.args.size() == 1) {
+      Value a = eval(e.args[0]);
+      if (a.dims.size() != 2)
+        fail("csr_extract_w: argument must be a matrix", e.raw);
+      const int64_t rows = a.dims[0], cols = a.dims[1];
+      using Mat = Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>;
+      Eigen::Map<const Mat> matrix(a.r.data(), rows, cols);
+      const auto weights = stan::math::csr_extract_w(matrix);
+      r.r.assign(weights.data(), weights.data() + weights.size());
+      r.dims = {(int64_t)r.r.size()};
       return r;
     }
     if (e.name == "append_array" && e.args.size() == 2) {

--- a/runtime/include/stanli/mir_prog.hpp
+++ b/runtime/include/stanli/mir_prog.hpp
@@ -1673,6 +1673,8 @@ struct ProgramCompiler {
         }
         return out;
       }
+      if (e.name == "FnNegInf" && e.args.empty())
+        return {konst(-std::numeric_limits<double>::infinity()), 1};
       bail("internal function " + e.name);
     }
     if (e.args.empty() && e.name == "negative_infinity")
@@ -2055,6 +2057,10 @@ struct ProgramCompiler {
         c = Program::FMAX;
       else if (e.name == "fmin")
         c = Program::FMIN;
+      else if (e.name == "log_sum_exp")
+        c = Program::LSE2;
+      else if (e.name == "log_diff_exp")
+        c = Program::LOG_DIFF_EXP;
       else if (e.name == "Greater__")
         c = Program::GT;
       else if (e.name == "Geq__")
@@ -2085,6 +2091,14 @@ struct ProgramCompiler {
     }
     if (e.args.size() == 1) {
       const Range a = expr(e.args[0]);
+      if (e.name == "log_sum_exp") {
+        if (a.len == 0)
+          return {konst(-std::numeric_limits<double>::infinity()), 1};
+        const int r = alloc(1);
+        p.code.push_back(
+            Program::Instr{Program::LSE_RANGE, r, a.reg, 0, 0, a.len});
+        return {r, 1};
+      }
       if (e.name == "sum") {
         if (a.len == 0) return {konst(0.0), 1};
         const int r = alloc(1);
@@ -2095,12 +2109,23 @@ struct ProgramCompiler {
       // Predicates, spelled on the comparison opcodes rather than opcodes of
       // their own: both read through value_of, so neither carries an adjoint
       // edge, which is what a 0/1 answer wants. x != x holds for NaN alone.
-      if (e.name == "is_nan" || e.name == "PNot__") {
+      if (e.name == "is_nan" || e.name == "is_inf" || e.name == "PNot__") {
         const int rhs = e.name == "is_nan" ? -1 : konst(0.0);
         const Program::Code c = e.name == "is_nan" ? Program::NE : Program::EQ;
         const int r = alloc(a.len);
-        for (int i = 0; i < a.len; ++i)
-          emit(c, r + i, a.reg + i, rhs < 0 ? a.reg + i : rhs);
+        if (e.name == "is_inf") {
+          const int pos = konst(std::numeric_limits<double>::infinity());
+          const int neg = konst(-std::numeric_limits<double>::infinity());
+          const int eq_pos = alloc(a.len), eq_neg = alloc(a.len);
+          for (int i = 0; i < a.len; ++i) {
+            emit(Program::EQ, eq_pos + i, a.reg + i, pos);
+            emit(Program::EQ, eq_neg + i, a.reg + i, neg);
+            emit(Program::ADD, r + i, eq_pos + i, eq_neg + i);
+          }
+        } else {
+          for (int i = 0; i < a.len; ++i)
+            emit(c, r + i, a.reg + i, rhs < 0 ? a.reg + i : rhs);
+        }
         Range out = a;
         out.reg = r;
         return typed(out, e.type_);

--- a/runtime/include/stanli/program.hpp
+++ b/runtime/include/stanli/program.hpp
@@ -101,6 +101,7 @@ enum ProgramOpFlag : uint16_t {
   X(LSE_RANGE, kProgramRangeA | kProgramSaveA | kProgramSaveOut)             \
   X(SOFTMAX, kProgramRangeA | kProgramSaveOut | kProgramRangeOutput)         \
   X(LSE2, kProgramReadB | kProgramSaveA | kProgramSaveB)                     \
+  X(LOG_DIFF_EXP, kProgramReadB | kProgramSaveA | kProgramSaveB)             \
   X(LOG_MIX, kProgramReadB | kProgramReadC | kProgramSaveA | kProgramSaveB | \
                  kProgramSaveC)                                              \
   X(FMA, kProgramReadB | kProgramReadC | kProgramSaveA | kProgramSaveB)      \
@@ -124,8 +125,8 @@ struct Program {
     // CONST/CONSTR, MOV/MOVR, arithmetic, comparisons, jumps, ranged
     // arithmetic, densities, and CALL appear above in that order. Their
     // exact execution semantics live in run_program below.
-    // Any scalar continuous density: `len` selects which
-    // (program_density.hpp). One opcode rather than one per density is
+    // Any scalar continuous density or distribution function: `len` selects
+    // which (program_density.hpp). One opcode rather than one per function is
     // what lets the machine speak the runtime's whole list instead of a
     // hand-picked subset of it.
     //
@@ -411,6 +412,9 @@ void run_program(const Program& p, T* reg) {
       case Program::LSE2:
         d() = stan::math::log_sum_exp(ra(), rb());
         break;
+      case Program::LOG_DIFF_EXP:
+        d() = stan::math::log_diff_exp(ra(), rb());
+        break;
       case Program::LOG_MIX:
         d() = stan::math::log_mix(ra(), rb(), reg[(size_t)I.c]);
         break;
@@ -499,10 +503,10 @@ void run_program(const Program& p, T* reg) {
         }
         break;
       }
-        // One call for every scalar continuous density the runtime has;
-      // program_density.cpp holds the switch, so the 27 instantiations
-      // are paid in one translation unit instead of in every one that
-      // runs a program.
+      // One call for every scalar continuous probability function the runtime
+      // has; program_density.cpp holds the switch, so the instantiations are
+      // paid in one translation unit instead of in every one that runs a
+      // program.
       case Program::CALL:
         if constexpr (std::is_same_v<T, double>) {
           run_call(p.calls[(size_t)I.a], reg);

--- a/runtime/include/stanli/program_density.hpp
+++ b/runtime/include/stanli/program_density.hpp
@@ -1,5 +1,5 @@
-// The scalar continuous densities, once, for everything that is not a
-// graph kernel.
+// The scalar continuous densities and distribution functions, once, for
+// everything that is not a graph kernel.
 //
 // There used to be two lists. The graph had all of them
 // (STANLI_SCALAR_DENSITY_LIST, optable.hpp); the register machine carried
@@ -13,11 +13,13 @@
 // everywhere else. `target += chi_square_lpdf(y | nu)` inside an
 // `if (theta > 0)` did not compile; the same line outside the `if` did.
 //
-// So there is one list now, and this is the one place that switches on it.
-// Three callers share these definitions rather than instantiating 27
-// densities apiece: the register machine's interpreter (program.hpp), its
-// generated adjoint (adjoint.cpp), and the MIR interpreter
-// (mir_interp.hpp).
+// So there is one shared dispatch now, and this is the one place that
+// switches on it. CDF/LCDF/LCCDF functions use the same scalar argument and
+// partials contract and are included as well, which lets truncation inside a
+// runtime-control region use the same implementation as the graph.
+// Three callers share these definitions rather than instantiating the whole
+// set apiece: the register machine's interpreter (program.hpp), its generated
+// adjoint (adjoint.cpp), and the MIR interpreter (mir_interp.hpp).
 #ifndef STANLI_PROGRAM_DENSITY_HPP
 #define STANLI_PROGRAM_DENSITY_HPP
 
@@ -28,8 +30,9 @@
 
 namespace stanli {
 
-// The widest Stan gives a scalar continuous density: student_t,
-// skew_normal, exp_mod_normal, pareto_type_2, skew_double_exponential.
+// The widest scalar probability functions here take four arguments
+// (student_t, skew_normal, exp_mod_normal, pareto_type_2, and
+// skew_double_exponential).
 constexpr int kMaxDensityArgs = 4;
 
 // How many densities there are; ids run over [0, count).

--- a/runtime/src/adjoint.cpp
+++ b/runtime/src/adjoint.cpp
@@ -660,6 +660,14 @@ void run_adjoint(const Program& fwd, const AdjProgram& ap, const double* val,
         adj[I.a] += t * stan::math::inv_logit(val[I.va] - val[I.vb]);
         adj[I.b] += t * stan::math::inv_logit(val[I.vb] - val[I.va]);
         break;
+      case Program::LOG_DIFF_EXP:
+        adj[I.dst] = 0.0;
+        // Match rev/fun/log_diff_exp.hpp exactly. Besides being stable when
+        // the arguments are close, expm1 has observably different rounding
+        // from spelling either denominator with exp.
+        adj[I.a] -= t / stan::math::expm1(val[I.vb] - val[I.va]);
+        adj[I.b] -= t / stan::math::expm1(val[I.va] - val[I.vb]);
+        break;
       case Program::LOG_MIX: {
         adj[I.dst] = 0.0;
         // rev/fun/log_mix.hpp: partials through the helper, with the arms

--- a/runtime/src/lower.cpp
+++ b/runtime/src/lower.cpp
@@ -690,6 +690,9 @@ struct Lowering {
         fail("size expression needs unknown int " + e.name);
       }
       case mir::Expr::Indexed: {
+        // O1 can leave an empty Indexed wrapper around a fully composed
+        // integer access, just as it does for real-valued expressions.
+        if (e.args.size() == 1) return eval_int(e.args[0]);
         DataMap::Entry* en = e.args[0].kind == mir::Expr::Var
                                  ? td.find(e.args[0].name)
                                  : nullptr;
@@ -1691,8 +1694,10 @@ struct Lowering {
         }
         // Row range of the same layout: A[i, lo:hi] is contiguous.
         if (e.args.size() == 3 && is_array(base.si) && bdims &&
-            array_shape(base.si).leaf == ViewKind::Flat && bdims->size() == 2 &&
-            e.args[1].name == "IndexSingle" &&
+            (array_shape(base.si).leaf == ViewKind::Flat ||
+             array_shape(base.si).leaf == ViewKind::Vector ||
+             array_shape(base.si).leaf == ViewKind::RowVector) &&
+            bdims->size() == 2 && e.args[1].name == "IndexSingle" &&
             e.args[2].name == "IndexBetween") {
           const int64_t i = eval_int(e.args[1].args[0]);
           const int64_t lo = eval_int(e.args[2].args[0]);
@@ -1701,9 +1706,25 @@ struct Lowering {
           check_index(i, (*bdims)[0], "array index", e.raw);
           check_range(lo, hi, S, "array range", e.raw);
           const int64_t len = hi >= lo ? hi - lo + 1 : 0;
-          return emit_value(OP_SLICE, {base}, len,
-                            array_view({len}, ViewKind::Flat),
+          SlotInfo si = array_shape(base.si).leaf == ViewKind::Flat
+                            ? array_view({len}, ViewKind::Flat)
+                            : view_of(e.type_);
+          return emit_value(OP_SLICE, {base}, len, si,
                             {(int)(len ? (i - 1) * S + lo - 1 : 0)});
+        }
+        // A whole vector leaf selected from array[N] vector[S]. The explicit
+        // trailing All survives O1 for this spelling and addresses the same
+        // contiguous outer-element block as the range directly above.
+        if (e.args.size() == 3 && is_array(base.si) && bdims &&
+            (array_shape(base.si).leaf == ViewKind::Vector ||
+             array_shape(base.si).leaf == ViewKind::RowVector) &&
+            bdims->size() == 2 && e.args[1].name == "IndexSingle" &&
+            e.args[2].name == "IndexAll") {
+          const int64_t i = eval_int(e.args[1].args[0]);
+          const int64_t count = (*bdims)[0], width = (*bdims)[1];
+          check_index(i, count, "array index", e.raw);
+          return emit_value(OP_SLICE, {base}, width, view_of(e.type_),
+                            {(int)((i - 1) * width)});
         }
         // Row-range column read M[a:b, j] (contiguous within the column).
         if (e.args.size() == 3 && is_matrix(base.si) &&
@@ -4000,7 +4021,63 @@ struct Lowering {
           fail(e.name + " needs a matrix argument", e.raw);
         }
         const int64_t K = shapes[last].rows;
-        idata = {(int)K, (int)(g.slots[ins[0]].len / K)};
+        if (K < 0 || shapes[last].cols != K)
+          fail(e.name + ": matrix argument must be square", e.raw);
+
+        // The native kernels accept one vector/row-vector location and a
+        // vector or array of vectors on the left. Derive repetitions from
+        // the logical view, not a division by K: that remains defined for
+        // legal zero-dimensional vectors and catches short flat storage
+        // before a kernel can read past it. multi_student_t has nu between
+        // y and mu; the multi_normal forms do not.
+        const auto vector_repetitions = [&](size_t arg, const char* role) {
+          const SlotInfo& si = shapes[arg];
+          const int64_t len = g.slots[ins[arg]].len;
+          if (is_vector(si) || is_row_vector(si)) {
+            if (len != K) {
+              if (arg == 0)
+                fail(e.name + ": random variable length " +
+                         std::to_string(len) +
+                         " is not a positive multiple of matrix size " +
+                         std::to_string(K),
+                     e.raw);
+              fail(e.name + ": " + role + " length " + std::to_string(len) +
+                       " does not match matrix size " + std::to_string(K),
+                   e.raw);
+            }
+            return int64_t{1};
+          }
+          if (is_array(si)) {
+            const ArrayShape& array = array_shape(si);
+            if ((array.leaf != ViewKind::Vector &&
+                 array.leaf != ViewKind::RowVector) ||
+                array.dims.empty() || array.dims.back() != K)
+              fail(e.name + ": " + role +
+                       " must be a vector or an array of vectors",
+                   e.raw);
+            std::vector<int64_t> outer(array.dims.begin(),
+                                       array.dims.end() - 1);
+            const int64_t repetitions =
+                checked_product(outer, e.name + ": " + role + " shape");
+            if (checked_product({repetitions, K},
+                                e.name + ": " + role + " storage") != len)
+              fail(e.name + ": " + role +
+                       " logical shape does not match storage length",
+                   e.raw);
+            return repetitions;
+          }
+          fail(
+              e.name + ": " + role + " must be a vector or an array of vectors",
+              e.raw);
+        };
+        const int64_t repetitions = vector_repetitions(0, "random variable");
+        if (repetitions == 0)
+          fail(e.name + ": an empty array of random variables is unsupported",
+               e.raw);
+        const size_t location = e.name.rfind("multi_student_t", 0) == 0 ? 2 : 1;
+        if (vector_repetitions(location, "location") != 1)
+          fail(e.name + ": an array-valued location is unsupported", e.raw);
+        idata = {(int)K, (int)repetitions};
       }
       Val dv =
           emit_raw(spec.opcode, ins, 1, result_si, idata, -1, result_autodiff);
@@ -4260,7 +4337,10 @@ struct Lowering {
                    " times " + std::to_string(rb) + "x" + std::to_string(cb) +
                    ")",
                e.raw);
-        SlotInfo si = cb == 1 ? view_of("UVector") : matrix_view(a.si.rows, cb);
+        SlotInfo si =
+            e.type_ == "UMatrix"
+                ? matrix_view(a.si.rows, cb)
+                : (cb == 1 ? view_of("UVector") : matrix_view(a.si.rows, cb));
         Val v = emit_value(OP_GEMM, {a, b}, a.si.rows * cb, si,
                            {(int)a.si.rows, (int)a.si.cols, (int)cb});
         return v;
@@ -4500,6 +4580,86 @@ struct Lowering {
       return emit_value(OP_DOT, {a, a}, 1);
     }
 
+    if ((e.name == "columns_dot_product" || e.name == "rows_dot_product" ||
+         e.name == "columns_dot_self" || e.name == "rows_dot_self") &&
+        (e.args.size() == 1 || e.args.size() == 2)) {
+      Val a = lower_expr(e.args[0]);
+      Val b = e.args.size() == 2 ? lower_expr(e.args[1]) : a;
+      if (!is_matrix(a.si) || !is_matrix(b.si) || a.si.rows != b.si.rows ||
+          a.si.cols != b.si.cols)
+        fail(e.name + ": arguments must be matrices of the same size", e.raw);
+      SlotInfo product_si =
+          matrix_view(a.si.rows, a.si.cols, a.si.param_free && b.si.param_free);
+      Val product = emit_value(OP_MUL, {a, b}, g.slots[a.slot].len, product_si);
+      const bool by_columns = e.name.rfind("columns_", 0) == 0;
+      const int64_t ones_len = by_columns ? a.si.rows : a.si.cols;
+      const int ones_slot = add_slot(ones_len, false);
+      out.fills.emplace_back(ones_slot, std::vector<double>(ones_len, 1.0));
+      SlotInfo ones_si = view_of(by_columns ? "URowVector" : "UVector");
+      ones_si.param_free = true;
+      Val ones{ones_slot, false, ones_si};
+      if (by_columns)
+        return emit_value(OP_GEMM, {ones, product}, a.si.cols,
+                          view_of("URowVector"),
+                          {1, (int)a.si.rows, (int)a.si.cols});
+      return emit_value(OP_GEMM, {product, ones}, a.si.rows, view_of("UVector"),
+                        {(int)a.si.rows, (int)a.si.cols, 1});
+    }
+
+    if (e.name == "csr_matrix_times_vector" && e.args.size() == 6) {
+      const int64_t rows = eval_int(e.args[0]);
+      const int64_t cols = eval_int(e.args[1]);
+      if (rows <= 0 || cols <= 0)
+        fail(e.name + ": row and column counts must be positive", e.raw);
+      Val weights = lower_expr(e.args[2]);
+      Val vector = lower_expr(e.args[5]);
+      if (!is_vector(weights.si) || !is_vector(vector.si))
+        fail(e.name + ": w and b must be vectors", e.raw);
+      if (g.slots[vector.slot].len != cols)
+        fail(e.name + ": column count does not match vector size", e.raw);
+      const std::vector<int> columns = const_ints(e.args[3]);
+      const std::vector<int> starts = const_ints(e.args[4]);
+      const int64_t nnz = g.slots[weights.slot].len;
+      if ((int64_t)columns.size() != nnz)
+        fail(e.name + ": w and v sizes differ", e.raw);
+      if ((int64_t)starts.size() != rows + 1 || starts.front() != 1 ||
+          starts.back() != nnz + 1)
+        fail(e.name + ": u does not describe the requested rows", e.raw);
+      for (int column : columns)
+        if (column < 1 || column > cols)
+          fail(e.name + ": v contains an out-of-range column", e.raw);
+
+      Val result{-1, false, {}};
+      for (int64_t row = 0; row < rows; ++row) {
+        const int64_t begin = starts[(size_t)row] - 1;
+        const int64_t end = starts[(size_t)row + 1] - 1;
+        if (begin < 0 || end < begin || end > nnz)
+          fail(e.name + ": u is not monotone or is out of range", e.raw);
+        Val row_sum;
+        if (begin == end) {
+          row_sum = constant(0.0);
+        } else {
+          const int64_t len = end - begin;
+          Val row_weights = emit_value(OP_SLICE, {weights}, len,
+                                       view_of("UVector"), {(int)begin});
+          std::vector<int> gather;
+          gather.reserve((size_t)len);
+          for (int64_t k = begin; k < end; ++k)
+            gather.push_back(columns[(size_t)k] - 1);
+          Val row_vector =
+              emit_value(OP_GATHER, {vector}, len, view_of("UVector"), gather);
+          Val products = emit_value(OP_MUL, {row_weights, row_vector}, len,
+                                    view_of("UVector"));
+          row_sum = emit_value(OP_SUM_VEC, {products}, 1);
+        }
+        result = row == 0 ? row_sum
+                          : emit_value(OP_CONCAT2, {result, row_sum}, row + 1,
+                                       view_of("UVector"));
+      }
+      result.si = view_of("UVector");
+      return result;
+    }
+
     // squared_distance(x, y) = dot_self(x - y). Two graph kernels that
     // already carry native adjoints, so no new opcode. It does not go
     // through shape_of: the language pairs a vector with a row_vector
@@ -4599,6 +4759,12 @@ struct Lowering {
         return Val{a.slot, a.autodiff, si};
       }
       if (is_matrix(a.si)) return Val{a.slot, a.autodiff, a.si};
+      if (is_vector(a.si))
+        return Val{a.slot, a.autodiff,
+                   matrix_view(g.slots[a.slot].len, 1, a.si.param_free)};
+      if (is_row_vector(a.si))
+        return Val{a.slot, a.autodiff,
+                   matrix_view(1, g.slots[a.slot].len, a.si.param_free)};
       std::vector<int64_t> dims;
       if (is_array(a.si)) dims = array_shape(a.si).dims;
       if (dims.size() != 2) fail("to_matrix: unknown source shape", e.raw);
@@ -4612,10 +4778,14 @@ struct Lowering {
         e.args.size() == 1) {
       // Col-major flattening is the identity on our storage.
       Val a = lower_expr(e.args[0]);
-      SlotInfo si = a.si;
-      si.rows = 0;
-      si.cols = 0;
-      stamp_kind(&si, e.type_);
+      SlotInfo si = view_of(e.type_);
+      si.param_free = a.si.param_free;
+      return Val{a.slot, a.autodiff, si};
+    }
+    if (e.name == "to_array_1d" && e.args.size() == 1) {
+      Val a = lower_expr(e.args[0]);
+      SlotInfo si =
+          array_view({g.slots[a.slot].len}, ViewKind::Flat, a.si.param_free);
       return Val{a.slot, a.autodiff, si};
     }
     if (e.name == "rep_matrix") {
@@ -5671,6 +5841,26 @@ struct Lowering {
             sync_indexed_data_local(s.lhs, nv);
             return;
           }
+          // Whole vector leaf write A[i, :] = rhs for array[N] vector[S].
+          // Graph array storage keeps each outer element contiguous, so this
+          // is the assignment mirror of the read path above.
+          if (s.lhs_idx.size() == 2 && s.lhs_idx[0].name == "IndexSingle" &&
+              s.lhs_idx[1].name == "IndexAll" && dd && dd->size() == 2 &&
+              (array_shape(prev_v.si).leaf == ViewKind::Vector ||
+               array_shape(prev_v.si).leaf == ViewKind::RowVector)) {
+            const int64_t i = eval_int(s.lhs_idx[0].args[0]);
+            const int64_t width = (*dd)[1];
+            check_index(i, (*dd)[0], "array assignment index", s.raw);
+            SlotInfo expected = indexed_view(prev_v.si, 1, width, s.rhs.type_);
+            require_binding(rhs_v, width, expected, s.lhs, s.raw);
+            const int64_t start = (i - 1) * width;
+            Val nv = emit_value(OP_SET_SLICE, {prev_v, rhs_v},
+                                g.slots[prev].len, out_si, {(int)start});
+            propagate_int_update(nv, prev_v, rhs_v, start, 1);
+            scope[s.lhs] = nv;
+            sync_indexed_data_local(s.lhs, nv);
+            return;
+          }
           // Between write w[a:b] = rhs (contiguous on 1-D values).
           if (s.lhs_idx.size() == 1 && s.lhs_idx[0].name == "IndexBetween") {
             const bool flat_1d_array =
@@ -5847,7 +6037,11 @@ struct Lowering {
                 dl->second.len = g.slots[rhs.slot].len;
                 dl->second.si = rhs.si;
                 dl->second.deferred_shape = false;
-              } else if (dl->second.len == 0 && g.slots[rhs.slot].len != 0) {
+              } else if (dl->second.len == 0 &&
+                         (g.slots[rhs.slot].len != 0 ||
+                          (is_matrix(dl->second.si) && is_matrix(rhs.si) &&
+                           (dl->second.si.rows != rhs.si.rows ||
+                            dl->second.si.cols != rhs.si.cols)))) {
                 // stanc3's --O1 inliner declares a function's return
                 // variable zero-length (`array[real, 0]`, `vector[0]`)
                 // because the returned size is the callee's business, and

--- a/runtime/src/program_density.cpp
+++ b/runtime/src/program_density.cpp
@@ -1,5 +1,5 @@
-// The one switch over STANLI_SCALAR_DENSITY_LIST for the non-kernel
-// callers (program_density.hpp says why there is only one list now).
+// The one switch over the scalar continuous probability functions for the
+// non-kernel callers (program_density.hpp says why there is only one list).
 //
 // Everything here is generated from that list, so a density added to it
 // reaches the register machine's forward, the generated adjoint and the
@@ -25,6 +25,7 @@ namespace {
 enum : int {
 #define STANLI_PD_ENUM(opc, fn, arity, tier) kId_##fn,
   STANLI_SCALAR_DENSITY_LIST(STANLI_PD_ENUM)
+      STANLI_SCALAR_CDF_LIST(STANLI_PD_ENUM)
 #undef STANLI_PD_ENUM
 };
 
@@ -37,6 +38,7 @@ struct Entry {
 constexpr Entry kDensities[] = {
 #define STANLI_PD_ENTRY(opc, fn, arity, tier) {#fn, opc, arity},
     STANLI_SCALAR_DENSITY_LIST(STANLI_PD_ENTRY)
+        STANLI_SCALAR_CDF_LIST(STANLI_PD_ENTRY)
 #undef STANLI_PD_ENTRY
 };
 constexpr int kCount = (int)(sizeof(kDensities) / sizeof(kDensities[0]));
@@ -156,6 +158,12 @@ T program_density(int id, const T* args) {
         [](const auto&... x) { return stan::math::fn<false>(x...); }, args);
     STANLI_SCALAR_DENSITY_LIST(STANLI_PD_CASE)
 #undef STANLI_PD_CASE
+#define STANLI_PCDF_CASE(opc, fn, arity, tier) \
+  case kId_##fn:                               \
+    return call_with<arity>(                   \
+        [](const auto&... x) { return stan::math::fn(x...); }, args);
+    STANLI_SCALAR_CDF_LIST(STANLI_PCDF_CASE)
+#undef STANLI_PCDF_CASE
     default:
       return T(0.0);
   }
@@ -187,6 +195,17 @@ bool program_density_partials(int id, unsigned mask, const double* args,
     break;
     STANLI_SCALAR_DENSITY_LIST(STANLI_PD_PARTIALS)
 #undef STANLI_PD_PARTIALS
+#define STANLI_PCDF_PARTIALS(opc, fn, arity, tier)                        \
+  case kId_##fn:                                                          \
+    with_mask<arity, density_tier(tier)>(mask, [&](auto m) {              \
+      record_probability_call([&] {                                       \
+        return call_rvar<arity, m.value>(                                 \
+            [](const auto&... x) { return stan::math::fn(x...); }, args); \
+      });                                                                 \
+    });                                                                   \
+    break;
+    STANLI_SCALAR_CDF_LIST(STANLI_PCDF_PARTIALS)
+#undef STANLI_PCDF_PARTIALS
     default:
       break;
   }

--- a/tests/lit/issue_257/array_vector_range_slice.stan
+++ b/tests/lit/issue_257/array_vector_range_slice.stan
@@ -1,5 +1,5 @@
-// STANLI-LIT: XFAIL
-// STANLI-LIT-EXPECT: COMPILE_FAIL stanli compile: unsupported index expression: base=eta [IndexSingle] [IndexBetween] type=UVector
+// STANLI-LIT: PASS
+// STANLI-LIT-EXPECT: OK
 // STANLI-LIT-DATA: {"K": 2, "TT": 4}
 data { int K; int TT; }
 parameters { array[K] vector[TT] eta; }

--- a/tests/lit/issue_257/array_vector_whole_assignment.stan
+++ b/tests/lit/issue_257/array_vector_whole_assignment.stan
@@ -1,5 +1,5 @@
-// STANLI-LIT: XFAIL
-// STANLI-LIT-EXPECT: COMPILE_FAIL stanli compile: unsupported indexed assignment: lhs=mu [IndexSingle] [IndexAll]
+// STANLI-LIT: PASS
+// STANLI-LIT-EXPECT: OK
 // STANLI-LIT-DATA: {"T": 3}
 data { int T; }
 parameters { vector[2] phi0; }

--- a/tests/lit/issue_257/bounded_real_array_to_vector.stan
+++ b/tests/lit/issue_257/bounded_real_array_to_vector.stan
@@ -1,5 +1,5 @@
-// STANLI-LIT: XFAIL
-// STANLI-LIT-EXPECT: COMPILE_FAIL stanli compile: binding current: array kind and shape id disagree
+// STANLI-LIT: PASS
+// STANLI-LIT-EXPECT: OK
 parameters { array[2] real<lower=0, upper=1> start; }
 transformed parameters {
   vector[2] current;

--- a/tests/lit/issue_257/columns_dot_product.stan
+++ b/tests/lit/issue_257/columns_dot_product.stan
@@ -1,5 +1,5 @@
-// STANLI-LIT: XFAIL
-// STANLI-LIT-EXPECT: COMPILE_FAIL stanli compile: unsupported function columns_dot_product
+// STANLI-LIT: PASS
+// STANLI-LIT-EXPECT: OK
 // STANLI-LIT-DATA: {"A": [[1, 2], [3, 4]]}
 data { matrix[2, 2] A; }
 parameters { vector[4] y; }

--- a/tests/lit/issue_257/columns_dot_self.stan
+++ b/tests/lit/issue_257/columns_dot_self.stan
@@ -1,5 +1,5 @@
-// STANLI-LIT: XFAIL
-// STANLI-LIT-EXPECT: COMPILE_FAIL stanli compile: unsupported function columns_dot_self
+// STANLI-LIT: PASS
+// STANLI-LIT-EXPECT: OK
 parameters { vector[4] y; }
 model {
   y ~ std_normal();

--- a/tests/lit/issue_257/computed_parameter_extent.stan
+++ b/tests/lit/issue_257/computed_parameter_extent.stan
@@ -1,5 +1,5 @@
-// STANLI-LIT: XFAIL
-// STANLI-LIT-EXPECT: COMPILE_FAIL stanli compile: size expression needs unknown int total
+// STANLI-LIT: PASS
+// STANLI-LIT-EXPECT: OK
 // STANLI-LIT-DATA: {"J": [2, 3]}
 data { array[2] int J; }
 transformed data { int total = sum(J); }

--- a/tests/lit/issue_257/csr_extract_w_transformed_data.stan
+++ b/tests/lit/issue_257/csr_extract_w_transformed_data.stan
@@ -1,5 +1,5 @@
-// STANLI-LIT: XFAIL
-// STANLI-LIT-EXPECT: COMPILE_FAIL stanli prepare_data: unsupported function csr_extract_w
+// STANLI-LIT: PASS
+// STANLI-LIT-EXPECT: OK
 transformed data {
   vector[4] w = csr_extract_w([[1.0, 2.0], [3.0, 4.0]]);
 }

--- a/tests/lit/issue_257/csr_matrix_times_vector.stan
+++ b/tests/lit/issue_257/csr_matrix_times_vector.stan
@@ -1,5 +1,5 @@
-// STANLI-LIT: XFAIL
-// STANLI-LIT-EXPECT: COMPILE_FAIL stanli compile: unsupported function csr_matrix_times_vector
+// STANLI-LIT: PASS
+// STANLI-LIT-EXPECT: OK
 // STANLI-LIT-DATA: {"N": 2, "w": [1, 2, 3], "v": [1, 2, 1], "u": [1, 3, 4]}
 data {
   int N;

--- a/tests/lit/issue_257/gamma_lcdf_transformed_data.stan
+++ b/tests/lit/issue_257/gamma_lcdf_transformed_data.stan
@@ -1,5 +1,5 @@
-// STANLI-LIT: XFAIL
-// STANLI-LIT-EXPECT: COMPILE_FAIL stanli prepare_data: unsupported function gamma_lcdf
+// STANLI-LIT: PASS
+// STANLI-LIT-EXPECT: OK
 transformed data { real c = gamma_lcdf(1.0 | 2.0, 3.0); }
 parameters { real y; }
 model { y ~ normal(c, 1); }

--- a/tests/lit/issue_257/multi_normal_long_random_variable.stan
+++ b/tests/lit/issue_257/multi_normal_long_random_variable.stan
@@ -1,5 +1,5 @@
-// STANLI-LIT: XFAIL
-// STANLI-LIT-EXPECT: OK
+// STANLI-LIT: PASS
+// STANLI-LIT-EXPECT: COMPILE_FAIL stanli compile: multi_normal_lpdf: random variable length 3 is not a positive multiple of matrix size 2
 // STANLI-LIT-DATA: {"mu": [0, 0], "S": [[1, 0], [0, 1]]}
 data { vector[2] mu; cov_matrix[2] S; }
 parameters { vector[3] y; }

--- a/tests/lit/issue_257/multi_normal_short_random_variable.stan
+++ b/tests/lit/issue_257/multi_normal_short_random_variable.stan
@@ -1,5 +1,5 @@
-// STANLI-LIT: XFAIL
-// STANLI-LIT-EXPECT: CRASH
+// STANLI-LIT: PASS
+// STANLI-LIT-EXPECT: COMPILE_FAIL stanli compile: multi_normal_lpdf: random variable length 2 is not a positive multiple of matrix size 3
 // STANLI-LIT-DATA: {"mu": [0, 0, 0], "S": [[1, 0, 0], [0, 1, 0], [0, 0, 1]]}
 data { vector[3] mu; cov_matrix[3] S; }
 parameters { vector[2] y; }

--- a/tests/lit/issue_257/one_row_transposed_product.stan
+++ b/tests/lit/issue_257/one_row_transposed_product.stan
@@ -1,5 +1,5 @@
-// STANLI-LIT: XFAIL
-// STANLI-LIT-EXPECT: COMPILE_FAIL stanli compile: assignment logical view mismatch for theta
+// STANLI-LIT: PASS
+// STANLI-LIT-EXPECT: OK
 // STANLI-LIT-DATA: {"D": 3, "N": 1}
 data { int D; int N; }
 parameters { matrix[D, N] z; matrix[D, D] L; }

--- a/tests/lit/issue_257/parameter_truncation_declared_bound.stan
+++ b/tests/lit/issue_257/parameter_truncation_declared_bound.stan
@@ -1,4 +1,4 @@
-// STANLI-LIT: XFAIL
-// STANLI-LIT-EXPECT: COMPILE_FAIL stanli compile: runtime-control region: internal function FnNegInf
+// STANLI-LIT: PASS
+// STANLI-LIT-EXPECT: OK
 parameters { real<lower=0> sigma; }
 model { sigma ~ cauchy(0, 1) T[0, ]; }

--- a/tests/lit/issue_257/parameter_truncation_lower.stan
+++ b/tests/lit/issue_257/parameter_truncation_lower.stan
@@ -1,4 +1,4 @@
-// STANLI-LIT: XFAIL
-// STANLI-LIT-EXPECT: COMPILE_FAIL stanli compile: runtime-control region: internal function FnNegInf
+// STANLI-LIT: PASS
+// STANLI-LIT-EXPECT: OK
 parameters { real sigma; }
 model { sigma ~ cauchy(0, 1) T[0, ]; }

--- a/tests/lit/issue_257/parameter_truncation_two_sided.stan
+++ b/tests/lit/issue_257/parameter_truncation_two_sided.stan
@@ -1,4 +1,4 @@
-// STANLI-LIT: XFAIL
-// STANLI-LIT-EXPECT: COMPILE_FAIL stanli compile: runtime-control region: internal function FnNegInf
+// STANLI-LIT: PASS
+// STANLI-LIT-EXPECT: OK
 parameters { real sigma; }
 model { sigma ~ normal(0, 1) T[-1, 1]; }

--- a/tests/lit/issue_257/rows_dot_product_transformed_data.stan
+++ b/tests/lit/issue_257/rows_dot_product_transformed_data.stan
@@ -1,5 +1,5 @@
-// STANLI-LIT: XFAIL
-// STANLI-LIT-EXPECT: COMPILE_FAIL stanli prepare_data: unsupported function rows_dot_product
+// STANLI-LIT: PASS
+// STANLI-LIT-EXPECT: OK
 transformed data {
   matrix[2, 2] A = [[1, 2], [3, 4]];
   matrix[2, 2] B = [[5, 6], [7, 8]];

--- a/tests/lit/issue_257/rows_dot_self_transformed_data.stan
+++ b/tests/lit/issue_257/rows_dot_self_transformed_data.stan
@@ -1,5 +1,5 @@
-// STANLI-LIT: XFAIL
-// STANLI-LIT-EXPECT: COMPILE_FAIL stanli prepare_data: unsupported function rows_dot_self
+// STANLI-LIT: PASS
+// STANLI-LIT-EXPECT: OK
 transformed data {
   matrix[2, 2] A = [[1, 2], [3, 4]];
   vector[2] r = rows_dot_self(A);

--- a/tests/lit/issue_257/runtime_control_is_inf.stan
+++ b/tests/lit/issue_257/runtime_control_is_inf.stan
@@ -1,5 +1,5 @@
-// STANLI-LIT: XFAIL
-// STANLI-LIT-EXPECT: COMPILE_FAIL stanli compile: runtime-control region: function is_inf
+// STANLI-LIT: PASS
+// STANLI-LIT-EXPECT: OK
 parameters { real y; }
 model {
   y ~ std_normal();

--- a/tests/lit/issue_257/runtime_control_log_sum_exp.stan
+++ b/tests/lit/issue_257/runtime_control_log_sum_exp.stan
@@ -1,5 +1,5 @@
-// STANLI-LIT: XFAIL
-// STANLI-LIT-EXPECT: COMPILE_FAIL stanli compile: runtime-control region: function log_sum_exp
+// STANLI-LIT: PASS
+// STANLI-LIT-EXPECT: OK
 parameters { vector[2] y; }
 model {
   y ~ std_normal();

--- a/tests/lit/issue_257/to_array_1d.stan
+++ b/tests/lit/issue_257/to_array_1d.stan
@@ -1,5 +1,5 @@
-// STANLI-LIT: XFAIL
-// STANLI-LIT-EXPECT: COMPILE_FAIL stanli compile: unsupported function to_array_1d
+// STANLI-LIT: PASS
+// STANLI-LIT-EXPECT: OK
 parameters { vector[3] y; }
 model {
   array[3] real a = to_array_1d(y);

--- a/tests/lit/issue_257/to_matrix_column.stan
+++ b/tests/lit/issue_257/to_matrix_column.stan
@@ -1,5 +1,5 @@
-// STANLI-LIT: XFAIL
-// STANLI-LIT-EXPECT: COMPILE_FAIL stanli compile: to_matrix: unknown source shape
+// STANLI-LIT: PASS
+// STANLI-LIT-EXPECT: OK
 parameters { matrix[3, 2] w; }
 model {
   to_vector(w) ~ std_normal();

--- a/tests/lit/issue_257/two_dimensional_int_column_slice.stan
+++ b/tests/lit/issue_257/two_dimensional_int_column_slice.stan
@@ -1,5 +1,5 @@
-// STANLI-LIT: XFAIL
-// STANLI-LIT-EXPECT: COMPILE_FAIL stanli compile: unsupported int index expression
+// STANLI-LIT: PASS
+// STANLI-LIT-EXPECT: OK
 // STANLI-LIT-DATA: {"winner": [[1, 2], [3, 4], [2, 1]]}
 functions {
   real f(vector v, array[] int idx) {

--- a/tests/lit/issue_257/unit_vector_parameter.stan
+++ b/tests/lit/issue_257/unit_vector_parameter.stan
@@ -1,5 +1,5 @@
-// STANLI-LIT: XFAIL
-// STANLI-LIT-EXPECT: COMPILE_FAIL stanli prepare_data: unsupported statement function FnValidateSizeUnitVector
+// STANLI-LIT: PASS
+// STANLI-LIT-EXPECT: OK
 // STANLI-LIT-DATA: {"K": 3}
 data { int K; }
 parameters { unit_vector[K] u; }

--- a/tests/lit/issue_257/zero_row_inlined_function_result.stan
+++ b/tests/lit/issue_257/zero_row_inlined_function_result.stan
@@ -1,5 +1,5 @@
-// STANLI-LIT: XFAIL
-// STANLI-LIT-EXPECT: COMPILE_FAIL stanli compile: assignment logical view mismatch for inline_pick_return_sym8__
+// STANLI-LIT: PASS
+// STANLI-LIT-EXPECT: OK
 // STANLI-LIT-DATA: {"K": 2, "g": [2, 2, 2]}
 functions {
   matrix pick(matrix y, int k, array[] int ref, int value) {

--- a/tests/test_adjoint.cpp
+++ b/tests/test_adjoint.cpp
@@ -811,6 +811,11 @@ static void test_reductions() {
     const int d = b.emit(Program::LSE2, 0, 1);
     check("lse2", b.done({d}, {1.9}));
   }
+  {
+    Build b({1.1, 0.3});
+    const int d = b.emit(Program::LOG_DIFF_EXP, 0, 1);
+    check("log_diff_exp", b.done({d}, {1.9}));
+  }
   // Long enough that Eigen vectorizes the reductions. A short vector hides
   // any disagreement between the double pass's redux over the register file
   // and whatever the var pass reduces.
@@ -908,16 +913,17 @@ static void test_nan_operands() {
   }
 }
 
-// ---- densities ---------------------------------------------------------
+// ---- scalar probability functions -------------------------------------
 
 static void test_densities() {
-  // EVERY density the register machine speaks, discovered from the shared
-  // table rather than listed here, so one added to the runtime is covered
-  // the day it arrives instead of the day someone remembers this file.
+  // EVERY scalar density/CDF the register machine speaks, discovered from
+  // the shared table rather than listed here, so one added to the runtime is
+  // covered the day it arrives instead of the day someone remembers this
+  // file.
   //
-  // Each has its own support, so rather than curate a point per density
-  // the loop tries a few tuples and keeps the first the density accepts
-  // (a finite value). A density that accepts none of them is a failure,
+  // Each has its own support, so rather than curate a point per function the
+  // loop tries a few tuples and keeps the first one it accepts (a finite
+  // value). A function that accepts none of them is a failure,
   // not a skip -- silently testing nothing is the thing to avoid.
   static const double kPoints[][kMaxDensityArgs] = {
       {0.63, 0.4, 1.7, 0.5}, {0.63, 1.4, 2.2, 0.25}, {2.5, 3.0, 1.0, 0.75},


### PR DESCRIPTION
## Summary

- implement the missing dot-product, sparse-matrix, conversion, indexing, and transformed-data paths from #257
- extend runtime-control programs for truncation, `is_inf`, `log_sum_exp`, `log_diff_exp`, and scalar CDF/LCDF/LCCDF calls
- preserve degenerate matrix/array views and computed integer extents
- validate mismatched `multi_normal` inputs before entering the native kernel, replacing the crash/silent acceptance with checked compile failures
- promote every issue #257 source-lit case from `XFAIL` to `PASS`

This is intentionally stacked on #268 so the lit-infrastructure cleanup remains a small, independently reviewable PR. Merge #268 first, then retarget or merge this PR.

Closes #257.

## Verification

All build and test parallelism used 24 jobs:

- `cmake --build build -j24`
- `cmake --build build --target lit -j24` — 41/41 passed
- `cmake --build build --target lit-broken -j24` — no known-broken cases remain
- `ctest --test-dir build --parallel 24 --output-on-failure` — 108/108 passed
- strict graph/interpreter cross checks pass for the one-row matrix product, dot-product functions, CSR multiplication, and the shared `multi_student_t` shape path
