### PR TITLE
Optimize Program CALL dispatch

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -673,6 +673,12 @@ set_tests_properties(test_prep_profile_reroll_dispositions PROPERTIES
 add_executable(bench_opcost tools/bench_opcost.cpp
   $<TARGET_OBJECTS:stanli_tbb_stub>)
 target_link_libraries(bench_opcost PRIVATE stanli)
+# Developer-only Program::CALL dispatch/context benchmark.  It builds a
+# synthetic, model-independent register program so CALL overhead can be
+# measured without attributing a kernel's own arithmetic to the mechanism.
+add_executable(bench_program_call EXCLUDE_FROM_ALL
+  tools/bench_program_call.cpp tests/tbb_stub.cpp)
+target_link_libraries(bench_program_call PRIVATE stanli)
 # Developer-only ODE RHS generated-adjoint spike.  Not a test and not installed.
 add_executable(bench_rhs_adjoint EXCLUDE_FROM_ALL
   tools/bench_rhs_adjoint.cpp tests/tbb_stub.cpp)

--- a/runtime/include/stanli/adjoint.hpp
+++ b/runtime/include/stanli/adjoint.hpp
@@ -80,8 +80,8 @@ struct AdjProgram {
 // forward never rewrites shares one adjoint cell with its source, the way
 // the replay's registers share one vari, so a live-out or live-in register
 // may not have an adjoint cell of its own.
-// `fwd` rides along for the CALL payloads: a CALL's adjoint is its
-// kernel's own backward, and the ranges live in fwd.calls.
+// `fwd` supplies normalized CALL payloads: one per CALL instruction, with a
+// pre-resolved kernel backward and precomputed value/adjoint ranges.
 void run_adjoint(const Program& fwd, const AdjProgram& ap, const double* val,
                  double* adj);
 

--- a/runtime/include/stanli/island.hpp
+++ b/runtime/include/stanli/island.hpp
@@ -78,15 +78,21 @@ struct Softmax3IslandProg : IslandProg {
   std::shared_ptr<const Program> optimized_double;
 };
 
-// OP_ISLAND's variant is otherwise unused. This value selects the derived
-// payload's double-only plan while retaining the ordinary island opcode and
-// kernel-table layout. Setting it on a plain IslandProg violates the tagged
-// payload contract; the graph carver is the only production producer. Its
+// This value selects the derived payload's double-only plan while retaining
+// the ordinary island opcode and kernel-table layout. Setting it on a plain
+// IslandProg violates the tagged payload contract; the graph carver is the
+// only production producer. Its
 // forward must leave outputs and scratch bitwise-identical to OP_ISLAND's
 // canonical forward: the profiled executor and direct kernel-table callers
 // use that path, and the generated adjoint consumes either register file.
 // test_softmax3_double_exact enforces this contract.
 constexpr uint8_t kIslandSoftmax3Variant = 1;
+// Generic variant for a canonical IslandProg whose forward bytecode contains
+// Program::CALL. Executor binding selects its context-reusing forward once;
+// ordinary islands retain the context-free evaluator with no runtime check.
+constexpr uint8_t kIslandCallVariant = 2;
+
+void island_calls_fwd(KernelCtx& ctx);
 
 // Run compact_program (program.hpp) over the region's forward code, live-ins
 // included, before the adjoint generator reads it -- so the backward is

--- a/runtime/include/stanli/program.hpp
+++ b/runtime/include/stanli/program.hpp
@@ -20,6 +20,7 @@
 #ifndef STANLI_PROGRAM_HPP
 #define STANLI_PROGRAM_HPP
 
+#include <stanli/kernel_types.hpp>
 #include <stanli/program_density.hpp>
 
 #include <stan/math.hpp>
@@ -33,7 +34,7 @@
 
 namespace stanli {
 
-struct KernelCtx;  // graph.hpp; only CALL's helpers touch it
+using KernelFn = void (*)(KernelCtx&);
 
 // Structural facts used by the program compilers and the generated-adjoint
 // pass. The evaluator's arithmetic stays in the explicit switch below: its
@@ -162,23 +163,33 @@ struct Program {
   // A CALL's payload: which kernel, and which register ranges stand in
   // for its slots. `scratch` is a range inside the register file, so the
   // partials the forward stashes are retained for the backward the same
-  // way every value is. `bwd_in`/`bwd_out` are where the VALUES live at
-  // backward time -- the same registers, unless the adjoint generator
-  // had to checkpoint them (some kernel backwards re-read their inputs;
-  // backward_ignores_values is a whitelist, not a guarantee).
+  // way every value is. The adjoint generator normalizes each CALL
+  // instruction to its own payload and binds checkpointed value and compact
+  // adjoint ranges below (adjoint.hpp).
   struct Call {
     uint16_t opcode = 0;
     uint8_t variant = 0;
     int8_t n_in = 0;
+    // Resolved once when the call site is built. A registered kernel's
+    // function identity is stable, so repeated table lookup during program
+    // execution can add no information. The generated adjoint uses the same
+    // bound `backward` pointer.
+    KernelFn forward = nullptr;
+    KernelFn backward = nullptr;
     int32_t in[6] = {0, 0, 0, 0, 0, 0};
     int32_t in_len[6] = {0, 0, 0, 0, 0, 0};
     int32_t out = 0;
     int32_t out_len = 0;
     int32_t scratch = 0;
     int32_t scratch_len = 0;
-    int32_t bwd_in[6] = {0, 0, 0, 0, 0, 0};
-    int32_t bwd_out = 0;
     std::vector<int> idata;
+    // Generated reverse binding. gen_adjoint normalizes CALL instructions to
+    // one payload each, then caches their checkpointed value ranges and
+    // compact adjoint ranges here. Forward-only Programs leave these zero.
+    int32_t bwd_value_in[6] = {0, 0, 0, 0, 0, 0};
+    int32_t bwd_adj_in[6] = {0, 0, 0, 0, 0, 0};
+    int32_t bwd_value_out = 0;
+    int32_t bwd_adj_out = 0;
   };
 
   std::vector<Instr> code;
@@ -243,17 +254,33 @@ bool compact_program_gated(Program& p, std::vector<std::pair<int, int>>& seeded,
 // Backward-only fields are left null; run_adjoint fills its own.
 KernelCtx call_fwd_ctx(const Program::Call& call, double* reg);
 
-// Run one CALL forward. Out of line: KernelCtx lives in graph.hpp and
-// the kernel table in the executor, neither of which this header needs
-// for anything else.
+// Resolve a manually constructed call site once. Production carvers already
+// have the Kernel in hand and bind its pointers directly. False leaves the
+// call unbound, so malformed or unavailable opcodes fail closed.
+bool bind_call(Program::Call& call);
+
+// Run one CALL forward through its pre-resolved function.
 void run_call(const Program::Call& call, double* reg);
+
+// Reuse a caller-owned transient context. Its pointer fields are rebound per
+// site, while construction/defaulting of the full packet is not paid again.
+void run_call(const Program::Call& call, double* reg, KernelCtx& ctx);
 
 // Run `p` over `reg`, which the caller has seeded and sized to at least
 // p.n_regs. The compilers guarantee every register is written before it is
 // read, so a reused file never leaks a previous call's values.
-template <typename T>
-void run_program(const Program& p, T* reg) {
+template <bool ReuseCallCtx>
+struct ProgramCallCtx {};
+
+template <>
+struct ProgramCallCtx<true> {
+  KernelCtx ctx;
+};
+
+template <bool ReuseCallCtx, typename T>
+void run_program_impl(const Program& p, T* reg) {
   using VecT = Eigen::Matrix<T, Eigen::Dynamic, 1>;
+  ProgramCallCtx<ReuseCallCtx> call_ctx;
   const int64_t n = (int64_t)p.code.size();
   for (int64_t pc = 0; pc < n; ++pc) {
     const Program::Instr& I = p.code[(size_t)pc];
@@ -509,7 +536,10 @@ void run_program(const Program& p, T* reg) {
       // program.
       case Program::CALL:
         if constexpr (std::is_same_v<T, double>) {
-          run_call(p.calls[(size_t)I.a], reg);
+          if constexpr (ReuseCallCtx)
+            run_call(p.calls[(size_t)I.a], reg, call_ctx.ctx);
+          else
+            run_call(p.calls[(size_t)I.a], reg);
         } else {
           // Kernels are double machinery; a program that reaches here
           // under var was carved wrong, and saying so beats corrupting
@@ -532,6 +562,17 @@ void run_program(const Program& p, T* reg) {
       }
     }
   }
+}
+
+template <typename T>
+void run_program(const Program& p, T* reg) {
+  if constexpr (std::is_same_v<T, double>) {
+    if (!p.calls.empty()) {
+      run_program_impl<true>(p, reg);
+      return;
+    }
+  }
+  run_program_impl<false>(p, reg);
 }
 
 template <typename T>

--- a/runtime/kernels/island.cpp
+++ b/runtime/kernels/island.cpp
@@ -41,7 +41,8 @@ int64_t island_scratch(const Op& op, const Slot* slots) {
   return sum_in_lens(op, slots);
 }
 
-void island_fwd(KernelCtx& ctx) {
+template <bool ReuseCallCtx>
+void island_fwd_impl(KernelCtx& ctx) {
   const auto& p = *static_cast<const IslandProg*>(ctx.udata);
   if (p.native_adj) {
     // Mirrored by island_softmax3_fwd; keep these seed and harvest loops in
@@ -52,7 +53,7 @@ void island_fwd(KernelCtx& ctx) {
       for (int i = 0; i < li.len; ++i)
         ctx.scratch[li.reg + i] = ctx.in[input].data[li.offset + i];
     }
-    run_program(p, ctx.scratch);
+    run_program_impl<ReuseCallCtx>(p, ctx.scratch);
     for (size_t m = 0; m < p.out_regs.size(); ++m)
       ctx.out.data[m] = ctx.scratch[p.out_regs[m]];
     return;
@@ -67,6 +68,8 @@ void island_fwd(KernelCtx& ctx) {
   }
   run_island<double>(p, in, ctx.out.data);
 }
+
+void island_fwd(KernelCtx& ctx) { island_fwd_impl<false>(ctx); }
 
 // The generated backward: seed the live-outs, sweep, harvest the live-ins.
 void island_bwd_native(const IslandProg& p, KernelCtx& ctx) {
@@ -126,6 +129,8 @@ void island_bwd(KernelCtx& ctx) {
 }
 
 }  // namespace
+
+void island_calls_fwd(KernelCtx& ctx) { island_fwd_impl<true>(ctx); }
 
 void register_island_kernel() {
   register_kernel(OP_ISLAND, Kernel{island_fwd, island_bwd, island_scratch});

--- a/runtime/src/adjoint.cpp
+++ b/runtime/src/adjoint.cpp
@@ -45,8 +45,18 @@ bool gen_adjoint(IslandProg& p) {
   const int n0 = fwd.n_regs;
   // Reversing flat jumps needs the structured if/else form the instruction
   // stream has already lost. Such programs keep the var replay.
-  for (const auto& I : orig)
+  for (const auto& I : orig) {
     if (program_code_spec(I.code).has(kProgramNoAdjoint)) return false;
+    if (I.code != Program::CALL) continue;
+    if (I.a < 0 || (size_t)I.a >= fwd.calls.size()) return false;
+    const Program::Call& call = fwd.calls[(size_t)I.a];
+    // A forward-only call (including a malformed manually built payload)
+    // cannot acquire a generated derivative. Check before any checkpoint or
+    // call metadata is written so refusal leaves the program untouched.
+    if (call.n_in < 0 || call.n_in > 6 || call.forward == nullptr ||
+        call.backward == nullptr)
+      return false;
+  }
 
   // Where each register was first and last written. A value the backward
   // needs survives in place exactly when no later instruction overwrites it;
@@ -202,6 +212,8 @@ bool gen_adjoint(IslandProg& p) {
 
   std::vector<Program::Instr> ncode;
   ncode.reserve(orig.size());
+  std::vector<Program::Call> bound_calls;
+  bound_calls.reserve(fwd.calls.size());
   AdjProgram ap;
   ap.code.reserve(orig.size());
   ap.adj_reg.resize((size_t)n0);
@@ -298,18 +310,21 @@ bool gen_adjoint(IslandProg& p) {
       // scratch (backward_ignores_values is a whitelist, not a
       // guarantee), and some read their output values too -- so both are
       // checkpointed whenever a later instruction overwrites them.
-      Program::Call& call = fwd.calls[(size_t)I.a];
+      Program::Call call = fwd.calls[(size_t)I.a];
       for (int j = 0; j < call.n_in; ++j) {
-        (void)mapn(call.in[j], call.in_len[j]);
-        call.bwd_in[j] = save_range(call.in[j], call.in_len[j], i);
+        call.bwd_adj_in[j] = mapn(call.in[j], call.in_len[j]);
+        call.bwd_value_in[j] = save_range(call.in[j], call.in_len[j], i);
       }
-      (void)mapn(call.out, call.out_len);
+      call.bwd_adj_out = mapn(call.out, call.out_len);
       if (!mapped_ranges_ok) return false;
-      ncode.push_back(I);
-      call.bwd_out = save_range(call.out, call.out_len, i);
+      Program::Instr F = I;
+      F.a = static_cast<int32_t>(bound_calls.size());
+      ncode.push_back(F);
+      call.bwd_value_out = save_range(call.out, call.out_len, i);
       AdjInstr A;
       A.code = Program::CALL;
-      A.a = I.a;
+      A.a = static_cast<int32_t>(bound_calls.size());
+      bound_calls.push_back(std::move(call));
       ap.code.push_back(A);
       continue;
     }
@@ -390,6 +405,7 @@ bool gen_adjoint(IslandProg& p) {
 
   std::reverse(ap.code.begin(), ap.code.end());
   fwd.code = std::move(ncode);
+  fwd.calls = std::move(bound_calls);
   fwd.n_regs = n_regs;
   p.adj = std::move(ap);
   return true;
@@ -404,6 +420,11 @@ using CAdjA = Eigen::Map<const Eigen::ArrayXd>;
 
 void run_adjoint(const Program& fwd, const AdjProgram& ap, const double* val,
                  double* adj) {
+  KernelCtx* call_ctx = nullptr;
+  if (!fwd.calls.empty()) {
+    static thread_local KernelCtx worker_call_ctx;
+    call_ctx = &worker_call_ctx;
+  }
   for (const AdjInstr& I : ap.code) {
     if (I.code == Program::CALL) {
       // The kernel's own backward is the rule: values from the (possibly
@@ -414,25 +435,23 @@ void run_adjoint(const Program& fwd, const AdjProgram& ap, const double* val,
       // contiguity. Then the output's cells are cleared, the same
       // consume-and-clear every other rule performs.
       const Program::Call& call = fwd.calls[(size_t)I.a];
-      KernelCtx ctx;
+      KernelCtx& ctx = *call_ctx;
       ctx.n_in = call.n_in;
       for (int k = 0; k < call.n_in; ++k) {
-        ctx.in[k] =
-            Desc{const_cast<double*>(val) + call.bwd_in[k], call.in_len[k]};
-        const int in_adj = call.in_len[k] ? ap.adj_reg[(size_t)call.in[k]] : 0;
-        ctx.in_adj[k] = Desc{adj + in_adj, call.in_len[k]};
+        ctx.in[k] = Desc{const_cast<double*>(val) + call.bwd_value_in[k],
+                         call.in_len[k]};
+        ctx.in_adj[k] = Desc{adj + call.bwd_adj_in[k], call.in_len[k]};
       }
-      ctx.out = Desc{const_cast<double*>(val) + call.bwd_out, call.out_len};
-      const int out_adj = ap.adj_reg[(size_t)call.out];
-      ctx.out_adj_vec = Desc{adj + out_adj, call.out_len};
-      if (call.out_len == 1) ctx.out_adj = adj[out_adj];
+      ctx.out =
+          Desc{const_cast<double*>(val) + call.bwd_value_out, call.out_len};
+      ctx.out_adj_vec = Desc{adj + call.bwd_adj_out, call.out_len};
+      ctx.out_adj = call.out_len == 1 ? adj[call.bwd_adj_out] : 0.0;
       ctx.variant = call.variant;
       ctx.scratch = const_cast<double*>(val) + call.scratch;
       ctx.idata = call.idata.data();
       ctx.n_idata = (int64_t)call.idata.size();
-      const Kernel* k = find_kernel(call.opcode);
-      k->backward(ctx);
-      for (int j = 0; j < call.out_len; ++j) adj[out_adj + j] = 0.0;
+      call.backward(ctx);
+      for (int j = 0; j < call.out_len; ++j) adj[call.bwd_adj_out + j] = 0.0;
       continue;
     }
     // Every instruction consumes its output's adjoint and clears it: the

--- a/runtime/src/executor.cpp
+++ b/runtime/src/executor.cpp
@@ -70,12 +70,13 @@ const Kernel* find_kernel(uint16_t opcode) {
   return k.forward ? &k : nullptr;
 }
 
-// CALL support (program.hpp): the register machine invoking a graph
-// kernel. The context is assembled per call from the payload's ranges --
-// every field is a pointer into the register file plus immediates, so
-// this is loads and stores, no allocation.
-KernelCtx call_fwd_ctx(const Program::Call& call, double* reg) {
-  KernelCtx ctx;
+// CALL support (program.hpp): the register machine invoking a graph kernel.
+// Only pointer fields vary with a register-file base. Dispatch and the
+// integer/shape metadata are immutable call-site facts, so builders resolve
+// the former once and a program invocation reuses one context packet across
+// all of its CALL instructions.
+static void bind_call_fwd_ctx(const Program::Call& call, double* reg,
+                              KernelCtx& ctx) {
   ctx.n_in = call.n_in;
   for (int k = 0; k < call.n_in; ++k)
     ctx.in[k] = Desc{reg + call.in[k], call.in_len[k]};
@@ -84,14 +85,34 @@ KernelCtx call_fwd_ctx(const Program::Call& call, double* reg) {
   ctx.scratch = reg + call.scratch;
   ctx.idata = call.idata.data();
   ctx.n_idata = (int64_t)call.idata.size();
+}
+
+KernelCtx call_fwd_ctx(const Program::Call& call, double* reg) {
+  KernelCtx ctx;
+  bind_call_fwd_ctx(call, reg, ctx);
   return ctx;
 }
 
-void run_call(const Program::Call& call, double* reg) {
-  KernelCtx ctx = call_fwd_ctx(call, reg);
+bool bind_call(Program::Call& call) {
+  call.forward = nullptr;
+  call.backward = nullptr;
   const Kernel* k = find_kernel(call.opcode);
-  assert(k != nullptr);  // the carver only emits registered opcodes
-  k->forward(ctx);
+  if (k == nullptr || k->forward == nullptr) return false;
+  call.forward = k->forward;
+  call.backward = k->backward;
+  return true;
+}
+
+void run_call(const Program::Call& call, double* reg, KernelCtx& ctx) {
+  if (call.forward == nullptr)
+    throw std::logic_error("unbound Program::CALL forward");
+  bind_call_fwd_ctx(call, reg, ctx);
+  call.forward(ctx);
+}
+
+void run_call(const Program::Call& call, double* reg) {
+  KernelCtx ctx;
+  run_call(call, reg, ctx);
 }
 
 void register_elementwise_kernels();

--- a/runtime/src/island.cpp
+++ b/runtime/src/island.cpp
@@ -272,10 +272,11 @@ struct Compiler {
     call.opcode = op.opcode;
     call.variant = op.variant;
     call.n_in = (int8_t)op.n_in;
+    call.forward = k->forward;
+    call.backward = k->backward;
     for (int j = 0; j < op.n_in; ++j) {
       call.in[j] = read_reg(op.in[j]);
       call.in_len[j] = (int)g.slots[op.in[j]].len;
-      call.bwd_in[j] = call.in[j];
     }
     call.out = write_reg(op.out);
     call.out_len = (int)g.slots[op.out].len;
@@ -286,7 +287,6 @@ struct Compiler {
       if (call.out < call.in[j] + call.in_len[j] &&
           call.in[j] < call.out + call.out_len)
         return false;
-    call.bwd_out = call.out;
     call.scratch_len =
         k->scratch_size ? (int)k->scratch_size(op, g.slots.data()) : 0;
     call.scratch = call.scratch_len ? alloc(call.scratch_len) : 0;
@@ -683,7 +683,9 @@ int carve_islands(Graph& g,
       const bool specialized = static_cast<bool>(optimized);
       Op is;
       is.opcode = OP_ISLAND;
-      is.variant = specialized ? kIslandSoftmax3Variant : 0;
+      is.variant = specialized             ? kIslandSoftmax3Variant
+                   : cc.prog.calls.empty() ? 0
+                                           : kIslandCallVariant;
       is.n_in = (int)cc.live_in_slots.size();
       for (int k = 0; k < is.n_in; ++k) is.in[k] = cc.live_in_slots[k];
       is.out = g.add_slot(packed, false);

--- a/runtime/src/program_softmax.cpp
+++ b/runtime/src/program_softmax.cpp
@@ -86,6 +86,8 @@ using ForwardFn = void (*)(KernelCtx&);
 ForwardFn resolve_forward_fn(const Op& op) {
   if (op.opcode == OP_ISLAND && op.variant == kIslandSoftmax3Variant)
     return island_softmax3_fwd;
+  if (op.opcode == OP_ISLAND && op.variant == kIslandCallVariant)
+    return island_calls_fwd;
   return kernel(op.opcode).forward;
 }
 
@@ -98,6 +100,8 @@ std::shared_ptr<const Program> specialize_softmax3(const IslandProg& p,
   if (count == 0 || count < min_count) return nullptr;
   if (!within_clone_budget(p, count)) return nullptr;
   if (!ensure_program_softmax3_kernel()) return nullptr;
+  const Kernel* softmax3 = find_kernel(kProgramSoftmax3Opcode);
+  if (softmax3 == nullptr || softmax3->forward == nullptr) return nullptr;
 
   // Copy the whole Program base so a future field cannot be silently omitted
   // from the optimized clone. The one-time reserve may move existing CALLs,
@@ -110,6 +114,8 @@ std::shared_ptr<const Program> specialize_softmax3(const IslandProg& p,
     call.opcode = kProgramSoftmax3Opcode;
     call.variant = kProgramSoftmax3Variant;
     call.n_in = 1;
+    call.forward = softmax3->forward;
+    call.backward = softmax3->backward;
     call.in[0] = I.a;
     call.in_len[0] = 3;
     call.out = I.dst;
@@ -137,7 +143,7 @@ void island_softmax3_fwd(KernelCtx& ctx) {
     for (int i = 0; i < li.len; ++i)
       ctx.scratch[li.reg + i] = ctx.in[input].data[li.offset + i];
   }
-  run_program(optimized, ctx.scratch);
+  run_program_impl<true>(optimized, ctx.scratch);
   for (size_t m = 0; m < p.out_regs.size(); ++m)
     ctx.out.data[m] = ctx.scratch[p.out_regs[m]];
 }

--- a/tests/test_adjoint.cpp
+++ b/tests/test_adjoint.cpp
@@ -34,6 +34,19 @@ using namespace stanli;
 
 static int failures = 0;
 
+// A private CALL target proves execution uses the payload's resolved
+// functions rather than consulting the graph opcode table. Its additive
+// immediates make context reuse observable without affecting the derivative.
+static void test_call_forward(KernelCtx& ctx) {
+  ctx.out.data[0] = ctx.in[0].data[0] * ctx.in[1].data[0] + ctx.variant +
+                    (ctx.n_idata ? ctx.idata[0] : 0);
+}
+
+static void test_call_backward(KernelCtx& ctx) {
+  ctx.in_adj[0].data[0] += ctx.out_adj * ctx.in[1].data[0];
+  ctx.in_adj[1].data[0] += ctx.out_adj * ctx.in[0].data[0];
+}
+
 static void expect(const char* what, bool ok) {
   if (!ok) {
     ++failures;
@@ -134,6 +147,146 @@ static int64_t ulps(double a, double b) {
   if ((ia < 0) != (ib < 0)) return INT64_MAX;
   const int64_t d = ia - ib;
   return d < 0 ? -d : d;
+}
+
+static void test_call_binding_refusal() {
+  Program::Call registered;
+  registered.opcode = OP_POW;
+  expect("CALL registered bind", bind_call(registered));
+  const Kernel* pow = find_kernel(OP_POW);
+  expect("CALL caches registered forward",
+         pow && registered.forward == pow->forward);
+  expect("CALL caches registered backward",
+         pow && registered.backward == pow->backward);
+
+  Program::Call unknown;
+  unknown.opcode = OP_COUNT_;
+  expect("CALL unknown bind refuses", !bind_call(unknown));
+  expect("CALL unknown bind stays empty",
+         unknown.forward == nullptr && unknown.backward == nullptr);
+
+  Program::Call forward_only;
+  forward_only.opcode = OP_RNG;
+  expect("CALL forward-only bind", bind_call(forward_only));
+  expect("CALL forward-only has no reverse",
+         forward_only.forward != nullptr && forward_only.backward == nullptr);
+  IslandProg no_reverse;
+  no_reverse.n_regs = 1;
+  no_reverse.out_regs = {0};
+  no_reverse.calls.push_back(forward_only);
+  no_reverse.code.push_back(Program::Instr{Program::CALL, 0, 0, 0, 0, 0});
+  expect("CALL missing backward adjoint refuses", !gen_adjoint(no_reverse));
+  expect("CALL missing backward refusal is transactional",
+         no_reverse.n_regs == 1 && no_reverse.code.size() == 1 &&
+             no_reverse.adj.empty());
+
+  IslandProg p;
+  p.n_regs = 3;
+  p.ins = {IslandProg::LiveIn{0, 1}, IslandProg::LiveIn{1, 1}};
+  p.out_regs = {2};
+  p.calls.push_back(unknown);
+  p.code.push_back(Program::Instr{Program::CALL, 0, 0, 0, 0, 0});
+  const IslandProg before = p;
+  expect("CALL unbound adjoint refuses", !gen_adjoint(p));
+  expect("CALL refusal keeps register count", p.n_regs == before.n_regs);
+  expect("CALL refusal keeps code",
+         p.code.size() == before.code.size() &&
+             std::memcmp(p.code.data(), before.code.data(),
+                         p.code.size() * sizeof(Program::Instr)) == 0);
+  expect("CALL refusal keeps payload",
+         p.calls.size() == 1 && p.calls[0].opcode == before.calls[0].opcode &&
+             p.calls[0].forward == nullptr && p.calls[0].backward == nullptr);
+  expect("CALL refusal keeps adjoint empty", p.adj.empty());
+
+  std::vector<double> reg(3, 0.0);
+  bool threw = false;
+  try {
+    run_program(p, reg.data());
+  } catch (const std::logic_error&) {
+    threw = true;
+  }
+  expect("CALL unbound forward throws", threw);
+}
+
+static void test_call_cached_forward_reverse_aliasing() {
+  // Reuse one payload twice around overwrites of both its input and output.
+  // A payload-level reverse cache would make both adjoint instructions read
+  // the second site's checkpoints; gen_adjoint therefore normalizes it to
+  // one bound Program::Call per instruction.
+  IslandProg p;
+  p.n_regs = 5;
+  p.ins = {IslandProg::LiveIn{0, 1}, IslandProg::LiveIn{1, 1},
+           IslandProg::LiveIn{4, 1}};
+  p.out_regs = {3, 2};
+  Program::Call call;
+  call.opcode = OP_COUNT_;  // deliberately absent from the graph table
+  call.variant = 3;
+  call.n_in = 2;
+  call.forward = test_call_forward;
+  call.backward = test_call_backward;
+  call.in[0] = 0;
+  call.in[1] = 1;
+  call.in_len[0] = 1;
+  call.in_len[1] = 1;
+  call.out = 2;
+  call.out_len = 1;
+  call.idata = {5};
+  p.calls.push_back(call);
+  p.code.push_back(Program::Instr{Program::CALL, 0, 0, 0, 0, 0});
+  p.code.push_back(Program::Instr{Program::MOV, 3, 2, 0, 0, 0});
+  p.code.push_back(Program::Instr{Program::MOV, 0, 4, 0, 0, 0});
+  p.code.push_back(Program::Instr{Program::CALL, 0, 0, 0, 0, 0});
+
+  expect("CALL shared payload adjoint generated", gen_adjoint(p));
+  expect("CALL reverse payload per instruction", p.calls.size() == 2);
+  if (p.calls.size() == 2) {
+    expect("CALL input checkpoints stay per instruction",
+           p.calls[0].bwd_value_in[0] != p.calls[1].bwd_value_in[0]);
+    expect("CALL output checkpoints stay per instruction",
+           p.calls[0].bwd_value_out != p.calls[1].bwd_value_out);
+    expect("CALL reverse dispatch pre-resolved",
+           p.calls[0].backward == test_call_backward &&
+               p.calls[1].backward == test_call_backward);
+  }
+
+  double a = 1.125, b = 1.75, c = 0.625;
+  std::vector<double> val((size_t)p.n_regs, 0.0);
+  val[0] = a;
+  val[1] = b;
+  val[4] = c;
+  run_program(p, val.data());
+  const double first = a * b + 8.0;
+  const double second = c * b + 8.0;
+  expect("CALL cached first forward bitwise", ulps(val[3], first) == 0);
+  expect("CALL cached second forward bitwise", ulps(val[2], second) == 0);
+
+  std::vector<double> adj((size_t)p.adj.n_regs, 0.0);
+  const double first_seed = 0.7, second_seed = -1.1;
+  adj[(size_t)p.adj.adj_reg[3]] = first_seed;
+  adj[(size_t)p.adj.adj_reg[2]] = second_seed;
+  run_adjoint(p, p.adj, val.data(), adj.data());
+
+  double want_a = 0.0, want_b = 0.0, want_c = 0.0;
+  KernelCtx direct;
+  direct.n_in = 2;
+  direct.out = Desc{nullptr, 1};
+  direct.in_adj[0] = Desc{&want_c, 1};
+  direct.in_adj[1] = Desc{&want_b, 1};
+  direct.in[0] = Desc{&c, 1};
+  direct.in[1] = Desc{&b, 1};
+  direct.out_adj = second_seed;
+  test_call_backward(direct);
+  direct.in_adj[0] = Desc{&want_a, 1};
+  direct.in[0] = Desc{&a, 1};
+  direct.out_adj = first_seed;
+  test_call_backward(direct);
+
+  expect("CALL cached reverse a bitwise",
+         ulps(adj[(size_t)p.adj.adj_reg[0]], want_a) == 0);
+  expect("CALL cached reverse b bitwise",
+         ulps(adj[(size_t)p.adj.adj_reg[1]], want_b) == 0);
+  expect("CALL cached reverse replacement bitwise",
+         ulps(adj[(size_t)p.adj.adj_reg[4]], want_c) == 0);
 }
 
 // One case, both ways. `tol` is how many ulp of disagreement the case
@@ -1268,6 +1421,8 @@ static void test_fuzz_ranges() {
 }
 
 int main() {
+  test_call_binding_refusal();
+  test_call_cached_forward_reverse_aliasing();
   test_binary_ops();
   test_fma();
   test_unary_ops();

--- a/tests/test_island.cpp
+++ b/tests/test_island.cpp
@@ -944,8 +944,11 @@ static void test_kernel_call_ops_carved(bool compact) {
   bool shifted_call_range = false;
   for (const Op& op : g.ops) {
     if (op.opcode != OP_ISLAND) continue;
+    expect("call island dispatch variant", op.variant == kIslandCallVariant);
     const auto& p = *static_cast<const IslandProg*>(op.udata);
     for (const Program::Call& call : p.calls) {
+      expect("call forward dispatch prebound", call.forward != nullptr);
+      expect("call backward dispatch prebound", call.backward != nullptr);
       auto check_range = [&](int reg, int len) {
         if (len == 0) return;
         const int base = p.adj.adj_reg[(size_t)reg];
@@ -959,12 +962,22 @@ static void test_kernel_call_ops_carved(bool compact) {
         check_range(call.in[k], call.in_len[k]);
       check_range(call.out, call.out_len);
     }
+    const size_t call_instrs =
+        std::count_if(p.code.begin(), p.code.end(),
+                      [](const auto& I) { return I.code == Program::CALL; });
+    expect("call reverse packet count", p.calls.size() == call_instrs);
+    for (const Program::Call& call : p.calls)
+      expect("call reverse packet prebound", call.backward != nullptr);
   }
   // With compaction on, the copies gen_adjoint used to share a cell for are
   // gone before it runs, so the mapping is an identity it never built.
   if (!compact) expect("call range actually compacted", shifted_call_range);
   const std::vector<double> got = run_grad_twice(std::move(g), fills);
   expect("callops sizes", got.size() == want.size());
+  expect("callops forward/reverse bitwise",
+         got.size() == want.size() &&
+             std::memcmp(got.data(), want.data(),
+                         got.size() * sizeof(double)) == 0);
   for (size_t i = 0; i < want.size() && i < got.size(); ++i)
     expect_close("callops v" + std::to_string(i), got[i], want[i]);
   if (!compact) test_unsetenv("STANLI_NO_ISLAND_COMPACT");

--- a/tools/bench_program_call.cpp
+++ b/tools/bench_program_call.cpp
@@ -1,0 +1,91 @@
+// Per-site overhead of Program::CALL in its forward and generated-adjoint
+// sweeps.  The repeated kernel is deliberately selected by opcode and shape,
+// not by any source/model identity.  OP_POW has a cheap scalar body, no
+// scratch, and a backward that reads its input and output values, so the
+// benchmark exercises the complete CALL packet without letting setup or a
+// heavyweight kernel dominate it.
+#include <stanli/island.hpp>
+#include <stanli/optable.hpp>
+
+#include <chrono>
+#include <cstdio>
+#include <cstring>
+#include <stdexcept>
+#include <vector>
+
+namespace {
+
+constexpr int kSites = 4096;
+constexpr int kReps = 2000;
+
+template <typename F>
+double time_ns(F&& fn) {
+  fn();
+  fn();
+  const auto start = std::chrono::steady_clock::now();
+  for (int i = 0; i < kReps; ++i) fn();
+  return std::chrono::duration<double, std::nano>(
+             std::chrono::steady_clock::now() - start)
+             .count() /
+         kReps;
+}
+
+stanli::IslandProg make_program() {
+  using namespace stanli;
+  IslandProg p;
+  p.n_regs = 2 + kSites;
+  p.ins.push_back(IslandProg::LiveIn{0, 1, 0, 0, true});
+  p.ins.push_back(IslandProg::LiveIn{1, 1, 1, 0, true});
+  p.calls.reserve(kSites);
+  p.code.reserve(kSites);
+  p.out_regs.reserve(kSites);
+  for (int i = 0; i < kSites; ++i) {
+    Program::Call call;
+    call.opcode = OP_POW;
+    call.n_in = 2;
+    call.in[0] = 0;
+    call.in[1] = 1;
+    call.in_len[0] = 1;
+    call.in_len[1] = 1;
+    call.out = 2 + i;
+    call.out_len = 1;
+    if (!bind_call(call)) throw std::runtime_error("CALL bind refused");
+    p.calls.push_back(std::move(call));
+    p.code.push_back(Program::Instr{Program::CALL, 0, i, 0, 0, 0});
+    p.out_regs.push_back(2 + i);
+  }
+  if (!gen_adjoint(p)) throw std::runtime_error("CALL adjoint refused");
+  return p;
+}
+
+}  // namespace
+
+int main() {
+  using namespace stanli;
+  IslandProg p = make_program();
+  std::vector<double> value((size_t)p.n_regs, 0.0);
+  std::vector<double> adj((size_t)p.adj.n_regs, 0.0);
+  value[0] = 1.125;
+  value[1] = 1.75;
+  double sink = 0.0;
+
+  const double forward_ns = time_ns([&] {
+    run_program(p, value.data());
+    sink += value[(size_t)p.out_regs.back()];
+  });
+
+  run_program(p, value.data());
+  const double reverse_ns = time_ns([&] {
+    std::memset(adj.data(), 0, sizeof(double) * adj.size());
+    for (int r : p.out_regs) adj[(size_t)p.adj.adj_reg[(size_t)r]] = 1.0;
+    run_adjoint(p, p.adj, value.data(), adj.data());
+    sink += adj[(size_t)p.adj.adj_reg[0]];
+  });
+
+  std::printf(
+      "sites=%d reps=%d forward_ns=%.1f forward_ns_per_call=%.3f "
+      "reverse_ns=%.1f reverse_ns_per_call=%.3f sink=%.17g\n",
+      kSites, kReps, forward_ns, forward_ns / kSites, reverse_ns,
+      reverse_ns / kSites, sink);
+  return 0;
+}


### PR DESCRIPTION
## Summary

- pre-resolve Program CALL forward/reverse dispatch and reuse one invocation-local KernelCtx
- cache invariant generated-adjoint bindings while preserving transactional refusal and alias behavior
- prebind generic island CALL/no-CALL variants so zero-CALL programs retain the lean execution path
- add focused forward, reverse, refusal, shared-payload, and exact-bitwise coverage plus a developer benchmark

## Verification

- Release build with Apple Clang 21, -O3 -DNDEBUG -ffp-contract=off
- full suite: 112/112 tests passed
- focused test_adjoint and test_island: 2/2 passed
- git diff --check clean
- hot-path lookup audit: find_kernel remains only in explicit bind_call

## Performance

Fresh-process ABBA/BAAB alternation; values are median [Q1, Q3], with paired candidate/baseline ratios.

- 4096-site OP_POW CALL benchmark: forward 0.94441 [0.93441, 0.95341], 5.56% faster; reverse 0.87793 [0.87135, 0.89274], 12.21% faster
- generic 10-lgamma CALL recurrence: gradient 0.96350 [0.95710, 0.96602], 3.65% faster; forward 0.96462 [0.96191, 0.96598], 3.54% faster
- specialized IOHMM CALL stress: gradient 0.99743 [0.99372, 1.00092], forward 1.00364 [0.99835, 1.00841] (neutral)
- zero-CALL HMM canary: gradient 0.99909 [0.99225, 1.00387], forward 0.99278 [0.97225, 1.00439] (neutral)

All benchmark sinks matched; the synthetic benchmark sink matched at 17 digits.
