### PR TITLE
Expanding register-program function support 

### DIFF
--- a/runtime/include/stanli/graph.hpp
+++ b/runtime/include/stanli/graph.hpp
@@ -5,6 +5,7 @@
 #define STANLI_GRAPH_HPP
 
 #include <stanli/kernel_types.hpp>
+#include <stanli/message.hpp>
 
 #include <algorithm>
 #include <cstdint>
@@ -133,13 +134,6 @@ struct Graph {
 
  private:
   std::shared_ptr<const std::vector<int>> compact_idata_;
-};
-
-// Payload for OP_REJECT and OP_PRINT: the literal chunks of the message,
-// interleaved with the op's inputs at forward time. Chunk k precedes
-// input k; a trailing chunk with no input after it is just appended.
-struct MessageSpec {
-  std::vector<std::string> chunks;
 };
 
 // Payload for generated runtime bound and dimension checks.

--- a/runtime/include/stanli/message.hpp
+++ b/runtime/include/stanli/message.hpp
@@ -1,0 +1,70 @@
+// Shared semantics for Stan's print() and reject() statement functions.
+//
+// Backends deliberately keep their own value handles (graph slots, Program
+// registers, or interpreted Values).  What is common is the statement-function
+// dispatch, the literal template, the rendering rules, and the final effect.
+#ifndef STANLI_MESSAGE_HPP
+#define STANLI_MESSAGE_HPP
+
+#include <cstddef>
+#include <cstdint>
+#include <optional>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace stanli {
+
+enum class MessageAction : uint8_t { Print, Reject };
+
+inline std::optional<MessageAction> message_action(std::string_view name) {
+  if (name == "FnPrint") return MessageAction::Print;
+  if (name == "FnReject") return MessageAction::Reject;
+  return std::nullopt;
+}
+
+// Literal chunks surrounding runtime values.  There is exactly one more
+// chunk than value: chunk k precedes value k, and the final chunk trails it.
+struct MessageSpec {
+  std::vector<std::string> chunks;
+};
+
+// Render through accessors instead of owning a particular backend's values.
+// size(k) gives the flattened width of value k; value(k, i) gives its ith
+// scalar as a double.  This keeps scalar/container formatting identical while
+// letting every backend reuse its ordinary expression/value representation.
+template <typename Size, typename Value>
+std::string render_message(const MessageSpec& spec, std::size_t value_count,
+                           Size size, Value value) {
+  if (spec.chunks.size() != value_count + 1)
+    throw std::logic_error("malformed message template");
+  std::ostringstream out;
+  for (std::size_t k = 0; k < value_count; ++k) {
+    out << spec.chunks[k];
+    const int64_t len = size(k);
+    if (len < 0) throw std::logic_error("negative message value length");
+    if (len == 1) {
+      out << value(k, 0);
+      continue;
+    }
+    out << '[';
+    for (int64_t i = 0; i < len; ++i) {
+      if (i) out << ',';
+      out << value(k, i);
+    }
+    out << ']';
+  }
+  out << spec.chunks.back();
+  return out.str();
+}
+
+// Performs the only semantic difference between the two statement functions:
+// print writes one line to the configured sink; reject terminates evaluation
+// with the exception class samplers already recognize as a rejected proposal.
+void execute_message(MessageAction action, const std::string& message);
+
+}  // namespace stanli
+
+#endif

--- a/runtime/include/stanli/mir_interp.hpp
+++ b/runtime/include/stanli/mir_interp.hpp
@@ -24,7 +24,7 @@
 #include <stanli/container_shape.hpp>
 #include <stanli/data.hpp>
 #include <stanli/extrema_grouping.hpp>
-#include <stanli/message_sink.hpp>
+#include <stanli/mir_message.hpp>
 #include <stanli/mir.hpp>
 #include <stanli/optable.hpp>  // STANLI_SCALAR_UNARY_LIST
 #include <stanli/program.hpp>
@@ -38,7 +38,6 @@
 #include <functional>
 #include <limits>
 #include <map>
-#include <sstream>
 #include <string>
 #include <type_traits>
 #include <utility>
