### PR TITLE
ci: test stanr against current runtime

### DIFF
--- a/.github/workflows/stanr.yml
+++ b/.github/workflows/stanr.yml
@@ -1,0 +1,63 @@
+# Build the downstream stanr package with this checkout's vendored runtime,
+# then run stanr's own stanli-backend contract tests. This catches source/API
+# incompatibilities that the standalone R package cannot see: stanr embeds
+# Stanli directly and adapts it to Stan's model_base interface.
+name: stanr downstream
+
+on:
+  push:
+    branches: [main]
+    tags: ['v*']
+    paths:
+      - 'runtime/include/**'
+      - 'runtime/src/**'
+      - 'runtime/kernels/**'
+      - 'tests/test_stanr.sh'
+      - 'tests/test_stanr_backend.R'
+      - '.github/workflows/stanr.yml'
+  pull_request:
+    paths:
+      - 'runtime/include/**'
+      - 'runtime/src/**'
+      - 'runtime/kernels/**'
+      - 'tests/test_stanr.sh'
+      - 'tests/test_stanr_backend.R'
+      - '.github/workflows/stanr.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  backend:
+    name: current runtime in stanr
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+    env:
+      # Pin the downstream source so unrelated upstream changes cannot make a
+      # Stanli pull request fail. Refresh this together with the test if stanr
+      # changes its vendoring or backend contract.
+      STANR_REF: da5de850718ca62ad752365d5467566eea22a0c5
+      MAKEFLAGS: -j2
+      TESTTHAT_CPUS: 2
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          r-version: release
+          use-public-rspm: true
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          working-directory: r
+          dependencies: '"hard"'
+          extra-packages: >-
+            any::R6, any::QuickJSR, any::posterior, any::withr, any::testthat
+
+      - name: Build and test stanr's Stanli backend
+        run: ./tests/test_stanr.sh "$STANR_REF"

--- a/TESTING.md
+++ b/TESTING.md
@@ -53,6 +53,7 @@ known exceptions.
 | cross-path matrix | Do stanli's execution paths agree with one another? | Bitwise, except entries named in the ledger | every pull request, within CTest |
 | transformation A/B | Do selected graph optimizations preserve model results? | Optimizations enabled and disabled agree at the default point within 1e-11 | manually after optimization changes |
 | BridgeStan C-ABI comparison | Does the public C interface agree with reference BridgeStan? | Four fixture models must pass value, name, count, and output-shape checks | every pull request |
+| downstream `stanr` embedding | Can the R package vendor this checkout and use Stanli through its `model_base` adapter? | `stanr` must build, then its Stanli-backend construction, derivative, sampling, data, output, init, and cache tests must pass | every pull request that changes the vendored runtime surface |
 | generated conformance sweep | For cases that both systems evaluate, do results agree, and which generated cases remain unsupported? | 10 ULP by default; reviewed per-case policy where needed | nightly and on demand |
 | coverage baseline | Did a previously verified generated case stop verifying? | No loss of a verified case; obsolete policy exceptions must be removed | within the nightly sweep |
 | model census | Do stanc3's 1,231 integration models still compile into stanli's runtime representation and, where checked, agree with CmdStan? | No decrease in per-model classification | manually, on demand |
@@ -621,7 +622,9 @@ repeat-evaluation tests are needed for that case.
 The full source-change path in the pull-request workflows requires the
 following checks, as defined in
 [`.github/workflows/wheels.yml`](.github/workflows/wheels.yml) and
-[`.github/workflows/lint.yml`](.github/workflows/lint.yml):
+[`.github/workflows/lint.yml`](.github/workflows/lint.yml), with the downstream
+embedding check in
+[`.github/workflows/stanr.yml`](.github/workflows/stanr.yml):
 
 - one platform build, `manylinux_2_28_x86_64`;
 - the compiler-only Windows cross-build and executable parity gate described
@@ -644,6 +647,10 @@ following checks, as defined in
   source rather than only against stanli's own interface tests;
 - the R package's tests under `R CMD check` against the library that
   build produced, with a missing-runtime skip treated as a failure;
+- the pinned downstream `stanr` package rebuilt with the current checkout's
+  vendored headers, runtime sources, and kernels, followed by `stanr`'s own
+  Stanli-backend tests for model construction, derivatives, sampling, data
+  marshaling, generated quantities, initialization, and caching;
 - `clang-format` over tracked project-owned C/C++ files, excluding vendored
   dependencies and third-party code. The formatter version is pinned because
   output can differ across major versions.

--- a/runtime/src/function.cpp
+++ b/runtime/src/function.cpp
@@ -1,6 +1,14 @@
 #include <stanli/function.hpp>
 
+#if __has_include(<stanli/capi.h>)
 #include <stanli/capi.h>
+#define STANLI_FUNCTION_HAS_CAPI 1
+#else
+// Source-only consumers may deliberately omit the separately exported C API
+// while compiling runtime/src/*.cpp as a library. Function::from_mir remains
+// usable there; only the convenience constructor from Stan source is absent.
+#define STANLI_FUNCTION_HAS_CAPI 0
+#endif
 #include <stanli/mir_decode.hpp>
 #include <stanli/mir_interp.hpp>
 
