### PR TITLE
Add Pathfinder initialization to sampling interfaces

### DIFF
--- a/js/README.md
+++ b/js/README.md
@@ -27,6 +27,22 @@ fit.generatedStart;    // index where generated-quantity columns begin
 fit.ms;                // {stanc, lower, sample, total} in milliseconds
 ```
 
+NUTS can take its starting point from single-path Pathfinder. The same seed
+controls initialization and sampling, and an empty options object uses the
+defaults:
+
+```js
+const fit = await sample({
+  code,
+  data,
+  seed: 303,
+  pathfinderInit: { numIterations: 500, numElboDraws: 25 },
+});
+```
+
+`historySize` and Pathfinder's own `initRadius` are also supported. This mode
+does not perform PSIS resampling.
+
 For NUTS, `await diagnose(fit)` returns the same text report as the R and
 Python bindings: divergences, maximum-treedepth saturation, E-BFMI,
 rank-normalized R-hat, and bulk/tail ESS. Pass an array of fits from the

--- a/js/index.mjs
+++ b/js/index.mjs
@@ -95,6 +95,29 @@ export function compile(opts) {
   return request({ cmd: "compile", code: opts.code }, opts);
 }
 
+function pathfinderInitOptions(value) {
+  if (value == null) return null;
+  if (typeof value !== "object" || Array.isArray(value))
+    throw new TypeError("pathfinderInit must be an options object");
+  const defaults = { numIterations: 1000, numElboDraws: 25,
+                     historySize: 5, initRadius: 2 };
+  const unknown = Object.keys(value).filter((key) => !(key in defaults));
+  if (unknown.length)
+    throw new RangeError("unknown pathfinderInit option" +
+                         (unknown.length > 1 ? "s" : "") + ": " +
+                         unknown.join(", "));
+  const out = { ...defaults, ...value };
+  for (const name of ["numIterations", "numElboDraws", "historySize"])
+    if (!Number.isInteger(out[name]) || out[name] <= 0 ||
+        out[name] > 2147483647)
+      throw new RangeError(`pathfinderInit ${name} must be a positive integer`);
+  if (typeof out.initRadius !== "number" || !Number.isFinite(out.initRadius) ||
+      out.initRadius < 0)
+    throw new RangeError(
+        "pathfinderInit initRadius must be finite and nonnegative");
+  return out;
+}
+
 /** Compile (unless `mir` is given) and draw from the posterior.
  *
  * @param {Object} opts
@@ -108,6 +131,10 @@ export function compile(opts) {
  * @param {number} [opts.warmup=1000]
  * @param {number} [opts.samples=1000]
  * @param {number} [opts.delta=0.8]    Adaptation target acceptance (NUTS).
+ * @param {Object} [opts.pathfinderInit]  Generate the NUTS start with
+ *   single-path Pathfinder. `{}` uses defaults; supported keys are
+ *   `numIterations`, `numElboDraws`, `historySize`, and `initRadius`.
+ *   The sampling seed controls both stages. NUTS only; no PSIS resampling.
  * @param {string} [opts.sampler="nuts"]  "nuts", "walnuts" (within-orbit
  *   adaptive step-length NUTS, arXiv:2506.18746), or "pathfinder"
  *   (a normal approximation fitted along an L-BFGS path). Pathfinder
@@ -141,6 +168,11 @@ export function compile(opts) {
  *   divergent__, energy__. Other methods return null for samplerStats.
  */
 export function sample(opts) {
+  const sampler = opts.sampler === "walnuts" || opts.sampler === "pathfinder"
+      ? opts.sampler : "nuts";
+  const pathfinderInit = pathfinderInitOptions(opts.pathfinderInit);
+  if (pathfinderInit && sampler !== "nuts")
+    throw new RangeError("pathfinderInit is available only with NUTS");
   return request({
     cmd: "run",
     code: opts.code,
@@ -153,9 +185,9 @@ export function sample(opts) {
     warmup: opts.warmup == null ? 1000 : opts.warmup,
     samples: opts.samples == null ? 1000 : opts.samples,
     delta: opts.delta == null ? 0.8 : opts.delta,
-    sampler: opts.sampler === "walnuts" || opts.sampler === "pathfinder"
-        ? opts.sampler : "nuts",
+    sampler,
     maxError: opts.maxError == null ? 0 : opts.maxError,
+    pathfinderInit,
   }, opts).then((done) => {
     const { names, samples, generatedStart, ms, exactLp, pathfinder,
             sampler, maxDepth } = done;

--- a/js/worker.js
+++ b/js/worker.js
@@ -1,7 +1,8 @@
 // The sampling worker: stanc3 (js_of_ocaml) compiles the model to MIR,
 // stanli.wasm lowers it and runs NUTS or WALNUTS. Everything heavy lives
 // here so the page never blocks. Protocol: {cmd: "run", code, dataJson,
-// seed, warmup, samples, delta, sampler, maxError} in; {status} progress
+// seed, warmup, samples, delta, sampler, maxError, pathfinderInit} in;
+// {status} progress
 // messages and one {done} or {error} out. `sampler` is "nuts",
 // "walnuts" or "pathfinder".
 "use strict";
@@ -113,6 +114,25 @@ function runPathfinder(M, model, req, numDraws, drawsPtr, errPtr, errLen) {
            elapsedMs: sum[3] };
 }
 
+// Fit a single Pathfinder approximation and draw one unconstrained start for
+// this worker's NUTS chain. A page runs chains in separate workers, each with
+// its already-established per-chain seed, so the starts and subsequent chains
+// reproduce together without sharing mutable WASM state.
+function runPathfinderInit(M, model, req, initPtr, errPtr, errLen) {
+  const opts = req.pathfinderInit;
+  const cbPtr = M.addFunction((iter, lp) => {
+    if (req.live)
+      postMessage({ live: { phase: "pathfinder-init", iter, lp } });
+  }, "vidi");
+  const rc = M._stanli_pathfinder_inits(
+      model, req.seed >>> 0, 1, 1, opts.numIterations, opts.numElboDraws,
+      opts.historySize, opts.initRadius, initPtr, cbPtr, 0, errPtr, errLen);
+  M.removeFunction(cbPtr);
+  if (rc !== 0)
+    throw new Error("Pathfinder initialization failed: " +
+                    M.UTF8ToString(errPtr));
+}
+
 onmessage = async (e) => {
   const req = e.data;
   const t0 = performance.now();
@@ -177,6 +197,7 @@ onmessage = async (e) => {
         : (walnuts ? "WALNUTS: " : "NUTS: ") + warmup + " warmup + " +
           samples + " draws");
     const drawsPtr = M._malloc(8 * samples * n);
+    const initPtr = req.pathfinderInit ? M._malloc(8 * n) : 0;
 
     // Stream: every draw lands in the buffer before its callback, so the
     // page can plot the chain as it grows. Constrained rows batch in
@@ -222,13 +243,22 @@ onmessage = async (e) => {
       if (pathfinder) {
         pf = runPathfinder(M, model, req, samples, drawsPtr, errPtr, errLen);
       } else {
+        if (req.pathfinderInit) {
+          say("Pathfinder initialization: fitting approximation");
+          runPathfinderInit(M, model, req, initPtr, errPtr, errLen);
+          say("Pathfinder initialization complete; starting NUTS");
+        }
         const rc = walnuts
             ? M._stanli_sample_walnuts_stream(model, req.seed >>> 0, warmup,
                                               samples, +req.maxError || 0,
                                               drawsPtr, cbPtr, 0, errPtr, errLen)
-            : M._stanli_sample_stream_stats(model, req.seed >>> 0, warmup,
-                                            samples, +req.delta, drawsPtr,
-                                            statsPtr, cbPtr, 0, errPtr, errLen);
+            : req.pathfinderInit
+            ? M._stanli_sample_stream_stats_init(
+                model, req.seed >>> 0, warmup, samples, +req.delta, initPtr,
+                drawsPtr, statsPtr, cbPtr, 0, errPtr, errLen)
+            : M._stanli_sample_stream_stats(
+                model, req.seed >>> 0, warmup, samples, +req.delta, drawsPtr,
+                statsPtr, cbPtr, 0, errPtr, errLen);
         if (rc !== 0) throw new Error(M.UTF8ToString(errPtr));
         if (statsPtr)
           samplerStats = M.HEAPF64.slice(statsPtr / 8, statsPtr / 8 + samples * 7);
@@ -237,6 +267,7 @@ onmessage = async (e) => {
       if (cbPtr) M.removeFunction(cbPtr);
       if (liveRowPtr) M._free(liveRowPtr);
       if (statsPtr) M._free(statsPtr);
+      if (initPtr) M._free(initPtr);
     }
     const tSample = performance.now();
 

--- a/python/README.md
+++ b/python/README.md
@@ -261,6 +261,22 @@ fit = model.sample(seed=1, warmup=1000, samples=1000, delta=0.8,
 fit["theta.1"]                      # ndarray, chains concatenated
 ```
 
