### PR TITLE
Reroll every scalar density

### DIFF
--- a/runtime/include/stanli/optable.hpp
+++ b/runtime/include/stanli/optable.hpp
@@ -715,21 +715,15 @@ constexpr uint8_t kBackwardValueFree = 1 << 3;
 
 constexpr uint8_t op_traits(uint16_t opcode) {
   switch (opcode) {
-    // Real-argument lpdfs whose vector kernel returns a summed lp with
-    // per-element partials. The long-tail density kernels deliberately do
-    // not opt in until their vectorized path is supported by re-roll.
-    case OP_NORMAL_LPDF:
-    case OP_CAUCHY_LPDF:
-    case OP_STUDENT_T_LPDF:
-    case OP_GAMMA_LPDF:
-    case OP_BETA_LPDF:
-    case OP_LOGNORMAL_LPDF:
-    case OP_UNIFORM_LPDF:
-    case OP_DOUBLE_EXP_LPDF:
-    case OP_EXPONENTIAL_LPDF:
-    case OP_INV_GAMMA_LPDF:
-    case OP_STD_NORMAL_LPDF:
-      return op_trait::kRerollDensity;
+    // Every real-argument lpdf in the scalar list has the same summed and
+    // elementwise density_fwd_v contract. Generate the rewrite trait from
+    // that list too, so adding a scalar kernel cannot leave re-roll and
+    // partition silently narrower. Ordered/vector-argument and special
+    // density shapes live outside this list and remain excluded.
+#define STANLI_SCALAR_DENSITY_TRAIT(code, fn, arity, tier) case code:
+    STANLI_SCALAR_DENSITY_LIST(STANLI_SCALAR_DENSITY_TRAIT)
+#undef STANLI_SCALAR_DENSITY_TRAIT
+    return op_trait::kRerollDensity;
 
     // Integer-outcome lpmfs whose scalar-lane idata can be concatenated.
     // Ordered densities are intentionally absent: their cutpoint vector is

--- a/tests/test_partition.cpp
+++ b/tests/test_partition.cpp
@@ -85,7 +85,7 @@ struct Lanes {
   int base = -1, sigma = -1;
 };
 
-static Lanes build_index_lanes(int L) {
+static Lanes build_index_lanes(int L, uint16_t density = OP_NORMAL_LPDF) {
   Lanes b;
   b.base = b.g.add_slot(L, true);
   b.sigma = b.g.add_slot(1, true);
@@ -95,11 +95,32 @@ static Lanes build_index_lanes(int L) {
     const int idx = b.g.add_slot(1, false);
     b.g.add_op(OP_INDEX, {b.base}, idx, {l});
     const int lp = b.g.add_slot(1, false);
-    const int id = b.g.add_op(OP_NORMAL_LPDF, {y, idx, b.sigma}, lp);
+    const int id = b.g.add_op(density, {y, idx, b.sigma}, lp);
     b.g.ops[(size_t)id].variant = 0x06;
     b.terms.push_back(lp);
   }
   return b;
+}
+
+// A scalar-list density that the old hand-written trait omitted. Direct
+// target terms use the summed vector kernel: bit 6 must stay clear while the
+// lane lps and their gradients collapse into one logistic operation.
+static void test_logistic_direct_terms() {
+  const int L = 8;
+  Lanes b = build_index_lanes(L, OP_LOGISTIC_LPDF);
+  const std::vector<double> want = reference(b.g, b.fills, b.terms);
+
+  std::vector<int> tt = b.terms;
+  Fills f2 = b.fills;
+  const PartitionStats st = partition_lanes(b.g, f2, tt, {});
+  expect("logistic terms one group", st.groups == 1 && st.lanes == L);
+  expect("logistic terms summed", b.g.ops.size() == 1 && tt.size() == 1 &&
+                                      b.g.ops[0].opcode == OP_LOGISTIC_LPDF &&
+                                      (b.g.ops[0].variant & 0x40u) == 0);
+  expect("logistic terms vector input",
+         b.g.slots[(size_t)b.g.ops[0].in[0]].len == L &&
+             b.g.slots[(size_t)b.g.ops[0].in[1]].len == L);
+  expect_same_grad("logistic terms", std::move(b.g), f2, tt, want);
 }
 
 static void test_contiguous_bucket() {
@@ -947,6 +968,7 @@ int main() {
     (void)warm.n_params();
   }
   test_contiguous_bucket();
+  test_logistic_direct_terms();
   test_interleaved_lanes();
   test_scattered_indices();
   test_refuse_effectful();

--- a/tests/test_reroll.cpp
+++ b/tests/test_reroll.cpp
@@ -49,6 +49,23 @@ static std::vector<double> run_grad(Graph g, const Fills& fills) {
   return testutil::run_grad(std::move(g), fills, fill_at);
 }
 
+// Scalar LPDF kernels all use density_fwd_v, so their re-roll eligibility is
+// generated from the same list. Shapes with a distinct contract must remain
+// fail-closed rather than inheriting the trait by looking density-like.
+static void test_scalar_density_traits() {
+#define EXPECT_REROLL_TRAIT(code, fn, arity, tier) \
+  expect(#code " has scalar-density trait",        \
+         has_op_trait(code, op_trait::kRerollDensity));
+  STANLI_SCALAR_DENSITY_LIST(EXPECT_REROLL_TRAIT)
+#undef EXPECT_REROLL_TRAIT
+  expect("ordered density stays excluded",
+         !has_op_trait(OP_ORDERED_LOGISTIC_LPMF, op_trait::kRerollDensity));
+  expect("matrix density stays excluded",
+         !has_op_trait(OP_MULTI_NORMAL_LPDF, op_trait::kRerollDensity));
+  expect("unrelated opcode stays excluded",
+         !has_op_trait(OP_EXP, op_trait::kRerollDensity));
+}
+
 // radon shape: mu = vector intermediate written by an op; per lane
 // {INDEX(mu,n); NORMAL(y_const_n, idx, sigma)}, lp -> target term.
 // y consts deliberately share slots (dedup pool) between lanes 1 and 5.
@@ -240,6 +257,56 @@ static void test_gauss_mix_shape() {
   expect("gmix sizes", got.size() == want.size());
   for (size_t i = 0; i < want.size() && i < got.size(); ++i)
     expect_close(("gmix v" + std::to_string(i)).c_str(), got[i], want[i]);
+}
+
+// Logistic was historically omitted from the hand-maintained density
+// allowlist even though it has the same density_fwd_v elementwise kernel as
+// normal. Its lane-local lps must fuse behind bit 6, not merely acquire a
+// trait that no behavioral test exercises.
+static void test_logistic_elt_shape() {
+  const int L = 6;
+  Graph g;
+  Fills fills;
+  const int mu = g.add_slot(1, true);
+  const int sigma = g.add_slot(1, true);
+  auto cslot = [&](double v) {
+    const int s = g.add_slot(1, false);
+    fills.emplace_back(s, std::vector<double>{v});
+    return s;
+  };
+  std::vector<int> terms;
+  for (int l = 0; l < L; ++l) {
+    const int lp = g.add_slot(1, false);
+    const int id =
+        g.add_op(OP_LOGISTIC_LPDF, {cslot(0.35 * l - 0.8), mu, sigma}, lp);
+    g.ops[(size_t)id].variant = 0x06;
+    const int term = g.add_slot(1, false);
+    g.add_op(OP_ADD, {lp, cslot(0.1 * l - 0.25)}, term);
+    terms.push_back(term);
+  }
+  Graph ref = g;
+  reduce_into_result(ref, terms);
+  const std::vector<double> want = run_grad(std::move(ref), fills);
+
+  std::vector<int> tt = terms;
+  Fills f2 = fills;
+  const detail::ProfiledRerollStats profiled =
+      detail::reroll_profiled(g, f2, tt, {});
+  expect("logistic elt regions==1", profiled.work.regions == 1);
+  expect("logistic elt density disposition",
+         profiled.dispositions.element_density == 1);
+  expect("logistic elt term disposition",
+         profiled.dispositions.term_widen == 1);
+  expect("logistic elt ops==3", g.ops.size() == 3 && tt.size() == 1);
+  expect("logistic elt opcode", g.ops[0].opcode == OP_LOGISTIC_LPDF &&
+                                    (g.ops[0].variant & 0x40u) != 0 &&
+                                    g.slots[(size_t)g.ops[0].out].len == L);
+  g.result_slot = tt[0];
+  const std::vector<double> got = run_grad(std::move(g), f2);
+  expect("logistic elt sizes", got.size() == want.size());
+  for (size_t i = 0; i < want.size() && i < got.size(); ++i)
+    expect_close(("logistic elt v" + std::to_string(i)).c_str(), got[i],
+                 want[i]);
 }
 
 // (b2) idata-outcome lpmf feeding an in-lane op: the elementwise lpmf
@@ -1567,10 +1634,12 @@ static void test_bail_message_ops() {
 }
 
 int main() {
+  test_scalar_density_traits();
   test_radon_shape();
   test_ark_shape();
   test_bail_recurrence();
   test_gauss_mix_shape();
+  test_logistic_elt_shape();
   test_elt_lpmf_shape();
   test_elt_scalar_density_hoists();
   test_bail_cross_lane_density();


### PR DESCRIPTION
## Summary

- derive real-argument density rewrite eligibility from `STANLI_SCALAR_DENSITY_LIST` instead of a stale 11-opcode switch
- keep ordered, matrix/vector-argument, and other special density shapes fail-closed
- cover logistic direct-target summed fusion and lane-local bit-6 elementwise fusion
- assert every scalar-list density receives the shared trait

## Validation

- `ctest --test-dir build-shared-tests --output-on-failure` (109/109 passed, including 41 source lit tests and reference verification)
- `git diff --check`
- focused `test_reroll` and `test_partition`
- installed pinned posteriordb revision `28f8d3d6e975315f42aa274a8399f21e07a43b30` and ran the 120-model re-roll A/B

The corpus A/B completed and showed the existing `ldaK5` re-roll deviation (`9.21e-10`, above that harness's `1e-11` flag threshold). The newly admitted families occur in the corpus only as scalar priors, so the behavioral regression tests are the direct oracle for this change.