### PR TITLE
Expose Stan functions to Python via a typed-buffer adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Unreleased
 
+### Call Stan functions from Python
+
+`stanli.Function` exposes pure, value-returning Stan UDFs through a separate
+Python/NumPy adapter. It accepts source files, source strings, or cached MIR;
+calls use named Python arguments and typed numeric buffers, preserving integer
+identity and logical array dimensions without JSON serialization. Results are
+owned Python scalars or NumPy arrays. `tools/bench_python_function.py` compares
+steady-state call latency with plain Python and vectorized NumPy.
+
 ## 0.10.0
 
 ### ctsem's structured-control vocabulary lowers

--- a/README.md
+++ b/README.md
@@ -261,6 +261,25 @@ Stan in process. Windows runs the packaged `stanli-compile.exe`; pristine
 `stanc.exe` is selected only when that preferred executable is absent, and a
 compiler failure is reported without retrying the rollback path.
 
+Pure Stan functions are also callable directly, with a separate Python/NumPy
+adapter over typed buffers:
+
+```python
+affine = stanli.Function("affine", stan_file="functions.stan")
+affine(x=[1, 2, 4], a=2.5, b=-1)  # array([1.5, 4.0, 9.0])
+```
+
+`stan_code=` and cached `mir=` work too. See the
+[function API and benchmark command](python/README.md#call-a-stan-function-from-python).
+
+Call overhead matters: an affine-function benchmark (`a*x+b`) measured
+19.3 µs per scalar call and 145 µs for a 100,000-element vector, versus
+2,360 µs for a Python list loop and 26.0 µs for NumPy on that vector.
+These are 11-sample medians on an M3 Ultra, Release build, Python 3.11.15,
+and NumPy 2.4.6, excluding one-time compilation; the large-vector Stanli
+IQR was 139–149 µs. This is one workload, not a general Python speedup claim.
+[Run the comparison on your machine](tools/bench_python_function.py).
+
 ## R
 
 The same runtime behind an R binding, with `posterior`-shaped draws.

--- a/python/README.md
+++ b/python/README.md
@@ -111,6 +111,51 @@ change-of-variables Jacobian is folded into the graph when the model is
 lowered. `jacobian=False` raises rather than quietly handing back the
 other quantity.
 
+## Call a Stan function from Python
+
+`Function` exposes a pure, value-returning Stan user-defined function without
+building a model or compiling C++. Source compilation happens once:
+
+```python
+source = """
+functions {
+  vector affine(vector x, real a, real b) {
+    return a * x + b;
+  }
+}
+model {}
+"""
+affine = stanli.Function("affine", stan_code=source)
+affine(x=[1, 2, 4], a=2.5, b=-1)  # array([1.5, 4.0, 9.0])
+```
+
+Use `stan_file="functions.stan"` instead of `stan_code`, or pass
+`mir=stanli.stan_to_mir(source)` to reuse cached compilation. Calls take
+keyword arguments or one mapping, such as `affine({"x": x, "a": 2.5, "b": -1})`.
+Scalars return Python `float`/`int`; vectors, matrices, and arrays return owned
+NumPy arrays with the same logical shape. Inputs can be rectangular lists or
+NumPy arrays, including strided views. The adapter uses typed numeric buffers,
+not JSON.
+
+Integer inputs must fit Stan's 32-bit integers and promote to real formals.
+Overloads are selected using argument names, rank, and numeric type; select an
+ambiguous overload explicitly with a resolved name such as `f(real,vector)`.
+For empty integer arguments, supply an integer-dtype NumPy array (`[]` defaults
+to real). This is the native value-only interpreter, not autodiff: complex,
+void, RNG, and `_lp` entry points are outside this interface.
+
+From a repository checkout, compare an installed wheel's steady-state calls
+with plain Python and NumPy:
+
+```sh
+python tools/bench_python_function.py
+```
+
+For a development build, stage the Release library in `python/stanli/_bin/`
+and prefix the command with `PYTHONPATH=python`.
+The benchmark excludes one-time compilation from call latency, checks the
+answers first, alternates implementations, and reports medians and IQRs.
+
 ## How it works
 
 Every Stan model is a composition of a fixed vocabulary of operations:

--- a/python/stanli/__init__.py
+++ b/python/stanli/__init__.py
@@ -16,7 +16,7 @@ import sys
 
 import numpy as np
 
-__all__ = ["Model", "Fit", "Summary", "OptimizeResult",
+__all__ = ["Model", "Function", "Fit", "Summary", "OptimizeResult",
            "exact_lp", "thread_safe", "stan_to_mir", "build_id",
            "bridgestan_model",
            "SAMPLER_COLUMNS", "__version__"]
@@ -933,3 +933,7 @@ class Model:
             _print_sample_reports(reports, first_chain, opts.samples,
                                   opts.max_depth)
         return fit
+
+
+# Kept separate from Model's JSON data path: functions bind typed buffers.
+from ._function import Function  # noqa: E402

--- a/python/stanli/_function.py
+++ b/python/stanli/_function.py
@@ -1,0 +1,167 @@
+"""Python/NumPy adapter for the native, value-only Stan function interface."""
+import ctypes
+from collections.abc import Mapping
+
+import numpy as np
+
+from . import _lib, _read_utf8_file, stan_to_mir
+
+
+class _Argument(ctypes.Structure):
+    """Mirrors stanli_function_argument in stanli/function.hpp."""
+    _fields_ = [
+        ("name", ctypes.c_char_p),
+        ("is_int", ctypes.c_int),
+        ("reals", ctypes.POINTER(ctypes.c_double)),
+        ("ints", ctypes.POINTER(ctypes.c_int)),
+        ("size", ctypes.c_size_t),
+        ("dims", ctypes.POINTER(ctypes.c_int64)),
+        ("dim_size", ctypes.c_size_t),
+    ]
+
+
+_ResultWriter = ctypes.CFUNCTYPE(
+    ctypes.c_int, ctypes.c_void_p, ctypes.c_int,
+    ctypes.POINTER(ctypes.c_double), ctypes.c_size_t,
+    ctypes.POINTER(ctypes.c_int), ctypes.c_size_t,
+    ctypes.POINTER(ctypes.c_int64), ctypes.c_size_t)
+
+
+@_ResultWriter
+def _write_result(context, is_int, reals, real_size, ints, int_size,
+                  dims, dim_size):
+    """Copy while the runtime owns the buffers; never raise across ctypes."""
+    result = ctypes.cast(context, ctypes.POINTER(ctypes.py_object)).contents.value
+    try:
+        data, size = (ints, int_size) if is_int else (reals, real_size)
+        if dim_size == 0:
+            if size != 1:
+                raise RuntimeError("Stan function returned an invalid scalar")
+            result["value"] = data[0]
+        else:
+            shape = tuple(dims[i] for i in range(dim_size))
+            if size:
+                values = np.ctypeslib.as_array(data, shape=(size,)).copy()
+            else:
+                values = np.empty(0, dtype=np.intc if is_int else np.float64)
+            result["value"] = values.reshape(shape, order="F")
+        return 0
+    except BaseException as exc:
+        result["error"] = exc
+        return 1
+
+
+_lib.stanli_function_new_from_mir.restype = ctypes.c_void_p
+_lib.stanli_function_new_from_mir.argtypes = [
+    ctypes.c_char_p, ctypes.c_char_p, ctypes.c_char_p, ctypes.c_size_t]
+_lib.stanli_function_free.argtypes = [ctypes.c_void_p]
+_lib.stanli_function_free.restype = None
+_lib.stanli_function_call_values.restype = ctypes.c_int
+_lib.stanli_function_call_values.argtypes = [
+    ctypes.c_void_p, ctypes.POINTER(_Argument), ctypes.c_size_t,
+    _ResultWriter, ctypes.c_void_p, ctypes.c_char_p, ctypes.c_size_t]
+
+
+class Function:
+    """A callable, value-only Stan user-defined function, compiled once.
+
+    Supply its name (or a resolved overload such as ``f(real,vector)``)
+    and one of ``stan_file``, ``stan_code``, or cached ``mir``::
+
+        affine = stanli.Function("affine", stan_code=source)
+        affine(x=[1, 2, 4], a=2.5, b=-1)  # numpy array([1.5, 4., 9.])
+
+    Calls accept named keyword arguments or one mapping. Real/int scalars
+    return Python float/int; containers return independent NumPy arrays
+    with their logical dimensions preserved. Inputs can be numeric scalars,
+    rectangular lists, or NumPy arrays (including non-contiguous views).
+    Integer inputs must fit Stan's 32-bit integer type; they promote to real
+    formals. Empty lists default to real, so use an integer-dtype NumPy array
+    for an empty integer argument. Complex values are not supported.
+
+    Like the native Function API, this evaluates pure, value-returning UDFs
+    using doubles, not autodiff. RNG, void, and _lp functions are outside
+    this interface. No C++ compiler is needed.
+    """
+
+    def __init__(self, name, *, stan_file=None, stan_code=None, mir=None):
+        self._function = None
+        if not isinstance(name, str) or not name or "\0" in name:
+            raise ValueError("function name must be a nonempty string without NUL")
+        self.name = name
+        if mir is None:
+            if stan_code is None:
+                if stan_file is None:
+                    raise ValueError("provide stan_file, stan_code, or mir")
+                stan_code = _read_utf8_file(stan_file)
+            # Uses the bundled subprocess compiler on non-embedded builds
+            # (notably Windows), just like Model.
+            mir = stan_to_mir(stan_code)
+        err = ctypes.create_string_buffer(8192)
+        self._function = _lib.stanli_function_new_from_mir(
+            mir.encode(), name.encode(), err, len(err))
+        if not self._function:
+            raise RuntimeError(err.value.decode())
+
+    def __del__(self):
+        if getattr(self, "_function", None):
+            _lib.stanli_function_free(self._function)
+            self._function = None
+
+    def __call__(self, arguments=None, /, **kwargs):
+        if arguments is None:
+            arguments = kwargs
+        elif kwargs:
+            raise TypeError("supply one argument mapping or keyword arguments, not both")
+        if not isinstance(arguments, Mapping):
+            raise TypeError("Stan function arguments must be a mapping or keywords")
+
+        native = (_Argument * len(arguments))()
+        # ctypes borrows all these buffers until the call (including the
+        # result callback) finishes. Never let conversion temporaries die.
+        buffers = []
+        int_bounds = np.iinfo(np.intc)
+        for i, (name, value) in enumerate(arguments.items()):
+            if not isinstance(name, str) or not name or "\0" in name:
+                raise ValueError("argument names must be nonempty strings without NUL")
+            if isinstance(value, (int, np.integer)) and not (
+                    int_bounds.min <= value <= int_bounds.max):
+                raise OverflowError(f"argument '{name}' does not fit a Stan integer")
+            array = np.asarray(value)
+            is_int = array.dtype.kind in "iu"
+            if is_int:
+                if array.size and (array.min() < int_bounds.min or
+                                   array.max() > int_bounds.max):
+                    raise OverflowError(f"argument '{name}' does not fit a Stan integer")
+            elif array.dtype.kind != "f":
+                raise TypeError(f"argument '{name}' must contain real or integer numbers")
+            flat = np.ascontiguousarray(array.ravel(order="F"),
+                                        dtype=np.intc if is_int else np.float64)
+            dims = (ctypes.c_int64 * array.ndim)(*array.shape)
+            encoded_name = name.encode()
+            native[i] = _Argument(
+                encoded_name, is_int,
+                None if is_int else flat.ctypes.data_as(ctypes.POINTER(ctypes.c_double)),
+                flat.ctypes.data_as(ctypes.POINTER(ctypes.c_int)) if is_int else None,
+                flat.size, dims, array.ndim)
+            buffers.extend((flat, dims, encoded_name))
+
+        result = {"value": None, "error": None}
+        context = ctypes.py_object(result)
+        err = ctypes.create_string_buffer(8192)
+        rc = _lib.stanli_function_call_values(
+            self._function, native, len(native), _write_result,
+            ctypes.byref(context), err, len(err))
+        if result["error"] is not None:
+            raise result["error"]
+        if rc:
+            raise RuntimeError(err.value.decode())
+        return result["value"]
+
+    def __repr__(self):
+        return f"<stanli.Function {self.name}>"
+
+    def __reduce__(self):
+        # Duplicating a raw handle would double-free it; unpickling one in
+        # another process would dereference an unrelated address.
+        raise TypeError("Stan function handles cannot be copied or pickled; cache MIR instead")

--- a/runtime/include/stanli/function.hpp
+++ b/runtime/include/stanli/function.hpp
@@ -38,6 +38,28 @@ int stanli_function_call(const stanli_function* function,
                          stanli_function_result_writer write_result,
                          void* result_context, char* err, size_t err_len);
 
+// Plain-C input buffers for language bindings that cannot construct DataMap.
+// Exactly one of reals/ints is used, according to is_int (0 or 1). Values are
+// first-index-fastest, just like DataMap; no dimensions means one scalar.
+// All storage is borrowed for the call and may be null only when its size is
+// zero. The runtime copies inputs before evaluation and never mutates them.
+struct stanli_function_argument {
+  const char* name;
+  int is_int;
+  const double* reals;
+  const int* ints;
+  size_t size;
+  const int64_t* dims;
+  size_t dim_size;
+};
+
+int stanli_function_call_values(const stanli_function* function,
+                                const stanli_function_argument* arguments,
+                                size_t argument_size,
+                                stanli_function_result_writer write_result,
+                                void* result_context, char* err,
+                                size_t err_len);
+
 }  // extern "C"
 
 namespace stanli {

--- a/runtime/src/function.cpp
+++ b/runtime/src/function.cpp
@@ -245,4 +245,60 @@ int stanli_function_call(const stanli_function* function,
   }
 }
 
+int stanli_function_call_values(const stanli_function* function,
+                                const stanli_function_argument* arguments,
+                                size_t argument_size,
+                                stanli_function_result_writer write_result,
+                                void* result_context, char* err,
+                                size_t err_len) {
+  try {
+    if (argument_size != 0 && arguments == nullptr)
+      throw std::runtime_error("function arguments must not be null");
+    stanli::DataMap values;
+    for (size_t i = 0; i < argument_size; ++i) {
+      const auto& arg = arguments[i];
+      if (arg.name == nullptr || arg.name[0] == '\0')
+        throw std::runtime_error("function argument name must not be empty");
+      const std::string name = arg.name;
+      if (values.has(name))
+        throw std::runtime_error("duplicate function argument: " + name);
+      if (arg.dim_size != 0 && arg.dims == nullptr)
+        throw std::runtime_error("argument '" + name + "' dimensions are null");
+      std::vector<int64_t> dims;
+      if (arg.dim_size != 0) dims.assign(arg.dims, arg.dims + arg.dim_size);
+      if (static_cast<uint64_t>(checked_elements(dims, name)) != arg.size)
+        throw std::runtime_error("argument '" + name +
+                                 "' storage does not match its dimensions");
+      if (arg.is_int == 1) {
+        if (arg.size != 0 && arg.ints == nullptr)
+          throw std::runtime_error("integer argument '" + name + "' is null");
+        if (dims.empty()) {
+          values.set_int(name, arg.ints[0]);
+        } else {
+          std::vector<int> data;
+          if (arg.size != 0) data.assign(arg.ints, arg.ints + arg.size);
+          values.set_int_array(name, std::move(data), std::move(dims));
+        }
+      } else if (arg.is_int == 0) {
+        if (arg.size != 0 && arg.reals == nullptr)
+          throw std::runtime_error("real argument '" + name + "' is null");
+        if (dims.empty()) {
+          values.set_real(name, arg.reals[0]);
+        } else {
+          std::vector<double> data;
+          if (arg.size != 0) data.assign(arg.reals, arg.reals + arg.size);
+          values.set_real_array(name, std::move(data), std::move(dims));
+        }
+      } else {
+        throw std::runtime_error("argument '" + name + "' has invalid is_int");
+      }
+    }
+    return stanli_function_call(function, &values, write_result, result_context,
+                                err, err_len);
+  } catch (const std::exception& e) {
+    put_err(err, err_len, e.what());
+    return 1;
+  }
+}
+
 }  // extern "C"

