### PR TITLE
Fix copied Graph data lifetimes and benchmark scratch sizing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -679,6 +679,9 @@ target_link_libraries(bench_opcost PRIVATE stanli)
 add_executable(bench_program_call EXCLUDE_FROM_ALL
   tools/bench_program_call.cpp tests/tbb_stub.cpp)
 target_link_libraries(bench_program_call PRIVATE stanli)
+add_test(NAME test_bench_opcost_smoke COMMAND bench_opcost --smoke)
+set_tests_properties(test_bench_opcost_smoke PROPERTIES
+  PASS_REGULAR_EXPRESSION "sink=")
 # Developer-only ODE RHS generated-adjoint spike.  Not a test and not installed.
 add_executable(bench_rhs_adjoint EXCLUDE_FROM_ALL
   tools/bench_rhs_adjoint.cpp tests/tbb_stub.cpp)

--- a/runtime/include/stanli/graph.hpp
+++ b/runtime/include/stanli/graph.hpp
@@ -6,11 +6,14 @@
 
 #include <stanli/kernel_types.hpp>
 
+#include <algorithm>
 #include <cstdint>
+#include <functional>
 #include <initializer_list>
 #include <memory>
 #include <string>
 #include <stdexcept>
+#include <utility>
 #include <vector>
 
 namespace stanli {
@@ -18,11 +21,57 @@ namespace stanli {
 struct Graph {
   std::vector<Slot> slots;
   std::vector<Op> ops;
-  std::vector<std::vector<int>> idata_pool;  // owns per-op integer arrays
-  // Owns per-op opaque payloads; pointers into this outlive lowering because
-  // the graph is moved, never copied element-wise.
+  // Owns per-op integer arrays. Owned Op::idata views always name data(), not
+  // an interior element. A copy must rebind each view into its corresponding
+  // copied vector rather than retain a pointer into the source.
+  std::vector<std::vector<int>> idata_pool;
+  // Owns per-op opaque payloads. Graph copies share these immutable payloads,
+  // so the raw pointers in copied ops continue to name the shared objects.
   std::vector<std::shared_ptr<void>> udata_pool;
   int result_slot = -1;
+
+  Graph() = default;
+
+  Graph(const Graph& src)
+      : slots(src.slots),
+        ops(src.ops),
+        idata_pool(src.idata_pool),
+        udata_pool(src.udata_pool),
+        result_slot(src.result_slot) {
+    // One sorted, contiguous temporary keeps graph cloning O(P log P) without
+    // one hash-node allocation per integer payload. External Op::idata
+    // pointers, if a hand-built graph has one, retain their caller-owned
+    // lifetime; pointers owned by idata_pool are rebound to this graph.
+    using Rebind = std::pair<const int*, const int*>;
+    std::vector<Rebind> rebind;
+    rebind.reserve(src.idata_pool.size());
+    for (size_t i = 0; i < src.idata_pool.size(); ++i) {
+      if (!src.idata_pool[i].empty())
+        rebind.emplace_back(src.idata_pool[i].data(), idata_pool[i].data());
+    }
+    const auto before = [](const Rebind& a, const Rebind& b) {
+      return std::less<const int*>{}(a.first, b.first);
+    };
+    std::sort(rebind.begin(), rebind.end(), before);
+    for (size_t i = 0; i < src.ops.size(); ++i) {
+      const int* p = src.ops[i].idata;
+      if (p == nullptr) continue;
+      const auto it = std::lower_bound(rebind.begin(), rebind.end(),
+                                       Rebind{p, nullptr}, before);
+      if (it != rebind.end() && it->first == p) ops[i].idata = it->second;
+    }
+  }
+
+  Graph(Graph&&) noexcept = default;
+  Graph& operator=(Graph&&) noexcept = default;
+
+  Graph& operator=(const Graph& src) {
+    if (this != &src) {
+      Graph copy(src);
+      *this = std::move(copy);
+    }
+    return *this;
+  }
 
   int add_slot(int64_t len, bool is_param) {
     slots.push_back(Slot{0, len, is_param});

--- a/tests/test_executor.cpp
+++ b/tests/test_executor.cpp
@@ -6,6 +6,7 @@
 #include <cmath>
 #include <cstdint>
 #include <cstdio>
+#include <memory>
 
 static int failures = 0;
 static void expect_eq(const char* what, double got, double want) {
@@ -86,6 +87,45 @@ int main() {
   sparse_ex.value_ptr(sd)[17] = -1.25;
   expect_eq("sparse value 2", sparse_ex.gradient(sparse_grad), 5.0);
   expect_eq("sparse grad 2", sparse_grad[0], -1.25);
+
+  // The source dies before the copy executes. This is deliberately a
+  // black-box lifetime check: under ASan, any copied execution metadata that
+  // still refers to the source is reported when the gradient runs.
+  std::unique_ptr<Executor> idata_copy;
+  {
+    Graph source;
+    const int source_param = source.add_slot(3, true);
+    const int source_result = source.add_slot(1, false);
+    source.add_op(OP_INDEX, {source_param}, source_result, {1});
+    source.result_slot = source_result;
+    Executor source_ex(std::move(source));
+    source_ex.params_data()[0] = 2.0;
+    source_ex.params_data()[1] = 7.0;
+    source_ex.params_data()[2] = -3.0;
+    idata_copy = std::make_unique<Executor>(source_ex);
+  }
+  double idata_grad[3] = {0, 0, 0};
+  expect_eq("copied idata value", idata_copy->gradient(idata_grad), 7.0);
+  expect_eq("copied idata d0", idata_grad[0], 0.0);
+  expect_eq("copied idata d1", idata_grad[1], 1.0);
+  expect_eq("copied idata d2", idata_grad[2], 0.0);
+
+  // Cover Graph's copy assignment separately from Executor's copy
+  // construction, again through public execution behavior rather than an
+  // assertion about its internal pointer representation.
+  Graph assigned_graph;
+  {
+    Graph source;
+    const int source_input = source.add_slot(2, false);
+    const int source_output = source.add_slot(1, false);
+    source.add_op(OP_INDEX, {source_input}, source_output, {1});
+    source.result_slot = source_output;
+    assigned_graph = source;
+  }
+  Executor assigned_ex(std::move(assigned_graph));
+  assigned_ex.value_ptr(0)[0] = 3.0;
+  assigned_ex.value_ptr(0)[1] = 11.0;
+  expect_eq("assigned idata value", assigned_ex.forward(), 11.0);
 
   // BCAST_FMA forward: out[i] = a + b * x[i].
   Graph g2;

--- a/tests/test_multichain.cpp
+++ b/tests/test_multichain.cpp
@@ -16,6 +16,7 @@
 #include <algorithm>
 #include <cmath>
 #include <cstdio>
+#include <memory>
 #include <stdexcept>
 #include <string>
 #include <thread>
@@ -101,6 +102,42 @@ int main() {
     for (int64_t i = 0; i < n; ++i) src.params_data()[i] = q[(size_t)i];
     const double lp3 = src.gradient(g1.data());
     expect("clones do not share an arena", lp3 == lp1);
+  }
+
+  // Exercise the complete bound-executor lifetime as a black box. This
+  // model combines matrix metadata, integer-valued observations, density
+  // scratch, multiple reverse kernels, and immutable data in the arena. The
+  // clone must remain a usable model after both the source executor and the
+  // graph builder that supplied its metadata have died. Repetition also
+  // checks that forward/reverse scratch and adjoints are safely reusable.
+  {
+    std::unique_ptr<Executor> survivor;
+    std::vector<double> q;
+    std::vector<double> want_grad;
+    double want_lp = 0.0;
+    {
+      auto m = testmodels::logistic_glm();
+      Executor src(std::move(m.graph));
+      testmodels::fill_logistic_glm_data(m, src);
+      const int64_t n = src.n_params();
+      q.resize((size_t)n);
+      want_grad.resize((size_t)n);
+      for (int64_t i = 0; i < n; ++i) {
+        q[(size_t)i] = -0.2 + 0.07 * (double)i;
+        src.params_data()[i] = q[(size_t)i];
+      }
+      want_lp = src.gradient(want_grad.data());
+      survivor = std::make_unique<Executor>(src);
+    }
+
+    std::vector<double> got_grad(q.size());
+    bool same = true;
+    for (int rep = 0; rep < 8; ++rep) {
+      for (size_t i = 0; i < q.size(); ++i) survivor->params_data()[i] = q[i];
+      const double got_lp = survivor->gradient(got_grad.data());
+      same = same && got_lp == want_lp && got_grad == want_grad;
+    }
+    expect("source-destroyed clone remains bitwise identical", same);
   }
 
   // ---- chain ids give different streams, seeds reproduce ----------------

--- a/tools/bench_opcost.cpp
+++ b/tools/bench_opcost.cpp
@@ -13,6 +13,7 @@
 #include <chrono>
 #include <cmath>
 #include <cstdio>
+#include <cstring>
 #include <vector>
 
 using namespace stanli;
@@ -87,7 +88,15 @@ static double time_ns(int reps, F&& f) {
   return std::chrono::duration<double, std::nano>(t1 - t0).count() / reps;
 }
 
-int main() {
+int main(int argc, char** argv) {
+  int reps = REPS;
+  if (argc == 2 && std::strcmp(argv[1], "--smoke") == 0) {
+    reps = 1;
+  } else if (argc != 1) {
+    std::fprintf(stderr, "usage: %s [--smoke]\n", argv[0]);
+    return 2;
+  }
+
   double sink = 0;
   std::vector<double> grad(2);
 
@@ -97,40 +106,43 @@ int main() {
   fill_inputs(exd);
   fill_inputs(ext);
 
-  const double a_ns = time_ns(REPS, [&] { sink += exd.gradient(grad.data()); });
-  const double b_ns = time_ns(REPS, [&] { exd.run_forward_only(); });
-  const double e_ns = time_ns(REPS, [&] { sink += ext.gradient(grad.data()); });
+  const double a_ns = time_ns(reps, [&] { sink += exd.gradient(grad.data()); });
+  const double b_ns = time_ns(reps, [&] { exd.run_forward_only(); });
+  const double e_ns = time_ns(reps, [&] { sink += ext.gradient(grad.data()); });
 
   // C: direct kernel calls, ctx prebuilt once (what a bind-time-ctx executor
   // would do per op).
   double yv = 0.5, muv = 0.3, sigv = 1.2, lpv = 0;
-  double y_adj_dummy = 0, mu_adj = 0, sig_adj = 0;
-  double scratch[3] = {0, 0, 0};
-  KernelCtx ctx;
+  double mu_adj = 0, sig_adj = 0, output_adj = 1.0;
+  const Kernel& k = kernel(OP_NORMAL_LPDF);
+  const Op& direct_op = exd.graph().ops.front();
+  const int64_t scratch_len =
+      k.scratch_size ? k.scratch_size(direct_op, exd.graph().slots.data()) : 0;
+  std::vector<double> scratch(static_cast<size_t>(scratch_len));
+  KernelCtx ctx{};
   ctx.n_in = 3;
   ctx.in[0] = {&yv, 1};
   ctx.in[1] = {&muv, 1};
   ctx.in[2] = {&sigv, 1};
   ctx.out = {&lpv, 1};
   ctx.variant = 0x06;
-  ctx.scratch = scratch;
+  ctx.scratch = scratch.data();
   ctx.in_adj[0] = {nullptr, 1};  // y is data
   ctx.in_adj[1] = {&mu_adj, 1};
   ctx.in_adj[2] = {&sig_adj, 1};
   ctx.out_adj = 1.0;
-  ctx.out_adj_vec = {&lpv, 1};
-  const Kernel& k = kernel(OP_NORMAL_LPDF);
-  const double c_ns = time_ns(REPS, [&] {
+  ctx.out_adj_vec = {&output_adj, 1};
+  const double c_ns = time_ns(reps, [&] {
     for (int i = 0; i < N; ++i) {
       yv = 0.1 * ((i % 17) - 8);
       k.forward(ctx);
-      k.backward(const_cast<KernelCtx&>(ctx));
+      k.backward(ctx);
       sink += lpv;
     }
   });
 
   // D: the math floor on plain doubles.
-  const double d_ns = time_ns(REPS, [&] {
+  const double d_ns = time_ns(reps, [&] {
     for (int i = 0; i < N; ++i) {
       const double y = 0.1 * ((i % 17) - 8);
       const double z = (y - muv) / sigv;


### PR DESCRIPTION
## Summary
- Rebind `Op::idata` views when copying or copy-assigning a `Graph`, preventing dangling pointers into the source graph's integer payload pool.
- Add black-box executor lifetime coverage for copy construction and Graph copy assignment, including source destruction and repeated gradient evaluation.
- Size benchmark reverse scratch from the registered kernel contract and add a smoke-test entry; preserve the upstream Program::CALL benchmark target.

## Validation
- Release focused CTest matrix: 12/12 passed (`test_smoke`, `test_executor`, `test_multichain`, `test_pass_safety`, `test_cse`, `test_constfold`, `test_inplace`, `test_partition`, `test_reroll`, `test_island`, `test_pool`, `test_write_array`).
- ASan (`RelWithDebInfo`, `STANLI_SANITIZE=address`, `ASAN_OPTIONS=detect_leaks=0`): `test_smoke`, `test_executor`, `test_multichain` 3/3 passed.
- `git diff --check` passed.