@@ -175,12 +183,19 @@ stanli_function* stanli_function_new_from_stan(const char* stan_code,
     put_err(err, err_len, "function source and name must not be null");
     return nullptr;
   }
+#if STANLI_FUNCTION_HAS_CAPI
   char* mir = stanli_stan_to_mir(stan_code, err, err_len);
   if (mir == nullptr) return nullptr;
   stanli_function* out =
       stanli_function_new_from_mir(mir, function_name, err, err_len);
   stanli_string_free(mir);
   return out;
+#else
+  put_err(err, err_len,
+          "Stan source compilation is unavailable without the Stanli C API; "
+          "construct the function from MIR instead");
+  return nullptr;
+#endif
 }
 
 void stanli_function_free(stanli_function* function) { delete function; }

--- a/tests/test_stanr.sh
+++ b/tests/test_stanr.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 1 || -z $1 ]]; then
+  echo "usage: $0 STANR_GIT_REF" >&2
+  exit 2
+fi
+
+repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+stanr_ref=$1
+stanr_repository=${STANR_REPOSITORY:-https://github.com/andrjohns/stanr.git}
+test_dir=$(mktemp -d "${TMPDIR:-/tmp}/stanli-stanr.XXXXXX")
+trap 'find "$test_dir" -mindepth 1 -delete; rmdir "$test_dir"' EXIT
+
+stanr_dir=$test_dir/stanr
+source_stage=$test_dir/source/stanli-current-checkout
+r_library=$test_dir/library
+
+# Fetch only the reviewed downstream revision. stanr's repository is large
+# because it vendors Stan Math, so a one-commit fetch saves substantial time
+# and bandwidth without weakening the source pin.
+git init -q "$stanr_dir"
+git -C "$stanr_dir" remote add origin "$stanr_repository"
+git -C "$stanr_dir" fetch --depth=1 origin "$stanr_ref"
+git -C "$stanr_dir" checkout --detach FETCH_HEAD
+echo "testing stanr $(git -C "$stanr_dir" rev-parse HEAD)"
+
+# stanr's upgrade script expects a GitHub-style archive with one top-level
+# directory. Stage tracked and untracked, non-ignored runtime sources so this
+# command also tests a developer's current working tree before it is committed.
+mkdir -p "$source_stage"
+while IFS= read -r source_path; do
+  [[ -f $repo_root/$source_path ]] || continue
+  mkdir -p "$source_stage/$(dirname "$source_path")"
+  cp "$repo_root/$source_path" "$source_stage/$source_path"
+done < <(git -C "$repo_root" ls-files --cached --others --exclude-standard \
+  LICENSE runtime/include runtime/src runtime/kernels)
+
+tar -C "$test_dir/source" -czf \
+  "$stanr_dir/tools/stanli-current-checkout.tar.gz" \
+  stanli-current-checkout
+sed -i.bak 's/^STANLI_REF=.*/STANLI_REF="current-checkout"/' \
+  "$stanr_dir/tools/upgrade_stanli.sh"
+rm "$stanr_dir/tools/upgrade_stanli.sh.bak"
+grep -Fqx 'STANLI_REF="current-checkout"' \
+  "$stanr_dir/tools/upgrade_stanli.sh"
+(
+  cd "$stanr_dir/tools"
+  ./upgrade_stanli.sh
+)
+
+mkdir -p "$r_library"
+R CMD INSTALL --library="$r_library" "$stanr_dir"
+R_LIBS_USER="$r_library${R_LIBS_USER:+:$R_LIBS_USER}" \
+  Rscript --vanilla "$repo_root/tests/test_stanr_backend.R" "$stanr_dir"

--- a/tests/test_stanr_backend.R
+++ b/tests/test_stanr_backend.R
@@ -1,0 +1,21 @@
+# Run the downstream package's own Stanli backend suite against the installed
+# stanr built by test_stanr.sh. Keeping the tests in stanr means this gate
+# follows the real consumer contract rather than duplicating a partial facade.
+
+args <- commandArgs(trailingOnly = TRUE)
+if (length(args) != 1L || !dir.exists(args[[1L]]))
+  stop("usage: test_stanr_backend.R STANR_SOURCE_DIR", call. = FALSE)
+
+suppressPackageStartupMessages({
+  library(stanr)
+  library(testthat)
+})
+
+testthat::test_dir(
+  file.path(args[[1L]], "tests", "testthat"),
+  filter = "stanli-backend",
+  reporter = "summary",
+  stop_on_failure = TRUE
+)
+
+message("stanr's Stanli backend suite passed")


### PR DESCRIPTION
## Summary
- build a pinned stanr checkout with the current Stanli runtime vendored through stanr's own upgrade script
- run stanr's dedicated Stanli backend tests in a downstream Linux CI job
- keep `Function::from_mir` usable for source-only consumers that omit the standalone C API

## Testing
- `./tests/test_stanr.sh da5de850718ca62ad752365d5467566eea22a0c5`
- `./tools/format.sh --check`
- `bash -n tests/test_stanr.sh`
- R and workflow YAML syntax checks