### PR TITLE
Fix Windows stanc subprocess invocation

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -1227,7 +1227,8 @@ jobs:
             deps/stanc3/stanli-compile \
             "$STANC3_SRC_REPO" "$STANC3_SRC_SHA"
           chmod +x deps/stanc3/stanc deps/stanc3/stanli-compile
-          ./deps/stanc3/stanc --version
+          cp deps/stanc3/stanc deps/stanc3/stanc.exe
+          ./deps/stanc3/stanc.exe --version
 
       - name: Configure, build, test
         run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -577,13 +577,17 @@ endfunction()
 # binary -- .stan in, CmdStan-shaped CSV out, no toolchain and no separate
 # stanc to find -- which is the whole point of an interpreter for a
 # language whose reference implementation compiles C++ per model.
+add_library(stanli_stanc_process STATIC tools/stanc_process.cpp)
 add_executable(stanli_run tools/stanli_run.cpp
   $<TARGET_OBJECTS:stanli_tbb_stub>)
-target_link_libraries(stanli_run PRIVATE stanli)
+target_link_libraries(stanli_run PRIVATE stanli stanli_stanc_process)
 stanli_embed_stanc(stanli_run)
 add_executable(stanli_check tools/stanli_check.cpp
   $<TARGET_OBJECTS:stanli_tbb_stub>)
