### PR TITLE
Fix conformance nightly setup and Windows function reference checks

### DIFF
--- a/.github/workflows/stan-conformance-nightly.yml
+++ b/.github/workflows/stan-conformance-nightly.yml
@@ -82,7 +82,8 @@ jobs:
       - name: Build the public stanli Python runtime
         run: |
           cmake -B build-rel -DCMAKE_BUILD_TYPE=Release \
-            -DCMAKE_C_COMPILER="$CC" -DCMAKE_CXX_COMPILER="$CXX"
+            -DCMAKE_C_COMPILER="$CC" -DCMAKE_CXX_COMPILER="$CXX" \
+            -DSTANLI_STANC_EXECUTABLE="$PWD/deps/stanc3/stanc-pinned"
           cmake --build build-rel --target stanli_shared -j2
           mkdir -p python/stanli/_bin
           cp build-rel/libstanli.so python/stanli/_bin/

--- a/tests/function_coverage/README.md
+++ b/tests/function_coverage/README.md
@@ -46,8 +46,10 @@ python3 tools/gen_function_models.py
 python3 tools/check_function_models.py --build build-rel --record --jobs 2
 ```
 
-The reference artifact records compiler/dependency identities and exact model
-source hashes. Recording is independent of stanli's answers: all CmdStan rows
-are saved before replay, and a mismatch still fails. Never change references
-to match a stanli regression. The generated sources and reference artifact
-are committed so normal CI needs no CmdStan build or reference download.
+The reference artifact records compiler/dependency identities and model source
+hashes with CRLF normalized to LF, so Windows checkouts use the same references.
+Compiler binary hashes remain byte exact. Recording is independent of stanli's
+answers: all CmdStan rows are saved before replay, and a mismatch still fails.
+Never change references to match a stanli regression. The generated sources
+and reference artifact are committed so normal CI needs no CmdStan build or
+reference download.

--- a/tests/test_function_models.py
+++ b/tests/test_function_models.py
@@ -3,6 +3,7 @@
 import copy
 import pathlib
 import sys
+import tempfile
 import types
 import unittest
 from unittest import mock
@@ -28,18 +29,47 @@ class FunctionModelGateTest(unittest.TestCase):
                     "values": [1.0, 2.0]}
         reference = {"source_sha256": "source", "points": [expected] * 3}
         args = types.SimpleNamespace(build=REPO, data=REPO, stanc=REPO)
-        with mock.patch.object(gate, "digest", return_value="source"), \
+        with mock.patch.object(gate, "source_digest", return_value="source"), \
              mock.patch.object(gate, "run", return_value="OK 3 1\nWANAMES a,b\nWAVALS 2 1\n"):
             with self.assertRaisesRegex(ValueError, "values\\[a\\]"):
                 gate.compare("mutation", reference, args)
 
     def test_reference_requires_three_points_and_current_source(self):
         args = types.SimpleNamespace()
-        with mock.patch.object(gate, "digest", return_value="source"):
+        with mock.patch.object(gate, "source_digest", return_value="source"):
             with self.assertRaisesRegex(ValueError, "source changed"):
                 gate.compare("mutation", {"source_sha256": "stale"}, args)
             with self.assertRaisesRegex(ValueError, "three reference points"):
                 gate.compare("mutation", {"source_sha256": "source", "points": []}, args)
+
+    def test_crlf_checkout_replays_but_source_edits_still_fail(self):
+        with tempfile.TemporaryDirectory() as directory:
+            fixtures = pathlib.Path(directory)
+            source = fixtures / "mutation.stan"
+            original = b"parameters { real x; }\nmodel { target += x; }\n"
+            source.write_bytes(original)
+            expected = {"lp_grad": [3.0, 1.0], "names": ["x"], "values": [3.0]}
+            reference = {"source_sha256": gate.source_digest(source),
+                         "points": [expected] * 3}
+            args = types.SimpleNamespace(build=REPO, data=REPO, stanc=REPO)
+            source.write_bytes(original.replace(b"\n", b"\r\n"))
+            with mock.patch.object(gate, "FIXTURES", fixtures), \
+                 mock.patch.object(gate, "run", return_value="OK 3 1\nWANAMES x\nWAVALS 3\n") as run:
+                gate.compare("mutation", reference, args)
+                self.assertEqual(run.call_count, 3)
+                run.reset_mock()
+                source.write_bytes(source.read_bytes().replace(b"+= x", b"+= 2*x"))
+                with self.assertRaisesRegex(ValueError, "source changed"):
+                    gate.compare("mutation", reference, args)
+                run.assert_not_called()
+
+    def test_binary_digest_does_not_normalize_line_endings(self):
+        with tempfile.TemporaryDirectory() as directory:
+            binary = pathlib.Path(directory) / "compiler"
+            binary.write_bytes(b"\x00\xff\r\n")
+            original = gate.digest(binary)
+            binary.write_bytes(b"\x00\xff\n")
+            self.assertNotEqual(gate.digest(binary), original)
 
     def test_removing_a_runtime_function_probe_fails_the_inventory_gate(self):
         groups = copy.deepcopy(generator.GROUPS)

--- a/tools/check_function_models.py
+++ b/tools/check_function_models.py
@@ -39,6 +39,12 @@ def digest(path):
     return hashlib.sha256(path.read_bytes()).hexdigest()
 
 
+def source_digest(path):
+    # Git may check text files out as CRLF on Windows. Only normalize that
+    # checkout transformation; compiler binaries still use the raw digest.
+    return hashlib.sha256(path.read_bytes().replace(b"\r\n", b"\n")).hexdigest()
+
+
 def parse(text):
     fields = {}
     for line in text.splitlines():
@@ -62,7 +68,7 @@ def parse(text):
 
 def record_one(name, args):
     source = FIXTURES / (name + ".stan")
-    identity = hashlib.sha256((digest(source) + digest(REPO / "tools/ref_driver.cpp")
+    identity = hashlib.sha256((source_digest(source) + source_digest(REPO / "tools/ref_driver.cpp")
                               + json.dumps(args.toolchain, sort_keys=True)).encode()).hexdigest()[:16]
     cache = args.build / "function-refs" / (name + "-" + identity)
     cache.mkdir(parents=True, exist_ok=True)
@@ -72,12 +78,12 @@ def record_one(name, args):
         run(compile_cmd(args.cmdstan, hpp, REPO / "tools/ref_driver.cpp", exe))
     points = [parse(run([exe, args.data, p])) for p in range(3)]
     print(f"recorded {name}", flush=True)
-    return name, {"source_sha256": digest(source), "points": points}
+    return name, {"source_sha256": source_digest(source), "points": points}
 
 
 def compare(name, reference, args):
     source = FIXTURES / (name + ".stan")
-    if reference["source_sha256"] != digest(source):
+    if reference["source_sha256"] != source_digest(source):
         raise ValueError(name + ": source changed; re-record the CmdStan reference")
     if len(reference["points"]) != 3:
         raise ValueError(name + ": expected exactly three reference points")


### PR DESCRIPTION
The conformance nightly stopped during CMake configuration because fixture setup defaults to `deps/stanc3/stanc`, while the conformance toolchain installs `stanc-pinned`. The integrated function tests also failed on native Windows because Git checks out their sources with CRLF, making byte hashes disagree with the LF sources used to record CmdStan answers.

This PR passes the conformance compiler path explicitly to CMake and normalizes CRLF only when hashing source files. Compiler binary hashes remain byte exact, and real source edits still invalidate references. No numerical tolerance, function coverage, reference answers, or baseline gate is relaxed.

Validation:
- All 117 local CTest tests pass, including seven oracle mutation tests covering CRLF replay, real source edit rejection, and unchanged binary hashing.
- All ten function models replay against unchanged CmdStan references with both LF and CRLF sources.
- Full native Windows build passes, including all 116 CTest tests and installed-wheel Python tests. Linux and macOS on both architectures, WebAssembly, browser/Windows compiler parity, and R-package checks also pass.
- [Complete conformance nightly](https://github.com/seantalts/stanli/actions/runs/33407443918) is green: 24,277 cases accounted for, 18,752 numerically verified, zero mismatches/crashes/harness errors, and zero lost coverage. The fresh snapshot exactly matches the baseline already on main, including compiler hashes and every classification, so no baseline rewrite is needed.
- [Full platform workflow](https://github.com/seantalts/stanli/actions/runs/33407608331): is green, including the full AddressSanitizer suite.

The conformance run used `3f253d6`; the full platform run used `5199e6c`. The only subsequent commit documents the source hash rule. The final PR head passes the normal PR checks.
