### PR TITLE
Additional centralisations & fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -279,6 +279,7 @@ set(STANLI_RUNTIME_SOURCES
   runtime/kernels/ode.cpp
   runtime/src/ode_prog.cpp
   runtime/src/program.cpp
+  runtime/src/program_transform.cpp
   runtime/kernels/constrain.cpp
   runtime/kernels/eltwise_expr.cpp
   runtime/kernels/mixture.cpp

--- a/runtime/include/stanli/callable_transform.hpp
+++ b/runtime/include/stanli/callable_transform.hpp
@@ -1,0 +1,119 @@
+#ifndef STANLI_CALLABLE_TRANSFORM_HPP
+#define STANLI_CALLABLE_TRANSFORM_HPP
+
+#include <stanli/optable.hpp>
+
+#include <cstddef>
+#include <string_view>
+
+namespace stanli {
+
+// The Stan functions which expose parameter transforms as ordinary calls.
+// Keep name recognition and graph opcode selection here so graph lowering and
+// runtime-control lowering cannot acquire different transform vocabularies.
+enum class CallableTransformKind : unsigned char {
+  Lower,
+  Upper,
+  LowerUpper,
+  OffsetMultiplier,
+  Ordered,
+  PositiveOrdered,
+  Simplex,
+  StochasticColumn,
+  StochasticRow,
+  SumToZero,
+  UnitVector,
+  CholeskyFactorCorr,
+  CorrMatrix,
+  CovMatrix,
+  CholeskyFactorCov,
+};
+
+enum class TransformDirection : unsigned char {
+  Constrain,
+  Jacobian,
+  Unconstrain,
+};
+
+struct CallableTransformSpec {
+  CallableTransformKind kind;
+  TransformDirection direction;
+  uint16_t opcode;
+  size_t arity;
+  bool structured;
+};
+
+inline bool transform_suffix(std::string_view name, std::string_view ending) {
+  return name.size() >= ending.size() &&
+         name.substr(name.size() - ending.size()) == ending;
+}
+
+inline bool callable_transform(std::string_view name,
+                               CallableTransformSpec* out) {
+  TransformDirection direction;
+  std::string_view stem;
+  if (transform_suffix(name, "_jacobian")) {
+    direction = TransformDirection::Jacobian;
+    stem = name.substr(0, name.size() - 9);
+  } else if (transform_suffix(name, "_constrain")) {
+    direction = TransformDirection::Constrain;
+    stem = name.substr(0, name.size() - 10);
+  } else if (transform_suffix(name, "_unconstrain")) {
+    direction = TransformDirection::Unconstrain;
+    stem = name.substr(0, name.size() - 12);
+  } else {
+    return false;
+  }
+
+  CallableTransformSpec s{};
+  s.direction = direction;
+  s.structured = true;
+  if (stem == "lower_bound")
+    s = {CallableTransformKind::Lower, direction, OP_CONSTRAIN_LOWER, 2, false};
+  else if (stem == "upper_bound")
+    s = {CallableTransformKind::Upper, direction, OP_CONSTRAIN_UPPER, 2, false};
+  else if (stem == "lower_upper_bound")
+    s = {CallableTransformKind::LowerUpper, direction, OP_CONSTRAIN_LU, 3, false};
+  else if (stem == "offset_multiplier")
+    s = {CallableTransformKind::OffsetMultiplier, direction,
+         OP_CONSTRAIN_OFFSET_MULT, 3, false};
+  else if (stem == "ordered")
+    s = {CallableTransformKind::Ordered, direction, OP_CONSTRAIN_ORDERED, 1, true};
+  else if (stem == "positive_ordered")
+    s = {CallableTransformKind::PositiveOrdered, direction,
+         OP_CONSTRAIN_POS_ORDERED, 1, true};
+  else if (stem == "simplex")
+    s = {CallableTransformKind::Simplex, direction, OP_CONSTRAIN_SIMPLEX, 1, true};
+  else if (stem == "stochastic_column")
+    s = {CallableTransformKind::StochasticColumn, direction,
+         OP_CONSTRAIN_STOCHASTIC_COLUMN, 1, true};
+  else if (stem == "stochastic_row")
+    s = {CallableTransformKind::StochasticRow, direction,
+         OP_CONSTRAIN_STOCHASTIC_ROW, 1, true};
+  else if (stem == "sum_to_zero")
+    s = {CallableTransformKind::SumToZero, direction,
+         OP_CONSTRAIN_SUM_TO_ZERO, 1, true};
+  else if (stem == "unit_vector")
+    s = {CallableTransformKind::UnitVector, direction,
+         OP_CONSTRAIN_UNIT_VECTOR, 1, true};
+  else if (stem == "cholesky_factor_corr")
+    s = {CallableTransformKind::CholeskyFactorCorr, direction,
+         OP_CONSTRAIN_CHOL_CORR, 2, true};
+  else if (stem == "corr_matrix")
+    s = {CallableTransformKind::CorrMatrix, direction,
+         OP_CONSTRAIN_CORR_MATRIX, 2, true};
+  else if (stem == "cov_matrix")
+    s = {CallableTransformKind::CovMatrix, direction,
+         OP_CONSTRAIN_COV_MATRIX, 2, true};
+  else if (stem == "cholesky_factor_cov")
+    s = {CallableTransformKind::CholeskyFactorCov, direction,
+         OP_CONSTRAIN_CHOL_COV, 3, true};
+  else
+    return false;
+  *out = s;
+  return true;
+}
+
+}  // namespace stanli
+
+#endif

--- a/runtime/include/stanli/callable_transform.hpp
+++ b/runtime/include/stanli/callable_transform.hpp
@@ -73,17 +73,20 @@ inline bool callable_transform(std::string_view name,
   else if (stem == "upper_bound")
     s = {CallableTransformKind::Upper, direction, OP_CONSTRAIN_UPPER, 2, false};
   else if (stem == "lower_upper_bound")
-    s = {CallableTransformKind::LowerUpper, direction, OP_CONSTRAIN_LU, 3, false};
+    s = {CallableTransformKind::LowerUpper, direction, OP_CONSTRAIN_LU, 3,
+         false};
   else if (stem == "offset_multiplier")
     s = {CallableTransformKind::OffsetMultiplier, direction,
          OP_CONSTRAIN_OFFSET_MULT, 3, false};
   else if (stem == "ordered")
-    s = {CallableTransformKind::Ordered, direction, OP_CONSTRAIN_ORDERED, 1, true};
+    s = {CallableTransformKind::Ordered, direction, OP_CONSTRAIN_ORDERED, 1,
+         true};
   else if (stem == "positive_ordered")
     s = {CallableTransformKind::PositiveOrdered, direction,
          OP_CONSTRAIN_POS_ORDERED, 1, true};
   else if (stem == "simplex")
-    s = {CallableTransformKind::Simplex, direction, OP_CONSTRAIN_SIMPLEX, 1, true};
+    s = {CallableTransformKind::Simplex, direction, OP_CONSTRAIN_SIMPLEX, 1,
+         true};
   else if (stem == "stochastic_column")
     s = {CallableTransformKind::StochasticColumn, direction,
          OP_CONSTRAIN_STOCHASTIC_COLUMN, 1, true};
@@ -91,20 +94,20 @@ inline bool callable_transform(std::string_view name,
     s = {CallableTransformKind::StochasticRow, direction,
          OP_CONSTRAIN_STOCHASTIC_ROW, 1, true};
   else if (stem == "sum_to_zero")
-    s = {CallableTransformKind::SumToZero, direction,
-         OP_CONSTRAIN_SUM_TO_ZERO, 1, true};
+    s = {CallableTransformKind::SumToZero, direction, OP_CONSTRAIN_SUM_TO_ZERO,
+         1, true};
   else if (stem == "unit_vector")
-    s = {CallableTransformKind::UnitVector, direction,
-         OP_CONSTRAIN_UNIT_VECTOR, 1, true};
+    s = {CallableTransformKind::UnitVector, direction, OP_CONSTRAIN_UNIT_VECTOR,
+         1, true};
   else if (stem == "cholesky_factor_corr")
     s = {CallableTransformKind::CholeskyFactorCorr, direction,
          OP_CONSTRAIN_CHOL_CORR, 2, true};
   else if (stem == "corr_matrix")
-    s = {CallableTransformKind::CorrMatrix, direction,
-         OP_CONSTRAIN_CORR_MATRIX, 2, true};
+    s = {CallableTransformKind::CorrMatrix, direction, OP_CONSTRAIN_CORR_MATRIX,
+         2, true};
   else if (stem == "cov_matrix")
-    s = {CallableTransformKind::CovMatrix, direction,
-         OP_CONSTRAIN_COV_MATRIX, 2, true};
+    s = {CallableTransformKind::CovMatrix, direction, OP_CONSTRAIN_COV_MATRIX,
+         2, true};
   else if (stem == "cholesky_factor_cov")
     s = {CallableTransformKind::CholeskyFactorCov, direction,
          OP_CONSTRAIN_CHOL_COV, 3, true};

--- a/runtime/include/stanli/container_shape.hpp
+++ b/runtime/include/stanli/container_shape.hpp
@@ -24,6 +24,74 @@ inline int64_t checked_container_size(const std::vector<int64_t>& dims,
   return size;
 }
 
+// MIR/DataMap buffers follow Stan's serialized order: the first declared
+// index is fastest. Graph buffers keep every outer-array element contiguous,
+// with vector leaves contiguous and matrix leaves column-major. Keep the
+// permutation here so every bridge between the two representations agrees.
+template <typename T>
+std::vector<T> graph_container_order(const std::vector<T>& source,
+                                     const std::vector<int64_t>& dims,
+                                     size_t outer_rank) {
+  if (outer_rank > dims.size() || dims.size() - outer_rank > 2)
+    throw std::domain_error("container layout: invalid leaf rank");
+  const int64_t size = checked_container_size(dims, "container layout");
+  if ((uint64_t)size != source.size())
+    throw std::domain_error("container layout: size mismatch");
+  std::vector<T> result(source.size());
+  std::vector<int64_t> index(dims.size());
+  for (size_t serialized = 0; serialized < source.size(); ++serialized) {
+    int64_t rest = (int64_t)serialized;
+    for (size_t d = 0; d < dims.size(); ++d) {
+      index[d] = rest % dims[d];
+      rest /= dims[d];
+    }
+    int64_t graph = 0;
+    for (size_t d = 0; d < outer_rank; ++d) graph = graph * dims[d] + index[d];
+    int64_t leaf_size = 1;
+    for (size_t d = outer_rank; d < dims.size(); ++d) leaf_size *= dims[d];
+    graph *= leaf_size;
+    if (dims.size() == outer_rank + 1) {
+      graph += index[outer_rank];
+    } else if (dims.size() == outer_rank + 2) {
+      graph += index[outer_rank + 1] * dims[outer_rank] + index[outer_rank];
+    }
+    result[(size_t)graph] = source[serialized];
+  }
+  return result;
+}
+
+template <typename T>
+std::vector<T> serialized_container_order(const std::vector<T>& graph_source,
+                                          const std::vector<int64_t>& dims,
+                                          size_t outer_rank) {
+  if (outer_rank > dims.size() || dims.size() - outer_rank > 2)
+    throw std::domain_error("container layout: invalid leaf rank");
+  const int64_t size = checked_container_size(dims, "container layout");
+  if ((uint64_t)size != graph_source.size())
+    throw std::domain_error("container layout: size mismatch");
+  std::vector<T> result(graph_source.size());
+  std::vector<int64_t> index(dims.size());
+  for (size_t serialized = 0; serialized < result.size(); ++serialized) {
+    int64_t rest = (int64_t)serialized;
+    for (size_t d = 0; d < dims.size(); ++d) {
+      index[d] = rest % dims[d];
+      rest /= dims[d];
+    }
+    int64_t graph = 0;
+    for (size_t d = 0; d < outer_rank; ++d) graph = graph * dims[d] + index[d];
+    int64_t leaf_size = 1;
+    for (size_t d = outer_rank; d < dims.size(); ++d) leaf_size *= dims[d];
+    graph *= leaf_size;
+    if (dims.size() == outer_rank + 1) {
+      graph += index[outer_rank];
+    } else if (dims.size() == outer_rank + 2) {
+      graph += index[outer_rank + 1] * dims[outer_rank] + index[outer_rank];
+    }
+    result[serialized] = graph_source[(size_t)graph];
+  }
+  return result;
+}
+
 // Stan Math checks both the start and inclusive end of each block axis,
 // even when its length is zero. Subtraction avoids overflowing i+n-1.
 inline void check_block_shape(int64_t rows, int64_t cols, int64_t i, int64_t j,

--- a/runtime/include/stanli/island.hpp
+++ b/runtime/include/stanli/island.hpp
@@ -95,8 +95,8 @@ constexpr uint8_t kIslandCallVariant = 2;
 void island_calls_fwd(KernelCtx& ctx);
 
 // True when the region's program has an observable effect: a draw from the
-// caller's stream, or a reject. A pass that reasons about purity has to
-// leave such a region alone even when every one of its inputs is data.
+// caller's stream, a print, or a reject. A pass that reasons about purity has
+// to leave such a region alone even when every one of its inputs is data.
 // Nothing depends on this for correctness -- an effect kernel refuses to run
 // without the evaluation state a compile-time pass has no business owning,
 // so folding one fails rather than erasing it -- but that refusal costs the

--- a/runtime/include/stanli/mir.hpp
+++ b/runtime/include/stanli/mir.hpp
@@ -9,6 +9,7 @@
 #include <stanli/sexp.hpp>
 
 #include <cstdint>
+#include <limits>
 #include <map>
 #include <optional>
 #include <string>
@@ -59,6 +60,65 @@ struct Expr {
   bool promoted = false;   // explicit MIR Promotion to this adlevel/type
   std::string raw;         // Unsupported diagnostics
 };
+
+// stanc leaves these calls in MIR rather than folding them: four have
+// non-finite/platform values, while pi/e are still part of the same language
+// surface. Keep name recognition and values together so graph lowering, the
+// register compiler, and MirInterp cannot grow different subsets. FnNegInf is
+// the optimizer's internal spelling of the same negative-infinity constant.
+enum class NullaryConstantKind : uint8_t {
+  E,
+  Pi,
+  MachinePrecision,
+  NegativeInfinity,
+  PositiveInfinity,
+  NotANumber,
+};
+
+inline std::optional<NullaryConstantKind> nullary_constant_kind(
+    const Expr& e) {
+  if (e.kind != Expr::FunApp || !e.args.empty()) return std::nullopt;
+  if (e.fn_lib == Expr::Lib::Internal)
+    return e.name == "FnNegInf"
+               ? std::optional<NullaryConstantKind>(
+                     NullaryConstantKind::NegativeInfinity)
+               : std::nullopt;
+  if (e.fn_lib != Expr::Lib::StanLib) return std::nullopt;
+  if (e.name == "e") return NullaryConstantKind::E;
+  if (e.name == "pi") return NullaryConstantKind::Pi;
+  if (e.name == "machine_precision")
+    return NullaryConstantKind::MachinePrecision;
+  if (e.name == "negative_infinity")
+    return NullaryConstantKind::NegativeInfinity;
+  if (e.name == "positive_infinity")
+    return NullaryConstantKind::PositiveInfinity;
+  if (e.name == "not_a_number") return NullaryConstantKind::NotANumber;
+  return std::nullopt;
+}
+
+inline double nullary_constant_value(NullaryConstantKind kind) {
+  switch (kind) {
+    case NullaryConstantKind::E:
+      return 0x1.5bf0a8b145769p+1;
+    case NullaryConstantKind::Pi:
+      return 0x1.921fb54442d18p+1;
+    case NullaryConstantKind::MachinePrecision:
+      return std::numeric_limits<double>::epsilon();
+    case NullaryConstantKind::NegativeInfinity:
+      return -std::numeric_limits<double>::infinity();
+    case NullaryConstantKind::PositiveInfinity:
+      return std::numeric_limits<double>::infinity();
+    case NullaryConstantKind::NotANumber:
+      return std::numeric_limits<double>::quiet_NaN();
+  }
+  return std::numeric_limits<double>::quiet_NaN();
+}
+
+inline std::optional<double> nullary_constant(const Expr& e) {
+  const auto kind = nullary_constant_kind(e);
+  return kind ? std::optional<double>(nullary_constant_value(*kind))
+              : std::nullopt;
+}
 
 // A matrix row is a non-contiguous Eigen block.  Transposing it changes the
 // logical orientation but not the stride, so an outer elementwise expression

--- a/runtime/include/stanli/mir.hpp
+++ b/runtime/include/stanli/mir.hpp
@@ -75,14 +75,12 @@ enum class NullaryConstantKind : uint8_t {
   NotANumber,
 };
 
-inline std::optional<NullaryConstantKind> nullary_constant_kind(
-    const Expr& e) {
+inline std::optional<NullaryConstantKind> nullary_constant_kind(const Expr& e) {
   if (e.kind != Expr::FunApp || !e.args.empty()) return std::nullopt;
   if (e.fn_lib == Expr::Lib::Internal)
-    return e.name == "FnNegInf"
-               ? std::optional<NullaryConstantKind>(
-                     NullaryConstantKind::NegativeInfinity)
-               : std::nullopt;
+    return e.name == "FnNegInf" ? std::optional<NullaryConstantKind>(
+                                      NullaryConstantKind::NegativeInfinity)
+                                : std::nullopt;
   if (e.fn_lib != Expr::Lib::StanLib) return std::nullopt;
   if (e.name == "e") return NullaryConstantKind::E;
   if (e.name == "pi") return NullaryConstantKind::Pi;

--- a/runtime/include/stanli/mir_interp.hpp
+++ b/runtime/include/stanli/mir_interp.hpp
@@ -783,49 +783,6 @@ class MirInterp {
 
   static double val(const T& x) { return stan::math::value_of(x); }
 
-  // Arity of a bound transform called as a function, or 0 for any other
-  // name. The three directions of one transform share an arity, so the name
-  // alone decides how many arguments to expect.
-  static size_t bound_transform_arity(const std::string& name) {
-    static const std::pair<const char*, size_t> kStems[] = {
-        {"lower_bound_", 2},
-        {"upper_bound_", 2},
-        {"lower_upper_bound_", 3},
-        {"offset_multiplier_", 3}};
-    for (const auto& stem : kStems) {
-      const std::string prefix(stem.first);
-      if (name.compare(0, prefix.size(), prefix) != 0) continue;
-      const std::string tail = name.substr(prefix.size());
-      if (tail == "constrain" || tail == "jacobian" || tail == "unconstrain")
-        return stem.second;
-    }
-    return 0;
-  }
-
-  // One element of a bound transform, through stan-math's own scalar
-  // overloads: the free direction is stan-math's inverse rather than a
-  // hand-written one, so the two directions cannot drift apart here. `b2` is
-  // unread by the two-argument transforms.
-  static T bound_transform(const std::string& name, const T& x, const T& b1,
-                           const T& b2) {
-    if (name == "lower_bound_unconstrain") return stan::math::lb_free(x, b1);
-    if (name == "upper_bound_unconstrain") return stan::math::ub_free(x, b1);
-    if (name == "lower_upper_bound_unconstrain")
-      return stan::math::lub_free(x, b1, b2);
-    if (name == "offset_multiplier_unconstrain")
-      return stan::math::offset_multiplier_free(x, b1, b2);
-    // The constrain and jacobian directions differ only in a target
-    // increment, and this path has no target.
-    if (name == "lower_bound_constrain" || name == "lower_bound_jacobian")
-      return stan::math::lb_constrain(x, b1);
-    if (name == "upper_bound_constrain" || name == "upper_bound_jacobian")
-      return stan::math::ub_constrain(x, b1);
-    if (name == "lower_upper_bound_constrain" ||
-        name == "lower_upper_bound_jacobian")
-      return stan::math::lub_constrain(x, b1, b2);
-    return stan::math::offset_multiplier_constrain(x, b1, b2);
-  }
-
   static bool check_scalar_type(const mir::Expr& e) {
     return e.unsized.depth == 0 && (e.unsized.leaf == mir::UnsizedLeaf::Int ||
                                     e.unsized.leaf == mir::UnsizedLeaf::Real);
@@ -1792,27 +1749,109 @@ class MirInterp {
                                  c.r[c.r.size() == 1 ? 0 : i]);
       return o;
     }
-    // Stan's bound transforms, callable as functions rather than written on
-    // a declaration: elementwise over every container shape, with each bound
-    // either one value for the whole container or one value per element.
-    // The interpreter serves transformed data and the interpreted
-    // write_array, both of which the generated model instantiates with
-    // `jacobian__ = false`, so the `_jacobian` direction is the constrained
-    // value and nothing else -- there is no target here to increment.
-    const size_t bound_arity = bound_transform_arity(e.name);
-    if (bound_arity != 0 && bound_arity == e.args.size()) {
+    // Callable transforms share their name/arity dispatch and their typed
+    // execution with graph lowering and runtime-control Programs. The
+    // interpreter is used for write_array with jacobian__ false, so it keeps
+    // the constrained value and deliberately discards the auxiliary lp.
+    CallableTransformSpec transform;
+    if (callable_transform(e.name, &transform) &&
+        transform.arity == e.args.size()) {
+      if (transform.structured &&
+          transform.direction == TransformDirection::Unconstrain)
+        fail(e.name + ": structured inverse is unsupported", e.raw);
       std::vector<Value> a;
       a.reserve(e.args.size());
       for (const mir::Expr& arg : e.args) a.push_back(eval(arg));
-      const auto at = [&](size_t k, size_t i) {
-        return a[k].r[a[k].r.size() == 1 ? 0 : i];
-      };
+      Program::Transform tr;
+      tr.kind = transform.kind;
+      tr.direction = transform.direction;
+      tr.n_in = transform.structured ? 1 : (int8_t)transform.arity;
       Value o;
       o.dims = a[0].dims;
-      o.r.resize(a[0].r.size());
-      for (size_t i = 0; i < o.r.size(); ++i)
-        o.r[i] = bound_transform(e.name, at(0, i), at(1, i),
-                                 a.size() > 2 ? at(2, i) : T(0));
+      size_t outer_rank = 0;
+      if (!transform.structured) {
+        for (int k = 1; k < tr.n_in; ++k) {
+          const size_t n = a[(size_t)k].r.size();
+          if (n != 1 && n != a[0].r.size())
+            fail(e.name + ": bound has incompatible size", e.raw);
+        }
+        tr.out_len = (int32_t)a[0].r.size();
+        tr.inner_raw = tr.out_len;
+      } else {
+        outer_rank = e.args[0].unsized.depth;
+        const bool input_matrix =
+            e.args[0].unsized.leaf == mir::UnsizedLeaf::Matrix;
+        if (o.dims.size() < outer_rank + (input_matrix ? 2u : 1u))
+          fail(e.name + ": incomplete input dimensions", e.raw);
+        int64_t batch = 1;
+        for (size_t i = 0; i < outer_rank; ++i) batch *= o.dims[i];
+        const int64_t raw_rows =
+            input_matrix ? o.dims[outer_rank] : o.dims.back();
+        const int64_t raw_cols = input_matrix ? o.dims[outer_rank + 1] : 0;
+        int64_t rows = 0, cols = 0;
+        switch (transform.kind) {
+          case CallableTransformKind::Ordered:
+          case CallableTransformKind::PositiveOrdered:
+          case CallableTransformKind::UnitVector:
+            rows = raw_rows;
+            break;
+          case CallableTransformKind::Simplex:
+            rows = raw_rows + 1;
+            break;
+          case CallableTransformKind::SumToZero:
+            rows = raw_rows + 1;
+            if (input_matrix) cols = raw_cols + 1;
+            break;
+          case CallableTransformKind::StochasticColumn:
+            rows = raw_rows + 1;
+            cols = raw_cols;
+            break;
+          case CallableTransformKind::StochasticRow:
+            rows = raw_rows;
+            cols = raw_cols + 1;
+            break;
+          case CallableTransformKind::CholeskyFactorCorr:
+          case CallableTransformKind::CorrMatrix:
+          case CallableTransformKind::CovMatrix:
+            rows = cols = as_int(e.args[1]);
+            break;
+          case CallableTransformKind::CholeskyFactorCov:
+            rows = as_int(e.args[1]);
+            cols = as_int(e.args[2]);
+            break;
+          default:
+            fail(e.name + ": invalid structured transform", e.raw);
+        }
+        tr.batch = (int32_t)batch;
+        tr.inner_raw =
+            input_matrix ? (int32_t)(raw_rows * raw_cols) : (int32_t)raw_rows;
+        tr.out_rows = (int32_t)rows;
+        tr.out_cols = (int32_t)cols;
+        const bool output_matrix = e.unsized.leaf == mir::UnsizedLeaf::Matrix;
+        const int64_t inner_con = output_matrix ? rows * cols : rows;
+        tr.out_len = (int32_t)(batch * inner_con);
+        o.dims.resize(outer_rank);
+        o.dims.push_back(rows);
+        if (output_matrix) o.dims.push_back(cols);
+      }
+      std::vector<T> reg;
+      for (int k = 0; k < tr.n_in; ++k) {
+        tr.in[k] = (int32_t)reg.size();
+        std::vector<T> input =
+            transform.structured && k == 0 && outer_rank > 0
+                ? graph_container_order(a[0].r, a[0].dims, outer_rank)
+                : a[(size_t)k].r;
+        tr.in_len[k] = (int32_t)input.size();
+        reg.insert(reg.end(), input.begin(), input.end());
+      }
+      tr.out = (int32_t)reg.size();
+      reg.resize(reg.size() + (size_t)tr.out_len);
+      tr.jac = (int32_t)reg.size();
+      reg.emplace_back(T(0));
+      run_program_transform(tr, reg.data());
+      o.r.assign(reg.begin() + tr.out, reg.begin() + tr.out + tr.out_len);
+      if (transform.structured && outer_rank > 0)
+        o.r = serialized_container_order(o.r, o.dims, outer_rank);
       return o;
     }
     // minus and plus are the named spellings of the unary operators, so

--- a/runtime/include/stanli/mir_interp.hpp
+++ b/runtime/include/stanli/mir_interp.hpp
@@ -1314,6 +1314,10 @@ class MirInterp {
 
   Value eval_fun(const mir::Expr& e) {
     Value r;
+    if (const auto value = mir::nullary_constant(e)) {
+      r.r = {T(*value)};
+      return r;
+    }
     if (e.fn_lib == mir::Expr::Lib::UserDefined) return call_udf(e);
     if (mir::is_reduce_sum(e)) return call_reduce_sum(e);
     const auto is_scalar = [](const Value& v) {
@@ -2866,30 +2870,6 @@ class MirInterp {
         r.i.push_back((int)d);
         r.r.push_back(T((double)d));
       }
-      return r;
-    }
-    if (e.name == "pi" && e.args.empty()) {
-      r.r = {T(stan::math::pi())};
-      return r;
-    }
-    if (e.name == "e" && e.args.empty()) {
-      r.r = {T(stan::math::e())};
-      return r;
-    }
-    if (e.name == "machine_precision" && e.args.empty()) {
-      r.r = {T(std::numeric_limits<double>::epsilon())};
-      return r;
-    }
-    if (e.name == "negative_infinity") {
-      r.r = {T(-std::numeric_limits<double>::infinity())};
-      return r;
-    }
-    if (e.name == "positive_infinity") {
-      r.r = {T(std::numeric_limits<double>::infinity())};
-      return r;
-    }
-    if (e.name == "not_a_number") {
-      r.r = {T(std::numeric_limits<double>::quiet_NaN())};
       return r;
     }
     if (e.name == "student_t_lccdf" && e.args.size() == 4) {

--- a/runtime/include/stanli/mir_prog.hpp
+++ b/runtime/include/stanli/mir_prog.hpp
@@ -1632,6 +1632,8 @@ struct ProgramCompiler {
   }
 
   Range fun(const mir::Expr& e) {
+    if (const auto value = mir::nullary_constant(e))
+      return {konst(*value), 1};
     // A shape query is a constant whatever surrounds it. Ahead of every
     // other case because `FnLength` is an internal function and the rest
     // are library ones, and they are all answered the same way: from the
@@ -1917,12 +1919,8 @@ struct ProgramCompiler {
         }
         return out;
       }
-      if (e.name == "FnNegInf" && e.args.empty())
-        return {konst(-std::numeric_limits<double>::infinity()), 1};
       bail("internal function " + e.name);
     }
-    if (e.args.empty() && e.name == "negative_infinity")
-      return {konst(-std::numeric_limits<double>::infinity()), 1};
     if (e.args.size() == 2 && e.name == "append_array") {
       const Range a = expr(e.args[0]);
       const Range b = expr(e.args[1]);

--- a/runtime/include/stanli/mir_prog.hpp
+++ b/runtime/include/stanli/mir_prog.hpp
@@ -2923,6 +2923,25 @@ struct ProgramCompiler {
       }
       case mir::Stmt::NRFunApp:
         if (s.fn_name == "FnValidateSize") return;
+        if (s.fn_name == "FnPrint") {
+          Program::Print print;
+          std::string pending;
+          for (const auto& a : s.fn_args) {
+            if (a.kind == mir::Expr::LitStr) {
+              pending += a.lit_s;
+              continue;
+            }
+            print.chunks.push_back(std::move(pending));
+            pending.clear();
+            const Range value = expr(a);
+            print.value_reg.push_back(value.reg);
+            print.value_len.push_back(value.len);
+          }
+          print.chunks.push_back(std::move(pending));
+          p.prints.push_back(std::move(print));
+          emit(Program::PRINT, 0, (int)p.prints.size() - 1);
+          return;
+        }
         if (s.fn_name == "FnReject") {
           // Only a literal message: interleaving a runtime value would need
           // to format it into the thrown string at forward time, which this

--- a/runtime/include/stanli/mir_prog.hpp
+++ b/runtime/include/stanli/mir_prog.hpp
@@ -2094,8 +2094,26 @@ struct ProgramCompiler {
       const bool maximum = extrema.kind == mir::ExtremaKind::Max;
       const bool integer = extrema.surface == mir::ExtremaSurface::IntArray ||
                            extrema.surface == mir::ExtremaSurface::IntPair;
+      // Matrix<var>, vector<var>, and std::vector<var> all reduce in ascending
+      // scalar order. Otherwise retain the source expression's double
+      // evaluator grouping even though `expr` materialized it into a flat
+      // register run above. This mirrors Lowering::reduction_grouping.
+      const bool active = !in_write_array && !e.args[0].data_only;
+      const ExpressionLayout layout =
+          integer || active ? ExpressionLayout::scalar()
+                            : mir::source_expression_layout(e.args[0]);
+      if (!layout.known()) bail("min/max expression grouping is not native");
+      int32_t flags = integer ? kProgramExtremaInteger : 0;
+      if (layout.kind == ExpressionLayout::Kind::Scalar) {
+        flags |= kProgramExtremaScalar;
+      } else if (layout.kind == ExpressionLayout::Kind::Direct &&
+                 layout.element_offset != 0) {
+        flags |= kProgramExtremaPhased;
+        const int64_t phase = layout.element_offset % extrema_phase_modulus();
+        flags |= static_cast<int32_t>(phase << kProgramExtremaPhaseShift);
+      }
       p.code.push_back(Program::Instr{Program::EXTREMA_RANGE, r, a.reg,
-                                      maximum ? 1 : 0, integer ? 1 : 0, a.len});
+                                      maximum ? 1 : 0, flags, a.len});
       return typed(Range{r, 1}, e.type_);
     }
     // Ahead of the arity-keyed blocks below: those end in a bail on an

--- a/runtime/include/stanli/mir_prog.hpp
+++ b/runtime/include/stanli/mir_prog.hpp
@@ -1502,6 +1502,135 @@ struct ProgramCompiler {
     return out;
   }
 
+  Range transform_call(const mir::Expr& e, const CallableTransformSpec& spec) {
+    if (e.args.size() != spec.arity)
+      bail(e.name + ": wrong number of arguments");
+    if (spec.structured && spec.direction == TransformDirection::Unconstrain)
+      bail(e.name +
+           ": structured inverse is not supported in a runtime region");
+
+    Program::Transform tr;
+    tr.kind = spec.kind;
+    tr.direction = spec.direction;
+    tr.n_in = spec.structured ? 1 : (int8_t)spec.arity;
+    std::vector<Range> args;
+    args.reserve((size_t)tr.n_in);
+    for (int k = 0; k < tr.n_in; ++k) {
+      args.push_back(expr(e.args[(size_t)k]));
+      tr.in[k] = args.back().reg;
+      tr.in_len[k] = args.back().len;
+    }
+    Range out = args[0];
+    if (!spec.structured) {
+      for (int k = 1; k < tr.n_in; ++k)
+        if (args[k].len != 1 && args[k].len != args[0].len)
+          bail(e.name + ": bound is neither scalar nor the input size");
+      tr.out_len = args[0].len;
+      tr.inner_raw = args[0].len;
+    } else {
+      ViewKind leaf = args[0].kind;
+      std::vector<int64_t> dims;
+      if (leaf == ViewKind::Array) {
+        dims = args[0].dims;
+        leaf = args[0].leaf;
+      } else if (leaf == ViewKind::Matrix) {
+        dims = {args[0].rows, args[0].cols};
+      } else if (leaf == ViewKind::Vector || leaf == ViewKind::RowVector) {
+        dims = {args[0].len};
+      }
+      const size_t rank = leaf_rank(leaf);
+      if (rank == 0 || dims.size() < rank)
+        bail(e.name + ": invalid input container");
+      const size_t outer_rank = dims.size() - rank;
+      int64_t batch = 1;
+      for (size_t i = 0; i < outer_rank; ++i) batch *= dims[i];
+      int64_t raw_rows = leaf == ViewKind::Matrix ? dims[dims.size() - 2] : 0;
+      int64_t raw_cols = leaf == ViewKind::Matrix ? dims.back() : 0;
+      int64_t rows = 0, cols = 0;
+      ViewKind out_leaf = leaf;
+      switch (spec.kind) {
+        case CallableTransformKind::Ordered:
+        case CallableTransformKind::PositiveOrdered:
+          if (leaf != ViewKind::Vector) bail(e.name + ": expected vector");
+          rows = dims.back();
+          break;
+        case CallableTransformKind::Simplex:
+          if (leaf != ViewKind::Vector) bail(e.name + ": expected vector");
+          rows = dims.back() + 1;
+          break;
+        case CallableTransformKind::UnitVector:
+          if (leaf != ViewKind::Vector) bail(e.name + ": expected vector");
+          rows = dims.back();
+          break;
+        case CallableTransformKind::SumToZero:
+          if (leaf == ViewKind::Vector) {
+            rows = dims.back() + 1;
+          } else if (leaf == ViewKind::Matrix) {
+            rows = raw_rows + 1;
+            cols = raw_cols + 1;
+          } else {
+            bail(e.name + ": expected vector or matrix");
+          }
+          break;
+        case CallableTransformKind::StochasticColumn:
+        case CallableTransformKind::StochasticRow:
+          if (leaf != ViewKind::Matrix) bail(e.name + ": expected matrix");
+          rows =
+              raw_rows + (spec.kind == CallableTransformKind::StochasticColumn);
+          cols = raw_cols + (spec.kind == CallableTransformKind::StochasticRow);
+          break;
+        case CallableTransformKind::CholeskyFactorCorr:
+        case CallableTransformKind::CorrMatrix:
+        case CallableTransformKind::CovMatrix:
+          if (leaf != ViewKind::Vector) bail(e.name + ": expected vector");
+          out_leaf = ViewKind::Matrix;
+          rows = cols = cint(e.args[1]);
+          break;
+        case CallableTransformKind::CholeskyFactorCov:
+          if (leaf != ViewKind::Vector) bail(e.name + ": expected vector");
+          out_leaf = ViewKind::Matrix;
+          rows = cint(e.args[1]);
+          cols = cint(e.args[2]);
+          break;
+        default:
+          bail(e.name + ": invalid structured transform");
+      }
+      if (batch < 0 || rows < 0 || cols < 0) bail(e.name + ": invalid shape");
+      tr.batch = (int32_t)batch;
+      tr.inner_raw = leaf == ViewKind::Matrix ? (int32_t)(raw_rows * raw_cols)
+                                              : (int32_t)dims.back();
+      tr.out_rows = (int32_t)rows;
+      tr.out_cols = (int32_t)cols;
+      const int64_t inner_con =
+          out_leaf == ViewKind::Matrix ? rows * cols : rows;
+      if (inner_con < 0 || batch > kMaxRegs ||
+          (batch && inner_con > kMaxRegs / batch))
+        bail(e.name + ": result needs too many registers");
+      tr.out_len = (int32_t)(batch * inner_con);
+      out.len = tr.out_len;
+      out.kind = outer_rank ? ViewKind::Array : out_leaf;
+      out.rows = out.kind == ViewKind::Matrix ? rows : 0;
+      out.cols = out.kind == ViewKind::Matrix ? cols : 0;
+      if (outer_rank) {
+        out.dims.assign(dims.begin(), dims.begin() + outer_rank);
+        out.dims.push_back(rows);
+        if (out_leaf == ViewKind::Matrix) out.dims.push_back(cols);
+        out.leaf = out_leaf;
+      }
+    }
+    tr.out = alloc(tr.out_len);
+    tr.jac = alloc(1);
+    out.reg = tr.out;
+    p.transforms.push_back(tr);
+    p.code.push_back(
+        Program::Instr{Program::TRANSFORM, 0, (int)p.transforms.size() - 1});
+    if (spec.direction == TransformDirection::Jacobian && !in_write_array) {
+      if (target_reg < 0) bail("jacobian transform has no target");
+      emit(Program::ADD, target_reg, target_reg, tr.jac);
+    }
+    return out;
+  }
+
   Range fun(const mir::Expr& e) {
     // A shape query is a constant whatever surrounds it. Ahead of every
     // other case because `FnLength` is an internal function and the rest
@@ -1557,6 +1686,9 @@ struct ProgramCompiler {
       return out;
     }
     if (rng_call_name(e.name)) return rng_call(e);
+    CallableTransformSpec transform;
+    if (callable_transform(e.name, &transform))
+      return transform_call(e, transform);
     if (e.name == "tcrossprod" && e.args.size() == 1)
       return matrix_gram(expr(e.args[0]), false);
     if (e.name == "crossprod" && e.args.size() == 1)

--- a/runtime/include/stanli/mir_prog.hpp
+++ b/runtime/include/stanli/mir_prog.hpp
@@ -1632,8 +1632,7 @@ struct ProgramCompiler {
   }
 
   Range fun(const mir::Expr& e) {
-    if (const auto value = mir::nullary_constant(e))
-      return {konst(*value), 1};
+    if (const auto value = mir::nullary_constant(e)) return {konst(*value), 1};
     // A shape query is a constant whatever surrounds it. Ahead of every
     // other case because `FnLength` is an internal function and the rest
     // are library ones, and they are all answered the same way: from the
@@ -2096,8 +2095,7 @@ struct ProgramCompiler {
       const bool integer = extrema.surface == mir::ExtremaSurface::IntArray ||
                            extrema.surface == mir::ExtremaSurface::IntPair;
       p.code.push_back(Program::Instr{Program::EXTREMA_RANGE, r, a.reg,
-                                      maximum ? 1 : 0, integer ? 1 : 0,
-                                      a.len});
+                                      maximum ? 1 : 0, integer ? 1 : 0, a.len});
       return typed(Range{r, 1}, e.type_);
     }
     // Ahead of the arity-keyed blocks below: those end in a bail on an

--- a/runtime/include/stanli/mir_prog.hpp
+++ b/runtime/include/stanli/mir_prog.hpp
@@ -2079,12 +2079,28 @@ struct ProgramCompiler {
       out.cols = cols;
       return out;
     }
-    if (e.args.size() == 1 && e.name == "max") {
-      const Range a = expr(e.args[0]);
+    const mir::ExtremaCall extrema = mir::extrema_call(e);
+    if (extrema.kind != mir::ExtremaKind::Legacy) {
+      Range a;
+      if (extrema.surface == mir::ExtremaSurface::IntPair) {
+        const Range lhs = expr(e.args[0]);
+        const Range rhs = expr(e.args[1]);
+        if (!is_scalar(lhs) || !is_scalar(rhs))
+          bail("min/max integer pair needs scalar arguments");
+        a = Range{alloc(2), 2};
+        emit(Program::MOV, a.reg, lhs.reg);
+        emit(Program::MOV, a.reg + 1, rhs.reg);
+      } else {
+        a = expr(e.args[0]);
+      }
       const int r = alloc(1);
-      p.code.push_back(
-          Program::Instr{Program::MAX_RANGE, r, a.reg, 0, 0, a.len});
-      return {r, 1};
+      const bool maximum = extrema.kind == mir::ExtremaKind::Max;
+      const bool integer = extrema.surface == mir::ExtremaSurface::IntArray ||
+                           extrema.surface == mir::ExtremaSurface::IntPair;
+      p.code.push_back(Program::Instr{Program::EXTREMA_RANGE, r, a.reg,
+                                      maximum ? 1 : 0, integer ? 1 : 0,
+                                      a.len});
+      return typed(Range{r, 1}, e.type_);
     }
     // Ahead of the arity-keyed blocks below: those end in a bail on an
     // unknown name, so while this table sat after them a two-argument

--- a/runtime/include/stanli/optable.hpp
+++ b/runtime/include/stanli/optable.hpp
@@ -158,6 +158,8 @@ namespace stanli {
   X(OP_CONSTRAIN_CORR_MATRIX)       \
   X(OP_CONSTRAIN_COV_MATRIX)        \
   X(OP_CONSTRAIN_CHOL_COV)          \
+  X(OP_CONSTRAIN_STOCHASTIC_COLUMN) \
+  X(OP_CONSTRAIN_STOCHASTIC_ROW)    \
   X(OP_CHECK_STRUCTURED)            \
   X(OP_CHECK_MATCHING_DIMS)         \
   X(OP_CHECK_LOWER)                 \

--- a/runtime/include/stanli/program.hpp
+++ b/runtime/include/stanli/program.hpp
@@ -20,6 +20,7 @@
 #ifndef STANLI_PROGRAM_HPP
 #define STANLI_PROGRAM_HPP
 
+#include <stanli/callable_transform.hpp>
 #include <stanli/kernel_types.hpp>
 #include <stanli/program_density.hpp>
 
@@ -119,6 +120,7 @@ enum ProgramOpFlag : uint16_t {
   X(MULT_LOWER_TRI_SELF_TRANSPOSE, kProgramRangeA | kProgramNoAdjoint)       \
   X(DENSITY, 0)                                                              \
   X(CALL, 0)                                                                 \
+  X(TRANSFORM, kProgramNoInputs | kProgramNoAdjoint | kProgramNoOutput)      \
   X(PRINT, kProgramNoInputs | kProgramNoAdjoint | kProgramNoOutput)          \
   X(REJECT, kProgramNoInputs | kProgramNoAdjoint | kProgramNoOutput)         \
   X(DENSITY_VEC, kProgramNoAdjoint)
@@ -207,6 +209,24 @@ struct Program {
     std::vector<int32_t> value_len;
   };
 
+  // A callable constraint transform. Unlike CALL this is scalar-templated:
+  // runtime-control programs execute it for both double and var, while its
+  // kind comes from the same descriptor graph lowering uses.
+  struct Transform {
+    CallableTransformKind kind = CallableTransformKind::Ordered;
+    TransformDirection direction = TransformDirection::Constrain;
+    int8_t n_in = 0;
+    int32_t in[3] = {0, 0, 0};
+    int32_t in_len[3] = {0, 0, 0};
+    int32_t out = 0;
+    int32_t out_len = 0;
+    int32_t jac = 0;
+    int32_t batch = 1;
+    int32_t inner_raw = 0;
+    int32_t out_rows = 0;
+    int32_t out_cols = 0;
+  };
+
   // A DENSITY_VEC's payload: same density id DENSITY uses, but one or more
   // arguments is a same-length container rather than a scalar, evaluated
   // with one propto-OFF call the way CmdStan's generated code would (its
@@ -226,9 +246,10 @@ struct Program {
   };
 
   std::vector<Instr> code;
-  std::vector<Call> calls;    // CALL payloads, indexed by Instr::a
-  std::vector<Print> prints;  // PRINT payloads, indexed by Instr::a
-  std::vector<double> pool;   // CONSTR data
+  std::vector<Call> calls;            // CALL payloads, indexed by Instr::a
+  std::vector<Transform> transforms;  // TRANSFORM payloads, indexed by Instr::a
+  std::vector<Print> prints;          // PRINT payloads, indexed by Instr::a
+  std::vector<double> pool;           // CONSTR data
   // REJECT's literal message text, indexed by Instr::a. Never touched as a
   // register (REJECT is kProgramNoInputs), so it rides beside the register
   // file rather than in it.
@@ -331,6 +352,9 @@ template <>
 struct ProgramCallCtx<true> {
   KernelCtx ctx;
 };
+
+void run_program_transform(const Program::Transform& tr, double* reg);
+void run_program_transform(const Program::Transform& tr, stan::math::var* reg);
 
 template <bool ReuseCallCtx, typename T>
 void run_program_impl(const Program& p, T* reg, EvalState* state = nullptr) {
@@ -620,6 +644,9 @@ void run_program_impl(const Program& p, T* reg, EvalState* state = nullptr) {
           // a gradient.
           throw std::logic_error("CALL instruction in a var replay");
         }
+        break;
+      case Program::TRANSFORM:
+        run_program_transform(p.transforms[(size_t)I.a], reg);
         break;
       case Program::PRINT:
         if constexpr (std::is_same_v<T, double>)

--- a/runtime/include/stanli/program.hpp
+++ b/runtime/include/stanli/program.hpp
@@ -21,6 +21,7 @@
 #define STANLI_PROGRAM_HPP
 
 #include <stanli/callable_transform.hpp>
+#include <stanli/extrema_grouping.hpp>
 #include <stanli/kernel_types.hpp>
 #include <stanli/program_density.hpp>
 
@@ -59,6 +60,16 @@ enum ProgramOpFlag : uint16_t {
   kProgramReadC = 1u << 11,
 };
 
+// EXTREMA_RANGE's `c` immediate. The register file has already materialized
+// every input contiguously, but the source expression's Eigen traversal is
+// still observable for NaNs, signed zero, ties, and adjoint selection. Keep
+// that grouping beside the integer-surface marker instead of guessing from
+// the materialized address at execution time.
+inline constexpr int32_t kProgramExtremaInteger = 1 << 0;
+inline constexpr int32_t kProgramExtremaScalar = 1 << 1;
+inline constexpr int32_t kProgramExtremaPhased = 1 << 2;
+inline constexpr int32_t kProgramExtremaPhaseShift = 3;
+
 // `a` is an operand wherever kProgramNoInputs is absent; b and c are not,
 // and the ones that are not hold register zero rather than nothing, so
 // which registers a program actually reads needs saying. DENSITY's arity
@@ -94,7 +105,7 @@ enum ProgramOpFlag : uint16_t {
   X(EQ, kProgramReadB)                                                       \
   X(NE, kProgramReadB)                                                       \
   X(DYN_INDEX, kProgramReadB | kProgramNoAdjoint)                            \
-  /* b selects max (1) or min (0); c marks the integer-container surface. */ \
+  /* b selects max (1) or min (0); c stores kProgramExtrema* metadata. */    \
   X(EXTREMA_RANGE, kProgramRangeA | kProgramNoAdjoint)                       \
   X(JZ, kProgramNoAdjoint | kProgramNoOutput)                                \
   X(JMP, kProgramNoInputs | kProgramNoAdjoint | kProgramNoOutput)            \
@@ -474,20 +485,70 @@ void run_program_impl(const Program& p, T* reg, EvalState* state = nullptr) {
         break;
       }
       case Program::EXTREMA_RANGE: {
-        if (I.c != 0 && I.len == 0) {
+        const bool maximum = I.b != 0;
+        const bool integer = (I.c & kProgramExtremaInteger) != 0;
+        const bool scalar = (I.c & kProgramExtremaScalar) != 0;
+        const bool phased = (I.c & kProgramExtremaPhased) != 0;
+        if (integer && I.len == 0) {
           // The register file stores integers as doubles, so call the actual
           // integer overload solely to preserve Stan Math's empty-container
           // exception instead of returning a floating-point infinity.
           const std::vector<int> empty;
-          if (I.b != 0)
+          if (maximum)
             (void)stan::math::max(empty);
           else
             (void)stan::math::min(empty);
         }
-        std::vector<T> owning;
-        if (I.len > 0)
-          owning.assign(&reg[(size_t)I.a], &reg[(size_t)(I.a + I.len)]);
-        d() = I.b != 0 ? stan::math::max(owning) : stan::math::min(owning);
+        if (I.len == 0) {
+          d() = T(maximum ? -std::numeric_limits<double>::infinity()
+                          : std::numeric_limits<double>::infinity());
+          break;
+        }
+        if (scalar) {
+          T selected = reg[(size_t)I.a];
+          for (int32_t i = 1; i < I.len; ++i) {
+            const T& candidate = reg[(size_t)(I.a + i)];
+            if (maximum ? stan::math::value_of(selected) <
+                              stan::math::value_of(candidate)
+                        : stan::math::value_of(candidate) <
+                              stan::math::value_of(selected))
+              selected = candidate;
+          }
+          d() = selected;
+          break;
+        }
+        const int64_t phase =
+            static_cast<int64_t>(I.c) >> kProgramExtremaPhaseShift;
+        if constexpr (std::is_same_v<T, double>) {
+          if (phased) {
+            d() = extrema_phased(&reg[(size_t)I.a], I.len, phase, maximum);
+          } else {
+            const Eigen::Map<const Eigen::VectorXd> input(&reg[(size_t)I.a],
+                                                          I.len);
+            const auto owning_grouping = input.unaryExpr(
+                Eigen::internal::core_cast_op<double, double>());
+            d() = maximum ? stan::math::max(owning_grouping)
+                          : stan::math::min(owning_grouping);
+          }
+        } else {
+          // Packet/phased instructions are parameter-free: an active source
+          // is classified scalar by ProgramCompiler. Recreate the double
+          // value grouping during replay and keep the result constant, just
+          // as generated Stan computes the extrema before promoting it into
+          // any downstream var expression.
+          std::vector<double> values((size_t)I.len);
+          for (int32_t i = 0; i < I.len; ++i)
+            values[(size_t)i] = stan::math::value_of(reg[(size_t)(I.a + i)]);
+          if (phased) {
+            d() = T(extrema_phased(values.data(), I.len, phase, maximum));
+          } else {
+            const Eigen::Map<const Eigen::VectorXd> input(values.data(), I.len);
+            const auto owning_grouping = input.unaryExpr(
+                Eigen::internal::core_cast_op<double, double>());
+            d() = T(maximum ? stan::math::max(owning_grouping)
+                            : stan::math::min(owning_grouping));
+          }
+        }
         break;
       }
       case Program::JZ:

--- a/runtime/include/stanli/program.hpp
+++ b/runtime/include/stanli/program.hpp
@@ -119,6 +119,7 @@ enum ProgramOpFlag : uint16_t {
   X(MULT_LOWER_TRI_SELF_TRANSPOSE, kProgramRangeA | kProgramNoAdjoint)       \
   X(DENSITY, 0)                                                              \
   X(CALL, 0)                                                                 \
+  X(PRINT, kProgramNoInputs | kProgramNoAdjoint | kProgramNoOutput)          \
   X(REJECT, kProgramNoInputs | kProgramNoAdjoint | kProgramNoOutput)         \
   X(DENSITY_VEC, kProgramNoAdjoint)
 
@@ -196,6 +197,16 @@ struct Program {
     int32_t bwd_adj_out = 0;
   };
 
+  // A PRINT's payload: literal chunks interleaved with register ranges.
+  // The double forward renders it once; a var replay deliberately skips it,
+  // because replay exists only to recover derivatives and must not repeat an
+  // observable Stan statement.
+  struct Print {
+    std::vector<std::string> chunks;
+    std::vector<int32_t> value_reg;
+    std::vector<int32_t> value_len;
+  };
+
   // A DENSITY_VEC's payload: same density id DENSITY uses, but one or more
   // arguments is a same-length container rather than a scalar, evaluated
   // with one propto-OFF call the way CmdStan's generated code would (its
@@ -215,8 +226,9 @@ struct Program {
   };
 
   std::vector<Instr> code;
-  std::vector<Call> calls;   // CALL payloads, indexed by Instr::a
-  std::vector<double> pool;  // CONSTR data
+  std::vector<Call> calls;    // CALL payloads, indexed by Instr::a
+  std::vector<Print> prints;  // PRINT payloads, indexed by Instr::a
+  std::vector<double> pool;   // CONSTR data
   // REJECT's literal message text, indexed by Instr::a. Never touched as a
   // register (REJECT is kProgramNoInputs), so it rides beside the register
   // file rather than in it.
@@ -226,6 +238,11 @@ struct Program {
   int n_regs = 0;
   std::vector<int> out_regs;  // the values the caller reads back
 };
+
+// Render one register-program print through the same sink and formatting as
+// graph OP_PRINT. Kept out of the evaluator template so only the double path
+// needs to know how messages are assembled.
+void emit_program_print(const Program::Print& print, const double* reg);
 
 struct ProgramOpSpec {
   const char* name;
@@ -603,6 +620,10 @@ void run_program_impl(const Program& p, T* reg, EvalState* state = nullptr) {
           // a gradient.
           throw std::logic_error("CALL instruction in a var replay");
         }
+        break;
+      case Program::PRINT:
+        if constexpr (std::is_same_v<T, double>)
+          emit_program_print(p.prints[(size_t)I.a], reg);
         break;
       // reject(): the same exception CmdStan's generated code throws from
       // the same place, so the sampler counts it as a rejected proposal

--- a/runtime/include/stanli/program.hpp
+++ b/runtime/include/stanli/program.hpp
@@ -94,7 +94,8 @@ enum ProgramOpFlag : uint16_t {
   X(EQ, kProgramReadB)                                                       \
   X(NE, kProgramReadB)                                                       \
   X(DYN_INDEX, kProgramReadB | kProgramNoAdjoint)                            \
-  X(MAX_RANGE, kProgramRangeA | kProgramNoAdjoint)                           \
+  /* b selects max (1) or min (0); c marks the integer-container surface. */ \
+  X(EXTREMA_RANGE, kProgramRangeA | kProgramNoAdjoint)                       \
   X(JZ, kProgramNoAdjoint | kProgramNoOutput)                                \
   X(JMP, kProgramNoInputs | kProgramNoAdjoint | kProgramNoOutput)            \
   X(LOG_RANGE, kProgramRangeA | kProgramSaveA | kProgramRangeOutput)         \
@@ -472,11 +473,21 @@ void run_program_impl(const Program& p, T* reg, EvalState* state = nullptr) {
         d() = reg[(size_t)(I.a + I.c + static_cast<int32_t>(raw) - 1)];
         break;
       }
-      case Program::MAX_RANGE: {
+      case Program::EXTREMA_RANGE: {
+        if (I.c != 0 && I.len == 0) {
+          // The register file stores integers as doubles, so call the actual
+          // integer overload solely to preserve Stan Math's empty-container
+          // exception instead of returning a floating-point infinity.
+          const std::vector<int> empty;
+          if (I.b != 0)
+            (void)stan::math::max(empty);
+          else
+            (void)stan::math::min(empty);
+        }
         std::vector<T> owning;
         if (I.len > 0)
           owning.assign(&reg[(size_t)I.a], &reg[(size_t)(I.a + I.len)]);
-        d() = stan::math::max(owning);
+        d() = I.b != 0 ? stan::math::max(owning) : stan::math::min(owning);
         break;
       }
       case Program::JZ:

--- a/runtime/kernels/constrain.cpp
+++ b/runtime/kernels/constrain.cpp
@@ -431,6 +431,8 @@ enum class StructuredKind {
   CholeskyCorr,
   UnitVector,
   SumToZero,
+  StochasticColumn,
+  StochasticRow,
   CorrMatrix,
   CovMatrix,
   CholeskyCov
@@ -451,6 +453,10 @@ auto apply_structured(Y& y, Lp& lp, const KernelCtx& ctx) {
   else if constexpr (K == StructuredKind::SumToZero)
     // Volume preserving: intentionally leave lp untouched.
     return stan::math::sum_to_zero_constrain(y);
+  else if constexpr (K == StructuredKind::StochasticColumn)
+    return stan::math::stochastic_column_constrain(y, lp);
+  else if constexpr (K == StructuredKind::StochasticRow)
+    return stan::math::stochastic_row_constrain(y, lp);
   else if constexpr (K == StructuredKind::CorrMatrix)
     return stan::math::corr_matrix_constrain(y, (Eigen::Index)ctx.idata[2], lp);
   else if constexpr (K == StructuredKind::CovMatrix)
@@ -463,7 +469,12 @@ auto apply_structured(Y& y, Lp& lp, const KernelCtx& ctx) {
 template <StructuredKind K>
 constexpr bool kMatrixStructured =
     K == StructuredKind::CholeskyCorr || K == StructuredKind::CorrMatrix ||
-    K == StructuredKind::CovMatrix || K == StructuredKind::CholeskyCov;
+    K == StructuredKind::CovMatrix || K == StructuredKind::CholeskyCov ||
+    K == StructuredKind::StochasticColumn || K == StructuredKind::StochasticRow;
+
+template <StructuredKind K>
+constexpr bool kMatrixInput =
+    K == StructuredKind::StochasticColumn || K == StructuredKind::StochasticRow;
 
 template <StructuredKind K>
 int64_t structured_output_width(const KernelCtx& ctx) {
@@ -479,11 +490,23 @@ void structured_fwd(KernelCtx& ctx) {
   const int64_t inner_con = structured_output_width<K>(ctx);
   double lp = 0.0;
   for (int64_t b = 0; b < nb; ++b) {
-    const Eigen::Map<const Eigen::VectorXd> y(ctx.in[0].data + b * inner_raw,
-                                              inner_raw);
-    const auto x = apply_structured<K>(y, lp, ctx);
-    for (int64_t i = 0; i < inner_con; ++i)
-      ctx.out.data[b * inner_con + i] = x.data()[i];
+    if constexpr (kMatrixInput<K>) {
+      const int64_t raw_rows =
+          ctx.idata[2] - (K == StructuredKind::StochasticColumn ? 1 : 0);
+      const int64_t raw_cols =
+          ctx.idata[3] - (K == StructuredKind::StochasticRow ? 1 : 0);
+      const Eigen::Map<const Eigen::MatrixXd> y(ctx.in[0].data + b * inner_raw,
+                                                raw_rows, raw_cols);
+      const auto x = apply_structured<K>(y, lp, ctx);
+      for (int64_t i = 0; i < inner_con; ++i)
+        ctx.out.data[b * inner_con + i] = x.data()[i];
+    } else {
+      const Eigen::Map<const Eigen::VectorXd> y(ctx.in[0].data + b * inner_raw,
+                                                inner_raw);
+      const auto x = apply_structured<K>(y, lp, ctx);
+      for (int64_t i = 0; i < inner_con; ++i)
+        ctx.out.data[b * inner_con + i] = x.data()[i];
+    }
   }
   ctx.out2.data[0] = lp;
 }
@@ -496,26 +519,43 @@ void structured_bwd(KernelCtx& ctx) {
   using stan::math::var;
   for (int64_t b = 0; b < nb; ++b) {
     stan::math::nested_rev_autodiff nested;
-    Eigen::Matrix<var, -1, 1> y(inner_raw);
-    for (int64_t i = 0; i < inner_raw; ++i)
-      y(i) = ctx.in[0].data[b * inner_raw + i];
     var lp = 0.0;
-    const auto x = apply_structured<K>(y, lp, ctx);
     const Eigen::Map<const Eigen::VectorXd> seed(
         ctx.out_adj_vec.data + b * inner_con, inner_con);
-    if constexpr (kMatrixStructured<K>) {
+    if constexpr (kMatrixInput<K>) {
+      const int64_t raw_rows =
+          ctx.idata[2] - (K == StructuredKind::StochasticColumn ? 1 : 0);
+      const int64_t raw_cols =
+          ctx.idata[3] - (K == StructuredKind::StochasticRow ? 1 : 0);
+      Eigen::Matrix<var, -1, -1> y(raw_rows, raw_cols);
+      for (int64_t i = 0; i < inner_raw; ++i)
+        y.data()[i] = ctx.in[0].data[b * inner_raw + i];
+      const auto x = apply_structured<K>(y, lp, ctx);
       // Eigen storage is column-major here, matching the old explicit
       // j*rows+i flattening and therefore its dot-product construction order.
       Eigen::Matrix<var, -1, 1> flat(inner_con);
       for (int64_t i = 0; i < inner_con; ++i) flat(i) = x.data()[i];
       var objective = stan::math::dot_product(seed, flat) + ctx.out2_adj * lp;
       stan::math::grad(objective.vi_);
+      for (int64_t i = 0; i < inner_raw; ++i)
+        ctx.in_adj[0].data[b * inner_raw + i] += y.data()[i].adj();
     } else {
-      var objective = stan::math::dot_product(seed, x) + ctx.out2_adj * lp;
-      stan::math::grad(objective.vi_);
+      Eigen::Matrix<var, -1, 1> y(inner_raw);
+      for (int64_t i = 0; i < inner_raw; ++i)
+        y(i) = ctx.in[0].data[b * inner_raw + i];
+      const auto x = apply_structured<K>(y, lp, ctx);
+      if constexpr (kMatrixStructured<K>) {
+        Eigen::Matrix<var, -1, 1> flat(inner_con);
+        for (int64_t i = 0; i < inner_con; ++i) flat(i) = x.data()[i];
+        var objective = stan::math::dot_product(seed, flat) + ctx.out2_adj * lp;
+        stan::math::grad(objective.vi_);
+      } else {
+        var objective = stan::math::dot_product(seed, x) + ctx.out2_adj * lp;
+        stan::math::grad(objective.vi_);
+      }
+      for (int64_t i = 0; i < inner_raw; ++i)
+        ctx.in_adj[0].data[b * inner_raw + i] += y(i).adj();
     }
-    for (int64_t i = 0; i < inner_raw; ++i)
-      ctx.in_adj[0].data[b * inner_raw + i] += y(i).adj();
   }
 }
 
@@ -653,6 +693,10 @@ void register_constrain_kernels() {
   register_structured<StructuredKind::Ordered>(OP_CONSTRAIN_ORDERED);
   register_structured<StructuredKind::PositiveOrdered>(
       OP_CONSTRAIN_POS_ORDERED);
+  register_structured<StructuredKind::StochasticColumn>(
+      OP_CONSTRAIN_STOCHASTIC_COLUMN);
+  register_structured<StructuredKind::StochasticRow>(
+      OP_CONSTRAIN_STOCHASTIC_ROW);
 }
 
 }  // namespace stanli

--- a/runtime/kernels/island.cpp
+++ b/runtime/kernels/island.cpp
@@ -134,7 +134,7 @@ void island_calls_fwd(KernelCtx& ctx) { island_fwd_impl<true>(ctx); }
 
 bool island_has_effect(const Program& p) {
   for (const Program::Instr& I : p.code) {
-    if (I.code == Program::REJECT) return true;
+    if (I.code == Program::PRINT || I.code == Program::REJECT) return true;
     if (I.code != Program::CALL) continue;
     // A payload index out of range is malformed rather than pure; refusing
     // to fold is the safe answer either way.

--- a/runtime/kernels/message.cpp
+++ b/runtime/kernels/message.cpp
@@ -19,6 +19,7 @@
 #include <stanli/message_sink.hpp>
 #include <stanli/optable.hpp>
 #include <stanli/packet.hpp>
+#include <stanli/program.hpp>
 #include <stanli/structured_check.hpp>
 
 #include <stan/math/prim/err/check_cholesky_factor.hpp>
@@ -44,6 +45,27 @@
 #include <vector>
 
 namespace stanli {
+
+void emit_program_print(const Program::Print& print, const double* reg) {
+  std::ostringstream out;
+  for (size_t k = 0; k < print.chunks.size(); ++k) {
+    out << print.chunks[k];
+    if (k >= print.value_reg.size()) continue;
+    const int32_t first = print.value_reg[k];
+    const int32_t len = print.value_len[k];
+    if (len == 1) {
+      out << reg[first];
+    } else {
+      out << '[';
+      for (int32_t i = 0; i < len; ++i) {
+        if (i) out << ',';
+        out << reg[first + i];
+      }
+      out << ']';
+    }
+  }
+  emit_message(out.str());
+}
 
 namespace {
 

--- a/runtime/src/adjoint.cpp
+++ b/runtime/src/adjoint.cpp
@@ -746,7 +746,7 @@ void run_adjoint(const Program& fwd, const AdjProgram& ap, const double* val,
       }
       case Program::DYN_INDEX:
       case Program::IDIV:
-      case Program::MAX_RANGE:
+      case Program::EXTREMA_RANGE:
       case Program::JZ:
       case Program::JMP:
       case Program::DIAG_PRE_MULTIPLY:

--- a/runtime/src/adjoint.cpp
+++ b/runtime/src/adjoint.cpp
@@ -756,6 +756,7 @@ void run_adjoint(const Program& fwd, const AdjProgram& ap, const double* val,
       case Program::MDIVIDE_RIGHT_SPD:
       case Program::QUAD_FORM_SYM:
       case Program::MULT_LOWER_TRI_SELF_TRANSPOSE:
+      case Program::PRINT:
       case Program::REJECT:
       case Program::DENSITY_VEC:
         break;  // gen_adjoint refuses these; unreachable

--- a/runtime/src/adjoint.cpp
+++ b/runtime/src/adjoint.cpp
@@ -756,6 +756,7 @@ void run_adjoint(const Program& fwd, const AdjProgram& ap, const double* val,
       case Program::MDIVIDE_RIGHT_SPD:
       case Program::QUAD_FORM_SYM:
       case Program::MULT_LOWER_TRI_SELF_TRANSPOSE:
+      case Program::TRANSFORM:
       case Program::PRINT:
       case Program::REJECT:
       case Program::DENSITY_VEC:

--- a/runtime/src/lower.cpp
+++ b/runtime/src/lower.cpp
@@ -2729,10 +2729,9 @@ struct Lowering {
     // inliner's zero-length sentinel and the region's assignment sized it.
     std::vector<Range> out_views;
     bool has_target = false;  // the region contributed to the target
-    // The region compiled a reject(): it has an observable effect even when
-    // every data live-out is empty, so an emitter must not treat it as
-    // having nothing to produce.
-    bool has_reject = false;
+    // A print or reject is observable even when every data live-out is empty,
+    // so an emitter must not treat the region as having nothing to produce.
+    bool has_effect = false;
   };
 
   // Does `s` increment the target anywhere?
@@ -3021,14 +3020,11 @@ struct Lowering {
     // as `matrix[0, 0]` from a dimension table does, so there is nothing
     // for the program to carry out. Finding no live-out at all is the
     // mistake this catches -- a region that lost what it was to produce --
-    // unless the region's entire purpose was a conditional reject(): that
-    // has no data output by design, its value being the exception it may
-    // throw.
-    reg->has_reject = std::any_of(
-        prog->code.begin(), prog->code.end(),
-        [](const Program::Instr& i) { return i.code == Program::REJECT; });
+    // unless the region's entire purpose was a conditional effect: that has
+    // no data output by design, its value being the output or exception.
+    reg->has_effect = island_has_effect(*prog);
     if (prog->out_regs.empty() && !(e && expr_out->len == 0) &&
-        (s == nullptr || reg->out_names.empty()) && !reg->has_reject)
+        (s == nullptr || reg->out_names.empty()) && !reg->has_effect)
       fail("runtime-control region produces nothing", s ? s->raw : e->raw);
     // A region with a runtime branch keeps the var replay -- reversing
     // control flow needs the structured form the flat program has already
@@ -3139,8 +3135,8 @@ struct Lowering {
     // zero-width, so the region has no observable effect and its values
     // keep the empty shape they already have outside. A `target +=` would
     // have put its own register here, so this cannot drop one -- and a
-    // reject() has no live-out by design, so it cannot either.
-    if (prog->out_regs.empty() && !reg.has_reject) return;
+    // print()/reject() have no live-out by design, so it cannot either.
+    if (prog->out_regs.empty() && !reg.has_effect) return;
     std::vector<int> out_slots;
     emit_island(prog, reg, out_lens, &out_slots);
     // Later statements read the island's results, not the old values.

--- a/runtime/src/lower.cpp
+++ b/runtime/src/lower.cpp
@@ -1,4 +1,5 @@
 #include <stanli/algebra.hpp>
+#include <stanli/callable_transform.hpp>
 #include <stanli/compile.hpp>
 #include <stanli/unconstrain.hpp>
 #include <stanli/constfold.hpp>
@@ -384,18 +385,9 @@ Addr flat_addr(const std::vector<int64_t>& D, bool mat,
 
 std::vector<double> graph_order(const DataMap::Entry& en,
                                 bool standalone_matrix, bool innermost_matrix) {
-  std::vector<double> vals = en.r;
-  if (standalone_matrix || en.dims.size() <= 1) return vals;
-  std::vector<int64_t> ix(en.dims.size(), 0);
-  for (size_t src = 0; src < en.r.size(); ++src) {
-    int64_t t = (int64_t)src;
-    for (size_t d = 0; d < en.dims.size(); ++d) {
-      ix[d] = t % en.dims[d];
-      t /= en.dims[d];
-    }
-    vals[(size_t)flat_addr(en.dims, innermost_matrix, ix).off] = en.r[src];
-  }
-  return vals;
+  if (standalone_matrix || en.dims.size() <= 1) return en.r;
+  const size_t outer_rank = en.dims.size() - (innermost_matrix ? 2u : 0u);
+  return graph_container_order(en.r, en.dims, outer_rank);
 }
 
 struct Lowering {
@@ -636,7 +628,7 @@ struct Lowering {
     CategoricalRng,
     ScalarRng,
     Density,
-    BoundTransform,
+    CallableTransform,
     Elementwise,
     AppendArray,
     Matrix,
@@ -675,19 +667,6 @@ struct Lowering {
   static bool ends_with(std::string_view name, std::string_view suffix) {
     return name.size() >= suffix.size() &&
            name.substr(name.size() - suffix.size()) == suffix;
-  }
-
-  static bool bound_transform_name(std::string_view name) {
-    static constexpr std::string_view kStems[] = {
-        "lower_bound_", "upper_bound_", "lower_upper_bound_",
-        "offset_multiplier_"};
-    for (std::string_view stem : kStems) {
-      if (name.size() < stem.size() || name.substr(0, stem.size()) != stem)
-        continue;
-      const std::string_view tail = name.substr(stem.size());
-      return tail == "constrain" || tail == "jacobian" || tail == "unconstrain";
-    }
-    return false;
   }
 
   static BuiltinDispatch resolve_builtin(const mir::Expr& e) {
@@ -826,7 +805,9 @@ struct Lowering {
         ends_with(e.name, "_cdf") || ends_with(e.name, "_ccdf") ||
         ends_with(e.name, "_lcdf") || ends_with(e.name, "_lccdf"))
       return {BuiltinFamily::Density};
-    if (bound_transform_name(e.name)) return {BuiltinFamily::BoundTransform};
+    CallableTransformSpec transform;
+    if (callable_transform(e.name, &transform))
+      return {BuiltinFamily::CallableTransform};
     return {};
   }
 
@@ -2734,9 +2715,35 @@ struct Lowering {
     bool has_effect = false;
   };
 
-  // Does `s` increment the target anywhere?
+  static bool expr_has_jacobian(const mir::Expr& e) {
+    if (e.kind == mir::Expr::FunApp) {
+      CallableTransformSpec transform;
+      if (callable_transform(e.name, &transform) &&
+          transform.direction == TransformDirection::Jacobian)
+        return true;
+      // Stan permits Jacobian adjustments in a UDF precisely when its name
+      // has this suffix. Conservatively carry a target through such a call;
+      // an unused zero is cheaper than dropping a nested adjustment.
+      if (e.fn_lib == mir::Expr::Lib::UserDefined &&
+          transform_suffix(e.name, "_jacobian"))
+        return true;
+    }
+    for (const auto& a : e.args)
+      if (expr_has_jacobian(a)) return true;
+    return false;
+  }
+
+  // Does `s` increment the target, explicitly or through a Jacobian call?
   static bool has_target_pe(const mir::Stmt& s) {
     if (s.kind == mir::Stmt::TargetPE) return true;
+    if ((s.has_init && expr_has_jacobian(s.init)) || expr_has_jacobian(s.rhs) ||
+        expr_has_jacobian(s.target) || expr_has_jacobian(s.lower) ||
+        expr_has_jacobian(s.upper) || expr_has_jacobian(s.cond))
+      return true;
+    for (const auto& e : s.fn_args)
+      if (expr_has_jacobian(e)) return true;
+    for (const auto& e : s.lhs_idx)
+      if (expr_has_jacobian(e)) return true;
     for (const auto& k : s.body)
       if (has_target_pe(k)) return true;
     return false;
@@ -2926,9 +2933,8 @@ struct Lowering {
       r->kind = si.kind;
       if (is_array(si)) {
         const ArrayShape& arr = array_shape(si);
-        if (arr.leaf == ViewKind::Matrix)
-          c.bail("matrix-leaf arrays are unsupported by a runtime region");
         r->dims = arr.dims;
+        r->leaf = arr.leaf;
       }
       if (len > 0) {
         prog->ins.push_back(IslandProg::LiveIn{r->reg, (int)len});
@@ -2966,8 +2972,11 @@ struct Lowering {
           view.rows = dl->second.si.rows;
           view.cols = dl->second.si.cols;
           view.kind = dl->second.si.kind;
-          if (is_array(dl->second.si))
-            view.dims = array_shape(dl->second.si).dims;
+          if (is_array(dl->second.si)) {
+            const ArrayShape& arr = array_shape(dl->second.si);
+            view.dims = arr.dims;
+            view.leaf = arr.leaf;
+          }
           const double fill =
               dl->second.int_array
                   ? static_cast<double>(std::numeric_limits<int>::min())
@@ -3835,33 +3844,138 @@ struct Lowering {
   // library pairs it either with scalar bounds or with bounds of exactly
   // its own type, and none of them widens a scalar first argument against a
   // container bound.
-  std::optional<Val> lower_bound_transform(const mir::Expr& e,
-                                           CallArguments& actuals) {
-    struct Transform {
-      const char* stem;
-      uint16_t opcode;
-      size_t arity;
-    };
-    static const Transform kTransforms[] = {
-        {"lower_bound_", OP_CONSTRAIN_LOWER, 2},
-        {"upper_bound_", OP_CONSTRAIN_UPPER, 2},
-        {"lower_upper_bound_", OP_CONSTRAIN_LU, 3},
-        {"offset_multiplier_", OP_CONSTRAIN_OFFSET_MULT, 3},
-    };
-    const Transform* tr = nullptr;
-    std::string direction;
-    for (const Transform& t : kTransforms) {
-      const std::string prefix(t.stem);
-      if (e.name.compare(0, prefix.size(), prefix) != 0) continue;
-      const std::string tail = e.name.substr(prefix.size());
-      if (tail != "constrain" && tail != "jacobian" && tail != "unconstrain")
-        continue;
-      tr = &t;
-      direction = tail;
-    }
-    if (tr == nullptr) return std::nullopt;
+  std::optional<Val> lower_callable_transform(const mir::Expr& e,
+                                              CallArguments& actuals) {
+    CallableTransformSpec tr;
+    if (!callable_transform(e.name, &tr)) return std::nullopt;
+    actuals.require_arity(tr.arity);
 
-    actuals.require_arity(tr->arity);
+    if (tr.structured) {
+      // The inverse structured transforms are not needed by Jacobian calls
+      // and do not share the constrain kernels' two-output protocol.
+      if (tr.direction == TransformDirection::Unconstrain) return std::nullopt;
+      Val raw = actuals.at(0).value();
+      ViewKind leaf = raw.si.kind;
+      std::vector<int64_t> dims;
+      if (is_array(raw.si)) {
+        const ArrayShape& a = array_shape(raw.si);
+        dims = a.dims;
+        leaf = a.leaf;
+      } else if (is_matrix(raw.si)) {
+        dims = {raw.si.rows, raw.si.cols};
+      } else if (is_vector(raw.si) || is_row_vector(raw.si)) {
+        dims = {g.slots[raw.slot].len};
+      }
+      const size_t rank = (size_t)leaf_rank(leaf);
+      if (rank == 0 || dims.size() < rank)
+        fail(e.name + ": first argument has an invalid container type", e.raw);
+      const size_t outer_rank = dims.size() - rank;
+      std::vector<int64_t> outer(dims.begin(), dims.begin() + outer_rank);
+      const int64_t batch = checked_product(outer, e.name + " batch");
+      int64_t raw_rows = leaf == ViewKind::Matrix ? dims[dims.size() - 2] : 0;
+      int64_t raw_cols = leaf == ViewKind::Matrix ? dims.back() : 0;
+      int64_t out_rows = 0, out_cols = 0;
+      ViewKind out_leaf = leaf;
+      uint16_t opcode = tr.opcode;
+
+      switch (tr.kind) {
+        case CallableTransformKind::Ordered:
+        case CallableTransformKind::PositiveOrdered:
+          if (leaf != ViewKind::Vector)
+            fail(e.name + ": expected vector", e.raw);
+          out_rows = dims.back();
+          break;
+        case CallableTransformKind::Simplex:
+          if (leaf != ViewKind::Vector)
+            fail(e.name + ": expected vector", e.raw);
+          out_rows = dims.back() + 1;
+          break;
+        case CallableTransformKind::UnitVector:
+          if (leaf != ViewKind::Vector)
+            fail(e.name + ": expected vector", e.raw);
+          out_rows = dims.back();
+          break;
+        case CallableTransformKind::SumToZero:
+          if (leaf == ViewKind::Vector) {
+            out_rows = dims.back() + 1;
+          } else if (leaf == ViewKind::Matrix) {
+            out_rows = raw_rows + 1;
+            out_cols = raw_cols + 1;
+            opcode = OP_CONSTRAIN_SUM_TO_ZERO_MAT;
+          } else {
+            fail(e.name + ": expected vector or matrix", e.raw);
+          }
+          break;
+        case CallableTransformKind::StochasticColumn:
+        case CallableTransformKind::StochasticRow:
+          if (leaf != ViewKind::Matrix)
+            fail(e.name + ": expected matrix", e.raw);
+          out_rows =
+              raw_rows + (tr.kind == CallableTransformKind::StochasticColumn);
+          out_cols =
+              raw_cols + (tr.kind == CallableTransformKind::StochasticRow);
+          break;
+        case CallableTransformKind::CholeskyFactorCorr:
+        case CallableTransformKind::CorrMatrix:
+        case CallableTransformKind::CovMatrix: {
+          if (leaf != ViewKind::Vector)
+            fail(e.name + ": expected vector", e.raw);
+          const int64_t k =
+              actuals.at(1).require_constant_int("matrix dimension");
+          out_leaf = ViewKind::Matrix;
+          out_rows = out_cols = k;
+          break;
+        }
+        case CallableTransformKind::CholeskyFactorCov:
+          if (leaf != ViewKind::Vector)
+            fail(e.name + ": expected vector", e.raw);
+          out_leaf = ViewKind::Matrix;
+          out_rows = actuals.at(1).require_constant_int("matrix rows");
+          out_cols = actuals.at(2).require_constant_int("matrix columns");
+          break;
+        default:
+          fail(e.name + ": invalid structured transform", e.raw);
+      }
+      if (out_rows < 0 || out_cols < 0)
+        fail(e.name + ": negative result dimension", e.raw);
+      const int64_t inner_raw =
+          leaf == ViewKind::Matrix
+              ? checked_product({raw_rows, raw_cols}, e.name + " raw matrix")
+              : dims.back();
+      const int64_t inner_con =
+          out_leaf == ViewKind::Matrix
+              ? checked_product({out_rows, out_cols}, e.name)
+              : out_rows;
+      const int64_t out_len = checked_product({batch, inner_con}, e.name);
+      SlotInfo si;
+      if (outer_rank != 0) {
+        outer.push_back(out_rows);
+        if (out_leaf == ViewKind::Matrix) outer.push_back(out_cols);
+        si = array_view(std::move(outer), out_leaf, raw.si.param_free);
+      } else if (out_leaf == ViewKind::Matrix) {
+        si = matrix_view(out_rows, out_cols, raw.si.param_free);
+      } else {
+        si =
+            view_of(out_leaf == ViewKind::RowVector ? "URowVector" : "UVector");
+        si.param_free = raw.si.param_free;
+      }
+      std::vector<int> idata = {
+          checked_immediate(batch, e.name + " batch"),
+          checked_immediate(inner_raw, e.name + " raw leaf"),
+          checked_immediate(out_leaf == ViewKind::Matrix ? out_rows : inner_con,
+                            e.name + " result rows")};
+      if (out_leaf == ViewKind::Matrix)
+        idata.push_back(
+            checked_immediate(out_cols, e.name + " result columns"));
+      const int jac = add_slot(1, false);
+      Val v = emit_raw(opcode, {raw.slot}, out_len, si, std::move(idata), jac,
+                       raw.autodiff);
+      v.layout = owning_layout(si);
+      if (tr.direction == TransformDirection::Jacobian && !in_write_array)
+        target_terms.push_back(jac);
+      return v;
+    }
+
     std::vector<Val> a;
     a.reserve(actuals.size());
     for (size_t i = 0; i < actuals.size(); ++i)
@@ -3880,7 +3994,8 @@ struct Lowering {
       ins.push_back(v.slot);
     }
 
-    if (direction == "unconstrain") return free_transform(tr->opcode, a, si, n);
+    if (tr.direction == TransformDirection::Unconstrain)
+      return free_transform(tr.opcode, a, si, n);
     // The declaration kernels, unchanged: they carry the arithmetic that was
     // measured against stan-math's rev overloads, which composing exp,
     // inv_logit, and fma out of the elementwise ops would not reproduce.
@@ -3888,9 +4003,10 @@ struct Lowering {
     // and simply leaves it unrooted -- no term reaches the target, and its
     // adjoint stays zero, which is exactly the no-lp overload's gradient.
     const int jac = add_slot(1, /*is_param=*/false);
-    Val v = emit_raw(tr->opcode, ins, n, si, {}, jac, autodiff);
+    Val v = emit_raw(tr.opcode, ins, n, si, {}, jac, autodiff);
     v.layout = owning_layout(si);
-    if (direction == "jacobian" && !in_write_array) target_terms.push_back(jac);
+    if (tr.direction == TransformDirection::Jacobian && !in_write_array)
+      target_terms.push_back(jac);
     return v;
   }
 
@@ -4774,8 +4890,8 @@ struct Lowering {
       case BuiltinFamily::Density:
         if (auto v = lower_density_fn(e, actuals)) return *v;
         break;
-      case BuiltinFamily::BoundTransform:
-        if (auto v = lower_bound_transform(e, actuals)) return *v;
+      case BuiltinFamily::CallableTransform:
+        if (auto v = lower_callable_transform(e, actuals)) return *v;
         break;
       case BuiltinFamily::Elementwise:
         if (auto v = lower_eltwise_fn(

--- a/runtime/src/lower.cpp
+++ b/runtime/src/lower.cpp
@@ -4754,6 +4754,7 @@ struct Lowering {
   }
 
   Val lower_funapp(const mir::Expr& e) {
+    if (const auto value = mir::nullary_constant(e)) return constant(*value);
     if (e.fn_lib == mir::Expr::Lib::UserDefined) {
       if (!region_current)
         if (auto v = fold_const(e)) return *v;
@@ -4847,19 +4848,6 @@ struct Lowering {
     if (e.fn_lib != mir::Expr::Lib::StanLib) {
       if (auto v = fold_const(e)) return *v;
       fail("unsupported function kind for " + e.name, e.raw);
-    }
-    // Nullary math constants stanc's optimizer will not fold because their
-    // value is non-finite (or, for machine_precision, platform-specific).
-    // They are plain constant slots here, same as the interpreter returns.
-    if (e.args.empty()) {
-      if (e.name == "not_a_number")
-        return constant(std::numeric_limits<double>::quiet_NaN());
-      if (e.name == "positive_infinity")
-        return constant(std::numeric_limits<double>::infinity());
-      if (e.name == "negative_infinity")
-        return constant(-std::numeric_limits<double>::infinity());
-      if (e.name == "machine_precision")
-        return constant(std::numeric_limits<double>::epsilon());
     }
     // Construct the lazy argument state exactly once. Resolver and handlers
     // inspect source metadata freely; values are still acquired only when the

--- a/runtime/src/mir_reader.cpp
+++ b/runtime/src/mir_reader.cpp
@@ -1,3 +1,4 @@
+#include <stanli/callable_transform.hpp>
 #include <stanli/mir.hpp>
 #include <stanli/optable.hpp>
 
@@ -332,20 +333,11 @@ void validate_funapp_arity(const Expr& e) {
     return;
   }
 
-  const auto validate_transform_call = [&](const char* stem, size_t arity) {
-    const std::string prefix(stem);
-    if (e.name.compare(0, prefix.size(), prefix) != 0) return false;
-    const std::string tail = e.name.substr(prefix.size());
-    if (tail != "constrain" && tail != "jacobian" && tail != "unconstrain")
-      return false;
-    require_arity(e, arity);
-    return true;
-  };
-  if (validate_transform_call("lower_bound_", 2) ||
-      validate_transform_call("upper_bound_", 2) ||
-      validate_transform_call("lower_upper_bound_", 3) ||
-      validate_transform_call("offset_multiplier_", 3))
+  CallableTransformSpec transform;
+  if (callable_transform(e.name, &transform)) {
+    require_arity(e, transform.arity);
     return;
+  }
 
   std::string ode_name = e.name;
   bool ode_tolerance = false;

--- a/runtime/src/program.cpp
+++ b/runtime/src/program.cpp
@@ -41,6 +41,12 @@ void each_write(const Program& p, const Program::Instr& I, F fn) {
     fn(Span{c.scratch, c.scratch_len});
     return;
   }
+  if (I.code == Program::TRANSFORM) {
+    const Program::Transform& tr = p.transforms[(size_t)I.a];
+    fn(Span{tr.out, tr.out_len});
+    fn(Span{tr.jac, 1});
+    return;
+  }
   const int len = program_output_len(I);
   if (len > 0) fn(Span{I.dst, len});
 }
@@ -50,6 +56,11 @@ void each_read(const Program& p, const Program::Instr& I, F fn) {
   if (I.code == Program::CALL) {
     const Program::Call& c = p.calls[(size_t)I.a];
     for (int j = 0; j < c.n_in; ++j) fn(Span{c.in[j], c.in_len[j]});
+    return;
+  }
+  if (I.code == Program::TRANSFORM) {
+    const Program::Transform& tr = p.transforms[(size_t)I.a];
+    for (int k = 0; k < tr.n_in; ++k) fn(Span{tr.in[k], tr.in_len[k]});
     return;
   }
   if (I.code == Program::DENSITY) {
@@ -90,6 +101,13 @@ void remap(Program::Call& c, const std::vector<int>& m) {
   if (c.scratch_len > 0) c.scratch = m[(size_t)c.scratch];
 }
 
+void remap(Program::Transform& tr, const std::vector<int>& m) {
+  for (int k = 0; k < tr.n_in; ++k)
+    if (tr.in_len[k] > 0) tr.in[k] = m[(size_t)tr.in[k]];
+  if (tr.out_len > 0) tr.out = m[(size_t)tr.out];
+  tr.jac = m[(size_t)tr.jac];
+}
+
 void remap(Program::VecDensity& v, const std::vector<int>& m) {
   for (int k = 0; k < v.arity; ++k) v.arg_reg[k] = m[(size_t)v.arg_reg[k]];
 }
@@ -101,7 +119,7 @@ void remap(Program::Print& print, const std::vector<int>& m) {
 }
 
 void remap(Program::Instr& I, const std::vector<int>& m) {
-  if (I.code == Program::CALL) return;
+  if (I.code == Program::CALL || I.code == Program::TRANSFORM) return;
   const ProgramOpSpec& spec = program_code_spec(I.code);
   if (program_output_len(I) > 0) I.dst = m[(size_t)I.dst];
   // DENSITY_VEC's `a` is a vec_densities index, not a register; its own
@@ -132,7 +150,8 @@ bool forwardable_producer(Program::Code code) {
   // output and scratch ranges outside Instr. Instructions without a generated
   // adjoint are outside this experiment as well: the important saving is the
   // producer/copy pair in both the forward and generated reverse streams.
-  if (code == Program::MOV || code == Program::MOVR || code == Program::CALL)
+  if (code == Program::MOV || code == Program::MOVR || code == Program::CALL ||
+      code == Program::TRANSFORM)
     return false;
   const ProgramOpSpec& spec = program_code_spec(code);
   return !spec.has(kProgramNoOutput) && !spec.has(kProgramNoAdjoint);
@@ -254,6 +273,9 @@ bool compact_program_gated(Program& p, std::vector<std::pair<int, int>>& seeded,
         I.code == Program::DIAG_POST_MULTIPLY)
       return false;
     if (I.code == Program::CALL && (I.a < 0 || (size_t)I.a >= p.calls.size()))
+      return false;
+    if (I.code == Program::TRANSFORM &&
+        (I.a < 0 || (size_t)I.a >= p.transforms.size()))
       return false;
     if (I.code == Program::DENSITY_VEC &&
         (I.a < 0 || (size_t)I.a >= p.vec_densities.size()))
@@ -455,6 +477,7 @@ bool compact_program_gated(Program& p, std::vector<std::pair<int, int>>& seeded,
     if (remove[i]) continue;
     Program::Instr I = p.code[i];
     if (I.code == Program::CALL) remap(p.calls[(size_t)I.a], map);
+    if (I.code == Program::TRANSFORM) remap(p.transforms[(size_t)I.a], map);
     if (I.code == Program::DENSITY_VEC)
       remap(p.vec_densities[(size_t)I.a], map);
     if (I.code == Program::PRINT) remap(p.prints[(size_t)I.a], map);

--- a/runtime/src/program.cpp
+++ b/runtime/src/program.cpp
@@ -69,6 +69,12 @@ void each_read(const Program& p, const Program::Instr& I, F fn) {
       fn(Span{v.arg_reg[k], ((v.container_mask >> k) & 1u) ? v.len : 1});
     return;
   }
+  if (I.code == Program::PRINT) {
+    const Program::Print& print = p.prints[(size_t)I.a];
+    for (size_t k = 0; k < print.value_reg.size(); ++k)
+      fn(Span{print.value_reg[k], print.value_len[k]});
+    return;
+  }
   const ProgramOpSpec& spec = program_code_spec(I.code);
   if (spec.has(kProgramNoInputs)) return;
   fn(Span{I.a, spec.has(kProgramRangeA) ? I.len : 1});
@@ -86,6 +92,12 @@ void remap(Program::Call& c, const std::vector<int>& m) {
 
 void remap(Program::VecDensity& v, const std::vector<int>& m) {
   for (int k = 0; k < v.arity; ++k) v.arg_reg[k] = m[(size_t)v.arg_reg[k]];
+}
+
+void remap(Program::Print& print, const std::vector<int>& m) {
+  for (size_t k = 0; k < print.value_reg.size(); ++k)
+    if (print.value_len[k] > 0)
+      print.value_reg[k] = m[(size_t)print.value_reg[k]];
 }
 
 void remap(Program::Instr& I, const std::vector<int>& m) {
@@ -245,6 +257,8 @@ bool compact_program_gated(Program& p, std::vector<std::pair<int, int>>& seeded,
       return false;
     if (I.code == Program::DENSITY_VEC &&
         (I.a < 0 || (size_t)I.a >= p.vec_densities.size()))
+      return false;
+    if (I.code == Program::PRINT && (I.a < 0 || (size_t)I.a >= p.prints.size()))
       return false;
   }
 
@@ -443,6 +457,7 @@ bool compact_program_gated(Program& p, std::vector<std::pair<int, int>>& seeded,
     if (I.code == Program::CALL) remap(p.calls[(size_t)I.a], map);
     if (I.code == Program::DENSITY_VEC)
       remap(p.vec_densities[(size_t)I.a], map);
+    if (I.code == Program::PRINT) remap(p.prints[(size_t)I.a], map);
     remap(I, map);
     if (branches(I.code)) I.dst = new_pc[(size_t)I.dst];
     code.push_back(I);

--- a/runtime/src/program_transform.cpp
+++ b/runtime/src/program_transform.cpp
@@ -1,0 +1,120 @@
+#include <stanli/program.hpp>
+
+#include <stan/math.hpp>
+
+#include <algorithm>
+
+namespace stanli {
+namespace {
+
+template <typename T>
+void run_transform(const Program::Transform& tr, T* reg) {
+  T lp = 0.0;
+  const auto bound = [&](int k, int i) -> const T& {
+    return reg[tr.in[k] + (tr.in_len[k] == 1 ? 0 : i)];
+  };
+  switch (tr.kind) {
+    case CallableTransformKind::Lower:
+      for (int i = 0; i < tr.out_len; ++i)
+        reg[tr.out + i] = tr.direction == TransformDirection::Unconstrain
+                              ? stan::math::lb_free(reg[tr.in[0] + i], bound(1, i))
+                              : stan::math::lb_constrain(reg[tr.in[0] + i],
+                                                         bound(1, i), lp);
+      break;
+    case CallableTransformKind::Upper:
+      for (int i = 0; i < tr.out_len; ++i)
+        reg[tr.out + i] = tr.direction == TransformDirection::Unconstrain
+                              ? stan::math::ub_free(reg[tr.in[0] + i], bound(1, i))
+                              : stan::math::ub_constrain(reg[tr.in[0] + i],
+                                                         bound(1, i), lp);
+      break;
+    case CallableTransformKind::LowerUpper:
+      for (int i = 0; i < tr.out_len; ++i)
+        reg[tr.out + i] = tr.direction == TransformDirection::Unconstrain
+                              ? stan::math::lub_free(reg[tr.in[0] + i], bound(1, i),
+                                                     bound(2, i))
+                              : stan::math::lub_constrain(reg[tr.in[0] + i],
+                                                          bound(1, i), bound(2, i), lp);
+      break;
+    case CallableTransformKind::OffsetMultiplier:
+      for (int i = 0; i < tr.out_len; ++i)
+        reg[tr.out + i] =
+            tr.direction == TransformDirection::Unconstrain
+                ? stan::math::offset_multiplier_free(reg[tr.in[0] + i], bound(1, i),
+                                                      bound(2, i))
+                : stan::math::offset_multiplier_constrain(
+                      reg[tr.in[0] + i], bound(1, i), bound(2, i), lp);
+      break;
+    default: {
+      using Vec = Eigen::Matrix<T, Eigen::Dynamic, 1>;
+      using Mat = Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>;
+      const int con = tr.out_len / std::max(tr.batch, 1);
+      for (int b = 0; b < tr.batch; ++b) {
+        const T* input = reg + tr.in[0] + b * tr.inner_raw;
+        T* output = reg + tr.out + b * con;
+        if (tr.kind == CallableTransformKind::StochasticColumn ||
+            tr.kind == CallableTransformKind::StochasticRow ||
+            (tr.kind == CallableTransformKind::SumToZero && tr.out_cols)) {
+          const int rr = tr.out_rows -
+              (tr.kind == CallableTransformKind::StochasticColumn ||
+               tr.kind == CallableTransformKind::SumToZero);
+          const int rc = tr.out_cols -
+              (tr.kind == CallableTransformKind::StochasticRow ||
+               tr.kind == CallableTransformKind::SumToZero);
+          Eigen::Map<const Mat> y(input, rr, rc);
+          Mat x;
+          if (tr.kind == CallableTransformKind::StochasticColumn)
+            x = stan::math::stochastic_column_constrain(y, lp);
+          else if (tr.kind == CallableTransformKind::StochasticRow)
+            x = stan::math::stochastic_row_constrain(y, lp);
+          else
+            x = stan::math::sum_to_zero_constrain(y);
+          for (int i = 0; i < con; ++i) output[i] = x.data()[i];
+          continue;
+        }
+        Eigen::Map<const Vec> y(input, tr.inner_raw);
+        if (tr.out_cols) {
+          Mat x;
+          if (tr.kind == CallableTransformKind::CholeskyFactorCorr)
+            x = stan::math::cholesky_corr_constrain(y, tr.out_rows, lp);
+          else if (tr.kind == CallableTransformKind::CorrMatrix)
+            x = stan::math::corr_matrix_constrain(y, tr.out_rows, lp);
+          else if (tr.kind == CallableTransformKind::CovMatrix)
+            x = stan::math::cov_matrix_constrain(y, tr.out_rows, lp);
+          else
+            x = stan::math::cholesky_factor_constrain(y, tr.out_rows,
+                                                      tr.out_cols, lp);
+          for (int i = 0; i < con; ++i) output[i] = x.data()[i];
+        } else {
+          Vec x;
+          if (tr.kind == CallableTransformKind::Ordered)
+            x = stan::math::ordered_constrain(y, lp);
+          else if (tr.kind == CallableTransformKind::PositiveOrdered)
+            x = stan::math::positive_ordered_constrain(y, lp);
+          else if (tr.kind == CallableTransformKind::Simplex)
+            x = stan::math::simplex_constrain(y, lp);
+          else if (tr.kind == CallableTransformKind::UnitVector)
+            x = stan::math::unit_vector_constrain(y, lp);
+          else
+            x = stan::math::sum_to_zero_constrain(y);
+          for (int i = 0; i < con; ++i) output[i] = x[i];
+        }
+      }
+      break;
+    }
+  }
+  reg[tr.jac] = lp;
+}
+
+}  // namespace
+
+void run_program_transform(const Program::Transform& tr, double* reg) {
+  run_transform(tr, reg);
+}
+
+void run_program_transform(const Program::Transform& tr,
+                           stan::math::var* reg) {
+  run_transform(tr, reg);
+}
+
+}  // namespace stanli

--- a/runtime/src/program_transform.cpp
+++ b/runtime/src/program_transform.cpp
@@ -16,32 +16,33 @@ void run_transform(const Program::Transform& tr, T* reg) {
   switch (tr.kind) {
     case CallableTransformKind::Lower:
       for (int i = 0; i < tr.out_len; ++i)
-        reg[tr.out + i] = tr.direction == TransformDirection::Unconstrain
-                              ? stan::math::lb_free(reg[tr.in[0] + i], bound(1, i))
-                              : stan::math::lb_constrain(reg[tr.in[0] + i],
-                                                         bound(1, i), lp);
+        reg[tr.out + i] =
+            tr.direction == TransformDirection::Unconstrain
+                ? stan::math::lb_free(reg[tr.in[0] + i], bound(1, i))
+                : stan::math::lb_constrain(reg[tr.in[0] + i], bound(1, i), lp);
       break;
     case CallableTransformKind::Upper:
       for (int i = 0; i < tr.out_len; ++i)
-        reg[tr.out + i] = tr.direction == TransformDirection::Unconstrain
-                              ? stan::math::ub_free(reg[tr.in[0] + i], bound(1, i))
-                              : stan::math::ub_constrain(reg[tr.in[0] + i],
-                                                         bound(1, i), lp);
+        reg[tr.out + i] =
+            tr.direction == TransformDirection::Unconstrain
+                ? stan::math::ub_free(reg[tr.in[0] + i], bound(1, i))
+                : stan::math::ub_constrain(reg[tr.in[0] + i], bound(1, i), lp);
       break;
     case CallableTransformKind::LowerUpper:
       for (int i = 0; i < tr.out_len; ++i)
-        reg[tr.out + i] = tr.direction == TransformDirection::Unconstrain
-                              ? stan::math::lub_free(reg[tr.in[0] + i], bound(1, i),
-                                                     bound(2, i))
-                              : stan::math::lub_constrain(reg[tr.in[0] + i],
-                                                          bound(1, i), bound(2, i), lp);
+        reg[tr.out + i] =
+            tr.direction == TransformDirection::Unconstrain
+                ? stan::math::lub_free(reg[tr.in[0] + i], bound(1, i),
+                                       bound(2, i))
+                : stan::math::lub_constrain(reg[tr.in[0] + i], bound(1, i),
+                                            bound(2, i), lp);
       break;
     case CallableTransformKind::OffsetMultiplier:
       for (int i = 0; i < tr.out_len; ++i)
         reg[tr.out + i] =
             tr.direction == TransformDirection::Unconstrain
-                ? stan::math::offset_multiplier_free(reg[tr.in[0] + i], bound(1, i),
-                                                      bound(2, i))
+                ? stan::math::offset_multiplier_free(reg[tr.in[0] + i],
+                                                     bound(1, i), bound(2, i))
                 : stan::math::offset_multiplier_constrain(
                       reg[tr.in[0] + i], bound(1, i), bound(2, i), lp);
       break;
@@ -56,11 +57,11 @@ void run_transform(const Program::Transform& tr, T* reg) {
             tr.kind == CallableTransformKind::StochasticRow ||
             (tr.kind == CallableTransformKind::SumToZero && tr.out_cols)) {
           const int rr = tr.out_rows -
-              (tr.kind == CallableTransformKind::StochasticColumn ||
-               tr.kind == CallableTransformKind::SumToZero);
-          const int rc = tr.out_cols -
-              (tr.kind == CallableTransformKind::StochasticRow ||
-               tr.kind == CallableTransformKind::SumToZero);
+                         (tr.kind == CallableTransformKind::StochasticColumn ||
+                          tr.kind == CallableTransformKind::SumToZero);
+          const int rc =
+              tr.out_cols - (tr.kind == CallableTransformKind::StochasticRow ||
+                             tr.kind == CallableTransformKind::SumToZero);
           Eigen::Map<const Mat> y(input, rr, rc);
           Mat x;
           if (tr.kind == CallableTransformKind::StochasticColumn)
@@ -112,8 +113,7 @@ void run_program_transform(const Program::Transform& tr, double* reg) {
   run_transform(tr, reg);
 }
 
-void run_program_transform(const Program::Transform& tr,
-                           stan::math::var* reg) {
+void run_program_transform(const Program::Transform& tr, stan::math::var* reg) {
   run_transform(tr, reg);
 }
 

--- a/tests/fixtures/callable_jacobians.stan
+++ b/tests/fixtures/callable_jacobians.stan
@@ -1,0 +1,56 @@
+functions {
+  real all_jacobians_jacobian(vector v, vector cv, matrix m,
+                              array[] vector av, array[] matrix am,
+                              array[] vector acv) {
+    real z = 0;
+    z += sum(lower_bound_jacobian(v, -2));
+    z += sum(upper_bound_jacobian(v, 2));
+    z += sum(lower_upper_bound_jacobian(v, -2, 2));
+    z += sum(offset_multiplier_jacobian(v, 0.5, 1.5));
+    z += sum(ordered_jacobian(v));
+    z += sum(positive_ordered_jacobian(v));
+    z += sum(simplex_jacobian(v));
+    z += sum(stochastic_column_jacobian(m));
+    z += sum(stochastic_row_jacobian(m));
+    z += sum(sum_to_zero_jacobian(v));
+    z += sum(sum_to_zero_jacobian(m));
+    z += sum(unit_vector_jacobian(v));
+    z += sum(cholesky_factor_corr_jacobian(v, 3));
+    z += sum(corr_matrix_jacobian(v, 3));
+    z += sum(cov_matrix_jacobian(v, 2));
+    z += sum(cholesky_factor_cov_jacobian(cv, 3, 2));
+    // Representative array overloads for each result geometry. The
+    // Jacobian applies to every array element even though the value side
+    // below deliberately reads only one.
+    z += sum(simplex_jacobian(av)[1]);
+    z += sum(stochastic_column_jacobian(am)[1]);
+    z += sum(corr_matrix_jacobian(av, 3)[1]);
+    z += sum(cholesky_factor_cov_jacobian(acv, 3, 2)[1]);
+    return z;
+  }
+}
+parameters {
+  real probe;
+  vector[3] v;
+  vector[5] cv;
+  matrix[2, 2] m;
+  array[2] vector[3] av;
+  array[2] matrix[2, 2] am;
+  array[2] vector[5] acv;
+}
+transformed parameters {
+  real graph_jacobians = all_jacobians_jacobian(v, cv, m, av, am, acv);
+  real branch_jacobians = 0;
+  if (probe > 0)
+    branch_jacobians = all_jacobians_jacobian(v, cv, m, av, am, acv);
+}
+model {
+  target += graph_jacobians + branch_jacobians;
+  probe ~ normal(0, 1);
+  v ~ normal(0, 1);
+  cv ~ normal(0, 1);
+  to_vector(m) ~ normal(0, 1);
+  for (a in av) a ~ normal(0, 1);
+  for (a in am) to_vector(a) ~ normal(0, 1);
+  for (a in acv) a ~ normal(0, 1);
+}

--- a/tests/fixtures/necessity_print_only.stan
+++ b/tests/fixtures/necessity_print_only.stan
@@ -1,0 +1,8 @@
+// A parameter-dependent effect with no numeric live-out. The necessity
+// island must survive lowering solely because its taken arm can print.
+parameters {
+  real x;
+}
+model {
+  if (x > 0) print("print-only x=", x);
+}

--- a/tests/fixtures/runtime_extrema_grouping.stan
+++ b/tests/fixtures/runtime_extrema_grouping.stan
@@ -1,0 +1,15 @@
+data {
+  int mode;
+}
+parameters {
+  real probe;
+  matrix[2, 2] m;
+}
+model {
+  if (probe > 0) {
+    if (mode == 1)
+      target += 1 / min(m[1]);
+    else
+      target += 1 / max(m[1]);
+  }
+}

--- a/tests/tbb_stub.cpp
+++ b/tests/tbb_stub.cpp
@@ -1,11 +1,16 @@
 // Single-threaded tests: stan-math's rev core registers a TBB thread observer
 // so each worker gets its own AD tape. We run one thread and build no TBB, so
-// provide the one symbol the observer base class needs.
+// provide the observer and current-arena symbols it needs.
 #if defined(__APPLE__)
 extern "C" void stanli_observe_stub(void*, bool) {}
+extern "C" int stanli_current_slot_stub() { return 0; }
 asm(".globl __ZN3tbb8internal26task_scheduler_observer_v37observeEb\n"
     "__ZN3tbb8internal26task_scheduler_observer_v37observeEb = "
-    "_stanli_observe_stub\n");
+    "_stanli_observe_stub\n"
+    ".globl "
+    "__ZN3tbb10interface78internal15task_arena_base21internal_current_slotEv\n"
+    "__ZN3tbb10interface78internal15task_arena_base21internal_current_slotEv = "
+    "_stanli_current_slot_stub\n");
 #else
 namespace tbb {
 namespace internal {
@@ -15,5 +20,14 @@ class task_scheduler_observer_v3 {
 };
 void task_scheduler_observer_v3::observe(bool) {}
 }  // namespace internal
+inline namespace interface7 {
+namespace internal {
+class task_arena_base {
+ public:
+  static int internal_current_slot();
+};
+int task_arena_base::internal_current_slot() { return 0; }
+}  // namespace internal
+}  // namespace interface7
 }  // namespace tbb
 #endif

--- a/tests/test_bridgestan.cpp
+++ b/tests/test_bridgestan.cpp
@@ -791,36 +791,52 @@ void test_print_callback() {
   bs_model_destruct(m);
 }
 
-void test_necessity_effects_refused() {
+void test_necessity_effects() {
   const std::string mir = slurp("tests/fixtures/necessity_effects.tmir.sexp");
   char* err = nullptr;
   expect_eq_int("necessity callback install",
                 bs_set_print_callback(&collect_print, &err), 0);
 
-  for (int mode = 1; mode <= 2; ++mode) {
-    const std::string effect = mode == 1 ? "FnPrint" : "FnReject";
-    nlohmann::json root = {{"mode", mode}};
-    root["__stanli"] = {{"build_id", stanli::bs_build_id()},
-                        {"mir", mir},
-                        {"name", "necessity_effects"}};
-    g_printed.clear();
-    err = nullptr;
-    bs_model* m = bs_model_construct(root.dump().c_str(), 1, &err);
-    if (m != nullptr) {
-      fail("BridgeStan accepted necessity island containing " + effect);
-      bs_model_destruct(m);
-    } else if (err == nullptr ||
-               std::string(err).find("runtime-control region") ==
-                   std::string::npos ||
-               std::string(err).find(effect) == std::string::npos) {
-      fail("BridgeStan necessity " + effect +
-           " error: " + (err != nullptr ? err : "(no message)"));
-    }
+  nlohmann::json root = {{"mode", 1}};
+  root["__stanli"] = {{"build_id", stanli::bs_build_id()},
+                      {"mir", mir},
+                      {"name", "necessity_effects"}};
+  g_printed.clear();
+  bs_model* m = bs_model_construct(root.dump().c_str(), 1, &err);
+  if (m == nullptr) {
+    fail("BridgeStan refused necessity print: " +
+         std::string(err != nullptr ? err : "(no message)"));
     bs_free_error_msg(err);
-    if (!g_printed.empty())
-      fail("BridgeStan executed " + effect + " while refusing: [" + g_printed +
-           "]");
+  } else {
+    const double q = 0.1;
+    double lp = 0, grad = 0;
+    g_printed.clear();
+    expect_eq_int("BridgeStan necessity print gradient",
+                  bs_log_density_gradient(m, true, true, &q, &lp, &grad, &err),
+                  0);
+    if (g_printed != "positive x=0.1\n")
+      fail("BridgeStan necessity print did not execute exactly once: [" +
+           g_printed + "]");
+    bs_model_destruct(m);
   }
+
+  root["mode"] = 2;
+  g_printed.clear();
+  err = nullptr;
+  m = bs_model_construct(root.dump().c_str(), 1, &err);
+  if (m != nullptr) {
+    fail("BridgeStan accepted runtime-valued necessity reject");
+    bs_model_destruct(m);
+  } else if (err == nullptr ||
+             std::string(err).find("runtime-control region") ==
+                 std::string::npos ||
+             std::string(err).find("FnReject") == std::string::npos) {
+    fail("BridgeStan necessity FnReject error: " +
+         std::string(err != nullptr ? err : "(no message)"));
+  }
+  bs_free_error_msg(err);
+  if (!g_printed.empty())
+    fail("BridgeStan executed FnReject while refusing: [" + g_printed + "]");
 
   err = nullptr;
   expect_eq_int("necessity callback clear",
@@ -1115,7 +1131,7 @@ int main() {
   test_unsupported();
   test_initialize();
   test_print_callback();
-  test_necessity_effects_refused();
+  test_necessity_effects();
   test_manifest();
   test_embedded_manifest();
   test_construct_errors();

--- a/tests/test_capi.cpp
+++ b/tests/test_capi.cpp
@@ -509,26 +509,38 @@ void expect_compiled_scalar_rng() {
   stanli_model_free(model);
 }
 
-void expect_necessity_effects_refused() {
+void expect_necessity_effects() {
   const std::string mir = slurp("tests/fixtures/necessity_effects.tmir.sexp");
-  for (int mode = 1; mode <= 2; ++mode) {
-    const std::string effect = mode == 1 ? "FnPrint" : "FnReject";
-    const std::string data = "{\"mode\":" + std::to_string(mode) + "}";
-    char err[8192]{};
-    stanli_model* model =
-        stanli_model_new(mir.c_str(), data.c_str(), err, sizeof err);
-    if (model != nullptr) {
+  char err[8192]{};
+  stanli_model* model =
+      stanli_model_new(mir.c_str(), "{\"mode\":1}", err, sizeof err);
+  if (model == nullptr) {
+    ++failures;
+    std::printf("FAIL C API refused necessity print: %s\n", err);
+  } else {
+    const double q = 0.1;
+    double lp = 0, grad = 0;
+    if (stanli_grad(model, &q, &lp, &grad) != 0 || lp != 0.1 || grad != 1.0) {
       ++failures;
-      std::printf("FAIL C API accepted necessity island containing %s\n",
-                  effect.c_str());
-      stanli_model_free(model);
-      continue;
+      std::printf(
+          "FAIL C API necessity print evaluation: lp %.17g grad %.17g\n", lp,
+          grad);
     }
+    stanli_model_free(model);
+  }
+
+  std::fill(std::begin(err), std::end(err), '\0');
+  model = stanli_model_new(mir.c_str(), "{\"mode\":2}", err, sizeof err);
+  if (model != nullptr) {
+    ++failures;
+    std::printf("FAIL C API accepted runtime-valued necessity reject\n");
+    stanli_model_free(model);
+  } else {
     const std::string msg = err;
     if (msg.find("runtime-control region") == std::string::npos ||
-        msg.find(effect) == std::string::npos) {
+        msg.find("FnReject") == std::string::npos) {
       ++failures;
-      std::printf("FAIL C API necessity %s error: %s\n", effect.c_str(), err);
+      std::printf("FAIL C API necessity FnReject error: %s\n", err);
     }
   }
 }
@@ -792,7 +804,7 @@ int main() {
   expect_categorical_check();
   expect_categorical_interpreted_write_array();
   expect_compiled_scalar_rng();
-  expect_necessity_effects_refused();
+  expect_necessity_effects();
   expect_pathfinder();
   expect_sampling_progress();
   expect_streaming_stats();

--- a/tests/test_lower.cpp
+++ b/tests/test_lower.cpp
@@ -5148,6 +5148,45 @@ int main() {
     }
   }
 
+  // Runtime-control Programs materialize matrix rows into contiguous
+  // registers, but min/max must retain the source Matrix<var> scalar
+  // traversal. Interior NaNs and signed-zero ties make that grouping
+  // observable in both the value and the selected adjoint.
+  {
+    DataMap data;
+    data.set_int("mode", 1);
+    CompiledModel mm = compile_model(
+        slurp("tests/fixtures/runtime_extrema_grouping.tmir.sexp"), data);
+    check(count_opcode(mm, OP_ISLAND) > 0,
+          "runtime extrema grouping uses a control-flow island");
+    Executor mex(std::move(mm.graph));
+    mm.bind(mex);
+    const double q[] = {0.1, -4.0, -4.0,
+                        std::numeric_limits<double>::quiet_NaN(), -4.0};
+    for (int i = 0; i < 5; ++i) mex.params_data()[i] = q[i];
+    double grad[5] = {0};
+    expect_eq("runtime row min lp", mex.gradient(grad), -0.25);
+    expect_eq("runtime row min selected grad", grad[1], -0.0625);
+    expect_eq("runtime row min NaN grad", grad[3], 0.0);
+  }
+  {
+    DataMap data;
+    data.set_int("mode", 2);
+    CompiledModel mm = compile_model(
+        slurp("tests/fixtures/runtime_extrema_grouping.tmir.sexp"), data);
+    Executor mex(std::move(mm.graph));
+    mm.bind(mex);
+    const double q[] = {0.1, -0.0, -2.0, +0.0, -3.0};
+    for (int i = 0; i < 5; ++i) mex.params_data()[i] = q[i];
+    double grad[5] = {0};
+    const double lp = mex.gradient(grad);
+    check(std::isinf(lp) && std::signbit(lp),
+          "runtime row max retains the first signed-zero tie");
+    check(std::isinf(grad[1]) && std::signbit(grad[1]),
+          "runtime row max routes the tied adjoint to the first coefficient");
+    expect_eq("runtime row max second tie grad", grad[3], 0.0);
+  }
+
   // Every callable Jacobian transform, including the two stochastic-matrix
   // families and representative array overloads. The unconditional call is
   // graph-lowered; the parameter-dependent transformed-parameter branch is

--- a/tests/test_lower.cpp
+++ b/tests/test_lower.cpp
@@ -5148,6 +5148,37 @@ int main() {
     }
   }
 
+  // Every callable Jacobian transform, including the two stochastic-matrix
+  // families and representative array overloads. The unconditional call is
+  // graph-lowered; the parameter-dependent transformed-parameter branch is
+  // compiled into a typed Program::TRANSFORM and replayed under var.
+  {
+    CompiledModel jm = compile_model(
+        slurp("tests/fixtures/callable_jacobians.tmir.sexp"), DataMap());
+    check(jm.n_unconstrained == 37, "callable jacobians parameter width");
+    check(count_opcode(jm, OP_CONSTRAIN_STOCHASTIC_COLUMN) > 0,
+          "callable stochastic-column graph kernel");
+    check(count_opcode(jm, OP_CONSTRAIN_STOCHASTIC_ROW) > 0,
+          "callable stochastic-row graph kernel");
+    check(count_opcode(jm, OP_ISLAND) > 0,
+          "callable jacobians runtime-control island");
+    Executor jex(std::move(jm.graph));
+    jm.bind(jex);
+    std::vector<double> gradient((size_t)jm.n_unconstrained);
+    double lp[2] = {0, 0};
+    for (int side = 0; side < 2; ++side) {
+      for (int64_t i = 0; i < jm.n_unconstrained; ++i)
+        jex.params_data()[i] = 0.025 * (double)(i + 1);
+      jex.params_data()[0] = side ? 0.5 : -0.5;
+      lp[side] = jex.gradient(gradient.data());
+      check(std::isfinite(lp[side]), "callable jacobians finite log density");
+      check(std::all_of(gradient.begin(), gradient.end(),
+                        [](double x) { return std::isfinite(x); }),
+            "callable jacobians finite gradient");
+    }
+    check(lp[0] != lp[1], "callable jacobians runtime branch changes target");
+  }
+
   // tests/fixtures/infbounds.stan: infinite bounds on the declarations
   // themselves. An infinite bound is no bound -- the element is the
   // identity and adds no jacobian term -- and the kernels used to

--- a/tests/test_mir_program_conformance.cpp
+++ b/tests/test_mir_program_conformance.cpp
@@ -672,7 +672,7 @@ void test_nested_print_effect() {
   run_case("nested print effect",
            "print in a UDF emits exactly once before returning",
            {std::move(entry), std::move(echo)}, 1.0, {1.0},
-           "nested print x=1\n", "FnPrint");
+           "nested print x=1\n");
 }
 
 void test_print_then_reject_effects() {
@@ -688,7 +688,8 @@ void test_print_then_reject_effects() {
   run_domain_error_case(
       "print then reject effects",
       "print occurs first; reject throws domain_error with its full message",
-      {std::move(entry)}, 1.0, "bad rhs t=1", "before reject t=1\n", "FnPrint");
+      {std::move(entry)}, 1.0, "bad rhs t=1", "before reject t=1\n",
+      "FnReject");
 }
 
 FunDef runtime_effect_rhs() {
@@ -715,11 +716,11 @@ void test_runtime_guarded_effects() {
   const FunDef entry = runtime_effect_rhs();
   run_case("untaken runtime effects",
            "a false branch emits nothing and evaluation continues", {entry},
-           1.0, {1.0}, {}, "FnPrint");
+           1.0, {1.0}, {}, "FnReject");
   run_domain_error_case(
       "taken runtime effects",
       "a true branch prints once, then reject terminates evaluation", {entry},
-      -1.0, "negative t rejected: -1", "negative branch t=-1\n", "FnPrint");
+      -1.0, "negative t rejected: -1", "negative branch t=-1\n", "FnReject");
 }
 
 void test_unknown_nrfunapp_fails_loud() {

--- a/tests/test_mir_program_conformance.cpp
+++ b/tests/test_mir_program_conformance.cpp
@@ -660,6 +660,7 @@ void test_program_extrema() {
     compiler.reals[name] = range;
     Expr input = var(name, type);
     input.unsized = {depth, leaf};
+    input.data_only = leaf != UnsizedLeaf::Int;
     return input;
   };
   auto reduce = [&](const char* name, Expr input, const char* result_type,
@@ -701,14 +702,24 @@ void test_program_extrema() {
   int extrema_count = 0;
   int min_count = 0;
   int max_count = 0;
+  int packet_count = 0;
+  int scalar_count = 0;
   for (const auto& instruction : program.code) {
     if (instruction.code != stanli::Program::EXTREMA_RANGE) continue;
     ++extrema_count;
     instruction.b == 0 ? ++min_count : ++max_count;
+    if (instruction.c & stanli::kProgramExtremaScalar)
+      ++scalar_count;
+    else
+      ++packet_count;
   }
-  if (extrema_count != 6 || min_count != 3 || max_count != 3) {
+  if (extrema_count != 6 || min_count != 3 || max_count != 3 ||
+      packet_count != 4 || scalar_count != 2) {
     ++failures;
-    std::printf("FAIL Program extrema did not share the unified opcode\n");
+    std::printf(
+        "FAIL Program extrema opcode/grouping: total=%d min=%d max=%d "
+        "packet=%d scalar=%d\n",
+        extrema_count, min_count, max_count, packet_count, scalar_count);
   }
 
   std::vector<double> registers(static_cast<size_t>(program.n_regs));

--- a/tests/test_mir_program_conformance.cpp
+++ b/tests/test_mir_program_conformance.cpp
@@ -516,6 +516,30 @@ void test_uninitialized_real() {
            {std::move(entry)}, 1.0, {std::numeric_limits<double>::quiet_NaN()});
 }
 
+void test_nullary_constants() {
+  // All public nullary constants, plus stanc's internal negative-infinity
+  // spelling, share one resolver across ProgramCompiler and MirInterp.
+  const auto check = [&](const std::string& name, Expr value, double expected) {
+    FunDef entry = rhs_function(
+        "nullary_" + name + "_rhs",
+        {return_value(make_array({std::move(value)}))});
+    run_case("nullary " + name, "constant compiles identically",
+             {std::move(entry)}, 1.0, {expected});
+  };
+  check("e", fun("e", {}, "UReal"), stan::math::e());
+  check("pi", fun("pi", {}, "UReal"), stan::math::pi());
+  check("machine_precision", fun("machine_precision", {}, "UReal"),
+        std::numeric_limits<double>::epsilon());
+  check("negative_infinity", fun("negative_infinity", {}, "UReal"),
+        -std::numeric_limits<double>::infinity());
+  check("positive_infinity", fun("positive_infinity", {}, "UReal"),
+        std::numeric_limits<double>::infinity());
+  check("not_a_number", fun("not_a_number", {}, "UReal"),
+        std::numeric_limits<double>::quiet_NaN());
+  check("FnNegInf", fun("FnNegInf", {}, "UReal", Expr::Lib::Internal),
+        -std::numeric_limits<double>::infinity());
+}
+
 void test_full_span_ode_vector() {
   // ODE RHS compilation is one production caller of ProgramCompiler. The
   // destination is vector[1], and y supplies a vector view of exactly that
@@ -830,6 +854,7 @@ int main() {
   test_short_circuit_or_requires_rhs();
   test_short_circuit_and_requires_rhs();
   test_uninitialized_real();
+  test_nullary_constants();
   test_full_span_ode_vector();
   test_full_span_program_views();
   test_program_extrema();

--- a/tests/test_mir_program_conformance.cpp
+++ b/tests/test_mir_program_conformance.cpp
@@ -520,9 +520,8 @@ void test_nullary_constants() {
   // All public nullary constants, plus stanc's internal negative-infinity
   // spelling, share one resolver across ProgramCompiler and MirInterp.
   const auto check = [&](const std::string& name, Expr value, double expected) {
-    FunDef entry = rhs_function(
-        "nullary_" + name + "_rhs",
-        {return_value(make_array({std::move(value)}))});
+    FunDef entry = rhs_function("nullary_" + name + "_rhs",
+                                {return_value(make_array({std::move(value)}))});
     run_case("nullary " + name, "constant compiles identically",
              {std::move(entry)}, 1.0, {expected});
   };
@@ -671,22 +670,25 @@ void test_program_extrema() {
   };
 
   std::vector<int> outputs;
-  outputs.push_back(reduce("min", bind("v", "UVector", UnsizedLeaf::Vector,
-                                       0, stanli::ViewKind::Vector),
+  outputs.push_back(reduce(
+      "min",
+      bind("v", "UVector", UnsizedLeaf::Vector, 0, stanli::ViewKind::Vector),
+      "UReal", UnsizedLeaf::Real));
+  outputs.push_back(reduce("max",
+                           bind("rv", "URowVector", UnsizedLeaf::RowVector, 0,
+                                stanli::ViewKind::RowVector),
                            "UReal", UnsizedLeaf::Real));
-  outputs.push_back(reduce("max", bind("rv", "URowVector",
-                                       UnsizedLeaf::RowVector, 0,
-                                       stanli::ViewKind::RowVector),
-                           "UReal", UnsizedLeaf::Real));
-  outputs.push_back(reduce("min", bind("m", "UMatrix", UnsizedLeaf::Matrix,
-                                       0, stanli::ViewKind::Matrix),
-                           "UReal", UnsizedLeaf::Real));
-  outputs.push_back(reduce("max", bind("ar", "UArray", UnsizedLeaf::Real, 1,
-                                       stanli::ViewKind::Array),
-                           "UReal", UnsizedLeaf::Real));
-  outputs.push_back(reduce("min", bind("ai", "UArray", UnsizedLeaf::Int, 1,
-                                       stanli::ViewKind::Array),
-                           "UInt", UnsizedLeaf::Int));
+  outputs.push_back(reduce(
+      "min",
+      bind("m", "UMatrix", UnsizedLeaf::Matrix, 0, stanli::ViewKind::Matrix),
+      "UReal", UnsizedLeaf::Real));
+  outputs.push_back(reduce(
+      "max",
+      bind("ar", "UArray", UnsizedLeaf::Real, 1, stanli::ViewKind::Array),
+      "UReal", UnsizedLeaf::Real));
+  outputs.push_back(reduce(
+      "min", bind("ai", "UArray", UnsizedLeaf::Int, 1, stanli::ViewKind::Array),
+      "UInt", UnsizedLeaf::Int));
 
   Expr lhs = lit_int(9);
   Expr rhs = lit_int(-4);
@@ -715,8 +717,8 @@ void test_program_extrema() {
   for (size_t i = 0; i < outputs.size(); ++i) {
     if (registers[static_cast<size_t>(outputs[i])] == expected[i]) continue;
     ++failures;
-    std::printf("FAIL Program extrema output %zu: got %.17g, want %.17g\n",
-                i, registers[static_cast<size_t>(outputs[i])], expected[i]);
+    std::printf("FAIL Program extrema output %zu: got %.17g, want %.17g\n", i,
+                registers[static_cast<size_t>(outputs[i])], expected[i]);
   }
 }
 

--- a/tests/test_mir_program_conformance.cpp
+++ b/tests/test_mir_program_conformance.cpp
@@ -611,6 +611,91 @@ void test_full_span_program_views() {
   }
 }
 
+void test_program_extrema() {
+  // ProgramCompiler must use the same language-level overload classifier as
+  // graph lowering and MirInterp. Exercise every one-argument surface plus
+  // the scalar integer pair, and verify that min/max share one instruction
+  // whose immediate selects the operation.
+  stanli::Program program;
+  std::map<std::string, const FunDef*> functions;
+  stanli::ProgramCompiler compiler{program, functions};
+  const double values[] = {3.0, -2.0, 7.0, 1.0};
+
+  auto bind = [&](const std::string& name, const std::string& type,
+                  UnsizedLeaf leaf, uint8_t depth, stanli::ViewKind kind) {
+    stanli::Range range{compiler.alloc(4), 4};
+    range.kind = kind;
+    if (kind == stanli::ViewKind::Matrix) {
+      range.rows = 2;
+      range.cols = 2;
+    }
+    if (kind == stanli::ViewKind::Array) {
+      range.dims = {4};
+      range.leaf = stanli::ViewKind::Flat;
+    }
+    compiler.emit_const(range.reg, values, 4);
+    compiler.reals[name] = range;
+    Expr input = var(name, type);
+    input.unsized = {depth, leaf};
+    return input;
+  };
+  auto reduce = [&](const char* name, Expr input, const char* result_type,
+                    UnsizedLeaf result_leaf) {
+    Expr call = fun(name, {std::move(input)}, result_type);
+    call.unsized = {0, result_leaf};
+    return compiler.expr(call).reg;
+  };
+
+  std::vector<int> outputs;
+  outputs.push_back(reduce("min", bind("v", "UVector", UnsizedLeaf::Vector,
+                                       0, stanli::ViewKind::Vector),
+                           "UReal", UnsizedLeaf::Real));
+  outputs.push_back(reduce("max", bind("rv", "URowVector",
+                                       UnsizedLeaf::RowVector, 0,
+                                       stanli::ViewKind::RowVector),
+                           "UReal", UnsizedLeaf::Real));
+  outputs.push_back(reduce("min", bind("m", "UMatrix", UnsizedLeaf::Matrix,
+                                       0, stanli::ViewKind::Matrix),
+                           "UReal", UnsizedLeaf::Real));
+  outputs.push_back(reduce("max", bind("ar", "UArray", UnsizedLeaf::Real, 1,
+                                       stanli::ViewKind::Array),
+                           "UReal", UnsizedLeaf::Real));
+  outputs.push_back(reduce("min", bind("ai", "UArray", UnsizedLeaf::Int, 1,
+                                       stanli::ViewKind::Array),
+                           "UInt", UnsizedLeaf::Int));
+
+  Expr lhs = lit_int(9);
+  Expr rhs = lit_int(-4);
+  lhs.unsized = rhs.unsized = {0, UnsizedLeaf::Int};
+  Expr pair = fun("max", {std::move(lhs), std::move(rhs)}, "UInt");
+  pair.unsized = {0, UnsizedLeaf::Int};
+  outputs.push_back(compiler.expr(pair).reg);
+  compiler.finish();
+
+  int extrema_count = 0;
+  int min_count = 0;
+  int max_count = 0;
+  for (const auto& instruction : program.code) {
+    if (instruction.code != stanli::Program::EXTREMA_RANGE) continue;
+    ++extrema_count;
+    instruction.b == 0 ? ++min_count : ++max_count;
+  }
+  if (extrema_count != 6 || min_count != 3 || max_count != 3) {
+    ++failures;
+    std::printf("FAIL Program extrema did not share the unified opcode\n");
+  }
+
+  std::vector<double> registers(static_cast<size_t>(program.n_regs));
+  stanli::run_program(program, registers);
+  const double expected[] = {-2.0, 7.0, -2.0, 7.0, -2.0, 9.0};
+  for (size_t i = 0; i < outputs.size(); ++i) {
+    if (registers[static_cast<size_t>(outputs[i])] == expected[i]) continue;
+    ++failures;
+    std::printf("FAIL Program extrema output %zu: got %.17g, want %.17g\n",
+                i, registers[static_cast<size_t>(outputs[i])], expected[i]);
+  }
+}
+
 void test_matrix_row_indexing() {
   // A[1] is the complete first row.  For [[1,2],[3,4]], sum(A[1]) is 3;
   // indexing a flattened register is not the same operation.
@@ -747,6 +832,7 @@ int main() {
   test_uninitialized_real();
   test_full_span_ode_vector();
   test_full_span_program_views();
+  test_program_extrema();
   test_matrix_row_indexing();
   test_mixed_integer_udf_arguments();
   test_nested_print_effect();

--- a/tests/test_rejectprint.cpp
+++ b/tests/test_rejectprint.cpp
@@ -169,12 +169,10 @@ int main() {
              lines[0] == "before scalar=0.1");
   }
 
-  // ---- parameter-dependent effects fail loud ---------------------------
-  // Generated Stan executes the taken print/reject once while evaluating
-  // the model. Necessity islands replay their register program for reverse
-  // mode, so they cannot preserve that contract yet. Refusal is the honest
-  // boundary: silently dropping either effect changes observable behavior,
-  // and dropping reject changes the posterior support.
+  // ---- parameter-dependent print executes only in the forward ---------
+  // Necessity islands replay their register program for reverse mode. The
+  // PRINT instruction is double-only, so the taken arm emits once during
+  // the forward and is silent during the var replay.
   //
   // The generated-Stan oracle at x=0.1 and x=-0.04 is:
   //
@@ -184,36 +182,81 @@ int main() {
   //      2   0.10    0.10     1  none (reject arm untaken)
   //      2  -0.04       -     -  throws domain_error once
   //
-  // Construction cannot know which parameter point a host will evaluate,
-  // so it must refuse both models before either arm can run.
   {
     const std::string effect_mir =
         slurp("tests/fixtures/necessity_effects.tmir.sexp");
-    for (int mode = 1; mode <= 2; ++mode) {
-      std::vector<std::string> lines;
-      set_message_sink([&lines](const char* text, size_t len) {
-        lines.emplace_back(text, len);
-      });
-      bool threw = false;
-      std::string msg;
-      try {
-        DataMap d;
-        d.set_int("mode", mode);
-        (void)compile_model(effect_mir, d);
-      } catch (const CompileError& e) {
-        threw = true;
-        msg = e.what();
-      }
-      set_message_sink(nullptr);
+    DataMap d;
+    d.set_int("mode", 1);
+    CompiledModel cm = compile_model(effect_mir, d);
+    Executor ex(std::move(cm.graph));
+    cm.bind(ex);
+    std::vector<double> g((size_t)ex.n_params());
+    std::vector<std::string> lines;
+    set_message_sink([&lines](const char* text, size_t len) {
+      lines.emplace_back(text, len);
+    });
 
-      const std::string effect = mode == 1 ? "FnPrint" : "FnReject";
-      const std::string tag = "necessity " + effect;
-      expect(tag + " refuses compilation", threw);
-      expect(tag + " names the unsupported effect: " + msg,
-             msg.find("runtime-control region") != std::string::npos &&
-                 msg.find(effect) != std::string::npos);
-      expect(tag + " is not executed while refusing", lines.empty());
+    ex.params_data()[0] = 0.1;
+    const double positive_lp = ex.gradient(g.data());
+    expect("necessity print positive lp", positive_lp == 0.1);
+    expect("necessity print positive gradient", g[0] == 1.0);
+    expect("necessity print runs once, got " + std::to_string(lines.size()),
+           lines.size() == 1);
+    if (lines.size() == 1)
+      expect("necessity print message: " + lines[0],
+             lines[0] == "positive x=0.1");
+
+    lines.clear();
+    ex.params_data()[0] = -0.04;
+    const double negative_lp = ex.gradient(g.data());
+    expect("necessity print negative lp", negative_lp == -0.04);
+    expect("necessity print negative gradient", g[0] == 1.0);
+    expect("untaken necessity print is silent", lines.empty());
+    set_message_sink(nullptr);
+  }
+
+  // An effect is sufficient reason to retain an island even when it has no
+  // numeric live-out and contributes nothing to target.
+  {
+    const std::string print_only_mir =
+        slurp("tests/fixtures/necessity_print_only.tmir.sexp");
+    DataMap d;
+    CompiledModel cm = compile_model(print_only_mir, d);
+    Executor ex(std::move(cm.graph));
+    cm.bind(ex);
+    std::vector<double> g((size_t)ex.n_params());
+    std::vector<std::string> lines;
+    set_message_sink([&lines](const char* text, size_t len) {
+      lines.emplace_back(text, len);
+    });
+    ex.params_data()[0] = 0.2;
+    const double lp = ex.gradient(g.data());
+    set_message_sink(nullptr);
+    expect("print-only necessity island has zero lp", lp == 0.0);
+    expect("print-only necessity island has zero gradient", g[0] == 0.0);
+    expect("print-only necessity island is retained and executes once",
+           lines.size() == 1 && lines[0] == "print-only x=0.2");
+  }
+
+  // A runtime-valued reject message remains unsupported. Unlike print, its
+  // text must be preserved in the exception, so keep refusing it until the
+  // register program has a rendered-reject payload too.
+  {
+    bool threw = false;
+    std::string msg;
+    try {
+      DataMap d;
+      d.set_int("mode", 2);
+      (void)compile_model(slurp("tests/fixtures/necessity_effects.tmir.sexp"),
+                          d);
+    } catch (const CompileError& e) {
+      threw = true;
+      msg = e.what();
     }
+    expect("necessity runtime-valued reject refuses compilation", threw);
+    expect("necessity reject error names the unsupported effect: " + msg,
+           msg.find("runtime-control region") != std::string::npos &&
+               msg.find("FnReject") != std::string::npos);
   }
 
   if (failures == 0) std::printf("test_rejectprint: all checks passed\n");


### PR DESCRIPTION
## Summary of Changes

- Support `print` statements inside parameter-dependent runtime-control islands without duplicating effects during autodiff replay.
- Lower all 15 callable Jacobian transform families across graph, interpreter, and register-program paths, including structured and array overloads.
- Replace the register backend’s `MAX_RANGE` special case with a unified, typed `EXTREMA_RANGE` implementation supporting `min` and `max`.
- Centralise all nullary mathematical constants—including infinities, NaN, π, e, machine precision, and `FnNegInf`—across every execution backend.
- Add regression and cross-backend conformance coverage for the new lowering paths and supported overloads.