-target_link_libraries(stanli_check PRIVATE stanli)
+target_link_libraries(stanli_check PRIVATE stanli stanli_stanc_process)
+add_executable(test_stanc_process tests/test_stanc_process.cpp)
+target_link_libraries(test_stanc_process PRIVATE stanli_stanc_process)
+add_test(NAME test_stanc_process COMMAND test_stanc_process)
 add_test(NAME test_check_precompiled_mir
          COMMAND stanli_check tests/fixtures/ar1.stan tests/fixtures/ar1.json
                  --mir tests/fixtures/ar1.tmir.sexp
@@ -738,11 +742,18 @@ if(Python3_Interpreter_FOUND)
       string(REGEX REPLACE "[^A-Za-z0-9_]" "_" STANLI_LIT_NAME
              "${STANLI_LIT_NAME}")
       set(STANLI_LIT_TEST "lit_${STANLI_LIT_NAME}")
+      if(WIN32)
+        set(STANLI_LIT_STANC
+            ${CMAKE_CURRENT_SOURCE_DIR}/deps/stanc3/stanc.exe)
+      else()
+        set(STANLI_LIT_STANC
+            ${CMAKE_CURRENT_SOURCE_DIR}/deps/stanc3/stanc)
+      endif()
       add_test(NAME ${STANLI_LIT_TEST}
                COMMAND ${Python3_EXECUTABLE} tests/lit/run.py
                        ${STANLI_LIT_CASE}
                        $<TARGET_FILE:stanli_check>
-                       ${CMAKE_CURRENT_SOURCE_DIR}/deps/stanc3/stanc
+                       ${STANLI_LIT_STANC}
                WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
       set(STANLI_LIT_LABELS lit)
       if(STANLI_LIT_MARKER MATCHES "XFAIL$")

--- a/tests/test_stanc_process.cpp
+++ b/tests/test_stanc_process.cpp
@@ -1,0 +1,55 @@
+#include "../tools/stanc_process.hpp"
+
+#include <chrono>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <stdexcept>
+#include <string>
+
+namespace fs = std::filesystem;
+
+int main(int argc, char** argv) {
+  // A copied instance of this test is the fake compiler used by the parent.
+  if (argc > 1) {
+    if (argc != 4 || std::string(argv[1]) != "--O1" ||
+        std::string(argv[2]) != "--debug-optimized-mir")
+      return 2;
+    std::cout << "MIR from " << argv[3] << '\n';
+    return 0;
+  }
+
+  const auto nonce =
+      std::chrono::high_resolution_clock::now().time_since_epoch().count();
+  const fs::path root = fs::temp_directory_path() /
+                        ("stanli stanc ' process " + std::to_string(nonce));
+  try {
+    fs::create_directories(root);
+#ifdef _WIN32
+    const fs::path compiler = root / "fake stanc ' compiler.exe";
+#else
+    const fs::path compiler = root / "fake stanc ' compiler";
+#endif
+    fs::copy_file(fs::absolute(argv[0]), compiler);
+    fs::permissions(
+        compiler,
+        fs::perms::owner_exec | fs::perms::group_exec | fs::perms::others_exec,
+        fs::perm_options::add);
+    const fs::path model = root / "model with ' quote.stan";
+    std::ofstream(model)
+        << "parameters { real y; } model { y ~ normal(0, 1); }\n";
+
+    const std::string output =
+        stanli::tooling::run_stanc_process(compiler.string(), model.string());
+    const std::string expected = "MIR from " + model.string() + "\n";
+    if (output != expected)
+      throw std::runtime_error("unexpected compiler output: " + output);
+    fs::remove_all(root);
+    return 0;
+  } catch (const std::exception& error) {
+    std::cerr << error.what() << '\n';
+    std::error_code ignored;
+    fs::remove_all(root, ignored);
+    return 1;
+  }
+}

--- a/tools/stanc_process.cpp
+++ b/tools/stanc_process.cpp
@@ -1,0 +1,242 @@
+#include "stanc_process.hpp"
+
+#include <array>
+#include <cerrno>
+#include <cstring>
+#include <stdexcept>
+#include <string>
+
+#ifdef _WIN32
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#include <windows.h>
+#else
+#include <fcntl.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
+#endif
+
+namespace stanli::tooling {
+namespace {
+
+#ifdef _WIN32
+
+class Handle {
+ public:
+  explicit Handle(HANDLE handle = INVALID_HANDLE_VALUE) : handle_(handle) {}
+  Handle(const Handle&) = delete;
+  Handle& operator=(const Handle&) = delete;
+  Handle(Handle&& other) noexcept : handle_(other.release()) {}
+  Handle& operator=(Handle&& other) noexcept {
+    reset(other.release());
+    return *this;
+  }
+  ~Handle() { reset(); }
+
+  HANDLE get() const { return handle_; }
+  HANDLE release() {
+    const HANDLE handle = handle_;
+    handle_ = INVALID_HANDLE_VALUE;
+    return handle;
+  }
+  void reset(HANDLE handle = INVALID_HANDLE_VALUE) {
+    if (handle_ != INVALID_HANDLE_VALUE && handle_ != nullptr)
+      CloseHandle(handle_);
+    handle_ = handle;
+  }
+
+ private:
+  HANDLE handle_;
+};
+
+std::runtime_error windows_error(const char* operation) {
+  return std::runtime_error(std::string(operation) + " failed (Windows error " +
+                            std::to_string(GetLastError()) + ")");
+}
+
+std::wstring widen_utf8(const std::string& text) {
+  if (text.empty()) return {};
+  const int size =
+      MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, text.data(),
+                          static_cast<int>(text.size()), nullptr, 0);
+  if (size == 0) throw windows_error("MultiByteToWideChar");
+  std::wstring wide(static_cast<size_t>(size), L'\0');
+  if (MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, text.data(),
+                          static_cast<int>(text.size()), wide.data(),
+                          size) == 0)
+    throw windows_error("MultiByteToWideChar");
+  return wide;
+}
+
+// CreateProcess receives one command-line string even when the application is
+// named separately. Quote each argv element by the CommandLineToArgvW rules so
+// spaces and trailing backslashes survive unchanged in the child.
+std::wstring quote_windows_arg(const std::wstring& arg) {
+  if (arg.find_first_of(L" \t\n\v\"") == std::wstring::npos) return arg;
+  std::wstring quoted(1, L'"');
+  size_t backslashes = 0;
+  for (const wchar_t ch : arg) {
+    if (ch == L'\\') {
+      ++backslashes;
+      continue;
+    }
+    if (ch == L'"') {
+      quoted.append(backslashes * 2 + 1, L'\\');
+      quoted.push_back(ch);
+    } else {
+      quoted.append(backslashes, L'\\');
+      quoted.push_back(ch);
+    }
+    backslashes = 0;
+  }
+  quoted.append(backslashes * 2, L'\\');
+  quoted.push_back(L'"');
+  return quoted;
+}
+
+std::string run_stanc_windows(const std::string& stanc,
+                              const std::string& model) {
+  SECURITY_ATTRIBUTES inheritable{};
+  inheritable.nLength = sizeof(inheritable);
+  inheritable.bInheritHandle = TRUE;
+
+  HANDLE raw_read = INVALID_HANDLE_VALUE;
+  HANDLE raw_write = INVALID_HANDLE_VALUE;
+  if (!CreatePipe(&raw_read, &raw_write, &inheritable, 0))
+    throw windows_error("CreatePipe");
+  Handle read_pipe(raw_read);
+  Handle write_pipe(raw_write);
+  if (!SetHandleInformation(read_pipe.get(), HANDLE_FLAG_INHERIT, 0))
+    throw windows_error("SetHandleInformation");
+
+  Handle null_device(CreateFileW(
+      L"NUL", GENERIC_READ | GENERIC_WRITE, FILE_SHARE_READ | FILE_SHARE_WRITE,
+      &inheritable, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr));
+  if (null_device.get() == INVALID_HANDLE_VALUE)
+    throw windows_error("CreateFileW(NUL)");
+
+  const std::wstring executable = widen_utf8(stanc);
+  const std::array<std::wstring, 4> args = {
+      executable, L"--O1", L"--debug-optimized-mir", widen_utf8(model)};
+  std::wstring command_line;
+  for (const auto& arg : args) {
+    if (!command_line.empty()) command_line.push_back(L' ');
+    command_line += quote_windows_arg(arg);
+  }
+
+  STARTUPINFOW startup{};
+  startup.cb = sizeof(startup);
+  startup.dwFlags = STARTF_USESTDHANDLES;
+  startup.hStdInput = null_device.get();
+  startup.hStdOutput = write_pipe.get();
+  startup.hStdError = null_device.get();
+  PROCESS_INFORMATION process{};
+  if (!CreateProcessW(executable.c_str(), command_line.data(), nullptr, nullptr,
+                      TRUE, CREATE_NO_WINDOW, nullptr, nullptr, &startup,
+                      &process))
+    throw windows_error("CreateProcessW");
+  Handle process_handle(process.hProcess);
+  Handle thread_handle(process.hThread);
+  write_pipe.reset();
+  null_device.reset();
+
+  std::string out;
+  std::array<char, 1 << 16> buffer;
+  for (;;) {
+    DWORD read_size = 0;
+    if (!ReadFile(read_pipe.get(), buffer.data(),
+                  static_cast<DWORD>(buffer.size()), &read_size, nullptr)) {
+      if (GetLastError() == ERROR_BROKEN_PIPE) break;
+      throw windows_error("ReadFile");
+    }
+    if (read_size == 0) break;
+    out.append(buffer.data(), read_size);
+  }
+  if (WaitForSingleObject(process_handle.get(), INFINITE) != WAIT_OBJECT_0)
+    throw windows_error("WaitForSingleObject");
+  // _popen(..., "r") used to give callers a text-mode stream. Preserve that
+  // behavior now that ReadFile sees the child's raw CRLF bytes.
+  std::string normalized;
+  normalized.reserve(out.size());
+  for (size_t i = 0; i < out.size(); ++i) {
+    if (out[i] == '\r' && i + 1 < out.size() && out[i + 1] == '\n') continue;
+    normalized.push_back(out[i]);
+  }
+  return normalized;
+}
+
+#else
+
+std::string run_stanc_posix(const std::string& stanc,
+                            const std::string& model) {
+  int descriptors[2];
+  if (pipe(descriptors) != 0)
+    throw std::runtime_error(std::string("pipe failed: ") +
+                             std::strerror(errno));
+
+  const pid_t child = fork();
+  if (child == -1) {
+    const int error = errno;
+    close(descriptors[0]);
+    close(descriptors[1]);
+    throw std::runtime_error(std::string("fork failed: ") +
+                             std::strerror(error));
+  }
+  if (child == 0) {
+    close(descriptors[0]);
+    if (dup2(descriptors[1], STDOUT_FILENO) == -1) _exit(127);
+    close(descriptors[1]);
+    const int null_error = open("/dev/null", O_WRONLY);
+    if (null_error == -1 || dup2(null_error, STDERR_FILENO) == -1) _exit(127);
+    close(null_error);
+    execl(stanc.c_str(), stanc.c_str(), "--O1", "--debug-optimized-mir",
+          model.c_str(), static_cast<char*>(nullptr));
+    _exit(127);
+  }
+
+  close(descriptors[1]);
+  std::string out;
+  std::array<char, 1 << 16> buffer;
+  for (;;) {
+    const ssize_t read_size =
+        read(descriptors[0], buffer.data(), buffer.size());
+    if (read_size > 0) {
+      out.append(buffer.data(), static_cast<size_t>(read_size));
+      continue;
+    }
+    if (read_size == -1 && errno == EINTR) continue;
+    if (read_size == -1) {
+      const int error = errno;
+      close(descriptors[0]);
+      while (waitpid(child, nullptr, 0) == -1 && errno == EINTR) {
+      }
+      throw std::runtime_error(std::string("read failed: ") +
+                               std::strerror(error));
+    }
+    break;
+  }
+  close(descriptors[0]);
+  while (waitpid(child, nullptr, 0) == -1) {
+    if (errno != EINTR)
+      throw std::runtime_error(std::string("waitpid failed: ") +
+                               std::strerror(errno));
+  }
+  return out;
+}
+
+#endif
+
+}  // namespace
+
+std::string run_stanc_process(const std::string& stanc,
+                              const std::string& model) {
+#ifdef _WIN32
+  return run_stanc_windows(stanc, model);
+#else
+  return run_stanc_posix(stanc, model);
+#endif
+}
+
+}  // namespace stanli::tooling

