### PR TITLE
Show sampling diagnostics in the browser UI

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -1896,6 +1896,8 @@ jobs:
         run: |
           node tests/test_wasm.cjs web/stanli.js \
             web/stanli-compiler.js web/stancjs.bc.js
+          node tests/test_worker_diagnostics.cjs web/stanli.js \
+            web/stanli-compiler.js
 
       - name: Assemble the page and the npm package
         run: |

--- a/js/README.md
+++ b/js/README.md
@@ -27,6 +27,28 @@ fit.generatedStart;    // index where generated-quantity columns begin
 fit.ms;                // {stanc, lower, sample, total} in milliseconds
 ```
 
+For NUTS, `await diagnose(fit)` returns the same text report as the R and
+Python bindings: divergences, maximum-treedepth saturation, E-BFMI,
+rank-normalized R-hat, and bulk/tail ESS. Pass an array of fits from the
+same model and configuration to diagnose all chains together:
+
+```js
+import { compile, diagnose, sample } from "@seantalts/stanli";
+const { mir } = await compile({ code });
+const fits = await Promise.all([1, 2, 3, 4].map((seed) =>
+  sample({ mir, data, seed })));
+console.log(await diagnose(fits));
+```
+
+`fit.samplerStats` contains seven doubles per post-warmup draw, in order:
+`lp__`, `accept_stat__`, `stepsize__`, `treedepth__`, `n_leapfrog__`,
+`divergent__`, `energy__`. `fit.maxDepth` records the sampling limit (10).
+WALNUTS and Pathfinder return `null` for `samplerStats`; `diagnose()` rejects
+these methods rather than treating missing statistics as successful checks.
+The demo displays the report after NUTS runs, including comparisons, and
+explicitly marks WALNUTS sampler diagnostics as unavailable. Pathfinder keeps
+its existing importance-weight k-hat diagnostic.
+
 Columns cover the full CmdStan CSV: constrained parameters, transformed
 parameters, and generated quantities (RNG draws stream from `seed`).
 When there are no generated quantities, `generatedStart === fit.names.length`.

--- a/js/index.mjs
+++ b/js/index.mjs
@@ -126,6 +126,8 @@ export function compile(opts) {
  * @returns {Promise<{names: string[], samples: number, generatedStart: number,
  *                    columns: Object<string, Float64Array>,
  *                    exactLp: boolean,
+ *                    sampler: string, maxDepth: number|null,
+ *                    samplerStats: Float64Array|null,
  *                    pathfinder?: {path: {iter, lp}[], khat: number,
  *                                  selectedIter: number,
  *                                  selectedElbo: number,
@@ -134,6 +136,9 @@ export function compile(opts) {
  *                         total: number}}>}
  *   One column per CSV column CmdStan would write: constrained
  *   parameters, transformed parameters, and generated quantities.
+ *   NUTS also returns post-warmup samplerStats in draw-major order:
+ *   lp__, accept_stat__, stepsize__, treedepth__, n_leapfrog__,
+ *   divergent__, energy__. Other methods return null for samplerStats.
  */
 export function sample(opts) {
   return request({
@@ -152,12 +157,46 @@ export function sample(opts) {
         ? opts.sampler : "nuts",
     maxError: opts.maxError == null ? 0 : opts.maxError,
   }, opts).then((done) => {
-    const { names, samples, generatedStart, ms, exactLp, pathfinder } = done;
+    const { names, samples, generatedStart, ms, exactLp, pathfinder,
+            sampler, maxDepth } = done;
     const flat = new Float64Array(done.columns);
     const columns = {};
     names.forEach((name, i) => {
       columns[name] = flat.subarray(i * samples, (i + 1) * samples);
     });
-    return { names, samples, generatedStart, columns, ms, exactLp, pathfinder };
+    const samplerStats = done.samplerStats
+        ? new Float64Array(done.samplerStats) : null;
+    return { names, samples, generatedStart, columns, ms, exactLp, pathfinder,
+             sampler, maxDepth, samplerStats };
   });
+}
+
+/** Diagnose one NUTS fit, or an array of chains from the same model and
+ * configuration. Returns the native R/Python diagnostic report as text,
+ * using only post-warmup draws. Inputs are copied, never transferred away.
+ * WALNUTS and Pathfinder do not expose the required sampler statistics.
+ * @returns {Promise<string>} */
+export async function diagnose(fits) {
+  const chains = Array.isArray(fits) ? fits : [fits];
+  const first = chains[0];
+  if (!first || !Number.isInteger(first.samples) || first.samples < 1 ||
+      !Array.isArray(first.names) || !first.names.length)
+    throw new Error("diagnose requires nonempty NUTS draws");
+  for (const fit of chains) {
+    if (!fit || fit.sampler !== "nuts" || fit.samples !== first.samples ||
+        fit.maxDepth !== first.maxDepth || !Number.isInteger(fit.maxDepth) ||
+        fit.maxDepth < 1 || !Array.isArray(fit.names) ||
+        fit.names.length !== first.names.length ||
+        fit.names.some((name, j) => name !== first.names[j]) ||
+        !(fit.samplerStats instanceof Float64Array) ||
+        fit.samplerStats.length !== first.samples * 7 ||
+        !fit.columns || first.names.some((name) =>
+          !(fit.columns[name] instanceof Float64Array) ||
+          fit.columns[name].length !== first.samples))
+      throw new Error("diagnose requires matching NUTS chains with sampler statistics");
+  }
+  return request({ cmd: "diagnose", names: first.names, samples: first.samples,
+                   maxDepth: first.maxDepth,
+                   chains: chains.map((fit) => fit.columns),
+                   stats: chains.map((fit) => fit.samplerStats) }, {});
 }

--- a/js/worker.js
+++ b/js/worker.js
@@ -35,6 +35,54 @@ function compileMir(code) {
       "browser_model", code, ["O1", "debug-optimized-mir"]);
 }
 
+// Reuse the native report (including rank-normalized R-hat and bulk/tail
+// ESS) across all chains. Pack the column-oriented JS draws into the C ABI's
+// chain/draw/column order. Keep this work off the UI thread.
+function diagnose(M, req) {
+  const allocations = [];
+  const alloc = (bytes) => {
+    const ptr = M._malloc(bytes);
+    allocations.push(ptr);
+    return ptr;
+  };
+  try {
+    const { names, samples, chains, stats, maxDepth } = req;
+    const nCols = names.length;
+    const drawsPtr = alloc(8 * chains.length * samples * nCols);
+    const statsPtr = alloc(8 * chains.length * samples * 7);
+    const namesPtr = alloc(4 * nCols);
+    const namePtrs = names.map((name) => {
+      const ptr = M.stringToNewUTF8(name);
+      allocations.push(ptr);
+      return ptr;
+    });
+    // Allocations can grow WASM memory: acquire heap views only afterwards.
+    new Uint32Array(M.HEAPF64.buffer, namesPtr, nCols).set(namePtrs);
+    for (let c = 0; c < chains.length; ++c) {
+      M.HEAPF64.set(stats[c], statsPtr / 8 + c * samples * 7);
+      for (let j = 0; j < nCols; ++j)
+        for (let s = 0; s < samples; ++s)
+          M.HEAPF64[drawsPtr / 8 + (c * samples + s) * nCols + j] =
+              chains[c][names[j]][s];
+    }
+    let size = 8192;
+    let outPtr = alloc(size);
+    const report = () => Number(M._stanli_diagnose_text(
+        drawsPtr, BigInt(chains.length), BigInt(samples), BigInt(nCols),
+        namesPtr, statsPtr, maxDepth, outPtr, size));
+    const needed = report();
+    if (!needed) throw new Error("Could not compute sampling diagnostics");
+    if (needed > size) {
+      size = needed;
+      outPtr = alloc(size);
+      if (!report()) throw new Error("Could not compute sampling diagnostics");
+    }
+    return M.UTF8ToString(outPtr);
+  } finally {
+    for (const ptr of allocations) M._free(ptr);
+  }
+}
+
 
 // Pathfinder: one L-BFGS climb, a normal approximation fitted along it,
 // and draws from that approximation -- milliseconds, where a sampler
@@ -94,6 +142,10 @@ onmessage = async (e) => {
       return;
     }
     const M = await ready;
+    if (req.cmd === "diagnose") {
+      postMessage({ done: diagnose(M, req) });
+      return;
+    }
     let mir = req.mir;
     if (!mir) {
       say("compiling Stan -> MIR (stanc3)");
@@ -164,19 +216,27 @@ onmessage = async (e) => {
     // Hamiltonian error per macro step rather than NUTS's target
     // acceptance rate, and 0 asks the runtime for its default.
     let pf = null;
-    if (pathfinder) {
-      pf = runPathfinder(M, model, req, samples, drawsPtr, errPtr, errLen);
-    } else {
-      const rc = walnuts
-          ? M._stanli_sample_walnuts_stream(model, req.seed >>> 0, warmup,
-                                            samples, +req.maxError || 0,
-                                            drawsPtr, cbPtr, 0, errPtr, errLen)
-          : M._stanli_sample_stream(model, req.seed >>> 0, warmup,
-                                    samples, +req.delta, drawsPtr,
-                                    cbPtr, 0, errPtr, errLen);
+    let samplerStats = null;
+    const statsPtr = pathfinder || walnuts ? 0 : M._malloc(8 * samples * 7);
+    try {
+      if (pathfinder) {
+        pf = runPathfinder(M, model, req, samples, drawsPtr, errPtr, errLen);
+      } else {
+        const rc = walnuts
+            ? M._stanli_sample_walnuts_stream(model, req.seed >>> 0, warmup,
+                                              samples, +req.maxError || 0,
+                                              drawsPtr, cbPtr, 0, errPtr, errLen)
+            : M._stanli_sample_stream_stats(model, req.seed >>> 0, warmup,
+                                            samples, +req.delta, drawsPtr,
+                                            statsPtr, cbPtr, 0, errPtr, errLen);
+        if (rc !== 0) throw new Error(M.UTF8ToString(errPtr));
+        if (statsPtr)
+          samplerStats = M.HEAPF64.slice(statsPtr / 8, statsPtr / 8 + samples * 7);
+      }
+    } finally {
       if (cbPtr) M.removeFunction(cbPtr);
       if (liveRowPtr) M._free(liveRowPtr);
-      if (rc !== 0) throw new Error(M.UTF8ToString(errPtr));
+      if (statsPtr) M._free(statsPtr);
     }
     const tSample = performance.now();
 
@@ -216,6 +276,9 @@ onmessage = async (e) => {
     postMessage({
       done: {
         names, samples, generatedStart, pathfinder: pf,
+        sampler: pathfinder ? "pathfinder" : walnuts ? "walnuts" : "nuts",
+        maxDepth: pathfinder ? null : 10,
+        samplerStats: samplerStats ? samplerStats.buffer : null,
         // True unless the runtime was built with STANLI_LITE_LP, which
         // drops stan-math's propto instantiations and shifts lp__ by a
         // per-model constant. The shipped browser build does not, so this
@@ -230,7 +293,7 @@ onmessage = async (e) => {
           total: performance.now() - t0,
         },
       },
-    }, [cols.buffer]);
+    }, samplerStats ? [cols.buffer, samplerStats.buffer] : [cols.buffer]);
   } catch (err) {
     postMessage({ error: String(err && err.message || err) });
   }

--- a/runtime/include/stanli/capi.h
+++ b/runtime/include/stanli/capi.h
@@ -308,6 +308,16 @@ int stanli_sample_stream(stanli_model* m, uint32_t seed, int warmup,
                          stanli_draw_cb cb, void* user, char* err,
                          size_t err_len);
 
+/* Same draws, RNG stream, and callbacks as stanli_sample_stream. On success,
+ * `stats`, when non-null, receives samples * STANLI_N_SAMPLER_COLS doubles
+ * in draw-major order, excluding warmup. Both streaming entry points use
+ * the default maximum treedepth of 10. Stats are available after return,
+ * not during callbacks. */
+int stanli_sample_stream_stats(stanli_model* m, uint32_t seed, int warmup,
+                               int samples, double delta, double* draws,
+                               double* stats, stanli_draw_cb cb, void* user,
+                               char* err, size_t err_len);
+
 /* WALNUTS (within-orbit adaptive step-length NUTS, arXiv:2506.18746),
  * same streaming contract as stanli_sample_stream. `max_error` is the
  * sampler's tunable in place of NUTS's `delta`: the largest drift in

--- a/runtime/src/capi.cpp
+++ b/runtime/src/capi.cpp
@@ -268,6 +268,14 @@ int stanli_sample_stream(stanli_model* m, uint32_t seed, int warmup,
                          int samples, double delta, double* draws,
                          stanli_draw_cb cb, void* user, char* err,
                          size_t err_len) {
+  return stanli_sample_stream_stats(m, seed, warmup, samples, delta, draws,
+                                    nullptr, cb, user, err, err_len);
+}
+
+int stanli_sample_stream_stats(stanli_model* m, uint32_t seed, int warmup,
+                               int samples, double delta, double* draws,
+                               double* stats, stanli_draw_cb cb, void* user,
+                               char* err, size_t err_len) {
   try {
     stanli::NutsConfig cfg;
     cfg.seed = seed;
@@ -284,9 +292,16 @@ int stanli_sample_stream(stanli_model* m, uint32_t seed, int warmup,
         cb((int32_t)i, wu ? 1 : 0, user);
       };
     }
-    auto out = stanli::run_nuts(*m->ex, cfg, nullptr, observe);
+    stanli::SamplerStats sampler_stats;
+    auto out = stanli::run_nuts(*m->ex, cfg, stats ? &sampler_stats : nullptr,
+                                observe);
     for (size_t s = 0; s < out.size(); ++s)
       std::memcpy(draws + s * n, out[s].data(), sizeof(double) * n);
+    if (stats)
+      for (size_t s = 0; s < sampler_stats.rows.size(); ++s)
+        std::memcpy(stats + s * STANLI_N_SAMPLER_COLS,
+                    sampler_stats.rows[s].data(),
+                    sizeof(double) * STANLI_N_SAMPLER_COLS);
     return 0;
   } catch (const std::exception& e) {
     put_err(err, err_len, e.what());

--- a/runtime/src/diagnose.cpp
+++ b/runtime/src/diagnose.cpp
@@ -201,6 +201,7 @@ std::string format_summary(const std::vector<ParamSummary>& s) {
 std::string format_diagnostics(const FitDiagnostics& d) {
   std::string out;
   int problems = 0;
+  int unavailable = 0;
   const auto line = [&out](const std::string& s) { out += s + "\n"; };
   char buf[512];
 
@@ -235,11 +236,15 @@ std::string format_diagnostics(const FitDiagnostics& d) {
       line(buf);
     }
 
-    int bad_e = 0;
+    int bad_e = 0, missing_e = 0;
     double worst_e = 0;
     for (size_t c = 0; c < d.ebfmi_by_chain.size(); ++c) {
       const double e = d.ebfmi_by_chain[c];
-      if (!std::isnan(e) && e < kEbfmiThreshold) {
+      if (!std::isfinite(e)) {
+        ++missing_e;
+        continue;
+      }
+      if (e < kEbfmiThreshold) {
         if (bad_e == 0 || e < worst_e) worst_e = e;
         ++bad_e;
       }
@@ -253,14 +258,23 @@ std::string format_diagnostics(const FitDiagnostics& d) {
                     "are explored badly; reparameterize.",
                     kEbfmiThreshold, bad_e, (long long)d.n_chains, worst_e);
       line(buf);
-    } else {
+    } else if (missing_e == 0) {
       std::snprintf(buf, sizeof buf, "E-BFMI is above %.1f in every chain.",
                     kEbfmiThreshold);
       line(buf);
     }
+    if (missing_e > 0) {
+      ++unavailable;
+      line("E-BFMI is unavailable in " + std::to_string(missing_e) +
+           (missing_e == 1 ? " chain" : " chains") +
+           " (too few draws or non-varying energy).");
+    }
   }
 
-  if (!std::isnan(d.max_rhat)) {
+  if (std::isnan(d.max_rhat)) {
+    ++unavailable;
+    line("R-hat is unavailable (too few draws or non-varying parameters).");
+  } else {
     if (d.max_rhat > kRhatThreshold) {
       ++problems;
       std::snprintf(buf, sizeof buf,
@@ -280,7 +294,10 @@ std::string format_diagnostics(const FitDiagnostics& d) {
   // ESS is judged per chain, which is how the Vehtari et al. threshold is
   // stated: 100 per chain, not 100 overall.
   const double ess_floor = kEssPerChainThreshold * (double)d.n_chains;
-  if (!std::isnan(d.min_ess_bulk)) {
+  if (std::isnan(d.min_ess_bulk)) {
+    ++unavailable;
+    line("Bulk ESS is unavailable (too few draws or non-varying parameters).");
+  } else {
     if (d.min_ess_bulk < ess_floor) {
       ++problems;
       std::snprintf(buf, sizeof buf,
@@ -299,7 +316,10 @@ std::string format_diagnostics(const FitDiagnostics& d) {
       line(buf);
     }
   }
-  if (!std::isnan(d.min_ess_tail)) {
+  if (std::isnan(d.min_ess_tail)) {
+    ++unavailable;
+    line("Tail ESS is unavailable (too few draws or non-varying parameters).");
+  } else {
     if (d.min_ess_tail < ess_floor) {
       ++problems;
       std::snprintf(buf, sizeof buf,
@@ -318,7 +338,9 @@ std::string format_diagnostics(const FitDiagnostics& d) {
     }
   }
 
-  if (problems == 0)
+  if (problems == 0 && unavailable > 0)
+    line("Diagnostics are incomplete; unavailable checks have not passed.");
+  else if (problems == 0)
     line("No problems detected.");
   else
     line(problems == 1

--- a/tests/test_capi.cpp
+++ b/tests/test_capi.cpp
@@ -693,6 +693,63 @@ void expect_sampling_progress() {
   stanli_model_free(observed);
 }
 
+// Browser streaming must expose the same diagnostics as the existing
+// multi-chain API without changing any draw or callback-visible row.
+void expect_streaming_stats() {
+  const std::string mir = slurp("tests/fixtures/es.tmir.sexp");
+  const std::string data = slurp("tests/fixtures/es.json");
+  char err[8192]{};
+  auto* model = stanli_model_new(mir.c_str(), data.c_str(), err, sizeof err);
+  expect_true("stream stats model", model != nullptr);
+  if (!model) return;
+  stanli_sample_opts opts;
+  stanli_sample_opts_init(&opts);
+  opts.seed = 292;
+  opts.chains = 1;
+  opts.warmup = 100;
+  opts.samples = 50;
+  const int64_t n = stanli_n_unconstrained(model);
+  std::vector<double> reference((size_t)(opts.samples * n));
+  std::vector<double> stats((size_t)(opts.samples * STANLI_N_SAMPLER_COLS));
+  expect_true("reference sampling",
+              stanli_sample_multi(model, &opts, reference.data(), stats.data(),
+                                  err, sizeof err) == 0);
+  std::vector<double> streamed(reference.size());
+  std::vector<double> streamed_stats(stats.size());
+  struct Capture {
+    int warmup = 0, samples = 0;
+    int64_t width;
+    const double* draws;
+    std::vector<double> observed;
+  } capture{0, 0, n, streamed.data(), {}};
+  const auto callback = [](int32_t i, int32_t warmup, void* user) {
+    auto& c = *static_cast<Capture*>(user);
+    if (warmup) {
+      ++c.warmup;
+    } else {
+      ++c.samples;
+      c.observed.insert(c.observed.end(), c.draws + i * c.width,
+                        c.draws + (i + 1) * c.width);
+    }
+  };
+  expect_true("streaming stats sampling",
+              stanli_sample_stream_stats(
+                  model, opts.seed, opts.warmup, opts.samples, opts.delta,
+                  streamed.data(), streamed_stats.data(), callback, &capture,
+                  err, sizeof err) == 0);
+  expect_true("streamed draws match multi-chain bytes", streamed == reference);
+  expect_true("streamed stats match multi-chain bytes",
+              streamed_stats == stats);
+  expect_true("callback sees completed rows", capture.observed == reference);
+  expect_true("warmup is excluded from stats",
+              capture.warmup == opts.warmup && capture.samples == opts.samples);
+  expect_true("old sampler succeeds",
+              stanli_sample(model, opts.seed, opts.warmup, opts.samples,
+                            opts.delta, streamed.data(), err, sizeof err) == 0);
+  expect_true("old sampler retains identical draws", streamed == reference);
+  stanli_model_free(model);
+}
+
 }  // namespace
 
 int main() {
@@ -738,6 +795,7 @@ int main() {
   expect_necessity_effects_refused();
   expect_pathfinder();
   expect_sampling_progress();
+  expect_streaming_stats();
 
   if (failures == 0) std::printf("test_capi OK\n");
   return failures == 0 ? 0 : 1;

--- a/tests/test_diagnose.cpp
+++ b/tests/test_diagnose.cpp
@@ -208,6 +208,24 @@ int main() {
            format_diagnostics(fd).find("E-BFMI is below") != std::string::npos);
   }
 
+  // A short/constant fit must not turn missing diagnostics into an all-clear.
+  {
+    const double draws[] = {1, 1};
+    const double stats[2 * N_SAMPLER_COLS] = {};
+    DrawSet ds{draws, 1, 2, 1};
+    const auto text =
+        format_diagnostics(diagnose(ds, summarize(ds, {"x"}), stats, 10));
+    expect("constant energy is unavailable",
+           text.find("E-BFMI is unavailable") != std::string::npos);
+    expect("constant parameters are unavailable",
+           text.find("R-hat is unavailable") != std::string::npos &&
+               text.find("Bulk ESS is unavailable") != std::string::npos &&
+               text.find("Tail ESS is unavailable") != std::string::npos);
+    expect("missing checks are not an all-clear",
+           text.find("No problems detected") == std::string::npos &&
+               text.find("Diagnostics are incomplete") != std::string::npos);
+  }
+
   // ---- the summary table renders ----------------------------------------
   {
     std::vector<ParamSummary> s(1);

--- a/tests/test_worker_diagnostics.cjs
+++ b/tests/test_worker_diagnostics.cjs
@@ -1,0 +1,129 @@
+// Run the public JS API and actual worker against WASM, with a minimal Node
+// Worker adapter. No sampler/diagnostic mocks: this checks transfers, packing,
+// chain aggregation, parameter attribution, and unavailable-data handling.
+// node tests/test_worker_diagnostics.cjs stanli.js stanli-compiler.js [index.mjs]
+"use strict";
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const vm = require("node:vm");
+const { fileURLToPath, pathToFileURL } = require("node:url");
+const createStanli = require(path.resolve(process.argv[2]));
+const compiler = require(path.resolve(process.argv[3]));
+
+globalThis.Worker = class {
+  constructor(url) {
+    const context = vm.createContext({
+      performance, onmessage: null,
+      importScripts: (asset) => {
+        if (asset === "stanli.js") context.createStanli = createStanli;
+        else if (asset === "stanli-compiler.js") Object.assign(context, compiler);
+        else throw new Error("Unexpected worker asset: " + asset);
+      },
+      postMessage: (message, transfer = []) => {
+        const data = structuredClone(message, { transfer });
+        queueMicrotask(() => this.onmessage?.({ data }));
+      },
+    });
+    vm.runInContext(fs.readFileSync(fileURLToPath(url), "utf8"), context);
+    this.context = context;
+  }
+  postMessage(message) {
+    this.context.onmessage({ data: structuredClone(message) }).catch((error) => {
+      this.onerror?.(error);
+    });
+  }
+};
+
+(async () => {
+  const wrapper = path.resolve(process.argv[4] || "js/index.mjs");
+  const { compile, sample, diagnose } = await import(pathToFileURL(wrapper));
+  const { mir } = await compile({ code: `
+    parameters { real x; real y; }
+    model { x ~ normal(0, 1); y ~ normal(10, 2); }` });
+  const live = [];
+  const fits = await Promise.all([1, 2, 3, 4].map((seed) => sample({
+    mir, seed, warmup: 500, samples: 1000,
+    onLive: seed === 1 ? (message) => live.push(message) : undefined,
+  })));
+  for (const fit of fits) {
+    assert.equal(fit.sampler, "nuts");
+    assert.equal(fit.generatedStart, 2);
+    assert.equal(fit.maxDepth, 10);
+    assert.equal(fit.samplerStats.length, 7000);
+    assert(fit.samplerStats.every(Number.isFinite));
+  }
+  assert(live.some((m) => m.liveMeta));
+  assert(live.some((m) => m.live?.phase === "warmup"));
+  const rows = live.filter((m) => m.live?.rows).flatMap((m) =>
+    Array.from(new Float64Array(m.live.rows)));
+  for (let s = 0; s < fits[0].samples; ++s)
+    fits[0].names.forEach((name, j) =>
+      assert.equal(rows[s * fits[0].names.length + j], fits[0].columns[name][s]));
+
+  const saved = structuredClone(fits);
+  const text = await diagnose(fits);
+  assert.match(text, /No divergent transitions/);
+  assert.match(text, /No transitions saturated the maximum treedepth of 10/);
+  assert.match(text, /E-BFMI is above 0.3 in every chain/);
+  assert.match(text, /R-hat is below 1.01/);
+  assert.match(text, /Bulk ESS is at least 100 per chain/);
+  assert.match(text, /Tail ESS is at least 100 per chain/);
+  assert.match(text, /No problems detected/);
+  assert.deepEqual(fits, saved, "diagnosis must not detach or mutate fit data");
+
+  // Failures in different chains/columns catch transpose errors and ensure
+  // warnings count all chains, not just the first or last completed worker.
+  const bad = structuredClone(fits);
+  for (let c = 0; c < bad.length; ++c)
+    for (let s = 0; s < bad[c].samples; ++s) {
+      bad[c].columns.y[s] += c * 100;
+      bad[c].samplerStats[s * 7 + 6] = s;
+    }
+  bad[0].samplerStats[5] = 1;
+  bad[2].samplerStats[5] = 1;
+  bad[3].samplerStats[12] = 1;
+  bad[1].samplerStats[3] = 10;
+  bad[3].samplerStats[10] = 11;
+  const warning = await diagnose(bad);
+  assert.match(warning, /3 of 4000 transitions .* diverged/);
+  assert.match(warning, /2 of 4000 transitions saturated the maximum treedepth of 10/);
+  assert.match(warning, /E-BFMI is below 0.3 in 4 of 4 chains/);
+  assert.match(warning, /R-hat reaches .* \(y\)/);
+  assert.doesNotMatch(warning, /No problems detected/);
+
+  const short = { ...fits[0], samples: 1,
+    columns: { x: Float64Array.of(1), y: Float64Array.of(2) },
+    samplerStats: fits[0].samplerStats.slice(0, 7) };
+  const incomplete = await diagnose(short);
+  assert.match(incomplete, /E-BFMI is unavailable/);
+  assert.match(incomplete, /R-hat is unavailable/);
+  assert.doesNotMatch(incomplete, /No problems detected/);
+
+  for (const invalid of [[], [fits[0], short],
+    [{ ...fits[0], samplerStats: null }],
+    [{ ...fits[0], names: ["missing"] }],
+    [{ ...fits[0], sampler: "walnuts" }],
+    [{ ...fits[0], sampler: "pathfinder" }]])
+    await assert.rejects(diagnose(invalid), /diagnose requires/);
+
+  for (const sampler of ["walnuts", "pathfinder"]) {
+    const fit = await sample({ mir, sampler, warmup: 100, samples: 100 });
+    assert.equal(fit.sampler, sampler);
+    assert.equal(fit.samplerStats, null);
+    await assert.rejects(diagnose(fit), /diagnose requires/);
+  }
+  const gq = await sample({ code: `
+    parameters { real x; }
+    model { x ~ normal(0, 1); }
+    generated quantities { real doubled = 2 * x; }`,
+    warmup: 100, samples: 100 });
+  assert.equal(gq.generatedStart, 1);
+  assert.equal(gq.names.length, 2);
+  assert.deepEqual(gq.columns.doubled, gq.columns.x.map((x) => 2 * x));
+  assert.match(await diagnose(gq), /treedepth of 10/);
+  console.log("test_worker_diagnostics OK: clean, failing, short, and unsupported fits");
+})().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/tools/exported_symbols.def
+++ b/tools/exported_symbols.def
@@ -27,6 +27,7 @@ EXPORTS
   stanli_grad
   stanli_sample
   stanli_sample_stream
+  stanli_sample_stream_stats
   stanli_sample_walnuts_stream
   stanli_run_pathfinder
   stanli_n_constrained

--- a/web/index.html
+++ b/web/index.html
@@ -50,6 +50,16 @@
   tr { cursor: pointer; }
   tr:hover td { background: #8881; }
   td.bad { color: #c33; font-weight: 600; }
+  .diagnostics {
+    margin: .8rem 0; padding: .7rem .9rem;
+    border: 1px solid #8884; border-radius: 6px;
+  }
+  .diagnostics h4 { font-size: .85rem; margin: 0 0 .35rem; }
+  .diagnostics pre {
+    margin: 0; font: .8rem/1.5 ui-monospace, monospace;
+    white-space: pre-wrap; overflow-wrap: anywhere;
+  }
+  .diagnostic-note { font-size: .75rem; opacity: .75; margin: .45rem 0 0; }
   .plots { display: flex; gap: 1rem; flex-wrap: wrap; margin-top: .4rem; }
   tr.plotrow td { padding: .3rem 0 .7rem; border-bottom: 1px solid #8883; }
   tr.plotrow:hover td { background: none; }
@@ -180,7 +190,7 @@ Compare methods side by side.</p>
 <div class="times" id="times"></div>
 
 <script type="module">
-import { compile, preload, sample } from "./stanli.mjs";
+import { compile, diagnose, preload, sample } from "./stanli.mjs";
 const $ = (id) => document.getElementById(id);
 
 // ---- background warm-up ----------------------------------------------------
@@ -520,6 +530,44 @@ let cmpMode = null;
 let singleMode = null;
 let singleSelName = null;
 
+async function completedFit(results, sampler) {
+  let diagnostics = null;
+  if (sampler === "nuts") {
+    try {
+      diagnostics = await diagnose(results);
+    } catch (err) {
+      // A reporting failure must not discard successfully sampled draws.
+      diagnostics = "Sampling diagnostics unavailable: " + err.message;
+    }
+  } else if (sampler === "walnuts") {
+    diagnostics = "WALNUTS does not currently expose divergence, maximum " +
+        "treedepth, or E-BFMI diagnostics. These checks are unavailable, " +
+        "not passed. R-hat and ESS estimates are shown in the table below.";
+  }
+  return { names: results[0].names, samples: results[0].samples, sampler,
+           generatedStart: results[0].generatedStart,
+           chains: results.map((r) => r.columns), diagnostics };
+}
+
+function showDiagnostics(parent, f) {
+  if (!f.diagnostics) return;
+  const section = document.createElement("section");
+  section.className = "diagnostics";
+  const heading = document.createElement("h4");
+  heading.textContent = "Sampling diagnostics";
+  const report = document.createElement("pre");
+  report.textContent = f.diagnostics;
+  section.append(heading, report);
+  if (f.sampler === "nuts") {
+    const note = document.createElement("p");
+    note.className = "diagnostic-note";
+    note.textContent = "The NUTS report uses rank-normalized R-hat and " +
+        "bulk/tail ESS; summary tables use unnormalized estimates.";
+    section.appendChild(note);
+  }
+  parent.prepend(section);
+}
+
 // Run nChains chains of one sampler from already-compiled MIR, streaming
 // live draws into `onLive(chain, msg)`. Returns {fit, ms}.
 async function runChains(sampler, opts, nChains, seed, onLive) {
@@ -532,9 +580,7 @@ async function runChains(sampler, opts, nChains, seed, onLive) {
   for (const r of results)
     for (const k of ["lower", "sample"]) ms[k] += r.ms[k];
   return {
-    fit: { names: results[0].names, samples: results[0].samples,
-           generatedStart: results[0].generatedStart,
-           chains: results.map((r) => r.columns) },
+    fit: await completedFit(results, sampler),
     // Pathfinder only: which iterate of each path the ELBO chose.
     selected: results.map((r) => (r.pathfinder ? r.pathfinder.selectedIter
                                                : -1)),
@@ -753,16 +799,14 @@ async function runCompare(opts, nChains, seed, compiled, tWall) {
         onLive: (m) => handlers[w](c, m),
       }).then((r) => ({ w, r })));
   const done = await Promise.all(jobs);
-  const collect = (w) => {
+  const collect = async (w) => {
     const rs = done.filter((d) => d.w === w).map((d) => d.r);
     const ms = { lower: 0, sample: 0 };
     for (const r of rs)
       for (const k of ["lower", "sample"]) ms[k] += r.ms[k];
-    return { fit: { names: rs[0].names, samples: rs[0].samples,
-                    generatedStart: rs[0].generatedStart,
-                    chains: rs.map((r) => r.columns) }, ms };
+    return { fit: await completedFit(rs, w), ms };
   };
-  const rn = collect("nuts"), rw = collect("walnuts");
+  const [rn, rw] = await Promise.all([collect("nuts"), collect("walnuts")]);
   cmpFits = { nuts: rn.fit, walnuts: rw.fit };
   cmpMode = "both";
   const wall = performance.now() - tWall;
@@ -796,6 +840,7 @@ async function runCompare(opts, nChains, seed, compiled, tWall) {
     const f = cmpFits[w];
     const div = cols[w].querySelector(".ctable");
     div.innerHTML = summaryTable(f);
+    showDiagnostics(div, f);
     for (const tr of div.querySelectorAll("tr[data-n]"))
       tr.onclick = () => cmpSelect(tr.dataset.n);
   }
@@ -1064,7 +1109,8 @@ async function runNutsPathfinder(opts, nChains, seed, compiled, tWall) {
   const sum = document.createElement("div");
   sum.className = "cmpsum";
   $("out").append(wrap, sum);
-  cols.nuts.querySelector(".ctable").remove();
+  // Keep NUTS's result container for its sampling diagnostics; the
+  // parameter summary itself is shared with Pathfinder below.
 
   const live = newLive(nChains);
   const pfLive = newLive(1);
@@ -1157,9 +1203,8 @@ async function runNutsPathfinder(opts, nChains, seed, compiled, tWall) {
   const ms = { lower: 0, sample: 0 };
   for (const r of rs)
     for (const key of ["lower", "sample"]) ms[key] += r.ms[key];
-  v.nutsFit = { names: rs[0].names, samples: rs[0].samples,
-                generatedStart: rs[0].generatedStart,
-                chains: rs.map((r) => r.columns) };
+  v.nutsFit = await completedFit(rs, "nuts");
+  showDiagnostics(cols.nuts.querySelector(".ctable"), v.nutsFit);
   cmpFits = { nuts: v.nutsFit, pathfinder: v.pfFit };
   const wall = performance.now() - tWall;
 
@@ -1279,6 +1324,7 @@ function render(ms, nChains, mode) {
   const label = SAMPLER_LABEL[mode];
   const pathfinder = mode === "pathfinder";
   $("out").innerHTML = summaryTable(fit);
+  showDiagnostics($("out"), fit);
   const perChain = ms.sample / nChains;
   $("times").textContent =
       `${nChains} ${label} ` +

--- a/web/index.mjs
+++ b/web/index.mjs
@@ -126,6 +126,8 @@ export function compile(opts) {
  * @returns {Promise<{names: string[], samples: number, generatedStart: number,
  *                    columns: Object<string, Float64Array>,
  *                    exactLp: boolean,
+ *                    sampler: string, maxDepth: number|null,
+ *                    samplerStats: Float64Array|null,
  *                    pathfinder?: {path: {iter, lp}[], khat: number,
  *                                  selectedIter: number,
  *                                  selectedElbo: number,
@@ -134,6 +136,9 @@ export function compile(opts) {
  *                         total: number}}>}
  *   One column per CSV column CmdStan would write: constrained
  *   parameters, transformed parameters, and generated quantities.
+ *   NUTS also returns post-warmup samplerStats in draw-major order:
+ *   lp__, accept_stat__, stepsize__, treedepth__, n_leapfrog__,
+ *   divergent__, energy__. Other methods return null for samplerStats.
  */
 export function sample(opts) {
   return request({
@@ -152,12 +157,46 @@ export function sample(opts) {
         ? opts.sampler : "nuts",
     maxError: opts.maxError == null ? 0 : opts.maxError,
   }, opts).then((done) => {
-    const { names, samples, generatedStart, ms, exactLp, pathfinder } = done;
+    const { names, samples, generatedStart, ms, exactLp, pathfinder,
+            sampler, maxDepth } = done;
     const flat = new Float64Array(done.columns);
     const columns = {};
     names.forEach((name, i) => {
       columns[name] = flat.subarray(i * samples, (i + 1) * samples);
     });
-    return { names, samples, generatedStart, columns, ms, exactLp, pathfinder };
+    const samplerStats = done.samplerStats
+        ? new Float64Array(done.samplerStats) : null;
+    return { names, samples, generatedStart, columns, ms, exactLp, pathfinder,
+             sampler, maxDepth, samplerStats };
   });
+}
+
+/** Diagnose one NUTS fit, or an array of chains from the same model and
+ * configuration. Returns the native R/Python diagnostic report as text,
+ * using only post-warmup draws. Inputs are copied, never transferred away.
+ * WALNUTS and Pathfinder do not expose the required sampler statistics.
+ * @returns {Promise<string>} */
+export async function diagnose(fits) {
+  const chains = Array.isArray(fits) ? fits : [fits];
+  const first = chains[0];
+  if (!first || !Number.isInteger(first.samples) || first.samples < 1 ||
+      !Array.isArray(first.names) || !first.names.length)
+    throw new Error("diagnose requires nonempty NUTS draws");
+  for (const fit of chains) {
+    if (!fit || fit.sampler !== "nuts" || fit.samples !== first.samples ||
+        fit.maxDepth !== first.maxDepth || !Number.isInteger(fit.maxDepth) ||
+        fit.maxDepth < 1 || !Array.isArray(fit.names) ||
+        fit.names.length !== first.names.length ||
+        fit.names.some((name, j) => name !== first.names[j]) ||
+        !(fit.samplerStats instanceof Float64Array) ||
+        fit.samplerStats.length !== first.samples * 7 ||
+        !fit.columns || first.names.some((name) =>
+          !(fit.columns[name] instanceof Float64Array) ||
+          fit.columns[name].length !== first.samples))
+      throw new Error("diagnose requires matching NUTS chains with sampler statistics");
+  }
+  return request({ cmd: "diagnose", names: first.names, samples: first.samples,
+                   maxDepth: first.maxDepth,
+                   chains: chains.map((fit) => fit.columns),
+                   stats: chains.map((fit) => fit.samplerStats) }, {});
 }


### PR DESCRIPTION
The browser currently discards the sampler statistics needed to tell users whether a NUTS run diverged or hit its maximum tree depth. This adds the runtime’s existing R/Python diagnostic report to completed NUTS runs, including both comparison views.

- Expose post-warmup sampler statistics through an additive streaming C API and the JavaScript fit. The existing API and seeded draws remain unchanged.
- Add `diagnose(fit)` / `diagnose(fits)` to calculate divergences, tree-depth saturation, E-BFMI, rank-normalized R-hat, and bulk/tail ESS across chains in a worker.
- Explicitly mark WALNUTS sampler diagnostics as unavailable and preserve Pathfinder’s k-hat display. Note the estimator distinction between the report and the existing summary tables.
- Report undefined diagnostics as incomplete instead of an all-clear for short or constant runs. Preserve sampled results if reporting fails.

Rebased onto current main, including #290’s generated-quantity sections and parameter navigation.

Validation:
- Fresh Release builds for native AppleClang and Emscripten; seven relevant CTest suites passed (`test_capi`, `test_diagnose`, `test_sampling`, `test_nuts`, `test_multichain`, `test_walnuts`, `test_pathfinder`). The C API regression compares draws and sampler statistics exactly with the existing API and checks callback-visible rows.
- WASM end-to-end and worker integration tests passed: healthy chains, injected divergence/depth/energy/convergence failures, short runs, input validation, generated quantities, and unsupported samplers. The worker regression also runs before deployment of the browser demo.
- Browser checks covered default four-chain sampling, both comparison modes, reruns, short runs, and a funnel with 515/1,000 divergent transitions.
- Compiler-selection tests, JavaScript syntax checks, clang-format 22.1.8, and `git diff --check` passed.

Fixes #292.
