### PR TITLE
fix: keep BridgeStan helpers in C++ linkage

### DIFF
--- a/runtime/src/bridgestan_abi.cpp
+++ b/runtime/src/bridgestan_abi.cpp
@@ -540,6 +540,11 @@ int bs_param_constrain(const bs_model* m, bool include_tp, bool include_gq,
   }
 }
 
+// Keep the implementation-only initialization helpers in C++ linkage. GCC
+// rejects a C++ declaration followed by a definition inside this exported
+// C-linkage block, while Clang accepts the mismatch.
+}  // extern "C"
+
 namespace {
 
 const stanli::InitInterp* init_interp(const bs_model* m, std::string* why) {
@@ -598,6 +603,8 @@ int unconstrain_into(const bs_model* m,
 }
 
 }  // namespace
+
+extern "C" {
 
 int bs_param_unconstrain(const bs_model* m, const double* theta,
                          double* theta_unc, char** error_msg) {


### PR DESCRIPTION
## Summary
- keep internal BridgeStan initialization helpers outside the exported `extern "C"` block
- retain C linkage for the public `bs_*` API while satisfying GCC\'s stricter linkage diagnostics

## Main failure
Post-merge GCC builds exposed three helper definitions in `runtime/src/bridgestan_abi.cpp` whose earlier C++ declarations conflicted with definitions inside the C-linkage block. Clang accepted the mismatch; GCC failed on both manylinux x86_64 and Windows.

## Validation
- local `stanli_shared` build
- `test_bridgestan` and `test_capi` pass
- PR #284 already validated the no-build prerequisite fix across the native matrix