@@ -682,27 +681,21 @@ class MirInterp {
         // there rather than sampling from a model whose data is wrong.
         // Skipping it would mean stanli happily sampled a model CmdStan
         // refuses to build.
-        if (st.fn_name == "FnReject" || st.fn_name == "FnPrint") {
-          std::string msg;
-          for (const auto& a : st.fn_args) {
-            if (a.kind == mir::Expr::LitStr) {
-              msg += a.lit_s;
-              continue;
-            }
-            const Value v = eval(a);
-            if (v.r.size() == 1) {
-              msg += fmt_num(val(v.r[0]));
-            } else {
-              msg += '[';
-              for (size_t i = 0; i < v.r.size(); ++i) {
-                if (i) msg += ',';
-                msg += fmt_num(val(v.r[i]));
-              }
-              msg += ']';
-            }
-          }
-          if (st.fn_name == "FnReject") throw std::domain_error(msg);
-          emit_message(msg);
+        if (const auto action = message_action(st.fn_name)) {
+          std::vector<Value> values;
+          const MessageSpec spec = lower_message_arguments(
+              st.fn_args, [&](const mir::Expr& argument) {
+                values.push_back(eval(argument));
+              });
+          execute_message(*action,
+                          render_message(
+                              spec, values.size(),
+                              [&](size_t k) {
+                                return static_cast<int64_t>(values[k].r.size());
+                              },
+                              [&](size_t k, int64_t i) {
+                                return val(values[k].r[static_cast<size_t>(i)]);
+                              }));
           return;
         }
         if (st.fn_name == "FnCheck") {
@@ -740,16 +733,6 @@ class MirInterp {
   }
 
  private:
-  // How reject()/print() render a number. ostream's default formatting is
-  // what the OP_REJECT kernel uses on the graph side, so the two paths
-  // spell the same value the same way -- and it is also what stan-math's
-  // own reject produces.
-  static std::string fmt_num(double v) {
-    std::ostringstream os;
-    os << v;
-    return os.str();
-  }
-
   // Thrown by a Return statement inside an interpreted function body.
   struct ReturnV {
     Value v;

--- a/runtime/include/stanli/mir_message.hpp
+++ b/runtime/include/stanli/mir_message.hpp
@@ -1,0 +1,35 @@
+// MIR-specific half of shared print()/reject() lowering.  It owns no backend
+// handles: the callback lowers each non-literal argument using the caller's
+// normal expression dispatcher.
+#ifndef STANLI_MIR_MESSAGE_HPP
+#define STANLI_MIR_MESSAGE_HPP
+
+#include <stanli/message.hpp>
+#include <stanli/mir.hpp>
+
+#include <string>
+#include <vector>
+
+namespace stanli {
+
+template <typename LowerValue>
+MessageSpec lower_message_arguments(const std::vector<mir::Expr>& args,
+                                    LowerValue lower_value) {
+  MessageSpec spec;
+  std::string pending;
+  for (const auto& arg : args) {
+    if (arg.kind == mir::Expr::LitStr) {
+      pending += arg.lit_s;
+      continue;
+    }
+    spec.chunks.push_back(std::move(pending));
+    pending.clear();
+    lower_value(arg);
+  }
+  spec.chunks.push_back(std::move(pending));
+  return spec;
+}
+
+}  // namespace stanli
+
+#endif

--- a/runtime/include/stanli/mir_prog.hpp
+++ b/runtime/include/stanli/mir_prog.hpp
@@ -1113,6 +1113,17 @@ struct ProgramCompiler {
 
   // ---- expressions ---------------------------------------------------------
   Range expr(const mir::Expr& e) {
+    // A complete, concretely evaluable pure UDF is already executable by the
+    // surrounding MIR interpreter. Materialize its result once instead of
+    // expanding its call tree into a finite register program. The successful
+    // callback is the proof of concreteness: stanc can label the recursive
+    // remainder AutoDiffable even after all its actuals became data literals.
+    if (e.kind == mir::Expr::FunApp &&
+        e.fn_lib == mir::Expr::Lib::UserDefined && e.type_ == "UReal" &&
+        extern_real) {
+      double value = 0.0;
+      if (extern_real(e, &value)) return {konst(value), 1};
+    }
     switch (e.kind) {
       case mir::Expr::LitInt:
         return {konst((double)e.lit_i), 1};

--- a/runtime/include/stanli/mir_prog.hpp
+++ b/runtime/include/stanli/mir_prog.hpp
@@ -24,6 +24,7 @@
 #include <stanli/mir.hpp>
 #include <stanli/optable.hpp>
 #include <stanli/program.hpp>
+#include <stanli/regular_builtin.hpp>
 #include <stanli/rng_family.hpp>
 
 #include <algorithm>
@@ -107,8 +108,7 @@ struct ProgramCompiler {
   // being in `reals` only says the region has read one as a value.
   std::set<std::string> extern_bound;
   // Whether this region belongs to generated quantities. Only there is an
-  // RNG draw legal, and only there is a program guaranteed never to be
-  // replayed under var -- which is what lets it hold a CALL at all.
+  // RNG draw legal.
   bool in_write_array = false;
   int branch_depth = 0;  // inside a branch on a runtime value
   // A while is a genuinely runtime loop: its condition and state must be
@@ -1039,8 +1039,8 @@ struct ProgramCompiler {
       r.rows = r.cols = 0;
     } else if (type == "UMatrix" && r.kind != ViewKind::Matrix) {
       bail("matrix expression has unknown logical extents");
-    } else if (type == "UArray") {
-      bail("array expressions are unsupported by the register program");
+    } else if (type == "UArray" && r.kind != ViewKind::Array) {
+      bail("array expression has an unknown logical view");
     }
     return r;
   }
@@ -1470,10 +1470,8 @@ struct ProgramCompiler {
   // the graph's own OP_RNG kernel rather than transcribed family by family.
   // The stream, the stan-math call and the argument contract are then the
   // kernel's, so the region and the graph cannot disagree about what a draw
-  // is or where in the stream it lands. CALL is double-only, which is the
-  // right constraint here rather than a limitation: generated quantities
-  // never runs a gradient, and OP_RNG has no backward for the carver to
-  // generate one from, so the island keeps the replay it will never use.
+  // is or where in the stream it lands. Generated quantities never runs a
+  // gradient, and OP_RNG consequently needs no backward implementation.
   Range rng_call(const mir::Expr& e) {
     if (!in_write_array)
       bail(e.name + " is supported only in generated quantities");
@@ -1540,6 +1538,120 @@ struct ProgramCompiler {
     p.code.push_back(Program::Instr{Program::CALL, 0, (int)p.calls.size() - 1});
     Range out{r, out_len};
     out.kind = out_kind;
+    return out;
+  }
+
+  // Program-native instructions cover the hot elementary subset. Everything
+  // else in the shared regular-function registry reaches the exact same graph
+  // kernel through CALL, so adding an optable entry also makes it available in
+  // parameter-dependent control flow without another name table here.
+  static bool native_regular_opcode(uint16_t opcode) {
+    switch (opcode) {
+      case OP_ADD:
+      case OP_SUB:
+      case OP_MUL:
+      case OP_DIV:
+      case OP_POW:
+      case OP_FMAX:
+      case OP_FMIN:
+      case OP_LSE2:
+      case OP_LOG_DIFF_EXP:
+      case OP_NEG:
+      case OP_EXPV:
+      case OP_LOGV:
+      case OP_SQRT:
+      case OP_SQUARE:
+      case OP_INV:
+      case OP_ABS:
+      case OP_INV_LOGIT:
+      case OP_LOG1P_EXP:
+        return true;
+      default:
+        return false;
+    }
+  }
+
+  Range regular_kernel_call(const mir::Expr& e, const RegularSpec& spec) {
+    const size_t arity = spec.kind == RegularKind::Unary ? 1 : 2;
+    if (e.args.size() != arity) bail(e.name + ": wrong number of arguments");
+    std::vector<Range> args;
+    args.reserve(arity);
+    for (const mir::Expr& arg : e.args) args.push_back(expr(arg));
+
+    Range out = args[0];
+    if (spec.kind != RegularKind::Unary) {
+      const bool as = is_scalar(args[0]), bs = is_scalar(args[1]);
+      if (spec.kind == RegularKind::Binary) {
+        if (!as && !bs && !same_view(args[0], args[1]))
+          bail(e.name + ": incompatible logical views");
+        if (as && !bs) out = args[1];
+      } else {
+        const bool int_first = spec.kind == RegularKind::BinaryIntFirst;
+        const Range& re = args[int_first ? 1 : 0];
+        const Range& iv = args[int_first ? 0 : 1];
+        if (!is_scalar(re) && !is_scalar(iv) && re.len != iv.len)
+          bail(e.name + ": arguments must match in size");
+        out = is_scalar(re) ? iv : re;
+      }
+    }
+
+    const int result = alloc(out.len);
+    out.reg = result;
+    out = typed(out, e.type_);
+
+    Program::Call call;
+    call.opcode = spec.opcode;
+    call.n_in = (int8_t)args.size();
+    if (spec.kind == RegularKind::BinaryIntFirst)
+      call.input_adjoint_mask = 0x2;
+    else if (spec.kind == RegularKind::BinaryIntSecond)
+      call.input_adjoint_mask = 0x1;
+    for (size_t k = 0; k < args.size(); ++k) {
+      call.in[k] = args[k].reg;
+      call.in_len[k] = args[k].len;
+    }
+    call.out = result;
+    call.out_len = out.len;
+
+    if (spec.kind == RegularKind::BinaryIntFirst ||
+        spec.kind == RegularKind::BinaryIntSecond) {
+      const bool int_first = spec.kind == RegularKind::BinaryIntFirst;
+      const Range& re = args[int_first ? 1 : 0];
+      const Range& iv = args[int_first ? 0 : 1];
+      if (!is_scalar(iv)) {
+        if (re.kind == ViewKind::Matrix) {
+          call.idata = {(int)re.rows, (int)re.cols};
+        } else if (re.kind == ViewKind::Array && re.leaf == ViewKind::Matrix &&
+                   re.dims.size() >= 2) {
+          call.idata = {(int)re.dims[re.dims.size() - 2], (int)re.dims.back()};
+        }
+      }
+    }
+
+    const Kernel* kernel = find_kernel(call.opcode);
+    if (kernel == nullptr) bail(e.name + ": graph kernel is unavailable");
+    if (kernel->scratch_size != nullptr) {
+      Op op;
+      op.opcode = call.opcode;
+      op.n_in = call.n_in;
+      op.out = call.n_in;
+      op.idata = call.idata.data();
+      op.n_idata = (int64_t)call.idata.size();
+      std::vector<Slot> slots(args.size() + 1);
+      for (size_t k = 0; k < args.size(); ++k) {
+        op.in[k] = (int)k;
+        slots[k].len = args[k].len;
+      }
+      slots.back().len = out.len;
+      const int64_t scratch = kernel->scratch_size(op, slots.data());
+      if (scratch < 0 || scratch > kMaxRegs)
+        bail(e.name + ": kernel needs excessive scratch storage");
+      call.scratch_len = (int32_t)scratch;
+      call.scratch = scratch ? alloc((int)scratch) : 0;
+    }
+    if (!bind_call(call)) bail(e.name + ": graph kernel is unavailable");
+    p.calls.push_back(std::move(call));
+    p.code.push_back(Program::Instr{Program::CALL, 0, (int)p.calls.size() - 1});
     return out;
   }
 
@@ -1770,6 +1882,9 @@ struct ProgramCompiler {
     CallableTransformSpec transform;
     if (callable_transform(e.name, &transform))
       return transform_call(e, transform);
+    const auto regular = resolve_regular_builtin(e.name, e.args.size());
+    if (regular && !native_regular_opcode(regular->opcode))
+      return regular_kernel_call(e, *regular);
     if (e.name == "tcrossprod" && e.args.size() == 1)
       return matrix_gram(expr(e.args[0]), false);
     if (e.name == "crossprod" && e.args.size() == 1)

--- a/runtime/include/stanli/mir_prog.hpp
+++ b/runtime/include/stanli/mir_prog.hpp
@@ -20,6 +20,7 @@
 #ifndef STANLI_MIR_PROG_HPP
 #define STANLI_MIR_PROG_HPP
 
+#include <stanli/mir_message.hpp>
 #include <stanli/mir.hpp>
 #include <stanli/optable.hpp>
 #include <stanli/program.hpp>
@@ -3166,41 +3167,18 @@ struct ProgramCompiler {
       }
       case mir::Stmt::NRFunApp:
         if (s.fn_name == "FnValidateSize") return;
-        if (s.fn_name == "FnPrint") {
-          Program::Print print;
-          std::string pending;
-          for (const auto& a : s.fn_args) {
-            if (a.kind == mir::Expr::LitStr) {
-              pending += a.lit_s;
-              continue;
-            }
-            print.chunks.push_back(std::move(pending));
-            pending.clear();
-            const Range value = expr(a);
-            print.value_reg.push_back(value.reg);
-            print.value_len.push_back(value.len);
-          }
-          print.chunks.push_back(std::move(pending));
-          p.prints.push_back(std::move(print));
-          emit(Program::PRINT, 0, (int)p.prints.size() - 1);
-          return;
-        }
-        if (s.fn_name == "FnReject") {
-          // Only a literal message: interleaving a runtime value would need
-          // to format it into the thrown string at forward time, which this
-          // machine has no instruction for. `reject("some literal")` is the
-          // common case (a guard on a parameter's domain) and needs none.
-          std::string msg;
-          for (const auto& a : s.fn_args) {
-            if (a.kind != mir::Expr::LitStr)
-              bail(
-                  "statement function FnReject with a runtime-valued "
-                  "message argument (a literal-only message is supported "
-                  "here)");
-            msg += a.lit_s;
-          }
-          p.messages.push_back(std::move(msg));
-          emit(Program::REJECT, 0, (int)p.messages.size() - 1);
+        if (const auto action = message_action(s.fn_name)) {
+          Program::Message message;
+          message.spec = lower_message_arguments(
+              s.fn_args, [&](const mir::Expr& argument) {
+                const Range value = expr(argument);
+                message.value_reg.push_back(value.reg);
+                message.value_len.push_back(value.len);
+              });
+          p.messages.push_back(std::move(message));
+          emit(*action == MessageAction::Reject ? Program::REJECT
+                                                : Program::PRINT,
+               0, (int)p.messages.size() - 1);
           return;
         }
         bail("statement function " + s.fn_name +

--- a/runtime/include/stanli/mir_prog.hpp
+++ b/runtime/include/stanli/mir_prog.hpp
@@ -64,6 +64,8 @@ struct InlineArg {
   std::vector<long> ints;
   std::vector<int64_t> int_dims;
   bool is_const_int = false;
+  bool is_const_real = false;
+  double const_real = 0.0;
 };
 
 struct Bail {
@@ -75,6 +77,10 @@ struct ProgramCompiler {
   const std::map<std::string, const mir::FunDef*>& funs;
   std::map<std::string, Range> reals;
   std::map<std::string, std::vector<long>> ints;
+  // Known scalar real formals are retained beside their register binding.
+  // The register still supplies ordinary execution; this map is only what
+  // lets compile-time control decisions and nested calls retain the value.
+  std::map<std::string, double> known_reals;
   // Integer containers still occupy registers when a real-valued expression
   // consumes them, but their values are data and therefore available while
   // the program is being compiled.  Keep that provenance beside the register
@@ -140,6 +146,12 @@ struct ProgramCompiler {
   std::function<bool(const mir::Expr&, std::vector<long>*,
                      std::vector<int64_t>*)>
       extern_ints;
+  // A scalar real expression whose value the surrounding lowerer can prove
+  // at model-construction time. This is a value callback, not an activity
+  // test: generated-quantity draws are inactive but still unknown. Evaluating
+  // a complete data-only UDF here also handles recursion without trying to
+  // turn a dynamic call stack into finite inline instructions.
+  std::function<bool(const mir::Expr&, double*)> extern_real;
   // Where `target +=` accumulates, or -1 when the region may not have
   // one. Set by the caller, which also seeds it to zero.
   int target_reg = -1;
@@ -475,6 +487,64 @@ struct ProgramCompiler {
     return e.type_ == "UInt" || e.unsized.leaf == mir::UnsizedLeaf::Int;
   }
 
+  double creal(const mir::Expr& e) {
+    if (e.data_only && extern_real && e.type_ == "UReal") {
+      double value = 0.0;
+      if (extern_real(e, &value)) return value;
+    }
+    switch (e.kind) {
+      case mir::Expr::LitInt:
+        return static_cast<double>(e.lit_i);
+      case mir::Expr::LitReal:
+        return e.lit;
+      case mir::Expr::Var: {
+        auto real = known_reals.find(e.name);
+        if (real != known_reals.end()) return real->second;
+        auto integer = ints.find(e.name);
+        if (integer != ints.end() && integer->second.size() == 1)
+          return static_cast<double>(integer->second[0]);
+        bail("real " + e.name + " is not known at compile time");
+      }
+      case mir::Expr::Promotion:
+        if (e.args.size() != 1) bail("real promotion form");
+        return creal(e.args[0]);
+      case mir::Expr::TernaryIf:
+        if (e.args.size() != 3) bail("real conditional form");
+        return creal(e.args[cint(e.args[0]) != 0 ? 1 : 2]);
+      case mir::Expr::FunApp:
+        if (const auto value = mir::nullary_constant(e)) return *value;
+        if (e.args.size() == 1) {
+          if (e.name == "PMinus__" || e.name == "minus")
+            return -creal(e.args[0]);
+          if (e.name == "PPlus__" || e.name == "plus") return creal(e.args[0]);
+        }
+        if (e.args.size() == 2) {
+          const double lhs = creal(e.args[0]);
+          const double rhs = creal(e.args[1]);
+          if (e.name == "Plus__" || e.name == "add") return lhs + rhs;
+          if (e.name == "Minus__" || e.name == "subtract") return lhs - rhs;
+          if (e.name == "Times__" || e.name == "multiply" ||
+              e.name == "elt_multiply")
+            return lhs * rhs;
+          if (e.name == "Divide__" || e.name == "divide" ||
+              e.name == "elt_divide")
+            return lhs / rhs;
+        }
+        bail("real function " + e.name + " is not known at compile time");
+      default:
+        bail("real expression is not known at compile time");
+    }
+  }
+
+  bool try_creal(const mir::Expr& e, double* out) {
+    try {
+      *out = creal(e);
+      return true;
+    } catch (Bail&) {
+      return false;
+    }
+  }
+
   long cint(const mir::Expr& e) {
     switch (e.kind) {
       case mir::Expr::LitInt:
@@ -603,6 +673,15 @@ struct ProgramCompiler {
             if (e.name == "Leq__") return cint(e.args[0]) <= cint(e.args[1]);
             if (e.name == "Greater__") return cint(e.args[0]) > cint(e.args[1]);
             if (e.name == "Geq__") return cint(e.args[0]) >= cint(e.args[1]);
+          }
+          double lhs = 0.0, rhs = 0.0;
+          if (try_creal(e.args[0], &lhs) && try_creal(e.args[1], &rhs)) {
+            if (e.name == "Equals__") return lhs == rhs;
+            if (e.name == "NEquals__") return lhs != rhs;
+            if (e.name == "Less__") return lhs < rhs;
+            if (e.name == "Leq__") return lhs <= rhs;
+            if (e.name == "Greater__") return lhs > rhs;
+            if (e.name == "Geq__") return lhs >= rhs;
           }
         }
         if (e.args.size() == 1 && e.name == "PMinus__") return -cint(e.args[0]);
@@ -1844,6 +1923,8 @@ struct ProgramCompiler {
           arg.int_dims =
               view.dims.empty() ? std::vector<int64_t>{view.len} : view.dims;
         } else {
+          if (a.type_ == "UReal")
+            arg.is_const_real = try_creal(a, &arg.const_real);
           arg.real = expr(a);
         }
         args.push_back(std::move(arg));
@@ -3141,6 +3222,7 @@ struct ProgramCompiler {
     // restore afterwards. Registers are never reused, so nothing aliases.
     auto saved_reals = reals;
     auto saved_ints = ints;
+    auto saved_known_reals = known_reals;
     auto saved_known_int_arrays = known_int_arrays;
     auto saved_known_int_array_dims = known_int_array_dims;
     auto saved_int_array_names = int_array_names;
@@ -3150,6 +3232,7 @@ struct ProgramCompiler {
     const int saved_branch_depth = branch_depth;
     reals.clear();
     ints.clear();
+    known_reals.clear();
     known_int_arrays.clear();
     known_int_array_dims.clear();
     int_array_names.clear();
@@ -3158,6 +3241,8 @@ struct ProgramCompiler {
     extern_bound.clear();
     branch_depth = 0;
     inline_stack.push_back(f.name);
+    std::set<std::string> assigned;
+    for (const auto& statement : f.body) assigned_names(statement, &assigned);
     for (size_t k = 0; k < f.arg_names.size(); ++k) {
       if (args[k].is_const_int) {
         if (args[k].int_dims.empty()) {
@@ -3171,6 +3256,8 @@ struct ProgramCompiler {
         int_decl_at[f.arg_names[k]] = {0, loops.size()};
       } else {
         reals[f.arg_names[k]] = args[k].real;
+        if (args[k].is_const_real && !assigned.count(f.arg_names[k]))
+          known_reals[f.arg_names[k]] = args[k].const_real;
       }
     }
     Range out{0, 0};
@@ -3183,6 +3270,7 @@ struct ProgramCompiler {
       inline_stack.pop_back();
       reals = std::move(saved_reals);
       ints = std::move(saved_ints);
+      known_reals = std::move(saved_known_reals);
       known_int_arrays = std::move(saved_known_int_arrays);
       known_int_array_dims = std::move(saved_known_int_array_dims);
       int_array_names = std::move(saved_int_array_names);
@@ -3196,6 +3284,7 @@ struct ProgramCompiler {
     inline_stack.pop_back();
     reals = std::move(saved_reals);
     ints = std::move(saved_ints);
+    known_reals = std::move(saved_known_reals);
     known_int_arrays = std::move(saved_known_int_arrays);
     known_int_array_dims = std::move(saved_known_int_array_dims);
     int_array_names = std::move(saved_int_array_names);

--- a/runtime/include/stanli/program.hpp
+++ b/runtime/include/stanli/program.hpp
@@ -170,9 +170,9 @@ struct Program {
     // union point with the graph executor -- one instruction gives the
     // register machine the graph's whole vocabulary, and its derivative
     // is the kernel's own backward rather than a transcribed rule. The
-    // kernels compute on doubles, so only run_program<double> can execute
-    // one; the carver keeps a CALL-bearing island only when the generated
-    // adjoint exists, so the var replay never meets it.
+    // kernels compute their values and partials on doubles. A generated
+    // adjoint invokes the backward directly; var replay uses a small adapter
+    // that exposes its output adjoints to the same backward implementation.
   };
   struct Instr {
     Code code = CONST;
@@ -189,6 +189,9 @@ struct Program {
   struct Call {
     uint16_t opcode = 0;
     uint8_t variant = 0;
+    // Inputs that receive derivatives when CALL is replayed over var. Integer
+    // lanes are values in the register file but are never autodiff operands.
+    uint8_t input_adjoint_mask = 0x3f;
     int8_t n_in = 0;
     // Resolved once when the call site is built. A registered kernel's
     // function identity is stable, so repeated table lookup during program
@@ -344,6 +347,11 @@ KernelCtx call_fwd_ctx(const Program::Call& call, double* reg);
 // have the Kernel in hand and bind its pointers directly. False leaves the
 // call unbound, so malformed or unavailable opcodes fail closed.
 bool bind_call(Program::Call& call);
+
+// Replay a graph-kernel call on a var register file. The kernel still owns its
+// value and pullback; this adapter only gathers/scatters the non-contiguous
+// vari pointers used by a runtime-control program.
+void run_call_var(const Program::Call& call, stan::math::var* reg);
 
 // Run one CALL forward through its pre-resolved function. `state` is the
 // caller's evaluation state, which is how a generated-quantities region
@@ -714,10 +722,7 @@ void run_program_impl(const Program& p, T* reg, EvalState* state = nullptr) {
           else
             run_call(p.calls[(size_t)I.a], reg, state);
         } else {
-          // Kernels are double machinery; a program that reaches here
-          // under var was carved wrong, and saying so beats corrupting
-          // a gradient.
-          throw std::logic_error("CALL instruction in a var replay");
+          run_call_var(p.calls[(size_t)I.a], reg);
         }
         break;
       case Program::TRANSFORM:

--- a/runtime/include/stanli/program.hpp
+++ b/runtime/include/stanli/program.hpp
@@ -23,6 +23,7 @@
 #include <stanli/callable_transform.hpp>
 #include <stanli/extrema_grouping.hpp>
 #include <stanli/kernel_types.hpp>
+#include <stanli/message.hpp>
 #include <stanli/program_density.hpp>
 
 #include <stan/math.hpp>
@@ -211,12 +212,12 @@ struct Program {
     int32_t bwd_adj_out = 0;
   };
 
-  // A PRINT's payload: literal chunks interleaved with register ranges.
-  // The double forward renders it once; a var replay deliberately skips it,
-  // because replay exists only to recover derivatives and must not repeat an
-  // observable Stan statement.
-  struct Print {
-    std::vector<std::string> chunks;
+  // A PRINT or REJECT payload: the shared literal template plus the Program-
+  // specific register ranges supplying its runtime values. A var replay skips
+  // PRINT because it must not repeat an observable effect; REJECT never gets
+  // a replay because its double forward already threw.
+  struct Message {
+    MessageSpec spec;
     std::vector<int32_t> value_reg;
     std::vector<int32_t> value_len;
   };
@@ -260,22 +261,24 @@ struct Program {
   std::vector<Instr> code;
   std::vector<Call> calls;            // CALL payloads, indexed by Instr::a
   std::vector<Transform> transforms;  // TRANSFORM payloads, indexed by Instr::a
-  std::vector<Print> prints;          // PRINT payloads, indexed by Instr::a
+  std::vector<Message> messages;      // PRINT/REJECT payloads, by Instr::a
   std::vector<double> pool;           // CONSTR data
-  // REJECT's literal message text, indexed by Instr::a. Never touched as a
-  // register (REJECT is kProgramNoInputs), so it rides beside the register
-  // file rather than in it.
-  std::vector<std::string> messages;
   // DENSITY_VEC payloads, indexed by Instr::a.
   std::vector<VecDensity> vec_densities;
   int n_regs = 0;
   std::vector<int> out_regs;  // the values the caller reads back
 };
 
-// Render one register-program print through the same sink and formatting as
-// graph OP_PRINT. Kept out of the evaluator template so only the double path
-// needs to know how messages are assembled.
-void emit_program_print(const Program::Print& print, const double* reg);
+template <typename T>
+std::string render_program_message(const Program::Message& message,
+                                   const T* reg) {
+  return render_message(
+      message.spec, message.value_reg.size(),
+      [&](std::size_t k) { return static_cast<int64_t>(message.value_len[k]); },
+      [&](std::size_t k, int64_t i) {
+        return stan::math::value_of(reg[message.value_reg[k] + i]);
+      });
+}
 
 struct ProgramOpSpec {
   const char* name;
@@ -722,14 +725,17 @@ void run_program_impl(const Program& p, T* reg, EvalState* state = nullptr) {
         break;
       case Program::PRINT:
         if constexpr (std::is_same_v<T, double>)
-          emit_program_print(p.prints[(size_t)I.a], reg);
+          execute_message(MessageAction::Print,
+                          render_program_message(p.messages[(size_t)I.a], reg));
         break;
       // reject(): the same exception CmdStan's generated code throws from
       // the same place, so the sampler counts it as a rejected proposal
       // rather than a failure. No adjoint reaches this -- the forward
       // already threw -- so there is nothing to do under var either.
       case Program::REJECT:
-        throw std::domain_error(p.messages[(size_t)I.a]);
+        execute_message(MessageAction::Reject,
+                        render_program_message(p.messages[(size_t)I.a], reg));
+        break;
       case Program::DENSITY: {
         const int ar = program_density_arity(I.len);
         if (ar > 3) {

--- a/runtime/include/stanli/regular_builtin.hpp
+++ b/runtime/include/stanli/regular_builtin.hpp
@@ -1,0 +1,100 @@
+// Shared classification for ordinary scalar functions.  The opcode lists in
+// optable.hpp are the source of truth; backends decide only how to materialize
+// the selected operation.
+#ifndef STANLI_REGULAR_BUILTIN_HPP
+#define STANLI_REGULAR_BUILTIN_HPP
+
+#include <stanli/optable.hpp>
+
+#include <cstddef>
+#include <optional>
+#include <string_view>
+
+namespace stanli {
+
+enum class RegularKind { Binary, BinaryIntFirst, BinaryIntSecond, Unary };
+
+struct RegularSpec {
+  RegularKind kind;
+  uint16_t opcode;
+};
+
+inline std::optional<RegularSpec> resolve_regular_builtin(std::string_view name,
+                                                          size_t arity) {
+  if (arity == 2) {
+    if (name == "log_sum_exp") return RegularSpec{RegularKind::Binary, OP_LSE2};
+    if (name == "log_diff_exp")
+      return RegularSpec{RegularKind::Binary, OP_LOG_DIFF_EXP};
+
+    struct Named {
+      std::string_view name;
+      RegularSpec spec;
+    };
+    static constexpr Named kBinary[] = {
+        {"Plus__", {RegularKind::Binary, OP_ADD}},
+        {"Minus__", {RegularKind::Binary, OP_SUB}},
+        {"Divide__", {RegularKind::Binary, OP_DIV}},
+        {"EltTimes__", {RegularKind::Binary, OP_MUL}},
+        {"EltDivide__", {RegularKind::Binary, OP_DIV}},
+        {"Pow__", {RegularKind::Binary, OP_POW}},
+        {"EltPow__", {RegularKind::Binary, OP_POW}},
+        {"pow", {RegularKind::Binary, OP_POW}},
+        {"add", {RegularKind::Binary, OP_ADD}},
+        {"subtract", {RegularKind::Binary, OP_SUB}},
+        {"divide", {RegularKind::Binary, OP_DIV}},
+        {"elt_multiply", {RegularKind::Binary, OP_MUL}},
+        {"elt_divide", {RegularKind::Binary, OP_DIV}},
+#define STANLI_REGULAR_BINARY(code, fn_name, fn) \
+  {#fn_name, {RegularKind::Binary, code}},
+        STANLI_SCALAR_BINARY_LIST(STANLI_REGULAR_BINARY)
+#undef STANLI_REGULAR_BINARY
+            {"multiply_log", {RegularKind::Binary, OP_LMULTIPLY}},
+#define STANLI_REGULAR_INT_FIRST(code, fn_name, fn) \
+  {#fn_name, {RegularKind::BinaryIntFirst, code}},
+        STANLI_SCALAR_BINARY_INT_FIRST_LIST(STANLI_REGULAR_INT_FIRST)
+#undef STANLI_REGULAR_INT_FIRST
+#define STANLI_REGULAR_INT_SECOND(code, fn_name, fn) \
+  {#fn_name, {RegularKind::BinaryIntSecond, code}},
+            STANLI_SCALAR_BINARY_INT_SECOND_LIST(STANLI_REGULAR_INT_SECOND)
+#undef STANLI_REGULAR_INT_SECOND
+    };
+    for (const Named& candidate : kBinary)
+      if (candidate.name == name) return candidate.spec;
+    return std::nullopt;
+  }
+
+  if (arity == 1) {
+    struct Named {
+      std::string_view name;
+      RegularSpec spec;
+    };
+    static constexpr Named kUnary[] = {
+#define STANLI_REGULAR_UNARY(code, fn_name, value, delta, topology) \
+  {#fn_name, {RegularKind::Unary, code}},
+        STANLI_SCALAR_UNARY_LIST(STANLI_REGULAR_UNARY)
+#undef STANLI_REGULAR_UNARY
+            {"PMinus__", {RegularKind::Unary, OP_NEG}},
+        {"minus", {RegularKind::Unary, OP_NEG}},
+        {"std_normal_qf", {RegularKind::Unary, OP_INV_PHI}},
+        {"trigamma", {RegularKind::Unary, OP_TRIGAMMA}},
+        {"exp", {RegularKind::Unary, OP_EXPV}},
+        {"log", {RegularKind::Unary, OP_LOGV}},
+        {"inv_logit", {RegularKind::Unary, OP_INV_LOGIT}},
+        {"logit", {RegularKind::Unary, OP_LOGIT}},
+        {"sqrt", {RegularKind::Unary, OP_SQRT}},
+        {"square", {RegularKind::Unary, OP_SQUARE}},
+        {"log1m", {RegularKind::Unary, OP_LOG1M}},
+        {"softmax", {RegularKind::Unary, OP_SOFTMAX}},
+        {"tanh", {RegularKind::Unary, OP_TANHV}},
+        {"cumulative_sum", {RegularKind::Unary, OP_CUMSUM}},
+        {"log_softmax", {RegularKind::Unary, OP_LOG_SOFTMAX}},
+    };
+    for (const Named& candidate : kUnary)
+      if (candidate.name == name) return candidate.spec;
+  }
+  return std::nullopt;
+}
+
+}  // namespace stanli
+
+#endif

--- a/runtime/kernels/message.cpp
+++ b/runtime/kernels/message.cpp
@@ -16,6 +16,7 @@
 // because that is the only time the values exist. CmdStan formats a
 // vector as `[1,2,3]` and a scalar bare, and so does this.
 #include <stanli/graph.hpp>
+#include <stanli/message.hpp>
 #include <stanli/message_sink.hpp>
 #include <stanli/optable.hpp>
 #include <stanli/packet.hpp>
@@ -39,32 +40,15 @@
 
 #include <cmath>
 #include <limits>
-#include <sstream>
 #include <stdexcept>
 #include <string>
 #include <vector>
 
 namespace stanli {
 
-void emit_program_print(const Program::Print& print, const double* reg) {
-  std::ostringstream out;
-  for (size_t k = 0; k < print.chunks.size(); ++k) {
-    out << print.chunks[k];
-    if (k >= print.value_reg.size()) continue;
-    const int32_t first = print.value_reg[k];
-    const int32_t len = print.value_len[k];
-    if (len == 1) {
-      out << reg[first];
-    } else {
-      out << '[';
-      for (int32_t i = 0; i < len; ++i) {
-        if (i) out << ',';
-        out << reg[first + i];
-      }
-      out << ']';
-    }
-  }
-  emit_message(out.str());
+void execute_message(MessageAction action, const std::string& message) {
+  if (action == MessageAction::Reject) throw std::domain_error(message);
+  emit_message(message);
 }
 
 namespace {
@@ -200,24 +184,11 @@ namespace {
 // what a call ending in a string literal produces.
 std::string render(const KernelCtx& ctx) {
   const auto* msg = static_cast<const MessageSpec*>(ctx.udata);
-  std::ostringstream out;
-  for (size_t k = 0; k < msg->chunks.size(); ++k) {
-    out << msg->chunks[k];
-    if ((int)k >= ctx.n_in) continue;
-    const auto& in = ctx.in[k];
-    // CmdStan prints a container in brackets and a scalar bare.
-    if (in.len == 1) {
-      out << in.data[0];
-    } else {
-      out << '[';
-      for (int64_t i = 0; i < in.len; ++i) {
-        if (i) out << ',';
-        out << in.data[i];
-      }
-      out << ']';
-    }
-  }
-  return out.str();
+  if (msg == nullptr) throw std::logic_error("message op has no template");
+  return render_message(
+      *msg, static_cast<size_t>(ctx.n_in),
+      [&](size_t k) { return ctx.in[k].len; },
+      [&](size_t k, int64_t i) { return ctx.in[k].data[i]; });
 }
 
 void reject_fwd(KernelCtx& ctx) {
@@ -225,10 +196,12 @@ void reject_fwd(KernelCtx& ctx) {
   // stan-math's own reject throws, and it is what the executor's callers
   // and the sampler already treat as "this draw is not valid" rather than
   // as a failure of the run.
-  throw std::domain_error(render(ctx));
+  execute_message(MessageAction::Reject, render(ctx));
 }
 
-void print_fwd(KernelCtx& ctx) { emit_message(render(ctx)); }
+void print_fwd(KernelCtx& ctx) {
+  execute_message(MessageAction::Print, render(ctx));
+}
 
 void check_structured_fwd(KernelCtx& ctx) {
   if (ctx.n_in != 1 || ctx.out.len != 1 || ctx.udata == nullptr)

--- a/runtime/src/executor.cpp
+++ b/runtime/src/executor.cpp
@@ -4,6 +4,7 @@
 #include <stanli/packet.hpp>
 
 #include <algorithm>
+#include <array>
 #include <cassert>
 #include <chrono>
 #include <cstdio>
@@ -105,6 +106,102 @@ bool bind_call(Program::Call& call) {
   call.forward = k->forward;
   call.backward = k->backward;
   return true;
+}
+
+void run_call_var(const Program::Call& call, stan::math::var* reg) {
+  using ArenaDoubles = stan::arena_t<std::vector<double>>;
+  using ArenaVaris = stan::arena_t<std::vector<stan::math::vari*>>;
+  if (call.forward == nullptr || call.backward == nullptr)
+    throw std::logic_error("unbound Program::CALL var replay");
+
+  std::array<int32_t, 6> in_offset{};
+  int32_t total = 0;
+  for (int k = 0; k < call.n_in; ++k) {
+    in_offset[(size_t)k] = total;
+    total += call.in_len[k];
+  }
+  const int32_t out_offset = total;
+  total += call.out_len;
+  const int32_t scratch_offset = total;
+  total += call.scratch_len;
+
+  ArenaDoubles values((size_t)total, 0.0);
+  ArenaDoubles adjoints((size_t)total, 0.0);
+  ArenaVaris input_varis;
+  input_varis.reserve((size_t)out_offset);
+  for (int k = 0; k < call.n_in; ++k) {
+    for (int i = 0; i < call.in_len[k]; ++i) {
+      const stan::math::var& x = reg[(size_t)(call.in[k] + i)];
+      values[(size_t)(in_offset[(size_t)k] + i)] = x.val();
+      input_varis.push_back(x.vi_);
+    }
+  }
+
+  KernelCtx ctx;
+  double* const value_base = values.empty() ? nullptr : values.data();
+  ctx.n_in = call.n_in;
+  for (int k = 0; k < call.n_in; ++k)
+    ctx.in[k] = Desc{value_base ? value_base + in_offset[(size_t)k] : nullptr,
+                     call.in_len[k]};
+  ctx.out = Desc{value_base ? value_base + out_offset : nullptr, call.out_len};
+  ctx.variant = call.variant;
+  ctx.scratch = value_base ? value_base + scratch_offset : nullptr;
+  ctx.idata = call.idata.data();
+  ctx.n_idata = (int64_t)call.idata.size();
+  call.forward(ctx);
+
+  ArenaVaris output_varis((size_t)call.out_len);
+  for (int i = 0; i < call.out_len; ++i) {
+    reg[(size_t)(call.out + i)] =
+        stan::math::var(values[(size_t)(out_offset + i)]);
+    output_varis[(size_t)i] = reg[(size_t)(call.out + i)].vi_;
+  }
+
+  const Program::Call* site = &call;
+  stan::math::reverse_pass_callback([site, values, adjoints, input_varis,
+                                     output_varis, in_offset, out_offset,
+                                     scratch_offset]() mutable {
+    std::fill(adjoints.begin(), adjoints.end(), 0.0);
+    KernelCtx reverse;
+    double* const value_base = values.empty() ? nullptr : values.data();
+    double* const adjoint_base = adjoints.empty() ? nullptr : adjoints.data();
+    reverse.n_in = site->n_in;
+    for (int k = 0; k < site->n_in; ++k) {
+      reverse.in[k] =
+          Desc{value_base ? value_base + in_offset[(size_t)k] : nullptr,
+               site->in_len[k]};
+      reverse.in_adj[k] =
+          (site->input_adjoint_mask & (uint8_t)(1u << k))
+              ? Desc{adjoint_base ? adjoint_base + in_offset[(size_t)k]
+                                  : nullptr,
+                     site->in_len[k]}
+              : Desc{nullptr, site->in_len[k]};
+    }
+    reverse.out =
+        Desc{value_base ? value_base + out_offset : nullptr, site->out_len};
+    reverse.variant = site->variant;
+    reverse.scratch = value_base ? value_base + scratch_offset : nullptr;
+    reverse.idata = site->idata.data();
+    reverse.n_idata = (int64_t)site->idata.size();
+    if (site->out_len == 1) {
+      reverse.out_adj = output_varis[0]->adj_;
+    } else {
+      for (int i = 0; i < site->out_len; ++i)
+        adjoints[(size_t)(out_offset + i)] = output_varis[(size_t)i]->adj_;
+      reverse.out_adj_vec = Desc{
+          adjoint_base ? adjoint_base + out_offset : nullptr, site->out_len};
+    }
+    site->backward(reverse);
+
+    size_t vari_at = input_varis.size();
+    for (int k = site->n_in; k-- > 0;) {
+      vari_at -= (size_t)site->in_len[k];
+      if (!(site->input_adjoint_mask & (uint8_t)(1u << k))) continue;
+      for (int i = site->in_len[k]; i-- > 0;)
+        input_varis[vari_at + (size_t)i]->adj_ +=
+            adjoints[(size_t)(in_offset[(size_t)k] + i)];
+    }
+  });
 }
 
 void run_call(const Program::Call& call, double* reg, KernelCtx& ctx,

--- a/runtime/src/island.cpp
+++ b/runtime/src/island.cpp
@@ -590,10 +590,9 @@ int carve_islands(Graph& g,
       compact_island_gated(cc.prog, false);
       priced_gen = gen_adjoint(cc.prog);
       cc.prog.native_adj = priced_gen && !std::getenv("STANLI_NO_NATIVE_ADJ");
-      // The var replay cannot execute a CALL (kernels are double
-      // machinery), so a CALL-bearing island exists only with its
-      // generated adjoint; otherwise the run stays as ops, which is the
-      // same work the CALLs would have done anyway.
+      // A failed generated adjoint would make this optimization replay each
+      // kernel through callback vars. Leave the run as graph ops instead;
+      // that is the same work without the gather/scatter adapter.
       if (!cc.prog.calls.empty() && !cc.prog.native_adj) compiled = false;
       // A refusal is not an error -- the replay still gives the right
       // gradient -- but it is worth being able to see, because it is the

--- a/runtime/src/lower.cpp
+++ b/runtime/src/lower.cpp
@@ -17,6 +17,7 @@
 #include <stanli/structured_loop.hpp>
 #include <stanli/partition.hpp>
 #include <stanli/reroll.hpp>
+#include <stanli/regular_builtin.hpp>
 #include <stanli/structured_check.hpp>
 #include <stanli/wa_interp.hpp>
 
@@ -638,13 +639,6 @@ struct Lowering {
     ShapeQuery,
   };
 
-  enum class RegularKind { Binary, BinaryIntFirst, BinaryIntSecond, Unary };
-
-  struct RegularSpec {
-    RegularKind kind;
-    uint16_t opcode;
-  };
-
   struct BuiltinDispatch {
     BuiltinFamily family = BuiltinFamily::Elementwise;
     std::optional<RegularSpec> regular;
@@ -657,10 +651,6 @@ struct Lowering {
         : family(selected), regular(regular_call), scalar_rng(rng) {}
   };
 
-  static BuiltinDispatch regular_dispatch(RegularKind kind, uint16_t opcode) {
-    return {BuiltinFamily::Elementwise, RegularSpec{kind, opcode}};
-  }
-
   static BuiltinDispatch rng_dispatch(ScalarRng family) {
     return {BuiltinFamily::ScalarRng, std::nullopt, family};
   }
@@ -672,16 +662,6 @@ struct Lowering {
 
   static BuiltinDispatch resolve_builtin(const mir::Expr& e) {
     if (mir::is_reduce_sum(e)) return {BuiltinFamily::ReduceSum};
-    // These two names are overloaded by arity. Their reduction forms remain
-    // bespoke; their binary forms share the regular broadcast emitter.
-    if (e.name == "log_sum_exp")
-      return e.args.size() == 2 ? regular_dispatch(RegularKind::Binary, OP_LSE2)
-                                : BuiltinDispatch{};
-    if (e.name == "log_diff_exp")
-      return e.args.size() == 2
-                 ? regular_dispatch(RegularKind::Binary, OP_LOG_DIFF_EXP)
-                 : BuiltinDispatch{};
-
     // Bespoke functions still own their semantic checks. This registry only
     // selects the handler, replacing the old sequence in which every family
     // was probed and declined in turn.
@@ -745,58 +725,11 @@ struct Lowering {
             {"size", BuiltinFamily::ShapeQuery},
             {"num_elements", BuiltinFamily::ShapeQuery},
 
-            // Regular elementwise families and their aliases share one emitter.
-            {"Plus__", regular_dispatch(RegularKind::Binary, OP_ADD)},
-            {"Minus__", regular_dispatch(RegularKind::Binary, OP_SUB)},
-            {"Divide__", regular_dispatch(RegularKind::Binary, OP_DIV)},
-            {"EltTimes__", regular_dispatch(RegularKind::Binary, OP_MUL)},
-            {"EltDivide__", regular_dispatch(RegularKind::Binary, OP_DIV)},
-            {"Pow__", regular_dispatch(RegularKind::Binary, OP_POW)},
-            {"EltPow__", regular_dispatch(RegularKind::Binary, OP_POW)},
-            {"pow", regular_dispatch(RegularKind::Binary, OP_POW)},
-            {"add", regular_dispatch(RegularKind::Binary, OP_ADD)},
-            {"subtract", regular_dispatch(RegularKind::Binary, OP_SUB)},
-            {"divide", regular_dispatch(RegularKind::Binary, OP_DIV)},
-            {"elt_multiply", regular_dispatch(RegularKind::Binary, OP_MUL)},
-            {"elt_divide", regular_dispatch(RegularKind::Binary, OP_DIV)},
-#define STANLI_DISPATCH_BINARY(code, name, fn) \
-  {#name, regular_dispatch(RegularKind::Binary, code)},
-            STANLI_SCALAR_BINARY_LIST(STANLI_DISPATCH_BINARY)
-#undef STANLI_DISPATCH_BINARY
-                {"multiply_log",
-                 regular_dispatch(RegularKind::Binary, OP_LMULTIPLY)},
-#define STANLI_DISPATCH_INT_FIRST(code, name, fn) \
-  {#name, regular_dispatch(RegularKind::BinaryIntFirst, code)},
-            STANLI_SCALAR_BINARY_INT_FIRST_LIST(STANLI_DISPATCH_INT_FIRST)
-#undef STANLI_DISPATCH_INT_FIRST
-#define STANLI_DISPATCH_INT_SECOND(code, name, fn) \
-  {#name, regular_dispatch(RegularKind::BinaryIntSecond, code)},
-                STANLI_SCALAR_BINARY_INT_SECOND_LIST(STANLI_DISPATCH_INT_SECOND)
-#undef STANLI_DISPATCH_INT_SECOND
-#define STANLI_DISPATCH_UNARY(code, name, value, delta, topology) \
-  {#name, regular_dispatch(RegularKind::Unary, code)},
-                    STANLI_SCALAR_UNARY_LIST(STANLI_DISPATCH_UNARY)
-#undef STANLI_DISPATCH_UNARY
-                        {"PMinus__",
-                         regular_dispatch(RegularKind::Unary, OP_NEG)},
-            {"minus", regular_dispatch(RegularKind::Unary, OP_NEG)},
-            {"std_normal_qf", regular_dispatch(RegularKind::Unary, OP_INV_PHI)},
-            {"trigamma", regular_dispatch(RegularKind::Unary, OP_TRIGAMMA)},
-            {"exp", regular_dispatch(RegularKind::Unary, OP_EXPV)},
-            {"log", regular_dispatch(RegularKind::Unary, OP_LOGV)},
-            {"inv_logit", regular_dispatch(RegularKind::Unary, OP_INV_LOGIT)},
-            {"logit", regular_dispatch(RegularKind::Unary, OP_LOGIT)},
-            {"sqrt", regular_dispatch(RegularKind::Unary, OP_SQRT)},
-            {"square", regular_dispatch(RegularKind::Unary, OP_SQUARE)},
-            {"log1m", regular_dispatch(RegularKind::Unary, OP_LOG1M)},
-            {"softmax", regular_dispatch(RegularKind::Unary, OP_SOFTMAX)},
-            {"tanh", regular_dispatch(RegularKind::Unary, OP_TANHV)},
-            {"cumulative_sum", regular_dispatch(RegularKind::Unary, OP_CUMSUM)},
-            {"log_softmax",
-             regular_dispatch(RegularKind::Unary, OP_LOG_SOFTMAX)},
         };
     const auto builtin = kBuiltins.find(e.name);
     if (builtin != kBuiltins.end()) return builtin->second;
+    if (const auto regular = resolve_regular_builtin(e.name, e.args.size()))
+      return {BuiltinFamily::Elementwise, *regular};
     // Keep the scalar-RNG vocabulary in the shared classifier used by the
     // graph, interpreter, and runtime-region compiler. The selected family is
     // still carried into the handler, so dispatch performs this lookup once.

--- a/runtime/src/lower.cpp
+++ b/runtime/src/lower.cpp
@@ -804,7 +804,6 @@ struct Lowering {
   // return use the promoted type, but a direct formal reference keeps its own.
   std::map<std::string, bool> udf_formal_autodiff;
   std::map<std::string, bool> effectful_cache;
-  std::set<std::string> effectful_visiting;
   std::set<std::string> int_locals;  // SInt locals in log_prob (data-only)
   int udf_depth = 0;
   // Names the reduce_sum rewrite binds its lowered slice under, kept
@@ -3375,16 +3374,70 @@ struct Lowering {
   bool fun_effectful(const std::string& name) {
     auto memo = effectful_cache.find(name);
     if (memo != effectful_cache.end()) return memo->second;
-    if (!effectful_visiting.insert(name).second) return true;
-    bool effect = false;
-    auto f = fun_defs.find(name);
-    if (f != fun_defs.end())
-      for (const auto& s : f->second->body)
-        if (stmt_effectful(s)) {
-          effect = true;
-          break;
-        }
-    effectful_visiting.erase(name);
+
+    // Recursion is not itself an observable effect.  Walk the complete
+    // reachable call graph for this query, treating an edge back into the
+    // active component as already being examined.  Do not memoize an
+    // intermediate node: in an effectful recursive component its answer can
+    // depend on statements that the outer frame has not visited yet.
+    std::set<std::string> visiting;
+    std::function<bool(const std::string&)> visit_fun;
+    std::function<bool(const mir::Expr&)> visit_expr;
+    std::function<bool(const mir::Stmt&)> visit_stmt;
+
+    visit_fun = [&](const std::string& called) {
+      auto known = effectful_cache.find(called);
+      if (known != effectful_cache.end()) return known->second;
+      if (!visiting.insert(called).second) return false;
+      bool found = false;
+      auto f = fun_defs.find(called);
+      if (f != fun_defs.end())
+        for (const auto& s : f->second->body)
+          if (visit_stmt(s)) {
+            found = true;
+            break;
+          }
+      visiting.erase(called);
+      return found;
+    };
+
+    visit_expr = [&](const mir::Expr& e) {
+      if (e.kind == mir::Expr::FunApp && e.name.size() >= 4 &&
+          e.name.compare(e.name.size() - 4, 4, "_rng") == 0)
+        return true;
+      if (e.kind == mir::Expr::FunApp &&
+          e.fn_lib == mir::Expr::Lib::UserDefined && visit_fun(e.name))
+        return true;
+      if (mir::is_reduce_sum(e)) {
+        if (e.args.empty() || e.args[0].kind != mir::Expr::Var) return true;
+        bool propto = false;
+        const mir::FunDef* partial = mir::resolve_reduce_sum_partial(
+            fun_defs, mir::reduce_sum_partial_name(e.args[0].name, &propto),
+            mir::reduce_sum_partial_views(e));
+        if (partial == nullptr || visit_fun(partial->name)) return true;
+      }
+      for (const auto& a : e.args)
+        if (visit_expr(a)) return true;
+      return false;
+    };
+
+    visit_stmt = [&](const mir::Stmt& s) {
+      if (s.kind == mir::Stmt::NRFunApp && message_action(s.fn_name))
+        return true;
+      for (const auto& e : s.fn_args)
+        if (visit_expr(e)) return true;
+      if (s.has_init && visit_expr(s.init)) return true;
+      if (visit_expr(s.rhs) || visit_expr(s.target) || visit_expr(s.lower) ||
+          visit_expr(s.upper) || visit_expr(s.cond))
+        return true;
+      for (const auto& e : s.lhs_idx)
+        if (visit_expr(e)) return true;
+      for (const auto& child : s.body)
+        if (visit_stmt(child)) return true;
+      return false;
+    };
+
+    const bool effect = visit_fun(name);
     effectful_cache[name] = effect;
     return effect;
   }

--- a/runtime/src/lower.cpp
+++ b/runtime/src/lower.cpp
@@ -2915,6 +2915,14 @@ struct Lowering {
       *dims = evaluated->dims;
       return true;
     };
+    c.extern_real = [&](const mir::Expr& x, double* value) {
+      if (x.type_ != "UReal") return false;
+      auto evaluated = try_eval_pure(x);
+      if (!evaluated || evaluated->is_int || evaluated->r.size() != 1)
+        return false;
+      *value = evaluated->r[0];
+      return true;
+    };
     std::set<std::string> outer_names;
     for (const auto& [name, value] : scope) outer_names.insert(name);
     for (const auto& [name, value] : decls) outer_names.insert(name);

--- a/runtime/src/lower.cpp
+++ b/runtime/src/lower.cpp
@@ -6,6 +6,7 @@
 #include <stanli/cse.hpp>
 #include <stanli/expression_layout.hpp>
 #include <stanli/inplace.hpp>
+#include <stanli/mir_message.hpp>
 #include <stanli/mir_prog.hpp>
 #include <stanli/mir.hpp>
 #include <stanli/mir_decode.hpp>
@@ -3319,9 +3320,7 @@ struct Lowering {
   }
 
   bool stmt_effectful(const mir::Stmt& s) {
-    if (s.kind == mir::Stmt::NRFunApp &&
-        (s.fn_name == "FnPrint" || s.fn_name == "FnReject"))
-      return true;
+    if (s.kind == mir::Stmt::NRFunApp && message_action(s.fn_name)) return true;
     for (const auto& e : s.fn_args)
       if (expr_effectful(e)) return true;
     if (s.has_init && expr_effectful(s.init)) return true;
@@ -7720,30 +7719,22 @@ struct Lowering {
         // std::domain_error at forward time, which is the same exception
         // from the same place CmdStan's generated code throws it, so the
         // sampler counts it as a rejected proposal rather than a failure.
-        if (s.fn_name == "FnReject" || s.fn_name == "FnPrint") {
+        if (const auto action = message_action(s.fn_name)) {
           auto spec = std::make_shared<MessageSpec>();
           std::vector<int> ins;
-          std::string pending;
-          for (const auto& a : s.fn_args) {
-            if (a.kind == mir::Expr::LitStr) {
-              pending += a.lit_s;
-              continue;
-            }
-            // Each value input closes the chunk that precedes it. Op::in
-            // holds six, and a message longer than that is a diagnostic
-            // nobody will miss the tail of -- but say so rather than
-            // corrupting the op.
-            if (ins.size() >= 6)
-              fail(std::string(s.fn_name == "FnReject" ? "reject" : "print") +
-                       " with more than 6 printed values",
-                   s.raw);
-            spec->chunks.push_back(pending);
-            pending.clear();
-            ins.push_back(lower_expr(a).slot);
-          }
-          spec->chunks.push_back(pending);  // trailing literal, if any
+          *spec = lower_message_arguments(
+              s.fn_args, [&](const mir::Expr& argument) {
+                // Op::in holds six. Keep that backend capacity check here;
+                // parsing and semantic dispatch remain shared.
+                if (ins.size() >= 6)
+                  fail(std::string(*action == MessageAction::Reject ? "reject"
+                                                                    : "print") +
+                           " with more than 6 printed values",
+                       s.raw);
+                ins.push_back(lower_expr(argument).slot);
+              });
           Op op;
-          op.opcode = s.fn_name == "FnReject" ? OP_REJECT : OP_PRINT;
+          op.opcode = *action == MessageAction::Reject ? OP_REJECT : OP_PRINT;
           op.n_in = (int)ins.size();
           for (size_t k = 0; k < ins.size(); ++k) op.in[k] = ins[k];
           // The output is a dead scalar: every op writes somewhere, and

--- a/runtime/src/program.cpp
+++ b/runtime/src/program.cpp
@@ -80,10 +80,10 @@ void each_read(const Program& p, const Program::Instr& I, F fn) {
       fn(Span{v.arg_reg[k], ((v.container_mask >> k) & 1u) ? v.len : 1});
     return;
   }
-  if (I.code == Program::PRINT) {
-    const Program::Print& print = p.prints[(size_t)I.a];
-    for (size_t k = 0; k < print.value_reg.size(); ++k)
-      fn(Span{print.value_reg[k], print.value_len[k]});
+  if (I.code == Program::PRINT || I.code == Program::REJECT) {
+    const Program::Message& message = p.messages[(size_t)I.a];
+    for (size_t k = 0; k < message.value_reg.size(); ++k)
+      fn(Span{message.value_reg[k], message.value_len[k]});
     return;
   }
   const ProgramOpSpec& spec = program_code_spec(I.code);
@@ -112,10 +112,10 @@ void remap(Program::VecDensity& v, const std::vector<int>& m) {
   for (int k = 0; k < v.arity; ++k) v.arg_reg[k] = m[(size_t)v.arg_reg[k]];
 }
 
-void remap(Program::Print& print, const std::vector<int>& m) {
-  for (size_t k = 0; k < print.value_reg.size(); ++k)
-    if (print.value_len[k] > 0)
-      print.value_reg[k] = m[(size_t)print.value_reg[k]];
+void remap(Program::Message& message, const std::vector<int>& m) {
+  for (size_t k = 0; k < message.value_reg.size(); ++k)
+    if (message.value_len[k] > 0)
+      message.value_reg[k] = m[(size_t)message.value_reg[k]];
 }
 
 void remap(Program::Instr& I, const std::vector<int>& m) {
@@ -280,7 +280,8 @@ bool compact_program_gated(Program& p, std::vector<std::pair<int, int>>& seeded,
     if (I.code == Program::DENSITY_VEC &&
         (I.a < 0 || (size_t)I.a >= p.vec_densities.size()))
       return false;
-    if (I.code == Program::PRINT && (I.a < 0 || (size_t)I.a >= p.prints.size()))
+    if ((I.code == Program::PRINT || I.code == Program::REJECT) &&
+        (I.a < 0 || (size_t)I.a >= p.messages.size()))
       return false;
   }
 
@@ -480,7 +481,8 @@ bool compact_program_gated(Program& p, std::vector<std::pair<int, int>>& seeded,
     if (I.code == Program::TRANSFORM) remap(p.transforms[(size_t)I.a], map);
     if (I.code == Program::DENSITY_VEC)
       remap(p.vec_densities[(size_t)I.a], map);
-    if (I.code == Program::PRINT) remap(p.prints[(size_t)I.a], map);
+    if (I.code == Program::PRINT || I.code == Program::REJECT)
+      remap(p.messages[(size_t)I.a], map);
     remap(I, map);
     if (branches(I.code)) I.dst = new_pc[(size_t)I.dst];
     code.push_back(I);

--- a/tests/fixtures/known_real_udf.stan
+++ b/tests/fixtures/known_real_udf.stan
@@ -1,0 +1,19 @@
+functions {
+  real descend(real x) {
+    if (x > 0) return descend(x - 1);
+    return x;
+  }
+}
+
+transformed data {
+  real known = 2.5;
+}
+
+parameters {
+  real probe;
+}
+
+model {
+  probe ~ std_normal();
+  if (probe > 100) print("known recursive real: ", descend(known));
+}

--- a/tests/fixtures/known_real_udf_deep.stan
+++ b/tests/fixtures/known_real_udf_deep.stan
@@ -1,0 +1,19 @@
+functions {
+  real descend(real x) {
+    if (x > 0) return descend(x - 1);
+    return x;
+  }
+}
+
+transformed data {
+  real known = 40.5;
+}
+
+parameters {
+  real probe;
+}
+
+model {
+  probe ~ std_normal();
+  if (probe > 100) print("known deep recursive real: ", descend(known));
+}

--- a/tests/fixtures/known_real_udf_effect.stan
+++ b/tests/fixtures/known_real_udf_effect.stan
@@ -1,0 +1,21 @@
+functions {
+  real descend_with_print(real x) {
+    if (x > 0) return descend_with_print(x - 1);
+    print("recursive base");
+    return x;
+  }
+}
+
+transformed data {
+  real known = 2.5;
+}
+
+parameters {
+  real probe;
+}
+
+model {
+  probe ~ std_normal();
+  if (probe > 100)
+    print("known effectful recursive real: ", descend_with_print(known));
+}

--- a/tests/fixtures/paramcond_regular_calls.stan
+++ b/tests/fixtures/paramcond_regular_calls.stan
@@ -1,0 +1,26 @@
+transformed data {
+  array[3] int order = {0, 1, 2};
+  array[3] int label = {0, 1, 0};
+  array[3] int count = {0, 1, 2};
+  array[3] int degree = {2, 2, 2};
+}
+parameters {
+  real probe;
+  array[3] real x;
+  array[3] real probability;
+}
+model {
+  if (probe > 0) {
+    target += sum(atan2(x, probability));
+    target += sum(tgamma(x));
+    target += sum(bessel_first_kind(order, x));
+    target += sum(bessel_second_kind(order, x));
+    target += sum(binary_log_loss(label, probability));
+    target += sum(falling_factorial(x, count));
+    target += sum(ldexp(x, count));
+    target += sum(lmgamma(degree, x));
+    target += sum(modified_bessel_first_kind(order, x));
+    target += sum(modified_bessel_second_kind(order, x));
+    target += sum(rising_factorial(x, count));
+  }
+}

--- a/tests/test_bridgestan.cpp
+++ b/tests/test_bridgestan.cpp
@@ -824,19 +824,23 @@ void test_necessity_effects() {
   g_printed.clear();
   err = nullptr;
   m = bs_model_construct(root.dump().c_str(), 1, &err);
-  if (m != nullptr) {
-    fail("BridgeStan accepted runtime-valued necessity reject");
-    bs_model_destruct(m);
-  } else if (err == nullptr ||
-             std::string(err).find("runtime-control region") ==
-                 std::string::npos ||
-             std::string(err).find("FnReject") == std::string::npos) {
-    fail("BridgeStan necessity FnReject error: " +
+  if (m == nullptr) {
+    fail("BridgeStan refused dynamic necessity reject: " +
          std::string(err != nullptr ? err : "(no message)"));
+    bs_free_error_msg(err);
+  } else {
+    double lp = 0.0;
+    const double accepted = 0.1;
+    expect_eq_int("BridgeStan untaken dynamic reject",
+                  bs_log_density(m, true, true, &accepted, &lp, &err), 0);
+    const double rejected = -0.1;
+    expect_refused("BridgeStan taken dynamic reject",
+                   bs_log_density(m, true, true, &rejected, &lp, &err), &err,
+                   "negative x=-0.1");
+    bs_model_destruct(m);
   }
-  bs_free_error_msg(err);
   if (!g_printed.empty())
-    fail("BridgeStan executed FnReject while refusing: [" + g_printed + "]");
+    fail("BridgeStan dynamic reject unexpectedly printed: [" + g_printed + "]");
 
   err = nullptr;
   expect_eq_int("necessity callback clear",

--- a/tests/test_capi.cpp
+++ b/tests/test_capi.cpp
@@ -531,17 +531,24 @@ void expect_necessity_effects() {
 
   std::fill(std::begin(err), std::end(err), '\0');
   model = stanli_model_new(mir.c_str(), "{\"mode\":2}", err, sizeof err);
-  if (model != nullptr) {
+  if (model == nullptr) {
     ++failures;
-    std::printf("FAIL C API accepted runtime-valued necessity reject\n");
-    stanli_model_free(model);
+    std::printf("FAIL C API refused dynamic necessity reject: %s\n", err);
   } else {
-    const std::string msg = err;
-    if (msg.find("runtime-control region") == std::string::npos ||
-        msg.find("FnReject") == std::string::npos) {
+    double lp = 0.0, grad = 0.0;
+    const double accepted = 0.1;
+    if (stanli_grad(model, &accepted, &lp, &grad) != 0 || lp != 0.1 ||
+        grad != 1.0) {
       ++failures;
-      std::printf("FAIL C API necessity FnReject error: %s\n", err);
+      std::printf("FAIL C API untaken dynamic reject\n");
     }
+    const double rejected = -0.1;
+    if (stanli_grad(model, &rejected, &lp, &grad) != 1 || !std::isinf(lp) ||
+        lp > 0.0) {
+      ++failures;
+      std::printf("FAIL C API taken dynamic reject: lp %.17g\n", lp);
+    }
+    stanli_model_free(model);
   }
 }
 

--- a/tests/test_lower.cpp
+++ b/tests/test_lower.cpp
@@ -5282,9 +5282,9 @@ int main() {
   }
 
   // A transformed-data real passed to a recursive UDF inside parameter-
-  // dependent control flow remains known while ProgramCompiler inlines the
-  // call. Each recursive condition therefore folds, while the surrounding
-  // branch itself remains a runtime island.
+  // dependent control flow remains known. A complete pure call is evaluated
+  // once by the data interpreter instead of requiring a finite expansion of
+  // its recursive call tree, while the surrounding branch remains an island.
   {
     CompiledModel km = compile_model(
         slurp("tests/fixtures/known_real_udf.tmir.sexp"), DataMap());
@@ -5297,6 +5297,25 @@ int main() {
     const double lp = kex.gradient(gradient);
     expect_eq("known-real UDF lp", lp, -0.5 * 0.25 * 0.25);
     expect_eq("known-real UDF gradient", gradient[0], -0.25);
+  }
+
+  // Forty recursive steps exceed ProgramCompiler's inlining budget but stay
+  // within the MIR interpreter's supported call depth. This is the regression
+  // boundary: concrete pure recursion must use the latter rather than fail
+  // while trying to manufacture a finite register call stack.
+  {
+    CompiledModel km = compile_model(
+        slurp("tests/fixtures/known_real_udf_deep.tmir.sexp"), DataMap());
+    check(km.n_unconstrained == 1, "deep known-real UDF parameter width");
+    check(count_opcode(km, OP_ISLAND) > 0,
+          "deep known-real UDF runtime island");
+    Executor kex(std::move(km.graph));
+    km.bind(kex);
+    kex.params_data()[0] = 0.25;
+    double gradient[1];
+    const double lp = kex.gradient(gradient);
+    expect_eq("deep known-real UDF lp", lp, -0.5 * 0.25 * 0.25);
+    expect_eq("deep known-real UDF gradient", gradient[0], -0.25);
   }
 
   // tests/fixtures/infbounds.stan: infinite bounds on the declarations

--- a/tests/test_lower.cpp
+++ b/tests/test_lower.cpp
@@ -5218,6 +5218,24 @@ int main() {
     check(lp[0] != lp[1], "callable jacobians runtime branch changes target");
   }
 
+  // A transformed-data real passed to a recursive UDF inside parameter-
+  // dependent control flow remains known while ProgramCompiler inlines the
+  // call. Each recursive condition therefore folds, while the surrounding
+  // branch itself remains a runtime island.
+  {
+    CompiledModel km = compile_model(
+        slurp("tests/fixtures/known_real_udf.tmir.sexp"), DataMap());
+    check(km.n_unconstrained == 1, "known-real UDF parameter width");
+    check(count_opcode(km, OP_ISLAND) > 0, "known-real UDF runtime island");
+    Executor kex(std::move(km.graph));
+    km.bind(kex);
+    kex.params_data()[0] = 0.25;
+    double gradient[1];
+    const double lp = kex.gradient(gradient);
+    expect_eq("known-real UDF lp", lp, -0.5 * 0.25 * 0.25);
+    expect_eq("known-real UDF gradient", gradient[0], -0.25);
+  }
+
   // tests/fixtures/infbounds.stan: infinite bounds on the declarations
   // themselves. An infinite bound is no bound -- the element is the
   // identity and adds no jacobian term -- and the kernels used to

--- a/tests/test_lower.cpp
+++ b/tests/test_lower.cpp
@@ -4964,6 +4964,69 @@ int main() {
     }
   }
 
+  // Regular scalar-function metadata is shared with the runtime-control
+  // compiler. The branch forces ordinary unary/binary calls and all nine
+  // int/real binary families through Program::CALL, including array results
+  // and both int argument positions.
+  {
+    CompiledModel rm = compile_model(
+        slurp("tests/fixtures/paramcond_regular_calls.tmir.sexp"), DataMap());
+    check(rm.n_unconstrained == 7, "regular-call island parameter width");
+    check(count_opcode(rm, OP_ISLAND) > 0, "regular-call runtime island");
+    Executor rex(std::move(rm.graph));
+    rm.bind(rex);
+
+    const double xv[3] = {3.2, 3.6, 4.1};
+    const double pv[3] = {0.2, 0.4, 0.7};
+    rex.params_data()[0] = -0.5;
+    for (int i = 0; i < 3; ++i) {
+      rex.params_data()[1 + i] = xv[i];
+      rex.params_data()[4 + i] = pv[i];
+    }
+    double gradient[7] = {};
+    expect_eq("regular-call untaken lp", rex.gradient(gradient), 0.0);
+    for (double g : gradient)
+      expect_eq("regular-call untaken gradient", g, 0.0);
+
+    rex.params_data()[0] = 0.5;
+    const double lp = rex.gradient(gradient);
+    using stan::math::var;
+    std::vector<var> x = {xv[0], xv[1], xv[2]};
+    std::vector<var> probability = {pv[0], pv[1], pv[2]};
+    const int order[3] = {0, 1, 2};
+    const int label[3] = {0, 1, 0};
+    const int count[3] = {0, 1, 2};
+    var acc = 0, term = 0;
+#define REGULAR_TERM(expr)                  \
+  term = 0;                                 \
+  for (int i = 0; i < 3; ++i) term += expr; \
+  acc += term;
+    REGULAR_TERM(stan::math::atan2(x[i], probability[i]))
+    REGULAR_TERM(stan::math::tgamma(x[i]))
+    REGULAR_TERM(stan::math::bessel_first_kind(order[i], x[i]))
+    REGULAR_TERM(stan::math::bessel_second_kind(order[i], x[i]))
+    REGULAR_TERM(stan::math::binary_log_loss(label[i], probability[i]))
+    REGULAR_TERM(stan::math::falling_factorial(x[i], count[i]))
+    REGULAR_TERM(stan::math::ldexp(x[i], count[i]))
+    REGULAR_TERM(stan::math::lmgamma(2, x[i]))
+    REGULAR_TERM(stan::math::modified_bessel_first_kind(order[i], x[i]))
+    REGULAR_TERM(stan::math::modified_bessel_second_kind(order[i], x[i]))
+    REGULAR_TERM(stan::math::rising_factorial(x[i], count[i]))
+#undef REGULAR_TERM
+    acc.grad();
+
+    check(std::abs(lp - acc.val()) <=
+              16 * 2.220446049250313e-16 * std::abs(acc.val()),
+          "regular-call island lp matches stan-math");
+    expect_eq("regular-call branch gradient", gradient[0], 0.0);
+    for (int i = 0; i < 3; ++i) {
+      expect_ulp("regular-call real gradient", gradient[1 + i], x[i].adj());
+      expect_ulp("regular-call probability gradient", gradient[4 + i],
+                 probability[i].adj());
+    }
+    stan::math::recover_memory();
+  }
+
   // The one-argument scalar math library over containers. See
   // tests/fixtures/unaryfns.stan: transformed data runs the MIR interpreter
   // on doubles and the model block runs the graph kernels, so a name wired

--- a/tests/test_mir_program_conformance.cpp
+++ b/tests/test_mir_program_conformance.cpp
@@ -810,8 +810,7 @@ void test_print_then_reject_effects() {
   run_domain_error_case(
       "print then reject effects",
       "print occurs first; reject throws domain_error with its full message",
-      {std::move(entry)}, 1.0, "bad rhs t=1", "before reject t=1\n",
-      "FnReject");
+      {std::move(entry)}, 1.0, "bad rhs t=1", "before reject t=1\n", nullptr);
 }
 
 FunDef runtime_effect_rhs() {
@@ -838,11 +837,11 @@ void test_runtime_guarded_effects() {
   const FunDef entry = runtime_effect_rhs();
   run_case("untaken runtime effects",
            "a false branch emits nothing and evaluation continues", {entry},
-           1.0, {1.0}, {}, "FnReject");
+           1.0, {1.0});
   run_domain_error_case(
       "taken runtime effects",
       "a true branch prints once, then reject terminates evaluation", {entry},
-      -1.0, "negative t rejected: -1", "negative branch t=-1\n", "FnReject");
+      -1.0, "negative t rejected: -1", "negative branch t=-1\n");
 }
 
 void test_unknown_nrfunapp_fails_loud() {

--- a/tests/test_mir_unary_fallback.cpp
+++ b/tests/test_mir_unary_fallback.cpp
@@ -1,4 +1,4 @@
-// Keep graph, MIR double/var, and ODE-fallback unary semantics aligned with
+// Keep graph, MIR double/var, and ODE-program unary semantics aligned with
 // Stan Math. Raw finite bits pin the shared pullback expression's ordering;
 // NaNs are compared by category because payload bits are not Stan semantics.
 #include <stanli/graph.hpp>
@@ -319,6 +319,8 @@ void expect_disconnected(const std::string& name, const Observation& got) {
 }
 
 void test_program_and_topology() {
+  check_program("sin", "sin", stanli::OP_SIN, 0.3,
+                [](const stan::math::var& x) { return stan::math::sin(x); });
   check_program("inv", "inv", stanli::OP_INV, 0.3,
                 [](const stan::math::var& x) { return stan::math::inv(x); });
   check_program("abs positive", "abs", stanli::OP_ABS, 0.3,
@@ -455,7 +457,7 @@ void test_vector_jacobian() {
   }
 }
 
-void test_ode_fallback() {
+void test_ode_program() {
   Expr rate = call("sin", {element(variable("theta", "UVector"), 1)}, "UReal");
   Expr value =
       call("Times__", {std::move(rate), element(variable("y", "UVector"), 1)},
@@ -480,10 +482,9 @@ void test_ode_fallback() {
   spec->prog = compile_rhs(f, defs, 1, 1, 1, x_i);
 
   const double want = 1.1 * std::exp(std::sin(0.2) * 0.4);
-  if (spec->prog.ok ||
-      spec->prog.why.find("function sin") == std::string::npos) {
+  if (!spec->prog.ok) {
     ++failures;
-    std::printf("FAIL ODE did not exercise unary fallback: %s\n",
+    std::printf("FAIL ODE did not inherit unary dispatch: %s\n",
                 spec->prog.why.c_str());
   }
 
@@ -503,8 +504,8 @@ void test_ode_fallback() {
     *executor.param_ptr(parameter) = 0.2;
     double gradient = 0;
     const double got = executor.gradient(&gradient);
-    expect_close(std::string("ODE fallback value ") + label, got, want, 2e-8);
-    expect_close(std::string("ODE fallback gradient ") + label, gradient,
+    expect_close(std::string("ODE program value ") + label, got, want, 2e-8);
+    expect_close(std::string("ODE program gradient ") + label, gradient,
                  want * 0.4 * std::cos(0.2), 2e-8);
   };
   run(0x0u, "legacy var/var");
@@ -519,7 +520,7 @@ int main() {
   test_program_and_topology();
   test_blocker_edges();
   test_vector_jacobian();
-  test_ode_fallback();
+  test_ode_program();
   if (failures == 0) std::printf("test_mir_unary_fallback: all cases passed\n");
   return failures == 0 ? 0 : 1;
 }

--- a/tests/test_rejectprint.cpp
+++ b/tests/test_rejectprint.cpp
@@ -238,25 +238,32 @@ int main() {
            lines.size() == 1 && lines[0] == "print-only x=0.2");
   }
 
-  // A runtime-valued reject message remains unsupported. Unlike print, its
-  // text must be preserved in the exception, so keep refusing it until the
-  // register program has a rendered-reject payload too.
+  // A runtime-valued reject uses the same literal/value message template as
+  // print. The untaken arm is silent and the taken arm preserves the rendered
+  // value in the domain error.
   {
-    bool threw = false;
-    std::string msg;
+    DataMap d;
+    d.set_int("mode", 2);
+    CompiledModel cm =
+        compile_model(slurp("tests/fixtures/necessity_effects.tmir.sexp"), d);
+    Executor ex(std::move(cm.graph));
+    cm.bind(ex);
+    std::vector<double> g((size_t)ex.n_params());
+
+    ex.params_data()[0] = 0.1;
+    const double accepted_lp = ex.gradient(g.data());
+    expect("necessity untaken reject lp", accepted_lp == 0.1);
+    expect("necessity untaken reject gradient", g[0] == 1.0);
+
+    ex.params_data()[0] = -0.1;
+    std::string message;
     try {
-      DataMap d;
-      d.set_int("mode", 2);
-      (void)compile_model(slurp("tests/fixtures/necessity_effects.tmir.sexp"),
-                          d);
-    } catch (const CompileError& e) {
-      threw = true;
-      msg = e.what();
+      (void)ex.gradient(g.data());
+    } catch (const std::domain_error& e) {
+      message = e.what();
     }
-    expect("necessity runtime-valued reject refuses compilation", threw);
-    expect("necessity reject error names the unsupported effect: " + msg,
-           msg.find("runtime-control region") != std::string::npos &&
-               msg.find("FnReject") != std::string::npos);
+    expect("necessity dynamic reject message: " + message,
+           message == "negative x=-0.1");
   }
 
   if (failures == 0) std::printf("test_rejectprint: all checks passed\n");

--- a/tests/test_rejectprint.cpp
+++ b/tests/test_rejectprint.cpp
@@ -266,6 +266,46 @@ int main() {
            message == "negative x=-0.1");
   }
 
+  // A recursive cycle is not itself an effect, but an effect reachable in
+  // that cycle still prevents compile-time evaluation. The untaken runtime
+  // arm must therefore be silent, and the taken arm emits each print once.
+  {
+    std::vector<std::string> lines;
+    set_message_sink([&lines](const char* text, size_t len) {
+      lines.emplace_back(text, len);
+    });
+    DataMap d;
+    CompiledModel cm = compile_model(
+        slurp("tests/fixtures/known_real_udf_effect.tmir.sexp"), d);
+    Executor ex(std::move(cm.graph));
+    cm.bind(ex);
+    std::vector<double> g((size_t)ex.n_params());
+
+    ex.params_data()[0] = 0.25;
+    const double untaken_lp = ex.gradient(g.data());
+    expect("effectful recursive UDF untaken lp",
+           untaken_lp == -0.5 * 0.25 * 0.25);
+    expect("effectful recursive UDF untaken gradient", g[0] == -0.25);
+    expect("effectful recursive UDF is not evaluated during compilation",
+           lines.empty());
+
+    ex.params_data()[0] = 101.0;
+    const double taken_lp = ex.gradient(g.data());
+    set_message_sink(nullptr);
+    expect("effectful recursive UDF taken lp",
+           taken_lp == -0.5 * 101.0 * 101.0);
+    expect("effectful recursive UDF taken gradient", g[0] == -101.0);
+    expect("effectful recursive UDF emits exactly twice, got " +
+               std::to_string(lines.size()),
+           lines.size() == 2);
+    if (lines.size() == 2) {
+      expect("recursive effect remains ordered: " + lines[0],
+             lines[0] == "recursive base");
+      expect("outer recursive print remains ordered: " + lines[1],
+             lines[1] == "known effectful recursive real: -0.5");
+    }
+  }
+
   if (failures == 0) std::printf("test_rejectprint: all checks passed\n");
   return failures == 0 ? 0 : 1;
 }


### PR DESCRIPTION
## Summary

- Preserve compile-time-known scalar real values through `ProgramCompiler` and nested UDF calls, enabling data-dependent and recursive UDF control flow inside parameter-dependent regions.
- Centralise `print` and `reject` dispatch, message construction, formatting, and execution across graph, MIR interpreter, and register-program backends.
- Support runtime-valued `reject` messages inside parameter-dependent control flow, including consistent behavior through the C API and BridgeStan.
- Centralise regular unary and binary function metadata so graph and register-program backends automatically inherit newly registered functions and aliases.
- Lower non-native regular functions through existing graph kernels, preserving scalar broadcasting and array, vector, row-vector, and matrix output shapes.
- Support mixed integer/real function arguments in either position, retaining layout metadata and excluding integer inputs from autodiff.
- Add reverse-mode autodiff for register-program kernel calls by reusing existing kernel forward and backward implementations.
- Enable additional functions—including `sin`, `atan2`, `tgamma`, Bessel functions, factorial functions, `ldexp`, `lmgamma`, and `binary_log_loss`—inside parameter-dependent control flow and ODE programs.
- Add regression coverage for known-real recursive UDFs, dynamic print/reject behavior, regular function calls, container outputs, broadcasting, and value/gradient agreement with Stan Math.