--- a/tests/test_function.cpp
+++ b/tests/test_function.cpp
@@ -3,6 +3,7 @@
 
 #include <cstdio>
 #include <fstream>
+#include <limits>
 #include <sstream>
 #include <stdexcept>
 #include <string>
@@ -66,6 +67,60 @@ std::string slurp(const char* path) {
   return text.str();
 }
 
+void typed_boundary(const std::string& mir) {
+  char err[8192] = {};
+  auto* f =
+      stanli_function_new_from_mir(mir.c_str(), "choose", err, sizeof(err));
+  check(f != nullptr, "typed boundary constructs from MIR");
+  if (!f) return;
+  double x = 4.0;
+  int first = 1;
+  stanli_function_argument args[] = {
+      {"x", 0, &x, nullptr, 1, nullptr, 0},
+      {"first", 1, nullptr, &first, 1, nullptr, 0}};
+  double result = 0;
+  const auto writer = [](void* context, int is_int, const double* reals,
+                         size_t real_size, const int*, size_t, const int64_t*,
+                         size_t dim_size) -> int {
+    if (is_int || real_size != 1 || dim_size != 0) return 1;
+    *static_cast<double*>(context) = reals[0];
+    return 0;
+  };
+  const auto call = [&] {
+    return stanli_function_call_values(f, args, 2, writer, &result, err,
+                                       sizeof(err));
+  };
+  check(call() == 0 && result == 8.0,
+        "typed boundary real and integer scalars");
+  args[0].size = 0;
+  check(call() != 0, "typed boundary rejects invalid scalar length");
+  args[0].size = 1;
+  args[1].ints = nullptr;
+  check(call() != 0, "typed boundary rejects null nonempty integer buffer");
+  args[1].ints = &first;
+  args[0].is_int = 2;
+  check(call() != 0, "typed boundary rejects invalid type discriminator");
+  args[0].is_int = 0;
+  args[0].name = "first";
+  check(call() != 0, "typed boundary rejects duplicate names");
+  args[0].name = "x";
+  args[0].dim_size = 1;
+  check(call() != 0, "typed boundary rejects null dimension buffer");
+  int64_t dims[] = {-1, 2};
+  args[0].dims = dims;
+  check(call() != 0, "typed boundary rejects negative dimensions");
+  dims[0] = std::numeric_limits<int64_t>::max();
+  args[0].dim_size = 2;
+  check(call() != 0, "typed boundary rejects overflowing dimensions");
+  args[0].dims = nullptr;
+  args[0].dim_size = 0;
+  check(call() == 0 && result == 8.0, "typed boundary recovers after errors");
+  check(stanli_function_call_values(f, nullptr, 2, writer, &result, err,
+                                    sizeof(err)) != 0,
+        "typed boundary rejects null argument table");
+  stanli_function_free(f);
+}
+
 }  // namespace
 
 int main() {
@@ -82,6 +137,7 @@ int main() {
     cached_args.set_int("first", 1);
     check(cached(cached_args).r == std::vector<double>({8.0}),
           "cached MIR function call");
+    typed_boundary(slurp("tests/fixtures/early_return.tmir.sexp"));
 
     if (!stanli_has_embedded_stanc()) {
       throws_with([&] { Function unavailable(source, "affine"); },

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -8,8 +8,10 @@ Run against an installed wheel (CI does) or a local build:
 import base64
 import concurrent.futures
 import contextlib
+import copy
 import io
 import pathlib
+import pickle
 import re
 import shutil
 import subprocess
@@ -23,6 +25,161 @@ import numpy as np
 import stanli
 
 FIXTURES = pathlib.Path(__file__).resolve().parent / "fixtures"
+
+FUNCTION_SOURCE = """
+functions {
+  vector affine(vector x, real a, real b) { return a * x + b; }
+  real real_identity(real x) { return x; }
+  int int_identity(int x) { return x; }
+  matrix scale_matrix(matrix x, real a) { return a * x; }
+  matrix flip_matrix(matrix x) { return x'; }
+  array[,] int int_matrix(array[,] int x) { return x; }
+  array[] int second_row(array[,] int x) { return x[2]; }
+  array[,,] real tensor(array[,,] real x) { return x; }
+  real tensor_element(array[,,] real x) { return x[2, 1, 3]; }
+  array[] vector vectors(array[] vector x) { return x; }
+  vector second_vector(array[] vector x) { return x[2]; }
+  real numeric(int x) { return x + 10.0; }
+  real numeric(real x) { return x + 20.0; }
+  real constant() { return 3.5; }
+  real density(real sigma) { return normal_lpdf(0.0 | 0.0, sigma); }
+}
+model {}
+"""
+
+
+def test_function_source_file_and_cached_mir():
+    f = stanli.Function("affine", stan_code=FUNCTION_SOURCE)
+    assert "Function" in stanli.__all__
+    assert repr(f) == "<stanli.Function affine>"
+    np.testing.assert_array_equal(f(x=[1, 2, 4], a=2.5, b=-1), [1.5, 4, 9])
+    with tempfile.TemporaryDirectory() as tmp:
+        path = pathlib.Path(tmp) / "functions π.stan"
+        path.write_text(FUNCTION_SOURCE, encoding="utf-8")
+        from_file = stanli.Function("affine", stan_file=path)
+        np.testing.assert_array_equal(
+            from_file({"x": [1., 2., 4.], "a": 2.5, "b": -1.}), [1.5, 4, 9])
+    mir = stanli.stan_to_mir(FUNCTION_SOURCE)
+    # A cached function must never re-enter either compiler path.
+    with mock.patch("stanli._function.stan_to_mir", side_effect=AssertionError):
+        cached = stanli.Function("constant", mir=mir)
+        assert cached() == 3.5
+    with mock.patch.object(stanli._lib, "stanli_has_embedded_stanc", return_value=0), \
+            mock.patch.object(stanli, "_subprocess_mir", return_value=mir) as compiler:
+        fallback = stanli.Function("constant", stan_code=FUNCTION_SOURCE)
+        assert fallback() == fallback() == 3.5
+        compiler.assert_called_once_with(FUNCTION_SOURCE)
+    for duplicate in (copy.copy, copy.deepcopy, pickle.dumps):
+        try:
+            duplicate(cached)
+        except TypeError:
+            pass
+        else:
+            raise AssertionError("native function handles must not be duplicated")
+
+
+def test_function_scalar_types_overloads_and_nonfinite():
+    mir = stanli.stan_to_mir(FUNCTION_SOURCE)
+    integer = stanli.Function("int_identity", mir=mir)
+    real = stanli.Function("real_identity", mir=mir)
+    assert integer(x=np.int64(41)) == 41
+    assert type(integer(x=41)) is int
+    assert type(real(x=41)) is float
+    assert real(x=np.float32(1.25)) == 1.25
+    for value in (-2**31, 2**31 - 1):
+        assert integer(x=value) == value
+    assert np.isnan(real(x=np.nan))
+    assert real(x=np.inf) == np.inf
+    assert real(x=-np.inf) == -np.inf
+    assert np.signbit(real(x=-0.0))
+    numeric = stanli.Function("numeric", mir=mir)
+    assert numeric(x=2) == 12.0
+    assert numeric(x=2.0) == 22.0
+    resolved = stanli.Function("numeric(real)", mir=mir)
+    assert resolved(x=2) == 22.0
+
+
+def test_function_container_layout_ownership_and_empty_dimensions():
+    mir = stanli.stan_to_mir(FUNCTION_SOURCE)
+    scale = stanli.Function("scale_matrix", mir=mir)
+    # Non-square and strided, so row/column-major mistakes cannot hide.
+    x = np.arange(24., dtype=np.float64).reshape(4, 6)[::2, ::-2]
+    original = x.copy()
+    result = scale(x=x, a=2.)
+    np.testing.assert_array_equal(result, 2. * x)
+    np.testing.assert_array_equal(stanli.Function("flip_matrix", mir=mir)(x=x), x.T)
+    np.testing.assert_array_equal(stanli.Function("second_vector", mir=mir)(x=x), x[1])
+    scale(x=x, a=-3.)
+    del scale
+    np.testing.assert_array_equal(result, 2. * x)
+    result[:] = -99
+    np.testing.assert_array_equal(x, original)
+    ints = stanli.Function("int_matrix", mir=mir)
+    ix = np.arange(6, dtype=np.int64).reshape(2, 3)
+    np.testing.assert_array_equal(ints(x=ix), ix)
+    np.testing.assert_array_equal(stanli.Function("second_row", mir=mir)(x=ix), ix[1])
+    assert ints(x=ix).dtype == np.dtype(np.intc)
+    tensor = stanli.Function("tensor", mir=mir)
+    cube = np.arange(24.).reshape(2, 3, 4)
+    np.testing.assert_array_equal(tensor(x=cube), cube)
+    assert stanli.Function("tensor_element", mir=mir)(x=cube) == cube[1, 0, 2]
+    vectors = stanli.Function("vectors", mir=mir)
+    np.testing.assert_array_equal(vectors(x=x), x)
+    for shape in ((0, 3), (2, 0)):
+        assert ints(x=np.empty(shape, dtype=np.int32)).shape == shape
+    assert tensor(x=np.empty((0, 2, 3))).shape == (0, 2, 3)
+    assert tensor(x=np.empty((2, 0, 3))).shape == (2, 0, 3)
+    assert stanli.Function("affine", mir=mir)(x=[], a=2., b=1.).shape == (0,)
+
+
+def test_function_errors_and_recovery():
+    mir = stanli.stan_to_mir(FUNCTION_SOURCE)
+    integer = stanli.Function("int_identity", mir=mir)
+    for value, error in [(1.5, RuntimeError), ([1], RuntimeError),
+                         (True, TypeError), (1j, TypeError), ("1", TypeError),
+                         (2**31, OverflowError), (-2**31 - 1, OverflowError),
+                         (2**100, OverflowError),
+                         (np.array([2**32], dtype=np.uint64), OverflowError)]:
+        try:
+            integer(x=value)
+        except error:
+            pass
+        else:
+            raise AssertionError(f"{value!r} did not raise {error.__name__}")
+    for call, error in [
+        (lambda: integer(), RuntimeError),
+        (lambda: integer({"x": 1}, x=2), TypeError),
+        (lambda: integer(1), TypeError),
+        (lambda: integer({"x\0ignored": 1}), ValueError),
+        (lambda: stanli.Function("absent", mir=mir), RuntimeError),
+        (lambda: stanli.Function("constant"), ValueError),
+    ]:
+        try:
+            call()
+        except error:
+            pass
+        else:
+            raise AssertionError(f"call did not raise {error.__name__}")
+    assert integer(x=4) == 4
+    density = stanli.Function("density", mir=mir)
+    try:
+        density(sigma=-1.)
+    except RuntimeError:
+        pass
+    else:
+        raise AssertionError("a Stan domain error must reach Python")
+    assert np.isfinite(density(sigma=1.))
+    # Python exceptions during the borrowed-result callback must also be
+    # propagated, not printed-and-ignored by ctypes.
+    affine = stanli.Function("affine", mir=mir)
+    with mock.patch("stanli._function.np.ctypeslib.as_array",
+                    side_effect=MemoryError("result copy")):
+        try:
+            affine(x=[1.], a=1., b=0.)
+        except MemoryError as exc:
+            assert str(exc) == "result copy"
+        else:
+            raise AssertionError("callback exception was swallowed")
 
 
 def _portable_payload(mir):

--- a/tools/bench_python_function.py
+++ b/tools/bench_python_function.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""Steady-state Function calls versus plain Python and vectorized NumPy.
+
+Run with an installed package, or stage an optimized runtime in
+python/stanli/_bin and use PYTHONPATH=python. Compilation is timed separately.
+No JSON or source compilation occurs inside a timed function call.
+"""
+import argparse
+import json
+import platform
+import statistics
+import sys
+import time
+import timeit
+from pathlib import Path
+
+import numpy as np
+import stanli
+
+
+SOURCE = """
+functions {
+  real scalar_affine(real x, real a, real b) { return a * x + b; }
+  vector vector_affine(vector x, real a, real b) { return a * x + b; }
+}
+model {}
+"""
+
+
+def affine(x, a, b):
+    return a * x + b
+
+
+def affine_loop(x, a, b):
+    return [a * value + b for value in x]
+
+
+def measure(implementations, samples, target_seconds):
+    timers = {name: timeit.Timer(call) for name, call in implementations.items()}
+    counts = {}
+    raw = {name: [] for name in timers}
+    for name, timer in timers.items():
+        count = 1
+        while True:
+            elapsed = timer.timeit(count)
+            if elapsed >= target_seconds or count >= 1_000_000:
+                break
+            count *= 2
+        counts[name] = count
+    names = list(timers)
+    for sample in range(samples):
+        # Rotate order each round to distribute thermal/scheduling drift.
+        order = names[sample % len(names):] + names[:sample % len(names)]
+        for name in order:
+            raw[name].append(timers[name].timeit(counts[name]) / counts[name])
+    return {
+        name: {"median_us": statistics.median(values) * 1e6,
+               "q25_us": float(np.quantile(values, .25)) * 1e6,
+               "q75_us": float(np.quantile(values, .75)) * 1e6,
+               "calls_per_sample": counts[name],
+               "samples_us": [v * 1e6 for v in values]}
+        for name, values in raw.items()
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--samples", type=int, default=9)
+    parser.add_argument("--target-seconds", type=float, default=.03)
+    parser.add_argument("--sizes", nargs="+", type=int, default=[1, 100, 10_000, 100_000])
+    parser.add_argument("--output", type=Path, help="retain metadata and every raw sample")
+    args = parser.parse_args()
+    if args.samples < 3 or args.target_seconds <= 0 or min(args.sizes) < 0:
+        parser.error("need at least 3 samples, positive target time, and nonnegative sizes")
+    start = time.perf_counter()
+    mir = stanli.stan_to_mir(SOURCE)
+    compile_ms = (time.perf_counter() - start) * 1e3
+    start = time.perf_counter()
+    scalar = stanli.Function("scalar_affine", mir=mir)
+    vector = stanli.Function("vector_affine", mir=mir)
+    bind_ms = (time.perf_counter() - start) * 1e3
+    report = {
+        "python": sys.version, "numpy": np.__version__,
+        "platform": platform.platform(), "machine": platform.machine(),
+        "build_id": stanli.build_id(), "compile_ms": compile_ms,
+        "two_handles_from_mir_ms": bind_ms, "samples": args.samples,
+        "cases": {},
+    }
+    cases = [("scalar", {
+        "stanli": lambda: scalar(x=1.25, a=2.5, b=-1.),
+        "python": lambda: affine(x=1.25, a=2.5, b=-1.),
+    })]
+    for n in args.sizes:
+        x = np.arange(n, dtype=np.float64) / 8
+        xs = x.tolist()
+        cases.append((f"vector[{n}]", {
+            "stanli": lambda x=x: vector(x=x, a=2.5, b=-1.),
+            "python": lambda xs=xs: affine_loop(x=xs, a=2.5, b=-1.),
+            "numpy": lambda x=x: affine(x=x, a=2.5, b=-1.),
+        }))
+    print(f"Python {platform.python_version()}, NumPy {np.__version__}, {platform.machine()}")
+    print(f"Runtime: {stanli.build_id()}")
+    print(f"Compile: {compile_ms:.3f} ms; two handles from MIR: {bind_ms:.3f} ms")
+    print("Times are microseconds/call: median [25th, 75th percentile].")
+    for case, implementations in cases:
+        expected = implementations["python"]()
+        for call in implementations.values():
+            np.testing.assert_allclose(call(), expected, rtol=0, atol=0)
+        results = measure(implementations, args.samples, args.target_seconds)
+        report["cases"][case] = results
+        print(case)
+        for name, result in results.items():
+            print(f"  {name:6s} {result['median_us']:10.3f} "
+                  f"[{result['q25_us']:.3f}, {result['q75_us']:.3f}]")
+        print(f"  Stanli/Python: {results['stanli']['median_us'] / results['python']['median_us']:.2f}x")
+        if "numpy" in results:
+            print(f"  Stanli/NumPy:  {results['stanli']['median_us'] / results['numpy']['median_us']:.2f}x")
+    if args.output:
+        args.output.write_text(json.dumps(report, indent=2) + "\n", encoding="utf-8")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/exported_symbols.def
+++ b/tools/exported_symbols.def
@@ -18,6 +18,7 @@ EXPORTS
   stanli_function_new_from_mir
   stanli_function_free
   stanli_function_call
+  stanli_function_call_values
   stanli_build_id
   stanli_exact_lp
   stanli_model_free


### PR DESCRIPTION
## Summary

- Expose the value-only Stan UDF API from #279 as `stanli.Function`, in a separate Python/NumPy adapter.
- Use typed numeric buffers, not JSON. Preserve integer identity, logical dimensions, strided inputs, empty dimensions, nonfinite values, and owned results.
- Support Stan source strings/files, cached MIR, overloads, and the bundled-compiler fallback; propagate native and callback failures safely and disallow copying/pickling raw handles.
- Add native boundary and Python shape/type/ownership/error coverage, a reproducible Python/NumPy comparison tool, and README examples plus a measured performance note.

```python
affine = stanli.Function("affine", stan_code=source)
affine(x=[1, 2, 4], a=2.5, b=-1)
```

This uses the existing value-only interpreter. No compiler/interpreter optimization, autodiff support, or JSON function-call bridge is introduced.

## Performance characterization

Affine function `a*x+b`, M3 Ultra, Release build, Python 3.11.15, NumPy 2.4.6. Eleven warmed, alternating-order samples; compilation excluded; results checked with zero numerical tolerance before timing. Plain Python uses a scalar function or list loop; NumPy uses vectorized array operations.

| Input | Stanli median (IQR), µs | Plain Python median, µs | NumPy median, µs |
|---|---:|---:|---:|
| Scalar | 19.3 (19.2–19.5) | 0.062 | — |
| 10,000 elements | 35.9 (35.4–36.1) | 242 | 3.85 |
| 100,000 elements | 145 (139–149) | 2,360 | 26.0 |

Tiny calls have substantial fixed overhead. The large-vector result is roughly 16× faster than a Python loop but 5.6× slower than NumPy; it is not a general Python speedup claim. One-time source compilation was about 6 ms in this run.

```sh
PYTHONPATH=python python tools/bench_python_function.py \
  --samples 11 --target-seconds 0.05 --output results.json
```

## Validation

- Clean optimized native build; all 113 CTests passed.
- All 36 Python checks passed against both the staged library and a locally built/installed wheel.
- Exact affine output comparison; scalar/int promotion, resolved overloads, non-square and strided matrices, shape-sensitive transpose/indexing, rank-3 and empty arrays, nonfinite values, error recovery, callback failures, and result/handle ownership checks.
- `clang-format --dry-run --Werror`, Python byte-compilation, generated-document checks, and `git diff --check` passed.
- Current `origin/main` was merged into this branch before PR validation.
