### PR TITLE
fix: export generated-quantity offset on Windows

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -129,6 +129,8 @@ jobs:
       - run: python3 tools/gen_docs.py --check
       - name: Check static packaging inputs
         run: test -s LICENSE && test -s THIRD_PARTY_LICENSES.md
+      - name: Check the Windows C ABI exports
+        run: python3 tests/test_windows_exports.py
       - name: Check portable build parallelism
         shell: bash
         run: |

--- a/tests/test_windows_exports.py
+++ b/tests/test_windows_exports.py
@@ -1,0 +1,77 @@
+"""Keep the explicit PE exports in sync with the public C ABI headers."""
+
+import pathlib
+import re
+import unittest
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+HEADERS = (
+    "runtime/include/stanli/capi.h",
+    "runtime/include/stanli/function.hpp",
+    "runtime/third_party/bridgestan.h",
+)
+
+
+def declared_symbols(source):
+    # Comments mention API calls too; callback typedefs are types, not exports.
+    source = re.sub(r"/\*.*?\*/|//[^\n]*", "", source, flags=re.DOTALL)
+    functions = set(re.findall(r"\b((?:stanli|bs)_\w+)\s*\(", source))
+    data = set(re.findall(r"\bextern\s+const\s+int\s+(bs_\w+)\s*;", source))
+    return functions, data
+
+
+def exported_symbols(source):
+    functions, data = set(), set()
+    for line in source.splitlines():
+        fields = line.split(";", 1)[0].split()
+        if not fields or fields == ["EXPORTS"]:
+            continue
+        (data if "DATA" in fields[1:] else functions).add(fields[0])
+    return functions, data
+
+
+class WindowsExportsTest(unittest.TestCase):
+    def test_public_abi_matches_windows_exports(self):
+        declared_functions, declared_data = set(), set()
+        for header in HEADERS:
+            functions, data = declared_symbols(
+                (ROOT / header).read_text(encoding="utf-8")
+            )
+            self.assertTrue(functions, f"no functions found in {header}")
+            declared_functions.update(functions)
+            declared_data.update(data)
+        exported_functions, exported_data = exported_symbols(
+            (ROOT / "tools/exported_symbols.def").read_text(encoding="utf-8")
+        )
+        self.assertEqual(declared_functions, exported_functions)
+        self.assertEqual(declared_data, exported_data)
+
+    def test_declarations_ignore_comments_and_callback_types(self):
+        self.assertEqual(
+            declared_symbols("""
+                // stanli_comment();
+                /* bs_comment(); */
+                typedef void (*stanli_callback)(int value);
+                int64_t stanli_example
+                    (const stanli_model* model);
+                BS_PUBLIC extern const int bs_major_version;
+                BS_PUBLIC void bs_example(void);
+            """),
+            ({"stanli_example", "bs_example"}, {"bs_major_version"}),
+        )
+
+    def test_data_exports_are_distinct_from_functions(self):
+        self.assertEqual(
+            exported_symbols("""
+                ; stanli_comment
+                EXPORTS
+                  stanli_example ; a function
+                  bs_major_version DATA
+            """),
+            ({"stanli_example"}, {"bs_major_version"}),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/exported_symbols.def
+++ b/tools/exported_symbols.def
@@ -34,6 +34,7 @@ EXPORTS
   stanli_constrained_name
   stanli_constrain
   stanli_wa_n_columns
+  stanli_wa_n_generated_start
   stanli_wa_column_name
   stanli_wa_seed
   stanli_wa_seed_chain


### PR DESCRIPTION
## Summary
- export `stanli_wa_n_generated_start` from the Windows DLL so `test_capi.exe` and callers can link
- add a fast public-ABI/export-list consistency check, including BridgeStan data exports
- run that check in PR static validation before the post-submit Windows build

## Validation
- new regression check failed before the fix with exactly `stanli_wa_n_generated_start` missing
- `python3 tests/test_windows_exports.py`: 3 passed after the fix
- `./tools/format.sh --check`
- `git diff --check` and workflow YAML parsing