### PR TITLE
Fix web parameter navigation and generated quantities UI

### DIFF
--- a/js/README.md
+++ b/js/README.md
@@ -23,11 +23,13 @@ const fit = await sample({
 
 fit.columns["mu"];     // Float64Array, one entry per draw
 fit.names;             // every CSV column CmdStan would write
+fit.generatedStart;    // index where generated-quantity columns begin
 fit.ms;                // {stanc, lower, sample, total} in milliseconds
 ```
 
 Columns cover the full CmdStan CSV: constrained parameters, transformed
 parameters, and generated quantities (RNG draws stream from `seed`).
+When there are no generated quantities, `generatedStart === fit.names.length`.
 The heavy work runs in a worker the package owns, so the page never
 blocks; calls queue and run one at a time.
 

--- a/js/index.mjs
+++ b/js/index.mjs
@@ -123,7 +123,7 @@ export function compile(opts) {
  *   a transferred ArrayBuffer of constrained draws, nCon wide.
  *   Pathfinder streams {live: {phase: "path", iter, lp}} instead, one
  *   message per L-BFGS iterate.
- * @returns {Promise<{names: string[], samples: number,
+ * @returns {Promise<{names: string[], samples: number, generatedStart: number,
  *                    columns: Object<string, Float64Array>,
  *                    exactLp: boolean,
  *                    pathfinder?: {path: {iter, lp}[], khat: number,
@@ -152,12 +152,12 @@ export function sample(opts) {
         ? opts.sampler : "nuts",
     maxError: opts.maxError == null ? 0 : opts.maxError,
   }, opts).then((done) => {
-    const { names, samples, ms, exactLp, pathfinder } = done;
+    const { names, samples, generatedStart, ms, exactLp, pathfinder } = done;
     const flat = new Float64Array(done.columns);
     const columns = {};
     names.forEach((name, i) => {
       columns[name] = flat.subarray(i * samples, (i + 1) * samples);
     });
-    return { names, samples, columns, ms, exactLp, pathfinder };
+    return { names, samples, generatedStart, columns, ms, exactLp, pathfinder };
   });
 }

--- a/js/worker.js
+++ b/js/worker.js
@@ -188,6 +188,8 @@ onmessage = async (e) => {
     const nWa = Number(M._stanli_wa_n_columns(model));
     const useWa = nWa > 0;
     const nCon = useWa ? nWa : Number(M._stanli_n_constrained(model));
+    const generatedStart = useWa
+        ? Number(M._stanli_wa_n_generated_start(model)) : nCon;
     const names = [];
     for (let i = 0; i < nCon; ++i)
       names.push(M.UTF8ToString(
@@ -213,7 +215,7 @@ onmessage = async (e) => {
 
     postMessage({
       done: {
-        names, samples, pathfinder: pf,
+        names, samples, generatedStart, pathfinder: pf,
         // True unless the runtime was built with STANLI_LITE_LP, which
         // drops stan-math's propto instantiations and shifts lp__ by a
         // per-model constant. The shipped browser build does not, so this

--- a/runtime/include/stanli/capi.h
+++ b/runtime/include/stanli/capi.h
@@ -353,6 +353,10 @@ int stanli_run_pathfinder(stanli_model* m, uint32_t seed, int chain_id,
  * evaluates at unconstrained q and writes n_columns doubles; returns 0 on
  * success. */
 int64_t stanli_wa_n_columns(const stanli_model* m);
+/* Index of the first generated-quantity column in the write_array output.
+ * It equals n_columns when there are no generated quantities in that output.
+ * Returns 0 when write_array is unavailable. */
+int64_t stanli_wa_n_generated_start(const stanli_model* m);
 const char* stanli_wa_column_name(const stanli_model* m, int64_t i);
 void stanli_wa_seed(stanli_model* m, uint32_t seed);
 void stanli_wa_seed_chain(stanli_model* m, uint32_t seed, uint32_t chain);

--- a/runtime/src/capi.cpp
+++ b/runtime/src/capi.cpp
@@ -28,6 +28,15 @@ void put_err(char* err, size_t err_len, const char* what) {
   err[err_len - 1] = '\0';
 }
 
+int64_t scalar_column_start(
+    const std::vector<stanli::CompiledModel::ParamView>& columns,
+    size_t view_start) {
+  int64_t start = 0;
+  for (size_t i = 0; i < view_start && i < columns.size(); ++i)
+    start += columns[i].len;
+  return start;
+}
+
 }  // namespace
 
 struct stanli_model {
@@ -42,6 +51,7 @@ struct stanli_model {
   std::shared_ptr<stanli::WaInterp> wa_interp;
   std::vector<std::string> wa_names;  // CSV order, flattened
   int64_t wa_n = 0;
+  int64_t wa_gq_start = 0;
   // The stream stanli_wa_seed sets and stanli_wa_row draws from. This ABI
   // names one stream per model, so the model holds it; callers wanting a
   // stream per thread use WaInterp::eval directly with their own WaRng.
@@ -96,6 +106,8 @@ stanli_model* stanli_model_new(const char* tmir_sexp, const char* data_json,
             m->wa_n = (int64_t)row.size();
             m->wa_names =
                 stanli::CompiledModel::csv_names(m->wa_interp->columns());
+            m->wa_gq_start = scalar_column_start(m->wa_interp->columns(),
+                                                 m->wa_interp->n_gq_start());
             found = true;
           } catch (const std::exception&) {
           }
@@ -107,6 +119,7 @@ stanli_model* stanli_model_new(const char* tmir_sexp, const char* data_json,
         m->wa_cols = wa.columns;
         m->wa_names = stanli::CompiledModel::csv_names(wa.columns);
         for (const auto& c : wa.columns) m->wa_n += c.len;
+        m->wa_gq_start = scalar_column_start(wa.columns, wa.n_gq_start);
       }
     }
     return m.release();
@@ -640,6 +653,10 @@ const char* stanli_constrained_name(const stanli_model* m, int64_t i) {
 }
 
 int64_t stanli_wa_n_columns(const stanli_model* m) { return m->wa_n; }
+
+int64_t stanli_wa_n_generated_start(const stanli_model* m) {
+  return m->wa_n > 0 ? m->wa_gq_start : 0;
+}
 
 const char* stanli_wa_column_name(const stanli_model* m, int64_t i) {
   if (i < 0 || i >= (int64_t)m->wa_names.size()) return "";

--- a/tests/test_capi.cpp
+++ b/tests/test_capi.cpp
@@ -70,7 +70,8 @@ void expect_values(const std::string& what, const std::vector<double>& got,
 void expect_names(const char* fixture, const std::string& data,
                   const std::vector<std::string>& expected,
                   const std::vector<double>& q = {},
-                  const std::vector<double>& expected_values = {}) {
+                  const std::vector<double>& expected_values = {},
+                  int64_t expected_wa_gq_start = -1) {
   const std::string mir = slurp(fixture);
   char err[8192]{};
   stanli_model* model =
@@ -92,6 +93,14 @@ void expect_names(const char* fixture, const std::string& data,
     expect_eq((std::string(fixture) + " constrained name " + std::to_string(i))
                   .c_str(),
               name == nullptr ? "<null>" : name, expected[(size_t)i]);
+  }
+  if (expected_wa_gq_start >= 0 &&
+      stanli_wa_n_generated_start(model) != expected_wa_gq_start) {
+    ++failures;
+    std::printf("FAIL generated-quantity start for %s: got %lld want %lld\n",
+                fixture,
+                static_cast<long long>(stanli_wa_n_generated_start(model)),
+                static_cast<long long>(expected_wa_gq_start));
   }
   if (!q.empty()) {
     std::vector<double> values((size_t)n);
@@ -700,7 +709,8 @@ int main() {
                    "M.2.2",
                    "M.1.3",
                    "M.2.3",
-               });
+               },
+               {}, {}, 8);
 
   // Arrays are outer-major, while each matrix element is column-major.
   // This is the shape a flat "name.1 ... name.N" policy cannot represent.

--- a/web/index.html
+++ b/web/index.html
@@ -57,6 +57,9 @@
   .plots canvas { border: 1px solid #8883; border-radius: 6px;
                   max-width: 100%; }
   .times { font-size: .8rem; opacity: .7; margin-top: .5rem; }
+  .gq { margin-top: .8rem; }
+  .gq summary { cursor: pointer; font-weight: 600; }
+  .gq table { margin-top: .4rem; }
   #note { font-size: .82rem; opacity: .75; margin: -.4rem 0 .6rem;
           max-width: 62rem; }
   #note b { font-weight: 600; }
@@ -502,7 +505,8 @@ $("sampler").onchange = () => {
 };
 
 // ---- run -------------------------------------------------------------------
-// fit = {names, samples, chains: [{name: Float64Array} per chain]}
+// fit = {names, samples, generatedStart,
+//        chains: [{name: Float64Array} per chain]}
 // Single-sampler runs keep one fit; a comparison run keeps one per
 // sampler so both stay inspectable (and downloadable) side by side.
 let fit = null;
@@ -529,6 +533,7 @@ async function runChains(sampler, opts, nChains, seed, onLive) {
     for (const k of ["lower", "sample"]) ms[k] += r.ms[k];
   return {
     fit: { names: results[0].names, samples: results[0].samples,
+           generatedStart: results[0].generatedStart,
            chains: results.map((r) => r.columns) },
     // Pathfinder only: which iterate of each path the ELBO chose.
     selected: results.map((r) => (r.pathfinder ? r.pathfinder.selectedIter
@@ -754,6 +759,7 @@ async function runCompare(opts, nChains, seed, compiled, tWall) {
     for (const r of rs)
       for (const k of ["lower", "sample"]) ms[k] += r.ms[k];
     return { fit: { names: rs[0].names, samples: rs[0].samples,
+                    generatedStart: rs[0].generatedStart,
                     chains: rs.map((r) => r.columns) }, ms };
   };
   const rn = collect("nuts"), rw = collect("walnuts");
@@ -796,6 +802,18 @@ async function runCompare(opts, nChains, seed, compiled, tWall) {
   cmpSelect(cmpFits.nuts.names[0]);
 }
 
+// Reveal a selected row's section and, when plots are parked below it, the
+// plots too. Scrolling only the parameter row leaves the graph below the
+// viewport when the selected row is near the bottom of the page.
+function revealResultRow(tr) {
+  if (!tr) return;
+  const details = tr.closest("details");
+  if (details) details.open = true;
+  const next = tr.nextElementSibling;
+  const target = next && next.classList.contains("plotrow") ? next : tr;
+  target.scrollIntoView({ block: "nearest" });
+}
+
 // Arrow keys step the selected parameter in every finished result view,
 // unless focus is in a form control (the model picker owns its own arrows).
 let cmpSelName = null;
@@ -820,8 +838,8 @@ document.addEventListener("keydown", (e) => {
         `tr[data-n="${CSS.escape(names[next])}"]`);
     if (tr) showPlots(tr, singleMode, false);
   }
-  $("out").querySelector(`tr[data-n="${CSS.escape(names[next])}"]`)
-      ?.scrollIntoView({ block: "nearest" });
+  revealResultRow($("out").querySelector(
+      `tr[data-n="${CSS.escape(names[next])}"]`));
 });
 
 function cmpSelect(name) {
@@ -861,6 +879,8 @@ function placeComparisonPlots(col, name) {
   const tr = Array.from(col.querySelectorAll("tr[data-n]"))
       .find((row) => row.dataset.n === name);
   if (!plots || !tr) return;
+  const details = tr.closest("details");
+  if (details) details.open = true;
   col.querySelector("tr.plotrow")?.remove();
   const row = document.createElement("tr");
   row.className = "plotrow";
@@ -947,7 +967,14 @@ function fitMoments(f) {
 // One row per parameter, both methods on it, plus the discrepancy that
 // says whether the difference matters: how far apart the means are in
 // units of NUTS's own sd.
-function pfTable(names) {
+function resultSectionStart(f) {
+  const start = Number(f.generatedStart);
+  return Number.isFinite(start)
+      ? Math.min(f.names.length, Math.max(0, Math.trunc(start)))
+      : f.names.length;
+}
+
+function pfTablePart(names) {
   let html = "<table><tr><th>parameter</th><th>NUTS mean</th><th>NUTS sd</th>" +
              "<th>PF mean</th><th>PF sd</th>" +
              "<th>|&Delta;mean| / NUTS sd</th></tr>";
@@ -956,6 +983,15 @@ function pfTable(names) {
             `<td class="nsd"></td><td class="pm"></td><td class="psd"></td>` +
             `<td class="ds"></td></tr>`;
   return html + "</table>";
+}
+function pfTable(f) {
+  const start = resultSectionStart(f);
+  let html = pfTablePart(f.names.slice(0, start));
+  if (start < f.names.length)
+    html += `<details class="gq"><summary>Generated quantities ` +
+            `(${f.names.length - start})</summary>` +
+            pfTablePart(f.names.slice(start)) + "</details>";
+  return html;
 }
 const pfFmt = (x) => (x == null || !Number.isFinite(x) ? "-"
     : Math.abs(x) >= 1000 ? x.toFixed(0) : x.toPrecision(4));
@@ -985,8 +1021,14 @@ function pfPaint() {
                          : liveColumn(v.live, cmpSelName);
   const pf = v.pfFit && cmpSelName in v.pfFit.chains[0]
       ? allDraws(v.pfFit, cmpSelName) : null;
-  for (const tr of v.sum.querySelectorAll("tr[data-n]"))
-    tr.classList.toggle("selected", tr.dataset.n === cmpSelName);
+  for (const tr of v.sum.querySelectorAll("tr[data-n]")) {
+    const selected = tr.dataset.n === cmpSelName;
+    tr.classList.toggle("selected", selected);
+    if (selected) {
+      const details = tr.closest("details");
+      if (details) details.open = true;
+    }
+  }
   pfTableUpdate(v.sum, v.nutsFit ? fitMoments(v.nutsFit) : liveMoments(v.live),
                 v.pfMoments);
   if (v.nutsFit && cmpSelName in v.nutsFit.chains[0])
@@ -1084,9 +1126,10 @@ async function runNutsPathfinder(opts, nChains, seed, compiled, tWall) {
   const pfJob = await jobs[0];
   v.pf = pfJob.r.pathfinder;
   v.pfFit = { names: pfJob.r.names, samples: pfJob.r.samples,
+              generatedStart: pfJob.r.generatedStart,
               chains: [pfJob.r.columns] };
   v.pfMoments = fitMoments(v.pfFit);
-  sum.innerHTML = pfTable(v.pfFit.names);
+  sum.innerHTML = pfTable(v.pfFit);
   for (const tr of sum.querySelectorAll("tr[data-n]"))
     tr.onclick = () => cmpSelect(tr.dataset.n);
   if (!cmpSelName || !v.pfFit.names.includes(cmpSelName))
@@ -1115,6 +1158,7 @@ async function runNutsPathfinder(opts, nChains, seed, compiled, tWall) {
   for (const r of rs)
     for (const key of ["lower", "sample"]) ms[key] += r.ms[key];
   v.nutsFit = { names: rs[0].names, samples: rs[0].samples,
+                generatedStart: rs[0].generatedStart,
                 chains: rs.map((r) => r.columns) };
   cmpFits = { nuts: v.nutsFit, pathfinder: v.pfFit };
   const wall = performance.now() - tWall;
@@ -1205,12 +1249,12 @@ function colStats(f, name) {
            q5: q(0.05), q50: q(0.5), q95: q(0.95), ...rhatEss(f, name) };
 }
 
-function summaryTable(f) {
+function summaryTablePart(f, names) {
   const fmt = (x) => (Math.abs(x) >= 1000 ? x.toFixed(0) : x.toPrecision(4));
   let html = "<table><tr><th>parameter</th><th>mean</th><th>sd</th>" +
              "<th>5%</th><th>50%</th><th>95%</th><th>R&#770;</th>" +
              "<th>ESS</th></tr>";
-  f.names.forEach((n) => {
+  names.forEach((n) => {
     const st = colStats(f, n);
     const badR = st.rhat > 1.01 ? ' class="bad"' : "";
     html += `<tr data-n="${n}"><td>${n}</td><td>${fmt(st.mean)}</td>` +
@@ -1220,6 +1264,15 @@ function summaryTable(f) {
             `<td>${st.ess.toFixed(0)}</td></tr>`;
   });
   return html + "</table>";
+}
+function summaryTable(f) {
+  const start = resultSectionStart(f);
+  let html = summaryTablePart(f, f.names.slice(0, start));
+  if (start < f.names.length)
+    html += `<details class="gq"><summary>Generated quantities ` +
+            `(${f.names.length - start})</summary>` +
+            summaryTablePart(f, f.names.slice(start)) + "</details>";
+  return html;
 }
 
 function render(ms, nChains, mode) {

--- a/web/index.mjs
+++ b/web/index.mjs
@@ -123,7 +123,7 @@ export function compile(opts) {
  *   a transferred ArrayBuffer of constrained draws, nCon wide.
  *   Pathfinder streams {live: {phase: "path", iter, lp}} instead, one
  *   message per L-BFGS iterate.
- * @returns {Promise<{names: string[], samples: number,
+ * @returns {Promise<{names: string[], samples: number, generatedStart: number,
  *                    columns: Object<string, Float64Array>,
  *                    exactLp: boolean,
  *                    pathfinder?: {path: {iter, lp}[], khat: number,
@@ -152,12 +152,12 @@ export function sample(opts) {
         ? opts.sampler : "nuts",
     maxError: opts.maxError == null ? 0 : opts.maxError,
   }, opts).then((done) => {
-    const { names, samples, ms, exactLp, pathfinder } = done;
+    const { names, samples, generatedStart, ms, exactLp, pathfinder } = done;
     const flat = new Float64Array(done.columns);
     const columns = {};
     names.forEach((name, i) => {
       columns[name] = flat.subarray(i * samples, (i + 1) * samples);
     });
-    return { names, samples, columns, ms, exactLp, pathfinder };
+    return { names, samples, generatedStart, columns, ms, exactLp, pathfinder };
   });
 }


### PR DESCRIPTION
## Summary
- keep the selected parameter's plot visible during arrow-key navigation
- put generated quantities in a collapsed table section
- expose the write_array generated-quantity boundary to the browser

## Verification
- JavaScript syntax checks
- `./build-ui/test_capi`