+Pathfinder can generate one initialization per chain before NUTS. The
+sampling seed controls both stages; an empty options object uses CmdStan's
+single-path defaults:
+
+```python
+fit = model.sample(
+    chains=4,
+    seed=303,
+    pathfinder_init={"num_iterations": 500, "num_elbo_draws": 25},
+)
+```
+
+The other supported options are `history_size` and Pathfinder's own
+`init_radius`. `pathfinder_init` and explicit `inits` are mutually exclusive;
+single-path Pathfinder does not perform PSIS resampling.
+
 `data` accepts a path to a JSON file or a dict of Python scalars,
 lists, and numpy arrays. `sample` returns every column CmdStan's CSV
 would carry (constrained parameters, transformed parameters, generated
@@ -294,8 +310,9 @@ the user's machine.
 Stated plainly:
 
 - The sampler is Stan's own NUTS with diagonal-metric adaptation, and
-  `optimize()` is Stan's L-BFGS. No variational inference or Pathfinder
-  yet.
+  `optimize()` is Stan's L-BFGS. Single-path Pathfinder is available for
+  sampler initialization; a standalone Python Pathfinder result is not yet
+  exposed.
 - `inits` are on the unconstrained scale. `model.unconstrain({...})`
   turns constrained starting values into that vector, so unconstraining is
   a step per starting point rather than a second kind of argument.

--- a/python/stanli/__init__.py
+++ b/python/stanli/__init__.py
@@ -6,6 +6,7 @@ to an op graph in-process, and samples with NUTS. No C++ toolchain, no model
 compilation on this machine.
 """
 import ctypes
+from collections.abc import Mapping
 import json
 import math
 import operator
@@ -164,6 +165,12 @@ def _load_lib():
         ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double),
         _SampleProgressCallback, ctypes.c_void_p,
         ctypes.POINTER(_SampleReport), ctypes.c_char_p, ctypes.c_size_t]
+    lib.stanli_pathfinder_inits.restype = ctypes.c_int
+    lib.stanli_pathfinder_inits.argtypes = [
+        ctypes.c_void_p, ctypes.c_uint32, ctypes.c_int, ctypes.c_int,
+        ctypes.c_int, ctypes.c_int, ctypes.c_int, ctypes.c_double,
+        ctypes.POINTER(ctypes.c_double), ctypes.c_void_p, ctypes.c_void_p,
+        ctypes.c_char_p, ctypes.c_size_t]
     lib.stanli_summary_stats.restype = ctypes.c_int
     lib.stanli_summary_stats.argtypes = [ctypes.POINTER(ctypes.c_double),
                                          ctypes.c_int64, ctypes.c_int64,
@@ -200,6 +207,55 @@ SAMPLER_COLUMNS = tuple(_lib.stanli_sampler_column_name(i).decode()
 
 def _dptr(a):
     return a.ctypes.data_as(ctypes.POINTER(ctypes.c_double))
+
+
+_PATHFINDER_INIT_DEFAULTS = {
+    "num_iterations": 1000,
+    "num_elbo_draws": 25,
+    "history_size": 5,
+    "init_radius": 2.0,
+}
+
+
+def _pathfinder_init_options(value):
+    """Validate the small, deliberately separate Pathfinder-init surface."""
+    if not isinstance(value, Mapping):
+        raise TypeError("pathfinder_init must be a mapping of options")
+    unknown = set(value) - set(_PATHFINDER_INIT_DEFAULTS)
+    if unknown:
+        raise ValueError(
+            "unknown pathfinder_init option" + ("s" if len(unknown) > 1 else "")
+            + ": " + ", ".join(sorted(map(str, unknown))))
+    out = dict(_PATHFINDER_INIT_DEFAULTS)
+    out.update(value)
+    int_max = 2 ** (8 * ctypes.sizeof(ctypes.c_int) - 1) - 1
+    for name in ("num_iterations", "num_elbo_draws", "history_size"):
+        raw = out[name]
+        if isinstance(raw, (bool, np.bool_)):
+            raise TypeError(f"pathfinder_init {name} must be a positive integer")
+        try:
+            parsed = operator.index(raw)
+        except TypeError:
+            raise TypeError(
+                f"pathfinder_init {name} must be a positive integer") from None
+        if parsed <= 0:
+            raise ValueError(f"pathfinder_init {name} must be positive")
+        if parsed > int_max:
+            raise OverflowError(f"pathfinder_init {name} does not fit in a C int")
+        out[name] = parsed
+    radius = out["init_radius"]
+    if isinstance(radius, (bool, np.bool_)):
+        raise TypeError("pathfinder_init init_radius must be nonnegative")
+    try:
+        radius = float(radius)
+    except (TypeError, ValueError):
+        raise TypeError(
+            "pathfinder_init init_radius must be nonnegative") from None
+    if not math.isfinite(radius) or radius < 0:
+        raise ValueError(
+            "pathfinder_init init_radius must be finite and nonnegative")
+    out["init_radius"] = radius
+    return out
 
 
 def _compiler_command(model_path: pathlib.Path):
@@ -797,8 +853,8 @@ class Model:
 
     def sample(self, *, chains=4, seed=1, warmup=1000, samples=1000,
                delta=0.8, max_depth=10, thin=1, save_warmup=False,
-               inits=None, init_radius=2.0, parallel_chains=None,
-               refresh=100):
+               inits=None, init_radius=2.0, pathfinder_init=None,
+               parallel_chains=None, refresh=100):
         """NUTS draws as a Fit.
 
         Four chains by default, because R-hat needs more than one and a
@@ -811,6 +867,13 @@ class Model:
         passing them through `unconstrain()` first -- one scale here means
         one contract for what a start is. `init_radius=0` starts every
         chain at the origin, which is CmdStan's `init=0`.
+
+        `pathfinder_init={}` instead fits one single-path Pathfinder
+        approximation and draws one unconstrained start per chain from it.
+        The mapping can override `num_iterations` (1000), `num_elbo_draws`
+        (25), `history_size` (5), and Pathfinder's own `init_radius` (2).
+        It uses this call's seed and is mutually exclusive with `inits`.
+        Single-path Pathfinder does not perform PSIS resampling.
 
         `parallel_chains` defaults to running every chain at once, capped
         at the machine's cores. Threading changes nothing about the
@@ -861,7 +924,25 @@ class Model:
         # this buffer, so letting it fall out of scope would hand the
         # sampler freed memory.
         init_arr = None
-        if inits is not None:
+        if inits is not None and pathfinder_init is not None:
+            raise ValueError("inits and pathfinder_init are mutually exclusive")
+        if pathfinder_init is not None:
+            if opts.chains <= 0:
+                raise ValueError(
+                    "chains must be positive with Pathfinder initialization")
+            pf = _pathfinder_init_options(pathfinder_init)
+            init_arr = np.empty((opts.chains, self.n_unconstrained))
+            err = ctypes.create_string_buffer(4096)
+            rc = _lib.stanli_pathfinder_inits(
+                self._m, opts.seed, opts.chain_id, opts.chains,
+                pf["num_iterations"], pf["num_elbo_draws"],
+                pf["history_size"], pf["init_radius"], _dptr(init_arr),
+                None, None, err, len(err))
+            if rc != 0:
+                raise RuntimeError(
+                    f"Pathfinder initialization failed: {err.value.decode()}")
+            opts.inits = _dptr(init_arr)
+        elif inits is not None:
             init_arr = np.ascontiguousarray(inits, dtype=np.float64)
             if init_arr.ndim == 1:
                 init_arr = np.ascontiguousarray(

--- a/r/R/stanli.R
+++ b/r/R/stanli.R
@@ -142,6 +142,12 @@ unconstrain <- function(model, values) {
 #'   a start is.
 #' @param init_radius Random inits are drawn uniform(-r, r); 0 starts at
 #'   the origin.
+#' @param pathfinder_init Optional named list enabling Pathfinder-generated
+#'   starts. An empty list uses defaults; supported entries are
+#'   `num_iterations` (1000), `num_elbo_draws` (25), `history_size` (5), and
+#'   Pathfinder's own `init_radius` (2). Uses `seed`, returns one start per
+#'   chain, and cannot be combined with `init`. Single-path Pathfinder does
+#'   not perform PSIS resampling.
 #' @param parallel_chains Chains to run at once. Defaults to all of them.
 #' @param refresh Print a progress update every `refresh` transitions within
 #'   each phase, plus the first and last transition of the phase. Set to 0 to
@@ -155,15 +161,29 @@ unconstrain <- function(model, values) {
 sample_model <- function(model, chains = 4, seed = 1, warmup = 1000,
                          samples = 1000, thin = 1, delta = 0.8,
                          max_depth = 10, save_warmup = FALSE, init = NULL,
-                         init_radius = 2, parallel_chains = NULL,
-                         refresh = 100) {
+                         init_radius = 2, pathfinder_init = NULL,
+                         parallel_chains = NULL, refresh = 100) {
   if (length(refresh) != 1L || !is.numeric(refresh) || is.na(refresh) ||
       !is.finite(refresh) || refresh < 0 || refresh != floor(refresh) ||
       refresh > .Machine$integer.max)
     stop("refresh must be a single nonnegative integer", call. = FALSE)
   refresh <- as.integer(refresh)
+  if (!is.null(init) && !is.null(pathfinder_init))
+    stop("init and pathfinder_init are mutually exclusive", call. = FALSE)
+  if (!is.null(pathfinder_init))
+    pathfinder_init <- .pathfinder_init_options(pathfinder_init)
+  if (!is.null(pathfinder_init) &&
+      (length(chains) != 1L || !is.numeric(chains) || is.logical(chains) ||
+       is.na(chains) || !is.finite(chains) || chains <= 0 ||
+       chains != floor(chains) || chains > .Machine$integer.max))
+    stop("chains must be a positive integer with Pathfinder initialization",
+         call. = FALSE)
   load_runtime()
   if (is.null(parallel_chains)) parallel_chains <- chains
+  if (!is.null(pathfinder_init)) {
+    init <- .Call("stanli_r_pathfinder_inits", model$ptr, as.integer(seed),
+                  as.integer(chains), unname(pathfinder_init))
+  }
   init_vec <- numeric(0)
   if (!is.null(init)) {
     m <- if (is.matrix(init)) init else
@@ -205,6 +225,38 @@ sample_model <- function(model, chains = 4, seed = 1, warmup = 1000,
                  columns = model$columns, max_depth = max_depth, seed = seed,
                  model = model, report = report),
             class = "stanli_fit")
+}
+
+.pathfinder_init_options <- function(x) {
+  if (!is.list(x))
+    stop("pathfinder_init must be a named list of options", call. = FALSE)
+  defaults <- list(num_iterations = 1000L, num_elbo_draws = 25L,
+                   history_size = 5L, init_radius = 2)
+  if (length(x) > 0L) {
+    if (is.null(names(x)) || any(!nzchar(names(x))) || anyDuplicated(names(x)))
+      stop("pathfinder_init must be a named list of options", call. = FALSE)
+    unknown <- setdiff(names(x), names(defaults))
+    if (length(unknown) > 0L)
+      stop("unknown pathfinder_init option", if (length(unknown) > 1L) "s" else "",
+           ": ", paste(unknown, collapse = ", "), call. = FALSE)
+  }
+  out <- utils::modifyList(defaults, x)
+  for (name in c("num_iterations", "num_elbo_draws", "history_size")) {
+    value <- out[[name]]
+    if (length(value) != 1L || !is.numeric(value) || is.logical(value) ||
+        is.na(value) || !is.finite(value) || value <= 0 ||
+        value != floor(value) || value > .Machine$integer.max)
+      stop("pathfinder_init ", name, " must be a positive integer",
+           call. = FALSE)
+    out[[name]] <- as.integer(value)
+  }
+  radius <- out$init_radius
+  if (length(radius) != 1L || !is.numeric(radius) || is.logical(radius) ||
+      is.na(radius) || !is.finite(radius) || radius < 0)
+    stop("pathfinder_init init_radius must be finite and nonnegative",
+         call. = FALSE)
+  out$init_radius <- as.double(radius)
+  out
 }
 
 #' @export

--- a/r/README.md
+++ b/r/README.md
@@ -46,6 +46,13 @@ library(stanli)
 m <- stanli_model(file = "eight_schools.stan", data = list(J = 8L, y = y, sigma = s))
 fit <- sample_model(m, chains = 4, seed = 1)
 
+# Fit a single-path Pathfinder approximation first, then draw one
+# reproducible NUTS start per chain from it.
+fit_pf <- sample_model(
+  m, chains = 4, seed = 303,
+  pathfinder_init = list(num_iterations = 500L, num_elbo_draws = 25L)
+)
+
 summary(fit)          # mean, MCSE, sd, quantiles, bulk/tail ESS, R-hat
 stanli_diagnose(fit)  # divergences, treedepth, E-BFMI, R-hat, ESS
 as_draws_array(fit)   # a posterior::draws_array
@@ -71,6 +78,10 @@ including E-BFMI, the one that catches a badly explored heavy tail.
 `unconstrain(m, list(mu = 0.5, sigma = 1.2))` builds the same vector from
 starting values on the constrained scale, naming the parameter when one is
 missing, the wrong size, or outside its support.
+`pathfinder_init = list()` uses single-path Pathfinder defaults; its supported
+overrides are `num_iterations`, `num_elbo_draws`, `history_size`, and
+`init_radius`. It is mutually exclusive with explicit `init`, and does not
+perform PSIS resampling.
 
 Chains run in parallel by default. Threading does not change the
 answer: each chain owns its executor and its RNG stream, so a parallel

--- a/r/man/sample_model.Rd
+++ b/r/man/sample_model.Rd
@@ -16,6 +16,7 @@ sample_model(
   save_warmup = FALSE,
   init = NULL,
   init_radius = 2,
+  pathfinder_init = NULL,
   parallel_chains = NULL,
   refresh = 100
 )
@@ -39,6 +40,13 @@ a start is.}
 
 \item{init_radius}{Random inits are drawn uniform(-r, r); 0 starts at
 the origin.}
+
+\item{pathfinder_init}{Optional named list enabling Pathfinder-generated
+starts. An empty list uses defaults; supported entries are
+`num_iterations` (1000), `num_elbo_draws` (25), `history_size` (5), and
+Pathfinder's own `init_radius` (2). Uses `seed`, returns one start per
+chain, and cannot be combined with `init`. Single-path Pathfinder does
+not perform PSIS resampling.}
 
 \item{parallel_chains}{Chains to run at once. Defaults to all of them.}
 

--- a/r/src/bridge.c
+++ b/r/src/bridge.c
@@ -92,6 +92,7 @@ typedef struct {
 
 typedef void (*stanli_sample_progress_cb)(int32_t, int64_t, int64_t, int32_t,
                                           void*);
+typedef void (*stanli_path_cb)(int32_t, double, void*);
 
 typedef struct {
   uint32_t seed;
@@ -133,6 +134,9 @@ static int (*p_sample_multi_progress)(void*, const stanli_sample_opts*, int,
                                       double*, double*,
                                       stanli_sample_progress_cb, void*,
                                       stanli_sample_report*, char*, size_t);
+static int (*p_pathfinder_inits)(void*, uint32_t, int, int, int, int, int,
+                                 double, double*, stanli_path_cb, void*, char*,
+                                 size_t);
 static const char* (*p_sampler_column_name)(int);
 static int (*p_summary_stats)(const double*, int64_t, int64_t, int64_t,
                               double*);
@@ -211,6 +215,9 @@ SEXP stanli_bridge_load(SEXP path) {
    * than making an optional feature prevent the library loading. */
   *(void**)(&p_sample_multi_progress) =
       dl_sym(g_lib, "stanli_sample_multi_progress");
+  /* Pathfinder initialization is also additive. Only callers that request it
+   * require a runtime new enough to provide the symbol. */
+  *(void**)(&p_pathfinder_inits) = dl_sym(g_lib, "stanli_pathfinder_inits");
   BIND("stanli_sampler_column_name", p_sampler_column_name);
   BIND("stanli_summary_stats", p_summary_stats);
   BIND("stanli_diagnose_text", p_diagnose_text);
@@ -412,6 +419,38 @@ static void print_sample_reports(const stanli_sample_opts* o, int64_t nchain,
         (long long)n_max_treedepth, (long long)transitions,
         o->max_depth > 0 ? o->max_depth : 10);
   R_FlushConsole();
+}
+
+SEXP stanli_r_pathfinder_inits(SEXP m, SEXP seed, SEXP chains, SEXP options) {
+  require_loaded();
+  if (p_pathfinder_inits == NULL)
+    error(
+        "Pathfinder initialization is unavailable with this older stanli "
+        "runtime. Run stanli_install(overwrite = TRUE) to update.");
+  void* mm = model_ptr(m);
+  const int nchain = asInteger(chains);
+  if (nchain <= 0) error("chains must be positive");
+  const int64_t n = p_n_unconstrained(mm);
+  double* raw = (double*)R_alloc((size_t)nchain * (size_t)n, sizeof(double));
+  char err[4096];
+  err[0] = '\0';
+  const int rc = p_pathfinder_inits(
+      mm, (uint32_t)asInteger(seed), 1, nchain,
+      asInteger(VECTOR_ELT(options, 0)), asInteger(VECTOR_ELT(options, 1)),
+      asInteger(VECTOR_ELT(options, 2)), asReal(VECTOR_ELT(options, 3)), raw,
+      NULL, NULL, err, sizeof err);
+  if (rc != 0)
+    error("Pathfinder initialization failed: %s",
+          err[0] ? err : "unknown error");
+
+  /* Return an ordinary chains-by-parameters R matrix. R owns columns, while
+   * the C ABI owns chain-major rows, so transpose the memory layout here. */
+  SEXP out = PROTECT(allocMatrix(REALSXP, nchain, (int)n));
+  for (int c = 0; c < nchain; ++c)
+    for (int64_t j = 0; j < n; ++j)
+      REAL(out)[c + (int64_t)nchain * j] = raw[(int64_t)c * n + j];
+  UNPROTECT(1);
+  return out;
 }
 
 SEXP stanli_r_sample(SEXP m, SEXP optlist, SEXP inits, SEXP refresh) {

--- a/r/src/init.c
+++ b/r/src/init.c
@@ -14,6 +14,7 @@ extern SEXP stanli_r_n_unconstrained(SEXP);
 extern SEXP stanli_r_column_names(SEXP);
 extern SEXP stanli_r_grad(SEXP, SEXP);
 extern SEXP stanli_r_unconstrain_inits(SEXP, SEXP);
+extern SEXP stanli_r_pathfinder_inits(SEXP, SEXP, SEXP, SEXP);
 extern SEXP stanli_r_sample(SEXP, SEXP, SEXP, SEXP);
 extern SEXP stanli_r_sampler_columns(void);
 extern SEXP stanli_r_summary(SEXP, SEXP);
@@ -31,6 +32,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"stanli_r_column_names", (DL_FUNC)&stanli_r_column_names, 1},
     {"stanli_r_grad", (DL_FUNC)&stanli_r_grad, 2},
     {"stanli_r_unconstrain_inits", (DL_FUNC)&stanli_r_unconstrain_inits, 2},
+    {"stanli_r_pathfinder_inits", (DL_FUNC)&stanli_r_pathfinder_inits, 4},
     {"stanli_r_sample", (DL_FUNC)&stanli_r_sample, 4},
     {"stanli_r_sampler_columns", (DL_FUNC)&stanli_r_sampler_columns, 0},
     {"stanli_r_summary", (DL_FUNC)&stanli_r_summary, 2},

--- a/r/tests/testthat/test-sampling.R
+++ b/r/tests/testthat/test-sampling.R
@@ -198,6 +198,43 @@ test_that("chains are different streams of the same seed", {
   expect_false(identical(a$draws[, 1, "mu"], a$draws[, 2, "mu"]))
 })
 
+test_that("Pathfinder initialization is reproducible across chains", {
+  skip_without_runtime()
+  m <- progress_model()
+  options <- list(num_iterations = 100L, num_elbo_draws = 10L,
+                  history_size = 5L, init_radius = 2)
+  a <- sample_model(m, chains = 2, seed = 303, warmup = 30, samples = 20,
+                    pathfinder_init = options, parallel_chains = 1,
+                    refresh = 0)
+  b <- sample_model(m, chains = 2, seed = 303, warmup = 30, samples = 20,
+                    pathfinder_init = options, parallel_chains = 2,
+                    refresh = 0)
+  expect_identical(a$draws, b$draws)
+  expect_identical(a$sampler, b$sampler)
+  expect_false(identical(a$draws[, 1, "x"], a$draws[, 2, "x"]))
+})
+
+test_that("Pathfinder initialization validates its dedicated options", {
+  expect_identical(
+    stanli:::.pathfinder_init_options(list()),
+    list(num_iterations = 1000L, num_elbo_draws = 25L,
+         history_size = 5L, init_radius = 2))
+  bad <- list(
+    1,
+    list(1),
+    list(not_an_option = 1),
+    list(num_iterations = 0),
+    list(num_elbo_draws = 1.5),
+    list(history_size = TRUE),
+    list(init_radius = NaN),
+    list(init_radius = -1))
+  for (value in bad)
+    expect_error(stanli:::.pathfinder_init_options(value), "pathfinder_init")
+  expect_error(
+    sample_model(NULL, init = 0, pathfinder_init = list(), refresh = 0),
+    "mutually exclusive", fixed = TRUE)
+})
+
 test_that("the draws array is posterior-shaped and keeps its names", {
   skip_without_runtime()
   fit <- sample_model(es_model(), chains = 2, seed = 4, warmup = 200,

--- a/runtime/include/stanli/capi.h
+++ b/runtime/include/stanli/capi.h
@@ -318,6 +318,16 @@ int stanli_sample_stream_stats(stanli_model* m, uint32_t seed, int warmup,
                                double* stats, stanli_draw_cb cb, void* user,
                                char* err, size_t err_len);
 
+/* Explicit-init form of stanli_sample_stream_stats. `init` is one
+ * n_unconstrained vector on the unconstrained scale. This is an additive
+ * entry point so existing stream callers and stanli_sample_opts keep their
+ * version-1 layouts. */
+int stanli_sample_stream_stats_init(stanli_model* m, uint32_t seed, int warmup,
+                                    int samples, double delta,
+                                    const double* init, double* draws,
+                                    double* stats, stanli_draw_cb cb,
+                                    void* user, char* err, size_t err_len);
+
 /* WALNUTS (within-orbit adaptive step-length NUTS, arXiv:2506.18746),
  * same streaming contract as stanli_sample_stream. `max_error` is the
  * sampler's tunable in place of NUTS's `delta`: the largest drift in
@@ -352,6 +362,23 @@ int stanli_run_pathfinder(stanli_model* m, uint32_t seed, int chain_id,
                           int num_draws, double* draws, double* lp,
                           double* lp_approx, double* summary, stanli_path_cb cb,
                           void* user, char* err, size_t err_len);
+
+/* Generate one unconstrained NUTS starting point per chain from a single-path
+ * Pathfinder approximation. `inits` receives chains * n_unconstrained
+ * doubles in chain-major order, ready for stanli_sample_opts::inits. The
+ * sampling seed owns reproducibility: Pathfinder uses (seed, chain_id), then
+ * returns `chains` draws from the selected approximation. Single-path
+ * Pathfinder performs no PSIS resampling.
+ *
+ * The four tunables are the deliberately small initialization surface. Pass
+ * CmdStan defaults (1000, 25, 5, 2) unless the host's dedicated Pathfinder
+ * options object overrides them. `cb`, when non-null, observes the L-BFGS
+ * path and can provide initialization progress in an interactive caller. */
+int stanli_pathfinder_inits(stanli_model* m, uint32_t seed, int chain_id,
+                            int chains, int num_iterations, int num_elbo_draws,
+                            int history_size, double init_radius, double* inits,
+                            stanli_path_cb cb, void* user, char* err,
+                            size_t err_len);
 
 /* write_array: every CSV column CmdStan would emit for one draw --
  * constrained parameters, transformed parameters, generated quantities,

--- a/runtime/src/capi.cpp
+++ b/runtime/src/capi.cpp
@@ -12,11 +12,13 @@
 #include "build_id.hpp"
 
 #include <algorithm>
+#include <cmath>
 #include <cstdlib>
 #include <cstring>
 #include <map>
 #include <limits>
 #include <memory>
+#include <stdexcept>
 #include <string>
 #include <vector>
 
@@ -276,12 +278,23 @@ int stanli_sample_stream_stats(stanli_model* m, uint32_t seed, int warmup,
                                int samples, double delta, double* draws,
                                double* stats, stanli_draw_cb cb, void* user,
                                char* err, size_t err_len) {
+  return stanli_sample_stream_stats_init(m, seed, warmup, samples, delta,
+                                         nullptr, draws, stats, cb, user, err,
+                                         err_len);
+}
+
+int stanli_sample_stream_stats_init(stanli_model* m, uint32_t seed, int warmup,
+                                    int samples, double delta,
+                                    const double* init, double* draws,
+                                    double* stats, stanli_draw_cb cb,
+                                    void* user, char* err, size_t err_len) {
   try {
     stanli::NutsConfig cfg;
     cfg.seed = seed;
     cfg.warmup = warmup;
     cfg.samples = samples;
     cfg.delta = delta;
+    cfg.init = init;
     const int64_t n = m->ex->n_params();
     stanli::DrawObserver observe;
     if (cb) {
@@ -370,6 +383,64 @@ int stanli_run_pathfinder(stanli_model* m, uint32_t seed, int chain_id,
       summary[STANLI_PATHFINDER_SELECTED_ITER] = r.selected_iter;
       summary[STANLI_PATHFINDER_SELECTED_ELBO] = r.selected_elbo;
       summary[STANLI_PATHFINDER_ELAPSED_MS] = r.elapsed_ms;
+    }
+    return 0;
+  } catch (const std::exception& e) {
+    put_err(err, err_len, e.what());
+    return 1;
+  }
+}
+
+int stanli_pathfinder_inits(stanli_model* m, uint32_t seed, int chain_id,
+                            int chains, int num_iterations, int num_elbo_draws,
+                            int history_size, double init_radius, double* inits,
+                            stanli_path_cb cb, void* user, char* err,
+                            size_t err_len) {
+  try {
+    if (chains <= 0) throw std::invalid_argument("chains must be positive");
+    if (num_iterations <= 0)
+      throw std::invalid_argument("num_iterations must be positive");
+    if (num_elbo_draws <= 0)
+      throw std::invalid_argument("num_elbo_draws must be positive");
+    if (history_size <= 0)
+      throw std::invalid_argument("history_size must be positive");
+    if (!std::isfinite(init_radius) || init_radius < 0)
+      throw std::invalid_argument("init_radius must be finite and nonnegative");
+
+    stanli::PathfinderConfig cfg;
+    cfg.seed = seed;
+    cfg.chain_id = chain_id > 0 ? chain_id : 1;
+    cfg.num_draws = chains;
+    cfg.num_iterations = num_iterations;
+    cfg.num_elbo_draws = num_elbo_draws;
+    cfg.history_size = history_size;
+    cfg.init_radius = init_radius;
+    stanli::PathObserver observe;
+    if (cb) {
+      observe = [&](const stanli::PathIterate& it) {
+        cb((int32_t)it.iter, it.lp, user);
+      };
+    }
+    stanli::PathfinderResult r = stanli::run_pathfinder(*m->ex, cfg, observe);
+    if (r.return_code != 0) {
+      put_err(err, err_len,
+              r.message.empty() ? "pathfinder failed" : r.message.c_str());
+      return r.return_code;
+    }
+
+    const int64_t n = m->ex->n_params();
+    if ((int)r.draws.size() != chains)
+      throw std::runtime_error(
+          "pathfinder returned an unexpected number of draws");
+    for (int c = 0; c < chains; ++c) {
+      if ((int64_t)r.draws[(size_t)c].size() != n)
+        throw std::runtime_error(
+            "pathfinder returned a draw of the wrong size");
+      if (n > 0) {
+        if (inits == nullptr) throw std::invalid_argument("null inits buffer");
+        std::memcpy(inits + (int64_t)c * n, r.draws[(size_t)c].data(),
+                    sizeof(double) * (size_t)n);
+      }
     }
     return 0;
   } catch (const std::exception& e) {

--- a/tests/test_capi.cpp
+++ b/tests/test_capi.cpp
@@ -611,6 +611,38 @@ void expect_pathfinder() {
     std::printf("FAIL C API pathfinder summary: khat %g selected %g\n", khat,
                 selected);
   }
+
+  // Pathfinder-as-initialization is a distinct additive boundary: one
+  // chain-major unconstrained row per requested chain, reproducible from the
+  // sampling seed and not a change to stanli_sample_opts.
+  std::vector<double> inits((size_t)(3 * n));
+  std::vector<double> repeated(inits.size());
+  std::vector<double> changed(inits.size());
+  path.clear();
+  const int init_rc =
+      stanli_pathfinder_inits(model, 1729, 1, 3, 1000, 25, 5, 2.0, inits.data(),
+                              on_iter, &path, err, sizeof err);
+  const int repeated_rc = stanli_pathfinder_inits(
+      model, 1729, 1, 3, 1000, 25, 5, 2.0, repeated.data(), nullptr, nullptr,
+      err, sizeof err);
+  const int changed_rc = stanli_pathfinder_inits(model, 1730, 1, 3, 1000, 25, 5,
+                                                 2.0, changed.data(), nullptr,
+                                                 nullptr, err, sizeof err);
+  expect_true("C API Pathfinder inits succeed",
+              init_rc == 0 && repeated_rc == 0 && changed_rc == 0);
+  expect_true("C API Pathfinder inits expose progress", !path.empty());
+  expect_true("C API Pathfinder inits reproduce", inits == repeated);
+  expect_true("C API Pathfinder init seed changes output", inits != changed);
+  expect_true("C API Pathfinder gives chains distinct starts",
+              !std::equal(inits.begin(), inits.begin() + n, inits.begin() + n));
+
+  err[0] = '\0';
+  const int invalid = stanli_pathfinder_inits(
+      model, 1, 1, 3, 1000, 25, 5, std::numeric_limits<double>::quiet_NaN(),
+      inits.data(), nullptr, nullptr, err, sizeof err);
+  expect_true("C API Pathfinder init rejects invalid settings",
+              invalid != 0 &&
+                  std::string(err).find("init_radius") != std::string::npos);
   stanli_model_free(model);
 }
 
@@ -766,6 +798,23 @@ void expect_streaming_stats() {
               stanli_sample(model, opts.seed, opts.warmup, opts.samples,
                             opts.delta, streamed.data(), err, sizeof err) == 0);
   expect_true("old sampler retains identical draws", streamed == reference);
+
+  // The browser's additive explicit-init stream is the one-chain multi API,
+  // byte for byte. This is the handoff Pathfinder initialization uses.
+  std::vector<double> init((size_t)n, 0.0);
+  opts.inits = init.data();
+  expect_true("explicit-init multi sampling",
+              stanli_sample_multi(model, &opts, reference.data(), stats.data(),
+                                  err, sizeof err) == 0);
+  expect_true("explicit-init streaming sampling",
+              stanli_sample_stream_stats_init(
+                  model, opts.seed, opts.warmup, opts.samples, opts.delta,
+                  init.data(), streamed.data(), streamed_stats.data(), nullptr,
+                  nullptr, err, sizeof err) == 0);
+  expect_true("explicit-init stream matches multi draws",
+              streamed == reference);
+  expect_true("explicit-init stream matches multi stats",
+              streamed_stats == stats);
   stanli_model_free(model);
 }
 

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -631,6 +631,52 @@ def test_explicit_inits():
         raise AssertionError("expected ValueError for mismatched inits")
 
 
+def test_pathfinder_initialization_reproduces_multichain_sampling():
+    m = _normal()
+    options = {"num_iterations": 100, "num_elbo_draws": 10,
+               "history_size": 5, "init_radius": 2.0}
+    a = m.sample(chains=2, seed=303, warmup=30, samples=20,
+                 pathfinder_init=options, parallel_chains=1, refresh=0)
+    b = m.sample(chains=2, seed=303, warmup=30, samples=20,
+                 pathfinder_init=options, parallel_chains=2, refresh=0)
+    assert np.array_equal(a.draws(), b.draws()), \
+        "same seed and Pathfinder options must reproduce"
+    assert np.array_equal(a.sampler_stats, b.sampler_stats)
+    assert not np.array_equal(a.draws("x")[0], a.draws("x")[1]), \
+        "Pathfinder must provide one start for each chain"
+
+
+def test_pathfinder_initialization_options_and_explicit_init_exclusion():
+    assert stanli._pathfinder_init_options({}) == {
+        "num_iterations": 1000, "num_elbo_draws": 25,
+        "history_size": 5, "init_radius": 2.0}
+    assert stanli._pathfinder_init_options({
+        "num_iterations": np.int64(7), "init_radius": np.float64(0.5)
+    })["num_iterations"] == 7
+    for value, error in [([], TypeError),
+                         ({"not_an_option": 1}, ValueError),
+                         ({"num_iterations": 0}, ValueError),
+                         ({"num_elbo_draws": 1.5}, TypeError),
+                         ({"history_size": True}, TypeError),
+                         ({"init_radius": float("nan")}, ValueError),
+                         ({"init_radius": -1}, ValueError)]:
+        try:
+            stanli._pathfinder_init_options(value)
+        except error:
+            pass
+        else:
+            raise AssertionError(
+                f"pathfinder_init={value!r} did not raise {error.__name__}")
+
+    try:
+        _normal().sample(chains=1, warmup=1, samples=1, inits=[0.0],
+                         pathfinder_init={}, refresh=0)
+    except ValueError as exc:
+        assert "mutually exclusive" in str(exc)
+    else:
+        raise AssertionError("explicit and Pathfinder inits were both accepted")
+
+
 def test_generated_quantities_differ_across_chains():
     # Each chain must get its own RNG stream, or every chain reports the
     # same posterior-predictive draws and the predictive check is a lie.

--- a/tests/test_wasm.cjs
+++ b/tests/test_wasm.cjs
@@ -181,6 +181,39 @@ createStanli().then((M) => {
   const pfMs = M.HEAPF64[sumPtr / 8 + 3];
   M._free(sumPtr);
 
+  // The web initialization handoff: Pathfinder writes one unconstrained
+  // point, then the additive stream entry starts NUTS from exactly that
+  // buffer while retaining sampler statistics and live-draw compatibility.
+  const pfInitPtr = M._malloc(8 * n);
+  const pfInitPath = [];
+  const pfInitCb = M.addFunction(
+      (iter, plp) => pfInitPath.push([iter, plp]), "vidi");
+  const rcPI = M._stanli_pathfinder_inits(
+      model, 303, 1, 1, 100, 10, 5, 2, pfInitPtr, pfInitCb, 0, errPtr,
+      errLen);
+  M.removeFunction(pfInitCb);
+  if (rcPI !== 0)
+    fail("pathfinder initialization: " + M.UTF8ToString(errPtr));
+  if (!pfInitPath.length ||
+      !M.HEAPF64.subarray(pfInitPtr / 8, pfInitPtr / 8 + n)
+          .every(Number.isFinite))
+    fail("pathfinder initialization produced no finite start");
+  const initSamples = 20;
+  const initStatsPtr = M._malloc(8 * initSamples * 7);
+  const rcPISample = M._stanli_sample_stream_stats_init(
+      model, 303, 30, initSamples, 0.8, pfInitPtr, drawsPtr, initStatsPtr, 0,
+      0, errPtr, errLen);
+  if (rcPISample !== 0)
+    fail("sampling from Pathfinder initialization: " +
+         M.UTF8ToString(errPtr));
+  if (!M.HEAPF64.subarray(drawsPtr / 8, drawsPtr / 8 + initSamples * n)
+          .every(Number.isFinite) ||
+      !M.HEAPF64.subarray(initStatsPtr / 8, initStatsPtr / 8 + initSamples * 7)
+          .every(Number.isFinite))
+    fail("sampling from Pathfinder initialization produced nonfinite output");
+  M._free(initStatsPtr);
+  M._free(pfInitPtr);
+
   M._stanli_model_free(model);
 
   // A source-to-WASM generated-quantities smoke for the portable producer.

--- a/tools/exported_symbols.def
+++ b/tools/exported_symbols.def
@@ -28,8 +28,10 @@ EXPORTS
   stanli_sample
   stanli_sample_stream
   stanli_sample_stream_stats
+  stanli_sample_stream_stats_init
   stanli_sample_walnuts_stream
   stanli_run_pathfinder
+  stanli_pathfinder_inits
   stanli_n_constrained
   stanli_constrained_name
   stanli_constrain

--- a/web/index.html
+++ b/web/index.html
@@ -173,6 +173,18 @@ Compare methods side by side.</p>
   <label>seed <input id="seed" value="1"></label>
   <label id="deltalab">delta <input id="delta" value="0.8"></label>
   <label id="maxerrlab" hidden>max err <input id="maxerr" value="0.5"></label>
+  <label id="initlab">init <select id="initmethod">
+    <option value="random">random</option>
+    <option value="pathfinder">Pathfinder</option>
+  </select></label>
+  <label class="pfinit" hidden>PF iterations
+    <input id="pfiterations" value="1000"></label>
+  <label class="pfinit" hidden>PF ELBO draws
+    <input id="pfelbodraws" value="25"></label>
+  <label class="pfinit" hidden>PF history
+    <input id="pfhistory" value="5"></label>
+  <label class="pfinit" hidden>PF radius
+    <input id="pfradius" value="2"></label>
   <button id="csv" class="plain" hidden>Download CSV</button>
   <span id="status"></span>
 </div>
@@ -504,7 +516,7 @@ const MODE_SAMPLERS = {
   pathfinder: ["pathfinder"], nutspf: ["nuts", "pathfinder"],
 };
 function samplerMode() { return $("sampler").value; }
-$("sampler").onchange = () => {
+function updateSamplerControls() {
   const on = MODE_SAMPLERS[samplerMode()];
   // delta tunes NUTS's adaptation target; max err tunes how much the
   // joint log density may drift across one WALNUTS macro step. Each is
@@ -512,7 +524,20 @@ $("sampler").onchange = () => {
   // optimizes rather than samples.
   $("deltalab").hidden = !on.includes("nuts");
   $("maxerrlab").hidden = !on.includes("walnuts");
-};
+  // Pathfinder initialization is a NUTS start, not another sampler mode.
+  // Keep it out of comparison modes, whose point is to compare methods under
+  // their established shared-start contracts.
+  const canInitialize = samplerMode() === "nuts";
+  $("initlab").hidden = !canInitialize;
+  const showPathfinder = canInitialize &&
+      $("initmethod").value === "pathfinder";
+  document.querySelectorAll(".pfinit").forEach((el) => {
+    el.hidden = !showPathfinder;
+  });
+}
+$("sampler").onchange = updateSamplerControls;
+$("initmethod").onchange = updateSamplerControls;
+updateSamplerControls();
 
 // ---- run -------------------------------------------------------------------
 // fit = {names, samples, generatedStart,
@@ -600,6 +625,7 @@ function newLive(nChains) {
            // Pathfinder streams L-BFGS iterates instead of draws, one
            // climb per chain slot.
            path: Array.from({ length: nChains }, () => []),
+           pfInit: new Array(nChains).fill(0),
            lo: Infinity, hi: -Infinity };
 }
 // Fold one chain's live messages into `live`, then let `redraw` decide
@@ -613,6 +639,11 @@ function liveHandler(live, progress, redraw) {
       live.path[c].push({ iter: lv.iter, lp: lv.lp });
       progress();
       redraw();
+      return;
+    }
+    if (lv.phase === "pathfinder-init") {
+      live.pfInit[c] = lv.iter + 1;
+      progress();
       return;
     }
     if (lv.phase === "warmup") {
@@ -673,6 +704,14 @@ $("run").onclick = async () => {
     samples: parseInt($("samples").value, 10) || 1000,
     delta: parseFloat($("delta").value) || 0.8,
     maxError: parseFloat($("maxerr").value) || 0,
+    pathfinderInit: $("initmethod").value === "pathfinder" && mode === "nuts"
+        ? {
+            numIterations: parseInt($("pfiterations").value, 10),
+            numElboDraws: parseInt($("pfelbodraws").value, 10),
+            historySize: parseInt($("pfhistory").value, 10),
+            initRadius: Number($("pfradius").value),
+          }
+        : null,
   };
   try {
     // Compile once; every chain of every sampler then runs from the same
@@ -704,10 +743,14 @@ async function runSingle(mode, opts, nChains, seed, compiled, tWall) {
   const progress = throttled(() => {
     const w = live.warm.reduce((a, b) => a + b, 0);
     const d = live.drawn.reduce((a, b) => a + b, 0);
+    const pfi = live.pfInit.reduce((a, b) => a + b, 0);
     $("status").textContent = pathfinder
         ? `${label}: ${iterates()} L-BFGS iterates across ${nChains} paths`
         : d
         ? `${label} sampling: ${d}/${nChains * opts.samples} draws across ` +
+          `${nChains} chains`
+        : pfi && !w
+        ? `Pathfinder initialization: ${pfi} L-BFGS iterates across ` +
           `${nChains} chains`
         : `${label} warmup: ${w}/${nChains * opts.warmup} across ` +
           `${nChains} chains`;

--- a/web/index.mjs
+++ b/web/index.mjs
@@ -95,6 +95,29 @@ export function compile(opts) {
   return request({ cmd: "compile", code: opts.code }, opts);
 }
 
+function pathfinderInitOptions(value) {
+  if (value == null) return null;
+  if (typeof value !== "object" || Array.isArray(value))
+    throw new TypeError("pathfinderInit must be an options object");
+  const defaults = { numIterations: 1000, numElboDraws: 25,
+                     historySize: 5, initRadius: 2 };
+  const unknown = Object.keys(value).filter((key) => !(key in defaults));
+  if (unknown.length)
+    throw new RangeError("unknown pathfinderInit option" +
+                         (unknown.length > 1 ? "s" : "") + ": " +
+                         unknown.join(", "));
+  const out = { ...defaults, ...value };
+  for (const name of ["numIterations", "numElboDraws", "historySize"])
+    if (!Number.isInteger(out[name]) || out[name] <= 0 ||
+        out[name] > 2147483647)
+      throw new RangeError(`pathfinderInit ${name} must be a positive integer`);
+  if (typeof out.initRadius !== "number" || !Number.isFinite(out.initRadius) ||
+      out.initRadius < 0)
+    throw new RangeError(
+        "pathfinderInit initRadius must be finite and nonnegative");
+  return out;
+}
+
 /** Compile (unless `mir` is given) and draw from the posterior.
  *
  * @param {Object} opts
@@ -108,6 +131,10 @@ export function compile(opts) {
  * @param {number} [opts.warmup=1000]
  * @param {number} [opts.samples=1000]
  * @param {number} [opts.delta=0.8]    Adaptation target acceptance (NUTS).
+ * @param {Object} [opts.pathfinderInit]  Generate the NUTS start with
+ *   single-path Pathfinder. `{}` uses defaults; supported keys are
+ *   `numIterations`, `numElboDraws`, `historySize`, and `initRadius`.
+ *   The sampling seed controls both stages. NUTS only; no PSIS resampling.
  * @param {string} [opts.sampler="nuts"]  "nuts", "walnuts" (within-orbit
  *   adaptive step-length NUTS, arXiv:2506.18746), or "pathfinder"
  *   (a normal approximation fitted along an L-BFGS path). Pathfinder
@@ -141,6 +168,11 @@ export function compile(opts) {
  *   divergent__, energy__. Other methods return null for samplerStats.
  */
 export function sample(opts) {
+  const sampler = opts.sampler === "walnuts" || opts.sampler === "pathfinder"
+      ? opts.sampler : "nuts";
+  const pathfinderInit = pathfinderInitOptions(opts.pathfinderInit);
+  if (pathfinderInit && sampler !== "nuts")
+    throw new RangeError("pathfinderInit is available only with NUTS");
   return request({
     cmd: "run",
     code: opts.code,
@@ -153,9 +185,9 @@ export function sample(opts) {
     warmup: opts.warmup == null ? 1000 : opts.warmup,
     samples: opts.samples == null ? 1000 : opts.samples,
     delta: opts.delta == null ? 0.8 : opts.delta,
-    sampler: opts.sampler === "walnuts" || opts.sampler === "pathfinder"
-        ? opts.sampler : "nuts",
+    sampler,
     maxError: opts.maxError == null ? 0 : opts.maxError,
+    pathfinderInit,
   }, opts).then((done) => {
     const { names, samples, generatedStart, ms, exactLp, pathfinder,
             sampler, maxDepth } = done;


### PR DESCRIPTION
## Summary

- add an additive C API bridge that produces unconstrained Pathfinder draws and starts streaming sampling from explicit unconstrained initial values
- expose opt-in Pathfinder initialization in Python and R with validated tuning options, reproducible multichain seeding, and mutual exclusion with explicit initial values
- expose the same option in JavaScript and add standalone web controls, progress reporting, and clear initialization failures
- document the new workflow and cover C API, Python, R, and WASM behavior

Pathfinder initialization uses one Pathfinder path and skips PSIS resampling; the requested chain count determines how many unconstrained initial draws are returned. Existing explicit-initialization behavior is unchanged.

## Validation

- 5 native suites: `test_nuts`, `test_sampling`, `test_multichain`, `test_pathfinder`, `test_capi`
- full Python test script (40 tests)
- R sampling test suite
- WASM end-to-end test
- local browser smoke test for control visibility, two-chain sampling, and initialization failure reporting

Closes #303
