### PR TITLE
runtime: keep scratch layout out of Op metadata

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -741,6 +741,11 @@ target_link_libraries(bench_opcost PRIVATE stanli)
 add_executable(bench_program_call EXCLUDE_FROM_ALL
   tools/bench_program_call.cpp tests/tbb_stub.cpp)
 target_link_libraries(bench_program_call PRIVATE stanli)
+# Developer-only Executor metadata/clone evaluator. Fresh baseline/candidate
+# processes make its peak-RSS output comparable across layout changes.
+add_executable(bench_executor_clone EXCLUDE_FROM_ALL
+  tools/bench_executor_clone.cpp tests/tbb_stub.cpp)
+target_link_libraries(bench_executor_clone PRIVATE stanli)
 add_test(NAME test_bench_opcost_smoke COMMAND bench_opcost --smoke)
 set_tests_properties(test_bench_opcost_smoke PROPERTIES
   PASS_REGULAR_EXPRESSION "sink=")

--- a/docs/hacking.md
+++ b/docs/hacking.md
@@ -238,13 +238,37 @@ deliberately small:
 - `Op`: an opcode, up to six input slots, one output (occasionally
   two: a constraint transform also produces its Jacobian term),
   integer immediates (`idata`: index arrays, dimensions, outcome
-  counts), an opaque payload (`udata`: today only ODE specifications),
-  and a scratch window.
+  counts), and an opaque payload (`udata`: e.g. ODE specifications).
+  Scratch offsets exist only while binding; the bound `KernelCtx` retains
+  the scratch pointer, so graphs and executor copies do not store offsets.
 - `Graph`: the slots, the ops, and the pools that own the
   `idata`/`udata` arrays.
 - `KernelCtx`: what a kernel sees at run time. A raw `double*` and a
   length for each input, the output, and each adjoint, plus scratch.
   Assembled once at bind, never rebuilt.
+
+For metadata changes, build `bench_executor_clone` explicitly in separate
+baseline and candidate Release build directories. Keep the baseline binary
+unchanged, and clean-build the candidate after changing a layout header.
+The model-independent scalar ADD chain reports graph construction, binding,
+clone and gradient times, exact `Op` storage, and current/peak RSS in MiB.
+Each clone is checked against an exact value and gradient before timing.
+
+```sh
+cmake --build build-base --target bench_executor_clone -j4
+cmake --build build-candidate --target bench_executor_clone -j4
+python3 tools/bench_executor_clone.py \
+  build-base/bench_executor_clone build-candidate/bench_executor_clone \
+  --ops 25000 --executors 1 8 32 --samples 12 --reps 20 \
+  --json build-candidate/clone-layout.json
+```
+
+The driver alternates fresh processes and reports medians and interquartile
+ranges. RSS is descriptive: allocator retention and page rounding can mask
+small live-storage savings. The ADD chain is a metadata stress case, not a
+prediction of model-wide speedups; also run `bench_opcost` for density kernels
+and `bench_grad` for a compiled-model canary. Timing runs should not overlap
+builds or other benchmarks.
 
 ### The variant byte
 