--- a/tools/stanc_process.hpp
+++ b/tools/stanc_process.hpp
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <string>
+
+namespace stanli::tooling {
+
+// Run stock stanc with the flags used by the command-line tools and return
+// its MIR stdout. Arguments are passed directly to the child process: model
+// and compiler paths are never interpreted by a shell.
+std::string run_stanc_process(const std::string& stanc,
+                              const std::string& model);
+
+}  // namespace stanli::tooling

--- a/tools/stanli_check.cpp
+++ b/tools/stanli_check.cpp
@@ -22,7 +22,8 @@
 #include <stanli/graph.hpp>
 #include <stanli/wa_interp.hpp>
 
-#include <array>
+#include "stanc_process.hpp"
+
 #include <cmath>
 #include <cstdio>
 #include <cstdlib>
@@ -51,16 +52,7 @@ static double eval_point(int64_t i, int variant) {
 
 static std::string run_stanc(const std::string& stanc,
                              const std::string& model) {
-  const std::string cmd =
-      stanc + " --O1 --debug-optimized-mir '" + model + "' 2>/dev/null";
-  std::unique_ptr<FILE, int (*)(FILE*)> pipe(popen(cmd.c_str(), "r"), pclose);
-  if (!pipe) throw std::runtime_error("cannot run stanc");
-  std::string out;
-  std::array<char, 1 << 16> buf;
-  size_t n;
-  while ((n = fread(buf.data(), 1, buf.size(), pipe.get())) > 0)
-    out.append(buf.data(), n);
-  return out;
+  return stanli::tooling::run_stanc_process(stanc, model);
 }
 
 static std::string read_mir(const std::string& path) {
@@ -81,7 +73,11 @@ int main(int argc, char** argv) {
                  "[--draw-variant N] [--ledger PATH]]\n");
     return 2;
   }
+#ifdef _WIN32
+  std::string stanc = "deps/stanc3/stanc.exe";
+#else
   std::string stanc = "deps/stanc3/stanc";
+#endif
   std::string mir_path;
   bool stanc_arg = false;
   int variant = 0;

--- a/tools/stanli_run.cpp
+++ b/tools/stanli_run.cpp
@@ -27,6 +27,8 @@
 #include <stanli/nuts.hpp>
 #include <stanli/wa_interp.hpp>
 
+#include "stanc_process.hpp"
+
 #include <array>
 #include <cstdio>
 #include <cstdlib>
@@ -64,15 +66,7 @@ static std::string embedded_stanc(const std::string& model) {
 
 static std::string run_stanc(const std::string& stanc,
                              const std::string& model) {
-  const std::string cmd =
-      stanc + " --O1 --debug-optimized-mir '" + model + "' 2>/dev/null";
-  std::unique_ptr<FILE, int (*)(FILE*)> pipe(popen(cmd.c_str(), "r"), pclose);
-  if (!pipe) throw std::runtime_error("cannot run stanc: " + cmd);
-  std::string out;
-  std::array<char, 1 << 16> buf;
-  size_t n;
-  while ((n = fread(buf.data(), 1, buf.size(), pipe.get())) > 0)
-    out.append(buf.data(), n);
+  std::string out = stanli::tooling::run_stanc_process(stanc, model);
   if (out.empty())
     throw std::runtime_error("stanc produced no MIR (compile error?)");
   return out;
@@ -89,7 +83,11 @@ int main(int argc, char** argv) {
     return 2;
   }
   std::string model = argv[1], datafile = argv[2];
+#ifdef _WIN32
+  std::string stanc = "deps/stanc3/stanc.exe";
+#else
   std::string stanc = "deps/stanc3/stanc";
+#endif
   bool stanc_explicit = false;
   stanli::NutsConfig cfg;
   cfg.seed = 1;


### PR DESCRIPTION
## Summary
- replace shell-composed stanc calls with direct POSIX/Windows process launching
- use the real `stanc.exe` path in Windows lit tests
- add a regression test covering compiler and model paths with spaces and apostrophes

## Validation
- `./tools/format.sh --check`
- standalone process regression compiled with `-Wall -Wextra -Werror`
- CMake build of `test_stanc_process` and `stanli_check`
- `ctest -R "^(test_stanc_process|test_check_precompiled_mir|test_check_precompiled_mir_conflict)$"`