### PR TITLE
Add functionality for exposing individual stan functions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -340,6 +340,7 @@ endif()
 if(NOT EMSCRIPTEN)
 add_library(stanli_shared SHARED
   runtime/src/capi.cpp
+  runtime/src/function.cpp
   runtime/src/build_id.cpp
   $<TARGET_OBJECTS:stanli_runtime_objects>
   $<TARGET_OBJECTS:stanli_tbb_stub>)
@@ -736,6 +737,14 @@ if(STANLI_FAST_TEST_TUS)
   target_compile_options(test_capi PRIVATE -O0)
 endif()
 add_test(NAME test_capi COMMAND test_capi
+         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+
+add_executable(test_function tests/test_function.cpp)
+target_link_libraries(test_function PRIVATE stanli_shared)
+if(STANLI_FAST_TEST_TUS)
+  target_compile_options(test_function PRIVATE -O0)
+endif()
+add_test(NAME test_function COMMAND test_function
          WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
 # The conformance gate has its own failure modes (parser drift, a broad policy

--- a/README.md
+++ b/README.md
@@ -201,6 +201,39 @@ relinking). Loading the uncommon densities on demand was built and removed;
 the measurements and the emscripten limitation that blocks it are in
 [docs/density-pack.md](docs/density-pack.md).
 
+## C++
+
+Native builds with embedded stanc expose a value-only function entry point.
+The source is compiled once by `Function`; subsequent calls bind named
+`DataMap` arguments directly to the Stan formals and return a
+`DataMap::Entry`, including integer identity and logical dimensions.
+
+```cpp
+#include <stanli/function.hpp>
+
+const std::string source = R"stan(
+functions {
+  vector affine(vector x, real a, real b) {
+    return a * x + b;
+  }
+}
+model {}
+)stan";
+
+stanli::Function affine(source, "affine");
+stanli::DataMap args;
+args.set_real_array("x", {1, 2, 4});
+args.set_real("a", 2.5);
+args.set_real("b", -1);
+stanli::DataMap::Entry result = affine(args);  // {1.5, 4, 9}
+```
+
+`Function::from_mir(mir, name)` skips source compilation for cached portable
+or legacy MIR and works in builds without embedded stanc. Arguments are
+matched by formal name. The first version evaluates pure, value-returning
+functions on doubles; `_lp`, void, RNG, and autodiff entry points are not part
+of this surface.
+
 ## Python
 
 A ctypes wrapper over the shared library, published to PyPI as one

--- a/runtime/include/stanli/function.hpp
+++ b/runtime/include/stanli/function.hpp
@@ -1,0 +1,98 @@
+// Direct, value-only invocation of a Stan user-defined function.
+//
+// This is a C++ convenience surface over exported stanli_* symbols.  It uses
+// DataMap for named arguments and DataMap::Entry for the result, preserving
+// integer identity, logical dimensions, and Stan's column-major storage.
+#ifndef STANLI_FUNCTION_HPP
+#define STANLI_FUNCTION_HPP
+
+#include <stanli/data.hpp>
+
+#include <cstddef>
+#include <stdexcept>
+#include <string>
+#include <utility>
+
+struct stanli_function;
+
+extern "C" {
+
+stanli_function* stanli_function_new_from_stan(const char* stan_code,
+                                               const char* function_name,
+                                               char* err, size_t err_len);
+stanli_function* stanli_function_new_from_mir(const char* mir_text,
+                                              const char* function_name,
+                                              char* err, size_t err_len);
+void stanli_function_free(stanli_function* function);
+int stanli_function_call(const stanli_function* function,
+                         const stanli::DataMap* arguments,
+                         stanli::DataMap::Entry* result, char* err,
+                         size_t err_len);
+
+}  // extern "C"
+
+namespace stanli {
+
+class Function {
+ public:
+  Function(const std::string& stan_code, const std::string& function_name)
+      : handle_(construct(stan_code, function_name, false)) {}
+
+  static Function from_mir(const std::string& mir_text,
+                           const std::string& function_name) {
+    return Function(construct(mir_text, function_name, true));
+  }
+
+  ~Function() { stanli_function_free(handle_); }
+
+  Function(const Function&) = delete;
+  Function& operator=(const Function&) = delete;
+
+  Function(Function&& other) noexcept
+      : handle_(std::exchange(other.handle_, nullptr)) {}
+  Function& operator=(Function&& other) noexcept {
+    if (this != &other) {
+      stanli_function_free(handle_);
+      handle_ = std::exchange(other.handle_, nullptr);
+    }
+    return *this;
+  }
+
+  DataMap::Entry operator()(const DataMap& arguments) const {
+    char err[8192] = {};
+    DataMap::Entry result;
+    if (stanli_function_call(handle_, &arguments, &result, err, sizeof(err)))
+      throw std::runtime_error(err[0] ? err
+                                      : "Stan function evaluation failed");
+    return result;
+  }
+
+ private:
+  explicit Function(stanli_function* handle) : handle_(handle) {}
+
+  static stanli_function* construct(const std::string& text,
+                                    const std::string& name, bool mir) {
+    char err[8192] = {};
+    stanli_function* result =
+        mir ? stanli_function_new_from_mir(text.c_str(), name.c_str(), err,
+                                           sizeof(err))
+            : stanli_function_new_from_stan(text.c_str(), name.c_str(), err,
+                                            sizeof(err));
+    if (!result)
+      throw std::runtime_error(err[0] ? err
+                                      : "Stan function compilation failed");
+    return result;
+  }
+
+  stanli_function* handle_ = nullptr;
+};
+
+inline DataMap::Entry evaluate_function(const std::string& stan_code,
+                                        const std::string& function_name,
+                                        const DataMap& arguments) {
+  return Function(stan_code, function_name)(arguments);
+}
+
+}  // namespace stanli
+
+#endif

--- a/runtime/include/stanli/mir_interp.hpp
+++ b/runtime/include/stanli/mir_interp.hpp
@@ -154,6 +154,29 @@ class MirInterp {
     fail("function returned no value: " + f.name);
   }
 
+  // Bind already-typed values positionally and preserve the complete return
+  // value, including integer identity and logical dimensions.  Function's
+  // public C++ entry point uses this path: DataMap::Entry is Value itself for
+  // the double instantiation, so no host/container conversion is needed.
+  Value call(const mir::FunDef& f, const std::vector<Value>& args) {
+    if (udf_depth_ > 64) fail("UDF recursion too deep");
+    if (f.arg_names.size() != args.size())
+      fail("function argument count mismatch: " + f.name);
+    MirInterp sub(funs_, where_, hooks_);
+    sub.udf_depth_ = udf_depth_ + 1;
+    sub.propto_ctx_ = propto_ctx_;
+    for (size_t k = 0; k < args.size(); ++k) {
+      sub.env_[f.arg_names[k]] = args[k];
+      sub.set_declared_dims(f.arg_names[k], args[k].dims);
+    }
+    try {
+      for (const auto& s : f.body) sub.exec(s);
+    } catch (ReturnV& r) {
+      return std::move(r.v);
+    }
+    fail("function returned no value: " + f.name);
+  }
+
   Value eval(const mir::Expr& e) {
     Value r;
     switch (e.kind) {

--- a/runtime/src/function.cpp
+++ b/runtime/src/function.cpp
@@ -203,9 +203,17 @@ int stanli_function_call(const stanli_function* function,
     std::vector<stanli::DataMap::Entry> values;
     values.reserve(selected->arg_names.size());
     for (size_t i = 0; i < selected->arg_names.size(); ++i) {
-      const auto& value = arguments->at(selected->arg_names[i]);
+      auto value = arguments->at(selected->arg_names[i]);
       validate_argument(selected->arg_names[i], selected->arg_views[i], value);
-      values.push_back(value);
+      // DataMap keeps an integer mirror so integer data can be promoted to a
+      // real formal. Once selected, the formal owns the type: leaving the
+      // mirror set would make a real identity function return an integer and
+      // could make later interpreter operations choose integer semantics.
+      if (selected->arg_views[i].leaf != stanli::mir::UnsizedLeaf::Int) {
+        value.is_int = false;
+        value.i.clear();
+      }
+      values.push_back(std::move(value));
     }
 
     stanli::MirInterp<double> interpreter(

--- a/runtime/src/function.cpp
+++ b/runtime/src/function.cpp
@@ -1,0 +1,221 @@
+#include <stanli/function.hpp>
+
+#include <stanli/capi.h>
+#include <stanli/mir_decode.hpp>
+#include <stanli/mir_interp.hpp>
+
+#include <cstring>
+#include <limits>
+#include <map>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace {
+
+void put_err(char* err, size_t err_len, const std::string& what) {
+  if (err == nullptr || err_len == 0) return;
+  std::strncpy(err, what.c_str(), err_len - 1);
+  err[err_len - 1] = '\0';
+}
+
+size_t leaf_rank(stanli::mir::UnsizedLeaf leaf) {
+  using Leaf = stanli::mir::UnsizedLeaf;
+  switch (leaf) {
+    case Leaf::Int:
+    case Leaf::Real:
+      return 0;
+    case Leaf::Vector:
+    case Leaf::RowVector:
+      return 1;
+    case Leaf::Matrix:
+      return 2;
+    case Leaf::Complex:
+      throw std::runtime_error("complex function arguments are unsupported");
+    case Leaf::Unknown:
+      throw std::runtime_error("function has unknown argument type");
+  }
+  throw std::runtime_error("function has invalid argument type");
+}
+
+int64_t checked_elements(const std::vector<int64_t>& dims,
+                         const std::string& name) {
+  int64_t n = 1;
+  for (int64_t dim : dims) {
+    if (dim < 0)
+      throw std::runtime_error("argument '" + name +
+                               "' has a negative dimension");
+    if (dim != 0 && n > std::numeric_limits<int64_t>::max() / dim)
+      throw std::runtime_error("argument '" + name + "' is too large");
+    n *= dim;
+  }
+  return n;
+}
+
+void validate_argument(const std::string& name,
+                       const stanli::mir::UnsizedView& view,
+                       const stanli::DataMap::Entry& value) {
+  using Leaf = stanli::mir::UnsizedLeaf;
+  const size_t rank = static_cast<size_t>(view.depth) + leaf_rank(view.leaf);
+  if (value.dims.size() != rank)
+    throw std::runtime_error("argument '" + name + "' has rank " +
+                             std::to_string(value.dims.size()) + ", expected " +
+                             std::to_string(rank));
+
+  const int64_t expected = checked_elements(value.dims, name);
+  if (value.r.size() != static_cast<size_t>(expected))
+    throw std::runtime_error("argument '" + name +
+                             "' storage does not match its dimensions");
+  if (view.leaf == Leaf::Int) {
+    if (!value.is_int)
+      throw std::runtime_error("argument '" + name + "' must be integer");
+    if (value.i.size() != static_cast<size_t>(expected))
+      throw std::runtime_error("integer argument '" + name +
+                               "' has no matching integer storage");
+  }
+}
+
+bool named(const stanli::mir::FunDef& f, std::string_view requested) {
+  if (f.name == requested) return true;
+  return f.name.size() > requested.size() &&
+         f.name.compare(0, requested.size(), requested) == 0 &&
+         f.name[requested.size()] == '(';
+}
+
+const stanli::mir::FunDef* select_function(const stanli::mir::Program& program,
+                                           const std::string& requested,
+                                           const stanli::DataMap* arguments) {
+  std::vector<const stanli::mir::FunDef*> candidates;
+  for (const auto& f : program.fun_defs)
+    if (named(f, requested)) candidates.push_back(&f);
+  if (candidates.empty())
+    throw std::runtime_error("Stan function not found: " + requested);
+
+  // An explicitly resolved signature, e.g. foo(real,vector), selects one
+  // definition without inspecting values.
+  for (const auto* f : candidates)
+    if (f->name == requested) return f;
+  if (arguments == nullptr) {
+    if (candidates.size() == 1) return candidates.front();
+    throw std::runtime_error("Stan function '" + requested +
+                             "' is overloaded; use a resolved signature");
+  }
+
+  std::vector<const stanli::mir::FunDef*> matches;
+  int best_promotions = std::numeric_limits<int>::max();
+  for (const auto* f : candidates) {
+    try {
+      int promotions = 0;
+      for (size_t i = 0; i < f->arg_names.size(); ++i) {
+        const auto& value = arguments->at(f->arg_names[i]);
+        validate_argument(f->arg_names[i], f->arg_views[i], value);
+        // Match stanc's ordinary numeric promotion preference: an integer
+        // argument selects an integer overload ahead of a real overload.
+        if (value.is_int &&
+            f->arg_views[i].leaf == stanli::mir::UnsizedLeaf::Real)
+          ++promotions;
+      }
+      if (promotions < best_promotions) {
+        best_promotions = promotions;
+        matches.clear();
+      }
+      if (promotions == best_promotions) matches.push_back(f);
+    } catch (const std::exception&) {
+    }
+  }
+  if (matches.size() == 1) return matches.front();
+  if (matches.empty())
+    throw std::runtime_error("no overload of Stan function '" + requested +
+                             "' matches the arguments");
+  throw std::runtime_error(
+      "arguments ambiguously match overloaded Stan function '" + requested +
+      "'; use a resolved signature");
+}
+
+}  // namespace
+
+struct stanli_function {
+  std::shared_ptr<const stanli::mir::Program> program;
+  std::string requested_name;
+};
+
+extern "C" {
+
+stanli_function* stanli_function_new_from_mir(const char* mir_text,
+                                              const char* function_name,
+                                              char* err, size_t err_len) {
+  try {
+    if (mir_text == nullptr || function_name == nullptr)
+      throw std::runtime_error("function MIR and name must not be null");
+    auto out = std::make_unique<stanli_function>();
+    out->program = std::make_shared<stanli::mir::Program>(
+        stanli::decode_program(mir_text));
+    out->requested_name = function_name;
+    // Fail at construction for a missing name. Overloads are intentionally
+    // selected later, when their argument values are present.
+    bool found = false;
+    for (const auto& f : out->program->fun_defs)
+      found |= named(f, function_name);
+    if (!found)
+      throw std::runtime_error("Stan function not found: " +
+                               std::string(function_name));
+    return out.release();
+  } catch (const std::exception& e) {
+    put_err(err, err_len, e.what());
+    return nullptr;
+  }
+}
+
+stanli_function* stanli_function_new_from_stan(const char* stan_code,
+                                               const char* function_name,
+                                               char* err, size_t err_len) {
+  if (stan_code == nullptr || function_name == nullptr) {
+    put_err(err, err_len, "function source and name must not be null");
+    return nullptr;
+  }
+  char* mir = stanli_stan_to_mir(stan_code, err, err_len);
+  if (mir == nullptr) return nullptr;
+  stanli_function* out =
+      stanli_function_new_from_mir(mir, function_name, err, err_len);
+  stanli_string_free(mir);
+  return out;
+}
+
+void stanli_function_free(stanli_function* function) { delete function; }
+
+int stanli_function_call(const stanli_function* function,
+                         const stanli::DataMap* arguments,
+                         stanli::DataMap::Entry* result, char* err,
+                         size_t err_len) {
+  try {
+    if (function == nullptr || arguments == nullptr || result == nullptr)
+      throw std::runtime_error(
+          "function, arguments, and result must not be null");
+    const stanli::mir::FunDef* selected = select_function(
+        *function->program, function->requested_name, arguments);
+
+    std::map<std::string, const stanli::mir::FunDef*> functions;
+    for (const auto& f : function->program->fun_defs)
+      functions.emplace(f.name, &f);
+
+    std::vector<stanli::DataMap::Entry> values;
+    values.reserve(selected->arg_names.size());
+    for (size_t i = 0; i < selected->arg_names.size(); ++i) {
+      const auto& value = arguments->at(selected->arg_names[i]);
+      validate_argument(selected->arg_names[i], selected->arg_views[i], value);
+      values.push_back(value);
+    }
+
+    stanli::MirInterp<double> interpreter(
+        functions, "function " + function->requested_name);
+    *result = interpreter.call(*selected, values);
+    return 0;
+  } catch (const std::exception& e) {
+    put_err(err, err_len, e.what());
+    return 1;
+  }
+}
+
+}  // extern "C"

--- a/tests/test_function.cpp
+++ b/tests/test_function.cpp
@@ -1,0 +1,171 @@
+#include <stanli/function.hpp>
+#include <stanli/capi.h>
+
+#include <cstdio>
+#include <fstream>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace {
+
+int failures = 0;
+
+void check(bool condition, const char* message) {
+  if (!condition) {
+    ++failures;
+    std::printf("FAIL %s\n", message);
+  }
+}
+
+template <typename F>
+void throws_with(F&& f, const std::string& needle, const char* message) {
+  try {
+    f();
+    check(false, message);
+  } catch (const std::exception& e) {
+    check(std::string(e.what()).find(needle) != std::string::npos, message);
+  }
+}
+
+const char* source = R"stan(
+functions {
+  vector affine(vector x, real a, real b) {
+    return a * x + b;
+  }
+  int plus_one(int x) {
+    return x + 1;
+  }
+  matrix scale_matrix(matrix x, real a) {
+    return a * x;
+  }
+  real overloaded(real x) {
+    return x + 0.5;
+  }
+  real overloaded(vector x) {
+    return sum(x);
+  }
+  real numeric(int x) {
+    return x + 10;
+  }
+  real numeric(real x) {
+    return x + 20;
+  }
+}
+model {}
+)stan";
+
+std::string slurp(const char* path) {
+  std::ifstream input(path);
+  std::ostringstream text;
+  text << input.rdbuf();
+  return text.str();
+}
+
+}  // namespace
+
+int main() {
+  using stanli::DataMap;
+  using stanli::Function;
+
+  try {
+    // The MIR constructor works in every runtime build, including developer
+    // builds which deliberately omit the embedded source compiler.
+    Function cached = Function::from_mir(
+        slurp("tests/fixtures/early_return.tmir.sexp"), "choose");
+    DataMap cached_args;
+    cached_args.set_real("x", 4.0);
+    cached_args.set_int("first", 1);
+    check(cached(cached_args).r == std::vector<double>({8.0}),
+          "cached MIR function call");
+
+    if (!stanli_has_embedded_stanc()) {
+      throws_with([&] { Function unavailable(source, "affine"); },
+                  "does not embed stanc3",
+                  "source constructor reports unavailable compiler");
+      if (failures == 0) std::printf("OK function\n");
+      return failures == 0 ? 0 : 1;
+    }
+
+    Function affine(source, "affine");
+    DataMap args;
+    args.set_real_array("x", {1.0, 2.0, 4.0});
+    args.set_real("a", 2.5);
+    args.set_real("b", -1.0);
+    const DataMap::Entry result = affine(args);
+    check(!result.is_int, "vector result is real");
+    check(result.dims == std::vector<int64_t>{3},
+          "vector result keeps dimensions");
+    check(result.r == std::vector<double>({1.5, 4.0, 9.0}),
+          "vector result values");
+
+    Function plus_one(source, "plus_one");
+    DataMap ints;
+    ints.set_int("x", 41);
+    const DataMap::Entry integer = plus_one(ints);
+    check(integer.is_int && integer.i == std::vector<int>({42}) &&
+              integer.r == std::vector<double>({42.0}) && integer.dims.empty(),
+          "integer result keeps both representations");
+
+    Function scale(source, "scale_matrix");
+    DataMap matrix;
+    // Matrix storage is column-major: [1 3; 2 4].
+    matrix.set_real_array("x", {1.0, 2.0, 3.0, 4.0}, {2, 2});
+    matrix.set_real("a", 3.0);
+    const DataMap::Entry scaled = scale(matrix);
+    check(scaled.dims == std::vector<int64_t>({2, 2}),
+          "matrix result keeps dimensions");
+    check(scaled.r == std::vector<double>({3.0, 6.0, 9.0, 12.0}),
+          "matrix result keeps column-major values");
+
+    Function overloaded(source, "overloaded");
+    DataMap scalar;
+    scalar.set_real("x", 2.0);
+    check(overloaded(scalar).r == std::vector<double>({2.5}),
+          "overload selected by scalar rank");
+    DataMap vector;
+    vector.set_real_array("x", {1.0, 2.0, 3.0});
+    check(overloaded(vector).r == std::vector<double>({6.0}),
+          "overload selected by vector rank");
+
+    Function numeric(source, "numeric");
+    DataMap promoted;
+    promoted.set_int("x", 2);
+    check(numeric(promoted).r == std::vector<double>({12.0}),
+          "integer overload wins over real promotion");
+
+    throws_with(
+        [&] {
+          DataMap missing;
+          missing.set_real("a", 1.0);
+          missing.set_real("b", 2.0);
+          (void)affine(missing);
+        },
+        "variable not provided: x", "missing named argument reports its name");
+
+    throws_with(
+        [&] {
+          DataMap wrong;
+          wrong.set_real("x", 1.0);
+          wrong.set_real("a", 1.0);
+          wrong.set_real("b", 2.0);
+          (void)affine(wrong);
+        },
+        "rank 0, expected 1", "argument rank mismatch is rejected");
+
+    throws_with([&] { Function absent(source, "absent"); },
+                "Stan function not found", "missing function is rejected");
+
+    const DataMap::Entry one_shot =
+        stanli::evaluate_function(source, "plus_one", ints);
+    check(one_shot.i == std::vector<int>({42}),
+          "one-shot evaluate_function entry point");
+  } catch (const std::exception& e) {
+    std::printf("FAIL unexpected exception: %s\n", e.what());
+    ++failures;
+  }
+
+  if (failures == 0) std::printf("OK function\n");
+  return failures == 0 ? 0 : 1;
+}

--- a/tests/test_function.cpp
+++ b/tests/test_function.cpp
@@ -37,6 +37,9 @@ functions {
   int plus_one(int x) {
     return x + 1;
   }
+  real real_identity(real x) {
+    return x;
+  }
   matrix scale_matrix(matrix x, real a) {
     return a * x;
   }
@@ -107,6 +110,12 @@ int main() {
     check(integer.is_int && integer.i == std::vector<int>({42}) &&
               integer.r == std::vector<double>({42.0}) && integer.dims.empty(),
           "integer result keeps both representations");
+
+    Function real_identity(source, "real_identity");
+    const DataMap::Entry promoted_real = real_identity(ints);
+    check(!promoted_real.is_int && promoted_real.i.empty() &&
+              promoted_real.r == std::vector<double>({41.0}),
+          "integer argument is promoted to the real formal");
 
     Function scale(source, "scale_matrix");
     DataMap matrix;

--- a/tools/exported_symbols.def
+++ b/tools/exported_symbols.def
@@ -14,6 +14,10 @@ EXPORTS
   stanli_has_embedded_stanc
   stanli_stan_to_mir
   stanli_string_free
+  stanli_function_new_from_stan
+  stanli_function_new_from_mir
+  stanli_function_free
+  stanli_function_call
   stanli_build_id
   stanli_exact_lp
   stanli_model_free


### PR DESCRIPTION
The `expose_stan_functions` feature from the R interfaces is very popular, particularly when prototyping

## Summary

- Add a C++ `stanli::Function` API for evaluating pure, value-returning Stan UDFs.
- Accept named arguments through `DataMap` and return a shape-preserving `DataMap::Entry`.
- Support source compilation, cached MIR, overload resolution, and argument validation.
- Export the new native entrypoints and add coverage for scalar, integer, vector, matrix, overload, validation, and MIR paths.

## Example

```cpp
const std::string source = R"stan(
functions {
  vector affine(vector x, real a, real b) {
    return a * x + b;
  }
}
model {}
)stan";

stanli::Function affine(source, "affine");

stanli::DataMap args;
args.set_real_array("x", {1, 2, 4});
args.set_real("a", 2.5);
args.set_real("b", -1);

stanli::DataMap::Entry result = affine(args);
// result.r == {1.5, 4.0, 9.0}
```

## Validation

- Clean build completed with `-j32`.
- Full test suite passes: 110/110.