### PR TITLE
ci: gate releases on stanr compatibility

### DIFF
--- a/.github/workflows/stanr.yml
+++ b/.github/workflows/stanr.yml
@@ -2,35 +2,17 @@
 # then run stanr's own stanli-backend contract tests. This catches source/API
 # incompatibilities that the standalone R package cannot see: stanr embeds
 # Stanli directly and adapts it to Stan's model_base interface.
+#
+# The release workflow calls this workflow and makes every v* publisher wait
+# for it. Keep workflow_dispatch as an on-demand compatibility check.
 name: stanr downstream
 
 on:
-  push:
-    branches: [main]
-    tags: ['v*']
-    paths:
-      - 'runtime/include/**'
-      - 'runtime/src/**'
-      - 'runtime/kernels/**'
-      - 'tests/test_stanr.sh'
-      - 'tests/test_stanr_backend.R'
-      - '.github/workflows/stanr.yml'
-  pull_request:
-    paths:
-      - 'runtime/include/**'
-      - 'runtime/src/**'
-      - 'runtime/kernels/**'
-      - 'tests/test_stanr.sh'
-      - 'tests/test_stanr_backend.R'
-      - '.github/workflows/stanr.yml'
+  workflow_call:
   workflow_dispatch:
 
 permissions:
   contents: read
-
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   backend:
@@ -39,7 +21,7 @@ jobs:
     timeout-minutes: 60
     env:
       # Pin the downstream source so unrelated upstream changes cannot make a
-      # Stanli pull request fail. Refresh this together with the test if stanr
+      # Stanli release fail. Refresh this together with the test if stanr
       # changes its vendoring or backend contract.
       STANR_REF: da5de850718ca62ad752365d5467566eea22a0c5
       MAKEFLAGS: -j2

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -1918,6 +1918,14 @@ jobs:
       - id: deployment
         uses: actions/deploy-pages@v4
 
+  # The downstream package vendors this runtime and exercises an integration
+  # surface that is expensive and independent enough not to gate every pull
+  # request. Run it once for a full release and make every publisher below
+  # wait for it.
+  stanr:
+    if: startsWith(github.ref, 'refs/tags/v')
+    uses: ./.github/workflows/stanr.yml
+
   # npm, tag-gated like PyPI. A release tag v* publishes every channel
   # at once (PyPI, the runtime release, npm); versions move in lockstep,
   # and both publish jobs assert their manifest agrees with the tag.
@@ -1927,10 +1935,18 @@ jobs:
   # the artifacts are the same ones the wasm and browser-compiler jobs
   # produced for this exact commit.
   npm-publish:
+    # A full release waits for stanr. An npm-v* recovery tag only republishes
+    # npm, so it may proceed after the stanr job is intentionally skipped.
     if: >-
-      startsWith(github.ref, 'refs/tags/v') ||
-      startsWith(github.ref, 'refs/tags/npm-v')
-    needs: [static_checks, wasm, browser-compiler]
+      !cancelled() &&
+      (startsWith(github.ref, 'refs/tags/v') ||
+       startsWith(github.ref, 'refs/tags/npm-v')) &&
+      needs.static_checks.result == 'success' &&
+      needs.wasm.result == 'success' &&
+      needs.browser-compiler.result == 'success' &&
+      (startsWith(github.ref, 'refs/tags/npm-v') ||
+       needs.stanr.result == 'success')
+    needs: [static_checks, wasm, browser-compiler, stanr]
     runs-on: ubuntu-latest
     environment: npm
     permissions:
@@ -1998,7 +2014,7 @@ jobs:
   # source R-universe follows.
   runtime-release:
     if: startsWith(github.ref, 'refs/tags/v')
-    needs: [static_checks, build, windows, wasm-webr]
+    needs: [static_checks, build, windows, wasm-webr, stanr]
     runs-on: ubuntu-latest
     permissions:
       contents: write  # create the release and attach assets to it
@@ -2056,7 +2072,7 @@ jobs:
     # Tags only. PyPI versions can never be reused, so this must not fire
     # on a branch push.
     if: startsWith(github.ref, 'refs/tags/v')
