### PR TITLE
Fix main CI follow-up failures

### DIFF
--- a/.github/workflows/clang-ccache-seed.yml
+++ b/.github/workflows/clang-ccache-seed.yml
@@ -120,9 +120,16 @@ jobs:
         if: steps.stanc-cache.outputs.cache-hit != 'true'
         run: |
           url=https://github.com/ocaml/opam/releases/download
-          curl -fsSL --retry 5 --retry-all-errors --retry-delay 2 \
-            -o /tmp/opam \
-            "$url/$OPAM_VERSION/opam-$OPAM_VERSION-x86_64-linux"
+          # This runs in manylinux, whose old curl lacks --retry-all-errors.
+          # An outer loop still retries every curl failure, including resets.
+          for attempt in 1 2 3 4 5; do
+            if curl -fsSL -o /tmp/opam \
+              "$url/$OPAM_VERSION/opam-$OPAM_VERSION-x86_64-linux"; then
+              break
+            fi
+            [ "$attempt" -lt 5 ] || exit 1
+            sleep $((attempt * 2))
+          done
           chmod +x /tmp/opam
           sudo install -m 755 /tmp/opam /usr/local/bin/opam 2>/dev/null ||
             install -m 755 /tmp/opam /usr/local/bin/opam

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -291,18 +291,20 @@ jobs:
       # its target directory and takes no positional argument, so it is not
       # usable unattended. A warm artifact cache does not need opam at all.
       #
-      # No --retry-all-errors here, unlike the steps that run on the runner
-      # itself: this one runs inside the manylinux image, whose curl predates
-      # that flag (7.71) and exits 2 on it. Because a cache hit skips this
-      # step entirely, the break only surfaces on a change to compiler/ocaml,
-      # compiler/native, or tools/stanc_embed -- the inputs to the key above.
+      # This runs inside manylinux, whose curl predates --retry-all-errors.
+      # Use a portable outer retry loop so connection resets are retried too.
       - name: opam ${{ env.OPAM_VERSION }}
         if: steps.stanc-cache.outputs.cache-hit != 'true'
         run: |
           url=https://github.com/ocaml/opam/releases/download
-          curl -fsSL --retry 5 --retry-delay 2 \
-            -o /tmp/opam \
-            "$url/$OPAM_VERSION/opam-$OPAM_VERSION-${{ matrix.opam_arch }}"
+          for attempt in 1 2 3 4 5; do
+            if curl -fsSL -o /tmp/opam \
+              "$url/$OPAM_VERSION/opam-$OPAM_VERSION-${{ matrix.opam_arch }}"; then
+              break
+            fi
+            [ "$attempt" -lt 5 ] || exit 1
+            sleep $((attempt * 2))
+          done
           chmod +x /tmp/opam
           sudo install -m 755 /tmp/opam /usr/local/bin/opam 2>/dev/null ||
             install -m 755 /tmp/opam /usr/local/bin/opam

--- a/runtime/include/stanli/function.hpp
+++ b/runtime/include/stanli/function.hpp
@@ -9,6 +9,7 @@
 #include <stanli/data.hpp>
 
 #include <cstddef>
+#include <exception>
 #include <stdexcept>
 #include <string>
 #include <utility>
@@ -24,10 +25,18 @@ stanli_function* stanli_function_new_from_mir(const char* mir_text,
                                               const char* function_name,
                                               char* err, size_t err_len);
 void stanli_function_free(stanli_function* function);
+
+// Results are borrowed only for the duration of this callback. Keeping the
+// copy on the caller side avoids transferring STL-owned storage across the
+// shared-library boundary, where the two sides may use different C++ runtimes.
+typedef int (*stanli_function_result_writer)(
+    void* context, int is_int, const double* reals, size_t real_size,
+    const int* ints, size_t int_size, const int64_t* dims, size_t dim_size);
+
 int stanli_function_call(const stanli_function* function,
                          const stanli::DataMap* arguments,
-                         stanli::DataMap::Entry* result, char* err,
-                         size_t err_len);
+                         stanli_function_result_writer write_result,
+                         void* result_context, char* err, size_t err_len);
 
 }  // extern "C"
 
@@ -61,9 +70,37 @@ class Function {
   DataMap::Entry operator()(const DataMap& arguments) const {
     char err[8192] = {};
     DataMap::Entry result;
-    if (stanli_function_call(handle_, &arguments, &result, err, sizeof(err)))
+    struct ResultContext {
+      DataMap::Entry* result;
+      std::exception_ptr error;
+    } context{&result, nullptr};
+
+    const auto write_result = [](void* opaque, int is_int, const double* reals,
+                                 size_t real_size, const int* ints,
+                                 size_t int_size, const int64_t* dims,
+                                 size_t dim_size) -> int {
+      auto& context = *static_cast<ResultContext*>(opaque);
+      try {
+        context.result->is_int = is_int != 0;
+        context.result->r.clear();
+        context.result->i.clear();
+        context.result->dims.clear();
+        if (real_size != 0) context.result->r.assign(reals, reals + real_size);
+        if (int_size != 0) context.result->i.assign(ints, ints + int_size);
+        if (dim_size != 0) context.result->dims.assign(dims, dims + dim_size);
+        return 0;
+      } catch (...) {
+        context.error = std::current_exception();
+        return 1;
+      }
+    };
+
+    if (stanli_function_call(handle_, &arguments, write_result, &context, err,
+                             sizeof(err))) {
+      if (context.error) std::rethrow_exception(context.error);
       throw std::runtime_error(err[0] ? err
                                       : "Stan function evaluation failed");
+    }
     return result;
   }
 

--- a/runtime/src/function.cpp
+++ b/runtime/src/function.cpp
@@ -187,12 +187,12 @@ void stanli_function_free(stanli_function* function) { delete function; }
 
 int stanli_function_call(const stanli_function* function,
                          const stanli::DataMap* arguments,
-                         stanli::DataMap::Entry* result, char* err,
-                         size_t err_len) {
+                         stanli_function_result_writer write_result,
+                         void* result_context, char* err, size_t err_len) {
   try {
-    if (function == nullptr || arguments == nullptr || result == nullptr)
+    if (function == nullptr || arguments == nullptr || write_result == nullptr)
       throw std::runtime_error(
-          "function, arguments, and result must not be null");
+          "function, arguments, and result writer must not be null");
     const stanli::mir::FunDef* selected = select_function(
         *function->program, function->requested_name, arguments);
 
@@ -218,7 +218,11 @@ int stanli_function_call(const stanli_function* function,
 
     stanli::MirInterp<double> interpreter(
         functions, "function " + function->requested_name);
-    *result = interpreter.call(*selected, values);
+    const auto result = interpreter.call(*selected, values);
+    if (write_result(result_context, result.is_int ? 1 : 0, result.r.data(),
+                     result.r.size(), result.i.data(), result.i.size(),
+                     result.dims.data(), result.dims.size()) != 0)
+      throw std::runtime_error("function result writer failed");
     return 0;
   } catch (const std::exception& e) {
     put_err(err, err_len, e.what());


### PR DESCRIPTION
## Summary
- retry opam downloads with a portable shell loop in manylinux jobs whose old curl does not support `--retry-all-errors`
- keep function result storage owned by the caller, avoiding C++ allocator ownership transfer across the shipped shared-library boundary
- preserve exceptions from caller-side result allocation without allowing them to cross the C ABI

## Validation
- `cmake --build build-rel -j2`
- `ctest --test-dir build-rel --output-on-failure -j2` (112/112 passed)
- parsed both edited GitHub Actions workflows as YAML
- verified exported function symbols in the shipped shared library