--- a/docs/superpowers/plans/2026-08-30-op-scratch-layout-results.md
+++ b/docs/superpowers/plans/2026-08-30-op-scratch-layout-results.md
@@ -1,0 +1,172 @@
+# Bind-only Op scratch layout
+
+## Scope and proof
+
+Baseline: `a0dd9d86e989a8965994de2b2761481d5e00c858`. The candidate removes
+`Op::scratch_off` and `Op::scratch_len`; it does not change `KernelCtx`,
+`Slot`, the dispatch tables, `Program::Call`, or either execution sweep.
+
+Scratch sizing still visits operations in graph order and invokes each
+kernel's sizing callback exactly once. A bind-local offset vector retains
+the starts until the complete scratch arena is allocated. Contexts then
+receive their final pointers, and the offset vector dies. An Executor copy
+repeats binding into its own arena. Zero-sized windows preserve their place
+in the prefix sum; an entirely empty scratch arena yields a null pointer.
+No kernel arithmetic, model recognition, lowering eligibility, or fallback
+rule changes.
+
+The new black-box Executor test mixes scalar and vector normal densities
+with an intervening scratch-free ADD. It checks exact analytical gradients,
+clones the Executor, destroys the source, interleaves value-only and gradient
+evaluations eight times, and changes the clone's parameters. Existing tests
+also cover empty/zero-op graphs, integer and opaque payload lifetimes, and
+multithreaded pool reuse. No new pointer-identity assertions are needed.
+
+The primary performance gate is lower live metadata storage. A repeatable
+regression greater than 5% in binding, cloning, or gradients is a provisional
+investigation threshold, not a claimed timing improvement. The competing
+predictions are cheaper graph copies from fewer bytes versus extra bind-time
+allocation from the temporary offset vector. Hot gradient work is unchanged.
+
+## Measurement method
+
+Apple M3 Ultra, arm64, Apple clang 21.0.0. Separate clean Release builds use
+`-O3 -DNDEBUG -ffp-contract=off`. Stan Math is `8f326d14`; Stan is `c96d04115`.
+The baseline and candidate benchmark sources are identical. No timing run
+overlaps this task's builds or test runs.
+
+`bench_executor_clone` uses a scalar ADD chain with N operations, exactly
+N reserved operation records, N+2 slots/elements, and one parameter. Executor
+counts include the original. It checks each executor's exact result and
+gradient before timing repeated evaluations. The Python driver alternates
+AB/BA fresh processes, checks graph shape and numerical sink parity, and
+reports medians and interquartile ranges over 12 pairs. The primary size is
+25,000 operations at 1/8/32 executors; 100,000 operations checks scaling.
+One-operation graphs are a correctness boundary, not a timing claim.
+
+The canaries are `bench_opcost` (scalar normal densities and trivial ops)
+and compiled non-centered Eight Schools via `bench_grad`. RSS is measured
+with `mach_task_info` and `getrusage`, in MiB. It includes allocator retention
+and page rounding, so exact live-storage savings are reported separately.
+There is no x86-64 timing measurement in this experiment.
+
+## Results
+
+Both complete configured suites passed: **113/113 Release and 113/113
+AddressSanitizer** (`ASAN_OPTIONS=detect_leaks=0`). Formatting and diff checks
+passed. The one-operation benchmark boundary also passed with one and two
+executors. Every benchmark pair had matching sinks; the clone benchmark's
+unrounded value and gradient checks were exact. The compiled-model timing
+tool prints a rounded sink, so that canary alone is not a bitwise-gradient
+oracle; the lifecycle and model tests supply the exact clone checks.
+
+`sizeof(Op)` fell **80 -> 64 bytes**, a 20% reduction in operation-record
+storage. `sizeof(Slot)` stayed 24; `sizeof(KernelCtx)` stayed 312. Each
+25,000-op executor saves exactly 400,000 live Op bytes; each 100,000-op
+executor saves 1,600,000 bytes. The temporary bind array costs 8 bytes/op
+only while binding, and its freed allocation can remain resident.
+
+Current RSS after cloning, median [Q1, Q3], in MiB:
+
+| Ops | Executors | Baseline | Candidate |
+| ---: | ---: | ---: | ---: |
+| 25,000 | 1 | 13.750 [13.750, 13.750] | 13.516 [13.516, 13.531] |
+| 25,000 | 8 | 93.391 [93.391, 93.391] | 90.422 [90.422, 90.438] |
+| 25,000 | 32 | 366.422 [366.422, 366.473] | 354.453 [354.047, 354.469] |
+| 100,000 | 1 | 48.156 [48.156, 48.156] | 47.375 [47.375, 47.375] |
+| 100,000 | 8 | 364.125 [364.125, 364.125] | 352.609 [352.609, 352.609] |
+
+The large clone sets use about **3.2-3.3% less total resident memory**.
+This is not a 20% reduction in total Executor memory: contexts and numerical
+arenas still dominate. Peak RSS follows current RSS within 0.032 MiB here.
+
+Timing ratios, candidate/baseline paired median [Q1, Q3]; lower is better:
+
+| Ops / executors | Graph construction | Binding | Per clone | Gradient |
+| --- | --- | --- | --- | --- |
+| 25k / 1 | 0.902 [0.861, 0.964] | 1.038 [1.009, 1.086] | n/a | 1.027 [0.997, 1.059] |
+| 25k / 8 | 0.882 [0.838, 0.963] | 1.047 [0.966, 1.080] | 0.992 [0.943, 1.009] | 0.984 [0.957, 1.019] |
+| 25k / 32 | 0.882 [0.854, 0.899] | 1.004 [0.996, 1.015] | 0.980 [0.968, 1.010] | 1.001 [0.998, 1.005] |
+| 100k / 1 | 0.882 [0.867, 0.900] | 1.000 [0.989, 1.032] | n/a | 1.035 [0.976, 1.053] |
+| 100k / 8 | 0.889 [0.847, 0.939] | 0.997 [0.985, 1.010] | 0.979 [0.973, 0.984] | 1.000 [0.998, 1.003] |
+
+Absolute medians at 100k ops / eight executors: graph construction
+0.952 -> 0.839 ms, binding 3.189 -> 3.200 ms, per clone 3.760 -> 3.689 ms,
+and gradient 1.779 -> 1.778 ms. Graph construction benefits consistently
+from smaller records in this synthetic workload. Cloning improves modestly;
+binding is roughly flat to 5% slower at the smaller size, with overlapping
+sample ranges. No repeatable regression exceeded the investigation gate.
+
+Canary times are nanoseconds per complete graph evaluation, median [Q1, Q3]:
+
+| Canary | Baseline | Candidate | Paired ratio [Q1, Q3] |
+| --- | ---: | ---: | ---: |
+| Density gradient, 4,916 ops | 70,006 [69,748, 70,926] | 70,619 [70,185, 71,128] | 1.008 [0.991, 1.016] |
+| Density forward | 50,359 [49,954, 50,904] | 50,893 [50,378, 51,223] | 1.010 [0.994, 1.027] |
+| Trivial gradient, 4,916 ops | 28,267 [27,927, 29,690] | 28,002 [27,909, 28,491] | 0.992 [0.943, 1.008] |
+| Eight Schools gradient | 272.8 [269.7, 274.0] | 275.0 [272.3, 276.2] | 1.007 [0.996, 1.013] |
+| Eight Schools forward | 233.0 [232.1, 234.5] | 234.7 [232.6, 236.2] | 1.008 [0.990, 1.014] |
+
+These results support a memory/graph-copy change, **not a hot-loop speedup**.
+The roughly 1% canary differences and mixed small single-executor differences
+do not establish a general gradient performance effect. Timings were taken
+on a development host, without CPU pinning; independent background activity
+was not controlled. Repeated fresh-process pairing limits drift but does not
+replace a dedicated performance machine.
+
+Raw local samples are retained in `build-op-layout-candidate/`:
+`clone-layout-25k.json`, `clone-layout-100k.json`, and `canary-layout.json`.
+
+## Reproducing
+
+Configure the baseline before applying the runtime change, using the same
+benchmark sources on both sides. Do not rebuild its binaries afterwards.
+Replace the compiler path below with the pinned stanc in the local checkout.
+
+```sh
+cmake -S . -B build-op-layout-base -DCMAKE_BUILD_TYPE=Release \
+  -DSTANLI_STANC_EXECUTABLE=/path/to/pinned/stanc
+cmake --build build-op-layout-base -j4 \
+  --target bench_executor_clone bench_opcost bench_grad
+# Apply the runtime change, then build in a new directory.
+cmake -S . -B build-op-layout-candidate -DCMAKE_BUILD_TYPE=Release \
+  -DSTANLI_STANC_EXECUTABLE=/path/to/pinned/stanc
+cmake --build build-op-layout-candidate -j4
+cmake --build build-op-layout-candidate -j4 --target bench_executor_clone
+STANC=/path/to/pinned/stanc ctest --test-dir build-op-layout-candidate \
+  --output-on-failure -j4
+
+cmake -S . -B build-op-layout-asan -DCMAKE_BUILD_TYPE=None \
+  -DCMAKE_C_FLAGS='-O1 -g1' -DCMAKE_CXX_FLAGS='-O1 -g1' \
+  -DSTANLI_SANITIZE=address \
+  -DSTANLI_STANC_EXECUTABLE=/path/to/pinned/stanc
+cmake --build build-op-layout-asan -j4
+ASAN_OPTIONS=detect_leaks=0 STANC=/path/to/pinned/stanc \
+  ctest --test-dir build-op-layout-asan --output-on-failure -j4
+
+python3 tools/bench_executor_clone.py \
+  build-op-layout-base/bench_executor_clone \
+  build-op-layout-candidate/bench_executor_clone \
+  --ops 25000 --executors 1 8 32 --samples 12 --reps 20 \
+  --json build-op-layout-candidate/clone-layout-25k.json
+python3 tools/bench_executor_clone.py \
+  build-op-layout-base/bench_executor_clone \
+  build-op-layout-candidate/bench_executor_clone \
+  --ops 100000 --executors 1 8 --samples 12 --reps 20 \
+  --json build-op-layout-candidate/clone-layout-100k.json
+
+# Run each canary in both build directories, alternating order over 12 pairs.
+build-op-layout-candidate/bench_opcost
+build-op-layout-candidate/bench_grad \
+  tests/fixtures/es.tmir.sexp tests/fixtures/eight_schools.json 500000
+```
+
+The source-level lit tests need `STANC` here because the managed worktree
+does not contain the usual `deps/stanc3` symlink. The CMake compiler setting
+above controls fixture generation, not `stanli_check`'s runtime lookup.
+
+## Deferred work
+
+Flattened integer payload storage and shared immutable binding metadata
+remain separate experiments. KernelCtx packing is also deferred: this
+change deliberately does not claim better hot-context cache locality.