-    needs: [static_checks, build, windows]
+    needs: [static_checks, build, windows, stanr]
     runs-on: ubuntu-latest
     environment: pypi
     permissions:

--- a/TESTING.md
+++ b/TESTING.md
@@ -53,7 +53,7 @@ known exceptions.
 | cross-path matrix | Do stanli's execution paths agree with one another? | Bitwise, except entries named in the ledger | every pull request, within CTest |
 | transformation A/B | Do selected graph optimizations preserve model results? | Optimizations enabled and disabled agree at the default point within 1e-11 | manually after optimization changes |
 | BridgeStan C-ABI comparison | Does the public C interface agree with reference BridgeStan? | Four fixture models must pass value, name, count, and output-shape checks | every pull request |
-| downstream `stanr` embedding | Can the R package vendor this checkout and use Stanli through its `model_base` adapter? | `stanr` must build, then its Stanli-backend construction, derivative, sampling, data, output, init, and cache tests must pass | every pull request that changes the vendored runtime surface |
+| downstream `stanr` embedding | Can the R package vendor this checkout and use Stanli through its `model_base` adapter? | `stanr` must build, then its Stanli-backend construction, derivative, sampling, data, output, init, and cache tests must pass | every version release and on demand |
 | generated conformance sweep | For cases that both systems evaluate, do results agree, and which generated cases remain unsupported? | 10 ULP by default; reviewed per-case policy where needed | nightly and on demand |
 | coverage baseline | Did a previously verified generated case stop verifying? | No loss of a verified case; obsolete policy exceptions must be removed | within the nightly sweep |
 | model census | Do stanc3's 1,231 integration models still compile into stanli's runtime representation and, where checked, agree with CmdStan? | No decrease in per-model classification | manually, on demand |
@@ -623,9 +623,7 @@ repeat-evaluation tests are needed for that case.
 The full source-change path in the pull-request workflows requires the
 following checks, as defined in
 [`.github/workflows/wheels.yml`](.github/workflows/wheels.yml) and
-[`.github/workflows/lint.yml`](.github/workflows/lint.yml), with the downstream
-embedding check in
-[`.github/workflows/stanr.yml`](.github/workflows/stanr.yml):
+[`.github/workflows/lint.yml`](.github/workflows/lint.yml):
 
 - one platform build, `manylinux_2_28_x86_64`;
 - the compiler-only Windows cross-build and executable parity gate described
@@ -648,10 +646,6 @@ embedding check in
   source rather than only against stanli's own interface tests;
 - the R package's tests under `R CMD check` against the library that
   build produced, with a missing-runtime skip treated as a failure;
-- the pinned downstream `stanr` package rebuilt with the current checkout's
-  vendored headers, runtime sources, and kernels, followed by `stanr`'s own
-  Stanli-backend tests for model construction, derivatives, sampling, data
-  marshaling, generated quantities, initialization, and caching;
 - `clang-format` over tracked project-owned C/C++ files, excluding vendored
   dependencies and third-party code. The formatter version is pinned because
   output can differ across major versions.
@@ -681,7 +675,12 @@ still need to be read separately.
 Release tags additionally assert that the version in
 `python/stanli/__init__.py`, `js/package.json` and `r/R/install.R` agrees
 with the tag, that six runtime tarballs exist, and that the PyPI long
-description renders.
+description renders. Before any full-release publisher runs, the release
+workflow also calls [`.github/workflows/stanr.yml`](.github/workflows/stanr.yml)
+to rebuild the pinned downstream `stanr` package with the tagged runtime and
+run its Stanli-backend construction, derivative, sampling, data, output,
+initialization, and cache tests. The check remains available on demand through
+manual workflow dispatch.
 
 Documentation consistency is also checked. Every
 headline number in `README.md`, `python/README.md` and the demo page is


### PR DESCRIPTION
## Summary
- stop running the downstream stanr check on pull requests and main pushes
- call it as a reusable workflow for full version releases
- make npm, PyPI, and runtime publication wait for the downstream check
- preserve npm-only recovery tags and manual dispatch

## Validation
- YAML syntax parsing
- release dependency assertions
- python3 tools/gen_docs.py --check
- git diff --check