### PR TITLE
Release 0.10.0

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -881,16 +881,16 @@ jobs:
       - name: Fetch the previous release and the legacy anchor
         run: |
           mkdir -p previous-release/runtime legacy-release
-          previous=https://github.com/seantalts/stanli/releases/download/v0.9.5
+          previous=https://github.com/seantalts/stanli/releases/download/v0.9.6
           legacy=https://github.com/seantalts/stanli/releases/download/v0.9.3
           curl -fsSL "$previous/stanli-runtime-linux-x86_64.tar.gz" \
             -o previous-release/runtime.tar.gz
-          curl -fsSL "$previous/stanli_0.9.5.tar.gz" \
-            -o previous-release/stanli_0.9.5.tar.gz
+          curl -fsSL "$previous/stanli_0.9.6.tar.gz" \
+            -o previous-release/stanli_0.9.6.tar.gz
           curl -fsSL "$legacy/stanli_0.9.3.tar.gz" \
             -o legacy-release/stanli_0.9.3.tar.gz
-          echo '6634d517be4a2938197f945cb2f86409f60c05045f512bd1f48a859a2e29cd21  previous-release/runtime.tar.gz' | sha256sum -c -
-          echo '5a67cb58d57b1dd0b465858d07d0a40d21da1802644c93ead89369efd82892cb  previous-release/stanli_0.9.5.tar.gz' | sha256sum -c -
+          echo 'dee1311c5be011fa85070316302bde634f70e7f8c0cfe4e81954d91be5a75ffa  previous-release/runtime.tar.gz' | sha256sum -c -
+          echo 'ea5271500e363fceca94fb60005dee7a80266d1a40836305468723887c3a6629  previous-release/stanli_0.9.6.tar.gz' | sha256sum -c -
           echo '1acbe821c58115678a69451c553a9b23c141d009f53c142492cee94599430495  legacy-release/stanli_0.9.3.tar.gz' | sha256sum -c -
           tar xzf previous-release/runtime.tar.gz \
             -C previous-release/runtime
@@ -942,7 +942,7 @@ jobs:
         working-directory: r
         run: |
           current_library="$PWD/../r-current-library"
-          previous_library="$PWD/../r-v0.9.5-library"
+          previous_library="$PWD/../r-v0.9.6-library"
           legacy_library="$PWD/../r-v0.9.3-library"
           previous_runtime="$PWD/../previous-release/runtime/libstanli.so"
           current_runtime="$STANLI_RUNTIME"
@@ -953,7 +953,7 @@ jobs:
 
           mkdir -p "$previous_library"
           R CMD INSTALL --library="$previous_library" \
-            ../previous-release/stanli_0.9.5.tar.gz
+            ../previous-release/stanli_0.9.6.tar.gz
           STANLI_RUNTIME="$current_runtime" \
             R_LIBS_USER="$previous_library${R_LIBS_USER:+:$R_LIBS_USER}" \
             Rscript ../tests/test_r_portable_compiler.R

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 0.10.0
+
 ### ctsem's structured-control vocabulary lowers
 
 `crossprod`, `tcrossprod`, scalar/vector `add_diag`, `matrix_exp`,

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@seantalts/stanli",
-  "version": "0.9.6",
+  "version": "0.10.0",
   "description": "Full Stan in the browser: stanc3 compiles the model in JS, a WASM runtime lowers it to an op graph and runs NUTS. No server, no C++ toolchain.",
   "type": "module",
   "main": "index.mjs",

--- a/python/stanli/__init__.py
+++ b/python/stanli/__init__.py
@@ -22,7 +22,7 @@ __all__ = ["Model", "Fit", "Summary", "OptimizeResult",
            "SAMPLER_COLUMNS", "__version__"]
 # The one place the version lives. setup.py and the release workflow both
 # read it from here.
-__version__ = "0.9.6"
+__version__ = "0.10.0"
 
 _BIN = pathlib.Path(__file__).parent / "_bin"
 

--- a/r/DESCRIPTION
+++ b/r/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: stanli
 Type: Package
 Title: The Stan Language Interpreter
-Version: 0.9.6
+Version: 0.10.0
 Authors@R: person("Sean", "Talts", email = "xitrium@gmail.com",
                   role = c("aut", "cre"))
 Description: Compile and sample Stan models without a C++ toolchain. Stan

--- a/r/R/install.R
+++ b/r/R/install.R
@@ -14,7 +14,7 @@
 # and a default of "latest" would silently pair a pinned binding with a runtime
 # that has moved. The release workflow asserts this equals the tag being cut,
 # so bumping one without the other fails there rather than at a user's install.
-stanli_runtime_release <- "v0.9.6"
+stanli_runtime_release <- "v0.10.0"
 
 runtime_filename <- function() {
   switch(Sys.info()[["sysname"]],

--- a/runtime/src/data.cpp
+++ b/runtime/src/data.cpp
@@ -36,17 +36,13 @@ static DataMap::Entry entry_from_json(const std::string& name, const json& v) {
       // dims outer-to-inner.
       std::vector<int64_t> dims;
       const json* cur = &v;
-      while (cur->is_array() && !cur->empty()) {
+      // Include the first zero extent: [[], []] is array[2] vector[0], not
+      // a one-dimensional value whose elements should be parsed as numbers.
+      while (cur->is_array()) {
         dims.push_back(static_cast<int64_t>(cur->size()));
+        if (cur->empty()) break;
         cur = &(*cur)[0];
       }
-      // The first empty nested array still contributes a trailing zero
-      // extent.  Without it, JSON such as [[], []] was inferred as a
-      // one-dimensional value of length two and the N-D walker then tried
-      // to convert each empty array to a number.  This is the ordinary JSON
-      // representation of array[2] vector[0] (and likewise for deeper
-      // zero-width containers).
-      if (cur->is_array()) dims.push_back(0);
       e.dims = dims;
       if (dims.size() == 2) {
         // Column-major, the Stan/Eigen convention (and what stanc's data


### PR DESCRIPTION
Prepare the coordinated Python, npm, and R 0.10.0 release metadata; advance compatibility coverage to the v0.9.6 runtime; and retain the empty JSON dimension traversal cleanup.\n\nThe annotated v0.10.0 tag points at this branch head. Local validation passed all 109 configured tests, including all 41 source-lit cases with the pinned stanc3 compiler.