--- a/runtime/include/stanli/graph.hpp
+++ b/runtime/include/stanli/graph.hpp
@@ -199,7 +199,8 @@ class Executor {
 
  private:
   void bind_();
-  KernelCtx make_ctx_(const Op& op, const std::vector<char>& written,
+  KernelCtx make_ctx_(const Op& op, int64_t scratch_offset,
+                      const std::vector<char>& written,
                       const std::vector<int64_t>& adjoint_offsets);
 
   struct ProfEntry {

--- a/runtime/include/stanli/kernel_types.hpp
+++ b/runtime/include/stanli/kernel_types.hpp
@@ -46,8 +46,6 @@ struct Op {
   // Opaque per-op payload for kernels that need compile-time structure the
   // integer immediates cannot carry (ODEs, messages, declaration checks).
   const void* udata = nullptr;
-  int64_t scratch_off = 0;  // into the scratch arena (filled at bind)
-  int64_t scratch_len = 0;
 };
 
 // Per-call view handed to kernels. Assembled by the executor; kernels never

--- a/runtime/src/executor.cpp
+++ b/runtime/src/executor.cpp
@@ -225,7 +225,11 @@ void Executor::bind_() {
   }
 
   int64_t scratch = 0;
-  for (auto& op : graph_.ops) {
+  // Scratch layout is binding state, not graph structure. Only the bound
+  // context pointers survive this function; copies compute their own layout.
+  std::vector<int64_t> scratch_offsets;
+  scratch_offsets.reserve(graph_.ops.size());
+  for (const auto& op : graph_.ops) {
     const Kernel& k = kernel(op.opcode);
     if (op.opcode == OP_NONE_ || k.forward == nullptr)
       // Name it. A browser build can be missing a kernel because its
@@ -233,10 +237,8 @@ void Executor::bind_() {
       // to do from this string.
       throw std::runtime_error(std::string("opcode not registered: ") +
                                opcode_name(op.opcode));
-    op.scratch_off = scratch;
-    op.scratch_len =
-        k.scratch_size ? k.scratch_size(op, graph_.slots.data()) : 0;
-    scratch += op.scratch_len;
+    scratch_offsets.push_back(scratch);
+    scratch += k.scratch_size ? k.scratch_size(op, graph_.slots.data()) : 0;
   }
   scratch_.assign(scratch, 0.0);
 
@@ -248,7 +250,8 @@ void Executor::bind_() {
   ctx_.resize(graph_.ops.size());
   out2_adj_ptr_.assign(graph_.ops.size(), nullptr);
   for (size_t i = 0; i < graph_.ops.size(); ++i) {
-    ctx_[i] = make_ctx_(graph_.ops[i], written, adjoint_offsets);
+    ctx_[i] =
+        make_ctx_(graph_.ops[i], scratch_offsets[i], written, adjoint_offsets);
     const int o2 = graph_.ops[i].out2;
     if (o2 >= 0) {
       assert(adjoint_offsets[o2] >= 0);
@@ -268,7 +271,8 @@ void Executor::bind_() {
   }
 }
 
-KernelCtx Executor::make_ctx_(const Op& op, const std::vector<char>& written,
+KernelCtx Executor::make_ctx_(const Op& op, int64_t scratch_offset,
+                              const std::vector<char>& written,
                               const std::vector<int64_t>& adjoint_offsets) {
   KernelCtx ctx;
   ctx.n_in = op.n_in;
@@ -283,7 +287,7 @@ KernelCtx Executor::make_ctx_(const Op& op, const std::vector<char>& written,
     ctx.out2 = Desc{values_.data() + s2.offset, s2.len};
   }
   ctx.variant = op.variant;
-  ctx.scratch = scratch_.data() + op.scratch_off;
+  ctx.scratch = scratch_.empty() ? nullptr : scratch_.data() + scratch_offset;
   ctx.idata = op.idata;
   ctx.udata = op.udata;
   ctx.eval_state = &eval_state_;

--- a/tests/test_executor.cpp
+++ b/tests/test_executor.cpp
@@ -127,6 +127,57 @@ int main() {
   assigned_ex.value_ptr(0)[1] = 11.0;
   expect_eq("assigned idata value", assigned_ex.forward(), 11.0);
 
+  // A mixed scalar/vector density graph needs differently sized scratch
+  // windows, including across an intervening scratch-free op. Check the
+  // complete lifecycle without inspecting any context or arena pointers.
+  std::unique_ptr<Executor> density_copy;
+  double density_value = 0.0;
+  {
+    Graph density;
+    const int mu = density.add_slot(1, true);
+    const int sigma = density.add_slot(1, true);
+    const int scalar_y = density.add_slot(1, false);
+    const int vector_y = density.add_slot(3, false);
+    const int zero = density.add_slot(1, false);
+    const int scalar_lp = density.add_slot(1, false);
+    const int shifted_lp = density.add_slot(1, false);
+    const int vector_lp = density.add_slot(1, false);
+    const int total_lp = density.add_slot(1, false);
+    density.add_op(OP_NORMAL_LPDF, {scalar_y, mu, sigma}, scalar_lp);
+    density.ops.back().variant = 0x06;  // mu and sigma active
+    density.add_op(OP_ADD, {scalar_lp, zero}, shifted_lp);
+    density.add_op(OP_NORMAL_LPDF, {vector_y, mu, sigma}, vector_lp);
+    density.ops.back().variant = 0x06;
+    density.add_op(OP_ADD_N, {shifted_lp, vector_lp}, total_lp);
+    density.result_slot = total_lp;
+    Executor source(std::move(density));
+    source.params_data()[0] = 0.0;
+    source.params_data()[1] = 1.0;
+    *source.value_ptr(scalar_y) = 2.0;
+    source.value_ptr(vector_y)[0] = 1.0;
+    source.value_ptr(vector_y)[1] = 3.0;
+    source.value_ptr(vector_y)[2] = -1.0;
+    double density_grad[2];
+    density_value = source.gradient(density_grad);
+    expect_eq("density dmu", density_grad[0], 5.0);
+    expect_eq("density dsigma", density_grad[1], 11.0);
+    density_copy = std::make_unique<Executor>(source);
+  }
+  for (int repeat = 0; repeat < 8; ++repeat) {
+    density_copy->forward_value_only();
+    double density_grad[2];
+    expect_eq("copied density", density_copy->gradient(density_grad),
+              density_value);
+    expect_eq("copied density dmu", density_grad[0], 5.0);
+    expect_eq("copied density dsigma", density_grad[1], 11.0);
+  }
+  density_copy->params_data()[0] = 1.0;
+  density_copy->params_data()[1] = 2.0;
+  double changed_density_grad[2];
+  density_copy->gradient(changed_density_grad);
+  expect_eq("changed density dmu", changed_density_grad[0], 0.25);
+  expect_eq("changed density dsigma", changed_density_grad[1], -0.875);
+
   // BCAST_FMA forward: out[i] = a + b * x[i].
   Graph g2;
   const int s_a = g2.add_slot(1, true);

--- a/tools/bench_executor_clone.cpp
+++ b/tools/bench_executor_clone.cpp
@@ -1,0 +1,225 @@
+// Executor clone metadata and steady-state evaluator.
+//
+// The graph is a model-independent scalar ADD chain: cheap enough that its
+// fixed execution metadata is a visible share of memory, but still a complete
+// forward/reverse graph whose value and gradient can be checked exactly. Run
+// baseline and candidate binaries as fresh processes so peak RSS is comparable.
+#include <stanli/graph.hpp>
+#include <stanli/optable.hpp>
+
+#include <chrono>
+#include <cerrno>
+#include <climits>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <memory>
+#include <vector>
+
+#ifdef __APPLE__
+#include <mach/mach.h>
+#elif defined(__linux__)
+#include <fstream>
+#include <unistd.h>
+#endif
+#ifndef _WIN32
+#include <sys/resource.h>
+#endif
+
+namespace {
+
+struct Config {
+  int ops = 25000;
+  int executors = 8;
+  int reps = 5;
+};
+
+bool parse_positive(const char* text, int& out) {
+  errno = 0;
+  char* end = nullptr;
+  const long long value = std::strtoll(text, &end, 10);
+  if (errno != 0 || end == text || *end != '\0' || value <= 0 ||
+      value > INT_MAX)
+    return false;
+  out = static_cast<int>(value);
+  return true;
+}
+
+bool parse_args(int argc, char** argv, Config& cfg) {
+  for (int i = 1; i < argc; i += 2) {
+    if (i + 1 >= argc) return false;
+    if (std::strcmp(argv[i], "--ops") == 0) {
+      if (!parse_positive(argv[i + 1], cfg.ops)) return false;
+    } else if (std::strcmp(argv[i], "--executors") == 0) {
+      if (!parse_positive(argv[i + 1], cfg.executors)) return false;
+    } else if (std::strcmp(argv[i], "--reps") == 0) {
+      if (!parse_positive(argv[i + 1], cfg.reps)) return false;
+    } else {
+      return false;
+    }
+  }
+  return cfg.ops <= INT_MAX - 2;
+}
+
+const char* rss_method() {
+#ifdef __APPLE__
+  return "mach_task_info";
+#elif defined(__linux__)
+  return "proc_statm";
+#else
+  return "unavailable";
+#endif
+}
+
+double current_rss_mb() {
+#ifdef __APPLE__
+  mach_task_basic_info_data_t info;
+  mach_msg_type_number_t count = MACH_TASK_BASIC_INFO_COUNT;
+  if (task_info(mach_task_self(), MACH_TASK_BASIC_INFO,
+                reinterpret_cast<task_info_t>(&info), &count) != KERN_SUCCESS)
+    return -1.0;
+  return static_cast<double>(info.resident_size) / (1024.0 * 1024.0);
+#elif defined(__linux__)
+  std::ifstream statm("/proc/self/statm");
+  long long total = 0, resident = 0;
+  if (!(statm >> total >> resident)) return -1.0;
+  const long page_size = sysconf(_SC_PAGESIZE);
+  if (page_size <= 0) return -1.0;
+  return static_cast<double>(resident) * page_size / (1024.0 * 1024.0);
+#else
+  return -1.0;
+#endif
+}
+
+double peak_rss_mb() {
+#ifdef _WIN32
+  return -1.0;
+#else
+  struct rusage ru;
+  if (getrusage(RUSAGE_SELF, &ru) != 0) return -1.0;
+#ifdef __APPLE__
+  return static_cast<double>(ru.ru_maxrss) / (1024.0 * 1024.0);
+#else
+  return static_cast<double>(ru.ru_maxrss) / 1024.0;
+#endif
+#endif
+}
+
+struct Chain {
+  stanli::Graph graph;
+  int constant = -1;
+};
+
+Chain make_chain(int n_ops) {
+  using namespace stanli;
+  Chain chain;
+  Graph& graph = chain.graph;
+  graph.ops.reserve(static_cast<size_t>(n_ops));
+  graph.slots.reserve(static_cast<size_t>(n_ops) + 2);
+  const int parameter = graph.add_slot(1, true);
+  chain.constant = graph.add_slot(1, false);
+  int value = parameter;
+  for (int i = 0; i < n_ops; ++i) {
+    const int next = graph.add_slot(1, false);
+    graph.add_op(OP_ADD, {value, chain.constant}, next);
+    value = next;
+  }
+  graph.result_slot = value;
+  return chain;
+}
+
+template <typename Clock = std::chrono::steady_clock>
+double elapsed_ms(typename Clock::time_point start) {
+  return std::chrono::duration<double, std::milli>(Clock::now() - start)
+      .count();
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+  using namespace stanli;
+  using Clock = std::chrono::steady_clock;
+
+  Config cfg;
+  if (!parse_args(argc, argv, cfg)) {
+    std::fprintf(stderr, "usage: %s [--ops N] [--executors N] [--reps N]\n",
+                 argv[0]);
+    return 2;
+  }
+  if (find_kernel(OP_ADD) == nullptr) return 1;
+
+  const auto graph_start = Clock::now();
+  Chain chain = make_chain(cfg.ops);
+  const double graph_ms = elapsed_ms(graph_start);
+  int64_t slot_elements = 0;
+  for (const Slot& slot : chain.graph.slots) slot_elements += slot.len;
+
+  const auto bind_start = Clock::now();
+  auto prototype = std::make_unique<Executor>(std::move(chain.graph));
+  const double bind_ms = elapsed_ms(bind_start);
+  constexpr double increment = 0x1p-20;
+  prototype->value_ptr(chain.constant)[0] = increment;
+  const double rss_before_clone_mb = current_rss_mb();
+
+  std::vector<std::unique_ptr<Executor>> owned;
+  owned.reserve(static_cast<size_t>(cfg.executors - 1));
+  const auto clone_start = Clock::now();
+  for (int i = 1; i < cfg.executors; ++i)
+    owned.push_back(std::make_unique<Executor>(*prototype));
+  const double clone_ms = elapsed_ms(clone_start);
+  const double rss_after_clone_mb = current_rss_mb();
+
+  std::vector<Executor*> executors;
+  executors.reserve(static_cast<size_t>(cfg.executors));
+  executors.push_back(prototype.get());
+  for (auto& clone : owned) executors.push_back(clone.get());
+
+  constexpr double parameter = 0.25;
+  double want_value = parameter;
+  for (int i = 0; i < cfg.ops; ++i) want_value += increment;
+  double sink = 0.0;
+  double gradient = 0.0;
+  for (Executor* executor : executors) {
+    executor->params_data()[0] = parameter;
+    const double value = executor->gradient(&gradient);
+    if (value != want_value || gradient != 1.0) {
+      std::fprintf(stderr,
+                   "clone mismatch: value %.17g want %.17g, grad %.17g\n",
+                   value, want_value, gradient);
+      return 1;
+    }
+    sink += value + gradient;
+  }
+
+  const auto gradient_start = Clock::now();
+  for (int rep = 0; rep < cfg.reps; ++rep) {
+    for (Executor* executor : executors) {
+      executor->params_data()[0] = parameter;
+      const double value = executor->gradient(&gradient);
+      sink += value + gradient;
+    }
+  }
+  const double gradient_ns =
+      std::chrono::duration<double, std::nano>(Clock::now() - gradient_start)
+          .count() /
+      (static_cast<double>(cfg.reps) * cfg.executors);
+
+  const size_t op_bytes_per_executor =
+      prototype->graph().ops.capacity() * sizeof(Op);
+  std::printf(
+      "ops=%d ops_capacity=%zu slots=%zu slot_elements=%lld executors=%d "
+      "reps=%d "
+      "sizeof_op=%zu sizeof_slot=%zu sizeof_ctx=%zu "
+      "op_bytes_per_executor=%zu graph_ms=%.3f bind_ms=%.3f "
+      "clone_ms_total=%.3f clone_ms_each=%.3f gradient_ns=%.1f "
+      "rss_method=%s rss_before_clone_mb=%.3f rss_after_clone_mb=%.3f "
+      "peak_rss_mb=%.3f sink=%.17g\n",
+      cfg.ops, prototype->graph().ops.capacity(),
+      prototype->graph().slots.size(), static_cast<long long>(slot_elements),
+      cfg.executors, cfg.reps, sizeof(Op), sizeof(Slot), sizeof(KernelCtx),
+      op_bytes_per_executor, graph_ms, bind_ms, clone_ms,
+      cfg.executors > 1 ? clone_ms / (cfg.executors - 1) : 0.0, gradient_ns,
+      rss_method(), rss_before_clone_mb, rss_after_clone_mb, peak_rss_mb(),
+      sink);
+  return 0;
+}

--- a/tools/bench_executor_clone.py
+++ b/tools/bench_executor_clone.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+"""Alternate fresh baseline/candidate processes for Executor layout changes."""
+
+import argparse
+import json
+import platform
+import statistics
+import subprocess
+from pathlib import Path
+
+
+METRICS = (
+    "graph_ms",
+    "bind_ms",
+    "clone_ms_total",
+    "clone_ms_each",
+    "gradient_ns",
+    "rss_before_clone_mb",
+    "rss_after_clone_mb",
+    "peak_rss_mb",
+)
+
+
+def run_one(binary, ops, executors, reps):
+    command = [
+        str(binary),
+        "--ops",
+        str(ops),
+        "--executors",
+        str(executors),
+        "--reps",
+        str(reps),
+    ]
+    output = subprocess.check_output(command, text=True).strip()
+    fields = dict(token.split("=", 1) for token in output.split())
+    for key, expected in (("ops", ops), ("executors", executors), ("reps", reps)):
+        if int(fields[key]) != expected:
+            raise RuntimeError(f"unexpected {key} from {binary}: {fields[key]}")
+    for key in (
+        *METRICS,
+        "sizeof_op",
+        "sizeof_slot",
+        "sizeof_ctx",
+        "op_bytes_per_executor",
+    ):
+        fields[key] = float(fields[key])
+    return fields
+
+
+def summary(values):
+    quartiles = statistics.quantiles(values, n=4, method="inclusive")
+    return {
+        "median": statistics.median(values),
+        "q1": quartiles[0],
+        "q3": quartiles[2],
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("baseline", type=Path)
+    parser.add_argument("candidate", type=Path)
+    parser.add_argument("--ops", type=int, default=25000)
+    parser.add_argument("--executors", type=int, nargs="+", default=[1, 8, 32])
+    parser.add_argument("--samples", type=int, default=12)
+    parser.add_argument("--reps", type=int, default=20)
+    parser.add_argument("--json", type=Path, help="retain raw paired samples")
+    args = parser.parse_args()
+    if args.samples < 4 or args.ops < 1 or args.reps < 1:
+        parser.error("samples must be >= 4; ops and reps must be positive")
+    if any(count < 1 for count in args.executors):
+        parser.error("executor counts must be positive")
+    binaries = {
+        "baseline": args.baseline.resolve(),
+        "candidate": args.candidate.resolve(),
+    }
+    if binaries["baseline"] == binaries["candidate"]:
+        parser.error("baseline and candidate must be distinct binaries")
+
+    report = {
+        "platform": platform.platform(),
+        "binaries": {key: str(value) for key, value in binaries.items()},
+        "ops": args.ops,
+        "reps": args.reps,
+        "samples": args.samples,
+        "results": [],
+    }
+    for count in args.executors:
+        pairs = []
+        for sample in range(args.samples):
+            # AB, BA, AB, BA produces ABBA/BAAB blocks without reusing a
+            # process or its allocator high-water mark across measurements.
+            order = ("baseline", "candidate")
+            if sample % 2:
+                order = tuple(reversed(order))
+            pair = {
+                name: run_one(binaries[name], args.ops, count, args.reps)
+                for name in order
+            }
+            for key in ("ops_capacity", "slots", "slot_elements", "rss_method"):
+                if pair["baseline"][key] != pair["candidate"][key]:
+                    raise RuntimeError(f"baseline/candidate mismatch for {key}")
+            if pair["baseline"]["sink"] != pair["candidate"]["sink"]:
+                raise RuntimeError(f"numerical sink mismatch at {count} executors")
+            pairs.append(pair)
+
+        result = {"executors": count, "pairs": pairs, "metrics": {}}
+        print(f"executors={count} ops={args.ops} samples={args.samples}")
+        for metric in (
+            "sizeof_op",
+            "sizeof_slot",
+            "sizeof_ctx",
+            "op_bytes_per_executor",
+        ):
+            a = pairs[0]["baseline"][metric]
+            b = pairs[0]["candidate"][metric]
+            print(f"  {metric}: A={a:.0f} B={b:.0f} delta={b - a:+.0f}")
+        for metric in METRICS:
+            baseline = [pair["baseline"][metric] for pair in pairs]
+            candidate = [pair["candidate"][metric] for pair in pairs]
+            values = {"baseline": summary(baseline), "candidate": summary(candidate)}
+            if all(a > 0 and b >= 0 for a, b in zip(baseline, candidate)):
+                values["paired_ratio"] = summary(
+                    [b / a for a, b in zip(baseline, candidate)]
+                )
+            result["metrics"][metric] = values
+            a = values["baseline"]
+            b = values["candidate"]
+            ratio = values.get("paired_ratio")
+            ratio_text = (
+                f" B/A={ratio['median']:.4f} [{ratio['q1']:.4f}, {ratio['q3']:.4f}]"
+                if ratio
+                else ""
+            )
+            print(
+                f"  {metric}: A={a['median']:.3f} [{a['q1']:.3f}, {a['q3']:.3f}]"
+                f" B={b['median']:.3f} [{b['q1']:.3f}, {b['q3']:.3f}]{ratio_text}"
+            )
+        report["results"].append(result)
+
+    if args.json:
+        args.json.write_text(json.dumps(report, indent=2) + "\n")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
# Bind-only Op scratch layout

## Scope and proof

Baseline: `a0dd9d86e989a8965994de2b2761481d5e00c858`. The candidate removes
`Op::scratch_off` and `Op::scratch_len`; it does not change `KernelCtx`,
`Slot`, the dispatch tables, `Program::Call`, or either execution sweep.

Scratch sizing still visits operations in graph order and invokes each
kernel's sizing callback exactly once. A bind-local offset vector retains
the starts until the complete scratch arena is allocated. Contexts then
receive their final pointers, and the offset vector dies. An Executor copy
repeats binding into its own arena. Zero-sized windows preserve their place
in the prefix sum; an entirely empty scratch arena yields a null pointer.
No kernel arithmetic, model recognition, lowering eligibility, or fallback
rule changes.

The new black-box Executor test mixes scalar and vector normal densities
with an intervening scratch-free ADD. It checks exact analytical gradients,
clones the Executor, destroys the source, interleaves value-only and gradient
evaluations eight times, and changes the clone's parameters. Existing tests
also cover empty/zero-op graphs, integer and opaque payload lifetimes, and
multithreaded pool reuse. No new pointer-identity assertions are needed.

The primary performance gate is lower live metadata storage. A repeatable
regression greater than 5% in binding, cloning, or gradients is a provisional
investigation threshold, not a claimed timing improvement. The competing
predictions are cheaper graph copies from fewer bytes versus extra bind-time
allocation from the temporary offset vector. Hot gradient work is unchanged.

## Measurement method

Apple M3 Ultra, arm64, Apple clang 21.0.0. Separate clean Release builds use
`-O3 -DNDEBUG -ffp-contract=off`. Stan Math is `8f326d14`; Stan is `c96d04115`.
The baseline and candidate benchmark sources are identical. No timing run
overlaps this task's builds or test runs.

`bench_executor_clone` uses a scalar ADD chain with N operations, exactly
N reserved operation records, N+2 slots/elements, and one parameter. Executor
counts include the original. It checks each executor's exact result and
gradient before timing repeated evaluations. The Python driver alternates
AB/BA fresh processes, checks graph shape and numerical sink parity, and
reports medians and interquartile ranges over 12 pairs. The primary size is
25,000 operations at 1/8/32 executors; 100,000 operations checks scaling.
One-operation graphs are a correctness boundary, not a timing claim.

The canaries are `bench_opcost` (scalar normal densities and trivial ops)
and compiled non-centered Eight Schools via `bench_grad`. RSS is measured
with `mach_task_info` and `getrusage`, in MiB. It includes allocator retention
and page rounding, so exact live-storage savings are reported separately.
There is no x86-64 timing measurement in this experiment.

## Results

Both complete configured suites passed: **113/113 Release and 113/113
AddressSanitizer** (`ASAN_OPTIONS=detect_leaks=0`). Formatting and diff checks
passed. The one-operation benchmark boundary also passed with one and two
executors. Every benchmark pair had matching sinks; the clone benchmark's
unrounded value and gradient checks were exact. The compiled-model timing
tool prints a rounded sink, so that canary alone is not a bitwise-gradient
oracle; the lifecycle and model tests supply the exact clone checks.

`sizeof(Op)` fell **80 -> 64 bytes**, a 20% reduction in operation-record
storage. `sizeof(Slot)` stayed 24; `sizeof(KernelCtx)` stayed 312. Each
25,000-op executor saves exactly 400,000 live Op bytes; each 100,000-op
executor saves 1,600,000 bytes. The temporary bind array costs 8 bytes/op
only while binding, and its freed allocation can remain resident.

Current RSS after cloning, median [Q1, Q3], in MiB:

| Ops | Executors | Baseline | Candidate |
| ---: | ---: | ---: | ---: |
| 25,000 | 1 | 13.750 [13.750, 13.750] | 13.516 [13.516, 13.531] |
| 25,000 | 8 | 93.391 [93.391, 93.391] | 90.422 [90.422, 90.438] |
| 25,000 | 32 | 366.422 [366.422, 366.473] | 354.453 [354.047, 354.469] |
| 100,000 | 1 | 48.156 [48.156, 48.156] | 47.375 [47.375, 47.375] |
| 100,000 | 8 | 364.125 [364.125, 364.125] | 352.609 [352.609, 352.609] |

The large clone sets use about **3.2-3.3% less total resident memory**.
This is not a 20% reduction in total Executor memory: contexts and numerical
arenas still dominate. Peak RSS follows current RSS within 0.032 MiB here.

Timing ratios, candidate/baseline paired median [Q1, Q3]; lower is better:

| Ops / executors | Graph construction | Binding | Per clone | Gradient |
| --- | --- | --- | --- | --- |
| 25k / 1 | 0.902 [0.861, 0.964] | 1.038 [1.009, 1.086] | n/a | 1.027 [0.997, 1.059] |
| 25k / 8 | 0.882 [0.838, 0.963] | 1.047 [0.966, 1.080] | 0.992 [0.943, 1.009] | 0.984 [0.957, 1.019] |
| 25k / 32 | 0.882 [0.854, 0.899] | 1.004 [0.996, 1.015] | 0.980 [0.968, 1.010] | 1.001 [0.998, 1.005] |
| 100k / 1 | 0.882 [0.867, 0.900] | 1.000 [0.989, 1.032] | n/a | 1.035 [0.976, 1.053] |
| 100k / 8 | 0.889 [0.847, 0.939] | 0.997 [0.985, 1.010] | 0.979 [0.973, 0.984] | 1.000 [0.998, 1.003] |

Absolute medians at 100k ops / eight executors: graph construction
0.952 -> 0.839 ms, binding 3.189 -> 3.200 ms, per clone 3.760 -> 3.689 ms,
and gradient 1.779 -> 1.778 ms. Graph construction benefits consistently
from smaller records in this synthetic workload. Cloning improves modestly;
binding is roughly flat to 5% slower at the smaller size, with overlapping
sample ranges. No repeatable regression exceeded the investigation gate.

Canary times are nanoseconds per complete graph evaluation, median [Q1, Q3]:

| Canary | Baseline | Candidate | Paired ratio [Q1, Q3] |
| --- | ---: | ---: | ---: |
| Density gradient, 4,916 ops | 70,006 [69,748, 70,926] | 70,619 [70,185, 71,128] | 1.008 [0.991, 1.016] |
| Density forward | 50,359 [49,954, 50,904] | 50,893 [50,378, 51,223] | 1.010 [0.994, 1.027] |
| Trivial gradient, 4,916 ops | 28,267 [27,927, 29,690] | 28,002 [27,909, 28,491] | 0.992 [0.943, 1.008] |
| Eight Schools gradient | 272.8 [269.7, 274.0] | 275.0 [272.3, 276.2] | 1.007 [0.996, 1.013] |
| Eight Schools forward | 233.0 [232.1, 234.5] | 234.7 [232.6, 236.2] | 1.008 [0.990, 1.014] |

These results support a memory/graph-copy change, **not a hot-loop speedup**.
The roughly 1% canary differences and mixed small single-executor differences
do not establish a general gradient performance effect. Timings were taken
on a development host, without CPU pinning; independent background activity
was not controlled. Repeated fresh-process pairing limits drift but does not
replace a dedicated performance machine.

Raw local samples are retained in `build-op-layout-candidate/`:
`clone-layout-25k.json`, `clone-layout-100k.json`, and `canary-layout.json`.

## Reproducing

Configure the baseline before applying the runtime change, using the same
benchmark sources on both sides. Do not rebuild its binaries afterwards.
Replace the compiler path below with the pinned stanc in the local checkout.

```sh
cmake -S . -B build-op-layout-base -DCMAKE_BUILD_TYPE=Release \
  -DSTANLI_STANC_EXECUTABLE=/path/to/pinned/stanc
cmake --build build-op-layout-base -j4 \
  --target bench_executor_clone bench_opcost bench_grad
# Apply the runtime change, then build in a new directory.
cmake -S . -B build-op-layout-candidate -DCMAKE_BUILD_TYPE=Release \
  -DSTANLI_STANC_EXECUTABLE=/path/to/pinned/stanc
cmake --build build-op-layout-candidate -j4
cmake --build build-op-layout-candidate -j4 --target bench_executor_clone
STANC=/path/to/pinned/stanc ctest --test-dir build-op-layout-candidate \
  --output-on-failure -j4

cmake -S . -B build-op-layout-asan -DCMAKE_BUILD_TYPE=None \
  -DCMAKE_C_FLAGS='-O1 -g1' -DCMAKE_CXX_FLAGS='-O1 -g1' \
  -DSTANLI_SANITIZE=address \
  -DSTANLI_STANC_EXECUTABLE=/path/to/pinned/stanc
cmake --build build-op-layout-asan -j4
ASAN_OPTIONS=detect_leaks=0 STANC=/path/to/pinned/stanc \
  ctest --test-dir build-op-layout-asan --output-on-failure -j4

python3 tools/bench_executor_clone.py \
  build-op-layout-base/bench_executor_clone \
  build-op-layout-candidate/bench_executor_clone \
  --ops 25000 --executors 1 8 32 --samples 12 --reps 20 \
  --json build-op-layout-candidate/clone-layout-25k.json
python3 tools/bench_executor_clone.py \
  build-op-layout-base/bench_executor_clone \
  build-op-layout-candidate/bench_executor_clone \
  --ops 100000 --executors 1 8 --samples 12 --reps 20 \
  --json build-op-layout-candidate/clone-layout-100k.json

# Run each canary in both build directories, alternating order over 12 pairs.
build-op-layout-candidate/bench_opcost
build-op-layout-candidate/bench_grad \
  tests/fixtures/es.tmir.sexp tests/fixtures/eight_schools.json 500000
```

The source-level lit tests need `STANC` here because the managed worktree
does not contain the usual `deps/stanc3` symlink. The CMake compiler setting
above controls fixture generation, not `stanli_check`'s runtime lookup.

## Deferred work

Flattened integer payload storage and shared immutable binding metadata
remain separate experiments. KernelCtx packing is also deferred: this
change deliberately does not claim better hot-context cache locality.
