### PR TITLE
Isolate density kernels from graph header changes

### DIFF
--- a/runtime/include/stanli/graph.hpp
+++ b/runtime/include/stanli/graph.hpp
@@ -4,6 +4,8 @@
 #ifndef STANLI_GRAPH_HPP
 #define STANLI_GRAPH_HPP
 
+#include <stanli/kernel_types.hpp>
+
 #include <cstdint>
 #include <initializer_list>
 #include <memory>
@@ -12,48 +14,6 @@
 #include <vector>
 
 namespace stanli {
-
-class WaRng;
-
-// Per-evaluation resources that are neither graph structure nor arena state.
-// The caller owns every pointed-to resource. In particular, an RNG stream
-// belongs to one chain/drawing thread, never to a compiled model or executor.
-struct EvalState {
-  WaRng* wa_rng = nullptr;
-};
-
-// A view of one contiguous buffer. len == 1 means scalar.
-struct Desc {
-  double* data;
-  int64_t len;
-};
-
-// A value in the graph. Slots with is_param are the unconstrained parameter
-// vector, in declaration order; everything else is data or an intermediate.
-struct Slot {
-  int64_t offset = 0;  // into the value arena (filled at bind)
-  int64_t len = 0;
-  bool is_param = false;
-};
-
-struct Op {
-  uint16_t opcode = 0;
-  // Opcode-specific compact mode. Density kernels use bits 0..5 for
-  // per-argument activity, bit 6 for elementwise lp, and bit 7 for propto;
-  // other kernels use it for contracts such as ODE scalar types or RNG family.
-  uint8_t variant = 0;
-  int out = -1;
-  int out2 = -1;  // optional second output (e.g. constrain jacobian term)
-  int in[6] = {-1, -1, -1, -1, -1, -1};
-  int n_in = 0;
-  const int* idata = nullptr;  // integer immediates (outcome counts, dims)
-  int64_t n_idata = 0;
-  // Opaque per-op payload for kernels that need compile-time structure the
-  // integer immediates cannot carry (ODEs, messages, declaration checks).
-  const void* udata = nullptr;
-  int64_t scratch_off = 0;  // into the scratch arena (filled at bind)
-  int64_t scratch_len = 0;
-};
 
 struct Graph {
   std::vector<Slot> slots;
@@ -91,26 +51,6 @@ struct Graph {
     ops.push_back(op);
     return static_cast<int>(ops.size()) - 1;
   }
-};
-
-// Per-call view handed to kernels. Assembled by the executor; kernels never
-// see slots or arenas directly.
-struct KernelCtx {
-  Desc in[6];
-  int n_in = 0;
-  Desc out{nullptr, 0};
-  uint8_t variant = 0;
-  double* scratch = nullptr;
-  const int* idata = nullptr;
-  int64_t n_idata = 0;
-  const void* udata = nullptr;
-  EvalState* eval_state = nullptr;
-  Desc out2{nullptr, 0};  // second output value (scalar), if any
-  // Backward only. Data inputs get {nullptr, len}: kernels skip them.
-  Desc in_adj[6];
-  double out_adj = 0;            // scalar-output ops
-  Desc out_adj_vec{nullptr, 0};  // vector-output ops
-  double out2_adj = 0;           // adjoint of the second output
 };
 
 // Payload for OP_REJECT and OP_PRINT: the literal chunks of the message,

--- a/runtime/include/stanli/kernel_types.hpp
+++ b/runtime/include/stanli/kernel_types.hpp
@@ -1,0 +1,75 @@
+// Stable data layouts shared by the executor and native kernels. Keep Graph,
+// Executor, and their payload types out: the expensive kernel translation
+// units should not rebuild for changes to graph ownership or execution policy.
+#ifndef STANLI_KERNEL_TYPES_HPP
+#define STANLI_KERNEL_TYPES_HPP
+
+#include <cstdint>
+
+namespace stanli {
+
+class WaRng;
+
+// Per-evaluation resources that are neither graph structure nor arena state.
+// The caller owns every pointed-to resource. In particular, an RNG stream
+// belongs to one chain/drawing thread, never to a compiled model or executor.
+struct EvalState {
+  WaRng* wa_rng = nullptr;
+};
+
+// A view of one contiguous buffer. len == 1 means scalar.
+struct Desc {
+  double* data;
+  int64_t len;
+};
+
+// A value in the graph. Slots with is_param are the unconstrained parameter
+// vector, in declaration order; everything else is data or an intermediate.
+struct Slot {
+  int64_t offset = 0;  // into the value arena (filled at bind)
+  int64_t len = 0;
+  bool is_param = false;
+};
+
+struct Op {
+  uint16_t opcode = 0;
+  // Opcode-specific compact mode. Density kernels use bits 0..5 for
+  // per-argument activity, bit 6 for elementwise lp, and bit 7 for propto;
+  // other kernels use it for contracts such as ODE scalar types or RNG family.
+  uint8_t variant = 0;
+  int out = -1;
+  int out2 = -1;  // optional second output (e.g. constrain jacobian term)
+  int in[6] = {-1, -1, -1, -1, -1, -1};
+  int n_in = 0;
+  const int* idata = nullptr;  // integer immediates (outcome counts, dims)
+  int64_t n_idata = 0;
+  // Opaque per-op payload for kernels that need compile-time structure the
+  // integer immediates cannot carry (ODEs, messages, declaration checks).
+  const void* udata = nullptr;
+  int64_t scratch_off = 0;  // into the scratch arena (filled at bind)
+  int64_t scratch_len = 0;
+};
+
+// Per-call view handed to kernels. Assembled by the executor; kernels never
+// see slots or arenas directly.
+struct KernelCtx {
+  Desc in[6];
+  int n_in = 0;
+  Desc out{nullptr, 0};
+  uint8_t variant = 0;
+  double* scratch = nullptr;
+  const int* idata = nullptr;
+  int64_t n_idata = 0;
+  const void* udata = nullptr;
+  EvalState* eval_state = nullptr;
+  Desc out2{nullptr, 0};  // second output value (scalar), if any
+  // Backward only. Data inputs get {nullptr, len}: kernels skip them.
+  Desc in_adj[6];
+  double out_adj = 0;            // scalar-output ops
+  Desc out_adj_vec{nullptr, 0};  // vector-output ops
+  double out2_adj = 0;           // adjoint of the second output
+};
+
+}  // namespace stanli
+
+#endif

--- a/runtime/include/stanli/optable.hpp
+++ b/runtime/include/stanli/optable.hpp
@@ -2,7 +2,7 @@
 #ifndef STANLI_OPTABLE_HPP
 #define STANLI_OPTABLE_HPP
 
-#include <stanli/graph.hpp>
+#include <stanli/kernel_types.hpp>
 
 #include <limits>
 

--- a/runtime/include/stanli/recorder.hpp
+++ b/runtime/include/stanli/recorder.hpp
@@ -16,7 +16,7 @@
 #ifndef STANLI_RECORDER_HPP
 #define STANLI_RECORDER_HPP
 
-#include <stanli/graph.hpp>
+#include <stanli/kernel_types.hpp>
 
 #include <stan/math/prim/meta.hpp>
 #include <stan/math/prim/fun/Eigen.hpp>

--- a/runtime/kernels/densities_impl.hpp
+++ b/runtime/kernels/densities_impl.hpp
@@ -13,7 +13,9 @@
 #ifndef STANLI_KERNELS_DENSITIES_IMPL_HPP
 #define STANLI_KERNELS_DENSITIES_IMPL_HPP
 
-#include <stanli/graph.hpp>
+// Deliberately depend on the kernel-facing layouts rather than graph.hpp:
+// otherwise any Graph or Executor edit reinstantiates every density shard.
+#include <stanli/kernel_types.hpp>
 #include <stanli/optable.hpp>
 #include <stanli/recorder.hpp>
 


### PR DESCRIPTION
## Summary

- move EvalState, Desc, Slot, Op, and KernelCtx verbatim into a small kernel_types.hpp leaf header
- keep graph.hpp as the public umbrella for Graph, Executor, payload types, and the kernel-facing layouts
- make optable.hpp, recorder.hpp, and the density shards independent of Graph and Executor changes

## Incremental-build measurement

Apple M3 Ultra, RelWithDebInfo, Apple Clang 21, -j24:

- baseline graph.hpp rebuild: 84.94 s
- after: 54.87 s, 57.74 s, 55.93 s; median 55.93 s
- median improvement: 29.01 s (34%)
- graph.hpp-dependent outputs: 105 -> 85
- all eight heavy density shards no longer depend on graph.hpp
- changing kernel_types.hpp still rebuilds the density shards, as required

## Verification

- 109/109 CTest tests pass, including 41 lit tests
- format and diff checks pass
- kernel_types.hpp and graph.hpp compile standalone
- install packaging includes kernel_types.hpp
