### PR TITLE
Reduce dynamic structured-loop history and memory

### DIFF
--- a/runtime/include/stanli/structured_loop.hpp
+++ b/runtime/include/stanli/structured_loop.hpp
@@ -33,9 +33,11 @@ struct DynamicIndexSpec {
   bool matrix_leaf = false;
   int64_t selected_size = 0;
   // Zero preserves the original two-input read / three-input update ABI.
-  // A positive value is the exact direct-input arity for a read. Updates keep
-  // the packed ABI until their compact-update alias contract is generalized.
+  // A positive value is the exact direct-input arity. Direct updates keep the
+  // RHS last and record its descriptor index explicitly; reads and packed
+  // updates leave rhs_input at -1.
   int input_count = 0;
+  int rhs_input = -1;
 };
 
 // One ordered stream: scalar leaves and counted fragments from retained

--- a/runtime/include/stanli/structured_loop.hpp
+++ b/runtime/include/stanli/structured_loop.hpp
@@ -65,6 +65,9 @@ struct StructuredLoop {
       Continue,
       Target
     } kind = Sequence;
+    // Dense immutable call-site identity for compact dynamic reverse records.
+    // This occupies the padding before children on supported 64-bit targets.
+    uint32_t record_site = ~uint32_t{0};
     std::vector<Node> children;
     int op = -1;
     int dst = -1, src = -1;
@@ -96,7 +99,7 @@ struct StructuredLoop {
   int64_t initial_size = 0, bindings_offset = 0, history_offset = 0;
   int64_t primal_size = 0, target_refs_offset = 0, target_work_offset = 0;
   int64_t adjoint_offset = 0, scratch_size = 0;
-  size_t node_count = 0, compact_update_sites = 0;
+  size_t node_count = 0, record_node_count = 0, compact_update_sites = 0;
 
   // Validate and size without enumerating execution. Throws on malformed
   // graphs or checked resource limits; builders publish only after success.

--- a/runtime/src/lower_structured_loop.inc
+++ b/runtime/src/lower_structured_loop.inc
@@ -876,13 +876,13 @@ Val region_index(const Val& base, const std::vector<mir::Expr>& selectors,
     si = array_view(output_dims, leaf_kind(result_view.leaf));
   }
   Val result;
-  // Keep the packed ABI for variable-width selectors, active selectors, and
-  // indexed updates. Direct scalar data operands avoid recording CONCAT2
-  // intermediates without changing their adjoint or aliasing semantics.
+  // Keep the packed ABI for active selectors and indexed updates. Direct
+  // fixed-capacity data operands avoid recording CONCAT2 intermediates;
+  // runtime logical counts remain separate direct operands in the same order.
   const bool direct_inputs =
       !rhs && indices.size() >= 2 && indices.size() <= 5 &&
       std::all_of(indices.begin(), indices.end(), [&](const Val& input) {
-        return g.slots[input.slot].len == 1 && !input.autodiff &&
+        return g.slots[input.slot].len > 0 && !input.autodiff &&
                input.si.param_free;
       }) &&
       std::getenv("STANLI_NO_STRUCTURED_DIRECT_INDEX_INPUTS") == nullptr;

--- a/runtime/src/lower_structured_loop.inc
+++ b/runtime/src/lower_structured_loop.inc
@@ -876,12 +876,16 @@ Val region_index(const Val& base, const std::vector<mir::Expr>& selectors,
     si = array_view(output_dims, leaf_kind(result_view.leaf));
   }
   Val result;
-  // Keep the packed ABI for active selectors and indexed updates. Direct
-  // fixed-capacity data operands avoid recording CONCAT2 intermediates;
-  // runtime logical counts remain separate direct operands in the same order.
+  if (rhs && g.slots[rhs->slot].len != selected)
+    fail("structured indexed assignment width mismatch");
+  // Direct fixed-capacity data operands avoid recording CONCAT2
+  // intermediates. Updates keep the RHS last, leaving room for at most four
+  // selector/count/extent operands in the six-input kernel ABI.
+  const size_t max_direct_selectors = rhs ? 4 : 5;
   const bool direct_inputs =
-      !rhs && indices.size() >= 2 && indices.size() <= 5 &&
-      std::all_of(indices.begin(), indices.end(), [&](const Val& input) {
+      indices.size() >= 2 && indices.size() <= max_direct_selectors &&
+      std::all_of(indices.begin(), indices.end(),
+                  [&](const Val& input) {
         return g.slots[input.slot].len > 0 && !input.autodiff &&
                input.si.param_free;
       }) &&
@@ -907,19 +911,28 @@ Val region_index(const Val& base, const std::vector<mir::Expr>& selectors,
       if (axis.extent_input_offset >= 0)
         remap(&axis.extent_input_offset, &axis.extent_input);
     }
-    spec->input_count = static_cast<int>(indices.size() + 1);
+    spec->input_count = static_cast<int>(indices.size() + 1 + (rhs ? 1 : 0));
     std::vector<int> inputs;
-    inputs.reserve(indices.size() + 1);
+    inputs.reserve(static_cast<size_t>(spec->input_count));
     inputs.push_back(base.slot);
-    si.param_free = base.si.param_free;
+    SlotInfo output_info = rhs ? base.si : si;
+    output_info.param_free = base.si.param_free;
     bool autodiff = base.autodiff;
     for (const Val& input : indices) {
       inputs.push_back(input.slot);
-      si.param_free = si.param_free && input.si.param_free;
+      output_info.param_free = output_info.param_free && input.si.param_free;
       autodiff = autodiff || input.autodiff;
     }
-    result = emit_raw(OP_INDEX_DYNAMIC, std::move(inputs), selected, si, {}, -1,
-                      autodiff);
+    if (rhs) {
+      inputs.push_back(rhs->slot);
+      spec->rhs_input = static_cast<int>(inputs.size() - 1);
+      output_info.param_free = output_info.param_free && rhs->si.param_free;
+      autodiff = autodiff || rhs->autodiff;
+    }
+    result = emit_raw(
+        rhs ? OP_SET_INDEX_DYNAMIC : OP_INDEX_DYNAMIC, std::move(inputs),
+        rhs ? g.slots[base.slot].len : selected, output_info, {}, -1, autodiff);
+    if (rhs) result.runtime_dims = base.runtime_dims;
   } else {
     Val packed = indices.empty() ? constant(0) : indices[0];
     for (size_t i = 1; i < indices.size(); ++i)
@@ -927,8 +940,6 @@ Val region_index(const Val& base, const std::vector<mir::Expr>& selectors,
           OP_CONCAT2, {packed, indices[i]},
           g.slots[packed.slot].len + g.slots[indices[i].slot].len);
     if (rhs) {
-      if (g.slots[rhs->slot].len != selected)
-        fail("structured indexed assignment width mismatch");
       result = emit_value(OP_SET_INDEX_DYNAMIC, {base, packed, *rhs},
                           g.slots[base.slot].len, base.si);
       // An element update changes values, not the declaration-time logical

--- a/runtime/src/structured_loop.cpp
+++ b/runtime/src/structured_loop.cpp
@@ -936,17 +936,40 @@ double handle(int64_t at, bool active) {
 
 // Dynamic counted-loop iterators are inactive int32 scalars.  Keep their
 // exact value in a disjoint handle band instead of allocating a value and a
-// generic Ref for every reached iteration.  Ordinary inactive Ref handles
-// occupy [-2^52, -1]; this band occupies the next 2^32 exact integers and
-// remains strictly inside binary64's exact-integer range.
+// generic Ref for every reached iteration. Ordinary inactive Ref handles use
+// the first 2^40 negative integers, an unreachable 24-TiB table ceiling. Arena
+// locations use the rest of the original 2^52 band, and inline int32 values
+// occupy the next 2^32 exact integers.
+constexpr int64_t ordinary_ref_limit = int64_t{1} << 40;
 constexpr int64_t inline_int_count = int64_t{1} << 32;
 constexpr int64_t inline_int_first = exact_limit + 1;
 constexpr int64_t inline_int_last = exact_limit + inline_int_count;
-static_assert(inline_int_last < (int64_t{1} << 53),
-              "inline integer handles must remain exact doubles");
+constexpr int64_t arena_location_first = ordinary_ref_limit + 1;
+constexpr int64_t arena_location_count = exact_limit - arena_location_first + 1;
+constexpr size_t arena_location_offset_bits = 24;
+constexpr size_t arena_location_block_values = size_t{1}
+                                               << arena_location_offset_bits;
+constexpr uint64_t arena_location_block_count =
+    static_cast<uint64_t>(arena_location_count) >> arena_location_offset_bits;
+static_assert(std::numeric_limits<double>::is_iec559 &&
+                  std::numeric_limits<double>::digits == 53,
+              "structured handles require IEEE binary64 doubles");
+static_assert(ordinary_ref_limit < arena_location_first &&
+                  arena_location_first <= exact_limit &&
+                  exact_limit < inline_int_first &&
+                  inline_int_last <= (int64_t{1} << 53),
+              "structured handle bands must be disjoint");
+static_assert(arena_location_count > 0 &&
+                  (arena_location_count % arena_location_block_values) == 0,
+              "arena handle range must contain complete blocks");
 
 bool is_inline_int(double h) noexcept {
   return h < -static_cast<double>(exact_limit);
+}
+
+bool is_arena_location(double h) noexcept {
+  return h < -static_cast<double>(ordinary_ref_limit) &&
+         h >= -static_cast<double>(exact_limit);
 }
 
 double inline_int_handle(int32_t value) noexcept {
@@ -1164,6 +1187,12 @@ struct Execution {
 // unused loop capacity consume no numerical history. Blocks keep every frame
 // address stable without a geometrically over-allocated contiguous vector.
 struct DynamicArena {
+  struct Allocation {
+    double* data = nullptr;
+    size_t block = 0;
+    size_t offset = 0;
+    size_t count = 0;
+  };
   struct Block {
     std::unique_ptr<double[]> data;
     size_t capacity = 0;
@@ -1180,29 +1209,65 @@ struct DynamicArena {
     used_values = capacity_values = 0;
   }
 
-  double* allocate(int64_t count) {
+  Allocation allocate_located(int64_t count) {
     if (count < 0 ||
         static_cast<uint64_t>(count) > std::numeric_limits<size_t>::max())
       throw std::length_error("dynamic structured history overflow");
     const size_t n = static_cast<size_t>(count);
-    if (n == 0) return nullptr;
+    if (n == 0) return {};
     if (blocks.empty() || n > blocks.back().capacity - blocks.back().used) {
       const size_t capacity = std::max(n, next_capacity);
       if (capacity > std::numeric_limits<uint64_t>::max() - capacity_values)
         throw std::length_error("dynamic structured history overflow");
       blocks.push_back({std::make_unique<double[]>(capacity), capacity, 0});
       capacity_values += capacity;
-      constexpr size_t maximum_block = size_t{1} << 24;  // 128 MiB
-      if (next_capacity < maximum_block)
-        next_capacity = std::min(maximum_block, next_capacity * 2);
+      if (next_capacity < arena_location_block_values)
+        next_capacity =
+            std::min(arena_location_block_values, next_capacity * 2);
     }
+    const size_t block_index = blocks.size() - 1;
     Block& block = blocks.back();
     if (n > std::numeric_limits<uint64_t>::max() - used_values)
       throw std::length_error("dynamic structured history overflow");
-    double* result = block.data.get() + block.used;
+    const size_t block_offset = block.used;
+    double* result = block.data.get() + block_offset;
     block.used += n;
     used_values += n;
-    return result;
+    return {result, block_index, block_offset, n};
+  }
+
+  double* allocate(int64_t count) { return allocate_located(count).data; }
+
+  bool location_handle(const Allocation& allocation, size_t relative,
+                       int64_t len, double& result) const noexcept {
+    if (len <= 0 || allocation.block >= arena_location_block_count ||
+        allocation.block >= blocks.size() || relative > allocation.count ||
+        static_cast<uint64_t>(len) > allocation.count - relative ||
+        allocation.offset >= arena_location_block_values ||
+        relative > arena_location_block_values - allocation.offset ||
+        static_cast<uint64_t>(len) >
+            arena_location_block_values - allocation.offset - relative)
+      return false;
+    const uint64_t code = (static_cast<uint64_t>(allocation.block)
+                           << arena_location_offset_bits) |
+                          static_cast<uint64_t>(allocation.offset + relative);
+    if (code >= static_cast<uint64_t>(arena_location_count)) return false;
+    result =
+        -static_cast<double>(arena_location_first + static_cast<int64_t>(code));
+    return true;
+  }
+
+  double* value(double h) const noexcept {
+    // location_handle() validates every coordinate before publication. Arena
+    // blocks remain stable until all evaluation-local handles are discarded.
+    const uint64_t code =
+        static_cast<uint64_t>(-h - static_cast<double>(arena_location_first));
+    const size_t block_index =
+        static_cast<size_t>(code >> arena_location_offset_bits);
+    const size_t block_offset = static_cast<size_t>(
+        code & static_cast<uint64_t>(arena_location_block_values - 1));
+    const Block& block = blocks[block_index];
+    return block.data.get() + block_offset;
   }
 };
 
@@ -1220,6 +1285,7 @@ struct DynamicAllocationProfile {
     uint64_t inactive_transient_values = 0;
     uint64_t inactive_output_values = 0;
     uint64_t inactive_output_refs = 0;
+    uint64_t arena_location_refs = 0;
     uint64_t arena_values = 0;
     uint64_t input_handle_values = 0;
     uint64_t output_values = 0;
@@ -1308,7 +1374,8 @@ struct DynamicAllocationProfile {
   }
 
   void note_inactive_split(const Op& op, const Node& node,
-                           int64_t retained_outputs) noexcept {
+                           int64_t retained_outputs,
+                           uint64_t arena_locations) noexcept {
     Bucket* b = bucket(op);
     if (!b) return;
     const uint64_t inputs = count(op.n_in);
@@ -1326,6 +1393,10 @@ struct DynamicAllocationProfile {
     const uint64_t new_padding = new_frame >= outputs ? new_frame - outputs : 0;
     if (new_frame < outputs) overflow = true;
     const uint64_t refs = op.out2 >= 0 ? 2 : 1;
+    if (arena_locations > refs) {
+      arena_locations = refs;
+      overflow = true;
+    }
     uint64_t transient = inputs;
     add(transient, scratch);
     add(transient, old_padding);
@@ -1334,7 +1405,9 @@ struct DynamicAllocationProfile {
     add(b->arena_values, new_frame);
     add(b->output_values, outputs);
     add(b->padding_values, new_padding);
-    add(b->refs, refs);
+    add(b->refs, refs - arena_locations);
+    add(b->elided_refs, arena_locations);
+    add(b->arena_location_refs, arena_locations);
     add(b->referenced_values, outputs);
     add(b->inactive_transient_values, transient);
     add(b->inactive_output_values, outputs);
@@ -1659,6 +1732,7 @@ void report_memory_profile(const StructuredLoop& p,
   uint64_t inactive_transient_values = 0;
   uint64_t inactive_output_values = 0;
   uint64_t inactive_output_refs = 0;
+  uint64_t arena_location_refs = 0;
   for (const auto& bucket : allocation->buckets) {
     kernel_arena_values = profile_add(kernel_arena_values, bucket.arena_values,
                                       allocation_overflow);
@@ -1698,6 +1772,8 @@ void report_memory_profile(const StructuredLoop& p,
     inactive_output_refs =
         profile_add(inactive_output_refs, bucket.inactive_output_refs,
                     allocation_overflow);
+    arena_location_refs = profile_add(
+        arena_location_refs, bucket.arena_location_refs, allocation_overflow);
   }
   uint64_t profiled_arena_values =
       profile_add(allocation->initial_arena_values, kernel_arena_values,
@@ -1723,7 +1799,7 @@ void report_memory_profile(const StructuredLoop& p,
       "actual_records=%zu records_match=%d inline_integer_calls=%llu "
       "elided_arena_values=%llu elided_refs=%llu "
       "inactive_transient_values=%llu inactive_output_values=%llu "
-      "inactive_output_refs=%llu\n",
+      "inactive_output_refs=%llu arena_location_refs=%llu\n",
       static_cast<const void*>(&p), allocation_overflow ? 1 : 0,
       static_cast<unsigned long long>(allocation->initial_arena_values),
       static_cast<unsigned long long>(kernel_arena_values),
@@ -1751,7 +1827,8 @@ void report_memory_profile(const StructuredLoop& p,
       static_cast<unsigned long long>(elided_refs),
       static_cast<unsigned long long>(inactive_transient_values),
       static_cast<unsigned long long>(inactive_output_values),
-      static_cast<unsigned long long>(inactive_output_refs));
+      static_cast<unsigned long long>(inactive_output_refs),
+      static_cast<unsigned long long>(arena_location_refs));
 
   for (uint16_t opcode = 0; opcode < OP_COUNT_; ++opcode) {
     const auto& bucket = allocation->buckets[opcode];
@@ -1768,6 +1845,7 @@ void report_memory_profile(const StructuredLoop& p,
         "elided_arena_values=%llu elided_refs=%llu arena_values=%llu "
         "inactive_transient_values=%llu inactive_output_values=%llu "
         "inactive_output_refs=%llu "
+        "arena_location_refs=%llu "
         "input_handle_values=%llu output_values=%llu scratch_values=%llu "
         "padding_values=%llu refs=%llu active_refs=%llu "
         "referenced_values=%llu conceptual_adjoint_values=%llu "
@@ -1787,6 +1865,7 @@ void report_memory_profile(const StructuredLoop& p,
         static_cast<unsigned long long>(bucket.inactive_transient_values),
         static_cast<unsigned long long>(bucket.inactive_output_values),
         static_cast<unsigned long long>(bucket.inactive_output_refs),
+        static_cast<unsigned long long>(bucket.arena_location_refs),
         static_cast<unsigned long long>(bucket.input_handle_values),
         static_cast<unsigned long long>(bucket.output_values),
         static_cast<unsigned long long>(bucket.scratch_values),
@@ -1837,9 +1916,9 @@ struct DynamicExecution {
   }
 
   DynamicLoopState::Ref& ref(double h) {
-    if (is_inline_int(h))
+    if (is_inline_int(h) || is_arena_location(h))
       throw std::logic_error(
-          "dynamic structured inline integer used as a reference");
+          "dynamic structured immediate handle used as a reference");
     return ordinary_ref(h);
   }
 
@@ -1849,7 +1928,7 @@ struct DynamicExecution {
     if (len < 0)
       throw std::logic_error(
           "dynamic structured reference has negative length");
-    if (state.refs.size() >= static_cast<size_t>(exact_limit))
+    if (state.refs.size() >= static_cast<size_t>(ordinary_ref_limit))
       throw std::length_error("dynamic structured reference overflow");
     DynamicLoopState::Ref r;
     r.value = value;
@@ -1886,7 +1965,10 @@ struct DynamicExecution {
   }
 
   double scalar_value(double h) {
-    return is_inline_int(h) ? inline_int_value(h) : ordinary_ref(h).value[0];
+    if (h < -static_cast<double>(exact_limit)) return inline_int_value(h);
+    return h < -static_cast<double>(ordinary_ref_limit)
+               ? state.arena.value(h)[0]
+               : ordinary_ref(h).value[0];
   }
 
   double scalar_value(int slot) {
@@ -1894,25 +1976,32 @@ struct DynamicExecution {
   }
 
   void copy_value(double h, int64_t len, double* output) {
-    if (is_inline_int(h)) {
+    if (h < -static_cast<double>(exact_limit)) {
       if (len != 1)
         throw std::logic_error(
             "dynamic structured inline integer has nonscalar extent");
       output[0] = inline_int_value(h);
       return;
     }
-    std::copy_n(ordinary_ref(h).value, len, output);
+    std::copy_n(h < -static_cast<double>(ordinary_ref_limit)
+                    ? state.arena.value(h)
+                    : ordinary_ref(h).value,
+                len, output);
   }
 
   bool value_overlaps(double h, int64_t len, Desc other) {
-    if (is_inline_int(h)) {
+    if (h < -static_cast<double>(exact_limit)) {
       if (len != 1)
         throw std::logic_error(
             "dynamic structured inline integer has nonscalar extent");
       (void)inline_int_value(h);
       return false;
     }
-    return overlaps({ordinary_ref(h).value, len}, other);
+    return overlaps(
+        {h < -static_cast<double>(ordinary_ref_limit) ? state.arena.value(h)
+                                                      : ordinary_ref(h).value,
+         len},
+        other);
   }
 
   void begin_loop_invariant_scope(const Node& n) noexcept {
@@ -2290,7 +2379,7 @@ struct DynamicExecution {
       c.state = nullptr;
       for (int k = 0; k < op.n_in; ++k) {
         const double h = frame[k];
-        if (is_inline_int(h)) {
+        if (h < -static_cast<double>(exact_limit)) {
           if (c.in[k].len != 1)
             throw std::logic_error(
                 "dynamic structured inline integer has nonscalar input");
@@ -2306,9 +2395,10 @@ struct DynamicExecution {
             inline_inputs[static_cast<size_t>(k)] = inline_int_value(h);
             c.in[k].data = &inline_inputs[static_cast<size_t>(k)];
           }
-        } else {
+        } else if (h < -static_cast<double>(ordinary_ref_limit))
+          c.in[k].data = state.arena.value(h);
+        else
           c.in[k].data = ordinary_ref(h).value;
-        }
         c.in_adj[k].data = backward ? adj(h, c.in[k].len) : nullptr;
       }
       int64_t pos = op.n_in;
@@ -2436,15 +2526,20 @@ struct DynamicExecution {
       throw std::logic_error("compact structured update arity is invalid");
     const int cell = n.compact_update_cell;
     const double base_handle = state.bindings[static_cast<size_t>(op.in[0])];
-    if (is_inline_int(base_handle)) return false;
-    DynamicLoopState::Ref& base = ordinary_ref(base_handle);
-    if (state.compact_primal_by_cell[static_cast<size_t>(cell)] != base.value)
+    double* base = nullptr;
+    if (base_handle < -static_cast<double>(exact_limit))
+      return false;
+    else if (base_handle < -static_cast<double>(ordinary_ref_limit))
+      base = state.arena.value(base_handle);
+    else
+      base = ordinary_ref(base_handle).value;
+    if (state.compact_primal_by_cell[static_cast<size_t>(cell)] != base)
       return false;
 
     double handles[6] = {};
     for (int k = 0; k < op.n_in; ++k)
       handles[k] = state.bindings[static_cast<size_t>(op.in[k])];
-    ContextLease context(*this, n, handles, false, -1, -1, base.value);
+    ContextLease context(*this, n, handles, false, -1, -1, base);
     KernelCtx& c = context.get();
     if (overlaps(c.out, c.in[1]) || overlaps(c.out, c.in[2])) return false;
     const auto& spec = *static_cast<const DynamicIndexSpec*>(op.udata);
@@ -2499,11 +2594,12 @@ struct DynamicExecution {
         add(p.body.slots[static_cast<size_t>(op.out)].len,
             op.out2 >= 0 ? p.body.slots[static_cast<size_t>(op.out2)].len : 0);
     const int64_t retained_outputs = output_values;
-    double* outputs = output_values > 0 ? state.arena.allocate(output_values)
-                                        : &state.inactive_empty_value;
-    double* output2 =
-        op.out2 >= 0 ? outputs + p.body.slots[static_cast<size_t>(op.out)].len
-                     : nullptr;
+    const DynamicArena::Allocation allocation =
+        state.arena.allocate_located(output_values);
+    double* outputs =
+        output_values > 0 ? allocation.data : &state.inactive_empty_value;
+    const int64_t primary_len = p.body.slots[static_cast<size_t>(op.out)].len;
+    double* output2 = op.out2 >= 0 ? outputs + primary_len : nullptr;
     ContextLease context(*this, n, handles, false, -1, -1, outputs, output2,
                          state.inactive_scratch.get());
     KernelCtx& c = context.get();
@@ -2511,17 +2607,36 @@ struct DynamicExecution {
     // and scratch stop entering persistent history; output storage remains in
     // the stable arena and is published after successful completion.
     n.forward(c);
-    state.bindings[static_cast<size_t>(op.out)] =
-        make_ref(c.out.data, c.out.len, false);
-    if (op.out2 >= 0)
-      state.bindings[static_cast<size_t>(op.out2)] =
-          make_ref(c.out2.data, c.out2.len, false);
+    uint64_t arena_locations = 0;
+    const auto output_handle = [&](double* actual, double* expected,
+                                   int64_t actual_len, int64_t expected_len,
+                                   size_t relative) {
+      double packed = 0.0;
+      if (actual == expected && actual_len == expected_len &&
+          state.arena.location_handle(allocation, relative, expected_len,
+                                      packed)) {
+        ++arena_locations;
+        return packed;
+      }
+      return make_ref(actual, actual_len, false);
+    };
+    const double out =
+        output_handle(c.out.data, outputs, c.out.len, primary_len, 0);
+    const double out2 =
+        op.out2 >= 0
+            ? output_handle(c.out2.data, output2, c.out2.len,
+                            p.body.slots[static_cast<size_t>(op.out2)].len,
+                            static_cast<size_t>(primary_len))
+            : -1;
+    state.bindings[static_cast<size_t>(op.out)] = out;
+    if (op.out2 >= 0) state.bindings[static_cast<size_t>(op.out2)] = out2;
     if (n.compact_update_cell >= 0)
       state.compact_primal_by_cell[static_cast<size_t>(n.compact_update_cell)] =
           c.out.data;
     publish_loop_invariant(n);
     if (state.allocation_profile)
-      state.allocation_profile->note_inactive_split(op, n, retained_outputs);
+      state.allocation_profile->note_inactive_split(op, n, retained_outputs,
+                                                    arena_locations);
     return true;
   }
 

--- a/runtime/src/structured_loop.cpp
+++ b/runtime/src/structured_loop.cpp
@@ -159,11 +159,12 @@ struct StructuredSlotUses {
 };
 
 // H2A is deliberately narrower than ordinary indexed assignment support. It
-// recognizes a scalar functional update whose result is immediately installed
-// in one stable binding cell and whose historical handles cannot escape through
-// another binding or delayed target publication. Ordinary kernel/control reads
-// of the cell are synchronous; reverse sees their historical values after LIFO
-// undo. Anything less explicit keeps the immutable copying kernel.
+// recognizes a functional update whose result is immediately installed in one
+// stable binding cell. Ordinary kernel/control reads of the cell are
+// synchronous; reverse sees their historical values after LIFO undo. A reached
+// alias from the binding invalidates its mutable anchor, so the next update
+// takes the ordinary copying path before compact mutation can resume. Anything
+// less explicit keeps the immutable copying kernel.
 void classify_compact_updates(StructuredLoop& p) {
   p.compact_update_sites = 0;
   std::vector<StructuredSlotUses> uses(p.body.slots.size());
@@ -243,7 +244,7 @@ void classify_compact_updates(StructuredLoop& p) {
             output.alias_sources != 1 || output.alias_destinations != 0 ||
             output.control != 0 || output.targets != 0 || output.outputs != 0 ||
             output.imports != 0 || binding.producers != 0 ||
-            binding.alias_sources != 0 || binding.targets != 0)
+            binding.targets != 0)
           continue;
         call.compact_update_cell = cell;
         ++p.compact_update_sites;
@@ -2906,6 +2907,10 @@ struct DynamicExecution {
       case Node::Alias:
         state.bindings[static_cast<size_t>(n.dst)] =
             state.bindings[static_cast<size_t>(n.src)];
+        // The destination now preserves the source's current value. Prevent a
+        // later compact update from mutating that shared storage: its ordinary
+        // fallback creates a fresh output and reanchors the updated binding.
+        state.compact_primal_by_cell[static_cast<size_t>(n.src)] = nullptr;
         return Normal;
       case Node::If:
         return forward(n.children[scalar_value(n.condition) != 0.0 ? 0 : 1]);

--- a/runtime/src/structured_loop.cpp
+++ b/runtime/src/structured_loop.cpp
@@ -3,6 +3,7 @@
 
 #include <algorithm>
 #include <array>
+#include <cerrno>
 #include <cmath>
 #include <cstdio>
 #include <cstdlib>
@@ -1205,6 +1206,123 @@ struct DynamicArena {
   }
 };
 
+struct DynamicAllocationProfile {
+  struct Bucket {
+    uint64_t ordinary_visits = 0;
+    uint64_t active_visits = 0;
+    uint64_t compact_visits = 0;
+    uint64_t invariant_reuses = 0;
+    uint64_t inactive_control_calls = 0;
+    uint64_t direct_control_calls = 0;
+    uint64_t inline_integer_calls = 0;
+    uint64_t elided_arena_values = 0;
+    uint64_t elided_refs = 0;
+    uint64_t arena_values = 0;
+    uint64_t input_handle_values = 0;
+    uint64_t output_values = 0;
+    uint64_t scratch_values = 0;
+    uint64_t padding_values = 0;
+    uint64_t refs = 0;
+    uint64_t active_refs = 0;
+    uint64_t referenced_values = 0;
+    uint64_t conceptual_adjoint_values = 0;
+    uint64_t physical_adjoint_values = 0;
+    uint64_t records = 0;
+  };
+
+  std::array<Bucket, OP_COUNT_> buckets{};
+  uint64_t initial_arena_values = 0;
+  uint64_t initial_slot_refs = 0;
+  uint64_t canonical_refs = 0;
+  uint64_t import_refs = 0;
+  bool overflow = false;
+
+  void add(uint64_t& total, uint64_t value) noexcept {
+    if (total > std::numeric_limits<uint64_t>::max() - value) {
+      total = std::numeric_limits<uint64_t>::max();
+      overflow = true;
+    } else {
+      total += value;
+    }
+  }
+
+  uint64_t count(int64_t value) noexcept {
+    if (value < 0) {
+      overflow = true;
+      return 0;
+    }
+    return static_cast<uint64_t>(value);
+  }
+
+  Bucket* bucket(const Op& op) noexcept {
+    if (op.opcode >= OP_COUNT_) {
+      overflow = true;
+      return nullptr;
+    }
+    return &buckets[op.opcode];
+  }
+
+  void note_reuse(const Op& op, uint64_t Bucket::* field) noexcept {
+    if (Bucket* b = bucket(op)) add(b->*field, 1);
+  }
+
+  void note_ordinary(const Op& op, const Node& node, int64_t retained,
+                     bool active) noexcept {
+    Bucket* b = bucket(op);
+    if (!b) return;
+    const uint64_t inputs = count(op.n_in);
+    const uint64_t outputs = count(node.frame_size - 6 - node.kernel_scratch);
+    const uint64_t scratch = count(node.kernel_scratch);
+    const uint64_t frame = count(retained);
+    uint64_t components = inputs;
+    add(components, outputs);
+    add(components, scratch);
+    const uint64_t padding = frame >= components ? frame - components : 0;
+    if (frame < components) overflow = true;
+    const uint64_t refs = op.out2 >= 0 ? 2 : 1;
+
+    add(b->ordinary_visits, 1);
+    add(b->active_visits, active ? 1 : 0);
+    add(b->arena_values, frame);
+    add(b->input_handle_values, inputs);
+    add(b->output_values, outputs);
+    add(b->scratch_values, scratch);
+    add(b->padding_values, padding);
+    add(b->refs, refs);
+    add(b->active_refs, active ? refs : 0);
+    add(b->referenced_values, outputs);
+    add(b->conceptual_adjoint_values, active ? outputs : 0);
+    add(b->physical_adjoint_values, active ? outputs : 0);
+    add(b->records, active ? 1 : 0);
+  }
+
+  void note_compact(const Op& op, int64_t retained, int64_t output_len,
+                    bool active, bool shared_adjoint) noexcept {
+    Bucket* b = bucket(op);
+    if (!b) return;
+    const uint64_t frame = count(retained);
+    const uint64_t extent = count(output_len);
+    add(b->compact_visits, 1);
+    add(b->active_visits, active ? 1 : 0);
+    add(b->arena_values, frame);
+    add(b->input_handle_values, count(op.n_in));
+    add(b->refs, 1);
+    add(b->active_refs, active ? 1 : 0);
+    add(b->referenced_values, extent);
+    add(b->conceptual_adjoint_values, active ? extent : 0);
+    add(b->physical_adjoint_values, active && !shared_adjoint ? extent : 0);
+    add(b->records, 1);
+  }
+
+  void note_inline_integer(const Op& op, int64_t retained) noexcept {
+    Bucket* b = bucket(op);
+    if (!b) return;
+    add(b->inline_integer_calls, 1);
+    add(b->elided_arena_values, count(retained));
+    add(b->elided_refs, 1);
+  }
+};
+
 struct DynamicLoopState final : KernelState {
   struct Ref {
     double* value = nullptr;
@@ -1250,6 +1368,7 @@ struct DynamicLoopState final : KernelState {
   std::unique_ptr<DirectControlPlan> direct_control_plan;
   std::unique_ptr<LoopInvariantPlan> loop_invariant_plan;
   std::unique_ptr<InactiveControlPlan> inactive_control_plan;
+  std::unique_ptr<DynamicAllocationProfile> allocation_profile;
   std::vector<double> inactive_control_values;
   int64_t conceptual_adjoint_size = 0;
   int64_t adjoint_size = 0;
@@ -1375,6 +1494,7 @@ struct DynamicLoopState final : KernelState {
     iterator_values = 0;
     cached_context_in_use = false;
     memory_profile = false;
+    allocation_profile.reset();
   }
 };
 static_assert(sizeof(DynamicLoopState::Ref) == 24,
@@ -1398,7 +1518,8 @@ uint64_t profile_add(uint64_t first, uint64_t second, bool& overflow) noexcept {
 }
 
 void report_memory_profile(const StructuredLoop& p,
-                           const DynamicLoopState& state) {
+                           const DynamicLoopState& state) noexcept {
+  const int saved_errno = errno;
   bool overflow = false;
   const uint64_t arena_used =
       profile_bytes(state.arena.used_values, sizeof(double), overflow);
@@ -1428,8 +1549,10 @@ void report_memory_profile(const StructuredLoop& p,
       stderr,
       "stanli_structured_memory phase=forward region=%p nodes=%zu "
       "body_kernels=%zu accounting_overflow=%d "
-      "iterator_values=%llu iterator_value_bytes=%llu "
-      "iterator_ref_bytes=%llu iterator_total_bytes=%llu "
+      "elided_iterator_instances=%llu "
+      "elided_iterator_value_bytes=%llu "
+      "elided_iterator_ref_bytes=%llu "
+      "elided_iterator_total_bytes=%llu "
       "arena_used_bytes=%llu arena_capacity_bytes=%llu "
       "ref_count=%zu ref_used_bytes=%llu ref_capacity_bytes=%llu "
       "record_count=%zu record_used_bytes=%llu record_capacity_bytes=%llu "
@@ -1449,6 +1572,148 @@ void report_memory_profile(const StructuredLoop& p,
       static_cast<unsigned long long>(undo_used),
       static_cast<unsigned long long>(undo_capacity),
       static_cast<unsigned long long>(planned_adjoint));
+
+  const auto* allocation = state.allocation_profile.get();
+  if (!allocation) {
+    errno = saved_errno;
+    return;
+  }
+  bool allocation_overflow = allocation->overflow;
+  uint64_t kernel_arena_values = 0;
+  uint64_t input_handle_values = 0;
+  uint64_t output_values = 0;
+  uint64_t scratch_values = 0;
+  uint64_t padding_values = 0;
+  uint64_t kernel_refs = 0;
+  uint64_t active_refs = 0;
+  uint64_t referenced_values = 0;
+  uint64_t conceptual_adjoint_values = 0;
+  uint64_t physical_adjoint_values = 0;
+  uint64_t profiled_records = 0;
+  uint64_t inline_integer_calls = 0;
+  uint64_t elided_arena_values = 0;
+  uint64_t elided_refs = 0;
+  for (const auto& bucket : allocation->buckets) {
+    kernel_arena_values = profile_add(kernel_arena_values, bucket.arena_values,
+                                      allocation_overflow);
+    input_handle_values = profile_add(
+        input_handle_values, bucket.input_handle_values, allocation_overflow);
+    output_values =
+        profile_add(output_values, bucket.output_values, allocation_overflow);
+    scratch_values =
+        profile_add(scratch_values, bucket.scratch_values, allocation_overflow);
+    padding_values =
+        profile_add(padding_values, bucket.padding_values, allocation_overflow);
+    kernel_refs = profile_add(kernel_refs, bucket.refs, allocation_overflow);
+    active_refs =
+        profile_add(active_refs, bucket.active_refs, allocation_overflow);
+    referenced_values = profile_add(referenced_values, bucket.referenced_values,
+                                    allocation_overflow);
+    conceptual_adjoint_values =
+        profile_add(conceptual_adjoint_values, bucket.conceptual_adjoint_values,
+                    allocation_overflow);
+    physical_adjoint_values =
+        profile_add(physical_adjoint_values, bucket.physical_adjoint_values,
+                    allocation_overflow);
+    profiled_records =
+        profile_add(profiled_records, bucket.records, allocation_overflow);
+    inline_integer_calls = profile_add(
+        inline_integer_calls, bucket.inline_integer_calls, allocation_overflow);
+    elided_arena_values = profile_add(
+        elided_arena_values, bucket.elided_arena_values, allocation_overflow);
+    elided_refs =
+        profile_add(elided_refs, bucket.elided_refs, allocation_overflow);
+  }
+  uint64_t profiled_arena_values =
+      profile_add(allocation->initial_arena_values, kernel_arena_values,
+                  allocation_overflow);
+  uint64_t setup_refs =
+      profile_add(allocation->initial_slot_refs, allocation->canonical_refs,
+                  allocation_overflow);
+  setup_refs =
+      profile_add(setup_refs, allocation->import_refs, allocation_overflow);
+  const uint64_t profiled_refs =
+      profile_add(setup_refs, kernel_refs, allocation_overflow);
+  std::fprintf(
+      stderr,
+      "stanli_structured_alloc_summary region=%p accounting_overflow=%d "
+      "initial_arena_values=%llu kernel_arena_values=%llu "
+      "profiled_arena_values=%llu actual_arena_values=%llu arena_match=%d "
+      "input_handle_values=%llu output_values=%llu scratch_values=%llu "
+      "padding_values=%llu initial_slot_refs=%llu canonical_refs=%llu "
+      "import_refs=%llu kernel_refs=%llu profiled_refs=%llu "
+      "actual_refs=%zu refs_match=%d active_refs=%llu "
+      "referenced_values=%llu conceptual_adjoint_values=%llu "
+      "physical_adjoint_values=%llu profiled_records=%llu "
+      "actual_records=%zu records_match=%d inline_integer_calls=%llu "
+      "elided_arena_values=%llu elided_refs=%llu\n",
+      static_cast<const void*>(&p), allocation_overflow ? 1 : 0,
+      static_cast<unsigned long long>(allocation->initial_arena_values),
+      static_cast<unsigned long long>(kernel_arena_values),
+      static_cast<unsigned long long>(profiled_arena_values),
+      static_cast<unsigned long long>(state.arena.used_values),
+      profiled_arena_values == state.arena.used_values ? 1 : 0,
+      static_cast<unsigned long long>(input_handle_values),
+      static_cast<unsigned long long>(output_values),
+      static_cast<unsigned long long>(scratch_values),
+      static_cast<unsigned long long>(padding_values),
+      static_cast<unsigned long long>(allocation->initial_slot_refs),
+      static_cast<unsigned long long>(allocation->canonical_refs),
+      static_cast<unsigned long long>(allocation->import_refs),
+      static_cast<unsigned long long>(kernel_refs),
+      static_cast<unsigned long long>(profiled_refs), state.refs.size(),
+      profiled_refs == state.refs.size() ? 1 : 0,
+      static_cast<unsigned long long>(active_refs),
+      static_cast<unsigned long long>(referenced_values),
+      static_cast<unsigned long long>(conceptual_adjoint_values),
+      static_cast<unsigned long long>(physical_adjoint_values),
+      static_cast<unsigned long long>(profiled_records), state.records.size(),
+      profiled_records == state.records.size() ? 1 : 0,
+      static_cast<unsigned long long>(inline_integer_calls),
+      static_cast<unsigned long long>(elided_arena_values),
+      static_cast<unsigned long long>(elided_refs));
+
+  for (uint16_t opcode = 0; opcode < OP_COUNT_; ++opcode) {
+    const auto& bucket = allocation->buckets[opcode];
+    if (bucket.ordinary_visits == 0 && bucket.compact_visits == 0 &&
+        bucket.invariant_reuses == 0 && bucket.inactive_control_calls == 0 &&
+        bucket.direct_control_calls == 0 && bucket.inline_integer_calls == 0)
+      continue;
+    std::fprintf(
+        stderr,
+        "stanli_structured_alloc_opcode region=%p opcode=%u name=%s "
+        "ordinary_visits=%llu active_visits=%llu compact_visits=%llu "
+        "invariant_reuses=%llu inactive_control_calls=%llu "
+        "direct_control_calls=%llu inline_integer_calls=%llu "
+        "elided_arena_values=%llu elided_refs=%llu arena_values=%llu "
+        "input_handle_values=%llu output_values=%llu scratch_values=%llu "
+        "padding_values=%llu refs=%llu active_refs=%llu "
+        "referenced_values=%llu conceptual_adjoint_values=%llu "
+        "physical_adjoint_values=%llu records=%llu\n",
+        static_cast<const void*>(&p), static_cast<unsigned>(opcode),
+        opcode_name(opcode),
+        static_cast<unsigned long long>(bucket.ordinary_visits),
+        static_cast<unsigned long long>(bucket.active_visits),
+        static_cast<unsigned long long>(bucket.compact_visits),
+        static_cast<unsigned long long>(bucket.invariant_reuses),
+        static_cast<unsigned long long>(bucket.inactive_control_calls),
+        static_cast<unsigned long long>(bucket.direct_control_calls),
+        static_cast<unsigned long long>(bucket.inline_integer_calls),
+        static_cast<unsigned long long>(bucket.elided_arena_values),
+        static_cast<unsigned long long>(bucket.elided_refs),
+        static_cast<unsigned long long>(bucket.arena_values),
+        static_cast<unsigned long long>(bucket.input_handle_values),
+        static_cast<unsigned long long>(bucket.output_values),
+        static_cast<unsigned long long>(bucket.scratch_values),
+        static_cast<unsigned long long>(bucket.padding_values),
+        static_cast<unsigned long long>(bucket.refs),
+        static_cast<unsigned long long>(bucket.active_refs),
+        static_cast<unsigned long long>(bucket.referenced_values),
+        static_cast<unsigned long long>(bucket.conceptual_adjoint_values),
+        static_cast<unsigned long long>(bucket.physical_adjoint_values),
+        static_cast<unsigned long long>(bucket.records));
+  }
+  errno = saved_errno;
 }
 
 int64_t compact_scalar_update_position(const DynamicIndexSpec& p,
@@ -1464,6 +1729,9 @@ DynamicLoopState& dynamic_state(KernelCtx& c) {
   if (!c.state) throw std::logic_error("dynamic structured loop has no state");
   return *static_cast<DynamicLoopState*>(c.state);
 }
+
+void compare_forward(KernelCtx& c);
+void int_forward(KernelCtx& c);
 
 struct DynamicExecution {
   const StructuredLoop& p;
@@ -2003,6 +2271,37 @@ struct DynamicExecution {
     KernelCtx& get() { return *call; }
   };
 
+  bool inline_integer_result(const Node& n) {
+    const Op& op = p.body.ops[static_cast<size_t>(n.op)];
+    if (op.opcode != OP_COMPARE && op.opcode != OP_INT_ARITH) return false;
+    const auto builtin =
+        op.opcode == OP_COMPARE ? compare_forward : int_forward;
+    // Only the built-in, synchronous, scalar, scratch-free callbacks have the
+    // exact-int32 result contract used by the compact handle encoding.  A
+    // custom callback, second output, reverse callback, or different layout
+    // keeps the ordinary retained-frame behavior.
+    if (n.forward != builtin || n.backward != nullptr ||
+        op.out2 >= 0 || p.body.slots[static_cast<size_t>(op.out)].len != 1 ||
+        n.kernel_scratch != 0)
+      return false;
+
+    double handles[6] = {};
+    for (int k = 0; k < op.n_in; ++k)
+      handles[k] = state.bindings[static_cast<size_t>(op.in[k])];
+    double output = 0.0;
+    ContextLease context(*this, n, handles, false, -1, -1, &output);
+    // Invoke the resolved callback before publishing anything, preserving its
+    // validation order and exact exception type/message.  OP_COMPARE returns
+    // 0/1 and OP_INT_ARITH validates its result is int32 before returning.
+    n.forward(context.get());
+    state.bindings[static_cast<size_t>(op.out)] =
+        inline_int_handle(static_cast<int32_t>(output));
+    if (state.allocation_profile)
+      state.allocation_profile->note_inline_integer(op,
+                                                    retained_frame_values(n));
+    return true;
+  }
+
   bool direct_control(const Node& n) {
     DirectControlPlan::Site* site = direct_control_site(n);
     if (!site) return false;
@@ -2089,6 +2388,10 @@ struct DynamicExecution {
           "compact structured adjoint exceeds preallocated work");
     c.out.data[position] = c.in[2].data[0];
     state.bindings[static_cast<size_t>(op.out)] = out;
+    if (state.allocation_profile)
+      state.allocation_profile->note_compact(op, std::max(1, retained_inputs),
+                                             c.out.len, active,
+                                             shared_adjoint >= 0);
     return true;
   }
 
@@ -2106,19 +2409,33 @@ struct DynamicExecution {
         auto* inactive_site = inactive_control_site(n);
         begin_inactive_control_cone(inactive_site);
         if (reuse_loop_invariant(n)) {
+          if (state.allocation_profile)
+            state.allocation_profile->note_reuse(
+                op, &DynamicAllocationProfile::Bucket::invariant_reuses);
           finish_inactive_control_site(inactive_site);
           return Normal;
         }
         if (inactive_control(n, inactive_site)) {
+          if (state.allocation_profile)
+            state.allocation_profile->note_reuse(
+                op, &DynamicAllocationProfile::Bucket::inactive_control_calls);
           publish_loop_invariant(n);
           return Normal;
         }
         if (op.opcode == OP_COMPARE && direct_control(n)) {
+          if (state.allocation_profile)
+            state.allocation_profile->note_reuse(
+                op, &DynamicAllocationProfile::Bucket::direct_control_calls);
+          publish_loop_invariant(n);
+          return Normal;
+        }
+        if (inline_integer_result(n)) {
           publish_loop_invariant(n);
           return Normal;
         }
         if (compact_update(n)) return Normal;
-        double* frame = state.arena.allocate(retained_frame_values(n));
+        const int64_t retained = retained_frame_values(n);
+        double* frame = state.arena.allocate(retained);
         for (int k = 0; k < op.n_in; ++k)
           frame[k] = state.bindings[static_cast<size_t>(op.in[k])];
         ContextLease context(*this, n, frame, false);
@@ -2142,6 +2459,8 @@ struct DynamicExecution {
               n.compact_update_cell)] = c.out.data;
         }
         publish_loop_invariant(n);
+        if (state.allocation_profile)
+          state.allocation_profile->note_ordinary(op, n, retained, active);
         return Normal;
       }
       case Node::Alias:
@@ -2282,6 +2601,15 @@ void dynamic_loop_forward(KernelCtx& ctx) {
   // or a partially built replacement resident/available to reverse.
   s.release_tape();
   s.memory_profile = std::getenv("STANLI_STRUCTURED_MEMORY_PROFILE") != nullptr;
+  if (s.memory_profile) {
+    try {
+      s.allocation_profile = std::make_unique<DynamicAllocationProfile>();
+    } catch (...) {
+      // Profiling is observational. Failure to allocate its counters cannot
+      // reduce model coverage or change the exception seen by the caller.
+      s.allocation_profile.reset();
+    }
+  }
   if (s.loop_invariant_plan) s.loop_invariant_plan->reset_runtime();
   s.loop_invariant_reuse =
       s.loop_invariant_plan &&
@@ -2304,6 +2632,9 @@ void dynamic_loop_forward(KernelCtx& ctx) {
     throw std::logic_error("dynamic structured output size mismatch");
 
   double* initial = s.arena.allocate(p.initial_size);
+  if (s.allocation_profile)
+    s.allocation_profile->initial_arena_values =
+        static_cast<uint64_t>(p.initial_size);
   e.initial_values = initial;
   std::fill_n(initial, p.initial_size, 0.0);
   s.bindings.resize(p.body.slots.size());
@@ -2314,8 +2645,18 @@ void dynamic_loop_forward(KernelCtx& ctx) {
   for (size_t slot = 0; slot < p.body.slots.size(); ++slot)
     s.bindings[slot] = e.make_ref(initial + p.body.slots[slot].offset,
                                   p.body.slots[slot].len, false);
+  if (s.allocation_profile)
+    s.allocation_profile->initial_slot_refs = s.refs.size();
   e.initialize_direct_control_handles();
   e.initialize_inactive_control_handles();
+  if (s.allocation_profile) {
+    if (s.refs.size() < s.allocation_profile->initial_slot_refs) {
+      s.allocation_profile->overflow = true;
+    } else {
+      s.allocation_profile->canonical_refs =
+          s.refs.size() - s.allocation_profile->initial_slot_refs;
+    }
+  }
   for (const auto& fill : p.fills)
     std::copy(fill.second.begin(), fill.second.end(),
               initial + p.body.slots[fill.first].offset);
@@ -2329,6 +2670,16 @@ void dynamic_loop_forward(KernelCtx& ctx) {
                    ctx.in_adj[in.input].data != nullptr, in.input, in.offset);
     std::copy_n(ctx.in[in.input].data + in.offset, slot.len,
                 initial + slot.offset);
+  }
+  if (s.allocation_profile) {
+    uint64_t before_imports = s.allocation_profile->initial_slot_refs;
+    s.allocation_profile->add(before_imports,
+                              s.allocation_profile->canonical_refs);
+    if (s.refs.size() < before_imports) {
+      s.allocation_profile->overflow = true;
+    } else {
+      s.allocation_profile->import_refs = s.refs.size() - before_imports;
+    }
   }
 
   e.forward(p.root);

--- a/runtime/src/structured_loop.cpp
+++ b/runtime/src/structured_loop.cpp
@@ -13,6 +13,7 @@
 #include <new>
 #include <numeric>
 #include <stdexcept>
+#include <type_traits>
 
 namespace stanli {
 namespace {
@@ -1276,6 +1277,7 @@ struct DynamicAllocationProfile {
     uint64_t ordinary_visits = 0;
     uint64_t active_visits = 0;
     uint64_t compact_visits = 0;
+    uint64_t frame_free_compact_visits = 0;
     uint64_t invariant_reuses = 0;
     uint64_t inactive_control_calls = 0;
     uint64_t direct_control_calls = 0;
@@ -1288,6 +1290,7 @@ struct DynamicAllocationProfile {
     uint64_t arena_location_refs = 0;
     uint64_t arena_values = 0;
     uint64_t input_handle_values = 0;
+    uint64_t record_handle_values = 0;
     uint64_t output_values = 0;
     uint64_t scratch_values = 0;
     uint64_t padding_values = 0;
@@ -1415,15 +1418,18 @@ struct DynamicAllocationProfile {
   }
 
   void note_compact(const Op& op, int64_t retained, int64_t output_len,
-                    bool active, bool shared_adjoint) noexcept {
+                    bool active, bool shared_adjoint,
+                    bool frame_free) noexcept {
     Bucket* b = bucket(op);
     if (!b) return;
     const uint64_t frame = count(retained);
     const uint64_t extent = count(output_len);
     add(b->compact_visits, 1);
+    add(b->frame_free_compact_visits, frame_free ? 1 : 0);
     add(b->active_visits, active ? 1 : 0);
     add(b->arena_values, frame);
-    add(b->input_handle_values, count(op.n_in));
+    add(b->input_handle_values, frame);
+    add(b->record_handle_values, frame_free && active ? 1 : 0);
     add(b->refs, 1);
     add(b->active_refs, active ? 1 : 0);
     add(b->referenced_values, extent);
@@ -1452,13 +1458,19 @@ struct DynamicLoopState final : KernelState {
   };
   struct Record {
     const Node* node = nullptr;
-    double* frame = nullptr;
+    // Ordinary and retained compact records store their input frame. A
+    // frame-free active compact record stores only its RHS handle; an inactive
+    // frame-free compact record leaves the pointer null.
+    union {
+      double* frame = nullptr;
+      double rhs_handle;
+    };
     double out = -1;
     // Ordinary calls store the optional second-output handle. Compact updates
     // have no second output and store the overwritten value here instead.
     double out2 = -1;
-    // Compact updates store the overwritten position directly. Ordinary
-    // records use -1.
+    // Retained compact updates store a nonnegative position. Ordinary records
+    // use -1. Frame-free compact updates encode position as -2 - position.
     int64_t undo = -1;
   };
   DynamicArena arena;
@@ -1636,6 +1648,10 @@ struct DynamicLoopState final : KernelState {
 };
 static_assert(sizeof(DynamicLoopState::Ref) == 16,
               "dynamic structured references must stay compact");
+static_assert(sizeof(DynamicLoopState::Record) == 40,
+              "dynamic structured reverse records must stay compact");
+static_assert(std::is_trivially_copyable_v<DynamicLoopState::Record>,
+              "dynamic structured reverse records must copy by value");
 
 uint64_t profile_bytes(uint64_t count, uint64_t width,
                        bool& overflow) noexcept {
@@ -1716,6 +1732,7 @@ void report_memory_profile(const StructuredLoop& p,
   bool allocation_overflow = allocation->overflow;
   uint64_t kernel_arena_values = 0;
   uint64_t input_handle_values = 0;
+  uint64_t record_handle_values = 0;
   uint64_t output_values = 0;
   uint64_t scratch_values = 0;
   uint64_t padding_values = 0;
@@ -1725,6 +1742,7 @@ void report_memory_profile(const StructuredLoop& p,
   uint64_t conceptual_adjoint_values = 0;
   uint64_t physical_adjoint_values = 0;
   uint64_t profiled_records = 0;
+  uint64_t frame_free_compact_visits = 0;
   uint64_t inline_integer_calls = 0;
   uint64_t elided_arena_values = 0;
   uint64_t elided_refs = 0;
@@ -1737,6 +1755,8 @@ void report_memory_profile(const StructuredLoop& p,
                                       allocation_overflow);
     input_handle_values = profile_add(
         input_handle_values, bucket.input_handle_values, allocation_overflow);
+    record_handle_values = profile_add(
+        record_handle_values, bucket.record_handle_values, allocation_overflow);
     output_values =
         profile_add(output_values, bucket.output_values, allocation_overflow);
     scratch_values =
@@ -1756,6 +1776,9 @@ void report_memory_profile(const StructuredLoop& p,
                     allocation_overflow);
     profiled_records =
         profile_add(profiled_records, bucket.records, allocation_overflow);
+    frame_free_compact_visits =
+        profile_add(frame_free_compact_visits, bucket.frame_free_compact_visits,
+                    allocation_overflow);
     inline_integer_calls = profile_add(
         inline_integer_calls, bucket.inline_integer_calls, allocation_overflow);
     elided_arena_values = profile_add(
@@ -1789,13 +1812,15 @@ void report_memory_profile(const StructuredLoop& p,
       "stanli_structured_alloc_summary region=%p accounting_overflow=%d "
       "initial_arena_values=%llu kernel_arena_values=%llu "
       "profiled_arena_values=%llu actual_arena_values=%llu arena_match=%d "
-      "input_handle_values=%llu output_values=%llu scratch_values=%llu "
+      "input_handle_values=%llu record_handle_values=%llu "
+      "output_values=%llu scratch_values=%llu "
       "padding_values=%llu initial_slot_refs=%llu canonical_refs=%llu "
       "import_refs=%llu kernel_refs=%llu profiled_refs=%llu "
       "actual_refs=%zu refs_match=%d active_refs=%llu "
       "referenced_values=%llu conceptual_adjoint_values=%llu "
       "physical_adjoint_values=%llu profiled_records=%llu "
       "actual_records=%zu records_match=%d inline_integer_calls=%llu "
+      "frame_free_compact_visits=%llu "
       "elided_arena_values=%llu elided_refs=%llu "
       "inactive_transient_values=%llu inactive_output_values=%llu "
       "inactive_output_refs=%llu arena_location_refs=%llu\n",
@@ -1806,6 +1831,7 @@ void report_memory_profile(const StructuredLoop& p,
       static_cast<unsigned long long>(state.arena.used_values),
       profiled_arena_values == state.arena.used_values ? 1 : 0,
       static_cast<unsigned long long>(input_handle_values),
+      static_cast<unsigned long long>(record_handle_values),
       static_cast<unsigned long long>(output_values),
       static_cast<unsigned long long>(scratch_values),
       static_cast<unsigned long long>(padding_values),
@@ -1822,6 +1848,7 @@ void report_memory_profile(const StructuredLoop& p,
       static_cast<unsigned long long>(profiled_records), state.records.size(),
       profiled_records == state.records.size() ? 1 : 0,
       static_cast<unsigned long long>(inline_integer_calls),
+      static_cast<unsigned long long>(frame_free_compact_visits),
       static_cast<unsigned long long>(elided_arena_values),
       static_cast<unsigned long long>(elided_refs),
       static_cast<unsigned long long>(inactive_transient_values),
@@ -1839,13 +1866,15 @@ void report_memory_profile(const StructuredLoop& p,
         stderr,
         "stanli_structured_alloc_opcode region=%p opcode=%u name=%s "
         "ordinary_visits=%llu active_visits=%llu compact_visits=%llu "
+        "frame_free_compact_visits=%llu "
         "invariant_reuses=%llu inactive_control_calls=%llu "
         "direct_control_calls=%llu inline_integer_calls=%llu "
         "elided_arena_values=%llu elided_refs=%llu arena_values=%llu "
         "inactive_transient_values=%llu inactive_output_values=%llu "
         "inactive_output_refs=%llu "
         "arena_location_refs=%llu "
-        "input_handle_values=%llu output_values=%llu scratch_values=%llu "
+        "input_handle_values=%llu record_handle_values=%llu "
+        "output_values=%llu scratch_values=%llu "
         "padding_values=%llu refs=%llu active_refs=%llu "
         "referenced_values=%llu conceptual_adjoint_values=%llu "
         "physical_adjoint_values=%llu records=%llu\n",
@@ -1854,6 +1883,7 @@ void report_memory_profile(const StructuredLoop& p,
         static_cast<unsigned long long>(bucket.ordinary_visits),
         static_cast<unsigned long long>(bucket.active_visits),
         static_cast<unsigned long long>(bucket.compact_visits),
+        static_cast<unsigned long long>(bucket.frame_free_compact_visits),
         static_cast<unsigned long long>(bucket.invariant_reuses),
         static_cast<unsigned long long>(bucket.inactive_control_calls),
         static_cast<unsigned long long>(bucket.direct_control_calls),
@@ -1866,6 +1896,7 @@ void report_memory_profile(const StructuredLoop& p,
         static_cast<unsigned long long>(bucket.inactive_output_refs),
         static_cast<unsigned long long>(bucket.arena_location_refs),
         static_cast<unsigned long long>(bucket.input_handle_values),
+        static_cast<unsigned long long>(bucket.record_handle_values),
         static_cast<unsigned long long>(bucket.output_values),
         static_cast<unsigned long long>(bucket.scratch_values),
         static_cast<unsigned long long>(bucket.padding_values),
@@ -1895,6 +1926,7 @@ DynamicLoopState& dynamic_state(KernelCtx& c) {
 
 void compare_forward(KernelCtx& c);
 void int_forward(KernelCtx& c);
+void set_index_backward(KernelCtx& c);
 
 struct DynamicExecution {
   const StructuredLoop& p;
@@ -2586,23 +2618,46 @@ struct DynamicExecution {
                                         c.in[2].len)
                : -1;
 
+    bool frame_free =
+        !active || (shared_adjoint >= 0 && n.backward == set_index_backward);
+    int64_t undo = position;
+    if (frame_free) {
+      if (position > std::numeric_limits<int64_t>::max() - 2) {
+        frame_free = false;
+      } else {
+        undo = -2 - position;
+      }
+    }
+
     // Every allocation that can throw precedes the destructive write. A later
     // failure still drops the entire evaluation-local tape, but this ordering
     // also keeps the state internally coherent under allocation failure.
     const int retained_inputs = op.n_in;
-    double* frame = state.arena.allocate(std::max(1, retained_inputs));
-    std::copy_n(handles, retained_inputs, frame);
+    double* frame = nullptr;
+    if (!frame_free) {
+      frame = state.arena.allocate(std::max(1, retained_inputs));
+      std::copy_n(handles, retained_inputs, frame);
+    }
     const double out = make_ref(c.out.data, c.out.len, active, shared_adjoint);
-    state.records.push_back({&n, frame, out, c.out.data[position], position});
     if (shared_adjoint >= 0 && c.out.len > state.compact_adjoint_work_size)
       throw std::logic_error(
           "compact structured adjoint exceeds preallocated work");
+    DynamicLoopState::Record record;
+    record.node = &n;
+    if (frame_free && active)
+      record.rhs_handle = handles[2];
+    else
+      record.frame = frame;
+    record.out = out;
+    record.out2 = c.out.data[position];
+    record.undo = undo;
+    state.records.push_back(record);
     c.out.data[position] = c.in[2].data[0];
     state.bindings[static_cast<size_t>(op.out)] = out;
     if (state.allocation_profile)
-      state.allocation_profile->note_compact(op, std::max(1, retained_inputs),
-                                             c.out.len, active,
-                                             shared_adjoint >= 0);
+      state.allocation_profile->note_compact(
+          op, frame_free ? 0 : std::max(1, retained_inputs), c.out.len, active,
+          shared_adjoint >= 0, frame_free);
     return true;
   }
 
@@ -2823,24 +2878,76 @@ struct DynamicExecution {
     return true;
   }
 
+  void backward_frame_free_compact(const DynamicLoopState::Record& record,
+                                   int64_t position) {
+    const Op& op = p.body.ops[static_cast<size_t>(record.node->op)];
+    const int64_t output_len = p.body.slots[static_cast<size_t>(op.out)].len;
+    if (record.out < 0 || record.node->backward != set_index_backward ||
+        op.opcode != OP_SET_INDEX_DYNAMIC || op.n_in != 3 || op.out2 >= 0 ||
+        p.body.slots[static_cast<size_t>(op.in[2])].len != 1 || position < 0 ||
+        position >= output_len || output_len <= 0 ||
+        output_len > state.compact_adjoint_work_size ||
+        !state.compact_adjoint_work)
+      throw std::logic_error("frame-free compact structured record is invalid");
+    auto& output = ref(record.out);
+    if (is_import_ref(output) || output.adjoint_or_import < 0)
+      throw std::logic_error(
+          "frame-free compact structured output is not internal");
+    if (!output.value)
+      throw std::logic_error(
+          "frame-free compact structured output is unavailable");
+    double* const shared_adjoint = adj(record.out, output_len);
+    double* const rhs_adjoint = adj(record.rhs_handle, 1);
+    if (!shared_adjoint)
+      throw std::logic_error(
+          "frame-free compact structured adjoint is unavailable");
+
+    double* const conceptual_output = state.compact_adjoint_work.get();
+    if (adjoint_ranges_overlap(record.out, output_len, record.rhs_handle, 1) ||
+        overlaps({conceptual_output, output_len},
+                 {shared_adjoint, output_len}) ||
+        (rhs_adjoint &&
+         overlaps({conceptual_output, output_len}, {rhs_adjoint, 1})))
+      throw std::logic_error(
+          "frame-free compact structured adjoints are not disjoint");
+    // The saved forward position is the tape value. The built-in scalar
+    // update has no selector adjoint; its reverse behavior depends only on
+    // that position, the RHS adjoint, and the ordered output-adjoint scan.
+    std::copy_n(shared_adjoint, output_len, conceptual_output);
+    std::fill_n(shared_adjoint, output_len, 0.0);
+    for (int64_t i = 0; i < output_len; ++i) {
+      if (i == position) {
+        if (rhs_adjoint) rhs_adjoint[0] += conceptual_output[i];
+      } else {
+        shared_adjoint[i] += conceptual_output[i];
+      }
+    }
+  }
+
   void backward() {
     for (size_t i = state.records.size(); i-- > 0;) {
       const auto& record = state.records[i];
-      if (record.undo >= 0) {
+      if (record.undo != -1) {
+        const bool frame_free = record.undo < -1;
+        const int64_t position = frame_free ? -(record.undo + 2) : record.undo;
         auto& output = ref(record.out);
         const int64_t output_len =
             p.body.slots[p.body.ops[record.node->op].out].len;
-        if (record.undo >= output_len)
+        if (position < 0 || position >= output_len)
           throw std::logic_error(
               "compact structured undo position out of range");
         if (record.out >= 0 && record.node->backward) {
-          ContextLease context(*this, *record.node, record.frame, true,
-                               record.out, -1, output.value);
-          KernelCtx& c = context.get();
-          prepare_shared_compact_adjoint(record, c);
-          record.node->backward(c);
+          if (frame_free) {
+            backward_frame_free_compact(record, position);
+          } else {
+            ContextLease context(*this, *record.node, record.frame, true,
+                                 record.out, -1, output.value);
+            KernelCtx& c = context.get();
+            prepare_shared_compact_adjoint(record, c);
+            record.node->backward(c);
+          }
         }
-        output.value[record.undo] = record.out2;
+        output.value[position] = record.out2;
       } else if (record.node->backward) {
         ContextLease context(*this, *record.node, record.frame, true,
                              record.out, record.out2);

--- a/runtime/src/structured_loop.cpp
+++ b/runtime/src/structured_loop.cpp
@@ -1217,6 +1217,9 @@ struct DynamicAllocationProfile {
     uint64_t inline_integer_calls = 0;
     uint64_t elided_arena_values = 0;
     uint64_t elided_refs = 0;
+    uint64_t inactive_transient_values = 0;
+    uint64_t inactive_output_values = 0;
+    uint64_t inactive_output_refs = 0;
     uint64_t arena_values = 0;
     uint64_t input_handle_values = 0;
     uint64_t output_values = 0;
@@ -1294,6 +1297,48 @@ struct DynamicAllocationProfile {
     add(b->conceptual_adjoint_values, active ? outputs : 0);
     add(b->physical_adjoint_values, active ? outputs : 0);
     add(b->records, active ? 1 : 0);
+    if (!active) {
+      uint64_t transient = inputs;
+      add(transient, scratch);
+      add(transient, padding);
+      add(b->inactive_transient_values, transient);
+      add(b->inactive_output_values, outputs);
+      add(b->inactive_output_refs, refs);
+    }
+  }
+
+  void note_inactive_split(const Op& op, const Node& node,
+                           int64_t retained_outputs) noexcept {
+    Bucket* b = bucket(op);
+    if (!b) return;
+    const uint64_t inputs = count(op.n_in);
+    const uint64_t outputs = count(node.frame_size - 6 - node.kernel_scratch);
+    const uint64_t scratch = count(node.kernel_scratch);
+    const uint64_t old_frame = count(std::max<int64_t>(
+        1, node.frame_size - (6 - static_cast<int64_t>(op.n_in))));
+    uint64_t old_components = inputs;
+    add(old_components, outputs);
+    add(old_components, scratch);
+    const uint64_t old_padding =
+        old_frame >= old_components ? old_frame - old_components : 0;
+    if (old_frame < old_components) overflow = true;
+    const uint64_t new_frame = count(retained_outputs);
+    const uint64_t new_padding = new_frame >= outputs ? new_frame - outputs : 0;
+    if (new_frame < outputs) overflow = true;
+    const uint64_t refs = op.out2 >= 0 ? 2 : 1;
+    uint64_t transient = inputs;
+    add(transient, scratch);
+    add(transient, old_padding);
+
+    add(b->ordinary_visits, 1);
+    add(b->arena_values, new_frame);
+    add(b->output_values, outputs);
+    add(b->padding_values, new_padding);
+    add(b->refs, refs);
+    add(b->referenced_values, outputs);
+    add(b->inactive_transient_values, transient);
+    add(b->inactive_output_values, outputs);
+    add(b->inactive_output_refs, refs);
   }
 
   void note_compact(const Op& op, int64_t retained, int64_t output_len,
@@ -1361,6 +1406,11 @@ struct DynamicLoopState final : KernelState {
   // output range to preserve the ordinary callback's distinct descriptors.
   std::unique_ptr<double[]> compact_adjoint_work;
   int64_t compact_adjoint_work_size = 0;
+  // Reused only by synchronous inactive forward callbacks. Its maximum size
+  // is immutable body metadata, so no per-visit scratch enters the tape.
+  std::unique_ptr<double[]> inactive_scratch;
+  int64_t inactive_scratch_size = 0;
+  double inactive_empty_value = 0.0;
   // Pointer-free call-site templates. They retain only immutable graph
   // structure between calls; context() refreshes every evaluation-local
   // pointer and adjoint before each reached forward or reverse callback.
@@ -1420,21 +1470,24 @@ struct DynamicLoopState final : KernelState {
       if (op.out2 >= 0) c.out2 = {nullptr, p.body.slots[op.out2].len};
       context_templates.push_back(c);
     }
-    const auto visit_compact = [&](const auto& self, const Node& n) -> void {
-      if (n.kind == Node::KernelCall && n.compact_update_cell >= 0) {
+    const auto visit_workspace = [&](const auto& self, const Node& n) -> void {
+      if (n.kind == Node::KernelCall) {
         if (n.op < 0 || static_cast<size_t>(n.op) >= p.body.ops.size())
-          throw std::invalid_argument(
-              "compact dynamic structured body op is invalid");
-        const Op& op = p.body.ops[static_cast<size_t>(n.op)];
-        const int64_t len = p.body.slots[static_cast<size_t>(op.out)].len;
-        if (len <= 0)
-          throw std::invalid_argument(
-              "compact dynamic structured output extent is invalid");
-        compact_adjoint_work_size = std::max(compact_adjoint_work_size, len);
+          throw std::invalid_argument("dynamic structured body op is invalid");
+        inactive_scratch_size =
+            std::max(inactive_scratch_size, n.kernel_scratch);
+        if (n.compact_update_cell >= 0) {
+          const Op& op = p.body.ops[static_cast<size_t>(n.op)];
+          const int64_t len = p.body.slots[static_cast<size_t>(op.out)].len;
+          if (len <= 0)
+            throw std::invalid_argument(
+                "compact dynamic structured output extent is invalid");
+          compact_adjoint_work_size = std::max(compact_adjoint_work_size, len);
+        }
       }
       for (const auto& child : n.children) self(self, child);
     };
-    visit_compact(visit_compact, p.root);
+    visit_workspace(visit_workspace, p.root);
     if (compact_adjoint_work_size < 0 ||
         static_cast<uint64_t>(compact_adjoint_work_size) >
             std::numeric_limits<size_t>::max())
@@ -1442,6 +1495,20 @@ struct DynamicLoopState final : KernelState {
     if (compact_adjoint_work_size > 0)
       compact_adjoint_work.reset(
           new double[static_cast<size_t>(compact_adjoint_work_size)]);
+    try {
+      if (inactive_scratch_size < 0 ||
+          static_cast<uint64_t>(inactive_scratch_size) >
+              std::numeric_limits<size_t>::max())
+        throw std::length_error("inactive structured scratch overflow");
+      if (inactive_scratch_size > 0)
+        inactive_scratch.reset(
+            new double[static_cast<size_t>(inactive_scratch_size)]);
+    } catch (...) {
+      // This workspace is optional. Preserve the ordinary retained-frame path
+      // if validation or eager allocation cannot be satisfied at bind time.
+      inactive_scratch.reset();
+      inactive_scratch_size = 0;
+    }
     // This body-sized proof is built once with the bound Executor and never
     // rebuilt from reached iterations or observed parameter values.
     try {
@@ -1539,6 +1606,9 @@ void report_memory_profile(const StructuredLoop& p,
       state.undos.capacity(), sizeof(DynamicLoopState::Undo), overflow);
   const uint64_t planned_adjoint = profile_bytes(
       static_cast<uint64_t>(state.adjoint_size), sizeof(double), overflow);
+  const uint64_t inactive_scratch =
+      profile_bytes(static_cast<uint64_t>(state.inactive_scratch_size),
+                    sizeof(double), overflow);
   const uint64_t iterator_value_bytes =
       profile_bytes(state.iterator_values, sizeof(double), overflow);
   const uint64_t iterator_ref_bytes = profile_bytes(
@@ -1557,7 +1627,7 @@ void report_memory_profile(const StructuredLoop& p,
       "ref_count=%zu ref_used_bytes=%llu ref_capacity_bytes=%llu "
       "record_count=%zu record_used_bytes=%llu record_capacity_bytes=%llu "
       "undo_count=%zu undo_used_bytes=%llu undo_capacity_bytes=%llu "
-      "planned_adjoint_bytes=%llu\n",
+      "planned_adjoint_bytes=%llu inactive_scratch_bytes=%llu\n",
       static_cast<const void*>(&p), p.node_count, p.body.ops.size(),
       overflow ? 1 : 0, static_cast<unsigned long long>(state.iterator_values),
       static_cast<unsigned long long>(iterator_value_bytes),
@@ -1571,7 +1641,8 @@ void report_memory_profile(const StructuredLoop& p,
       static_cast<unsigned long long>(record_capacity), state.undos.size(),
       static_cast<unsigned long long>(undo_used),
       static_cast<unsigned long long>(undo_capacity),
-      static_cast<unsigned long long>(planned_adjoint));
+      static_cast<unsigned long long>(planned_adjoint),
+      static_cast<unsigned long long>(inactive_scratch));
 
   const auto* allocation = state.allocation_profile.get();
   if (!allocation) {
@@ -1593,6 +1664,9 @@ void report_memory_profile(const StructuredLoop& p,
   uint64_t inline_integer_calls = 0;
   uint64_t elided_arena_values = 0;
   uint64_t elided_refs = 0;
+  uint64_t inactive_transient_values = 0;
+  uint64_t inactive_output_values = 0;
+  uint64_t inactive_output_refs = 0;
   for (const auto& bucket : allocation->buckets) {
     kernel_arena_values = profile_add(kernel_arena_values, bucket.arena_values,
                                       allocation_overflow);
@@ -1623,6 +1697,15 @@ void report_memory_profile(const StructuredLoop& p,
         elided_arena_values, bucket.elided_arena_values, allocation_overflow);
     elided_refs =
         profile_add(elided_refs, bucket.elided_refs, allocation_overflow);
+    inactive_transient_values =
+        profile_add(inactive_transient_values,
+                    bucket.inactive_transient_values, allocation_overflow);
+    inactive_output_values =
+        profile_add(inactive_output_values, bucket.inactive_output_values,
+                    allocation_overflow);
+    inactive_output_refs =
+        profile_add(inactive_output_refs, bucket.inactive_output_refs,
+                    allocation_overflow);
   }
   uint64_t profiled_arena_values =
       profile_add(allocation->initial_arena_values, kernel_arena_values,
@@ -1646,7 +1729,9 @@ void report_memory_profile(const StructuredLoop& p,
       "referenced_values=%llu conceptual_adjoint_values=%llu "
       "physical_adjoint_values=%llu profiled_records=%llu "
       "actual_records=%zu records_match=%d inline_integer_calls=%llu "
-      "elided_arena_values=%llu elided_refs=%llu\n",
+      "elided_arena_values=%llu elided_refs=%llu "
+      "inactive_transient_values=%llu inactive_output_values=%llu "
+      "inactive_output_refs=%llu\n",
       static_cast<const void*>(&p), allocation_overflow ? 1 : 0,
       static_cast<unsigned long long>(allocation->initial_arena_values),
       static_cast<unsigned long long>(kernel_arena_values),
@@ -1671,7 +1756,10 @@ void report_memory_profile(const StructuredLoop& p,
       profiled_records == state.records.size() ? 1 : 0,
       static_cast<unsigned long long>(inline_integer_calls),
       static_cast<unsigned long long>(elided_arena_values),
-      static_cast<unsigned long long>(elided_refs));
+      static_cast<unsigned long long>(elided_refs),
+      static_cast<unsigned long long>(inactive_transient_values),
+      static_cast<unsigned long long>(inactive_output_values),
+      static_cast<unsigned long long>(inactive_output_refs));
 
   for (uint16_t opcode = 0; opcode < OP_COUNT_; ++opcode) {
     const auto& bucket = allocation->buckets[opcode];
@@ -1686,6 +1774,8 @@ void report_memory_profile(const StructuredLoop& p,
         "invariant_reuses=%llu inactive_control_calls=%llu "
         "direct_control_calls=%llu inline_integer_calls=%llu "
         "elided_arena_values=%llu elided_refs=%llu arena_values=%llu "
+        "inactive_transient_values=%llu inactive_output_values=%llu "
+        "inactive_output_refs=%llu "
         "input_handle_values=%llu output_values=%llu scratch_values=%llu "
         "padding_values=%llu refs=%llu active_refs=%llu "
         "referenced_values=%llu conceptual_adjoint_values=%llu "
@@ -1702,6 +1792,9 @@ void report_memory_profile(const StructuredLoop& p,
         static_cast<unsigned long long>(bucket.elided_arena_values),
         static_cast<unsigned long long>(bucket.elided_refs),
         static_cast<unsigned long long>(bucket.arena_values),
+        static_cast<unsigned long long>(bucket.inactive_transient_values),
+        static_cast<unsigned long long>(bucket.inactive_output_values),
+        static_cast<unsigned long long>(bucket.inactive_output_refs),
         static_cast<unsigned long long>(bucket.input_handle_values),
         static_cast<unsigned long long>(bucket.output_values),
         static_cast<unsigned long long>(bucket.scratch_values),
@@ -2182,12 +2275,15 @@ struct DynamicExecution {
   KernelCtx& context(const Node& n, double* frame, bool backward,
                      std::array<double, 6>& inline_inputs,
                      double out_handle = -1, double out2_handle = -1,
-                     double* output_override = nullptr) {
+                     double* output_override = nullptr,
+                     double* output2_override = nullptr,
+                     double* scratch_override = nullptr) {
     const Op& op = p.body.ops[n.op];
     if (op.n_in < 0 || op.n_in > 6)
       throw std::logic_error("dynamic structured frame arity is invalid");
-    if (output_override && op.out2 >= 0)
-      throw std::logic_error("compact structured update has second output");
+    if ((output2_override != nullptr) !=
+        (output_override != nullptr && op.out2 >= 0))
+      throw std::logic_error("structured output overrides are inconsistent");
     if (n.op < 0 || static_cast<size_t>(n.op) >= state.context_templates.size())
       throw std::logic_error(
           "dynamic structured context template is out of range");
@@ -2232,11 +2328,11 @@ struct DynamicExecution {
       c.out2.data = nullptr;
       c.out2_adj = 0.0;
       if (op.out2 >= 0) {
-        c.out2.data = frame + pos;
+        c.out2.data = output2_override ? output2_override : frame + pos;
         if (backward) c.out2_adj = *adj(out2_handle, c.out2.len);
         pos += c.out2.len;
       }
-      c.scratch = output_override ? nullptr : frame + pos;
+      c.scratch = output_override ? scratch_override : frame + pos;
     } catch (...) {
       clear_context(c);
       throw;
@@ -2257,10 +2353,13 @@ struct DynamicExecution {
 
     ContextLease(DynamicExecution& execution, const Node& n, double* frame,
                  bool backward, double out_handle = -1, double out2_handle = -1,
-                 double* output_override = nullptr)
+                 double* output_override = nullptr,
+                 double* output2_override = nullptr,
+                 double* scratch_override = nullptr)
         : execution(execution) {
       call = &execution.context(n, frame, backward, inline_inputs, out_handle,
-                                out2_handle, output_override);
+                                out2_handle, output_override, output2_override,
+                                scratch_override);
     }
     ContextLease(const ContextLease&) = delete;
     ContextLease& operator=(const ContextLease&) = delete;
@@ -2395,6 +2494,49 @@ struct DynamicExecution {
     return true;
   }
 
+  bool transient_inactive_call(const Node& n, double* handles, bool& active) {
+    const Op& op = p.body.ops[static_cast<size_t>(n.op)];
+    bool any_active_input = false;
+    for (int k = 0; k < op.n_in; ++k) {
+      handles[k] = state.bindings[static_cast<size_t>(op.in[k])];
+      any_active_input |= handles[k] >= 0;
+    }
+    active = n.backward && any_active_input;
+    if (active) return false;
+    if (n.kernel_scratch > state.inactive_scratch_size ||
+        (n.kernel_scratch > 0 && !state.inactive_scratch))
+      return false;
+
+    const int64_t output_values =
+        add(p.body.slots[static_cast<size_t>(op.out)].len,
+            op.out2 >= 0 ? p.body.slots[static_cast<size_t>(op.out2)].len : 0);
+    const int64_t retained_outputs = output_values;
+    double* outputs = output_values > 0 ? state.arena.allocate(output_values)
+                                        : &state.inactive_empty_value;
+    double* output2 =
+        op.out2 >= 0 ? outputs + p.body.slots[static_cast<size_t>(op.out)].len
+                     : nullptr;
+    ContextLease context(*this, n, handles, false, -1, -1, outputs, output2,
+                         state.inactive_scratch.get());
+    KernelCtx& c = context.get();
+    // The same callback runs in the same order. Only its call-local handles
+    // and scratch stop entering persistent history; output storage remains in
+    // the stable arena and is published after successful completion.
+    n.forward(c);
+    state.bindings[static_cast<size_t>(op.out)] =
+        make_ref(c.out.data, c.out.len, false);
+    if (op.out2 >= 0)
+      state.bindings[static_cast<size_t>(op.out2)] =
+          make_ref(c.out2.data, c.out2.len, false);
+    if (n.compact_update_cell >= 0)
+      state.compact_primal_by_cell[static_cast<size_t>(n.compact_update_cell)] =
+          c.out.data;
+    publish_loop_invariant(n);
+    if (state.allocation_profile)
+      state.allocation_profile->note_inactive_split(op, n, retained_outputs);
+    return true;
+  }
+
   enum Flow { Normal, Break, Continue };
   Flow forward(const Node& n) {
     switch (n.kind) {
@@ -2434,19 +2576,18 @@ struct DynamicExecution {
           return Normal;
         }
         if (compact_update(n)) return Normal;
+        double handles[6] = {};
+        bool active = false;
+        if (transient_inactive_call(n, handles, active)) return Normal;
         const int64_t retained = retained_frame_values(n);
         double* frame = state.arena.allocate(retained);
-        for (int k = 0; k < op.n_in; ++k)
-          frame[k] = state.bindings[static_cast<size_t>(op.in[k])];
+        std::copy_n(handles, op.n_in, frame);
         ContextLease context(*this, n, frame, false);
         KernelCtx& c = context.get();
         // Preserve the kernel's exception type and message. In particular,
         // reject/domain errors and bounds errors are part of Stan's visible
         // behavior and must match the ordinary graph path.
         n.forward(c);
-        bool active = false;
-        for (int k = 0; k < c.n_in; ++k) active |= frame[k] >= 0;
-        active &= n.backward != nullptr;
         const double out = make_ref(c.out.data, c.out.len, active);
         state.bindings[static_cast<size_t>(op.out)] = out;
         double out2 = -1;

--- a/runtime/src/structured_loop.cpp
+++ b/runtime/src/structured_loop.cpp
@@ -949,6 +949,136 @@ struct InactiveControlPlan {
   }
 };
 
+// Reuse one body-sized output buffer for an inactive call when its result is
+// provably forward-only.  A consumer with a reverse callback may need an
+// inactive input's primal during the reverse sweep, so such inputs stay on the
+// ordinary persistent arena path.  Aliases and targets also let a particular
+// reached value escape its producing binding.  The remaining results have no
+// lifetime beyond their current binding and synchronous forward consumers;
+// reexecuting the same unique call site may therefore overwrite its buffer.
+//
+// Keep these sites disjoint from loop-invariant and inactive-control plans.
+// Both plans use canonical handles as cached identity, while this plan
+// deliberately gives every dynamic version from one site the same handle.
+struct InactiveWorkspacePlan {
+  struct Uses {
+    uint64_t producers = 0;
+    uint64_t aliases = 0;
+    uint64_t targets = 0;
+    std::vector<const Node*> kernel_consumers;
+  };
+  struct Site {
+    const Node* node = nullptr;
+    int op = -1;
+    int64_t value_count = 0;
+    std::unique_ptr<double[]> values;
+    double canonical_handle = -1;
+    bool canonical_ready = false;
+    bool disabled = false;
+  };
+
+  std::vector<int32_t> site_by_op;
+  std::vector<Site> sites;
+  uint64_t value_count = 0;
+
+  InactiveWorkspacePlan(const StructuredLoop& p,
+                        const LoopInvariantPlan* invariants,
+                        const InactiveControlPlan* controls)
+      : site_by_op(p.body.ops.size(), int32_t{-1}) {
+    const size_t op_count = p.body.ops.size();
+    std::vector<Uses> uses(p.body.slots.size());
+    std::vector<uint32_t> op_nodes(op_count, 0);
+    std::vector<const Node*> node_by_op(op_count, nullptr);
+    std::vector<uint8_t> inside_loop(op_count, 0);
+    const auto inventory = [&](const auto& self, const Node& n,
+                               uint32_t loop_depth) -> void {
+      switch (n.kind) {
+        case Node::KernelCall: {
+          if (n.op < 0 || static_cast<size_t>(n.op) >= op_count)
+            throw std::logic_error(
+                "inactive-workspace operation is out of range");
+          const Op& op = p.body.ops[static_cast<size_t>(n.op)];
+          ++op_nodes[static_cast<size_t>(n.op)];
+          node_by_op[static_cast<size_t>(n.op)] = &n;
+          if (loop_depth) inside_loop[static_cast<size_t>(n.op)] = 1;
+          ++uses.at(static_cast<size_t>(op.out)).producers;
+          if (op.out2 >= 0) ++uses.at(static_cast<size_t>(op.out2)).producers;
+          for (int k = 0; k < op.n_in; ++k)
+            uses.at(static_cast<size_t>(op.in[k]))
+                .kernel_consumers.push_back(&n);
+          break;
+        }
+        case Node::Alias:
+          ++uses.at(static_cast<size_t>(n.src)).aliases;
+          ++uses.at(static_cast<size_t>(n.dst)).aliases;
+          break;
+        case Node::Target:
+          ++uses.at(static_cast<size_t>(n.src)).targets;
+          break;
+        default:
+          break;
+      }
+      const uint32_t child_depth =
+          loop_depth + (n.kind == Node::For || n.kind == Node::While);
+      for (const auto& child : n.children) self(self, child, child_depth);
+    };
+    inventory(inventory, p.root, 0);
+
+    const auto planned_elsewhere = [&](size_t op_id) {
+      return (invariants && op_id < invariants->site_by_op.size() &&
+              invariants->site_by_op[op_id] >= 0) ||
+             (controls && op_id < controls->site_by_op.size() &&
+              controls->site_by_op[op_id] >= 0);
+    };
+    for (size_t op_id = 0; op_id < op_count; ++op_id) {
+      if (!inside_loop[op_id] || op_nodes[op_id] != 1 ||
+          planned_elsewhere(op_id))
+        continue;
+      const Node& node = *node_by_op[op_id];
+      const Op& op = p.body.ops[op_id];
+      const Kernel* kernel = find_kernel(op.opcode);
+      if (!kernel || !node.forward || node.forward != kernel->forward ||
+          node.backward != kernel->backward || is_effectful_op(op.opcode) ||
+          op.out2 >= 0 || node.compact_update_cell >= 0)
+        continue;
+      const Uses& output = uses.at(static_cast<size_t>(op.out));
+      if (output.producers != 1 || output.aliases != 0 || output.targets != 0)
+        continue;
+      bool safe_consumers = true;
+      for (const Node* consumer : output.kernel_consumers) {
+        if (!consumer || consumer->backward || consumer->op < 0 ||
+            static_cast<size_t>(consumer->op) >= op_count ||
+            planned_elsewhere(static_cast<size_t>(consumer->op))) {
+          safe_consumers = false;
+          break;
+        }
+      }
+      if (!safe_consumers) continue;
+      bool self_input = false;
+      for (int k = 0; k < op.n_in; ++k) self_input |= op.in[k] == op.out;
+      if (self_input) continue;
+      const int64_t len = p.body.slots.at(static_cast<size_t>(op.out)).len;
+      if (len <= 0 || static_cast<uint64_t>(len) >
+                          static_cast<uint64_t>(exact_limit) - value_count)
+        continue;
+      if (sites.size() >=
+          static_cast<size_t>(std::numeric_limits<int32_t>::max()))
+        throw std::length_error("inactive-workspace plan is too large");
+      site_by_op[op_id] = static_cast<int32_t>(sites.size());
+      sites.push_back(
+          {&node, static_cast<int>(op_id), len, nullptr, double{-1}});
+      value_count += static_cast<uint64_t>(len);
+    }
+  }
+
+  void reset_runtime() noexcept {
+    for (auto& site : sites) {
+      site.canonical_handle = -1;
+      site.canonical_ready = false;
+    }
+  }
+};
+
 int64_t offset(double handle) {
   return static_cast<int64_t>(handle >= 0 ? handle : -handle - 1);
 }
@@ -1327,6 +1457,7 @@ struct DynamicAllocationProfile {
     uint64_t frame_free_compact_visits = 0;
     uint64_t invariant_reuses = 0;
     uint64_t inactive_control_calls = 0;
+    uint64_t inactive_workspace_calls = 0;
     uint64_t direct_control_calls = 0;
     uint64_t inline_integer_calls = 0;
     uint64_t elided_arena_values = 0;
@@ -1469,6 +1600,34 @@ struct DynamicAllocationProfile {
     add(b->inactive_transient_values, transient);
     add(b->inactive_output_values, outputs);
     add(b->inactive_output_refs, refs);
+  }
+
+  void note_inactive_workspace(const Op& op, const Node& node) noexcept {
+    Bucket* b = bucket(op);
+    if (!b) return;
+    const uint64_t inputs = count(op.n_in);
+    const uint64_t outputs = count(node.frame_size - 6 - node.kernel_scratch);
+    const uint64_t scratch = count(node.kernel_scratch);
+    const uint64_t old_frame = count(std::max<int64_t>(
+        1, node.frame_size - (6 - static_cast<int64_t>(op.n_in))));
+    uint64_t old_components = inputs;
+    add(old_components, outputs);
+    add(old_components, scratch);
+    const uint64_t old_padding =
+        old_frame >= old_components ? old_frame - old_components : 0;
+    if (old_frame < old_components) overflow = true;
+    uint64_t transient = inputs;
+    add(transient, scratch);
+    add(transient, old_padding);
+    const uint64_t refs = op.out2 >= 0 ? 2 : 1;
+    add(b->ordinary_visits, 1);
+    add(b->inactive_workspace_calls, 1);
+    add(b->elided_arena_values, outputs);
+    add(b->elided_refs, refs);
+    add(b->inactive_output_values, outputs);
+    add(b->inactive_output_refs, refs);
+    add(b->inactive_transient_values, transient);
+    add(b->referenced_values, outputs);
   }
 
   void note_compact(const Op& op, int64_t retained, int64_t output_len,
@@ -1619,13 +1778,16 @@ struct DynamicLoopState final : KernelState {
   std::unique_ptr<DirectControlPlan> direct_control_plan;
   std::unique_ptr<LoopInvariantPlan> loop_invariant_plan;
   std::unique_ptr<InactiveControlPlan> inactive_control_plan;
+  std::unique_ptr<InactiveWorkspacePlan> inactive_workspace_plan;
   std::unique_ptr<DynamicAllocationProfile> allocation_profile;
   std::vector<double> inactive_control_values;
+  uint64_t inactive_workspace_allocated_values = 0;
   int64_t conceptual_adjoint_size = 0;
   int64_t adjoint_size = 0;
   uint64_t iterator_values = 0;
   bool loop_invariant_reuse = false;
   bool inactive_control_reuse = false;
+  bool inactive_workspace_reuse = false;
   bool record_scalar_reuse = false;
   bool memory_profile = false;
   bool cached_context_in_use = false;
@@ -1757,6 +1919,16 @@ struct DynamicLoopState final : KernelState {
       inactive_control_plan.reset();
       std::vector<double>{}.swap(inactive_control_values);
     }
+    try {
+      inactive_workspace_plan = std::make_unique<InactiveWorkspacePlan>(
+          p, loop_invariant_plan.get(), inactive_control_plan.get());
+      if (inactive_workspace_plan->sites.empty())
+        inactive_workspace_plan.reset();
+    } catch (...) {
+      // Forward-only workspace reuse is optional.  Allocation or proof
+      // failure leaves every call on the persistent dynamic arena path.
+      inactive_workspace_plan.reset();
+    }
   }
 
   void release_tape() noexcept {
@@ -1822,6 +1994,8 @@ void report_memory_profile(const StructuredLoop& p,
   const uint64_t inactive_scratch =
       profile_bytes(static_cast<uint64_t>(state.inactive_scratch_size),
                     sizeof(double), overflow);
+  const uint64_t inactive_workspace = profile_bytes(
+      state.inactive_workspace_allocated_values, sizeof(double), overflow);
   const uint64_t iterator_value_bytes =
       profile_bytes(state.iterator_values, sizeof(double), overflow);
   const uint64_t iterator_ref_bytes = profile_bytes(
@@ -1840,7 +2014,8 @@ void report_memory_profile(const StructuredLoop& p,
       "ref_count=%zu ref_used_bytes=%llu ref_capacity_bytes=%llu "
       "record_count=%zu record_used_bytes=%llu record_capacity_bytes=%llu "
       "undo_count=0 undo_used_bytes=0 undo_capacity_bytes=0 "
-      "planned_adjoint_bytes=%llu inactive_scratch_bytes=%llu\n",
+      "planned_adjoint_bytes=%llu inactive_scratch_bytes=%llu "
+      "inactive_workspace_bytes=%llu\n",
       static_cast<const void*>(&p), p.node_count, p.body.ops.size(),
       overflow ? 1 : 0, static_cast<unsigned long long>(state.iterator_values),
       static_cast<unsigned long long>(iterator_value_bytes),
@@ -1853,7 +2028,8 @@ void report_memory_profile(const StructuredLoop& p,
       static_cast<unsigned long long>(record_used),
       static_cast<unsigned long long>(record_capacity),
       static_cast<unsigned long long>(planned_adjoint),
-      static_cast<unsigned long long>(inactive_scratch));
+      static_cast<unsigned long long>(inactive_scratch),
+      static_cast<unsigned long long>(inactive_workspace));
 
   const auto* allocation = state.allocation_profile.get();
   if (!allocation) {
@@ -1888,6 +2064,11 @@ void report_memory_profile(const StructuredLoop& p,
   uint64_t inactive_output_values = 0;
   uint64_t inactive_output_refs = 0;
   uint64_t arena_location_refs = 0;
+  uint64_t inactive_workspace_calls = 0;
+  uint64_t inactive_workspace_refs = 0;
+  if (state.inactive_workspace_plan)
+    for (const auto& site : state.inactive_workspace_plan->sites)
+      if (site.canonical_ready) ++inactive_workspace_refs;
   for (const auto& bucket : allocation->buckets) {
     kernel_arena_values = profile_add(kernel_arena_values, bucket.arena_values,
                                       allocation_overflow);
@@ -1955,6 +2136,9 @@ void report_memory_profile(const StructuredLoop& p,
                     allocation_overflow);
     arena_location_refs = profile_add(
         arena_location_refs, bucket.arena_location_refs, allocation_overflow);
+    inactive_workspace_calls =
+        profile_add(inactive_workspace_calls, bucket.inactive_workspace_calls,
+                    allocation_overflow);
   }
   uint64_t profiled_arena_values =
       profile_add(allocation->initial_arena_values, kernel_arena_values,
@@ -1964,6 +2148,8 @@ void report_memory_profile(const StructuredLoop& p,
                   allocation_overflow);
   setup_refs =
       profile_add(setup_refs, allocation->import_refs, allocation_overflow);
+  setup_refs =
+      profile_add(setup_refs, inactive_workspace_refs, allocation_overflow);
   const uint64_t profiled_refs =
       profile_add(setup_refs, kernel_refs, allocation_overflow);
   std::fprintf(
@@ -1976,7 +2162,8 @@ void report_memory_profile(const StructuredLoop& p,
       "compact_rhs_handle_values=%llu "
       "output_values=%llu scratch_values=%llu "
       "padding_values=%llu initial_slot_refs=%llu canonical_refs=%llu "
-      "import_refs=%llu kernel_refs=%llu profiled_refs=%llu "
+      "import_refs=%llu inactive_workspace_refs=%llu kernel_refs=%llu "
+      "profiled_refs=%llu "
       "actual_refs=%zu refs_match=%d active_refs=%llu "
       "referenced_values=%llu conceptual_adjoint_values=%llu "
       "physical_adjoint_values=%llu "
@@ -1988,7 +2175,8 @@ void report_memory_profile(const StructuredLoop& p,
       "frame_free_compact_visits=%llu "
       "elided_arena_values=%llu elided_refs=%llu "
       "inactive_transient_values=%llu inactive_output_values=%llu "
-      "inactive_output_refs=%llu arena_location_refs=%llu\n",
+      "inactive_output_refs=%llu arena_location_refs=%llu "
+      "inactive_workspace_calls=%llu inactive_workspace_values=%llu\n",
       static_cast<const void*>(&p), allocation_overflow ? 1 : 0,
       static_cast<unsigned long long>(allocation->initial_arena_values),
       static_cast<unsigned long long>(kernel_arena_values),
@@ -2006,6 +2194,7 @@ void report_memory_profile(const StructuredLoop& p,
       static_cast<unsigned long long>(allocation->initial_slot_refs),
       static_cast<unsigned long long>(allocation->canonical_refs),
       static_cast<unsigned long long>(allocation->import_refs),
+      static_cast<unsigned long long>(inactive_workspace_refs),
       static_cast<unsigned long long>(kernel_refs),
       static_cast<unsigned long long>(profiled_refs), state.refs.size(),
       profiled_refs == state.refs.size() ? 1 : 0,
@@ -2026,12 +2215,16 @@ void report_memory_profile(const StructuredLoop& p,
       static_cast<unsigned long long>(inactive_transient_values),
       static_cast<unsigned long long>(inactive_output_values),
       static_cast<unsigned long long>(inactive_output_refs),
-      static_cast<unsigned long long>(arena_location_refs));
+      static_cast<unsigned long long>(arena_location_refs),
+      static_cast<unsigned long long>(inactive_workspace_calls),
+      static_cast<unsigned long long>(
+          state.inactive_workspace_allocated_values));
 
   for (uint16_t opcode = 0; opcode < OP_COUNT_; ++opcode) {
     const auto& bucket = allocation->buckets[opcode];
     if (bucket.ordinary_visits == 0 && bucket.compact_visits == 0 &&
         bucket.invariant_reuses == 0 && bucket.inactive_control_calls == 0 &&
+        bucket.inactive_workspace_calls == 0 &&
         bucket.direct_control_calls == 0 && bucket.inline_integer_calls == 0)
       continue;
     std::fprintf(
@@ -2040,6 +2233,7 @@ void report_memory_profile(const StructuredLoop& p,
         "ordinary_visits=%llu active_visits=%llu compact_visits=%llu "
         "frame_free_compact_visits=%llu "
         "invariant_reuses=%llu inactive_control_calls=%llu "
+        "inactive_workspace_calls=%llu "
         "direct_control_calls=%llu inline_integer_calls=%llu "
         "elided_arena_values=%llu elided_refs=%llu arena_values=%llu "
         "inactive_transient_values=%llu inactive_output_values=%llu "
@@ -2064,6 +2258,7 @@ void report_memory_profile(const StructuredLoop& p,
         static_cast<unsigned long long>(bucket.frame_free_compact_visits),
         static_cast<unsigned long long>(bucket.invariant_reuses),
         static_cast<unsigned long long>(bucket.inactive_control_calls),
+        static_cast<unsigned long long>(bucket.inactive_workspace_calls),
         static_cast<unsigned long long>(bucket.direct_control_calls),
         static_cast<unsigned long long>(bucket.inline_integer_calls),
         static_cast<unsigned long long>(bucket.elided_arena_values),
@@ -2481,6 +2676,22 @@ struct DynamicExecution {
     }
   }
 
+  InactiveWorkspacePlan::Site* inactive_workspace_site(const Node& n) noexcept {
+    auto* plan = state.inactive_workspace_plan.get();
+    if (!plan || !state.inactive_workspace_reuse || n.op < 0 ||
+        static_cast<size_t>(n.op) >= plan->site_by_op.size())
+      return nullptr;
+    const int32_t id = plan->site_by_op[static_cast<size_t>(n.op)];
+    if (id < 0 || static_cast<size_t>(id) >= plan->sites.size()) return nullptr;
+    auto& site = plan->sites[static_cast<size_t>(id)];
+    if (site.disabled) return nullptr;
+    if (site.node != &n || site.op != n.op) {
+      state.inactive_workspace_reuse = false;
+      return nullptr;
+    }
+    return &site;
+  }
+
   bool inactive_control(const Node& n, InactiveControlPlan::Site* site) {
     if (!site) return false;
     auto* plan = state.inactive_control_plan.get();
@@ -2783,6 +2994,83 @@ struct DynamicExecution {
     KernelCtx& get() { return *call; }
   };
 
+  bool inactive_workspace_call(const Node& n, double* handles) {
+    InactiveWorkspacePlan::Site* site = inactive_workspace_site(n);
+    if (!site) return false;
+    const Op& op = p.body.ops.at(static_cast<size_t>(n.op));
+    const int64_t output_len = p.body.slots.at(static_cast<size_t>(op.out)).len;
+    if (op.out2 >= 0 || output_len <= 0 || output_len != site->value_count) {
+      state.inactive_workspace_reuse = false;
+      return false;
+    }
+    DynamicLoopState::Ref* canonical = nullptr;
+    try {
+      if (!site->values) {
+        site->values.reset(new double[static_cast<size_t>(output_len)]);
+        state.inactive_workspace_allocated_values +=
+            static_cast<uint64_t>(output_len);
+      }
+      if (!site->canonical_ready) {
+        site->canonical_handle =
+            make_ref(site->values.get(), output_len, false);
+        site->canonical_ready = true;
+      }
+      canonical = &ref(site->canonical_handle);
+      if (!canonical->value || canonical->adjoint_or_import != -1 ||
+          canonical->value != site->values.get())
+        throw std::logic_error("inactive-workspace output is invalid");
+      const Desc output{canonical->value, output_len};
+      for (int k = 0; k < op.n_in; ++k)
+        if (value_overlaps(handles[k],
+                           p.body.slots.at(static_cast<size_t>(op.in[k])).len,
+                           output))
+          return false;
+    } catch (...) {
+      // A failed proof guard disables this optional path before the callback
+      // is invoked, so the ordinary executor remains authoritative.
+      site->disabled = true;
+      return false;
+    }
+
+    ContextLease context(*this, n, handles, false, -1, -1, canonical->value,
+                         nullptr, state.inactive_scratch.get());
+    KernelCtx& c = context.get();
+    n.forward(c);
+    // The plan admits only the registered resolved callback. Still fail
+    // closed if its descriptor contract is ever changed: the callback has
+    // already run, so materialize the produced value once instead of running
+    // it a second time.
+    double out = site->canonical_handle;
+    bool used_workspace = true;
+    uint64_t arena_locations = 0;
+    if (c.out.data != canonical->value ||
+        c.out.len != p.body.slots[static_cast<size_t>(op.out)].len) {
+      if (!c.out.data ||
+          c.out.len != p.body.slots[static_cast<size_t>(op.out)].len)
+        throw std::logic_error(
+            "inactive-workspace callback changed output shape");
+      const DynamicArena::Allocation allocation =
+          state.arena.allocate_located(c.out.len);
+      std::copy_n(c.out.data, c.out.len, allocation.data);
+      if (state.arena.location_handle(allocation, 0, c.out.len, out)) {
+        arena_locations = 1;
+      } else {
+        out = make_ref(allocation.data, c.out.len, false);
+      }
+      used_workspace = false;
+    }
+    state.bindings[static_cast<size_t>(op.out)] = out;
+    if (state.allocation_profile) {
+      if (used_workspace) {
+        state.allocation_profile->note_inactive_workspace(op, n);
+      } else {
+        state.allocation_profile->note_inactive_split(op, n, c.out.len,
+                                                      arena_locations);
+      }
+    }
+    return true;
+  }
+
   bool inline_integer_result(const Node& n) {
     const Op& op = p.body.ops[static_cast<size_t>(n.op)];
     if (op.opcode != OP_COMPARE && op.opcode != OP_INT_ARITH) return false;
@@ -3059,6 +3347,10 @@ struct DynamicExecution {
     if (n.kernel_scratch > state.inactive_scratch_size ||
         (n.kernel_scratch > 0 && !state.inactive_scratch))
       return false;
+    if (inactive_workspace_call(n, handles)) {
+      publish_loop_invariant(n);
+      return true;
+    }
 
     const int64_t output_values =
         add(p.body.slots[static_cast<size_t>(op.out)].len,
@@ -3077,9 +3369,11 @@ struct DynamicExecution {
     // and scratch stop entering persistent history; output storage remains in
     // the stable arena and is published after successful completion.
     n.forward(c);
-    stabilize_ephemeral_aliased_output(c.out, outputs, handles, c);
+    stabilize_ephemeral_aliased_output(c.out, outputs, primary_len, handles, c);
     if (op.out2 >= 0)
-      stabilize_ephemeral_aliased_output(c.out2, output2, handles, c);
+      stabilize_ephemeral_aliased_output(
+          c.out2, output2, p.body.slots[static_cast<size_t>(op.out2)].len,
+          handles, c);
     uint64_t arena_locations = 0;
     const auto output_handle = [&](double* actual, double* expected,
                                    int64_t actual_len, int64_t expected_len,
@@ -3113,14 +3407,25 @@ struct DynamicExecution {
     return true;
   }
 
+  bool is_inactive_workspace_handle(double handle) const noexcept {
+    const auto* plan = state.inactive_workspace_plan.get();
+    if (!plan || handle >= 0) return false;
+    for (const auto& site : plan->sites)
+      if (site.canonical_ready && site.canonical_handle == handle) return true;
+    return false;
+  }
+
   void stabilize_ephemeral_aliased_output(Desc& output, double* stable,
+                                          int64_t stable_len,
                                           const double* handles,
                                           const KernelCtx& context) {
     if (!output.data) return;
     for (int k = 0; k < context.n_in; ++k) {
-      if (!is_record_scalar(handles[k]) && !is_inline_int(handles[k])) continue;
-      if (output.data != context.in[k].data) continue;
-      if (output.len != context.in[k].len)
+      if (!overlaps(output, context.in[k])) continue;
+      if (!is_record_scalar(handles[k]) && !is_inline_int(handles[k]) &&
+          !is_inactive_workspace_handle(handles[k]))
+        continue;
+      if (output.len != stable_len)
         throw std::logic_error(
             "dynamic structured ephemeral input aliases mismatched output");
       std::copy_n(output.data, output.len, stable);
@@ -3187,10 +3492,14 @@ struct DynamicExecution {
         // Callback output redirection may alias an input. Record storage can
         // move at the next push, so materialize that special case into the
         // stable frame before publishing a persistent Ref.
-        stabilize_ephemeral_aliased_output(c.out, frame + op.n_in, handles, c);
+        const int64_t primary_len =
+            p.body.slots[static_cast<size_t>(op.out)].len;
+        stabilize_ephemeral_aliased_output(c.out, frame + op.n_in, primary_len,
+                                           handles, c);
         if (op.out2 >= 0)
           stabilize_ephemeral_aliased_output(
-              c.out2, frame + op.n_in + c.out.len, handles, c);
+              c.out2, frame + op.n_in + primary_len,
+              p.body.slots[static_cast<size_t>(op.out2)].len, handles, c);
         const double out = make_ref(c.out.data, c.out.len, active);
         state.bindings[static_cast<size_t>(op.out)] = out;
         double out2 = -1;
@@ -3563,6 +3872,10 @@ void dynamic_loop_forward(KernelCtx& ctx) {
   s.inactive_control_reuse =
       s.inactive_control_plan &&
       std::getenv("STANLI_NO_STRUCTURED_INACTIVE_CONTROL") == nullptr;
+  if (s.inactive_workspace_plan) s.inactive_workspace_plan->reset_runtime();
+  s.inactive_workspace_reuse =
+      s.inactive_workspace_plan &&
+      std::getenv("STANLI_NO_STRUCTURED_INACTIVE_WORKSPACE") == nullptr;
   s.record_scalar_reuse =
       std::getenv("STANLI_NO_STRUCTURED_RECORD_SCALARS") == nullptr;
   struct ReleaseOnFailure {

--- a/runtime/src/structured_loop.cpp
+++ b/runtime/src/structured_loop.cpp
@@ -37,6 +37,40 @@ void index_backward(KernelCtx& c);
 int64_t scalar_index_forward(KernelCtx& c);
 void set_index_forward(KernelCtx& c);
 void set_index_backward(KernelCtx& c);
+struct IndexInputLayout {
+  int expected = 0;
+  int selector_end = 0;
+  int rhs = -1;
+};
+bool index_input_layout(const DynamicIndexSpec& p, bool update,
+                        IndexInputLayout& result) noexcept {
+  if (p.input_count < 0 || p.input_count > 6) return false;
+  if (!update) {
+    if (p.rhs_input != -1) return false;
+    if (p.input_count == 0) {
+      result = {2, 2, -1};
+      return true;
+    }
+    if (p.input_count < 2) return false;
+    result = {p.input_count, p.input_count, -1};
+    return true;
+  }
+  if (p.input_count == 0) {
+    if (p.rhs_input != -1) return false;
+    result = {3, 2, 2};
+    return true;
+  }
+  if (p.input_count < 3 || p.rhs_input != p.input_count - 1) return false;
+  result = {p.input_count, p.rhs_input, p.rhs_input};
+  return true;
+}
+IndexInputLayout require_index_input_layout(const DynamicIndexSpec& p,
+                                            bool update) {
+  IndexInputLayout result;
+  if (!index_input_layout(p, update, result))
+    throw std::logic_error("invalid structured index input count");
+  return result;
+}
 bool index_selection_is_ordered_unique(const DynamicIndexSpec& p) {
   return std::all_of(p.axes.begin(), p.axes.end(), [](const auto& axis) {
     return axis.kind != DynamicIndexSpec::Axis::Multi || axis.count <= 1;
@@ -226,22 +260,28 @@ void classify_compact_updates(StructuredLoop& p) {
         const Op& op = p.body.ops[static_cast<size_t>(call.op)];
         if (op.opcode != OP_SET_INDEX_DYNAMIC) continue;
         if (install.src != op.out || install.dst != op.in[0]) continue;
-        if (op.n_in != 3 || op.out2 >= 0 || call.forward != set_index_forward ||
+        if (op.out2 >= 0 || call.forward != set_index_forward ||
             call.backward != set_index_backward)
           continue;
-        if (op.out == op.in[0] || op.in[1] == op.in[0] ||
-            op.in[2] == op.in[0] || op.in[1] == op.out || op.in[2] == op.out ||
-            op.in[1] == op.in[2] || call.kernel_scratch != 0)
-          continue;
-        const int cell = install.dst;
         const auto* spec = static_cast<const DynamicIndexSpec*>(op.udata);
-        if (!spec || spec->axes.empty() || spec->selected_size < 0 ||
-            spec->input_count != 0 || !index_selection_is_ordered_unique(*spec))
+        IndexInputLayout layout;
+        if (!spec || !index_input_layout(*spec, true, layout) ||
+            op.n_in != layout.expected || spec->axes.empty() ||
+            spec->selected_size < 0 ||
+            !index_selection_is_ordered_unique(*spec) ||
+            call.kernel_scratch != 0)
           continue;
+        bool invalid_alias = op.out == op.in[0];
+        for (int k = 1; k < op.n_in; ++k)
+          invalid_alias |=
+              op.in[k] == op.in[0] || op.in[k] == op.out ||
+              (k < layout.selector_end && op.in[k] == op.in[layout.rhs]);
+        if (invalid_alias) continue;
+        const int cell = install.dst;
         if (p.body.slots[static_cast<size_t>(op.out)].len == 0 ||
             p.body.slots[static_cast<size_t>(op.out)].len !=
                 p.body.slots[static_cast<size_t>(cell)].len ||
-            p.body.slots[static_cast<size_t>(op.in[2])].len !=
+            p.body.slots[static_cast<size_t>(op.in[layout.rhs])].len !=
                 spec->selected_size)
           continue;
         const auto& output = uses[static_cast<size_t>(op.out)];
@@ -2342,11 +2382,11 @@ struct DynamicExecution {
       throw std::logic_error("record scalar index node is invalid");
     const Op& op = p.body.ops[static_cast<size_t>(node.op)];
     const auto* spec = static_cast<const DynamicIndexSpec*>(op.udata);
-    if (!spec || op.n_in < 2 || op.n_in > 6 ||
-        op.n_in != (spec->input_count > 0 ? spec->input_count : 2) ||
-        node.forward != index_forward || node.backward != index_backward ||
-        op.opcode != OP_INDEX_DYNAMIC || op.out2 >= 0 ||
-        spec->selected_size != 1 ||
+    IndexInputLayout layout;
+    if (!spec || !index_input_layout(*spec, false, layout) ||
+        op.n_in != layout.expected || node.forward != index_forward ||
+        node.backward != index_backward || op.opcode != OP_INDEX_DYNAMIC ||
+        op.out2 >= 0 || spec->selected_size != 1 ||
         p.body.slots[static_cast<size_t>(op.out)].len != 1 ||
         node.kernel_scratch != 0)
       throw std::logic_error("record scalar index record is invalid");
@@ -2849,19 +2889,22 @@ struct DynamicExecution {
   }
 
   int64_t compact_adjoint_offset(double base_handle, int64_t base_len,
-                                 int64_t output_len, double selector_handle,
-                                 int64_t selector_len, double rhs_handle,
-                                 int64_t rhs_len) {
+                                 int64_t output_len, const double* handles,
+                                 const KernelCtx& c) {
     if (base_handle < 0 || is_record_scalar(base_handle)) return -1;
     const auto& base = ref(base_handle);
     if (is_import_ref(base) || base.adjoint_or_import < 0 || base_len <= 0 ||
-        base_len != output_len ||
-        adjoint_ranges_overlap(base_handle, base_len, selector_handle,
-                               selector_len) ||
-        adjoint_ranges_overlap(base_handle, base_len, rhs_handle, rhs_len) ||
-        adjoint_ranges_overlap(selector_handle, selector_len, rhs_handle,
-                               rhs_len))
+        base_len != output_len)
       return -1;
+    for (int k = 1; k < c.n_in; ++k) {
+      if (adjoint_ranges_overlap(base_handle, base_len, handles[k],
+                                 c.in[k].len))
+        return -1;
+      for (int j = k + 1; j < c.n_in; ++j)
+        if (adjoint_ranges_overlap(handles[k], c.in[k].len, handles[j],
+                                   c.in[j].len))
+      return -1;
+    }
     return base.adjoint_or_import;
   }
 
@@ -3211,8 +3254,12 @@ struct DynamicExecution {
   bool compact_update(const Node& n) {
     if (n.compact_update_cell < 0) return false;
     const Op& op = p.body.ops[n.op];
-    if (op.n_in != 3 || op.out2 >= 0)
+    const auto* spec_ptr = static_cast<const DynamicIndexSpec*>(op.udata);
+    IndexInputLayout layout;
+    if (!spec_ptr || !index_input_layout(*spec_ptr, true, layout) ||
+        op.n_in != layout.expected || op.out2 >= 0)
       throw std::logic_error("compact structured update arity is invalid");
+    const auto& spec = *spec_ptr;
     const int cell = n.compact_update_cell;
     const double base_handle = state.bindings[static_cast<size_t>(op.in[0])];
     double* base = nullptr;
@@ -3232,16 +3279,15 @@ struct DynamicExecution {
       handles[k] = state.bindings[static_cast<size_t>(op.in[k])];
     ContextLease context(*this, n, handles, false, -1, -1, base);
     KernelCtx& c = context.get();
-    if (overlaps(c.out, c.in[1]) || overlaps(c.out, c.in[2])) return false;
-    const auto& spec = *static_cast<const DynamicIndexSpec*>(op.udata);
+    for (int k = 1; k < c.n_in; ++k)
+      if (overlaps(c.out, c.in[k])) return false;
     const bool scalar_site = scalar_compact_update_spec(spec);
     bool active = false;
     for (int k = 0; k < c.n_in; ++k) active |= handles[k] >= 0;
     active &= n.backward != nullptr;
     const int64_t shared_adjoint =
         active ? compact_adjoint_offset(base_handle, c.in[0].len, c.out.len,
-                                        handles[1], c.in[1].len, handles[2],
-                                        c.in[2].len)
+                                        handles, c)
                : -1;
 
     if (!scalar_site) {
@@ -3267,7 +3313,7 @@ struct DynamicExecution {
         const int64_t position = static_cast<int64_t>(delta[i]);
         delta[selected + i] = c.out.data[position];
       }
-      if (active) delta[2 * selected] = handles[2];
+      if (active) delta[2 * selected] = handles[layout.rhs];
       const double out =
           make_ref(c.out.data, c.out.len, active, shared_adjoint);
       DynamicLoopState::Record record;
@@ -3276,12 +3322,13 @@ struct DynamicExecution {
       record.out2 = static_cast<double>(selected);
       record.site = n.record_site;
       record.code = DynamicLoopState::delta_record;
-      const bool resident_rhs = is_record_scalar(handles[2]);
-      const double resident_rhs_value = resident_rhs ? c.in[2].data[0] : 0.0;
+      const bool resident_rhs = is_record_scalar(handles[layout.rhs]);
+      const double resident_rhs_value =
+          resident_rhs ? c.in[layout.rhs].data[0] : 0.0;
       state.records.push_back(record);
       for (int64_t i = 0; i < selected; ++i)
         c.out.data[static_cast<int64_t>(delta[i])] =
-            resident_rhs ? resident_rhs_value : c.in[2].data[i];
+            resident_rhs ? resident_rhs_value : c.in[layout.rhs].data[i];
       state.bindings[static_cast<size_t>(op.out)] = out;
       if (state.allocation_profile)
         state.allocation_profile->note_delta_compact(op, selected, c.out.len,
@@ -3316,7 +3363,7 @@ struct DynamicExecution {
           "compact structured adjoint exceeds preallocated work");
     DynamicLoopState::Record record;
     if (frame_free && active)
-      record.rhs_handle = handles[2];
+      record.rhs_handle = handles[layout.rhs];
     else
       record.frame = frame;
     record.out = out;
@@ -3324,7 +3371,7 @@ struct DynamicExecution {
     record.site = n.record_site;
     record.code = frame_free ? static_cast<uint32_t>(position)
                              : DynamicLoopState::retained_scalar_record;
-    const double rhs_value = c.in[2].data[0];
+    const double rhs_value = c.in[layout.rhs].data[0];
     state.records.push_back(record);
     c.out.data[position] = rhs_value;
     state.bindings[static_cast<size_t>(op.out)] = out;
@@ -3579,8 +3626,13 @@ struct DynamicExecution {
 
   bool prepare_shared_compact_adjoint(const DynamicLoopState::Record& record,
                                       KernelCtx& c) {
+    const Node& node = record_node(record);
+    const Op& op = p.body.ops[static_cast<size_t>(node.op)];
+    const auto* spec = static_cast<const DynamicIndexSpec*>(op.udata);
+    IndexInputLayout layout;
     if (record.code != DynamicLoopState::retained_scalar_record ||
-        record.out < 0 || c.n_in != 3)
+        record.out < 0 || !spec || !index_input_layout(*spec, true, layout) ||
+        op.n_in != layout.expected || c.n_in != layout.expected)
       return false;
     const double base_handle = record.frame[0];
     if (base_handle < 0) return false;
@@ -3596,14 +3648,15 @@ struct DynamicExecution {
       throw std::logic_error(
           "shared compact structured adjoint layout is invalid");
     Desc conceptual_output{state.compact_adjoint_work.get(), c.out_adj_vec.len};
-    if (overlaps(c.in_adj[0], c.in_adj[1]) ||
-        overlaps(c.in_adj[0], c.in_adj[2]) ||
-        overlaps(conceptual_output, c.in_adj[0]) ||
-        overlaps(conceptual_output, c.in_adj[1]) ||
-        overlaps(conceptual_output, c.in_adj[2]) ||
-        overlaps(c.in_adj[1], c.in_adj[2]))
+    for (int k = 0; k < c.n_in; ++k) {
+      if (overlaps(conceptual_output, c.in_adj[k]))
+        throw std::logic_error(
+            "shared compact structured adjoints are not disjoint");
+      for (int j = k + 1; j < c.n_in; ++j)
+        if (overlaps(c.in_adj[k], c.in_adj[j]))
       throw std::logic_error(
           "shared compact structured adjoints are not disjoint");
+    }
 
     // The ordinary callback sees a distinct zero-initialized conceptual base
     // and the exact output-adjoint bits. Clear with +0.0, then let its existing
@@ -3623,8 +3676,9 @@ struct DynamicExecution {
       throw std::logic_error("compact scalar index node is invalid");
     const Op& op = p.body.ops[static_cast<size_t>(node.op)];
     const auto* spec = static_cast<const DynamicIndexSpec*>(op.udata);
-    if (!spec || op.n_in < 2 || op.n_in > 6 ||
-        op.n_in != (spec->input_count > 0 ? spec->input_count : 2))
+    IndexInputLayout layout;
+    if (!spec || !index_input_layout(*spec, false, layout) ||
+        op.n_in != layout.expected)
       throw std::logic_error("compact scalar index record is invalid");
     const int64_t base_len = p.body.slots[static_cast<size_t>(op.in[0])].len;
     if (node.forward != index_forward || node.backward != index_backward ||
@@ -3674,14 +3728,20 @@ struct DynamicExecution {
       throw std::logic_error("delta compact structured record is invalid");
     const Op& op = p.body.ops[static_cast<size_t>(node.op)];
     const auto* spec = static_cast<const DynamicIndexSpec*>(op.udata);
+    IndexInputLayout layout;
     const int64_t selected = static_cast<int64_t>(record.out2);
     const int64_t output_len = p.body.slots[static_cast<size_t>(op.out)].len;
-    const int64_t rhs_len = p.body.slots[static_cast<size_t>(op.in[2])].len;
     if (!spec || node.forward != set_index_forward ||
         node.backward != set_index_backward ||
-        op.opcode != OP_SET_INDEX_DYNAMIC || op.n_in != 3 || op.out2 >= 0 ||
-        selected > spec->selected_size || rhs_len != spec->selected_size ||
-        output_len <= 0 || (selected > 0 && !record.frame))
+        op.opcode != OP_SET_INDEX_DYNAMIC ||
+        !index_input_layout(*spec, true, layout) ||
+        op.n_in != layout.expected || op.out2 >= 0 ||
+        selected > spec->selected_size || output_len <= 0 ||
+        (selected > 0 && !record.frame))
+      throw std::logic_error("delta compact structured record is invalid");
+    const int64_t rhs_len =
+        p.body.slots[static_cast<size_t>(op.in[layout.rhs])].len;
+    if (rhs_len != spec->selected_size)
       throw std::logic_error("delta compact structured record is invalid");
 
     double* const delta = record.frame;
@@ -3738,11 +3798,15 @@ struct DynamicExecution {
                                    int64_t position) {
     const Node& node = record_node(record);
     const Op& op = p.body.ops[static_cast<size_t>(node.op)];
+    const auto* spec = static_cast<const DynamicIndexSpec*>(op.udata);
+    IndexInputLayout layout;
     const int64_t output_len = p.body.slots[static_cast<size_t>(op.out)].len;
     if (record.out < 0 || node.backward != set_index_backward ||
-        op.opcode != OP_SET_INDEX_DYNAMIC || op.n_in != 3 || op.out2 >= 0 ||
-        p.body.slots[static_cast<size_t>(op.in[2])].len != 1 || position < 0 ||
-        position >= output_len || output_len <= 0 ||
+        op.opcode != OP_SET_INDEX_DYNAMIC || !spec ||
+        !index_input_layout(*spec, true, layout) ||
+        op.n_in != layout.expected || op.out2 >= 0 ||
+        p.body.slots[static_cast<size_t>(op.in[layout.rhs])].len != 1 ||
+        position < 0 || position >= output_len || output_len <= 0 ||
         output_len > state.compact_adjoint_work_size ||
         !state.compact_adjoint_work)
       throw std::logic_error("frame-free compact structured record is invalid");
@@ -4315,16 +4379,11 @@ int64_t selected_position(const DynamicIndexSpec& p, const KernelCtx& c,
 }
 IndexRuntime validate_index(const DynamicIndexSpec& p, const KernelCtx& c,
                             bool update) {
-  if (p.input_count < 0 || p.input_count > 6)
-    throw std::logic_error("invalid structured index input count");
-  const int expected_inputs =
-      !update && p.input_count > 0 ? p.input_count : (update ? 3 : 2);
-  if (c.n_in != expected_inputs || (update && p.input_count > 0) ||
-      (p.matrix_leaf && p.axes.size() < 2))
+  const IndexInputLayout layout = require_index_input_layout(p, update);
+  if (c.n_in != layout.expected || (p.matrix_leaf && p.axes.size() < 2))
     throw std::logic_error("invalid structured index descriptor");
-  const int selector_end = p.input_count > 0 ? p.input_count : 2;
   const auto validate_selector_input = [&](int input, const char* what) {
-    if (input < 1 || input >= selector_end)
+    if (input < 1 || input >= layout.selector_end)
       throw std::logic_error(std::string("invalid ") + what + " input");
   };
   IndexRuntime runtime(p.axes.size());
@@ -4410,7 +4469,8 @@ IndexRuntime validate_index(const DynamicIndexSpec& p, const KernelCtx& c,
   }
   if (capacity != c.in[0].len || logical_size > capacity ||
       runtime.selected > p.selected_size ||
-      (update ? (c.out.len != capacity || c.in[2].len != p.selected_size)
+      (update
+           ? (c.out.len != capacity || c.in[layout.rhs].len != p.selected_size)
               : c.out.len != p.selected_size))
     throw std::logic_error("invalid structured index storage");
   return runtime;
@@ -4471,13 +4531,14 @@ void index_backward(KernelCtx& c) {
 }
 void set_index_forward(KernelCtx& c) {
   const auto& p = *static_cast<const DynamicIndexSpec*>(c.udata);
+  const IndexInputLayout layout = require_index_input_layout(p, true);
   const IndexRuntime runtime = validate_index(p, c, true);
   std::copy_n(c.in[0].data, c.in[0].len, c.out.data);
   const bool may_repeat = !index_selection_is_ordered_unique(p);
   if (may_repeat) std::fill(c.scratch, c.scratch + c.in[0].len, -1.0);
   for (int64_t i = 0; i < runtime.selected; ++i) {
     const int64_t at = selected_position(p, c, runtime, i);
-    c.out.data[at] = c.in[2].data[i];
+    c.out.data[at] = c.in[layout.rhs].data[i];
     if (may_repeat)
       c.scratch[at] =
           static_cast<double>(i);  // last write wins for duplicate indices
@@ -4485,6 +4546,9 @@ void set_index_forward(KernelCtx& c) {
 }
 void set_index_backward(KernelCtx& c) {
   const auto& p = *static_cast<const DynamicIndexSpec*>(c.udata);
+  const IndexInputLayout layout = require_index_input_layout(p, true);
+  if (c.n_in != layout.expected)
+    throw std::logic_error("invalid structured index descriptor");
   if (index_selection_is_ordered_unique(p)) {
     const IndexRuntime runtime = validate_index(p, c, true);
     int64_t selected = 0;
@@ -4492,8 +4556,8 @@ void set_index_backward(KernelCtx& c) {
         runtime.selected > 0 ? selected_position(p, c, runtime, 0) : -1;
     for (int64_t i = 0; i < c.out.len; ++i) {
       if (selected < runtime.selected && i == selected_at) {
-        if (c.in_adj[2].data)
-          c.in_adj[2].data[selected] += c.out_adj_vec.data[i];
+        if (c.in_adj[layout.rhs].data)
+          c.in_adj[layout.rhs].data[selected] += c.out_adj_vec.data[i];
         ++selected;
         if (selected < runtime.selected)
           selected_at = selected_position(p, c, runtime, selected);
@@ -4509,8 +4573,8 @@ void set_index_backward(KernelCtx& c) {
     const int64_t selected = static_cast<int64_t>(c.scratch[i]);
     if (selected < 0) {
       if (c.in_adj[0].data) c.in_adj[0].data[i] += c.out_adj_vec.data[i];
-    } else if (c.in_adj[2].data) {
-      c.in_adj[2].data[selected] += c.out_adj_vec.data[i];
+    } else if (c.in_adj[layout.rhs].data) {
+      c.in_adj[layout.rhs].data[selected] += c.out_adj_vec.data[i];
     }
   }
 }

--- a/runtime/src/structured_loop.cpp
+++ b/runtime/src/structured_loop.cpp
@@ -4,6 +4,7 @@
 #include <algorithm>
 #include <array>
 #include <cmath>
+#include <cstdio>
 #include <cstdlib>
 #include <functional>
 #include <limits>
@@ -932,6 +933,36 @@ double handle(int64_t at, bool active) {
   return active ? static_cast<double>(at) : -static_cast<double>(at) - 1;
 }
 
+// Dynamic counted-loop iterators are inactive int32 scalars.  Keep their
+// exact value in a disjoint handle band instead of allocating a value and a
+// generic Ref for every reached iteration.  Ordinary inactive Ref handles
+// occupy [-2^52, -1]; this band occupies the next 2^32 exact integers and
+// remains strictly inside binary64's exact-integer range.
+constexpr int64_t inline_int_count = int64_t{1} << 32;
+constexpr int64_t inline_int_first = exact_limit + 1;
+constexpr int64_t inline_int_last = exact_limit + inline_int_count;
+static_assert(inline_int_last < (int64_t{1} << 53),
+              "inline integer handles must remain exact doubles");
+
+bool is_inline_int(double h) noexcept {
+  return h < -static_cast<double>(exact_limit);
+}
+
+double inline_int_handle(int32_t value) noexcept {
+  const int64_t biased =
+      static_cast<int64_t>(value) -
+      static_cast<int64_t>(std::numeric_limits<int32_t>::min());
+  return -static_cast<double>(inline_int_first + biased);
+}
+
+double inline_int_value(double h) noexcept {
+  // Handles are executor-private and only inline_int_handle constructs this
+  // band.  Decode with exact double arithmetic so the hot callback path needs
+  // no floating-to-integer conversion or repeated canonical-form validation.
+  return static_cast<double>(std::numeric_limits<int32_t>::min()) +
+         (-h - static_cast<double>(inline_int_first));
+}
+
 struct Execution {
   const StructuredLoop& p;
   KernelCtx& outer;
@@ -1222,8 +1253,10 @@ struct DynamicLoopState final : KernelState {
   std::vector<double> inactive_control_values;
   int64_t conceptual_adjoint_size = 0;
   int64_t adjoint_size = 0;
+  uint64_t iterator_values = 0;
   bool loop_invariant_reuse = false;
   bool inactive_control_reuse = false;
+  bool memory_profile = false;
   bool cached_context_in_use = false;
   // A dynamic tape belongs to exactly one completed forward sweep.  Forward
   // invalidates the previous tape before doing any validation or allocation;
@@ -1339,11 +1372,84 @@ struct DynamicLoopState final : KernelState {
     std::vector<Undo>{}.swap(undos);
     conceptual_adjoint_size = 0;
     adjoint_size = 0;
+    iterator_values = 0;
     cached_context_in_use = false;
+    memory_profile = false;
   }
 };
 static_assert(sizeof(DynamicLoopState::Ref) == 24,
               "dynamic structured references must stay compact");
+
+uint64_t profile_bytes(uint64_t count, uint64_t width,
+                       bool& overflow) noexcept {
+  if (width && count > std::numeric_limits<uint64_t>::max() / width) {
+    overflow = true;
+    return std::numeric_limits<uint64_t>::max();
+  }
+  return count * width;
+}
+
+uint64_t profile_add(uint64_t first, uint64_t second, bool& overflow) noexcept {
+  if (first > std::numeric_limits<uint64_t>::max() - second) {
+    overflow = true;
+    return std::numeric_limits<uint64_t>::max();
+  }
+  return first + second;
+}
+
+void report_memory_profile(const StructuredLoop& p,
+                           const DynamicLoopState& state) {
+  bool overflow = false;
+  const uint64_t arena_used =
+      profile_bytes(state.arena.used_values, sizeof(double), overflow);
+  const uint64_t arena_capacity =
+      profile_bytes(state.arena.capacity_values, sizeof(double), overflow);
+  const uint64_t ref_used =
+      profile_bytes(state.refs.size(), sizeof(DynamicLoopState::Ref), overflow);
+  const uint64_t ref_capacity = profile_bytes(
+      state.refs.capacity(), sizeof(DynamicLoopState::Ref), overflow);
+  const uint64_t record_used = profile_bytes(
+      state.records.size(), sizeof(DynamicLoopState::Record), overflow);
+  const uint64_t record_capacity = profile_bytes(
+      state.records.capacity(), sizeof(DynamicLoopState::Record), overflow);
+  const uint64_t undo_used = profile_bytes(
+      state.undos.size(), sizeof(DynamicLoopState::Undo), overflow);
+  const uint64_t undo_capacity = profile_bytes(
+      state.undos.capacity(), sizeof(DynamicLoopState::Undo), overflow);
+  const uint64_t planned_adjoint = profile_bytes(
+      static_cast<uint64_t>(state.adjoint_size), sizeof(double), overflow);
+  const uint64_t iterator_value_bytes =
+      profile_bytes(state.iterator_values, sizeof(double), overflow);
+  const uint64_t iterator_ref_bytes = profile_bytes(
+      state.iterator_values, sizeof(DynamicLoopState::Ref), overflow);
+  const uint64_t iterator_total_bytes =
+      profile_add(iterator_value_bytes, iterator_ref_bytes, overflow);
+  std::fprintf(
+      stderr,
+      "stanli_structured_memory phase=forward region=%p nodes=%zu "
+      "body_kernels=%zu accounting_overflow=%d "
+      "iterator_values=%llu iterator_value_bytes=%llu "
+      "iterator_ref_bytes=%llu iterator_total_bytes=%llu "
+      "arena_used_bytes=%llu arena_capacity_bytes=%llu "
+      "ref_count=%zu ref_used_bytes=%llu ref_capacity_bytes=%llu "
+      "record_count=%zu record_used_bytes=%llu record_capacity_bytes=%llu "
+      "undo_count=%zu undo_used_bytes=%llu undo_capacity_bytes=%llu "
+      "planned_adjoint_bytes=%llu\n",
+      static_cast<const void*>(&p), p.node_count, p.body.ops.size(),
+      overflow ? 1 : 0, static_cast<unsigned long long>(state.iterator_values),
+      static_cast<unsigned long long>(iterator_value_bytes),
+      static_cast<unsigned long long>(iterator_ref_bytes),
+      static_cast<unsigned long long>(iterator_total_bytes),
+      static_cast<unsigned long long>(arena_used),
+      static_cast<unsigned long long>(arena_capacity), state.refs.size(),
+      static_cast<unsigned long long>(ref_used),
+      static_cast<unsigned long long>(ref_capacity), state.records.size(),
+      static_cast<unsigned long long>(record_used),
+      static_cast<unsigned long long>(record_capacity), state.undos.size(),
+      static_cast<unsigned long long>(undo_used),
+      static_cast<unsigned long long>(undo_capacity),
+      static_cast<unsigned long long>(planned_adjoint));
+}
 
 int64_t compact_scalar_update_position(const DynamicIndexSpec& p,
                                        const KernelCtx& c);
@@ -1370,11 +1476,18 @@ struct DynamicExecution {
         outer(c),
         state(dynamic_state(c)) {}
 
-  DynamicLoopState::Ref& ref(double h) {
+  DynamicLoopState::Ref& ordinary_ref(double h) {
     const int64_t id = offset(h);
     if (id < 0 || static_cast<size_t>(id) >= state.refs.size())
       throw std::logic_error("dynamic structured value handle out of range");
     return state.refs[static_cast<size_t>(id)];
+  }
+
+  DynamicLoopState::Ref& ref(double h) {
+    if (is_inline_int(h))
+      throw std::logic_error(
+          "dynamic structured inline integer used as a reference");
+    return ordinary_ref(h);
   }
 
   double make_ref(double* value, int64_t len, bool active, int outer_input = -1,
@@ -1419,8 +1532,34 @@ struct DynamicExecution {
     return handle(id, active);
   }
 
-  double* value(int s) {
-    return ref(state.bindings.at(static_cast<size_t>(s))).value;
+  double scalar_value(double h) {
+    return is_inline_int(h) ? inline_int_value(h) : ordinary_ref(h).value[0];
+  }
+
+  double scalar_value(int slot) {
+    return scalar_value(state.bindings.at(static_cast<size_t>(slot)));
+  }
+
+  void copy_value(double h, int64_t len, double* output) {
+    if (is_inline_int(h)) {
+      if (len != 1)
+        throw std::logic_error(
+            "dynamic structured inline integer has nonscalar extent");
+      output[0] = inline_int_value(h);
+      return;
+    }
+    std::copy_n(ordinary_ref(h).value, len, output);
+  }
+
+  bool value_overlaps(double h, int64_t len, Desc other) {
+    if (is_inline_int(h)) {
+      if (len != 1)
+        throw std::logic_error(
+            "dynamic structured inline integer has nonscalar extent");
+      (void)inline_int_value(h);
+      return false;
+    }
+    return overlaps({ordinary_ref(h).value, len}, other);
   }
 
   void begin_loop_invariant_scope(const Node& n) noexcept {
@@ -1543,10 +1682,10 @@ struct DynamicExecution {
     }
     const Desc output{state.inactive_control_values.data() + cone.value_offset,
                       static_cast<int64_t>(cone.value_count)};
-    for (int slot : cone.external_slots) {
-      const auto& input = ref(state.bindings.at(static_cast<size_t>(slot)));
-      if (overlaps(output, {input.value, p.body.slots[slot].len})) return;
-    }
+    for (int slot : cone.external_slots)
+      if (value_overlaps(state.bindings.at(static_cast<size_t>(slot)),
+                         p.body.slots[slot].len, output))
+        return;
     cone.decision = InactiveControlPlan::Cone::Direct;
   }
 
@@ -1671,7 +1810,7 @@ struct DynamicExecution {
     if (h < 0) return nullptr;
     if (expected_len < 0)
       throw std::logic_error("dynamic structured adjoint has negative length");
-    const auto& r = ref(h);
+    const auto& r = ordinary_ref(h);
     if (r.outer_input >= 0) {
       if (r.outer_input >= outer.n_in || r.adjoint_or_outer_offset < 0)
         throw std::logic_error(
@@ -1773,6 +1912,7 @@ struct DynamicExecution {
   }
 
   KernelCtx& context(const Node& n, double* frame, bool backward,
+                     std::array<double, 6>& inline_inputs,
                      double out_handle = -1, double out2_handle = -1,
                      double* output_override = nullptr) {
     const Op& op = p.body.ops[n.op];
@@ -1794,7 +1934,25 @@ struct DynamicExecution {
       c.state = nullptr;
       for (int k = 0; k < op.n_in; ++k) {
         const double h = frame[k];
-        c.in[k].data = ref(h).value;
+        if (is_inline_int(h)) {
+          if (c.in[k].len != 1)
+            throw std::logic_error(
+                "dynamic structured inline integer has nonscalar input");
+          int alias = -1;
+          for (int j = 0; j < k; ++j)
+            if (frame[j] == h && is_inline_int(frame[j])) {
+              alias = j;
+              break;
+            }
+          if (alias >= 0) {
+            c.in[k].data = c.in[alias].data;
+          } else {
+            inline_inputs[static_cast<size_t>(k)] = inline_int_value(h);
+            c.in[k].data = &inline_inputs[static_cast<size_t>(k)];
+          }
+        } else {
+          c.in[k].data = ordinary_ref(h).value;
+        }
         c.in_adj[k].data = backward ? adj(h, c.in[k].len) : nullptr;
       }
       int64_t pos = op.n_in;
@@ -1825,14 +1983,16 @@ struct DynamicExecution {
   // reentry and restores pointer-free template state after every exception.
   struct ContextLease {
     DynamicExecution& execution;
+    // context() initializes only the entries referenced by inline inputs.
+    std::array<double, 6> inline_inputs;
     KernelCtx* call = nullptr;
 
     ContextLease(DynamicExecution& execution, const Node& n, double* frame,
                  bool backward, double out_handle = -1, double out2_handle = -1,
                  double* output_override = nullptr)
         : execution(execution) {
-      call = &execution.context(n, frame, backward, out_handle, out2_handle,
-                                output_override);
+      call = &execution.context(n, frame, backward, inline_inputs, out_handle,
+                                out2_handle, output_override);
     }
     ContextLease(const ContextLease&) = delete;
     ContextLease& operator=(const ContextLease&) = delete;
@@ -1859,7 +2019,7 @@ struct DynamicExecution {
       bool overlap = false;
       for (int k = 0; k < op.n_in; ++k) {
         const int64_t len = p.body.slots.at(static_cast<size_t>(op.in[k])).len;
-        overlap |= overlaps(output, {ref(handles[k]).value, len});
+        overlap |= value_overlaps(handles[k], len, output);
       }
       if (overlap) return false;
     } catch (...) {
@@ -1886,7 +2046,8 @@ struct DynamicExecution {
       throw std::logic_error("compact structured update arity is invalid");
     const int cell = n.compact_update_cell;
     const double base_handle = state.bindings[static_cast<size_t>(op.in[0])];
-    DynamicLoopState::Ref& base = ref(base_handle);
+    if (is_inline_int(base_handle)) return false;
+    DynamicLoopState::Ref& base = ordinary_ref(base_handle);
     if (state.compact_primal_by_cell[static_cast<size_t>(cell)] != base.value)
       return false;
 
@@ -1988,10 +2149,10 @@ struct DynamicExecution {
             state.bindings[static_cast<size_t>(n.src)];
         return Normal;
       case Node::If:
-        return forward(n.children[value(n.condition)[0] != 0.0 ? 0 : 1]);
+        return forward(n.children[scalar_value(n.condition) != 0.0 ? 0 : 1]);
       case Node::For: {
         begin_loop_invariant_scope(n);
-        const double lo = value(n.lower)[0], hi = value(n.upper)[0];
+        const double lo = scalar_value(n.lower), hi = scalar_value(n.upper);
         if (!std::isfinite(lo) || !std::isfinite(hi) || std::trunc(lo) != lo ||
             std::trunc(hi) != hi || lo < std::numeric_limits<int32_t>::min() ||
             hi < std::numeric_limits<int32_t>::min() ||
@@ -2002,10 +2163,9 @@ struct DynamicExecution {
         if (count > n.capacity)
           throw std::logic_error("structured loop capacity proof failed");
         for (int64_t i = 0; i < count; ++i) {
-          double* iterator = state.arena.allocate(1);
-          *iterator = lo + double(i);
-          state.bindings[static_cast<size_t>(n.iterator)] =
-              make_ref(iterator, 1, false);
+          state.bindings[static_cast<size_t>(n.iterator)] = inline_int_handle(
+              static_cast<int32_t>(static_cast<int64_t>(lo) + i));
+          if (state.memory_profile) ++state.iterator_values;
           if (forward(n.children[0]) == Break) break;
         }
         return Normal;
@@ -2014,7 +2174,7 @@ struct DynamicExecution {
         begin_loop_invariant_scope(n);
         for (int64_t i = 0;; ++i) {
           forward(n.children[0]);
-          if (value(n.condition)[0] == 0.0) break;
+          if (scalar_value(n.condition) == 0.0) break;
           if (i == n.capacity)
             throw std::logic_error("structured while capacity proof failed");
           if (forward(n.children[1]) == Break) break;
@@ -2121,6 +2281,7 @@ void dynamic_loop_forward(KernelCtx& ctx) {
   // A failed replacement forward must never leave either the preceding tape
   // or a partially built replacement resident/available to reverse.
   s.release_tape();
+  s.memory_profile = std::getenv("STANLI_STRUCTURED_MEMORY_PROFILE") != nullptr;
   if (s.loop_invariant_plan) s.loop_invariant_plan->reset_runtime();
   s.loop_invariant_reuse =
       s.loop_invariant_plan &&
@@ -2173,7 +2334,8 @@ void dynamic_loop_forward(KernelCtx& ctx) {
   e.forward(p.root);
   int64_t pos = 0;
   for (int slot : p.outputs) {
-    std::copy_n(e.value(slot), p.body.slots[slot].len, ctx.out.data + pos);
+    e.copy_value(s.bindings[static_cast<size_t>(slot)], p.body.slots[slot].len,
+                 ctx.out.data + pos);
     pos += p.body.slots[slot].len;
   }
   if (p.has_target) {
@@ -2181,14 +2343,14 @@ void dynamic_loop_forward(KernelCtx& ctx) {
       ctx.out.data[pos++] = static_cast<double>(s.target_refs.size());
       for (size_t i = 0; i < s.target_refs.size(); ++i)
         ctx.out.data[pos + static_cast<int64_t>(i)] =
-            e.ref(s.target_refs[i]).value[0];
+            e.scalar_value(s.target_refs[i]);
       std::fill(ctx.out.data + pos + static_cast<int64_t>(s.target_refs.size()),
                 ctx.out.data + pos + p.root.target_capacity, 0.0);
       pos += p.root.target_capacity;
     } else {
       s.target_work.resize(s.target_refs.size());
       for (size_t i = 0; i < s.target_refs.size(); ++i)
-        s.target_work[i] = e.ref(s.target_refs[i]).value[0];
+        s.target_work[i] = e.scalar_value(s.target_refs[i]);
       size_t count = s.target_work.size();
       while (count > 1) {
         size_t next = 0;
@@ -2209,6 +2371,7 @@ void dynamic_loop_forward(KernelCtx& ctx) {
   }
   if (pos != ctx.out.len)
     throw std::logic_error("dynamic structured output size mismatch");
+  if (s.memory_profile) report_memory_profile(p, s);
   s.reverse_ready = true;
   release_on_failure.published = true;
 }

--- a/runtime/src/structured_loop.cpp
+++ b/runtime/src/structured_loop.cpp
@@ -2168,14 +2168,13 @@ void report_memory_profile(const StructuredLoop& p,
     elided_refs =
         profile_add(elided_refs, bucket.elided_refs, allocation_overflow);
     inactive_transient_values =
-        profile_add(inactive_transient_values,
-                    bucket.inactive_transient_values, allocation_overflow);
+        profile_add(inactive_transient_values, bucket.inactive_transient_values,
+                    allocation_overflow);
     inactive_output_values =
         profile_add(inactive_output_values, bucket.inactive_output_values,
                     allocation_overflow);
-    inactive_output_refs =
-        profile_add(inactive_output_refs, bucket.inactive_output_refs,
-                    allocation_overflow);
+    inactive_output_refs = profile_add(
+        inactive_output_refs, bucket.inactive_output_refs, allocation_overflow);
     arena_location_refs = profile_add(
         arena_location_refs, bucket.arena_location_refs, allocation_overflow);
     inactive_workspace_calls =
@@ -2474,9 +2473,8 @@ struct DynamicExecution {
     return append_ref(r, active);
   }
 
-  double make_compact_update_ref(double base_handle, double* value,
-                                 int64_t len, bool active,
-                                 int64_t shared_adjoint_offset,
+  double make_compact_update_ref(double base_handle, double* value, int64_t len,
+                                 bool active, int64_t shared_adjoint_offset,
                                  bool frame_free, bool& reused) {
     reused = false;
     if (!state.shared_update_ref_reuse || !active || !frame_free ||
@@ -2932,7 +2930,7 @@ struct DynamicExecution {
       for (int j = k + 1; j < c.n_in; ++j)
         if (adjoint_ranges_overlap(handles[k], c.in[k].len, handles[j],
                                    c.in[j].len))
-      return -1;
+          return -1;
     }
     return base.adjoint_or_import;
   }
@@ -3152,8 +3150,8 @@ struct DynamicExecution {
     // exact-int32 result contract used by the compact handle encoding.  A
     // custom callback, second output, reverse callback, or different layout
     // keeps the ordinary retained-frame behavior.
-    if (n.forward != builtin || n.backward != nullptr ||
-        op.out2 >= 0 || p.body.slots[static_cast<size_t>(op.out)].len != 1 ||
+    if (n.forward != builtin || n.backward != nullptr || op.out2 >= 0 ||
+        p.body.slots[static_cast<size_t>(op.out)].len != 1 ||
         n.kernel_scratch != 0)
       return false;
 
@@ -3371,9 +3369,8 @@ struct DynamicExecution {
 
     bool frame_free =
         !active || (shared_adjoint >= 0 && n.backward == set_index_backward);
-    if (frame_free &&
-        static_cast<uint64_t>(position) >
-            DynamicLoopState::max_frame_free_position)
+    if (frame_free && static_cast<uint64_t>(position) >
+                          DynamicLoopState::max_frame_free_position)
       frame_free = false;
 
     // Every allocation that can throw precedes the destructive write. A later
@@ -3387,9 +3384,9 @@ struct DynamicExecution {
       frame[retained_inputs] = static_cast<double>(position);
     }
     bool reused_output_ref = false;
-    const double out = make_compact_update_ref(
-        base_handle, c.out.data, c.out.len, active, shared_adjoint, frame_free,
-        reused_output_ref);
+    const double out =
+        make_compact_update_ref(base_handle, c.out.data, c.out.len, active,
+                                shared_adjoint, frame_free, reused_output_ref);
     if (shared_adjoint >= 0 && c.out.len > state.compact_adjoint_work_size)
       throw std::logic_error(
           "compact structured adjoint exceeds preallocated work");
@@ -3686,8 +3683,8 @@ struct DynamicExecution {
             "shared compact structured adjoints are not disjoint");
       for (int j = k + 1; j < c.n_in; ++j)
         if (overlaps(c.in_adj[k], c.in_adj[j]))
-      throw std::logic_error(
-          "shared compact structured adjoints are not disjoint");
+          throw std::logic_error(
+              "shared compact structured adjoints are not disjoint");
     }
 
     // The ordinary callback sees a distinct zero-initialized conceptual base
@@ -3701,8 +3698,7 @@ struct DynamicExecution {
     return true;
   }
 
-  void backward_compact_scalar_index(
-      const DynamicLoopState::Record& record) {
+  void backward_compact_scalar_index(const DynamicLoopState::Record& record) {
     const Node& node = record_node(record);
     if (node.op < 0 || static_cast<size_t>(node.op) >= p.body.ops.size())
       throw std::logic_error("compact scalar index node is invalid");
@@ -3714,8 +3710,8 @@ struct DynamicExecution {
       throw std::logic_error("compact scalar index record is invalid");
     const int64_t base_len = p.body.slots[static_cast<size_t>(op.in[0])].len;
     if (node.forward != index_forward || node.backward != index_backward ||
-        op.opcode != OP_INDEX_DYNAMIC ||
-        op.out2 >= 0 || spec->selected_size != 1 ||
+        op.opcode != OP_INDEX_DYNAMIC || op.out2 >= 0 ||
+        spec->selected_size != 1 ||
         p.body.slots[static_cast<size_t>(op.out)].len != 1 ||
         node.kernel_scratch != 0 || record.out < 0 || base_len < 0 ||
         !std::isfinite(record.out2) || std::trunc(record.out2) != record.out2 ||
@@ -3723,14 +3719,13 @@ struct DynamicExecution {
       throw std::logic_error("compact scalar index record is invalid");
 
     const auto& output = ref(record.out);
-    if (is_import_ref(output) || output.adjoint_or_import < 0 ||
-        !output.value)
+    if (is_import_ref(output) || output.adjoint_or_import < 0 || !output.value)
       throw std::logic_error("compact scalar index output is invalid");
     double* const base_adjoint = adj(record.base_handle, base_len);
     if (!base_adjoint || record.out2 < 0) return;
     double* const output_adjoint = adj(record.out, 1);
-    if (!output_adjoint || overlaps({base_adjoint, base_len},
-                                    {output_adjoint, 1}))
+    if (!output_adjoint ||
+        overlaps({base_adjoint, base_len}, {output_adjoint, 1}))
       throw std::logic_error("compact scalar index adjoints overlap");
     base_adjoint[static_cast<int64_t>(record.out2)] += output_adjoint[0];
   }
@@ -3901,8 +3896,7 @@ struct DynamicExecution {
         if (!std::isfinite(raw_position) ||
             std::trunc(raw_position) != raw_position || raw_position < 0 ||
             raw_position > static_cast<double>(exact_limit))
-          throw std::logic_error(
-              "compact structured undo position is invalid");
+          throw std::logic_error("compact structured undo position is invalid");
         const int64_t position = static_cast<int64_t>(raw_position);
         auto& output = ref(record.out);
         const int64_t output_len = p.body.slots[p.body.ops[node.op].out].len;
@@ -4505,7 +4499,7 @@ IndexRuntime validate_index(const DynamicIndexSpec& p, const KernelCtx& c,
       runtime.selected > p.selected_size ||
       (update
            ? (c.out.len != capacity || c.in[layout.rhs].len != p.selected_size)
-              : c.out.len != p.selected_size))
+           : c.out.len != p.selected_size))
     throw std::logic_error("invalid structured index storage");
   return runtime;
 }

--- a/runtime/src/structured_loop.cpp
+++ b/runtime/src/structured_loop.cpp
@@ -32,6 +32,20 @@ int64_t mul(int64_t a, int64_t b) {
   return a * b;
 }
 using Node = StructuredLoop::Node;
+void set_index_forward(KernelCtx& c);
+void set_index_backward(KernelCtx& c);
+bool index_selection_is_ordered_unique(const DynamicIndexSpec& p) {
+  return std::all_of(p.axes.begin(), p.axes.end(), [](const auto& axis) {
+    return axis.kind != DynamicIndexSpec::Axis::Multi || axis.count <= 1;
+  });
+}
+bool scalar_compact_update_spec(const DynamicIndexSpec& p) {
+  return p.selected_size == 1 &&
+         std::all_of(p.axes.begin(), p.axes.end(), [](const auto& axis) {
+           return axis.kind == DynamicIndexSpec::Axis::Single &&
+                  axis.count == 1 && axis.count_input_offset < 0;
+         });
+}
 void slot(const StructuredLoop& p, int s) {
   if (s < 0 || static_cast<size_t>(s) >= p.body.slots.size())
     throw std::invalid_argument("structured loop invalid slot");
@@ -202,26 +216,25 @@ void classify_compact_updates(StructuredLoop& p) {
         if (call.kind != Node::KernelCall || install.kind != Node::Alias)
           continue;
         const Op& op = p.body.ops[static_cast<size_t>(call.op)];
-        if (op.opcode != OP_SET_INDEX_DYNAMIC || op.n_in != 3 || op.out2 >= 0 ||
-            install.src != op.out || install.dst != op.in[0] ||
-            op.out == op.in[0] || op.in[1] == op.in[0] ||
+        if (op.opcode != OP_SET_INDEX_DYNAMIC) continue;
+        if (install.src != op.out || install.dst != op.in[0]) continue;
+        if (op.n_in != 3 || op.out2 >= 0 || call.forward != set_index_forward ||
+            call.backward != set_index_backward)
+          continue;
+        if (op.out == op.in[0] || op.in[1] == op.in[0] ||
             op.in[2] == op.in[0] || op.in[1] == op.out || op.in[2] == op.out ||
             op.in[1] == op.in[2] || call.kernel_scratch != 0)
           continue;
         const int cell = install.dst;
         const auto* spec = static_cast<const DynamicIndexSpec*>(op.udata);
-        if (!spec || spec->axes.empty() || spec->selected_size != 1 ||
-            !std::all_of(spec->axes.begin(), spec->axes.end(),
-                         [](const DynamicIndexSpec::Axis& axis) {
-                           return axis.kind == DynamicIndexSpec::Axis::Single &&
-                                  axis.count == 1 &&
-                                  axis.count_input_offset < 0;
-                         }))
+        if (!spec || spec->axes.empty() || spec->selected_size < 0 ||
+            spec->input_count != 0 || !index_selection_is_ordered_unique(*spec))
           continue;
         if (p.body.slots[static_cast<size_t>(op.out)].len == 0 ||
             p.body.slots[static_cast<size_t>(op.out)].len !=
                 p.body.slots[static_cast<size_t>(cell)].len ||
-            p.body.slots[static_cast<size_t>(op.in[2])].len != 1)
+            p.body.slots[static_cast<size_t>(op.in[2])].len !=
+                spec->selected_size)
           continue;
         const auto& output = uses[static_cast<size_t>(op.out)];
         const auto& binding = uses[static_cast<size_t>(cell)];
@@ -1291,6 +1304,9 @@ struct DynamicAllocationProfile {
     uint64_t arena_values = 0;
     uint64_t input_handle_values = 0;
     uint64_t record_handle_values = 0;
+    uint64_t compact_position_values = 0;
+    uint64_t compact_old_value_values = 0;
+    uint64_t compact_rhs_handle_values = 0;
     uint64_t output_values = 0;
     uint64_t scratch_values = 0;
     uint64_t padding_values = 0;
@@ -1438,6 +1454,29 @@ struct DynamicAllocationProfile {
     add(b->records, 1);
   }
 
+  void note_delta_compact(const Op& op, int64_t selected, int64_t output_len,
+                          bool active) noexcept {
+    Bucket* b = bucket(op);
+    if (!b) return;
+    const uint64_t count = this->count(selected);
+    const uint64_t extent = this->count(output_len);
+    uint64_t retained = count;
+    add(retained, count);
+    add(retained, active ? 1 : 0);
+    add(b->compact_visits, 1);
+    add(b->frame_free_compact_visits, 1);
+    add(b->active_visits, active ? 1 : 0);
+    add(b->arena_values, retained);
+    add(b->compact_position_values, count);
+    add(b->compact_old_value_values, count);
+    add(b->compact_rhs_handle_values, active ? 1 : 0);
+    add(b->refs, 1);
+    add(b->active_refs, active ? 1 : 0);
+    add(b->referenced_values, extent);
+    add(b->conceptual_adjoint_values, active ? extent : 0);
+    add(b->records, 1);
+  }
+
   void note_inline_integer(const Op& op, int64_t retained) noexcept {
     Bucket* b = bucket(op);
     if (!b) return;
@@ -1466,11 +1505,13 @@ struct DynamicLoopState final : KernelState {
       double rhs_handle;
     };
     double out = -1;
-    // Ordinary calls store the optional second-output handle. Compact updates
-    // have no second output and store the overwritten value here instead.
+    // Ordinary calls store the optional second-output handle. Scalar compact
+    // updates store the overwritten value. Delta compact updates store their
+    // exact reached selection count.
     double out2 = -1;
     // Retained compact updates store a nonnegative position. Ordinary records
-    // use -1. Frame-free compact updates encode position as -2 - position.
+    // use -1. Frame-free scalar updates encode position as -2 - position.
+    // INT64_MIN identifies a variable-width ordered-unique delta payload.
     int64_t undo = -1;
   };
   DynamicArena arena;
@@ -1565,7 +1606,10 @@ struct DynamicLoopState final : KernelState {
           if (len <= 0)
             throw std::invalid_argument(
                 "compact dynamic structured output extent is invalid");
-          compact_adjoint_work_size = std::max(compact_adjoint_work_size, len);
+          const auto* spec = static_cast<const DynamicIndexSpec*>(op.udata);
+          if (spec && scalar_compact_update_spec(*spec))
+            compact_adjoint_work_size =
+                std::max(compact_adjoint_work_size, len);
         }
       }
       for (const auto& child : n.children) self(self, child);
@@ -1733,6 +1777,9 @@ void report_memory_profile(const StructuredLoop& p,
   uint64_t kernel_arena_values = 0;
   uint64_t input_handle_values = 0;
   uint64_t record_handle_values = 0;
+  uint64_t compact_position_values = 0;
+  uint64_t compact_old_value_values = 0;
+  uint64_t compact_rhs_handle_values = 0;
   uint64_t output_values = 0;
   uint64_t scratch_values = 0;
   uint64_t padding_values = 0;
@@ -1757,6 +1804,15 @@ void report_memory_profile(const StructuredLoop& p,
         input_handle_values, bucket.input_handle_values, allocation_overflow);
     record_handle_values = profile_add(
         record_handle_values, bucket.record_handle_values, allocation_overflow);
+    compact_position_values =
+        profile_add(compact_position_values, bucket.compact_position_values,
+                    allocation_overflow);
+    compact_old_value_values =
+        profile_add(compact_old_value_values, bucket.compact_old_value_values,
+                    allocation_overflow);
+    compact_rhs_handle_values =
+        profile_add(compact_rhs_handle_values, bucket.compact_rhs_handle_values,
+                    allocation_overflow);
     output_values =
         profile_add(output_values, bucket.output_values, allocation_overflow);
     scratch_values =
@@ -1813,6 +1869,8 @@ void report_memory_profile(const StructuredLoop& p,
       "initial_arena_values=%llu kernel_arena_values=%llu "
       "profiled_arena_values=%llu actual_arena_values=%llu arena_match=%d "
       "input_handle_values=%llu record_handle_values=%llu "
+      "compact_position_values=%llu compact_old_value_values=%llu "
+      "compact_rhs_handle_values=%llu "
       "output_values=%llu scratch_values=%llu "
       "padding_values=%llu initial_slot_refs=%llu canonical_refs=%llu "
       "import_refs=%llu kernel_refs=%llu profiled_refs=%llu "
@@ -1832,6 +1890,9 @@ void report_memory_profile(const StructuredLoop& p,
       profiled_arena_values == state.arena.used_values ? 1 : 0,
       static_cast<unsigned long long>(input_handle_values),
       static_cast<unsigned long long>(record_handle_values),
+      static_cast<unsigned long long>(compact_position_values),
+      static_cast<unsigned long long>(compact_old_value_values),
+      static_cast<unsigned long long>(compact_rhs_handle_values),
       static_cast<unsigned long long>(output_values),
       static_cast<unsigned long long>(scratch_values),
       static_cast<unsigned long long>(padding_values),
@@ -1874,6 +1935,8 @@ void report_memory_profile(const StructuredLoop& p,
         "inactive_output_refs=%llu "
         "arena_location_refs=%llu "
         "input_handle_values=%llu record_handle_values=%llu "
+        "compact_position_values=%llu compact_old_value_values=%llu "
+        "compact_rhs_handle_values=%llu "
         "output_values=%llu scratch_values=%llu "
         "padding_values=%llu refs=%llu active_refs=%llu "
         "referenced_values=%llu conceptual_adjoint_values=%llu "
@@ -1897,6 +1960,9 @@ void report_memory_profile(const StructuredLoop& p,
         static_cast<unsigned long long>(bucket.arena_location_refs),
         static_cast<unsigned long long>(bucket.input_handle_values),
         static_cast<unsigned long long>(bucket.record_handle_values),
+        static_cast<unsigned long long>(bucket.compact_position_values),
+        static_cast<unsigned long long>(bucket.compact_old_value_values),
+        static_cast<unsigned long long>(bucket.compact_rhs_handle_values),
         static_cast<unsigned long long>(bucket.output_values),
         static_cast<unsigned long long>(bucket.scratch_values),
         static_cast<unsigned long long>(bucket.padding_values),
@@ -1912,6 +1978,8 @@ void report_memory_profile(const StructuredLoop& p,
 
 int64_t compact_scalar_update_position(const DynamicIndexSpec& p,
                                        const KernelCtx& c);
+int64_t compact_ordered_update_positions(const DynamicIndexSpec& p,
+                                         const KernelCtx& c, double* positions);
 
 bool overlaps(Desc a, Desc b) {
   if (!a.data || !b.data || a.len <= 0 || b.len <= 0) return false;
@@ -1926,7 +1994,6 @@ DynamicLoopState& dynamic_state(KernelCtx& c) {
 
 void compare_forward(KernelCtx& c);
 void int_forward(KernelCtx& c);
-void set_index_backward(KernelCtx& c);
 
 struct DynamicExecution {
   const StructuredLoop& p;
@@ -2597,6 +2664,8 @@ struct DynamicExecution {
       base = ordinary_ref(base_handle).value;
     if (state.compact_primal_by_cell[static_cast<size_t>(cell)] != base)
       return false;
+    if (n.forward != set_index_forward || n.backward != set_index_backward)
+      return false;
 
     double handles[6] = {};
     for (int k = 0; k < op.n_in; ++k)
@@ -2605,10 +2674,7 @@ struct DynamicExecution {
     KernelCtx& c = context.get();
     if (overlaps(c.out, c.in[1]) || overlaps(c.out, c.in[2])) return false;
     const auto& spec = *static_cast<const DynamicIndexSpec*>(op.udata);
-    const int64_t position = compact_scalar_update_position(spec, c);
-    if (position < 0 || position >= c.out.len)
-      throw std::logic_error("compact structured update position out of range");
-
+    const bool scalar_site = scalar_compact_update_spec(spec);
     bool active = false;
     for (int k = 0; k < c.n_in; ++k) active |= handles[k] >= 0;
     active &= n.backward != nullptr;
@@ -2617,6 +2683,52 @@ struct DynamicExecution {
                                         handles[1], c.in[1].len, handles[2],
                                         c.in[2].len)
                : -1;
+
+    if (!scalar_site) {
+      if (active && shared_adjoint < 0) return false;
+      const int64_t selected =
+          compact_ordered_update_positions(spec, c, nullptr);
+      int64_t retained = mul(2, selected);
+      if (active) retained = add(retained, 1);
+      if (active) {
+        if (retained >= retained_frame_values(n)) return false;
+      } else if (add(retained, 7) >= c.out.len) {
+        // Inactive ordinary calls retain only the output buffer. A compact
+        // delta also adds one 16-byte Ref and one 40-byte Record, so demand a
+        // strict total-byte win rather than comparing arena values alone.
+        return false;
+      }
+      double* const delta = state.arena.allocate(retained);
+      const int64_t reached = compact_ordered_update_positions(spec, c, delta);
+      if (reached != selected)
+        throw std::logic_error(
+            "compact structured selection changed during forward");
+      for (int64_t i = 0; i < selected; ++i) {
+        const int64_t position = static_cast<int64_t>(delta[i]);
+        delta[selected + i] = c.out.data[position];
+      }
+      if (active) delta[2 * selected] = handles[2];
+      const double out =
+          make_ref(c.out.data, c.out.len, active, shared_adjoint);
+      DynamicLoopState::Record record;
+      record.node = &n;
+      record.frame = delta;
+      record.out = out;
+      record.out2 = static_cast<double>(selected);
+      record.undo = std::numeric_limits<int64_t>::min();
+      state.records.push_back(record);
+      for (int64_t i = 0; i < selected; ++i)
+        c.out.data[static_cast<int64_t>(delta[i])] = c.in[2].data[i];
+      state.bindings[static_cast<size_t>(op.out)] = out;
+      if (state.allocation_profile)
+        state.allocation_profile->note_delta_compact(op, selected, c.out.len,
+                                                     active);
+      return true;
+    }
+
+    const int64_t position = compact_scalar_update_position(spec, c);
+    if (position < 0 || position >= c.out.len)
+      throw std::logic_error("compact structured update position out of range");
 
     bool frame_free =
         !active || (shared_adjoint >= 0 && n.backward == set_index_backward);
@@ -2878,6 +2990,74 @@ struct DynamicExecution {
     return true;
   }
 
+  void backward_delta_compact(const DynamicLoopState::Record& record) {
+    if (!record.node || record.node->op < 0 ||
+        static_cast<size_t>(record.node->op) >= p.body.ops.size() ||
+        !std::isfinite(record.out2) || std::trunc(record.out2) != record.out2 ||
+        record.out2 < 0 || record.out2 > static_cast<double>(exact_limit))
+      throw std::logic_error("delta compact structured record is invalid");
+    const Op& op = p.body.ops[static_cast<size_t>(record.node->op)];
+    const auto* spec = static_cast<const DynamicIndexSpec*>(op.udata);
+    const int64_t selected = static_cast<int64_t>(record.out2);
+    const int64_t output_len = p.body.slots[static_cast<size_t>(op.out)].len;
+    const int64_t rhs_len = p.body.slots[static_cast<size_t>(op.in[2])].len;
+    if (!spec || record.node->forward != set_index_forward ||
+        record.node->backward != set_index_backward ||
+        op.opcode != OP_SET_INDEX_DYNAMIC || op.n_in != 3 || op.out2 >= 0 ||
+        selected > spec->selected_size || rhs_len != spec->selected_size ||
+        output_len <= 0 || (selected > 0 && !record.frame))
+      throw std::logic_error("delta compact structured record is invalid");
+
+    double* const delta = record.frame;
+    int64_t previous = -1;
+    for (int64_t i = 0; i < selected; ++i) {
+      const double raw = delta[i];
+      if (!std::isfinite(raw) || std::trunc(raw) != raw || raw < 0 ||
+          raw >= static_cast<double>(output_len) ||
+          static_cast<int64_t>(raw) <= previous)
+        throw std::logic_error(
+            "delta compact structured positions are invalid");
+      previous = static_cast<int64_t>(raw);
+    }
+
+    auto& output = ref(record.out);
+    if (!output.value)
+      throw std::logic_error("delta compact structured output is unavailable");
+    if (record.out >= 0) {
+      if (is_import_ref(output) || output.adjoint_or_import < 0 || !delta)
+        throw std::logic_error(
+            "delta compact structured adjoint layout is invalid");
+      const double rhs_handle = delta[2 * selected];
+      double* const shared_adjoint = adj(record.out, output_len);
+      double* const rhs_adjoint = adj(rhs_handle, rhs_len);
+      if (!shared_adjoint ||
+          adjoint_ranges_overlap(record.out, output_len, rhs_handle, rhs_len))
+        throw std::logic_error(
+            "delta compact structured adjoints are not disjoint");
+
+      int64_t ordinal = 0;
+      int64_t position = selected > 0 ? static_cast<int64_t>(delta[0]) : -1;
+      for (int64_t i = 0; i < output_len; ++i) {
+        const double contribution = shared_adjoint[i];
+        shared_adjoint[i] = 0.0;
+        if (ordinal < selected && i == position) {
+          if (rhs_adjoint) rhs_adjoint[ordinal] += contribution;
+          ++ordinal;
+          if (ordinal < selected)
+            position = static_cast<int64_t>(delta[ordinal]);
+        } else {
+          shared_adjoint[i] += contribution;
+        }
+      }
+      if (ordinal != selected)
+        throw std::logic_error(
+            "delta compact structured selection is unordered");
+    }
+
+    for (int64_t i = selected; i-- > 0;)
+      output.value[static_cast<int64_t>(delta[i])] = delta[selected + i];
+  }
+
   void backward_frame_free_compact(const DynamicLoopState::Record& record,
                                    int64_t position) {
     const Op& op = p.body.ops[static_cast<size_t>(record.node->op)];
@@ -2927,7 +3107,9 @@ struct DynamicExecution {
   void backward() {
     for (size_t i = state.records.size(); i-- > 0;) {
       const auto& record = state.records[i];
-      if (record.undo != -1) {
+      if (record.undo == std::numeric_limits<int64_t>::min()) {
+        backward_delta_compact(record);
+      } else if (record.undo != -1) {
         const bool frame_free = record.undo < -1;
         const int64_t position = frame_free ? -(record.undo + 2) : record.undo;
         auto& output = ref(record.out);
@@ -3532,6 +3714,23 @@ IndexRuntime validate_index(const DynamicIndexSpec& p, const KernelCtx& c,
     throw std::logic_error("invalid structured index storage");
   return runtime;
 }
+int64_t compact_ordered_update_positions(const DynamicIndexSpec& p,
+                                         const KernelCtx& c,
+                                         double* positions) {
+  if (!index_selection_is_ordered_unique(p))
+    throw std::logic_error("compact structured update selection is unordered");
+  const IndexRuntime runtime = validate_index(p, c, true);
+  int64_t previous = -1;
+  for (int64_t i = 0; i < runtime.selected; ++i) {
+    const int64_t position = selected_position(p, c, runtime, i);
+    if (position <= previous || position > exact_limit)
+      throw std::logic_error(
+          "compact structured update positions are not ordered and unique");
+    if (positions) positions[i] = static_cast<double>(position);
+    previous = position;
+  }
+  return runtime.selected;
+}
 int64_t compact_scalar_update_position(const DynamicIndexSpec& p,
                                        const KernelCtx& c) {
   const IndexRuntime runtime = validate_index(p, c, true);
@@ -3553,11 +3752,6 @@ void index_backward(KernelCtx& c) {
   for (int64_t i = 0; i < runtime.selected; ++i)
     c.in_adj[0].data[selected_position(p, c, runtime, i)] +=
         c.out_adj_vec.data[i];
-}
-bool index_selection_is_ordered_unique(const DynamicIndexSpec& p) {
-  return std::all_of(p.axes.begin(), p.axes.end(), [](const auto& axis) {
-    return axis.kind != DynamicIndexSpec::Axis::Multi || axis.count <= 1;
-  });
 }
 void set_index_forward(KernelCtx& c) {
   const auto& p = *static_cast<const DynamicIndexSpec*>(c.udata);

--- a/runtime/src/structured_loop.cpp
+++ b/runtime/src/structured_loop.cpp
@@ -1241,7 +1241,17 @@ struct DynamicArena {
       const size_t capacity = std::max(n, next_capacity);
       if (capacity > std::numeric_limits<uint64_t>::max() - capacity_values)
         throw std::length_error("dynamic structured history overflow");
-      blocks.push_back({std::make_unique<double[]>(capacity), capacity, 0});
+      // Every allocated range is initialized by its owner before publication.
+      // Avoid value-initializing unused capacity in production: touching a
+      // geometrically grown block here makes its entire reserved tail
+      // resident. Debug builds poison blocks so the focused structured-loop
+      // suite exposes any accidental dependence on fresh zeroes.
+      std::unique_ptr<double[]> data(new double[capacity]);
+#ifndef NDEBUG
+      std::fill_n(data.get(), capacity,
+                  std::numeric_limits<double>::quiet_NaN());
+#endif
+      blocks.push_back({std::move(data), capacity, 0});
       capacity_values += capacity;
       if (next_capacity < arena_location_block_values)
         next_capacity =

--- a/runtime/src/structured_loop.cpp
+++ b/runtime/src/structured_loop.cpp
@@ -1444,12 +1444,11 @@ struct DynamicAllocationProfile {
 struct DynamicLoopState final : KernelState {
   struct Ref {
     double* value = nullptr;
-    // Internal references store their adjoint offset here. Outer references
-    // cannot have an internal adjoint, so the same field stores their offset
-    // into the outer input. The expected length comes from the graph slot at
-    // every use and need not be repeated for every reached value.
-    int64_t adjoint_or_outer_offset = -1;
-    int outer_input = -1;
+    // Nonnegative values are internal adjoint offsets, -1 marks an inactive
+    // internal value, and values <= -2 encode an ordinal in the immutable
+    // StructuredLoop::imports table. The expected length comes from the graph
+    // slot at every use and need not be repeated for every reached value.
+    int64_t adjoint_or_import = -1;
   };
   struct Record {
     const Node* node = nullptr;
@@ -1635,7 +1634,7 @@ struct DynamicLoopState final : KernelState {
     allocation_profile.reset();
   }
 };
-static_assert(sizeof(DynamicLoopState::Ref) == 24,
+static_assert(sizeof(DynamicLoopState::Ref) == 16,
               "dynamic structured references must stay compact");
 
 uint64_t profile_bytes(uint64_t count, uint64_t width,
@@ -1922,46 +1921,76 @@ struct DynamicExecution {
     return ordinary_ref(h);
   }
 
-  double make_ref(double* value, int64_t len, bool active, int outer_input = -1,
-                  int64_t outer_offset = 0,
+  static bool is_import_ref(const DynamicLoopState::Ref& ref) noexcept {
+    return ref.adjoint_or_import < -1;
+  }
+
+  const StructuredLoop::Import& import_ref(
+      const DynamicLoopState::Ref& ref) const {
+    if (!is_import_ref(ref))
+      throw std::logic_error(
+          "dynamic structured value is not an import reference");
+    const uint64_t ordinal =
+        static_cast<uint64_t>(-(ref.adjoint_or_import + 2));
+    if (ordinal >= p.imports.size())
+      throw std::logic_error(
+          "dynamic structured import reference out of range");
+    return p.imports[static_cast<size_t>(ordinal)];
+  }
+
+  double append_ref(DynamicLoopState::Ref ref, bool active) {
+    if (state.refs.size() >= static_cast<size_t>(ordinary_ref_limit))
+      throw std::length_error("dynamic structured reference overflow");
+    const int64_t id = static_cast<int64_t>(state.refs.size());
+    state.refs.push_back(ref);
+    return handle(id, active);
+  }
+
+  double make_ref(double* value, int64_t len, bool active,
                   int64_t shared_adjoint_offset = -1) {
     if (len < 0)
       throw std::logic_error(
           "dynamic structured reference has negative length");
-    if (state.refs.size() >= static_cast<size_t>(ordinary_ref_limit))
-      throw std::length_error("dynamic structured reference overflow");
     DynamicLoopState::Ref r;
     r.value = value;
-    r.outer_input = outer_input;
-    if (outer_input >= 0) {
-      if (shared_adjoint_offset >= 0)
-        throw std::logic_error(
-            "outer structured reference cannot share an internal adjoint");
-      if (outer_input >= outer.n_in || outer_offset < 0 ||
-          outer_offset > outer.in[outer_input].len ||
-          len > outer.in[outer_input].len - outer_offset)
-        throw std::logic_error(
-            "dynamic structured outer reference exceeds graph input");
-      r.adjoint_or_outer_offset = outer_offset;
-    } else if (active) {
+    if (active) {
       state.conceptual_adjoint_size = add(state.conceptual_adjoint_size, len);
       if (shared_adjoint_offset >= 0) {
         if (shared_adjoint_offset > state.adjoint_size ||
             len > state.adjoint_size - shared_adjoint_offset)
           throw std::logic_error(
               "shared structured adjoint range is out of bounds");
-        r.adjoint_or_outer_offset = shared_adjoint_offset;
+        r.adjoint_or_import = shared_adjoint_offset;
       } else {
-        r.adjoint_or_outer_offset = state.adjoint_size;
+        r.adjoint_or_import = state.adjoint_size;
         state.adjoint_size = add(state.adjoint_size, len);
       }
     } else if (shared_adjoint_offset >= 0) {
       throw std::logic_error(
           "inactive structured reference cannot share an adjoint");
     }
-    const int64_t id = static_cast<int64_t>(state.refs.size());
-    state.refs.push_back(r);
-    return handle(id, active);
+    return append_ref(r, active);
+  }
+
+  double make_import_ref(double* value, int64_t len, bool active,
+                         size_t import_ordinal) {
+    if (len < 0)
+      throw std::logic_error(
+          "dynamic structured import reference has negative length");
+    if (import_ordinal >= p.imports.size() ||
+        import_ordinal >
+            static_cast<uint64_t>(std::numeric_limits<int64_t>::max() - 2))
+      throw std::length_error("dynamic structured import reference overflow");
+    const auto& import = p.imports[import_ordinal];
+    if (import.input < 0 || import.input >= outer.n_in || import.offset < 0 ||
+        import.offset > outer.in[import.input].len ||
+        len > outer.in[import.input].len - import.offset)
+      throw std::logic_error(
+          "dynamic structured import reference exceeds graph input");
+    DynamicLoopState::Ref r;
+    r.value = value;
+    r.adjoint_or_import = -2 - static_cast<int64_t>(import_ordinal);
+    return append_ref(r, active);
   }
 
   double scalar_value(double h) {
@@ -2162,8 +2191,7 @@ struct DynamicExecution {
         if (canonical >= 0 ||
             canonical_ref.value !=
                 state.inactive_control_values.data() + site.value_offset ||
-            canonical_ref.outer_input >= 0 ||
-            canonical_ref.adjoint_or_outer_offset >= 0)
+            canonical_ref.adjoint_or_import != -1)
           throw std::logic_error(
               "inactive-control canonical result handle is invalid");
         site.canonical_handle = canonical;
@@ -2235,8 +2263,7 @@ struct DynamicExecution {
         if (!initial_values || canonical >= 0 || output.len != 1 ||
             output.offset < 0 || output.offset >= p.initial_size ||
             canonical_ref.value != initial_values + output.offset ||
-            canonical_ref.outer_input >= 0 ||
-            canonical_ref.adjoint_or_outer_offset >= 0)
+            canonical_ref.adjoint_or_import != -1)
           throw std::logic_error(
               "direct-control canonical result handle is invalid");
         site.canonical_handle = canonical;
@@ -2253,20 +2280,21 @@ struct DynamicExecution {
     if (expected_len < 0)
       throw std::logic_error("dynamic structured adjoint has negative length");
     const auto& r = ordinary_ref(h);
-    if (r.outer_input >= 0) {
-      if (r.outer_input >= outer.n_in || r.adjoint_or_outer_offset < 0)
+    if (is_import_ref(r)) {
+      const auto& import = import_ref(r);
+      if (import.input < 0 || import.input >= outer.n_in || import.offset < 0)
         throw std::logic_error(
             "dynamic structured outer adjoint handle out of range");
-      const int64_t at = r.adjoint_or_outer_offset;
-      const Desc& value_desc = outer.in[r.outer_input];
-      const Desc& adj_desc = outer.in_adj[r.outer_input];
+      const int64_t at = import.offset;
+      const Desc& value_desc = outer.in[import.input];
+      const Desc& adj_desc = outer.in_adj[import.input];
       if (at > value_desc.len || expected_len > value_desc.len - at ||
           at > adj_desc.len || expected_len > adj_desc.len - at)
         throw std::logic_error(
             "dynamic structured outer adjoint handle out of range");
       return adj_desc.data ? adj_desc.data + at : nullptr;
     }
-    const int64_t at = r.adjoint_or_outer_offset;
+    const int64_t at = r.adjoint_or_import;
     if (at < 0 || at > state.adjoint_size ||
         expected_len > state.adjoint_size - at ||
         static_cast<uint64_t>(state.adjoint_size) > state.adjoints.size())
@@ -2281,9 +2309,11 @@ struct DynamicExecution {
       throw std::logic_error("structured adjoint range has negative length");
     const auto& first = ref(first_handle);
     const auto& second = ref(second_handle);
-    if (first.outer_input < 0 && second.outer_input < 0) {
-      const int64_t first_at = first.adjoint_or_outer_offset;
-      const int64_t second_at = second.adjoint_or_outer_offset;
+    const bool first_import = is_import_ref(first);
+    const bool second_import = is_import_ref(second);
+    if (!first_import && !second_import) {
+      const int64_t first_at = first.adjoint_or_import;
+      const int64_t second_at = second.adjoint_or_import;
       if (first_at < 0 || second_at < 0 || first_at > state.adjoint_size ||
           second_at > state.adjoint_size ||
           first_len > state.adjoint_size - first_at ||
@@ -2293,15 +2323,15 @@ struct DynamicExecution {
       return first_at < second_at + second_len &&
              second_at < first_at + first_len;
     }
-    if ((first.outer_input < 0) != (second.outer_input < 0)) return false;
+    if (first_import != second_import) return false;
     const auto outer_desc = [&](const DynamicLoopState::Ref& r,
                                 int64_t len) -> Desc {
-      if (r.outer_input < 0 || r.outer_input >= outer.n_in ||
-          r.adjoint_or_outer_offset < 0)
+      const auto& import = import_ref(r);
+      if (import.input < 0 || import.input >= outer.n_in || import.offset < 0)
         throw std::logic_error(
             "structured outer adjoint range is out of bounds");
-      const Desc& desc = outer.in_adj[r.outer_input];
-      const int64_t at = r.adjoint_or_outer_offset;
+      const Desc& desc = outer.in_adj[import.input];
+      const int64_t at = import.offset;
       if (!desc.data || at > desc.len || len > desc.len - at)
         throw std::logic_error(
             "structured outer adjoint range is out of bounds");
@@ -2317,15 +2347,15 @@ struct DynamicExecution {
                                  int64_t rhs_len) {
     if (base_handle < 0) return -1;
     const auto& base = ref(base_handle);
-    if (base.outer_input >= 0 || base.adjoint_or_outer_offset < 0 ||
-        base_len <= 0 || base_len != output_len ||
+    if (is_import_ref(base) || base.adjoint_or_import < 0 || base_len <= 0 ||
+        base_len != output_len ||
         adjoint_ranges_overlap(base_handle, base_len, selector_handle,
                                selector_len) ||
         adjoint_ranges_overlap(base_handle, base_len, rhs_handle, rhs_len) ||
         adjoint_ranges_overlap(selector_handle, selector_len, rhs_handle,
                                rhs_len))
       return -1;
-    return base.adjoint_or_outer_offset;
+    return base.adjoint_or_import;
   }
 
   int64_t retained_frame_values(const Node& n) const {
@@ -2562,8 +2592,7 @@ struct DynamicExecution {
     const int retained_inputs = op.n_in;
     double* frame = state.arena.allocate(std::max(1, retained_inputs));
     std::copy_n(handles, retained_inputs, frame);
-    const double out =
-        make_ref(c.out.data, c.out.len, active, -1, 0, shared_adjoint);
+    const double out = make_ref(c.out.data, c.out.len, active, shared_adjoint);
     state.records.push_back({&n, frame, out, c.out.data[position], position});
     if (shared_adjoint >= 0 && c.out.len > state.compact_adjoint_work_size)
       throw std::logic_error(
@@ -2764,8 +2793,8 @@ struct DynamicExecution {
     if (base_handle < 0) return false;
     const auto& base = ref(base_handle);
     const auto& output = ref(record.out);
-    if (base.outer_input >= 0 || output.outer_input >= 0 ||
-        base.adjoint_or_outer_offset != output.adjoint_or_outer_offset)
+    if (is_import_ref(base) || is_import_ref(output) ||
+        base.adjoint_or_import != output.adjoint_or_import)
       return false;
     if (c.in_adj[0].len != c.out_adj_vec.len || c.in_adj[0].len <= 0 ||
         !c.in_adj[0].data || !c.out_adj_vec.data ||
@@ -2900,14 +2929,16 @@ void dynamic_loop_forward(KernelCtx& ctx) {
   for (const auto& fill : p.fills)
     std::copy(fill.second.begin(), fill.second.end(),
               initial + p.body.slots[fill.first].offset);
-  for (const auto& in : p.imports) {
+  for (size_t import_ordinal = 0; import_ordinal < p.imports.size();
+       ++import_ordinal) {
+    const auto& in = p.imports[import_ordinal];
     const Slot& slot = p.body.slots[in.slot];
     if (in.input >= ctx.n_in || in.offset > ctx.in[in.input].len ||
         slot.len > ctx.in[in.input].len - in.offset)
       throw std::logic_error("dynamic structured import exceeds graph input");
     s.bindings[static_cast<size_t>(in.slot)] =
-        e.make_ref(initial + slot.offset, slot.len,
-                   ctx.in_adj[in.input].data != nullptr, in.input, in.offset);
+        e.make_import_ref(initial + slot.offset, slot.len,
+                          ctx.in_adj[in.input].data != nullptr, import_ordinal);
     std::copy_n(ctx.in[in.input].data + in.offset, slot.len,
                 initial + slot.offset);
   }

--- a/runtime/src/structured_loop.cpp
+++ b/runtime/src/structured_loop.cpp
@@ -963,6 +963,8 @@ double handle(int64_t at, bool active) {
 // locations use the rest of the original 2^52 band, and inline int32 values
 // occupy the next 2^32 exact integers.
 constexpr int64_t ordinary_ref_limit = int64_t{1} << 40;
+constexpr int64_t record_scalar_first = ordinary_ref_limit;
+constexpr int64_t record_scalar_count = exact_limit - record_scalar_first + 1;
 constexpr int64_t inline_int_count = int64_t{1} << 32;
 constexpr int64_t inline_int_first = exact_limit + 1;
 constexpr int64_t inline_int_last = exact_limit + inline_int_count;
@@ -981,6 +983,8 @@ static_assert(ordinary_ref_limit < arena_location_first &&
                   exact_limit < inline_int_first &&
                   inline_int_last <= (int64_t{1} << 53),
               "structured handle bands must be disjoint");
+static_assert(record_scalar_count > 0,
+              "structured record-scalar handle band must be nonempty");
 static_assert(arena_location_count > 0 &&
                   (arena_location_count % arena_location_block_values) == 0,
               "arena handle range must contain complete blocks");
@@ -992,6 +996,18 @@ bool is_inline_int(double h) noexcept {
 bool is_arena_location(double h) noexcept {
   return h < -static_cast<double>(ordinary_ref_limit) &&
          h >= -static_cast<double>(exact_limit);
+}
+
+bool is_record_scalar(double h) noexcept {
+  return h >= static_cast<double>(record_scalar_first) &&
+         h <= static_cast<double>(exact_limit);
+}
+
+double record_scalar_handle(uint64_t ordinal) {
+  if (ordinal >= static_cast<uint64_t>(record_scalar_count))
+    throw std::length_error("dynamic structured record-scalar overflow");
+  return static_cast<double>(record_scalar_first) +
+         static_cast<double>(ordinal);
 }
 
 double inline_int_handle(int32_t value) noexcept {
@@ -1333,6 +1349,10 @@ struct DynamicAllocationProfile {
     uint64_t referenced_values = 0;
     uint64_t conceptual_adjoint_values = 0;
     uint64_t physical_adjoint_values = 0;
+    uint64_t record_embedded_primal_values = 0;
+    uint64_t record_embedded_adjoint_values = 0;
+    uint64_t embedded_scalar_index_visits = 0;
+    uint64_t empty_embedded_scalar_index_visits = 0;
     uint64_t records = 0;
   };
 
@@ -1495,21 +1515,31 @@ struct DynamicAllocationProfile {
     add(b->records, 1);
   }
 
-  void note_compact_index(const Op& op) noexcept {
+  void note_compact_index(const Op& op, bool embedded,
+                          bool empty = false) noexcept {
     Bucket* b = bucket(op);
     if (!b) return;
     add(b->compact_visits, 1);
     add(b->frame_free_compact_visits, 1);
     add(b->active_visits, 1);
-    add(b->arena_values, 1);
     add(b->record_handle_values, 1);
     add(b->output_values, 1);
-    add(b->refs, 1);
-    add(b->active_refs, 1);
     add(b->referenced_values, 1);
     add(b->conceptual_adjoint_values, 1);
     add(b->physical_adjoint_values, 1);
     add(b->records, 1);
+    if (embedded) {
+      add(b->elided_arena_values, 1);
+      add(b->elided_refs, 1);
+      add(b->record_embedded_primal_values, 1);
+      add(b->record_embedded_adjoint_values, 1);
+      add(b->embedded_scalar_index_visits, 1);
+      add(b->empty_embedded_scalar_index_visits, empty ? 1 : 0);
+    } else {
+      add(b->arena_values, 1);
+      add(b->refs, 1);
+      add(b->active_refs, 1);
+    }
   }
 
   void note_inline_integer(const Op& op, int64_t retained) noexcept {
@@ -1527,7 +1557,8 @@ struct DynamicLoopState final : KernelState {
   static constexpr uint32_t retained_scalar_record = ordinary_record - 1;
   static constexpr uint32_t delta_record = ordinary_record - 2;
   static constexpr uint32_t scalar_index_record = ordinary_record - 3;
-  static constexpr uint32_t max_frame_free_position = ordinary_record - 4;
+  static constexpr uint32_t scalar_index_empty_record = ordinary_record - 4;
+  static constexpr uint32_t max_frame_free_position = ordinary_record - 5;
 
   struct Ref {
     double* value = nullptr;
@@ -1548,9 +1579,10 @@ struct DynamicLoopState final : KernelState {
     };
     double out = -1;
     // Ordinary calls store the optional second-output handle. Scalar compact
-    // updates store the overwritten value; compact scalar reads store their
-    // exact reached position, or -1 for an empty selection. Delta compact
-    // updates store their exact reached selection count.
+    // updates store the overwritten value. Ref-backed compact scalar reads
+    // store their exact reached position, or -1 for an empty selection;
+    // record-resident reads use this cell as their local adjoint. Delta
+    // compact updates store their exact reached selection count.
     double out2 = -1;
     uint32_t site = ~uint32_t{0};
     // Reserved tags identify ordinary, retained scalar update, ordered-delta,
@@ -1594,6 +1626,7 @@ struct DynamicLoopState final : KernelState {
   uint64_t iterator_values = 0;
   bool loop_invariant_reuse = false;
   bool inactive_control_reuse = false;
+  bool record_scalar_reuse = false;
   bool memory_profile = false;
   bool cached_context_in_use = false;
   // A dynamic tape belongs to exactly one completed forward sweep.  Forward
@@ -1842,6 +1875,10 @@ void report_memory_profile(const StructuredLoop& p,
   uint64_t referenced_values = 0;
   uint64_t conceptual_adjoint_values = 0;
   uint64_t physical_adjoint_values = 0;
+  uint64_t record_embedded_primal_values = 0;
+  uint64_t record_embedded_adjoint_values = 0;
+  uint64_t embedded_scalar_index_visits = 0;
+  uint64_t empty_embedded_scalar_index_visits = 0;
   uint64_t profiled_records = 0;
   uint64_t frame_free_compact_visits = 0;
   uint64_t inline_integer_calls = 0;
@@ -1884,6 +1921,18 @@ void report_memory_profile(const StructuredLoop& p,
     physical_adjoint_values =
         profile_add(physical_adjoint_values, bucket.physical_adjoint_values,
                     allocation_overflow);
+    record_embedded_primal_values =
+        profile_add(record_embedded_primal_values,
+                    bucket.record_embedded_primal_values, allocation_overflow);
+    record_embedded_adjoint_values =
+        profile_add(record_embedded_adjoint_values,
+                    bucket.record_embedded_adjoint_values, allocation_overflow);
+    embedded_scalar_index_visits =
+        profile_add(embedded_scalar_index_visits,
+                    bucket.embedded_scalar_index_visits, allocation_overflow);
+    empty_embedded_scalar_index_visits = profile_add(
+        empty_embedded_scalar_index_visits,
+        bucket.empty_embedded_scalar_index_visits, allocation_overflow);
     profiled_records =
         profile_add(profiled_records, bucket.records, allocation_overflow);
     frame_free_compact_visits =
@@ -1930,7 +1979,11 @@ void report_memory_profile(const StructuredLoop& p,
       "import_refs=%llu kernel_refs=%llu profiled_refs=%llu "
       "actual_refs=%zu refs_match=%d active_refs=%llu "
       "referenced_values=%llu conceptual_adjoint_values=%llu "
-      "physical_adjoint_values=%llu profiled_records=%llu "
+      "physical_adjoint_values=%llu "
+      "record_embedded_primal_values=%llu "
+      "record_embedded_adjoint_values=%llu "
+      "embedded_scalar_index_visits=%llu "
+      "empty_embedded_scalar_index_visits=%llu profiled_records=%llu "
       "actual_records=%zu records_match=%d inline_integer_calls=%llu "
       "frame_free_compact_visits=%llu "
       "elided_arena_values=%llu elided_refs=%llu "
@@ -1960,6 +2013,10 @@ void report_memory_profile(const StructuredLoop& p,
       static_cast<unsigned long long>(referenced_values),
       static_cast<unsigned long long>(conceptual_adjoint_values),
       static_cast<unsigned long long>(physical_adjoint_values),
+      static_cast<unsigned long long>(record_embedded_primal_values),
+      static_cast<unsigned long long>(record_embedded_adjoint_values),
+      static_cast<unsigned long long>(embedded_scalar_index_visits),
+      static_cast<unsigned long long>(empty_embedded_scalar_index_visits),
       static_cast<unsigned long long>(profiled_records), state.records.size(),
       profiled_records == state.records.size() ? 1 : 0,
       static_cast<unsigned long long>(inline_integer_calls),
@@ -1994,7 +2051,11 @@ void report_memory_profile(const StructuredLoop& p,
         "output_values=%llu scratch_values=%llu "
         "padding_values=%llu refs=%llu active_refs=%llu "
         "referenced_values=%llu conceptual_adjoint_values=%llu "
-        "physical_adjoint_values=%llu records=%llu\n",
+        "physical_adjoint_values=%llu "
+        "record_embedded_primal_values=%llu "
+        "record_embedded_adjoint_values=%llu "
+        "embedded_scalar_index_visits=%llu "
+        "empty_embedded_scalar_index_visits=%llu records=%llu\n",
         static_cast<const void*>(&p), static_cast<unsigned>(opcode),
         opcode_name(opcode),
         static_cast<unsigned long long>(bucket.ordinary_visits),
@@ -2025,6 +2086,11 @@ void report_memory_profile(const StructuredLoop& p,
         static_cast<unsigned long long>(bucket.referenced_values),
         static_cast<unsigned long long>(bucket.conceptual_adjoint_values),
         static_cast<unsigned long long>(bucket.physical_adjoint_values),
+        static_cast<unsigned long long>(bucket.record_embedded_primal_values),
+        static_cast<unsigned long long>(bucket.record_embedded_adjoint_values),
+        static_cast<unsigned long long>(bucket.embedded_scalar_index_visits),
+        static_cast<unsigned long long>(
+            bucket.empty_embedded_scalar_index_visits),
         static_cast<unsigned long long>(bucket.records));
   }
   errno = saved_errno;
@@ -2074,8 +2140,47 @@ struct DynamicExecution {
     return state.refs[static_cast<size_t>(id)];
   }
 
+  const Node& validate_record_scalar(
+      const DynamicLoopState::Record& record) const {
+    const Node& node = record_node(record);
+    if (node.op < 0 || static_cast<size_t>(node.op) >= p.body.ops.size())
+      throw std::logic_error("record scalar index node is invalid");
+    const Op& op = p.body.ops[static_cast<size_t>(node.op)];
+    const auto* spec = static_cast<const DynamicIndexSpec*>(op.udata);
+    if (!spec || op.n_in < 2 || op.n_in > 6 ||
+        op.n_in != (spec->input_count > 0 ? spec->input_count : 2) ||
+        node.forward != index_forward || node.backward != index_backward ||
+        op.opcode != OP_INDEX_DYNAMIC || op.out2 >= 0 ||
+        spec->selected_size != 1 ||
+        p.body.slots[static_cast<size_t>(op.out)].len != 1 ||
+        node.kernel_scratch != 0)
+      throw std::logic_error("record scalar index record is invalid");
+    const int64_t base_len = p.body.slots[static_cast<size_t>(op.in[0])].len;
+    const bool empty =
+        record.code == DynamicLoopState::scalar_index_empty_record;
+    if (base_len < 0 ||
+        (!empty && (record.code > DynamicLoopState::max_frame_free_position ||
+                    static_cast<uint64_t>(record.code) >=
+                        static_cast<uint64_t>(base_len))))
+      throw std::logic_error("record scalar index record is invalid");
+    return node;
+  }
+
+  size_t record_scalar_id(double h) const {
+    const uint64_t id =
+        static_cast<uint64_t>(h - static_cast<double>(record_scalar_first));
+    if (id >= state.records.size())
+      throw std::logic_error(
+          "dynamic structured record-scalar handle out of range");
+    return static_cast<size_t>(id);
+  }
+
+  DynamicLoopState::Record& record_scalar(double h) {
+    return state.records[record_scalar_id(h)];
+  }
+
   DynamicLoopState::Ref& ref(double h) {
-    if (is_inline_int(h) || is_arena_location(h))
+    if (is_inline_int(h) || is_arena_location(h) || is_record_scalar(h))
       throw std::logic_error(
           "dynamic structured immediate handle used as a reference");
     return ordinary_ref(h);
@@ -2154,10 +2259,10 @@ struct DynamicExecution {
   }
 
   double scalar_value(double h) {
-    if (h < -static_cast<double>(exact_limit)) return inline_int_value(h);
-    return h < -static_cast<double>(ordinary_ref_limit)
-               ? state.arena.value(h)[0]
-               : ordinary_ref(h).value[0];
+    if (is_inline_int(h)) return inline_int_value(h);
+    if (is_arena_location(h)) return state.arena.value(h)[0];
+    if (is_record_scalar(h)) return record_scalar(h).out;
+    return ordinary_ref(h).value[0];
   }
 
   double scalar_value(int slot) {
@@ -2165,30 +2270,41 @@ struct DynamicExecution {
   }
 
   void copy_value(double h, int64_t len, double* output) {
-    if (h < -static_cast<double>(exact_limit)) {
+    if (is_inline_int(h)) {
       if (len != 1)
         throw std::logic_error(
             "dynamic structured inline integer has nonscalar extent");
       output[0] = inline_int_value(h);
       return;
     }
-    std::copy_n(h < -static_cast<double>(ordinary_ref_limit)
-                    ? state.arena.value(h)
-                    : ordinary_ref(h).value,
-                len, output);
+    if (is_record_scalar(h)) {
+      if (len != 1)
+        throw std::logic_error(
+            "dynamic structured record scalar has nonscalar extent");
+      output[0] = record_scalar(h).out;
+      return;
+    }
+    std::copy_n(
+        is_arena_location(h) ? state.arena.value(h) : ordinary_ref(h).value,
+        len, output);
   }
 
   bool value_overlaps(double h, int64_t len, Desc other) {
-    if (h < -static_cast<double>(exact_limit)) {
+    if (is_inline_int(h)) {
       if (len != 1)
         throw std::logic_error(
             "dynamic structured inline integer has nonscalar extent");
       (void)inline_int_value(h);
       return false;
     }
+    if (is_record_scalar(h)) {
+      if (len != 1)
+        throw std::logic_error(
+            "dynamic structured record scalar has nonscalar extent");
+      return overlaps({&record_scalar(h).out, 1}, other);
+    }
     return overlaps(
-        {h < -static_cast<double>(ordinary_ref_limit) ? state.arena.value(h)
-                                                      : ordinary_ref(h).value,
+        {is_arena_location(h) ? state.arena.value(h) : ordinary_ref(h).value,
          len},
         other);
   }
@@ -2439,6 +2555,12 @@ struct DynamicExecution {
     if (h < 0) return nullptr;
     if (expected_len < 0)
       throw std::logic_error("dynamic structured adjoint has negative length");
+    if (is_record_scalar(h)) {
+      if (expected_len != 1)
+        throw std::logic_error(
+            "dynamic structured record scalar has nonscalar adjoint");
+      return &record_scalar(h).out2;
+    }
     const auto& r = ordinary_ref(h);
     if (is_import_ref(r)) {
       const auto& import = import_ref(r);
@@ -2467,6 +2589,20 @@ struct DynamicExecution {
     if (first_handle < 0 || second_handle < 0) return false;
     if (first_len < 0 || second_len < 0)
       throw std::logic_error("structured adjoint range has negative length");
+    const bool first_record = is_record_scalar(first_handle);
+    const bool second_record = is_record_scalar(second_handle);
+    const size_t first_id = first_record ? record_scalar_id(first_handle) : 0;
+    const size_t second_id =
+        second_record ? record_scalar_id(second_handle) : 0;
+    if (!first_record) (void)ref(first_handle);
+    if (!second_record) (void)ref(second_handle);
+    if (first_record || second_record) {
+      if ((first_record && first_len != 1) ||
+          (second_record && second_len != 1))
+        throw std::logic_error(
+            "structured record-scalar adjoint has nonscalar extent");
+      return first_record && second_record && first_id == second_id;
+    }
     const auto& first = ref(first_handle);
     const auto& second = ref(second_handle);
     const bool first_import = is_import_ref(first);
@@ -2505,7 +2641,7 @@ struct DynamicExecution {
                                  int64_t output_len, double selector_handle,
                                  int64_t selector_len, double rhs_handle,
                                  int64_t rhs_len) {
-    if (base_handle < 0) return -1;
+    if (base_handle < 0 || is_record_scalar(base_handle)) return -1;
     const auto& base = ref(base_handle);
     if (is_import_ref(base) || base.adjoint_or_import < 0 || base_len <= 0 ||
         base_len != output_len ||
@@ -2569,7 +2705,7 @@ struct DynamicExecution {
       c.state = nullptr;
       for (int k = 0; k < op.n_in; ++k) {
         const double h = frame[k];
-        if (h < -static_cast<double>(exact_limit)) {
+        if (is_inline_int(h)) {
           if (c.in[k].len != 1)
             throw std::logic_error(
                 "dynamic structured inline integer has nonscalar input");
@@ -2585,9 +2721,14 @@ struct DynamicExecution {
             inline_inputs[static_cast<size_t>(k)] = inline_int_value(h);
             c.in[k].data = &inline_inputs[static_cast<size_t>(k)];
           }
-        } else if (h < -static_cast<double>(ordinary_ref_limit))
+        } else if (is_arena_location(h))
           c.in[k].data = state.arena.value(h);
-        else
+        else if (is_record_scalar(h)) {
+          if (c.in[k].len != 1)
+            throw std::logic_error(
+                "dynamic structured record scalar has nonscalar input");
+          c.in[k].data = &record_scalar(h).out;
+        } else
           c.in[k].data = ordinary_ref(h).value;
         c.in_adj[k].data = backward ? adj(h, c.in[k].len) : nullptr;
       }
@@ -2727,15 +2868,45 @@ struct DynamicExecution {
     }
     if (!active) return false;
 
-    // Keep the selected value immutable, but move the historical base handle
-    // into the fixed-size reverse record and save the validated position
-    // instead of retaining every selector handle. The shared helper is also
-    // the built-in callback's scalar path, so validation and exception order
-    // remain identical and every allocation precedes publication.
-    double* const output = state.arena.allocate(1);
-    ContextLease context(*this, n, handles, false, -1, -1, output);
+    // Keep the selected value and its adjoint inside the already-required
+    // reverse record. The public handle contains only the record ordinal, so
+    // vector growth cannot leave a dangling pointer. The shared helper is
+    // also the built-in callback's scalar path, preserving validation and
+    // exception order.
+    double output = 0.0;
+    ContextLease context(*this, n, handles, false, -1, -1, &output);
     const int64_t position = scalar_index_forward(context.get());
-    const double out = make_ref(output, 1, true);
+    const bool encodable_record =
+        state.record_scalar_reuse &&
+        state.records.size() < static_cast<uint64_t>(record_scalar_count);
+    const bool encodable_position =
+        position == -1 ||
+        (position >= 0 && static_cast<uint64_t>(position) <=
+                              DynamicLoopState::max_frame_free_position);
+    if (encodable_record && encodable_position) {
+      const size_t ordinal = state.records.size();
+      const double out = record_scalar_handle(ordinal);
+      state.conceptual_adjoint_size =
+          add(state.conceptual_adjoint_size, int64_t{1});
+      DynamicLoopState::Record record;
+      record.base_handle = handles[0];
+      record.out = output;
+      record.out2 = 0.0;
+      record.site = n.record_site;
+      record.code = position < 0 ? DynamicLoopState::scalar_index_empty_record
+                                 : static_cast<uint32_t>(position);
+      state.records.push_back(record);
+      state.bindings[static_cast<size_t>(op.out)] = out;
+      if (state.allocation_profile)
+        state.allocation_profile->note_compact_index(op, true, position < 0);
+      return true;
+    }
+
+    // Preserve the H6N Ref-backed form as the exact fallback when a record
+    // ordinal or reached position cannot be encoded in the compact bands.
+    double* const stored_output = state.arena.allocate(1);
+    stored_output[0] = output;
+    const double out = make_ref(stored_output, 1, true);
     DynamicLoopState::Record record;
     record.base_handle = handles[0];
     record.out = out;
@@ -2745,7 +2916,7 @@ struct DynamicExecution {
     state.records.push_back(record);
     state.bindings[static_cast<size_t>(op.out)] = out;
     if (state.allocation_profile)
-      state.allocation_profile->note_compact_index(op);
+      state.allocation_profile->note_compact_index(op, false);
     return true;
   }
 
@@ -2757,7 +2928,7 @@ struct DynamicExecution {
     const int cell = n.compact_update_cell;
     const double base_handle = state.bindings[static_cast<size_t>(op.in[0])];
     double* base = nullptr;
-    if (base_handle < -static_cast<double>(exact_limit))
+    if (is_inline_int(base_handle) || is_record_scalar(base_handle))
       return false;
     else if (base_handle < -static_cast<double>(ordinary_ref_limit))
       base = state.arena.value(base_handle);
@@ -2817,9 +2988,12 @@ struct DynamicExecution {
       record.out2 = static_cast<double>(selected);
       record.site = n.record_site;
       record.code = DynamicLoopState::delta_record;
+      const bool resident_rhs = is_record_scalar(handles[2]);
+      const double resident_rhs_value = resident_rhs ? c.in[2].data[0] : 0.0;
       state.records.push_back(record);
       for (int64_t i = 0; i < selected; ++i)
-        c.out.data[static_cast<int64_t>(delta[i])] = c.in[2].data[i];
+        c.out.data[static_cast<int64_t>(delta[i])] =
+            resident_rhs ? resident_rhs_value : c.in[2].data[i];
       state.bindings[static_cast<size_t>(op.out)] = out;
       if (state.allocation_profile)
         state.allocation_profile->note_delta_compact(op, selected, c.out.len,
@@ -2862,8 +3036,9 @@ struct DynamicExecution {
     record.site = n.record_site;
     record.code = frame_free ? static_cast<uint32_t>(position)
                              : DynamicLoopState::retained_scalar_record;
+    const double rhs_value = c.in[2].data[0];
     state.records.push_back(record);
-    c.out.data[position] = c.in[2].data[0];
+    c.out.data[position] = rhs_value;
     state.bindings[static_cast<size_t>(op.out)] = out;
     if (state.allocation_profile)
       state.allocation_profile->note_compact(
@@ -2902,6 +3077,9 @@ struct DynamicExecution {
     // and scratch stop entering persistent history; output storage remains in
     // the stable arena and is published after successful completion.
     n.forward(c);
+    stabilize_ephemeral_aliased_output(c.out, outputs, handles, c);
+    if (op.out2 >= 0)
+      stabilize_ephemeral_aliased_output(c.out2, output2, handles, c);
     uint64_t arena_locations = 0;
     const auto output_handle = [&](double* actual, double* expected,
                                    int64_t actual_len, int64_t expected_len,
@@ -2933,6 +3111,22 @@ struct DynamicExecution {
       state.allocation_profile->note_inactive_split(op, n, retained_outputs,
                                                     arena_locations);
     return true;
+  }
+
+  void stabilize_ephemeral_aliased_output(Desc& output, double* stable,
+                                          const double* handles,
+                                          const KernelCtx& context) {
+    if (!output.data) return;
+    for (int k = 0; k < context.n_in; ++k) {
+      if (!is_record_scalar(handles[k]) && !is_inline_int(handles[k])) continue;
+      if (output.data != context.in[k].data) continue;
+      if (output.len != context.in[k].len)
+        throw std::logic_error(
+            "dynamic structured ephemeral input aliases mismatched output");
+      std::copy_n(output.data, output.len, stable);
+      output.data = stable;
+      return;
+    }
   }
 
   enum Flow { Normal, Break, Continue };
@@ -2990,6 +3184,13 @@ struct DynamicExecution {
         // reject/domain errors and bounds errors are part of Stan's visible
         // behavior and must match the ordinary graph path.
         n.forward(c);
+        // Callback output redirection may alias an input. Record storage can
+        // move at the next push, so materialize that special case into the
+        // stable frame before publishing a persistent Ref.
+        stabilize_ephemeral_aliased_output(c.out, frame + op.n_in, handles, c);
+        if (op.out2 >= 0)
+          stabilize_ephemeral_aliased_output(
+              c.out2, frame + op.n_in + c.out.len, handles, c);
         const double out = make_ref(c.out.data, c.out.len, active);
         state.bindings[static_cast<size_t>(op.out)] = out;
         double out2 = -1;
@@ -3139,6 +3340,23 @@ struct DynamicExecution {
     base_adjoint[static_cast<int64_t>(record.out2)] += output_adjoint[0];
   }
 
+  void backward_record_scalar_index(const DynamicLoopState::Record& record,
+                                    double output_handle) {
+    const Node& node = validate_record_scalar(record);
+    const Op& op = p.body.ops[static_cast<size_t>(node.op)];
+    const int64_t base_len = p.body.slots[static_cast<size_t>(op.in[0])].len;
+    const bool empty =
+        record.code == DynamicLoopState::scalar_index_empty_record;
+
+    double* const base_adjoint = adj(record.base_handle, base_len);
+    if (!base_adjoint || empty) return;
+    double* const output_adjoint = adj(output_handle, 1);
+    if (!output_adjoint ||
+        adjoint_ranges_overlap(record.base_handle, base_len, output_handle, 1))
+      throw std::logic_error("record scalar index adjoints overlap");
+    base_adjoint[record.code] += output_adjoint[0];
+  }
+
   void backward_delta_compact(const DynamicLoopState::Record& record) {
     const Node& node = record_node(record);
     if (node.op < 0 || static_cast<size_t>(node.op) >= p.body.ops.size() ||
@@ -3264,6 +3482,11 @@ struct DynamicExecution {
         backward_delta_compact(record);
       } else if (record.code == DynamicLoopState::scalar_index_record) {
         backward_compact_scalar_index(record);
+      } else if (p.body.ops[static_cast<size_t>(node.op)].opcode ==
+                     OP_INDEX_DYNAMIC &&
+                 (record.code == DynamicLoopState::scalar_index_empty_record ||
+                  record.code <= DynamicLoopState::max_frame_free_position)) {
+        backward_record_scalar_index(record, record_scalar_handle(i));
       } else if (record.code != DynamicLoopState::ordinary_record) {
         const bool frame_free =
             record.code != DynamicLoopState::retained_scalar_record;
@@ -3340,6 +3563,8 @@ void dynamic_loop_forward(KernelCtx& ctx) {
   s.inactive_control_reuse =
       s.inactive_control_plan &&
       std::getenv("STANLI_NO_STRUCTURED_INACTIVE_CONTROL") == nullptr;
+  s.record_scalar_reuse =
+      std::getenv("STANLI_NO_STRUCTURED_RECORD_SCALARS") == nullptr;
   struct ReleaseOnFailure {
     DynamicLoopState& state;
     bool published = false;

--- a/runtime/src/structured_loop.cpp
+++ b/runtime/src/structured_loop.cpp
@@ -1671,8 +1671,8 @@ struct DynamicAllocationProfile {
   }
 
   void note_compact(const Op& op, int64_t retained, int64_t output_len,
-                    bool active, bool shared_adjoint,
-                    bool frame_free) noexcept {
+                    bool active, bool shared_adjoint, bool frame_free,
+                    bool reused_output_ref) noexcept {
     Bucket* b = bucket(op);
     if (!b) return;
     const uint64_t frame = count(retained);
@@ -1683,8 +1683,9 @@ struct DynamicAllocationProfile {
     add(b->arena_values, frame);
     add(b->input_handle_values, frame);
     add(b->record_handle_values, frame_free && active ? 1 : 0);
-    add(b->refs, 1);
-    add(b->active_refs, active ? 1 : 0);
+    add(b->refs, reused_output_ref ? 0 : 1);
+    add(b->active_refs, active && !reused_output_ref ? 1 : 0);
+    add(b->elided_refs, reused_output_ref ? 1 : 0);
     add(b->referenced_values, extent);
     add(b->conceptual_adjoint_values, active ? extent : 0);
     add(b->physical_adjoint_values, active && !shared_adjoint ? extent : 0);
@@ -1829,6 +1830,7 @@ struct DynamicLoopState final : KernelState {
   bool inactive_control_reuse = false;
   bool inactive_workspace_reuse = false;
   bool record_scalar_reuse = false;
+  bool shared_update_ref_reuse = false;
   bool memory_profile = false;
   bool cached_context_in_use = false;
   // A dynamic tape belongs to exactly one completed forward sweep.  Forward
@@ -2470,6 +2472,33 @@ struct DynamicExecution {
           "inactive structured reference cannot share an adjoint");
     }
     return append_ref(r, active);
+  }
+
+  double make_compact_update_ref(double base_handle, double* value,
+                                 int64_t len, bool active,
+                                 int64_t shared_adjoint_offset,
+                                 bool frame_free, bool& reused) {
+    reused = false;
+    if (!state.shared_update_ref_reuse || !active || !frame_free ||
+        shared_adjoint_offset < 0 || base_handle < 0 ||
+        is_record_scalar(base_handle))
+      return make_ref(value, len, active, shared_adjoint_offset);
+
+    const auto& base = ordinary_ref(base_handle);
+    if (is_import_ref(base) || base.value != value ||
+        base.adjoint_or_import != shared_adjoint_offset)
+      return make_ref(value, len, active, shared_adjoint_offset);
+    if (len < 0 || shared_adjoint_offset > state.adjoint_size ||
+        len > state.adjoint_size - shared_adjoint_offset)
+      return make_ref(value, len, active, shared_adjoint_offset);
+
+    // This output is a new conceptual autodiff value, but the compact
+    // update's ownership and shared-adjoint proofs make its physical Ref
+    // identical to the base Ref. The reverse record still preserves every
+    // reached update and observes the shared handle in the original order.
+    state.conceptual_adjoint_size = add(state.conceptual_adjoint_size, len);
+    reused = true;
+    return base_handle;
   }
 
   double make_import_ref(double* value, int64_t len, bool active,
@@ -3357,7 +3386,10 @@ struct DynamicExecution {
       std::copy_n(handles, retained_inputs, frame);
       frame[retained_inputs] = static_cast<double>(position);
     }
-    const double out = make_ref(c.out.data, c.out.len, active, shared_adjoint);
+    bool reused_output_ref = false;
+    const double out = make_compact_update_ref(
+        base_handle, c.out.data, c.out.len, active, shared_adjoint, frame_free,
+        reused_output_ref);
     if (shared_adjoint >= 0 && c.out.len > state.compact_adjoint_work_size)
       throw std::logic_error(
           "compact structured adjoint exceeds preallocated work");
@@ -3378,7 +3410,7 @@ struct DynamicExecution {
     if (state.allocation_profile)
       state.allocation_profile->note_compact(
           op, frame_free ? 0 : std::max(1, retained_inputs + 1), c.out.len,
-          active, shared_adjoint >= 0, frame_free);
+          active, shared_adjoint >= 0, frame_free, reused_output_ref);
     return true;
   }
 
@@ -3942,6 +3974,8 @@ void dynamic_loop_forward(KernelCtx& ctx) {
       std::getenv("STANLI_NO_STRUCTURED_INACTIVE_WORKSPACE") == nullptr;
   s.record_scalar_reuse =
       std::getenv("STANLI_NO_STRUCTURED_RECORD_SCALARS") == nullptr;
+  s.shared_update_ref_reuse =
+      std::getenv("STANLI_NO_STRUCTURED_SHARED_UPDATE_REFS") == nullptr;
   struct ReleaseOnFailure {
     DynamicLoopState& state;
     bool published = false;

--- a/runtime/src/structured_loop.cpp
+++ b/runtime/src/structured_loop.cpp
@@ -32,6 +32,9 @@ int64_t mul(int64_t a, int64_t b) {
   return a * b;
 }
 using Node = StructuredLoop::Node;
+void index_forward(KernelCtx& c);
+void index_backward(KernelCtx& c);
+int64_t scalar_index_forward(KernelCtx& c);
 void set_index_forward(KernelCtx& c);
 void set_index_backward(KernelCtx& c);
 bool index_selection_is_ordered_unique(const DynamicIndexSpec& p) {
@@ -1482,6 +1485,23 @@ struct DynamicAllocationProfile {
     add(b->records, 1);
   }
 
+  void note_compact_index(const Op& op) noexcept {
+    Bucket* b = bucket(op);
+    if (!b) return;
+    add(b->compact_visits, 1);
+    add(b->frame_free_compact_visits, 1);
+    add(b->active_visits, 1);
+    add(b->arena_values, 1);
+    add(b->record_handle_values, 1);
+    add(b->output_values, 1);
+    add(b->refs, 1);
+    add(b->active_refs, 1);
+    add(b->referenced_values, 1);
+    add(b->conceptual_adjoint_values, 1);
+    add(b->physical_adjoint_values, 1);
+    add(b->records, 1);
+  }
+
   void note_inline_integer(const Op& op, int64_t retained) noexcept {
     Bucket* b = bucket(op);
     if (!b) return;
@@ -1496,7 +1516,8 @@ struct DynamicLoopState final : KernelState {
       std::numeric_limits<uint32_t>::max();
   static constexpr uint32_t retained_scalar_record = ordinary_record - 1;
   static constexpr uint32_t delta_record = ordinary_record - 2;
-  static constexpr uint32_t max_frame_free_position = ordinary_record - 3;
+  static constexpr uint32_t scalar_index_record = ordinary_record - 3;
+  static constexpr uint32_t max_frame_free_position = ordinary_record - 4;
 
   struct Ref {
     double* value = nullptr;
@@ -1513,15 +1534,18 @@ struct DynamicLoopState final : KernelState {
     union {
       double* frame = nullptr;
       double rhs_handle;
+      double base_handle;
     };
     double out = -1;
     // Ordinary calls store the optional second-output handle. Scalar compact
-    // updates store the overwritten value. Delta compact updates store their
-    // exact reached selection count.
+    // updates store the overwritten value; compact scalar reads store their
+    // exact reached position, or -1 for an empty selection. Delta compact
+    // updates store their exact reached selection count.
     double out2 = -1;
     uint32_t site = ~uint32_t{0};
-    // Reserved tags identify ordinary, retained scalar, and ordered-delta
-    // records. Every lower code is an exact frame-free scalar position.
+    // Reserved tags identify ordinary, retained scalar update, ordered-delta,
+    // and scalar-read records. Every lower code is an exact frame-free scalar
+    // update position.
     uint32_t code = ordinary_record;
   };
   DynamicArena arena;
@@ -2675,6 +2699,46 @@ struct DynamicExecution {
     return true;
   }
 
+  bool compact_scalar_index(const Node& n) {
+    const Op& op = p.body.ops[static_cast<size_t>(n.op)];
+    if (op.opcode != OP_INDEX_DYNAMIC || op.n_in < 2 || op.out2 >= 0 ||
+        n.forward != index_forward || n.backward != index_backward ||
+        n.kernel_scratch != 0 ||
+        p.body.slots[static_cast<size_t>(op.out)].len != 1)
+      return false;
+    const auto* spec = static_cast<const DynamicIndexSpec*>(op.udata);
+    if (!spec || spec->selected_size != 1) return false;
+
+    double handles[6] = {};
+    bool active = false;
+    for (int k = 0; k < op.n_in; ++k) {
+      handles[k] = state.bindings[static_cast<size_t>(op.in[k])];
+      active |= handles[k] >= 0;
+    }
+    if (!active) return false;
+
+    // Keep the selected value immutable, but move the historical base handle
+    // into the fixed-size reverse record and save the validated position
+    // instead of retaining every selector handle. The shared helper is also
+    // the built-in callback's scalar path, so validation and exception order
+    // remain identical and every allocation precedes publication.
+    double* const output = state.arena.allocate(1);
+    ContextLease context(*this, n, handles, false, -1, -1, output);
+    const int64_t position = scalar_index_forward(context.get());
+    const double out = make_ref(output, 1, true);
+    DynamicLoopState::Record record;
+    record.base_handle = handles[0];
+    record.out = out;
+    record.out2 = static_cast<double>(position);
+    record.site = n.record_site;
+    record.code = DynamicLoopState::scalar_index_record;
+    state.records.push_back(record);
+    state.bindings[static_cast<size_t>(op.out)] = out;
+    if (state.allocation_profile)
+      state.allocation_profile->note_compact_index(op);
+    return true;
+  }
+
   bool compact_update(const Node& n) {
     if (n.compact_update_cell < 0) return false;
     const Op& op = p.body.ops[n.op];
@@ -2899,6 +2963,10 @@ struct DynamicExecution {
           publish_loop_invariant(n);
           return Normal;
         }
+        if (compact_scalar_index(n)) {
+          publish_loop_invariant(n);
+          return Normal;
+        }
         if (compact_update(n)) return Normal;
         double handles[6] = {};
         bool active = false;
@@ -3028,6 +3096,39 @@ struct DynamicExecution {
     return true;
   }
 
+  void backward_compact_scalar_index(
+      const DynamicLoopState::Record& record) {
+    const Node& node = record_node(record);
+    if (node.op < 0 || static_cast<size_t>(node.op) >= p.body.ops.size())
+      throw std::logic_error("compact scalar index node is invalid");
+    const Op& op = p.body.ops[static_cast<size_t>(node.op)];
+    const auto* spec = static_cast<const DynamicIndexSpec*>(op.udata);
+    if (!spec || op.n_in < 2 || op.n_in > 6 ||
+        op.n_in != (spec->input_count > 0 ? spec->input_count : 2))
+      throw std::logic_error("compact scalar index record is invalid");
+    const int64_t base_len = p.body.slots[static_cast<size_t>(op.in[0])].len;
+    if (node.forward != index_forward || node.backward != index_backward ||
+        op.opcode != OP_INDEX_DYNAMIC ||
+        op.out2 >= 0 || spec->selected_size != 1 ||
+        p.body.slots[static_cast<size_t>(op.out)].len != 1 ||
+        node.kernel_scratch != 0 || record.out < 0 || base_len < 0 ||
+        !std::isfinite(record.out2) || std::trunc(record.out2) != record.out2 ||
+        record.out2 < -1 || record.out2 >= static_cast<double>(base_len))
+      throw std::logic_error("compact scalar index record is invalid");
+
+    const auto& output = ref(record.out);
+    if (is_import_ref(output) || output.adjoint_or_import < 0 ||
+        !output.value)
+      throw std::logic_error("compact scalar index output is invalid");
+    double* const base_adjoint = adj(record.base_handle, base_len);
+    if (!base_adjoint || record.out2 < 0) return;
+    double* const output_adjoint = adj(record.out, 1);
+    if (!output_adjoint || overlaps({base_adjoint, base_len},
+                                    {output_adjoint, 1}))
+      throw std::logic_error("compact scalar index adjoints overlap");
+    base_adjoint[static_cast<int64_t>(record.out2)] += output_adjoint[0];
+  }
+
   void backward_delta_compact(const DynamicLoopState::Record& record) {
     const Node& node = record_node(record);
     if (node.op < 0 || static_cast<size_t>(node.op) >= p.body.ops.size() ||
@@ -3151,6 +3252,8 @@ struct DynamicExecution {
         throw std::logic_error("dynamic structured record node is invalid");
       if (record.code == DynamicLoopState::delta_record) {
         backward_delta_compact(record);
+      } else if (record.code == DynamicLoopState::scalar_index_record) {
+        backward_compact_scalar_index(record);
       } else if (record.code != DynamicLoopState::ordinary_record) {
         const bool frame_free =
             record.code != DynamicLoopState::retained_scalar_record;
@@ -3788,8 +3891,23 @@ int64_t compact_scalar_update_position(const DynamicIndexSpec& p,
     throw std::logic_error("compact structured update is not scalar");
   return selected_position(p, c, runtime, 0);
 }
+int64_t scalar_index_forward(KernelCtx& c) {
+  const auto& p = *static_cast<const DynamicIndexSpec*>(c.udata);
+  const IndexRuntime runtime = validate_index(p, c, false);
+  if (p.selected_size != 1 || c.out.len != 1 || runtime.selected > 1)
+    throw std::logic_error("invalid compact scalar index shape");
+  c.out.data[0] = 0.0;
+  if (runtime.selected == 0) return -1;
+  const int64_t position = selected_position(p, c, runtime, 0);
+  c.out.data[0] = c.in[0].data[position];
+  return position;
+}
 void index_forward(KernelCtx& c) {
   const auto& p = *static_cast<const DynamicIndexSpec*>(c.udata);
+  if (p.selected_size == 1 && c.out.len == 1) {
+    (void)scalar_index_forward(c);
+    return;
+  }
   const IndexRuntime runtime = validate_index(p, c, false);
   std::fill(c.out.data, c.out.data + c.out.len, 0.0);
   for (int64_t i = 0; i < runtime.selected; ++i)

--- a/runtime/src/structured_loop.cpp
+++ b/runtime/src/structured_loop.cpp
@@ -1382,12 +1382,12 @@ struct DynamicLoopState final : KernelState {
     const Node* node = nullptr;
     double* frame = nullptr;
     double out = -1;
+    // Ordinary calls store the optional second-output handle. Compact updates
+    // have no second output and store the overwritten value here instead.
     double out2 = -1;
+    // Compact updates store the overwritten position directly. Ordinary
+    // records use -1.
     int64_t undo = -1;
-  };
-  struct Undo {
-    int64_t position = -1;
-    double old_value = 0.0;
   };
   DynamicArena arena;
   std::vector<double> adjoints;
@@ -1400,7 +1400,6 @@ struct DynamicLoopState final : KernelState {
   std::vector<double> target_refs;
   std::vector<double> target_work;
   std::vector<Record> records;
-  std::vector<Undo> undos;
   // H2B may assign multiple conceptual compact-update Refs to one physical
   // internal-adjoint range. Reverse uses one fully overwritten temporary
   // output range to preserve the ordinary callback's distinct descriptors.
@@ -1555,7 +1554,6 @@ struct DynamicLoopState final : KernelState {
     std::vector<double>{}.swap(target_refs);
     std::vector<double>{}.swap(target_work);
     std::vector<Record>{}.swap(records);
-    std::vector<Undo>{}.swap(undos);
     conceptual_adjoint_size = 0;
     adjoint_size = 0;
     iterator_values = 0;
@@ -1600,10 +1598,6 @@ void report_memory_profile(const StructuredLoop& p,
       state.records.size(), sizeof(DynamicLoopState::Record), overflow);
   const uint64_t record_capacity = profile_bytes(
       state.records.capacity(), sizeof(DynamicLoopState::Record), overflow);
-  const uint64_t undo_used = profile_bytes(
-      state.undos.size(), sizeof(DynamicLoopState::Undo), overflow);
-  const uint64_t undo_capacity = profile_bytes(
-      state.undos.capacity(), sizeof(DynamicLoopState::Undo), overflow);
   const uint64_t planned_adjoint = profile_bytes(
       static_cast<uint64_t>(state.adjoint_size), sizeof(double), overflow);
   const uint64_t inactive_scratch =
@@ -1626,7 +1620,7 @@ void report_memory_profile(const StructuredLoop& p,
       "arena_used_bytes=%llu arena_capacity_bytes=%llu "
       "ref_count=%zu ref_used_bytes=%llu ref_capacity_bytes=%llu "
       "record_count=%zu record_used_bytes=%llu record_capacity_bytes=%llu "
-      "undo_count=%zu undo_used_bytes=%llu undo_capacity_bytes=%llu "
+      "undo_count=0 undo_used_bytes=0 undo_capacity_bytes=0 "
       "planned_adjoint_bytes=%llu inactive_scratch_bytes=%llu\n",
       static_cast<const void*>(&p), p.node_count, p.body.ops.size(),
       overflow ? 1 : 0, static_cast<unsigned long long>(state.iterator_values),
@@ -1638,9 +1632,7 @@ void report_memory_profile(const StructuredLoop& p,
       static_cast<unsigned long long>(ref_used),
       static_cast<unsigned long long>(ref_capacity), state.records.size(),
       static_cast<unsigned long long>(record_used),
-      static_cast<unsigned long long>(record_capacity), state.undos.size(),
-      static_cast<unsigned long long>(undo_used),
-      static_cast<unsigned long long>(undo_capacity),
+      static_cast<unsigned long long>(record_capacity),
       static_cast<unsigned long long>(planned_adjoint),
       static_cast<unsigned long long>(inactive_scratch));
 
@@ -2440,7 +2432,7 @@ struct DynamicExecution {
   bool compact_update(const Node& n) {
     if (n.compact_update_cell < 0) return false;
     const Op& op = p.body.ops[n.op];
-    if (op.n_in != 3)
+    if (op.n_in != 3 || op.out2 >= 0)
       throw std::logic_error("compact structured update arity is invalid");
     const int cell = n.compact_update_cell;
     const double base_handle = state.bindings[static_cast<size_t>(op.in[0])];
@@ -2472,16 +2464,12 @@ struct DynamicExecution {
     // Every allocation that can throw precedes the destructive write. A later
     // failure still drops the entire evaluation-local tape, but this ordering
     // also keeps the state internally coherent under allocation failure.
-    if (state.undos.size() >= static_cast<size_t>(exact_limit))
-      throw std::length_error("compact structured undo overflow");
     const int retained_inputs = op.n_in;
     double* frame = state.arena.allocate(std::max(1, retained_inputs));
     std::copy_n(handles, retained_inputs, frame);
-    const int64_t undo = static_cast<int64_t>(state.undos.size());
-    state.undos.push_back({position, c.out.data[position]});
     const double out =
         make_ref(c.out.data, c.out.len, active, -1, 0, shared_adjoint);
-    state.records.push_back({&n, frame, out, -1, undo});
+    state.records.push_back({&n, frame, out, c.out.data[position], position});
     if (shared_adjoint >= 0 && c.out.len > state.compact_adjoint_work_size)
       throw std::logic_error(
           "compact structured adjoint exceeds preallocated work");
@@ -2695,23 +2683,20 @@ struct DynamicExecution {
     for (size_t i = state.records.size(); i-- > 0;) {
       const auto& record = state.records[i];
       if (record.undo >= 0) {
-        if (static_cast<size_t>(record.undo) >= state.undos.size())
-          throw std::logic_error("compact structured undo out of range");
         auto& output = ref(record.out);
-        const auto& undo = state.undos[static_cast<size_t>(record.undo)];
         const int64_t output_len =
             p.body.slots[p.body.ops[record.node->op].out].len;
-        if (undo.position < 0 || undo.position >= output_len)
+        if (record.undo >= output_len)
           throw std::logic_error(
               "compact structured undo position out of range");
         if (record.out >= 0 && record.node->backward) {
           ContextLease context(*this, *record.node, record.frame, true,
-                               record.out, record.out2, output.value);
+                               record.out, -1, output.value);
           KernelCtx& c = context.get();
           prepare_shared_compact_adjoint(record, c);
           record.node->backward(c);
         }
-        output.value[undo.position] = undo.old_value;
+        output.value[record.undo] = record.out2;
       } else if (record.node->backward) {
         ContextLease context(*this, *record.node, record.frame, true,
                              record.out, record.out2);
@@ -2781,7 +2766,6 @@ void dynamic_loop_forward(KernelCtx& ctx) {
   s.bindings.resize(p.body.slots.size());
   s.compact_primal_by_cell.assign(p.body.slots.size(), nullptr);
   s.records.clear();
-  s.undos.clear();
   s.target_refs.clear();
   for (size_t slot = 0; slot < p.body.slots.size(); ++slot)
     s.bindings[slot] = e.make_ref(initial + p.body.slots[slot].offset,

--- a/runtime/src/structured_loop.cpp
+++ b/runtime/src/structured_loop.cpp
@@ -59,6 +59,7 @@ void prepare_node(StructuredLoop& p, Node& n, unsigned depth,
                   unsigned loop_depth) {
   if (depth > 256) throw std::length_error("structured loop nesting limit");
   ++p.node_count;
+  n.record_site = ~uint32_t{0};
   n.compact_update_cell = -1;
   n.frame_size = n.target_capacity = 0;
   const bool loop = n.kind == Node::For || n.kind == Node::While;
@@ -72,6 +73,9 @@ void prepare_node(StructuredLoop& p, Node& n, unsigned depth,
       }
       break;
     case Node::KernelCall: {
+      if (p.record_node_count >= std::numeric_limits<uint32_t>::max())
+        throw std::length_error("too many structured kernel call sites");
+      n.record_site = static_cast<uint32_t>(p.record_node_count++);
       if (n.op < 0 || static_cast<size_t>(n.op) >= p.body.ops.size())
         throw std::invalid_argument("structured loop invalid operation");
       const Op& op = p.body.ops[n.op];
@@ -1488,6 +1492,12 @@ struct DynamicAllocationProfile {
 };
 
 struct DynamicLoopState final : KernelState {
+  static constexpr uint32_t ordinary_record =
+      std::numeric_limits<uint32_t>::max();
+  static constexpr uint32_t retained_scalar_record = ordinary_record - 1;
+  static constexpr uint32_t delta_record = ordinary_record - 2;
+  static constexpr uint32_t max_frame_free_position = ordinary_record - 3;
+
   struct Ref {
     double* value = nullptr;
     // Nonnegative values are internal adjoint offsets, -1 marks an inactive
@@ -1497,7 +1507,6 @@ struct DynamicLoopState final : KernelState {
     int64_t adjoint_or_import = -1;
   };
   struct Record {
-    const Node* node = nullptr;
     // Ordinary and retained compact records store their input frame. A
     // frame-free active compact record stores only its RHS handle; an inactive
     // frame-free compact record leaves the pointer null.
@@ -1510,10 +1519,10 @@ struct DynamicLoopState final : KernelState {
     // updates store the overwritten value. Delta compact updates store their
     // exact reached selection count.
     double out2 = -1;
-    // Retained compact updates store a nonnegative position. Ordinary records
-    // use -1. Frame-free scalar updates encode position as -2 - position.
-    // INT64_MIN identifies a variable-width ordered-unique delta payload.
-    int64_t undo = -1;
+    uint32_t site = ~uint32_t{0};
+    // Reserved tags identify ordinary, retained scalar, and ordered-delta
+    // records. Every lower code is an exact frame-free scalar position.
+    uint32_t code = ordinary_record;
   };
   DynamicArena arena;
   std::vector<double> adjoints;
@@ -1540,6 +1549,7 @@ struct DynamicLoopState final : KernelState {
   // structure between calls; context() refreshes every evaluation-local
   // pointer and adjoint before each reached forward or reverse callback.
   std::vector<KernelCtx> context_templates;
+  std::vector<const Node*> record_nodes;
   std::unique_ptr<DirectControlPlan> direct_control_plan;
   std::unique_ptr<LoopInvariantPlan> loop_invariant_plan;
   std::unique_ptr<InactiveControlPlan> inactive_control_plan;
@@ -1595,10 +1605,16 @@ struct DynamicLoopState final : KernelState {
       if (op.out2 >= 0) c.out2 = {nullptr, p.body.slots[op.out2].len};
       context_templates.push_back(c);
     }
+    record_nodes.assign(p.record_node_count, nullptr);
     const auto visit_workspace = [&](const auto& self, const Node& n) -> void {
       if (n.kind == Node::KernelCall) {
         if (n.op < 0 || static_cast<size_t>(n.op) >= p.body.ops.size())
           throw std::invalid_argument("dynamic structured body op is invalid");
+        if (n.record_site >= record_nodes.size() ||
+            record_nodes[n.record_site] != nullptr)
+          throw std::invalid_argument(
+              "dynamic structured record site is invalid");
+        record_nodes[n.record_site] = &n;
         inactive_scratch_size =
             std::max(inactive_scratch_size, n.kernel_scratch);
         if (n.compact_update_cell >= 0) {
@@ -1616,6 +1632,9 @@ struct DynamicLoopState final : KernelState {
       for (const auto& child : n.children) self(self, child);
     };
     visit_workspace(visit_workspace, p.root);
+    if (std::any_of(record_nodes.begin(), record_nodes.end(),
+                    [](const Node* node) { return node == nullptr; }))
+      throw std::invalid_argument("dynamic structured record site is missing");
     if (compact_adjoint_work_size < 0 ||
         static_cast<uint64_t>(compact_adjoint_work_size) >
             std::numeric_limits<size_t>::max())
@@ -1693,7 +1712,7 @@ struct DynamicLoopState final : KernelState {
 };
 static_assert(sizeof(DynamicLoopState::Ref) == 16,
               "dynamic structured references must stay compact");
-static_assert(sizeof(DynamicLoopState::Record) == 40,
+static_assert(sizeof(DynamicLoopState::Record) == 32,
               "dynamic structured reverse records must stay compact");
 static_assert(std::is_trivially_copyable_v<DynamicLoopState::Record>,
               "dynamic structured reverse records must copy by value");
@@ -2006,6 +2025,13 @@ struct DynamicExecution {
       : p(*static_cast<const StructuredLoop*>(c.udata)),
         outer(c),
         state(dynamic_state(c)) {}
+
+  const Node& record_node(const DynamicLoopState::Record& record) const {
+    if (record.site >= state.record_nodes.size() ||
+        !state.record_nodes[record.site])
+      throw std::logic_error("dynamic structured record site is invalid");
+    return *state.record_nodes[record.site];
+  }
 
   DynamicLoopState::Ref& ordinary_ref(double h) {
     const int64_t id = offset(h);
@@ -2693,9 +2719,9 @@ struct DynamicExecution {
       if (active) retained = add(retained, 1);
       if (active) {
         if (retained >= retained_frame_values(n)) return false;
-      } else if (add(retained, 7) >= c.out.len) {
+      } else if (add(retained, 6) >= c.out.len) {
         // Inactive ordinary calls retain only the output buffer. A compact
-        // delta also adds one 16-byte Ref and one 40-byte Record, so demand a
+        // delta also adds one 16-byte Ref and one 32-byte Record, so demand a
         // strict total-byte win rather than comparing arena values alone.
         return false;
       }
@@ -2712,11 +2738,11 @@ struct DynamicExecution {
       const double out =
           make_ref(c.out.data, c.out.len, active, shared_adjoint);
       DynamicLoopState::Record record;
-      record.node = &n;
       record.frame = delta;
       record.out = out;
       record.out2 = static_cast<double>(selected);
-      record.undo = std::numeric_limits<int64_t>::min();
+      record.site = n.record_site;
+      record.code = DynamicLoopState::delta_record;
       state.records.push_back(record);
       for (int64_t i = 0; i < selected; ++i)
         c.out.data[static_cast<int64_t>(delta[i])] = c.in[2].data[i];
@@ -2733,14 +2759,10 @@ struct DynamicExecution {
 
     bool frame_free =
         !active || (shared_adjoint >= 0 && n.backward == set_index_backward);
-    int64_t undo = position;
-    if (frame_free) {
-      if (position > std::numeric_limits<int64_t>::max() - 2) {
-        frame_free = false;
-      } else {
-        undo = -2 - position;
-      }
-    }
+    if (frame_free &&
+        static_cast<uint64_t>(position) >
+            DynamicLoopState::max_frame_free_position)
+      frame_free = false;
 
     // Every allocation that can throw precedes the destructive write. A later
     // failure still drops the entire evaluation-local tape, but this ordering
@@ -2748,29 +2770,31 @@ struct DynamicExecution {
     const int retained_inputs = op.n_in;
     double* frame = nullptr;
     if (!frame_free) {
-      frame = state.arena.allocate(std::max(1, retained_inputs));
+      frame = state.arena.allocate(std::max(1, retained_inputs + 1));
       std::copy_n(handles, retained_inputs, frame);
+      frame[retained_inputs] = static_cast<double>(position);
     }
     const double out = make_ref(c.out.data, c.out.len, active, shared_adjoint);
     if (shared_adjoint >= 0 && c.out.len > state.compact_adjoint_work_size)
       throw std::logic_error(
           "compact structured adjoint exceeds preallocated work");
     DynamicLoopState::Record record;
-    record.node = &n;
     if (frame_free && active)
       record.rhs_handle = handles[2];
     else
       record.frame = frame;
     record.out = out;
     record.out2 = c.out.data[position];
-    record.undo = undo;
+    record.site = n.record_site;
+    record.code = frame_free ? static_cast<uint32_t>(position)
+                             : DynamicLoopState::retained_scalar_record;
     state.records.push_back(record);
     c.out.data[position] = c.in[2].data[0];
     state.bindings[static_cast<size_t>(op.out)] = out;
     if (state.allocation_profile)
       state.allocation_profile->note_compact(
-          op, frame_free ? 0 : std::max(1, retained_inputs), c.out.len, active,
-          shared_adjoint >= 0, frame_free);
+          op, frame_free ? 0 : std::max(1, retained_inputs + 1), c.out.len,
+          active, shared_adjoint >= 0, frame_free);
     return true;
   }
 
@@ -2894,7 +2918,14 @@ struct DynamicExecution {
         if (op.out2 >= 0)
           state.bindings[static_cast<size_t>(op.out2)] = out2 =
               make_ref(c.out2.data, c.out2.len, active);
-        if (active) state.records.push_back({&n, frame, out, out2, -1});
+        if (active) {
+          DynamicLoopState::Record record;
+          record.frame = frame;
+          record.out = out;
+          record.out2 = out2;
+          record.site = n.record_site;
+          state.records.push_back(record);
+        }
         if (n.compact_update_cell >= 0) {
           state.compact_primal_by_cell[static_cast<size_t>(
               n.compact_update_cell)] = c.out.data;
@@ -2960,7 +2991,9 @@ struct DynamicExecution {
 
   bool prepare_shared_compact_adjoint(const DynamicLoopState::Record& record,
                                       KernelCtx& c) {
-    if (record.undo < 0 || record.out < 0 || c.n_in != 3) return false;
+    if (record.code != DynamicLoopState::retained_scalar_record ||
+        record.out < 0 || c.n_in != 3)
+      return false;
     const double base_handle = record.frame[0];
     if (base_handle < 0) return false;
     const auto& base = ref(base_handle);
@@ -2996,18 +3029,18 @@ struct DynamicExecution {
   }
 
   void backward_delta_compact(const DynamicLoopState::Record& record) {
-    if (!record.node || record.node->op < 0 ||
-        static_cast<size_t>(record.node->op) >= p.body.ops.size() ||
+    const Node& node = record_node(record);
+    if (node.op < 0 || static_cast<size_t>(node.op) >= p.body.ops.size() ||
         !std::isfinite(record.out2) || std::trunc(record.out2) != record.out2 ||
         record.out2 < 0 || record.out2 > static_cast<double>(exact_limit))
       throw std::logic_error("delta compact structured record is invalid");
-    const Op& op = p.body.ops[static_cast<size_t>(record.node->op)];
+    const Op& op = p.body.ops[static_cast<size_t>(node.op)];
     const auto* spec = static_cast<const DynamicIndexSpec*>(op.udata);
     const int64_t selected = static_cast<int64_t>(record.out2);
     const int64_t output_len = p.body.slots[static_cast<size_t>(op.out)].len;
     const int64_t rhs_len = p.body.slots[static_cast<size_t>(op.in[2])].len;
-    if (!spec || record.node->forward != set_index_forward ||
-        record.node->backward != set_index_backward ||
+    if (!spec || node.forward != set_index_forward ||
+        node.backward != set_index_backward ||
         op.opcode != OP_SET_INDEX_DYNAMIC || op.n_in != 3 || op.out2 >= 0 ||
         selected > spec->selected_size || rhs_len != spec->selected_size ||
         output_len <= 0 || (selected > 0 && !record.frame))
@@ -3065,9 +3098,10 @@ struct DynamicExecution {
 
   void backward_frame_free_compact(const DynamicLoopState::Record& record,
                                    int64_t position) {
-    const Op& op = p.body.ops[static_cast<size_t>(record.node->op)];
+    const Node& node = record_node(record);
+    const Op& op = p.body.ops[static_cast<size_t>(node.op)];
     const int64_t output_len = p.body.slots[static_cast<size_t>(op.out)].len;
-    if (record.out < 0 || record.node->backward != set_index_backward ||
+    if (record.out < 0 || node.backward != set_index_backward ||
         op.opcode != OP_SET_INDEX_DYNAMIC || op.n_in != 3 || op.out2 >= 0 ||
         p.body.slots[static_cast<size_t>(op.in[2])].len != 1 || position < 0 ||
         position >= output_len || output_len <= 0 ||
@@ -3112,34 +3146,45 @@ struct DynamicExecution {
   void backward() {
     for (size_t i = state.records.size(); i-- > 0;) {
       const auto& record = state.records[i];
-      if (record.undo == std::numeric_limits<int64_t>::min()) {
+      const Node& node = record_node(record);
+      if (node.op < 0 || static_cast<size_t>(node.op) >= p.body.ops.size())
+        throw std::logic_error("dynamic structured record node is invalid");
+      if (record.code == DynamicLoopState::delta_record) {
         backward_delta_compact(record);
-      } else if (record.undo != -1) {
-        const bool frame_free = record.undo < -1;
-        const int64_t position = frame_free ? -(record.undo + 2) : record.undo;
+      } else if (record.code != DynamicLoopState::ordinary_record) {
+        const bool frame_free =
+            record.code != DynamicLoopState::retained_scalar_record;
+        double raw_position = frame_free
+                                  ? static_cast<double>(record.code)
+                                  : record.frame[p.body.ops[node.op].n_in];
+        if (!std::isfinite(raw_position) ||
+            std::trunc(raw_position) != raw_position || raw_position < 0 ||
+            raw_position > static_cast<double>(exact_limit))
+          throw std::logic_error(
+              "compact structured undo position is invalid");
+        const int64_t position = static_cast<int64_t>(raw_position);
         auto& output = ref(record.out);
-        const int64_t output_len =
-            p.body.slots[p.body.ops[record.node->op].out].len;
+        const int64_t output_len = p.body.slots[p.body.ops[node.op].out].len;
         if (position < 0 || position >= output_len)
           throw std::logic_error(
               "compact structured undo position out of range");
-        if (record.out >= 0 && record.node->backward) {
+        if (record.out >= 0 && node.backward) {
           if (frame_free) {
             backward_frame_free_compact(record, position);
           } else {
-            ContextLease context(*this, *record.node, record.frame, true,
-                                 record.out, -1, output.value);
+            ContextLease context(*this, node, record.frame, true, record.out,
+                                 -1, output.value);
             KernelCtx& c = context.get();
             prepare_shared_compact_adjoint(record, c);
-            record.node->backward(c);
+            node.backward(c);
           }
         }
         output.value[position] = record.out2;
-      } else if (record.node->backward) {
-        ContextLease context(*this, *record.node, record.frame, true,
-                             record.out, record.out2);
+      } else if (node.backward) {
+        ContextLease context(*this, node, record.frame, true, record.out,
+                             record.out2);
         KernelCtx& c = context.get();
-        record.node->backward(c);
+        node.backward(c);
       }
     }
   }
@@ -3828,7 +3873,7 @@ void StructuredLoop::prepare(int64_t max_bytes) {
       throw std::invalid_argument("invalid structured import");
   }
   for (int s : outputs) slot(*this, s);
-  node_count = compact_update_sites = 0;
+  node_count = record_node_count = compact_update_sites = 0;
   prepare_node(*this, root, 0, 0);
   classify_compact_updates(*this);
   bindings_offset = initial_size;

--- a/tests/fixtures/structured_direct_index.stan
+++ b/tests/fixtures/structured_direct_index.stan
@@ -6,6 +6,7 @@ model {
     int row = 1 + i % 2;
     state[row, 2] = sin(state[row, 2] + beta);
     state = state * 0.8;
+    target += sum(state[{1, 2}, 2]);
   }
   target += sum(state);
 }

--- a/tests/test_structured_loop_production.cpp
+++ b/tests/test_structured_loop_production.cpp
@@ -343,6 +343,186 @@ static void direct_index_kernel_tests() {
   check(extent_output[0] == 1 && extent_output[1] == 2 &&
             extent_output[2] == 0 && extent_output[3] == 0,
         "direct logical extent preserves output capacity and zero fill");
+
+  const Kernel* dynamic_update = find_kernel(OP_SET_INDEX_DYNAMIC);
+  check(dynamic_update && dynamic_update->forward && dynamic_update->backward,
+        "dynamic update kernel registered");
+  if (!dynamic_update || !dynamic_update->forward || !dynamic_update->backward)
+    return;
+
+  DynamicIndexSpec packed_update;
+  packed_update.matrix_leaf = true;
+  packed_update.axes = {
+      {DynamicIndexSpec::Axis::Single, 2, 1, 1, 0},
+      {DynamicIndexSpec::Axis::Range, 3, 2, 3, 1},
+  };
+  packed_update.axes[1].count_input_offset = 2;
+  packed_update.axes[1].extent_input_offset = 3;
+  packed_update.selected_size = 3;
+  double update_selectors[] = {2, 1, 3, 3};
+  double update_rhs[] = {10, 20, 30};
+  double update_seed[] = {1, 2, 3, 4, 5, 6};
+  double packed_update_output[6] = {};
+  double packed_update_base_adj[6] = {};
+  double packed_update_rhs_adj[3] = {};
+  KernelCtx packed_update_context{};
+  packed_update_context.n_in = 3;
+  packed_update_context.in[0] = {base, 6};
+  packed_update_context.in[1] = {update_selectors, 4};
+  packed_update_context.in[2] = {update_rhs, 3};
+  packed_update_context.in_adj[0] = {packed_update_base_adj, 6};
+  packed_update_context.in_adj[1] = {nullptr, 4};
+  packed_update_context.in_adj[2] = {packed_update_rhs_adj, 3};
+  packed_update_context.out = {packed_update_output, 6};
+  packed_update_context.out_adj_vec = {update_seed, 6};
+  packed_update_context.udata = &packed_update;
+  dynamic_update->forward(packed_update_context);
+  dynamic_update->backward(packed_update_context);
+
+  DynamicIndexSpec direct_update = packed_update;
+  direct_update.input_count = 6;
+  direct_update.rhs_input = 5;
+  direct_update.axes[0].selector_input = 1;
+  direct_update.axes[0].input_offset = 0;
+  direct_update.axes[1].selector_input = 2;
+  direct_update.axes[1].input_offset = 0;
+  direct_update.axes[1].count_input = 3;
+  direct_update.axes[1].count_input_offset = 0;
+  direct_update.axes[1].extent_input = 4;
+  direct_update.axes[1].extent_input_offset = 0;
+  double update_row = 2, update_lower = 1, update_upper = 3, update_extent = 3;
+  double direct_update_output[6] = {};
+  double direct_update_base_adj[6] = {};
+  double direct_update_rhs_adj[3] = {};
+  KernelCtx direct_update_context{};
+  direct_update_context.n_in = 6;
+  direct_update_context.in[0] = {base, 6};
+  direct_update_context.in[1] = {&update_row, 1};
+  direct_update_context.in[2] = {&update_lower, 1};
+  direct_update_context.in[3] = {&update_upper, 1};
+  direct_update_context.in[4] = {&update_extent, 1};
+  direct_update_context.in[5] = {update_rhs, 3};
+  direct_update_context.in_adj[0] = {direct_update_base_adj, 6};
+  direct_update_context.in_adj[1] = {nullptr, 1};
+  direct_update_context.in_adj[2] = {nullptr, 1};
+  direct_update_context.in_adj[3] = {nullptr, 1};
+  direct_update_context.in_adj[4] = {nullptr, 1};
+  direct_update_context.in_adj[5] = {direct_update_rhs_adj, 3};
+  direct_update_context.out = {direct_update_output, 6};
+  direct_update_context.out_adj_vec = {update_seed, 6};
+  direct_update_context.udata = &direct_update;
+  dynamic_update->forward(direct_update_context);
+  dynamic_update->backward(direct_update_context);
+  check(std::memcmp(packed_update_output, direct_update_output,
+                    sizeof(packed_update_output)) == 0,
+        "direct update matches packed values bitwise");
+  check(std::memcmp(packed_update_base_adj, direct_update_base_adj,
+                    sizeof(packed_update_base_adj)) == 0 &&
+            std::memcmp(packed_update_rhs_adj, direct_update_rhs_adj,
+                        sizeof(packed_update_rhs_adj)) == 0,
+        "direct update matches packed adjoints bitwise");
+
+  direct_update_context.n_in = 5;
+  try {
+    dynamic_update->forward(direct_update_context);
+    check(false, "direct update validates input arity");
+  } catch (const std::logic_error&) {
+  }
+  direct_update_context.n_in = 6;
+  DynamicIndexSpec invalid_update = direct_update;
+  invalid_update.axes[1].count_input = invalid_update.rhs_input;
+  direct_update_context.udata = &invalid_update;
+  try {
+    dynamic_update->forward(direct_update_context);
+    check(false, "direct update rejects the RHS as a selector descriptor");
+  } catch (const std::logic_error&) {
+  }
+  invalid_update = direct_update;
+  invalid_update.rhs_input = -1;
+  direct_update_context.udata = &invalid_update;
+  try {
+    dynamic_update->forward(direct_update_context);
+    check(false, "direct update requires an explicit direct RHS");
+  } catch (const std::logic_error&) {
+  }
+  DynamicIndexSpec invalid_read = direct_spec;
+  invalid_read.rhs_input = direct_spec.input_count - 1;
+  direct.udata = &invalid_read;
+  try {
+    dynamic_index->forward(direct);
+    check(false, "direct read rejects an RHS descriptor");
+  } catch (const std::logic_error&) {
+  }
+  direct.udata = &direct_spec;
+
+  DynamicIndexSpec packed_duplicate;
+  packed_duplicate.axes = {{DynamicIndexSpec::Axis::Multi, 4, 1, 3, 0}};
+  packed_duplicate.axes[0].count_input_offset = 3;
+  packed_duplicate.selected_size = 3;
+  double duplicate_base[] = {1, 2, 3, 4};
+  double duplicate_selector[] = {2, 2, 4, 3};
+  double duplicate_values[] = {10, 20, 30};
+  double duplicate_seed[] = {1, 2, 3, 4};
+  double packed_duplicate_output[4] = {};
+  double packed_duplicate_scratch[4] = {};
+  double packed_duplicate_base_adj[4] = {};
+  double packed_duplicate_rhs_adj[3] = {};
+  KernelCtx packed_duplicate_context{};
+  packed_duplicate_context.n_in = 3;
+  packed_duplicate_context.in[0] = {duplicate_base, 4};
+  packed_duplicate_context.in[1] = {duplicate_selector, 4};
+  packed_duplicate_context.in[2] = {duplicate_values, 3};
+  packed_duplicate_context.in_adj[0] = {packed_duplicate_base_adj, 4};
+  packed_duplicate_context.in_adj[1] = {nullptr, 4};
+  packed_duplicate_context.in_adj[2] = {packed_duplicate_rhs_adj, 3};
+  packed_duplicate_context.out = {packed_duplicate_output, 4};
+  packed_duplicate_context.out_adj_vec = {duplicate_seed, 4};
+  packed_duplicate_context.scratch = packed_duplicate_scratch;
+  packed_duplicate_context.udata = &packed_duplicate;
+  dynamic_update->forward(packed_duplicate_context);
+  dynamic_update->backward(packed_duplicate_context);
+
+  DynamicIndexSpec direct_duplicate = packed_duplicate;
+  direct_duplicate.input_count = 4;
+  direct_duplicate.rhs_input = 3;
+  direct_duplicate.axes[0].selector_input = 1;
+  direct_duplicate.axes[0].input_offset = 0;
+  direct_duplicate.axes[0].count_input = 2;
+  direct_duplicate.axes[0].count_input_offset = 0;
+  double duplicate_count = 3;
+  double direct_duplicate_output[4] = {};
+  double direct_duplicate_scratch[4] = {};
+  double direct_duplicate_base_adj[4] = {};
+  double direct_duplicate_rhs_adj[3] = {};
+  KernelCtx direct_duplicate_context{};
+  direct_duplicate_context.n_in = 4;
+  direct_duplicate_context.in[0] = {duplicate_base, 4};
+  direct_duplicate_context.in[1] = {duplicate_selector, 3};
+  direct_duplicate_context.in[2] = {&duplicate_count, 1};
+  direct_duplicate_context.in[3] = {duplicate_values, 3};
+  direct_duplicate_context.in_adj[0] = {direct_duplicate_base_adj, 4};
+  direct_duplicate_context.in_adj[1] = {nullptr, 3};
+  direct_duplicate_context.in_adj[2] = {nullptr, 1};
+  direct_duplicate_context.in_adj[3] = {direct_duplicate_rhs_adj, 3};
+  direct_duplicate_context.out = {direct_duplicate_output, 4};
+  direct_duplicate_context.out_adj_vec = {duplicate_seed, 4};
+  direct_duplicate_context.scratch = direct_duplicate_scratch;
+  direct_duplicate_context.udata = &direct_duplicate;
+  dynamic_update->forward(direct_duplicate_context);
+  dynamic_update->backward(direct_duplicate_context);
+  check(std::memcmp(packed_duplicate_output, direct_duplicate_output,
+                    sizeof(packed_duplicate_output)) == 0 &&
+            std::memcmp(packed_duplicate_base_adj, direct_duplicate_base_adj,
+                        sizeof(packed_duplicate_base_adj)) == 0 &&
+            std::memcmp(packed_duplicate_rhs_adj, direct_duplicate_rhs_adj,
+                        sizeof(packed_duplicate_rhs_adj)) == 0,
+        "direct duplicate update matches packed value and adjoints bitwise");
+  check(
+      direct_duplicate_output[0] == 1 && direct_duplicate_output[1] == 20 &&
+          direct_duplicate_output[2] == 3 && direct_duplicate_output[3] == 30 &&
+          direct_duplicate_rhs_adj[0] == 0 &&
+          direct_duplicate_rhs_adj[1] == 2 && direct_duplicate_rhs_adj[2] == 4,
+      "direct duplicate update preserves last-write semantics");
 }
 
 static std::string fixture_mir(const std::string& name) {
@@ -684,12 +864,14 @@ static std::shared_ptr<StructuredLoop> nested_iterator_plan() {
 
 static std::shared_ptr<StructuredLoop> iterator_update_plan(
     void (*backward)(KernelCtx&) = trace_update_backward,
-    void (*forward)(KernelCtx&) = nullptr) {
+    void (*forward)(KernelCtx&) = nullptr, bool direct = false,
+    bool separate_extent = false) {
   auto plan = std::make_shared<StructuredLoop>();
   const int theta = plan->body.add_slot(1, false);
   const int lower = scalar(*plan, 1);
   const int upper = scalar(*plan, 3);
   const int iterator = plan->body.add_slot(1, false);
+  const int extent = scalar(*plan, 3);
   const int base = plan->body.add_slot(3, false);
   plan->fills.push_back({base, {10, 20, 30}});
   const int current = plan->body.add_slot(3, false);
@@ -701,8 +883,18 @@ static std::shared_ptr<StructuredLoop> iterator_update_plan(
   auto spec = std::make_shared<DynamicIndexSpec>();
   spec->axes = {{DynamicIndexSpec::Axis::Single, 3, 1, 1, 0}};
   spec->selected_size = 1;
-  Node update =
-      call(*plan, OP_SET_INDEX_DYNAMIC, {current, iterator, rhs}, updated);
+  spec->input_count = direct ? (separate_extent ? 4 : 3) : 0;
+  spec->rhs_input = direct ? spec->input_count - 1 : -1;
+  if (separate_extent) {
+    check(direct, "separate update extent requires direct inputs");
+    spec->axes[0].extent_input = 2;
+    spec->axes[0].extent_input_offset = 0;
+  }
+  Node update = separate_extent
+                    ? call(*plan, OP_SET_INDEX_DYNAMIC,
+                           {current, iterator, extent, rhs}, updated)
+                    : call(*plan, OP_SET_INDEX_DYNAMIC,
+                           {current, iterator, rhs}, updated);
   const int update_op = update.op;
   plan->body.ops[static_cast<size_t>(update.op)].udata = spec.get();
   plan->body.udata_pool.push_back(spec);
@@ -726,7 +918,8 @@ static std::shared_ptr<StructuredLoop> iterator_update_plan(
   return plan;
 }
 
-static std::shared_ptr<StructuredLoop> range_update_plan(bool force_ordinary) {
+static std::shared_ptr<StructuredLoop> range_update_plan(
+    bool force_ordinary, bool direct = false, bool separate_extent = false) {
   auto plan = std::make_shared<StructuredLoop>();
   const int base = plan->body.add_slot(6, false);
   const int theta = plan->body.add_slot(1, false);
@@ -735,6 +928,7 @@ static std::shared_ptr<StructuredLoop> range_update_plan(bool force_ordinary) {
   const int upper = scalar(*plan, 3);
   const int iterator = plan->body.add_slot(1, false);
   const int selector = scalar(*plan, 1);
+  const int extent = scalar(*plan, 6);
   const int weights = plan->body.add_slot(6, false);
   plan->fills.push_back({weights, {1, 2, 4, 8, 16, 32}});
   const int current = plan->body.add_slot(6, false);
@@ -752,8 +946,18 @@ static std::shared_ptr<StructuredLoop> range_update_plan(bool force_ordinary) {
   auto spec = std::make_shared<DynamicIndexSpec>();
   spec->axes = {{DynamicIndexSpec::Axis::Range, 6, 1, 2, 0}};
   spec->selected_size = 2;
-  Node update =
-      call(*plan, OP_SET_INDEX_DYNAMIC, {current, selector, rhs}, updated);
+  spec->input_count = direct ? (separate_extent ? 4 : 3) : 0;
+  spec->rhs_input = direct ? spec->input_count - 1 : -1;
+  if (separate_extent) {
+    check(direct, "separate range extent requires direct inputs");
+    spec->axes[0].extent_input = 2;
+    spec->axes[0].extent_input_offset = 0;
+  }
+  Node update = separate_extent
+                    ? call(*plan, OP_SET_INDEX_DYNAMIC,
+                           {current, selector, extent, rhs}, updated)
+                    : call(*plan, OP_SET_INDEX_DYNAMIC,
+                           {current, selector, rhs}, updated);
   const int update_op = update.op;
   plan->body.ops[static_cast<size_t>(update_op)].udata = spec.get();
   plan->body.udata_pool.push_back(spec);
@@ -761,6 +965,8 @@ static std::shared_ptr<StructuredLoop> range_update_plan(bool force_ordinary) {
   zero_spec->axes = {{DynamicIndexSpec::Axis::Range, 6, 1, 2, 0}};
   zero_spec->axes[0].count_input_offset = 1;
   zero_spec->selected_size = 2;
+  zero_spec->input_count = direct ? 3 : 0;
+  zero_spec->rhs_input = direct ? 2 : -1;
   Node zero_update = call(*plan, OP_SET_INDEX_DYNAMIC,
                           {current, zero_selector, rhs}, zero_updated);
   const int zero_update_op = zero_update.op;
@@ -1572,13 +1778,23 @@ static void compact_iterator_history_tests() {
 
   Executor frame_free(outer(iterator_update_plan(nullptr)));
   Executor retained(outer(iterator_update_plan(retained_update_backward)));
+  Executor direct_retained(outer(
+      iterator_update_plan(retained_update_backward, nullptr, true, true)));
   const Evaluation compact = evaluate(frame_free, .25, 0);
   const Evaluation reference = evaluate(retained, .25, 0);
+  const Evaluation direct_reference = evaluate(direct_retained, .25, 0);
   check(std::memcmp(&compact, &reference, sizeof(Evaluation)) == 0,
         "frame-free compact reverse has bitwise ordinary-path parity");
+  check(std::memcmp(&reference, &direct_reference, sizeof(Evaluation)) == 0,
+        "multi-descriptor retained scalar reverse has bitwise packed parity");
   const Evaluation repeated = evaluate(frame_free, .25, 0);
   check(std::memcmp(&compact, &repeated, sizeof(Evaluation)) == 0,
         "frame-free compact reverse resets between evaluations");
+  Executor direct_frame_free(
+      outer(iterator_update_plan(nullptr, nullptr, true)));
+  const Evaluation direct_compact = evaluate(direct_frame_free, .25, 0);
+  check(std::memcmp(&compact, &direct_compact, sizeof(Evaluation)) == 0,
+        "direct-input frame-free compact reverse has bitwise packed parity");
   ordinary_update_forward_calls = 0;
   Executor custom_forward(
       outer(iterator_update_plan(nullptr, ordinary_update_forward)));
@@ -1594,10 +1810,12 @@ static void compact_iterator_history_tests() {
     std::vector<std::array<double, 6>> reverse_values;
     std::vector<const double*> forward_addresses;
   };
-  const auto run_range = [](bool ordinary) {
+  const auto run_range = [](bool ordinary, bool direct = false,
+                            bool separate_extent = false) {
     range_update_reverse_values.clear();
     range_update_forward_addresses.clear();
-    Executor executor(range_update_outer(range_update_plan(ordinary)));
+    Executor executor(range_update_outer(
+        range_update_plan(ordinary, direct, separate_extent)));
     const double point[] = {10, 20, 30, 40, 50, 60, .25, -.5};
     std::copy(std::begin(point), std::end(point), executor.params_data());
     RangeEvaluation result;
@@ -1610,10 +1828,15 @@ static void compact_iterator_history_tests() {
   range_update_forward_addresses.clear();
   const RangeEvaluation delta = run_range(false);
   const RangeEvaluation ordinary = run_range(true);
+  const RangeEvaluation direct_delta = run_range(false, true, true);
   check(std::memcmp(&delta.value, &ordinary.value, sizeof(double)) == 0 &&
             std::memcmp(delta.gradient, ordinary.gradient,
                         sizeof(delta.gradient)) == 0,
         "ordered range delta has bitwise ordinary-path parity");
+  check(std::memcmp(&delta.value, &direct_delta.value, sizeof(double)) == 0 &&
+            std::memcmp(delta.gradient, direct_delta.gradient,
+                        sizeof(delta.gradient)) == 0,
+        "multi-descriptor range delta has bitwise packed parity");
   check(
       ordinary_update_forward_calls == 4 && ordinary_update_backward_calls == 4,
       "custom ordered range callbacks force the ordinary path");
@@ -1628,7 +1851,8 @@ static void compact_iterator_history_tests() {
       {{.25, -.5, 30, 40, 50, 60}},
   };
   check(delta.reverse_values == expected_reverse &&
-            ordinary.reverse_values == expected_reverse,
+            ordinary.reverse_values == expected_reverse &&
+            direct_delta.reverse_values == expected_reverse,
         "ordered range delta restores historical primals in LIFO order");
   check(delta.forward_addresses.size() == 3 &&
             delta.forward_addresses[0] == delta.forward_addresses[1] &&
@@ -3189,16 +3413,25 @@ static void direct_index_lowering_tests() {
   const StructuredLoop* packed_plan = retained(packed);
   check(direct_plan && packed_plan,
         "direct-index ablation keeps structured execution");
-  size_t direct_reads = 0, direct_concats = 0, packed_reads = 0,
-         packed_concats = 0;
+  if (direct_plan && packed_plan)
+    check(direct_plan->compact_update_sites ==
+                  packed_plan->compact_update_sites &&
+              direct_plan->compact_update_sites > 0,
+          "direct updates preserve compact-update admission");
+  size_t direct_reads = 0, direct_updates = 0, direct_concats = 0,
+         packed_reads = 0, packed_updates = 0, packed_concats = 0;
   bool direct_multi_selector = false;
   if (direct_plan)
     for (const auto& op : direct_plan->body.ops) {
       direct_concats += op.opcode == OP_CONCAT2;
       if (op.opcode == OP_SET_INDEX_DYNAMIC) {
         const auto* spec = static_cast<const DynamicIndexSpec*>(op.udata);
-        check(spec && spec->input_count == 0 && op.n_in == 3,
-              "indexed updates preserve the packed ABI");
+        if (spec && spec->input_count > 0) {
+          ++direct_updates;
+          check(op.n_in == spec->input_count && op.n_in >= 4 && op.n_in <= 6 &&
+                    spec->rhs_input == op.n_in - 1,
+                "indexed updates bind direct selectors before the RHS");
+        }
       } else if (op.opcode == OP_INDEX_DYNAMIC) {
         const auto* spec = static_cast<const DynamicIndexSpec*>(op.udata);
         if (spec && spec->input_count > 0) {
@@ -3214,16 +3447,26 @@ static void direct_index_lowering_tests() {
   if (packed_plan)
     for (const auto& op : packed_plan->body.ops) {
       packed_concats += op.opcode == OP_CONCAT2;
-      if (op.opcode != OP_INDEX_DYNAMIC) continue;
+      if (op.opcode == OP_INDEX_DYNAMIC) {
       ++packed_reads;
       const auto* spec = static_cast<const DynamicIndexSpec*>(op.udata);
-      check(spec && spec->input_count == 0 && op.n_in == 2,
+        check(spec && spec->input_count == 0 && spec->rhs_input == -1 &&
+                  op.n_in == 2,
             "direct-index ablation preserves packed read ABI");
+      } else if (op.opcode == OP_SET_INDEX_DYNAMIC) {
+        ++packed_updates;
+        const auto* spec = static_cast<const DynamicIndexSpec*>(op.udata);
+        check(spec && spec->input_count == 0 && spec->rhs_input == -1 &&
+                  op.n_in == 3,
+              "direct-index ablation preserves packed update ABI");
+      }
     }
   check(direct_reads > 0 && packed_reads >= direct_reads,
         "structured model exposes direct-index read sites");
   check(direct_multi_selector,
         "fixed-capacity multi-index binds a direct data operand");
+  check(direct_updates > 0 && packed_updates >= direct_updates,
+        "structured model exposes direct-index update sites");
   check(direct_concats < packed_concats,
         "direct selectors remove packing operations");
   compare_gradients(direct, packed, {{.1, .7}, {-.2, .3}, {0, .5}},

--- a/tests/test_structured_loop_production.cpp
+++ b/tests/test_structured_loop_production.cpp
@@ -2782,6 +2782,7 @@ static void direct_index_lowering_tests() {
         "direct-index ablation keeps structured execution");
   size_t direct_reads = 0, direct_concats = 0, packed_reads = 0,
          packed_concats = 0;
+  bool direct_multi_selector = false;
   if (direct_plan)
     for (const auto& op : direct_plan->body.ops) {
       direct_concats += op.opcode == OP_CONCAT2;
@@ -2794,7 +2795,10 @@ static void direct_index_lowering_tests() {
         if (spec && spec->input_count > 0) {
           ++direct_reads;
           check(op.n_in == spec->input_count && op.n_in == 3,
-                "two-axis read binds direct scalar selector inputs");
+                "two-axis read binds direct selector inputs");
+          direct_multi_selector |=
+              direct_plan->body.slots[static_cast<size_t>(op.in[1])].len > 1 ||
+              direct_plan->body.slots[static_cast<size_t>(op.in[2])].len > 1;
         }
       }
     }
@@ -2809,8 +2813,10 @@ static void direct_index_lowering_tests() {
     }
   check(direct_reads > 0 && packed_reads >= direct_reads,
         "structured model exposes direct-index read sites");
+  check(direct_multi_selector,
+        "fixed-capacity multi-index binds a direct data operand");
   check(direct_concats < packed_concats,
-        "direct scalar selectors remove packing operations");
+        "direct selectors remove packing operations");
   compare_gradients(direct, packed, {{.1, .7}, {-.2, .3}, {0, .5}},
                     "direct-index value parity",
                     "direct-index gradient parity");

--- a/tests/test_structured_loop_production.cpp
+++ b/tests/test_structured_loop_production.cpp
@@ -477,6 +477,7 @@ static Evaluation evaluate(Executor& executor, double theta, double beta);
 
 static std::vector<double> iterator_forward_values;
 static std::vector<double> iterator_reverse_values;
+static std::vector<std::array<double, 3>> update_reverse_values;
 static bool iterator_throw_once = false;
 
 static void trace_iterator_forward(KernelCtx& context) {
@@ -491,6 +492,12 @@ static void trace_iterator_forward(KernelCtx& context) {
 static void trace_iterator_backward(KernelCtx& context) {
   iterator_reverse_values.push_back(context.in[1].data[0]);
   find_kernel(OP_MUL)->backward(context);
+}
+
+static void trace_update_backward(KernelCtx& context) {
+  update_reverse_values.push_back(
+      {context.in[0].data[0], context.in[0].data[1], context.in[0].data[2]});
+  find_kernel(OP_SET_INDEX_DYNAMIC)->backward(context);
 }
 
 static std::shared_ptr<StructuredLoop> iterator_history_plan() {
@@ -604,6 +611,7 @@ static std::shared_ptr<StructuredLoop> iterator_update_plan() {
   spec->selected_size = 1;
   Node update =
       call(*plan, OP_SET_INDEX_DYNAMIC, {current, iterator, rhs}, updated);
+  const int update_op = update.op;
   plan->body.ops[static_cast<size_t>(update.op)].udata = spec.get();
   plan->body.udata_pool.push_back(spec);
   plan->root =
@@ -617,6 +625,8 @@ static std::shared_ptr<StructuredLoop> iterator_update_plan() {
   plan->dynamic_history = true;
   check(plan->compact_update_sites == 1,
         "iterator update plan selects compact history");
+  check(set_backward(plan->root, update_op, trace_update_backward),
+        "find compact-update trace backward callback");
   return plan;
 }
 
@@ -679,12 +689,17 @@ static void compact_iterator_history_tests() {
   close(nested_result.gradient[0], 12, "nested inline iterator theta gradient");
   close(nested_result.gradient[1], 0, "nested inline iterator beta gradient");
 
+  update_reverse_values.clear();
   Executor update(outer(iterator_update_plan()));
   const Evaluation updated = evaluate(update, .25, 0);
   close(updated.value, 1.5, "inline iterator compact-update value");
   close(updated.gradient[0], 6,
         "inline iterator compact-update theta gradient");
   close(updated.gradient[1], 0, "inline iterator compact-update beta gradient");
+  check(update_reverse_values ==
+            std::vector<std::array<double, 3>>(
+                {{{.25, .5, .75}}, {{.25, .5, 30}}, {{10, 20, 30}}}),
+        "compact-update reverse restores overwritten values in LIFO order");
 }
 
 static std::shared_ptr<StructuredLoop> integer_history_plan() {

--- a/tests/test_structured_loop_production.cpp
+++ b/tests/test_structured_loop_production.cpp
@@ -521,6 +521,8 @@ static std::vector<const double*> range_update_forward_addresses;
 static bool iterator_throw_once = false;
 static int ordinary_update_forward_calls = 0;
 static int ordinary_update_backward_calls = 0;
+static int ordinary_index_forward_calls = 0;
+static int ordinary_index_backward_calls = 0;
 static int duplicate_site_backward_calls = 0;
 
 static void trace_iterator_forward(KernelCtx& context) {
@@ -555,6 +557,16 @@ static void ordinary_update_forward(KernelCtx& context) {
 static void ordinary_update_backward(KernelCtx& context) {
   ++ordinary_update_backward_calls;
   find_kernel(OP_SET_INDEX_DYNAMIC)->backward(context);
+}
+
+static void ordinary_index_forward(KernelCtx& context) {
+  ++ordinary_index_forward_calls;
+  find_kernel(OP_INDEX_DYNAMIC)->forward(context);
+}
+
+static void ordinary_index_backward(KernelCtx& context) {
+  ++ordinary_index_backward_calls;
+  find_kernel(OP_INDEX_DYNAMIC)->backward(context);
 }
 
 static void duplicate_site_backward(KernelCtx& context) {
@@ -1052,6 +1064,239 @@ static std::shared_ptr<StructuredLoop> duplicate_record_site_plan() {
         "duplicate operation nodes receive distinct record sites");
   plan->root.children[1].backward = duplicate_site_backward;
   return plan;
+}
+
+static std::shared_ptr<StructuredLoop> scalar_index_loop_plan(
+    bool direct, bool force_ordinary) {
+  auto plan = std::make_shared<StructuredLoop>();
+  const int base = plan->body.add_slot(3, false);
+  const int theta = plan->body.add_slot(1, false);
+  const int one = scalar(*plan, 1);
+  const int three = scalar(*plan, 3);
+  const int iterator = plan->body.add_slot(1, false);
+  const int selected = plan->body.add_slot(1, false);
+  const int term = plan->body.add_slot(1, false);
+  const int zero = scalar(*plan, 0);
+  const int total = plan->body.add_slot(1, false);
+  const int next = plan->body.add_slot(1, false);
+  plan->imports = {{base, 0, 1}, {theta, 1, 0}};
+
+  auto spec = std::make_shared<DynamicIndexSpec>();
+  spec->axes = {{DynamicIndexSpec::Axis::Single, 3, 1, 1, 0}};
+  spec->selected_size = 1;
+  spec->input_count = direct ? 2 : 0;
+  Node index = call(*plan, OP_INDEX_DYNAMIC, {base, iterator}, selected);
+  const int index_op = index.op;
+  plan->body.ops[static_cast<size_t>(index_op)].udata = spec.get();
+  plan->body.udata_pool.push_back(spec);
+  plan->root = sequence(
+      {alias(total, zero),
+       counted(one, three, iterator, 3,
+               sequence({std::move(index),
+                         call(*plan, OP_MUL, {selected, theta}, term),
+                         call(*plan, OP_ADD, {total, term}, next),
+                         alias(total, next)}))});
+  plan->outputs = {total};
+  plan->prepare(1 << 20);
+  plan->dynamic_history = true;
+  if (force_ordinary) {
+    check(set_forward(plan->root, index_op, ordinary_index_forward),
+          "find scalar index forward callback");
+    check(set_backward(plan->root, index_op, ordinary_index_backward),
+          "find scalar index backward callback");
+  }
+  return plan;
+}
+
+static Graph scalar_index_loop_outer(std::shared_ptr<StructuredLoop> plan) {
+  Graph graph;
+  graph.add_slot(5, true);
+  graph.add_slot(1, true);
+  const int output = graph.add_slot(1, false);
+  const int op = graph.add_op(OP_LOOP, {0, 1}, output);
+  graph.ops[op].udata = plan.get();
+  graph.udata_pool.push_back(std::move(plan));
+  graph.result_slot = output;
+  return graph;
+}
+
+static std::shared_ptr<StructuredLoop> zero_scalar_index_plan(bool invalid) {
+  auto plan = std::make_shared<StructuredLoop>();
+  const int base = plan->body.add_slot(4, false);
+  const int selectors = plan->body.add_slot(3, false);
+  plan->fills.push_back({selectors, {1, 0, invalid ? 3.0 : 2.0}});
+  const int result = plan->body.add_slot(1, false);
+  plan->imports = {{base, 0, 0}};
+
+  auto spec = std::make_shared<DynamicIndexSpec>();
+  spec->axes = {
+      {DynamicIndexSpec::Axis::Range, 2, 2, 1, 0},
+      {DynamicIndexSpec::Axis::Single, 2, 1, 1, 2},
+  };
+  spec->axes[0].count_input_offset = 1;
+  spec->selected_size = 1;
+  Node index = call(*plan, OP_INDEX_DYNAMIC, {base, selectors}, result);
+  plan->body.ops[static_cast<size_t>(index.op)].udata = spec.get();
+  plan->body.udata_pool.push_back(spec);
+  plan->root = std::move(index);
+  plan->outputs = {result};
+  plan->prepare(1 << 20);
+  plan->dynamic_history = true;
+  return plan;
+}
+
+static Graph zero_scalar_index_outer(std::shared_ptr<StructuredLoop> plan) {
+  Graph graph;
+  graph.add_slot(4, true);
+  const int output = graph.add_slot(1, false);
+  const int op = graph.add_op(OP_LOOP, {0}, output);
+  graph.ops[op].udata = plan.get();
+  graph.udata_pool.push_back(std::move(plan));
+  graph.result_slot = output;
+  return graph;
+}
+
+static std::shared_ptr<StructuredLoop> selector_only_scalar_index_plan() {
+  auto plan = std::make_shared<StructuredLoop>();
+  const int selector = plan->body.add_slot(1, false);
+  const int base = plan->body.add_slot(3, false);
+  plan->fills.push_back({base, {10, 20, 30}});
+  const int result = plan->body.add_slot(1, false);
+  plan->imports = {{selector, 0, 0}};
+  auto spec = std::make_shared<DynamicIndexSpec>();
+  spec->axes = {{DynamicIndexSpec::Axis::Single, 3, 1, 1, 0}};
+  spec->selected_size = 1;
+  Node index = call(*plan, OP_INDEX_DYNAMIC, {base, selector}, result);
+  plan->body.ops[static_cast<size_t>(index.op)].udata = spec.get();
+  plan->body.udata_pool.push_back(spec);
+  plan->root = std::move(index);
+  plan->outputs = {result};
+  plan->prepare(1 << 20);
+  plan->dynamic_history = true;
+  return plan;
+}
+
+static std::shared_ptr<StructuredLoop> scalar_index_after_updates_plan() {
+  auto plan = std::make_shared<StructuredLoop>();
+  const int base = plan->body.add_slot(3, false);
+  const int theta = plan->body.add_slot(1, false);
+  const int one = scalar(*plan, 1);
+  const int two = scalar(*plan, 2);
+  const int iterator = plan->body.add_slot(1, false);
+  const int current = plan->body.add_slot(3, false);
+  const int rhs = plan->body.add_slot(1, false);
+  const int updated = plan->body.add_slot(3, false);
+  const int selected = plan->body.add_slot(1, false);
+  plan->imports = {{base, 0, 0}, {theta, 1, 0}};
+
+  auto update_spec = std::make_shared<DynamicIndexSpec>();
+  update_spec->axes = {{DynamicIndexSpec::Axis::Single, 3, 1, 1, 0}};
+  update_spec->selected_size = 1;
+  Node update =
+      call(*plan, OP_SET_INDEX_DYNAMIC, {current, iterator, rhs}, updated);
+  plan->body.ops[static_cast<size_t>(update.op)].udata = update_spec.get();
+  plan->body.udata_pool.push_back(update_spec);
+  auto index_spec = std::make_shared<DynamicIndexSpec>();
+  index_spec->axes = {{DynamicIndexSpec::Axis::Single, 3, 1, 1, 0}};
+  index_spec->selected_size = 1;
+  Node index = call(*plan, OP_INDEX_DYNAMIC, {current, two}, selected);
+  plan->body.ops[static_cast<size_t>(index.op)].udata = index_spec.get();
+  plan->body.udata_pool.push_back(index_spec);
+  plan->root = sequence(
+      {alias(current, base),
+       counted(one, two, iterator, 2,
+               sequence({call(*plan, OP_MUL, {theta, iterator}, rhs),
+                         std::move(update), alias(current, updated)})),
+       std::move(index)});
+  plan->outputs = {selected};
+  plan->prepare(1 << 20);
+  plan->dynamic_history = true;
+  check(plan->compact_update_sites == 1,
+        "scalar index integration retains compact update site");
+  return plan;
+}
+
+static Graph scalar_index_after_updates_outer(
+    std::shared_ptr<StructuredLoop> plan) {
+  Graph graph;
+  graph.add_slot(3, true);
+  graph.add_slot(1, true);
+  const int output = graph.add_slot(1, false);
+  const int op = graph.add_op(OP_LOOP, {0, 1}, output);
+  graph.ops[op].udata = plan.get();
+  graph.udata_pool.push_back(std::move(plan));
+  graph.result_slot = output;
+  return graph;
+}
+
+static void compact_scalar_index_tests() {
+  const double point[] = {7, 1e16, -1e16, 1, 9, .25};
+  const double expected_gradient[] = {0, .25, .25, .25, 0, 0};
+  for (bool direct : {false, true}) {
+    ordinary_index_forward_calls = ordinary_index_backward_calls = 0;
+    Executor compact(scalar_index_loop_outer(
+        scalar_index_loop_plan(direct, false)));
+    Executor ordinary(scalar_index_loop_outer(
+        scalar_index_loop_plan(direct, true)));
+    std::copy(std::begin(point), std::end(point), compact.params_data());
+    std::copy(std::begin(point), std::end(point), ordinary.params_data());
+    double compact_gradient[6] = {};
+    double ordinary_gradient[6] = {};
+    const double compact_value = compact.gradient(compact_gradient);
+    const double ordinary_value = ordinary.gradient(ordinary_gradient);
+    check(std::memcmp(&compact_value, &ordinary_value, sizeof(double)) == 0 &&
+              std::memcmp(compact_gradient, ordinary_gradient,
+                          sizeof(compact_gradient)) == 0,
+          "compact scalar index has bitwise ordinary-path parity");
+    check(ordinary_index_forward_calls == 3 &&
+              ordinary_index_backward_calls == 3,
+          "custom scalar index callbacks force ordinary history");
+    close(compact_value, .25, "compact scalar index value");
+    for (size_t i = 0; i < std::size(expected_gradient); ++i)
+      close(compact_gradient[i], expected_gradient[i],
+            "compact scalar index gradient");
+  }
+
+  Executor zero(zero_scalar_index_outer(zero_scalar_index_plan(false)));
+  const double zero_point[] = {1, 2, 3, 4};
+  std::copy(std::begin(zero_point), std::end(zero_point), zero.params_data());
+  double zero_gradient[4] = {};
+  close(zero.gradient(zero_gradient), 0,
+        "compact scalar index supports an empty reached selection");
+  check(std::all_of(std::begin(zero_gradient), std::end(zero_gradient),
+                    [](double value) { return value == 0; }),
+        "empty compact scalar index does not scatter an adjoint");
+
+  Executor invalid(zero_scalar_index_outer(zero_scalar_index_plan(true)));
+  std::copy(std::begin(zero_point), std::end(zero_point),
+            invalid.params_data());
+  try {
+    (void)invalid.gradient(zero_gradient);
+    check(false, "empty scalar index validates every other selector");
+  } catch (const std::out_of_range&) {
+  }
+
+  Executor selector_only(outer(selector_only_scalar_index_plan()));
+  const Evaluation selector_result = evaluate(selector_only, 2, 0);
+  close(selector_result.value, 20,
+        "selector-only active scalar index value");
+  close(selector_result.gradient[0], 0,
+        "scalar index does not differentiate its selector");
+  close(selector_result.gradient[1], 0,
+        "unused scalar index input has zero gradient");
+
+  Executor updated(scalar_index_after_updates_outer(
+      scalar_index_after_updates_plan()));
+  const double updated_point[] = {10, 20, 30, .25};
+  std::copy(std::begin(updated_point), std::end(updated_point),
+            updated.params_data());
+  double updated_gradient[4] = {};
+  close(updated.gradient(updated_gradient), .5,
+        "scalar index reads a compactly updated value");
+  const double expected_updated_gradient[] = {0, 0, 0, 2};
+  for (size_t i = 0; i < std::size(expected_updated_gradient); ++i)
+    close(updated_gradient[i], expected_updated_gradient[i],
+          "scalar index routes through a shared update adjoint");
 }
 
 static void compact_iterator_history_tests() {
@@ -2597,6 +2842,7 @@ int main() {
   direct_index_kernel_tests();
   forced_control_tests();
   dynamic_history_tests();
+  compact_scalar_index_tests();
   compact_iterator_history_tests();
   compact_integer_result_tests();
   loop_invariant_reuse_tests();

--- a/tests/test_structured_loop_production.cpp
+++ b/tests/test_structured_loop_production.cpp
@@ -1790,6 +1790,16 @@ static void compact_iterator_history_tests() {
   const Evaluation repeated = evaluate(frame_free, .25, 0);
   check(std::memcmp(&compact, &repeated, sizeof(Evaluation)) == 0,
         "frame-free compact reverse resets between evaluations");
+  test_unsetenv("STANLI_NO_STRUCTURED_SHARED_UPDATE_REFS");
+  Executor shared_ref(outer(iterator_update_plan(nullptr)));
+  const Evaluation reused_ref = evaluate(shared_ref, .25, 0);
+  test_setenv("STANLI_NO_STRUCTURED_SHARED_UPDATE_REFS", "1");
+  const Evaluation distinct_ref = evaluate(shared_ref, .25, 0);
+  test_unsetenv("STANLI_NO_STRUCTURED_SHARED_UPDATE_REFS");
+  const Evaluation reused_again = evaluate(shared_ref, .25, 0);
+  check(std::memcmp(&reused_ref, &distinct_ref, sizeof(Evaluation)) == 0 &&
+            std::memcmp(&reused_ref, &reused_again, sizeof(Evaluation)) == 0,
+        "shared compact-update Ref reuse has bitwise ablation parity");
   Executor direct_frame_free(
       outer(iterator_update_plan(nullptr, nullptr, true)));
   const Evaluation direct_compact = evaluate(direct_frame_free, .25, 0);
@@ -2738,6 +2748,7 @@ static std::atomic<int> invariant_first_calls{0};
 static std::atomic<int> invariant_second_calls{0};
 static std::atomic<int> invariant_active_calls{0};
 static std::atomic<int> invariant_variant_calls{0};
+static std::atomic<int> compact_dependent_compare_calls{0};
 
 static void count_invariant_first(KernelCtx& context) {
   ++invariant_first_calls;
@@ -2758,6 +2769,11 @@ static void count_invariant_active(KernelCtx& context) {
 static void count_invariant_variant(KernelCtx& context) {
   ++invariant_variant_calls;
   find_kernel(OP_ADD)->forward(context);
+}
+
+static void count_compact_dependent_compare(KernelCtx& context) {
+  ++compact_dependent_compare_calls;
+  find_kernel(OP_COMPARE)->forward(context);
 }
 
 static std::shared_ptr<StructuredLoop> invariant_plan(int trips) {
@@ -2802,6 +2818,55 @@ static std::shared_ptr<StructuredLoop> invariant_plan(int trips) {
   return plan;
 }
 
+static std::shared_ptr<StructuredLoop> compact_invariant_guard_plan() {
+  auto plan = std::make_shared<StructuredLoop>();
+  const int theta = plan->body.add_slot(1, false);
+  const int one = scalar(*plan, 1);
+  const int three = scalar(*plan, 3);
+  const int threshold = scalar(*plan, .3);
+  const int zero = scalar(*plan, 0);
+  const int iterator = plan->body.add_slot(1, false);
+  const int base = plan->body.add_slot(1, false);
+  plan->fills.push_back({base, {0}});
+  const int current = plan->body.add_slot(1, false);
+  const int rhs = plan->body.add_slot(1, false);
+  const int updated = plan->body.add_slot(1, false);
+  const int compared = plan->body.add_slot(1, false);
+  const int term = plan->body.add_slot(1, false);
+  const int result = plan->body.add_slot(1, false);
+  const int next = plan->body.add_slot(1, false);
+  plan->imports = {{theta, 0, 0}};
+
+  auto spec = std::make_shared<DynamicIndexSpec>();
+  spec->axes = {{DynamicIndexSpec::Axis::Single, 1, 1, 1, 0}};
+  spec->selected_size = 1;
+  Node update =
+      call(*plan, OP_SET_INDEX_DYNAMIC, {current, one, rhs}, updated);
+  plan->body.ops[static_cast<size_t>(update.op)].udata = spec.get();
+  plan->body.udata_pool.push_back(spec);
+  Node comparison = call(*plan, OP_COMPARE, {current, threshold}, compared);
+  const int comparison_op = comparison.op;
+  plan->body.ops[static_cast<size_t>(comparison_op)].variant = 2;
+  plan->root = sequence(
+      {alias(current, base), alias(result, zero),
+       counted(one, three, iterator, 3,
+               sequence({call(*plan, OP_MUL, {theta, iterator}, rhs),
+                         std::move(update), alias(current, updated),
+                         std::move(comparison),
+                         call(*plan, OP_MUL, {theta, compared}, term),
+                         call(*plan, OP_ADD, {result, term}, next),
+                         alias(result, next)}))});
+  plan->outputs = {result};
+  plan->prepare(1 << 20);
+  plan->dynamic_history = true;
+  check(plan->compact_update_sites == 1,
+        "compact invariant guard selects compact history");
+  check(set_forward(plan->root, comparison_op,
+                    count_compact_dependent_compare),
+        "find compact-dependent comparison callback");
+  return plan;
+}
+
 static Evaluation evaluate_invariant(Executor& executor, double theta) {
   executor.params_data()[0] = theta;
   executor.params_data()[1] = 0;
@@ -2838,6 +2903,30 @@ static void loop_invariant_reuse_tests() {
         "invariant ablation executes every reached callback");
   check(std::memcmp(&first, &baseline, sizeof(Evaluation)) == 0,
         "invariant reuse has bitwise same-binary parity");
+
+  // Compact versions can deliberately reuse one physical handle. Their
+  // entire alias root must remain outside the handle-keyed invariant cache,
+  // including data-only consumers whose output is used by active work.
+  test_unsetenv("STANLI_NO_STRUCTURED_SHARED_UPDATE_REFS");
+  compact_dependent_compare_calls = 0;
+  Executor compact_guard(outer(compact_invariant_guard_plan()));
+  const Evaluation compact_guard_reused =
+      evaluate_invariant(compact_guard, .25);
+  check(compact_dependent_compare_calls == 3,
+        "compact-dependent data work recomputes with shared handles");
+  close(compact_guard_reused.value, .5,
+        "compact-dependent data work preserves changing values");
+  close(compact_guard_reused.gradient[0], 2,
+        "compact-dependent data work preserves active gradients");
+  test_setenv("STANLI_NO_STRUCTURED_SHARED_UPDATE_REFS", "1");
+  compact_dependent_compare_calls = 0;
+  const Evaluation compact_guard_distinct =
+      evaluate_invariant(compact_guard, .25);
+  test_unsetenv("STANLI_NO_STRUCTURED_SHARED_UPDATE_REFS");
+  check(compact_dependent_compare_calls == 3 &&
+            std::memcmp(&compact_guard_reused, &compact_guard_distinct,
+                        sizeof(Evaluation)) == 0,
+        "compact-dependent data work has bitwise Ref-ablation parity");
 
   auto zero = invariant_plan(0);
   Executor zero_executor(outer(zero));
@@ -3495,6 +3584,7 @@ static void direct_index_lowering_tests() {
 
 int main() {
   test_unsetenv("STANLI_STRUCTURED_LOOP_DIAGNOSTICS");
+  test_unsetenv("STANLI_NO_STRUCTURED_SHARED_UPDATE_REFS");
   runtime_trip_tests();
   compact_import_reference_tests();
   direct_index_kernel_tests();
@@ -3516,6 +3606,7 @@ int main() {
   test_unsetenv("STANLI_NO_STRUCTURED_INACTIVE_WORKSPACE");
   test_unsetenv("STANLI_NO_STRUCTURED_DIRECT_INDEX_INPUTS");
   test_unsetenv("STANLI_NO_STRUCTURED_RECORD_SCALARS");
+  test_unsetenv("STANLI_NO_STRUCTURED_SHARED_UPDATE_REFS");
   if (failures == 0) std::printf("test_structured_loop_production OK\n");
   return failures != 0;
 }

--- a/tests/test_structured_loop_production.cpp
+++ b/tests/test_structured_loop_production.cpp
@@ -838,6 +838,141 @@ static std::shared_ptr<StructuredLoop> inactive_range_update_plan(
   return plan;
 }
 
+static std::shared_ptr<StructuredLoop> aliased_update_plan(
+    bool force_ordinary) {
+  auto plan = std::make_shared<StructuredLoop>();
+  const int theta = plan->body.add_slot(1, false);
+  const int one = scalar(*plan, 1);
+  const int two = scalar(*plan, 2);
+  const int three = scalar(*plan, 3);
+  const int base = plan->body.add_slot(3, false);
+  plan->fills.push_back({base, {10, 20, 30}});
+  const int current = plan->body.add_slot(3, false);
+  const int snapshot1 = plan->body.add_slot(3, false);
+  const int snapshot2 = plan->body.add_slot(3, false);
+  const int rhs1 = plan->body.add_slot(1, false);
+  const int rhs2 = plan->body.add_slot(1, false);
+  const int rhs3 = plan->body.add_slot(1, false);
+  const int updated1_slot = plan->body.add_slot(3, false);
+  const int updated2_slot = plan->body.add_slot(3, false);
+  const int updated3_slot = plan->body.add_slot(3, false);
+  const int observed1 = plan->body.add_slot(1, false);
+  const int observed2 = plan->body.add_slot(1, false);
+  const int observed3 = plan->body.add_slot(1, false);
+  const int snapshot_sum1 = plan->body.add_slot(1, false);
+  const int snapshot_sum2 = plan->body.add_slot(1, false);
+  const int current_sum = plan->body.add_slot(1, false);
+  const int snapshot_total = plan->body.add_slot(1, false);
+  const int result = plan->body.add_slot(1, false);
+  plan->imports = {{theta, 0, 0}};
+
+  auto spec = std::make_shared<DynamicIndexSpec>();
+  spec->axes = {{DynamicIndexSpec::Axis::Single, 3, 1, 1, 0}};
+  spec->selected_size = 1;
+  Node update1 =
+      call(*plan, OP_SET_INDEX_DYNAMIC, {current, one, rhs1}, updated1_slot);
+  Node update2 =
+      call(*plan, OP_SET_INDEX_DYNAMIC, {current, two, rhs2}, updated2_slot);
+  Node update3 =
+      call(*plan, OP_SET_INDEX_DYNAMIC, {current, three, rhs3}, updated3_slot);
+  const int update_ops[] = {update1.op, update2.op, update3.op};
+  for (int op : update_ops)
+    plan->body.ops[static_cast<size_t>(op)].udata = spec.get();
+  plan->body.udata_pool.push_back(spec);
+  Node observe1 = call(*plan, OP_SUM_VEC, {current}, observed1);
+  Node observe2 = call(*plan, OP_SUM_VEC, {current}, observed2);
+  Node observe3 = call(*plan, OP_SUM_VEC, {current}, observed3);
+  const int observer_ops[] = {observe1.op, observe2.op, observe3.op};
+  plan->root = sequence(
+      {alias(current, base), call(*plan, OP_MUL, {theta, one}, rhs1),
+       std::move(update1), alias(current, updated1_slot), std::move(observe1),
+       alias(snapshot1, current), alias(snapshot2, current),
+       call(*plan, OP_MUL, {theta, two}, rhs2), std::move(update2),
+       alias(current, updated2_slot), std::move(observe2),
+       call(*plan, OP_MUL, {theta, three}, rhs3), std::move(update3),
+       alias(current, updated3_slot), std::move(observe3),
+       call(*plan, OP_SUM_VEC, {snapshot1}, snapshot_sum1),
+       call(*plan, OP_SUM_VEC, {snapshot2}, snapshot_sum2),
+       call(*plan, OP_SUM_VEC, {current}, current_sum),
+       call(*plan, OP_ADD, {snapshot_sum1, snapshot_sum2}, snapshot_total),
+       call(*plan, OP_ADD, {snapshot_total, current_sum}, result)});
+  plan->outputs = {result};
+  plan->prepare(1 << 20);
+  plan->dynamic_history = true;
+  check(plan->compact_update_sites == 3,
+        "outgoing alias keeps compact update sites eligible");
+  for (int op : observer_ops)
+    check(set_forward(plan->root, op, trace_range_sum_forward),
+          "find aliased update address observer");
+  if (force_ordinary) {
+    for (int op : update_ops) {
+      check(set_forward(plan->root, op, ordinary_update_forward),
+            "find aliased update forward callback");
+      check(set_backward(plan->root, op, ordinary_update_backward),
+            "find aliased update backward callback");
+    }
+  }
+  return plan;
+}
+
+static std::shared_ptr<StructuredLoop> loop_aliased_update_plan(
+    bool force_ordinary) {
+  auto plan = std::make_shared<StructuredLoop>();
+  const int theta = plan->body.add_slot(1, false);
+  const int lower = scalar(*plan, 1);
+  const int upper = scalar(*plan, 3);
+  const int iterator = plan->body.add_slot(1, false);
+  const int base = plan->body.add_slot(3, false);
+  plan->fills.push_back({base, {10, 20, 30}});
+  const int current = plan->body.add_slot(3, false);
+  const int snapshot = plan->body.add_slot(3, false);
+  const int rhs = plan->body.add_slot(1, false);
+  const int updated = plan->body.add_slot(3, false);
+  const int observed = plan->body.add_slot(1, false);
+  const int first = plan->body.add_slot(1, false);
+  const int snapshot_sum = plan->body.add_slot(1, false);
+  const int current_sum = plan->body.add_slot(1, false);
+  const int result = plan->body.add_slot(1, false);
+  plan->imports = {{theta, 0, 0}};
+
+  auto spec = std::make_shared<DynamicIndexSpec>();
+  spec->axes = {{DynamicIndexSpec::Axis::Single, 3, 1, 1, 0}};
+  spec->selected_size = 1;
+  Node update =
+      call(*plan, OP_SET_INDEX_DYNAMIC, {current, iterator, rhs}, updated);
+  const int update_op = update.op;
+  plan->body.ops[static_cast<size_t>(update_op)].udata = spec.get();
+  plan->body.udata_pool.push_back(spec);
+  Node observe = call(*plan, OP_SUM_VEC, {current}, observed);
+  const int observe_op = observe.op;
+  Node is_first = call(*plan, OP_COMPARE, {iterator, lower}, first);
+  plan->body.ops[static_cast<size_t>(is_first.op)].variant = 4;
+  plan->root = sequence(
+      {alias(current, base),
+       counted(lower, upper, iterator, 3,
+               sequence({call(*plan, OP_MUL, {theta, iterator}, rhs),
+                         std::move(update), alias(current, updated),
+                         std::move(observe), std::move(is_first),
+                         branch(first, alias(snapshot, current), sequence({}))})),
+       call(*plan, OP_SUM_VEC, {snapshot}, snapshot_sum),
+       call(*plan, OP_SUM_VEC, {current}, current_sum),
+       call(*plan, OP_ADD, {snapshot_sum, current_sum}, result)});
+  plan->outputs = {result};
+  plan->prepare(1 << 20);
+  plan->dynamic_history = true;
+  check(plan->compact_update_sites == 1,
+        "loop-backedge alias keeps compact update site eligible");
+  check(set_forward(plan->root, observe_op, trace_range_sum_forward),
+        "find loop-backedge update address observer");
+  if (force_ordinary) {
+    check(set_forward(plan->root, update_op, ordinary_update_forward),
+          "find loop-backedge update forward callback");
+    check(set_backward(plan->root, update_op, ordinary_update_backward),
+          "find loop-backedge update backward callback");
+  }
+  return plan;
+}
+
 static void compact_iterator_history_tests() {
   iterator_forward_values.clear();
   iterator_reverse_values.clear();
@@ -946,6 +1081,7 @@ static void compact_iterator_history_tests() {
     return result;
   };
   ordinary_update_forward_calls = ordinary_update_backward_calls = 0;
+  range_update_forward_addresses.clear();
   const RangeEvaluation delta = run_range(false);
   const RangeEvaluation ordinary = run_range(true);
   check(std::memcmp(&delta.value, &ordinary.value, sizeof(double)) == 0 &&
@@ -990,6 +1126,61 @@ static void compact_iterator_history_tests() {
   close(inactive_compact.value, 40.75, "inactive range delta result");
   close(inactive_compact.gradient[0], 163,
         "inactive range delta outer gradient");
+
+  ordinary_update_forward_calls = ordinary_update_backward_calls = 0;
+  Executor aliased_compact(outer(aliased_update_plan(false)));
+  Executor aliased_ordinary(outer(aliased_update_plan(true)));
+  range_update_forward_addresses.clear();
+  const Evaluation aliased = evaluate(aliased_compact, .25, 0);
+  const auto aliased_compact_addresses = range_update_forward_addresses;
+  range_update_forward_addresses.clear();
+  const Evaluation aliased_reference = evaluate(aliased_ordinary, .25, 0);
+  const auto aliased_ordinary_addresses = range_update_forward_addresses;
+  check(std::memcmp(&aliased, &aliased_reference, sizeof(Evaluation)) == 0 &&
+            ordinary_update_forward_calls == 3 &&
+            ordinary_update_backward_calls == 3,
+        "outgoing alias invalidation has bitwise ordinary-path parity");
+  check(aliased_compact_addresses.size() == 3 &&
+            aliased_compact_addresses[0] != aliased_compact_addresses[1] &&
+            aliased_compact_addresses[1] == aliased_compact_addresses[2] &&
+            aliased_ordinary_addresses.size() == 3 &&
+            aliased_ordinary_addresses[0] != aliased_ordinary_addresses[1] &&
+            aliased_ordinary_addresses[1] != aliased_ordinary_addresses[2],
+        "compact mutation resumes after one copy-on-write update");
+  close(aliased.value, 102, "outgoing aliases preserve snapshot values");
+  close(aliased.gradient[0], 8,
+        "outgoing aliases preserve snapshot gradients");
+
+  ordinary_update_forward_calls = ordinary_update_backward_calls = 0;
+  Executor loop_aliased_compact(outer(loop_aliased_update_plan(false)));
+  Executor loop_aliased_ordinary(outer(loop_aliased_update_plan(true)));
+  range_update_forward_addresses.clear();
+  const Evaluation loop_aliased = evaluate(loop_aliased_compact, .25, 0);
+  const auto loop_aliased_compact_addresses = range_update_forward_addresses;
+  range_update_forward_addresses.clear();
+  const Evaluation loop_aliased_reference =
+      evaluate(loop_aliased_ordinary, .25, 0);
+  const auto loop_aliased_ordinary_addresses = range_update_forward_addresses;
+  check(std::memcmp(&loop_aliased, &loop_aliased_reference,
+                    sizeof(Evaluation)) == 0 &&
+            ordinary_update_forward_calls == 3 &&
+            ordinary_update_backward_calls == 3,
+        "loop-backedge alias invalidation has bitwise ordinary-path parity");
+  check(loop_aliased_compact_addresses.size() == 3 &&
+            loop_aliased_compact_addresses[0] !=
+                loop_aliased_compact_addresses[1] &&
+            loop_aliased_compact_addresses[1] ==
+                loop_aliased_compact_addresses[2] &&
+            loop_aliased_ordinary_addresses.size() == 3 &&
+            loop_aliased_ordinary_addresses[0] !=
+                loop_aliased_ordinary_addresses[1] &&
+            loop_aliased_ordinary_addresses[1] !=
+                loop_aliased_ordinary_addresses[2],
+        "compact mutation resumes across an aliasing loop backedge");
+  close(loop_aliased.value, 51.75,
+        "loop-backedge alias preserves snapshot value");
+  close(loop_aliased.gradient[0], 7,
+        "loop-backedge alias preserves snapshot gradient");
 }
 
 static std::shared_ptr<StructuredLoop> integer_history_plan() {

--- a/tests/test_structured_loop_production.cpp
+++ b/tests/test_structured_loop_production.cpp
@@ -1112,13 +1112,21 @@ static std::shared_ptr<StructuredLoop> aliased_update_plan(
   Node observe3 = call(*plan, OP_SUM_VEC, {current}, observed3);
   const int observer_ops[] = {observe1.op, observe2.op, observe3.op};
   plan->root = sequence(
-      {alias(current, base), call(*plan, OP_MUL, {theta, one}, rhs1),
-       std::move(update1), alias(current, updated1_slot), std::move(observe1),
-       alias(snapshot1, current), alias(snapshot2, current),
-       call(*plan, OP_MUL, {theta, two}, rhs2), std::move(update2),
-       alias(current, updated2_slot), std::move(observe2),
-       call(*plan, OP_MUL, {theta, three}, rhs3), std::move(update3),
-       alias(current, updated3_slot), std::move(observe3),
+      {alias(current, base),
+       call(*plan, OP_MUL, {theta, one}, rhs1),
+       std::move(update1),
+       alias(current, updated1_slot),
+       std::move(observe1),
+       alias(snapshot1, current),
+       alias(snapshot2, current),
+       call(*plan, OP_MUL, {theta, two}, rhs2),
+       std::move(update2),
+       alias(current, updated2_slot),
+       std::move(observe2),
+       call(*plan, OP_MUL, {theta, three}, rhs3),
+       std::move(update3),
+       alias(current, updated3_slot),
+       std::move(observe3),
        call(*plan, OP_SUM_VEC, {snapshot1}, snapshot_sum1),
        call(*plan, OP_SUM_VEC, {snapshot2}, snapshot_sum2),
        call(*plan, OP_SUM_VEC, {current}, current_sum),
@@ -1177,11 +1185,12 @@ static std::shared_ptr<StructuredLoop> loop_aliased_update_plan(
   plan->body.ops[static_cast<size_t>(is_first.op)].variant = 4;
   plan->root = sequence(
       {alias(current, base),
-       counted(lower, upper, iterator, 3,
-               sequence({call(*plan, OP_MUL, {theta, iterator}, rhs),
-                         std::move(update), alias(current, updated),
-                         std::move(observe), std::move(is_first),
-                         branch(first, alias(snapshot, current), sequence({}))})),
+       counted(
+           lower, upper, iterator, 3,
+           sequence({call(*plan, OP_MUL, {theta, iterator}, rhs),
+                     std::move(update), alias(current, updated),
+                     std::move(observe), std::move(is_first),
+                     branch(first, alias(snapshot, current), sequence({}))})),
        call(*plan, OP_SUM_VEC, {snapshot}, snapshot_sum),
        call(*plan, OP_SUM_VEC, {current}, current_sum),
        call(*plan, OP_ADD, {snapshot_sum, current_sum}, result)});
@@ -1221,8 +1230,8 @@ static std::shared_ptr<StructuredLoop> retained_scalar_update_plan(
   auto spec = std::make_shared<DynamicIndexSpec>();
   spec->axes = {{DynamicIndexSpec::Axis::Single, 3, 1, 1, 0}};
   spec->selected_size = 1;
-  Node update1 = call(*plan, OP_SET_INDEX_DYNAMIC,
-                      {current, one, inactive_rhs}, updated1_slot);
+  Node update1 = call(*plan, OP_SET_INDEX_DYNAMIC, {current, one, inactive_rhs},
+                      updated1_slot);
   Node update2 =
       call(*plan, OP_SET_INDEX_DYNAMIC, {current, two, theta}, updated2_slot);
   const int update_ops[] = {update1.op, update2.op};
@@ -1233,10 +1242,9 @@ static std::shared_ptr<StructuredLoop> retained_scalar_update_plan(
   Node observe2 = call(*plan, OP_SUM_VEC, {current}, observed2);
   const int observer_ops[] = {observe1.op, observe2.op};
   plan->root = sequence(
-      {alias(current, base), std::move(update1),
-       alias(current, updated1_slot), std::move(observe1), std::move(update2),
-       alias(current, updated2_slot), std::move(observe2),
-       call(*plan, OP_SUM_VEC, {current}, result)});
+      {alias(current, base), std::move(update1), alias(current, updated1_slot),
+       std::move(observe1), std::move(update2), alias(current, updated2_slot),
+       std::move(observe2), call(*plan, OP_SUM_VEC, {current}, result)});
   plan->outputs = {result};
   plan->prepare(1 << 20);
   plan->dynamic_history = true;
@@ -1268,9 +1276,8 @@ static std::shared_ptr<StructuredLoop> duplicate_record_site_plan() {
   plan->outputs = {product};
   plan->prepare(1 << 20);
   plan->dynamic_history = true;
-  check(plan->record_node_count == 2 &&
-            plan->root.children[0].record_site !=
-                plan->root.children[1].record_site,
+  check(plan->record_node_count == 2 && plan->root.children[0].record_site !=
+                                            plan->root.children[1].record_site,
         "duplicate operation nodes receive distinct record sites");
   plan->root.children[1].backward = duplicate_site_backward;
   return plan;
@@ -1299,13 +1306,13 @@ static std::shared_ptr<StructuredLoop> scalar_index_loop_plan(
   const int index_op = index.op;
   plan->body.ops[static_cast<size_t>(index_op)].udata = spec.get();
   plan->body.udata_pool.push_back(spec);
-  plan->root = sequence(
-      {alias(total, zero),
-       counted(one, three, iterator, 3,
-               sequence({std::move(index),
-                         call(*plan, OP_MUL, {selected, theta}, term),
-                         call(*plan, OP_ADD, {total, term}, next),
-                         alias(total, next)}))});
+  plan->root =
+      sequence({alias(total, zero),
+                counted(one, three, iterator, 3,
+                        sequence({std::move(index),
+                                  call(*plan, OP_MUL, {selected, theta}, term),
+                                  call(*plan, OP_ADD, {total, term}, next),
+                                  alias(total, next)}))});
   plan->outputs = {total};
   plan->prepare(1 << 20);
   plan->dynamic_history = true;
@@ -1412,12 +1419,12 @@ static std::shared_ptr<StructuredLoop> scalar_index_after_updates_plan() {
   Node index = call(*plan, OP_INDEX_DYNAMIC, {current, two}, selected);
   plan->body.ops[static_cast<size_t>(index.op)].udata = index_spec.get();
   plan->body.udata_pool.push_back(index_spec);
-  plan->root = sequence(
-      {alias(current, base),
-       counted(one, two, iterator, 2,
-               sequence({call(*plan, OP_MUL, {theta, iterator}, rhs),
-                         std::move(update), alias(current, updated)})),
-       std::move(index)});
+  plan->root =
+      sequence({alias(current, base),
+                counted(one, two, iterator, 2,
+                        sequence({call(*plan, OP_MUL, {theta, iterator}, rhs),
+                                  std::move(update), alias(current, updated)})),
+                std::move(index)});
   plan->outputs = {selected};
   plan->prepare(1 << 20);
   plan->dynamic_history = true;
@@ -1582,10 +1589,10 @@ static void compact_scalar_index_tests() {
   const double expected_gradient[] = {0, .25, .25, .25, 0, 0};
   for (bool direct : {false, true}) {
     ordinary_index_forward_calls = ordinary_index_backward_calls = 0;
-    Executor compact(scalar_index_loop_outer(
-        scalar_index_loop_plan(direct, false)));
-    Executor ordinary(scalar_index_loop_outer(
-        scalar_index_loop_plan(direct, true)));
+    Executor compact(
+        scalar_index_loop_outer(scalar_index_loop_plan(direct, false)));
+    Executor ordinary(
+        scalar_index_loop_outer(scalar_index_loop_plan(direct, true)));
     std::copy(std::begin(point), std::end(point), compact.params_data());
     std::copy(std::begin(point), std::end(point), ordinary.params_data());
     double compact_gradient[6] = {};
@@ -1596,9 +1603,9 @@ static void compact_scalar_index_tests() {
               std::memcmp(compact_gradient, ordinary_gradient,
                           sizeof(compact_gradient)) == 0,
           "compact scalar index has bitwise ordinary-path parity");
-    check(ordinary_index_forward_calls == 3 &&
-              ordinary_index_backward_calls == 3,
-          "custom scalar index callbacks force ordinary history");
+    check(
+        ordinary_index_forward_calls == 3 && ordinary_index_backward_calls == 3,
+        "custom scalar index callbacks force ordinary history");
     close(compact_value, .25, "compact scalar index value");
     for (size_t i = 0; i < std::size(expected_gradient); ++i)
       close(compact_gradient[i], expected_gradient[i],
@@ -1626,15 +1633,14 @@ static void compact_scalar_index_tests() {
 
   Executor selector_only(outer(selector_only_scalar_index_plan()));
   const Evaluation selector_result = evaluate(selector_only, 2, 0);
-  close(selector_result.value, 20,
-        "selector-only active scalar index value");
+  close(selector_result.value, 20, "selector-only active scalar index value");
   close(selector_result.gradient[0], 0,
         "scalar index does not differentiate its selector");
   close(selector_result.gradient[1], 0,
         "unused scalar index input has zero gradient");
 
-  Executor updated(scalar_index_after_updates_outer(
-      scalar_index_after_updates_plan()));
+  Executor updated(
+      scalar_index_after_updates_outer(scalar_index_after_updates_plan()));
   const double updated_point[] = {10, 20, 30, .25};
   std::copy(std::begin(updated_point), std::end(updated_point),
             updated.params_data());
@@ -1908,8 +1914,7 @@ static void compact_iterator_history_tests() {
             aliased_ordinary_addresses[1] != aliased_ordinary_addresses[2],
         "compact mutation resumes after one copy-on-write update");
   close(aliased.value, 102, "outgoing aliases preserve snapshot values");
-  close(aliased.gradient[0], 8,
-        "outgoing aliases preserve snapshot gradients");
+  close(aliased.gradient[0], 8, "outgoing aliases preserve snapshot gradients");
 
   ordinary_update_forward_calls = ordinary_update_backward_calls = 0;
   Executor loop_aliased_compact(outer(loop_aliased_update_plan(false)));
@@ -1962,8 +1967,7 @@ static void compact_iterator_history_tests() {
             retained_ordinary_addresses[0] != retained_ordinary_addresses[1],
         "unshared active scalar update uses retained compact history");
   close(retained_result.value, 37.25, "retained scalar record value");
-  close(retained_result.gradient[0], 1,
-        "retained scalar record gradient");
+  close(retained_result.gradient[0], 1, "retained scalar record gradient");
 
   duplicate_site_backward_calls = 0;
   Executor duplicate_sites(outer(duplicate_record_site_plan()));
@@ -2502,10 +2506,8 @@ static void compact_integer_result_tests() {
   check(threw, "inline integer preserves division exception");
   const Evaluation divided = evaluate(division_retry, 4, 2);
   close(divided.value, 2, "inline integer division retry value");
-  close(divided.gradient[0], 0,
-        "inline integer division retry theta gradient");
-  close(divided.gradient[1], 0,
-        "inline integer division retry beta gradient");
+  close(divided.gradient[0], 0, "inline integer division retry theta gradient");
+  close(divided.gradient[1], 0, "inline integer division retry beta gradient");
 
   custom_integer_calls = 0;
   Executor custom(outer(custom_integer_plan()));
@@ -2840,29 +2842,27 @@ static std::shared_ptr<StructuredLoop> compact_invariant_guard_plan() {
   auto spec = std::make_shared<DynamicIndexSpec>();
   spec->axes = {{DynamicIndexSpec::Axis::Single, 1, 1, 1, 0}};
   spec->selected_size = 1;
-  Node update =
-      call(*plan, OP_SET_INDEX_DYNAMIC, {current, one, rhs}, updated);
+  Node update = call(*plan, OP_SET_INDEX_DYNAMIC, {current, one, rhs}, updated);
   plan->body.ops[static_cast<size_t>(update.op)].udata = spec.get();
   plan->body.udata_pool.push_back(spec);
   Node comparison = call(*plan, OP_COMPARE, {current, threshold}, compared);
   const int comparison_op = comparison.op;
   plan->body.ops[static_cast<size_t>(comparison_op)].variant = 2;
-  plan->root = sequence(
-      {alias(current, base), alias(result, zero),
-       counted(one, three, iterator, 3,
-               sequence({call(*plan, OP_MUL, {theta, iterator}, rhs),
-                         std::move(update), alias(current, updated),
-                         std::move(comparison),
-                         call(*plan, OP_MUL, {theta, compared}, term),
-                         call(*plan, OP_ADD, {result, term}, next),
-                         alias(result, next)}))});
+  plan->root =
+      sequence({alias(current, base), alias(result, zero),
+                counted(one, three, iterator, 3,
+                        sequence({call(*plan, OP_MUL, {theta, iterator}, rhs),
+                                  std::move(update), alias(current, updated),
+                                  std::move(comparison),
+                                  call(*plan, OP_MUL, {theta, compared}, term),
+                                  call(*plan, OP_ADD, {result, term}, next),
+                                  alias(result, next)}))});
   plan->outputs = {result};
   plan->prepare(1 << 20);
   plan->dynamic_history = true;
   check(plan->compact_update_sites == 1,
         "compact invariant guard selects compact history");
-  check(set_forward(plan->root, comparison_op,
-                    count_compact_dependent_compare),
+  check(set_forward(plan->root, comparison_op, count_compact_dependent_compare),
         "find compact-dependent comparison callback");
   return plan;
 }
@@ -3537,11 +3537,11 @@ static void direct_index_lowering_tests() {
     for (const auto& op : packed_plan->body.ops) {
       packed_concats += op.opcode == OP_CONCAT2;
       if (op.opcode == OP_INDEX_DYNAMIC) {
-      ++packed_reads;
-      const auto* spec = static_cast<const DynamicIndexSpec*>(op.udata);
+        ++packed_reads;
+        const auto* spec = static_cast<const DynamicIndexSpec*>(op.udata);
         check(spec && spec->input_count == 0 && spec->rhs_input == -1 &&
                   op.n_in == 2,
-            "direct-index ablation preserves packed read ABI");
+              "direct-index ablation preserves packed read ABI");
       } else if (op.opcode == OP_SET_INDEX_DYNAMIC) {
         ++packed_updates;
         const auto* spec = static_cast<const DynamicIndexSpec*>(op.udata);

--- a/tests/test_structured_loop_production.cpp
+++ b/tests/test_structured_loop_production.cpp
@@ -1878,6 +1878,8 @@ static double* inactive_workspace_address = nullptr;
 static bool inactive_workspace_stable = true;
 static bool inactive_workspace_disjoint = true;
 static bool inactive_workspace_throw_once = false;
+static int registered_redirect_calls = 0;
+static bool workspace_producer_throw_once = false;
 
 static int64_t inactive_workspace_size(const Op&, const Slot*) { return 3; }
 
@@ -1958,22 +1960,22 @@ static std::shared_ptr<StructuredLoop> inactive_zero_output_plan() {
 }
 
 static void redirect_inactive_output(KernelCtx& context) {
+  ++registered_redirect_calls;
   context.out.data = context.in[0].data;
 }
 
 static std::shared_ptr<StructuredLoop> redirected_inactive_output_plan() {
   auto plan = std::make_shared<StructuredLoop>();
-  const int source = scalar(*plan, 42);
+  const int lower = scalar(*plan, 1);
+  const int upper = scalar(*plan, 2);
+  const int iterator = plan->body.add_slot(1, false);
   const int zero = scalar(*plan, 0);
   const int result = plan->body.add_slot(1, false);
-  Node redirected = call(*plan, OP_ADD, {source, zero}, result);
-  const int redirected_op = redirected.op;
-  plan->root = std::move(redirected);
+  plan->root = counted(lower, upper, iterator, 2,
+                       call(*plan, OP_ADD, {iterator, zero}, result));
   plan->outputs = {result};
   plan->prepare(1 << 20);
   plan->dynamic_history = true;
-  check(set_forward(plan->root, redirected_op, redirect_inactive_output),
-        "find redirected inactive callback");
   return plan;
 }
 
@@ -2006,6 +2008,101 @@ static std::shared_ptr<StructuredLoop> inactive_location_bound_plan() {
   plan->outputs = {result};
   plan->prepare(1 << 20);
   plan->dynamic_history = true;
+  return plan;
+}
+
+static std::shared_ptr<StructuredLoop> repeated_forward_only_output_plan(
+    int upper_value = 4) {
+  auto plan = std::make_shared<StructuredLoop>();
+  const int lower = scalar(*plan, 1);
+  const int upper = scalar(*plan, upper_value);
+  const int iterator = plan->body.add_slot(1, false);
+  const int two = scalar(*plan, 2);
+  const int result = plan->body.add_slot(1, false);
+  plan->fills.push_back({result, {99}});
+  plan->root = counted(lower, upper, iterator, std::max(0, upper_value),
+                       call(*plan, OP_ADD, {iterator, two}, result));
+  plan->outputs = {result};
+  plan->prepare(1 << 20);
+  plan->dynamic_history = true;
+  return plan;
+}
+
+static std::vector<const double*> forward_only_output_addresses;
+
+static void trace_forward_only_output(KernelCtx& context) {
+  forward_only_output_addresses.push_back(context.out.data);
+  context.out.data[0] = context.in[0].data[0] + context.in[1].data[0];
+}
+
+static void throwing_workspace_producer(KernelCtx& context) {
+  if (workspace_producer_throw_once && context.in[0].data[0] == 2) {
+    workspace_producer_throw_once = false;
+    throw std::runtime_error("injected workspace producer failure");
+  }
+  context.out.data[0] = context.in[0].data[0] + context.in[1].data[0];
+}
+
+static std::shared_ptr<StructuredLoop> workspace_skipped_escape_plan() {
+  auto plan = std::make_shared<StructuredLoop>();
+  const int lower = scalar(*plan, 1);
+  const int upper = scalar(*plan, 2);
+  const int iterator = plan->body.add_slot(1, false);
+  const int one = scalar(*plan, 1);
+  const int ten = scalar(*plan, 10);
+  const int initial = scalar(*plan, 99);
+  const int produced = plan->body.add_slot(1, false);
+  const int condition = plan->body.add_slot(1, false);
+  const int redirected = plan->body.add_slot(1, false);
+  const int result = plan->body.add_slot(1, false);
+  Node compare = call(*plan, OP_COMPARE, {iterator, one}, condition);
+  plan->body.ops[static_cast<size_t>(compare.op)].variant = 4;
+  Node redirect = call(*plan, OP_COMPARE, {produced}, redirected);
+  const int redirect_op = redirect.op;
+  plan->root = sequence(
+      {alias(result, initial),
+       counted(lower, upper, iterator, 2,
+               sequence({call(*plan, OP_ADD, {iterator, ten}, produced),
+                         std::move(compare),
+                         branch(condition,
+                                sequence({std::move(redirect),
+                                          alias(result, redirected)}),
+                                sequence({}))}))});
+  plan->outputs = {result};
+  plan->prepare(1 << 20);
+  plan->dynamic_history = true;
+  check(set_forward(plan->root, redirect_op, redirect_first_input),
+        "find skipped workspace redirect callback");
+  return plan;
+}
+
+static std::shared_ptr<StructuredLoop> workspace_redirect_chain_plan() {
+  auto plan = std::make_shared<StructuredLoop>();
+  const int theta = plan->body.add_slot(1, false);
+  const int lower = scalar(*plan, 1);
+  const int upper = scalar(*plan, 3);
+  const int iterator = plan->body.add_slot(1, false);
+  const int one = scalar(*plan, 1);
+  const int produced = plan->body.add_slot(1, false);
+  const int redirected = plan->body.add_slot(1, false);
+  const int active = plan->body.add_slot(1, false);
+  plan->imports = {{theta, 0, 0}};
+  Node redirect = call(*plan, OP_COMPARE, {produced}, redirected);
+  const int redirect_op = redirect.op;
+  Node target;
+  target.kind = Node::Target;
+  target.src = active;
+  plan->root =
+      counted(lower, upper, iterator, 3,
+              sequence({call(*plan, OP_ADD, {iterator, one}, produced),
+                        std::move(redirect),
+                        call(*plan, OP_MUL, {theta, redirected}, active),
+                        std::move(target)}));
+  plan->has_target = true;
+  plan->prepare(1 << 20);
+  plan->dynamic_history = true;
+  check(set_forward(plan->root, redirect_op, redirect_first_input),
+        "find forward-only redirected consumer");
   return plan;
 }
 
@@ -2251,10 +2348,27 @@ static void compact_integer_result_tests() {
   check(inactive_workspace_stable && inactive_workspace_disjoint,
         "inactive zero-output workspace remains stable and disjoint");
 
-  Executor redirected(outer(redirected_inactive_output_plan()));
-  const Evaluation redirected_result = evaluate(redirected, 0, 0);
-  close(redirected_result.value, 42,
-        "redirected inactive output keeps ordinary reference fallback");
+  Evaluation redirected_result, retained_redirected_result;
+  registered_redirect_calls = 0;
+  {
+    Kernel replacement = *find_kernel(OP_ADD);
+    replacement.forward = redirect_inactive_output;
+    ScopedKernelOverride overridden(OP_ADD, replacement);
+    test_unsetenv("STANLI_NO_STRUCTURED_INACTIVE_WORKSPACE");
+    Executor redirected(outer(redirected_inactive_output_plan()));
+    redirected_result = evaluate(redirected, 0, 0);
+    test_setenv("STANLI_NO_STRUCTURED_INACTIVE_WORKSPACE", "1");
+    Executor retained_redirected(outer(redirected_inactive_output_plan()));
+    retained_redirected_result = evaluate(retained_redirected, 0, 0);
+    test_unsetenv("STANLI_NO_STRUCTURED_INACTIVE_WORKSPACE");
+  }
+  close(redirected_result.value, 2,
+        "registered redirected producer keeps its final value");
+  check(registered_redirect_calls == 4,
+        "registered redirected producer executes every reached call");
+  check(std::memcmp(&redirected_result, &retained_redirected_result,
+                    sizeof(Evaluation)) == 0,
+        "registered redirected producer has bitwise ablation parity");
 
   Executor inactive_target(outer(inactive_location_target_plan()));
   const Evaluation targeted = evaluate(inactive_target, 0, 0);
@@ -2263,6 +2377,101 @@ static void compact_integer_result_tests() {
   Executor inactive_bound(outer(inactive_location_bound_plan()));
   const Evaluation bounded = evaluate(inactive_bound, 0, 0);
   close(bounded.value, 3, "inactive arena handle supplies counted-loop bound");
+
+  Evaluation reused, retained;
+  {
+    Kernel replacement = *find_kernel(OP_ADD);
+    replacement.forward = trace_forward_only_output;
+    ScopedKernelOverride overridden(OP_ADD, replacement);
+    test_unsetenv("STANLI_NO_STRUCTURED_INACTIVE_WORKSPACE");
+    forward_only_output_addresses.clear();
+    Executor reused_output(outer(repeated_forward_only_output_plan()));
+    reused = evaluate(reused_output, 0, 0);
+    check(forward_only_output_addresses.size() == 4 &&
+              std::adjacent_find(forward_only_output_addresses.begin(),
+                                 forward_only_output_addresses.end(),
+                                 std::not_equal_to<const double*>()) ==
+                  forward_only_output_addresses.end(),
+          "forward-only loop calls reuse one output address");
+    test_setenv("STANLI_NO_STRUCTURED_INACTIVE_WORKSPACE", "1");
+    forward_only_output_addresses.clear();
+    Executor retained_output(outer(repeated_forward_only_output_plan()));
+    retained = evaluate(retained_output, 0, 0);
+    check(forward_only_output_addresses.size() == 4 &&
+              std::adjacent_find(forward_only_output_addresses.begin(),
+                                 forward_only_output_addresses.end(),
+                                 std::equal_to<const double*>()) ==
+                  forward_only_output_addresses.end(),
+          "forward-only workspace ablation retains distinct outputs");
+    test_unsetenv("STANLI_NO_STRUCTURED_INACTIVE_WORKSPACE");
+
+    forward_only_output_addresses.clear();
+    Executor zero_trip(outer(repeated_forward_only_output_plan(0)));
+    const Evaluation zero_trip_result = evaluate(zero_trip, 0, 0);
+    close(zero_trip_result.value, 99,
+          "zero-trip workspace loop preserves its initial output");
+    check(forward_only_output_addresses.empty(),
+          "zero-trip workspace loop allocates no reached call storage");
+  }
+  close(reused.value, 6, "forward-only loop output keeps final value");
+  check(std::memcmp(&reused, &retained, sizeof(Evaluation)) == 0,
+        "forward-only workspace has bitwise same-binary parity");
+
+  test_unsetenv("STANLI_NO_STRUCTURED_INACTIVE_WORKSPACE");
+  Executor skipped_escape(outer(workspace_skipped_escape_plan()));
+  const Evaluation escaped = evaluate(skipped_escape, 0, 0);
+  test_setenv("STANLI_NO_STRUCTURED_INACTIVE_WORKSPACE", "1");
+  Executor retained_escape(outer(workspace_skipped_escape_plan()));
+  const Evaluation retained_escaped = evaluate(retained_escape, 0, 0);
+  test_unsetenv("STANLI_NO_STRUCTURED_INACTIVE_WORKSPACE");
+  close(escaped.value, 11,
+        "skipped redirect keeps the earlier workspace producer value");
+  check(std::memcmp(&escaped, &retained_escaped, sizeof(Evaluation)) == 0,
+        "skipped workspace escape has bitwise ablation parity");
+
+  Evaluation retried_workspace, retained_retry;
+  {
+    Kernel replacement = *find_kernel(OP_ADD);
+    replacement.forward = throwing_workspace_producer;
+    ScopedKernelOverride overridden(OP_ADD, replacement);
+    test_unsetenv("STANLI_NO_STRUCTURED_INACTIVE_WORKSPACE");
+    Executor retry_workspace(outer(repeated_forward_only_output_plan(3)));
+    workspace_producer_throw_once = true;
+    bool workspace_producer_threw = false;
+    try {
+      (void)evaluate(retry_workspace, 0, 0);
+    } catch (const std::runtime_error& error) {
+      workspace_producer_threw =
+          std::string(error.what()) == "injected workspace producer failure";
+    }
+    check(workspace_producer_threw,
+          "workspace producer preserves its forward exception");
+    retried_workspace = evaluate(retry_workspace, 0, 0);
+    test_setenv("STANLI_NO_STRUCTURED_INACTIVE_WORKSPACE", "1");
+    Executor retained_workspace(outer(repeated_forward_only_output_plan(3)));
+    retained_retry = evaluate(retained_workspace, 0, 0);
+    test_unsetenv("STANLI_NO_STRUCTURED_INACTIVE_WORKSPACE");
+  }
+  close(retried_workspace.value, 5,
+        "workspace producer retry rebuilds its canonical output");
+  check(
+      std::memcmp(&retried_workspace, &retained_retry, sizeof(Evaluation)) == 0,
+      "workspace producer retry has bitwise ablation parity");
+
+  test_unsetenv("STANLI_NO_STRUCTURED_INACTIVE_WORKSPACE");
+  Executor redirect_chain(outer(workspace_redirect_chain_plan()));
+  const Evaluation redirected_chain = evaluate(redirect_chain, 2, 0);
+  test_setenv("STANLI_NO_STRUCTURED_INACTIVE_WORKSPACE", "1");
+  Executor retained_chain(outer(workspace_redirect_chain_plan()));
+  const Evaluation retained_redirect_chain = evaluate(retained_chain, 2, 0);
+  test_unsetenv("STANLI_NO_STRUCTURED_INACTIVE_WORKSPACE");
+  close(redirected_chain.value, 18,
+        "redirected workspace input preserves target values");
+  close(redirected_chain.gradient[0], 9,
+        "redirected workspace input preserves reverse primals");
+  check(std::memcmp(&redirected_chain, &retained_redirect_chain,
+                    sizeof(Evaluation)) == 0,
+        "redirected workspace input has bitwise ablation parity");
 
   Executor inactive_reverse(outer(inactive_location_reverse_plan()));
   const Evaluation reversed = evaluate(inactive_reverse, 4, 0);
@@ -3061,6 +3270,7 @@ int main() {
   test_unsetenv("STANLI_STRUCTURED_HISTORY_BYTES");
   test_unsetenv("STANLI_NO_STRUCTURED_INVARIANT_REUSE");
   test_unsetenv("STANLI_NO_STRUCTURED_INACTIVE_CONTROL");
+  test_unsetenv("STANLI_NO_STRUCTURED_INACTIVE_WORKSPACE");
   test_unsetenv("STANLI_NO_STRUCTURED_DIRECT_INDEX_INPUTS");
   test_unsetenv("STANLI_NO_STRUCTURED_RECORD_SCALARS");
   if (failures == 0) std::printf("test_structured_loop_production OK\n");

--- a/tests/test_structured_loop_production.cpp
+++ b/tests/test_structured_loop_production.cpp
@@ -817,6 +817,138 @@ struct ScopedKernelOverride {
   ~ScopedKernelOverride() { register_kernel(opcode, saved); }
 };
 
+static int inactive_workspace_calls = 0;
+static double* inactive_workspace_address = nullptr;
+static bool inactive_workspace_stable = true;
+static bool inactive_workspace_disjoint = true;
+static bool inactive_workspace_throw_once = false;
+
+static int64_t inactive_workspace_size(const Op&, const Slot*) { return 3; }
+
+static void inactive_workspace_forward(KernelCtx& context) {
+  ++inactive_workspace_calls;
+  if (!inactive_workspace_address) {
+    inactive_workspace_address = context.scratch;
+  } else {
+    inactive_workspace_stable &= inactive_workspace_address == context.scratch;
+  }
+  inactive_workspace_disjoint &=
+      context.scratch && context.scratch != context.in[0].data &&
+      context.scratch != context.in[1].data &&
+      context.scratch != context.out.data &&
+      (!context.out2.data || context.scratch != context.out2.data) &&
+      (context.out.len == 0 || !context.out2.data || context.out2.len == 0 ||
+       context.out.data != context.out2.data);
+  context.scratch[0] = context.in[0].data[0];
+  context.scratch[1] = context.in[1].data[0];
+  context.scratch[2] = context.scratch[0] + context.scratch[1];
+  if (inactive_workspace_throw_once && context.scratch[0] == 2) {
+    inactive_workspace_throw_once = false;
+    throw std::runtime_error("injected inactive workspace failure");
+  }
+  if (context.out.len > 0) context.out.data[0] = context.scratch[2];
+  if (context.out2.data)
+    context.out2.data[0] = context.scratch[0] * context.scratch[1];
+}
+
+static std::shared_ptr<StructuredLoop> inactive_workspace_plan() {
+  auto plan = std::make_shared<StructuredLoop>();
+  const int lower = scalar(*plan, 1);
+  const int upper = scalar(*plan, 3);
+  const int iterator = plan->body.add_slot(1, false);
+  const int two = scalar(*plan, 2);
+  const int first = plan->body.add_slot(1, false);
+  const int second = plan->body.add_slot(1, false);
+  const int combined = plan->body.add_slot(1, false);
+  const int zero = scalar(*plan, 0);
+  const int result = plan->body.add_slot(1, false);
+  Node workspace = call(*plan, OP_INT_ARITH, {iterator, two}, first);
+  plan->body.ops[static_cast<size_t>(workspace.op)].out2 = second;
+  plan->root = sequence(
+      {alias(result, zero),
+       counted(lower, upper, iterator, 3,
+               sequence({std::move(workspace),
+                         call(*plan, OP_ADD, {first, second}, combined),
+                         alias(result, combined)}))});
+  plan->outputs = {result};
+  plan->prepare(1 << 20);
+  plan->dynamic_history = true;
+  return plan;
+}
+
+static std::shared_ptr<StructuredLoop> inactive_zero_output_plan() {
+  auto plan = std::make_shared<StructuredLoop>();
+  const int lower = scalar(*plan, 1);
+  const int upper = scalar(*plan, 3);
+  const int iterator = plan->body.add_slot(1, false);
+  const int two = scalar(*plan, 2);
+  const int empty = plan->body.add_slot(0, false);
+  const int second_empty = plan->body.add_slot(0, false);
+  const int second = plan->body.add_slot(1, false);
+  const int zero = scalar(*plan, 0);
+  const int result = plan->body.add_slot(1, false);
+  Node empty_call = call(*plan, OP_INT_ARITH, {iterator, two}, empty);
+  Node second_call = call(*plan, OP_INT_ARITH, {iterator, two}, second_empty);
+  plan->body.ops[static_cast<size_t>(second_call.op)].out2 = second;
+  plan->root =
+      sequence({alias(result, zero),
+                counted(lower, upper, iterator, 3,
+                        sequence({std::move(empty_call), std::move(second_call),
+                                  alias(result, second)}))});
+  plan->outputs = {result};
+  plan->prepare(1 << 20);
+  plan->dynamic_history = true;
+  return plan;
+}
+
+static int active_workspace_forward_calls = 0;
+static int active_workspace_backward_calls = 0;
+static double* active_workspace_address = nullptr;
+static bool active_workspace_history_ok = true;
+
+static void active_workspace_forward(KernelCtx& context) {
+  ++active_workspace_forward_calls;
+  active_workspace_address = context.scratch;
+  context.scratch[0] = context.in[0].data[0];
+  context.scratch[1] = context.in[1].data[0];
+  context.scratch[2] = context.scratch[0] * context.scratch[1];
+  context.out.data[0] = context.scratch[2];
+  context.out2.data[0] = context.scratch[0] + context.scratch[1];
+}
+
+static void active_workspace_backward(KernelCtx& context) {
+  ++active_workspace_backward_calls;
+  active_workspace_history_ok &=
+      context.scratch == active_workspace_address &&
+      context.scratch[0] == context.in[0].data[0] &&
+      context.scratch[1] == context.in[1].data[0] &&
+      context.scratch[2] == context.in[0].data[0] * context.in[1].data[0];
+  if (context.in_adj[0].data)
+    context.in_adj[0].data[0] +=
+        context.scratch[1] * context.out_adj + context.out2_adj;
+  if (context.in_adj[1].data)
+    context.in_adj[1].data[0] +=
+        context.scratch[0] * context.out_adj + context.out2_adj;
+}
+
+static std::shared_ptr<StructuredLoop> active_workspace_plan() {
+  auto plan = std::make_shared<StructuredLoop>();
+  const int theta = plan->body.add_slot(1, false);
+  const int two = scalar(*plan, 2);
+  const int product = plan->body.add_slot(1, false);
+  const int sum = plan->body.add_slot(1, false);
+  const int result = plan->body.add_slot(1, false);
+  plan->imports = {{theta, 0, 0}};
+  Node workspace = call(*plan, OP_INT_ARITH, {theta, two}, product);
+  plan->body.ops[static_cast<size_t>(workspace.op)].out2 = sum;
+  plan->root = sequence(
+      {std::move(workspace), call(*plan, OP_ADD, {product, sum}, result)});
+  plan->outputs = {result};
+  plan->prepare(1 << 20);
+  plan->dynamic_history = true;
+  return plan;
+}
+
 static std::shared_ptr<StructuredLoop> custom_integer_plan() {
   auto plan = integer_output_plan(2, 3);
   check(set_forward(plan->root, 0, custom_integer_forward),
@@ -909,6 +1041,82 @@ static void compact_integer_result_tests() {
   }
   check(custom_integer_calls == 1,
         "pre-prepare custom integer callback keeps ordinary path");
+
+  inactive_workspace_calls = 0;
+  inactive_workspace_address = nullptr;
+  inactive_workspace_stable = true;
+  inactive_workspace_disjoint = true;
+  inactive_workspace_throw_once = true;
+  {
+    Kernel replacement = *find_kernel(OP_INT_ARITH);
+    replacement.forward = inactive_workspace_forward;
+    replacement.scratch_size = inactive_workspace_size;
+    ScopedKernelOverride overridden(OP_INT_ARITH, replacement);
+    Executor workspace(outer(inactive_workspace_plan()));
+    bool workspace_threw = false;
+    try {
+      (void)evaluate(workspace, 0, 0);
+    } catch (const std::runtime_error& error) {
+      workspace_threw =
+          std::string(error.what()) == "injected inactive workspace failure";
+    }
+    check(workspace_threw, "inactive workspace preserves callback exception");
+    const Evaluation workspace_result = evaluate(workspace, 0, 0);
+    close(workspace_result.value, 11,
+          "inactive workspace preserves second output and retry");
+    close(workspace_result.gradient[0], 0,
+          "inactive workspace retry theta gradient");
+    close(workspace_result.gradient[1], 0,
+          "inactive workspace retry beta gradient");
+  }
+  check(inactive_workspace_calls == 5,
+        "inactive workspace executes reached callbacks only");
+  check(inactive_workspace_stable,
+        "inactive callback scratch is reused across calls and retry");
+  check(inactive_workspace_disjoint,
+        "inactive callback workspace descriptors remain disjoint");
+
+  inactive_workspace_calls = 0;
+  inactive_workspace_address = nullptr;
+  inactive_workspace_stable = true;
+  inactive_workspace_disjoint = true;
+  inactive_workspace_throw_once = false;
+  {
+    Kernel replacement = *find_kernel(OP_INT_ARITH);
+    replacement.forward = inactive_workspace_forward;
+    replacement.scratch_size = inactive_workspace_size;
+    ScopedKernelOverride overridden(OP_INT_ARITH, replacement);
+    Executor zero_output(outer(inactive_zero_output_plan()));
+    const Evaluation result = evaluate(zero_output, 0, 0);
+    close(result.value, 6,
+          "inactive workspace preserves zero primary and second output");
+  }
+  check(inactive_workspace_calls == 6,
+        "inactive zero-output callbacks execute without arena anchors");
+  check(inactive_workspace_stable && inactive_workspace_disjoint,
+        "inactive zero-output workspace remains stable and disjoint");
+
+  active_workspace_forward_calls = 0;
+  active_workspace_backward_calls = 0;
+  active_workspace_address = nullptr;
+  active_workspace_history_ok = true;
+  {
+    Kernel replacement = *find_kernel(OP_INT_ARITH);
+    replacement.forward = active_workspace_forward;
+    replacement.backward = active_workspace_backward;
+    replacement.scratch_size = inactive_workspace_size;
+    ScopedKernelOverride overridden(OP_INT_ARITH, replacement);
+    Executor active_workspace(outer(active_workspace_plan()));
+    const Evaluation active = evaluate(active_workspace, 3, 0);
+    close(active.value, 11, "active scratchful callback value");
+    close(active.gradient[0], 3, "active scratchful callback gradient");
+    close(active.gradient[1], 0, "active scratchful callback beta gradient");
+  }
+  check(active_workspace_forward_calls == 1 &&
+            active_workspace_backward_calls == 1,
+        "active scratchful callback retains reverse record");
+  check(active_workspace_history_ok,
+        "active scratchful callback retains forward scratch for reverse");
 }
 
 static std::atomic<int> invariant_first_calls{0};

--- a/tests/test_structured_loop_production.cpp
+++ b/tests/test_structured_loop_production.cpp
@@ -516,7 +516,11 @@ static Evaluation evaluate(Executor& executor, double theta, double beta);
 static std::vector<double> iterator_forward_values;
 static std::vector<double> iterator_reverse_values;
 static std::vector<std::array<double, 3>> update_reverse_values;
+static std::vector<std::array<double, 6>> range_update_reverse_values;
+static std::vector<const double*> range_update_forward_addresses;
 static bool iterator_throw_once = false;
+static int ordinary_update_forward_calls = 0;
+static int ordinary_update_backward_calls = 0;
 
 static void trace_iterator_forward(KernelCtx& context) {
   iterator_forward_values.push_back(context.in[1].data[0]);
@@ -540,6 +544,28 @@ static void trace_update_backward(KernelCtx& context) {
 
 static void retained_update_backward(KernelCtx& context) {
   find_kernel(OP_SET_INDEX_DYNAMIC)->backward(context);
+}
+
+static void ordinary_update_forward(KernelCtx& context) {
+  ++ordinary_update_forward_calls;
+  find_kernel(OP_SET_INDEX_DYNAMIC)->forward(context);
+}
+
+static void ordinary_update_backward(KernelCtx& context) {
+  ++ordinary_update_backward_calls;
+  find_kernel(OP_SET_INDEX_DYNAMIC)->backward(context);
+}
+
+static void trace_range_sum_backward(KernelCtx& context) {
+  std::array<double, 6> values{};
+  std::copy_n(context.in[0].data, values.size(), values.data());
+  range_update_reverse_values.push_back(values);
+  find_kernel(OP_SUM_VEC)->backward(context);
+}
+
+static void trace_range_sum_forward(KernelCtx& context) {
+  range_update_forward_addresses.push_back(context.in[0].data);
+  find_kernel(OP_SUM_VEC)->forward(context);
 }
 
 static std::shared_ptr<StructuredLoop> iterator_history_plan() {
@@ -635,7 +661,8 @@ static std::shared_ptr<StructuredLoop> nested_iterator_plan() {
 }
 
 static std::shared_ptr<StructuredLoop> iterator_update_plan(
-    void (*backward)(KernelCtx&) = trace_update_backward) {
+    void (*backward)(KernelCtx&) = trace_update_backward,
+    void (*forward)(KernelCtx&) = nullptr) {
   auto plan = std::make_shared<StructuredLoop>();
   const int theta = plan->body.add_slot(1, false);
   const int lower = scalar(*plan, 1);
@@ -671,6 +698,143 @@ static std::shared_ptr<StructuredLoop> iterator_update_plan(
   if (backward)
     check(set_backward(plan->root, update_op, backward),
           "find compact-update replacement backward callback");
+  if (forward)
+    check(set_forward(plan->root, update_op, forward),
+          "find compact-update replacement forward callback");
+  return plan;
+}
+
+static std::shared_ptr<StructuredLoop> range_update_plan(bool force_ordinary) {
+  auto plan = std::make_shared<StructuredLoop>();
+  const int base = plan->body.add_slot(6, false);
+  const int theta = plan->body.add_slot(1, false);
+  const int beta = plan->body.add_slot(1, false);
+  const int lower = scalar(*plan, 1);
+  const int upper = scalar(*plan, 3);
+  const int iterator = plan->body.add_slot(1, false);
+  const int selector = scalar(*plan, 1);
+  const int weights = plan->body.add_slot(6, false);
+  plan->fills.push_back({weights, {1, 2, 4, 8, 16, 32}});
+  const int current = plan->body.add_slot(6, false);
+  const int theta_term = plan->body.add_slot(1, false);
+  const int beta_term = plan->body.add_slot(1, false);
+  const int rhs = plan->body.add_slot(2, false);
+  const int updated = plan->body.add_slot(6, false);
+  const int zero_selector = plan->body.add_slot(2, false);
+  plan->fills.push_back({zero_selector, {1, 0}});
+  const int zero_updated = plan->body.add_slot(6, false);
+  const int observed = plan->body.add_slot(1, false);
+  const int result = plan->body.add_slot(1, false);
+  plan->imports = {{base, 0, 0}, {theta, 1, 0}, {beta, 2, 0}};
+
+  auto spec = std::make_shared<DynamicIndexSpec>();
+  spec->axes = {{DynamicIndexSpec::Axis::Range, 6, 1, 2, 0}};
+  spec->selected_size = 2;
+  Node update =
+      call(*plan, OP_SET_INDEX_DYNAMIC, {current, selector, rhs}, updated);
+  const int update_op = update.op;
+  plan->body.ops[static_cast<size_t>(update_op)].udata = spec.get();
+  plan->body.udata_pool.push_back(spec);
+  auto zero_spec = std::make_shared<DynamicIndexSpec>();
+  zero_spec->axes = {{DynamicIndexSpec::Axis::Range, 6, 1, 2, 0}};
+  zero_spec->axes[0].count_input_offset = 1;
+  zero_spec->selected_size = 2;
+  Node zero_update = call(*plan, OP_SET_INDEX_DYNAMIC,
+                          {current, zero_selector, rhs}, zero_updated);
+  const int zero_update_op = zero_update.op;
+  plan->body.ops[static_cast<size_t>(zero_update_op)].udata = zero_spec.get();
+  plan->body.udata_pool.push_back(zero_spec);
+  Node observe = call(*plan, OP_SUM_VEC, {current}, observed);
+  const int observe_op = observe.op;
+  plan->root = sequence(
+      {alias(current, base),
+       counted(lower, upper, iterator, 3,
+               sequence({call(*plan, OP_MUL, {theta, iterator}, theta_term),
+                         call(*plan, OP_MUL, {beta, iterator}, beta_term),
+                         call(*plan, OP_CONCAT2, {theta_term, beta_term}, rhs),
+                         std::move(update), alias(current, updated),
+                         std::move(observe)})),
+       std::move(zero_update), alias(current, zero_updated),
+       call(*plan, OP_DOT, {current, weights}, result)});
+  plan->outputs = {result};
+  plan->prepare(1 << 20);
+  plan->dynamic_history = true;
+  check(plan->compact_update_sites == 2,
+        "ordered range update selects compact history");
+  check(set_backward(plan->root, observe_op, trace_range_sum_backward),
+        "find ordered range observer");
+  check(set_forward(plan->root, observe_op, trace_range_sum_forward),
+        "find ordered range forward observer");
+  if (force_ordinary) {
+    check(set_forward(plan->root, update_op, ordinary_update_forward),
+          "find ordered range update forward callback");
+    check(set_backward(plan->root, update_op, ordinary_update_backward),
+          "find ordered range update backward callback");
+    check(set_forward(plan->root, zero_update_op, ordinary_update_forward),
+          "find zero range update forward callback");
+    check(set_backward(plan->root, zero_update_op, ordinary_update_backward),
+          "find zero range update backward callback");
+  }
+  return plan;
+}
+
+static Graph range_update_outer(std::shared_ptr<StructuredLoop> plan) {
+  Graph graph;
+  graph.add_slot(6, true);
+  graph.add_slot(1, true);
+  graph.add_slot(1, true);
+  const int output = graph.add_slot(1, false);
+  const int op = graph.add_op(OP_LOOP, {0, 1, 2}, output);
+  graph.ops[op].udata = plan.get();
+  graph.udata_pool.push_back(std::move(plan));
+  graph.result_slot = output;
+  return graph;
+}
+
+static std::shared_ptr<StructuredLoop> inactive_range_update_plan(
+    bool force_ordinary) {
+  auto plan = std::make_shared<StructuredLoop>();
+  const int theta = plan->body.add_slot(1, false);
+  const int lower = scalar(*plan, 1);
+  const int upper = scalar(*plan, 3);
+  const int iterator = plan->body.add_slot(1, false);
+  const int base = plan->body.add_slot(16, false);
+  plan->fills.push_back(
+      {base, {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}});
+  const int current = plan->body.add_slot(16, false);
+  const int selector = scalar(*plan, 1);
+  const int rhs = plan->body.add_slot(2, false);
+  plan->fills.push_back({rhs, {10, 20}});
+  const int updated = plan->body.add_slot(16, false);
+  const int total = plan->body.add_slot(1, false);
+  const int result = plan->body.add_slot(1, false);
+  plan->imports = {{theta, 0, 0}};
+
+  auto spec = std::make_shared<DynamicIndexSpec>();
+  spec->axes = {{DynamicIndexSpec::Axis::Range, 16, 1, 2, 0}};
+  spec->selected_size = 2;
+  Node update =
+      call(*plan, OP_SET_INDEX_DYNAMIC, {current, selector, rhs}, updated);
+  const int update_op = update.op;
+  plan->body.ops[static_cast<size_t>(update_op)].udata = spec.get();
+  plan->body.udata_pool.push_back(spec);
+  plan->root =
+      sequence({alias(current, base),
+                counted(lower, upper, iterator, 3,
+                        sequence({std::move(update), alias(current, updated)})),
+                call(*plan, OP_SUM_VEC, {current}, total),
+                call(*plan, OP_MUL, {theta, total}, result)});
+  plan->outputs = {result};
+  plan->prepare(1 << 20);
+  plan->dynamic_history = true;
+  check(plan->compact_update_sites == 1,
+        "inactive ordered range selects compact history");
+  if (force_ordinary) {
+    check(set_forward(plan->root, update_op, ordinary_update_forward),
+          "find inactive range update forward callback");
+    check(set_backward(plan->root, update_op, ordinary_update_backward),
+          "find inactive range update backward callback");
+  }
   return plan;
 }
 
@@ -742,18 +906,90 @@ static void compact_iterator_history_tests() {
   close(updated.gradient[1], 0, "inline iterator compact-update beta gradient");
   check(update_reverse_values ==
             std::vector<std::array<double, 3>>(
-                {{{.25, .5, .75}}, {{.25, .5, 30}}, {{10, 20, 30}}}),
-        "compact-update reverse restores overwritten values in LIFO order");
+                {{{.25, .5, 30}}, {{.25, 20, 30}}, {{10, 20, 30}}}),
+        "custom update reverse sees ordinary historical inputs");
 
   Executor frame_free(outer(iterator_update_plan(nullptr)));
   Executor retained(outer(iterator_update_plan(retained_update_backward)));
   const Evaluation compact = evaluate(frame_free, .25, 0);
   const Evaluation reference = evaluate(retained, .25, 0);
   check(std::memcmp(&compact, &reference, sizeof(Evaluation)) == 0,
-        "frame-free compact reverse has bitwise retained-frame parity");
+        "frame-free compact reverse has bitwise ordinary-path parity");
   const Evaluation repeated = evaluate(frame_free, .25, 0);
   check(std::memcmp(&compact, &repeated, sizeof(Evaluation)) == 0,
         "frame-free compact reverse resets between evaluations");
+  ordinary_update_forward_calls = 0;
+  Executor custom_forward(
+      outer(iterator_update_plan(nullptr, ordinary_update_forward)));
+  const Evaluation custom_forward_result = evaluate(custom_forward, .25, 0);
+  check(ordinary_update_forward_calls == 3 &&
+            std::memcmp(&compact, &custom_forward_result, sizeof(Evaluation)) ==
+                0,
+        "custom update forward callback forces the ordinary path");
+
+  struct RangeEvaluation {
+    double value = 0;
+    double gradient[8] = {};
+    std::vector<std::array<double, 6>> reverse_values;
+    std::vector<const double*> forward_addresses;
+  };
+  const auto run_range = [](bool ordinary) {
+    range_update_reverse_values.clear();
+    range_update_forward_addresses.clear();
+    Executor executor(range_update_outer(range_update_plan(ordinary)));
+    const double point[] = {10, 20, 30, 40, 50, 60, .25, -.5};
+    std::copy(std::begin(point), std::end(point), executor.params_data());
+    RangeEvaluation result;
+    result.value = executor.gradient(result.gradient);
+    result.reverse_values = range_update_reverse_values;
+    result.forward_addresses = range_update_forward_addresses;
+    return result;
+  };
+  ordinary_update_forward_calls = ordinary_update_backward_calls = 0;
+  const RangeEvaluation delta = run_range(false);
+  const RangeEvaluation ordinary = run_range(true);
+  check(std::memcmp(&delta.value, &ordinary.value, sizeof(double)) == 0 &&
+            std::memcmp(delta.gradient, ordinary.gradient,
+                        sizeof(delta.gradient)) == 0,
+        "ordered range delta has bitwise ordinary-path parity");
+  check(
+      ordinary_update_forward_calls == 4 && ordinary_update_backward_calls == 4,
+      "custom ordered range callbacks force the ordinary path");
+  close(delta.value, 3157.75, "ordered range delta result");
+  const double expected_gradient[] = {0, 0, 4, 8, 16, 32, 3, 6};
+  for (size_t i = 0; i < std::size(expected_gradient); ++i)
+    close(delta.gradient[i], expected_gradient[i],
+          "ordered range delta gradient");
+  const std::vector<std::array<double, 6>> expected_reverse = {
+      {{.75, -1.5, 30, 40, 50, 60}},
+      {{.5, -1, 30, 40, 50, 60}},
+      {{.25, -.5, 30, 40, 50, 60}},
+  };
+  check(delta.reverse_values == expected_reverse &&
+            ordinary.reverse_values == expected_reverse,
+        "ordered range delta restores historical primals in LIFO order");
+  check(delta.forward_addresses.size() == 3 &&
+            delta.forward_addresses[0] == delta.forward_addresses[1] &&
+            delta.forward_addresses[1] == delta.forward_addresses[2],
+        "ordered range delta reuses one anchored primal buffer");
+  check(ordinary.forward_addresses.size() == 3 &&
+            ordinary.forward_addresses[0] != ordinary.forward_addresses[1] &&
+            ordinary.forward_addresses[1] != ordinary.forward_addresses[2],
+        "ordinary range fallback keeps distinct output buffers");
+
+  ordinary_update_forward_calls = ordinary_update_backward_calls = 0;
+  Executor inactive_delta(outer(inactive_range_update_plan(false)));
+  Executor inactive_ordinary(outer(inactive_range_update_plan(true)));
+  const Evaluation inactive_compact = evaluate(inactive_delta, .25, 0);
+  const Evaluation inactive_reference = evaluate(inactive_ordinary, .25, 0);
+  check(std::memcmp(&inactive_compact, &inactive_reference,
+                    sizeof(Evaluation)) == 0 &&
+            ordinary_update_forward_calls == 3 &&
+            ordinary_update_backward_calls == 0,
+        "inactive range delta has bitwise ordinary-path parity");
+  close(inactive_compact.value, 40.75, "inactive range delta result");
+  close(inactive_compact.gradient[0], 163,
+        "inactive range delta outer gradient");
 }
 
 static std::shared_ptr<StructuredLoop> integer_history_plan() {

--- a/tests/test_structured_loop_production.cpp
+++ b/tests/test_structured_loop_production.cpp
@@ -13,6 +13,7 @@
 #include <cstdio>
 #include <fstream>
 #include <functional>
+#include <limits>
 #include <sstream>
 #include <stdexcept>
 #include <string>
@@ -684,6 +685,230 @@ static void compact_iterator_history_tests() {
   close(updated.gradient[0], 6,
         "inline iterator compact-update theta gradient");
   close(updated.gradient[1], 0, "inline iterator compact-update beta gradient");
+}
+
+static std::shared_ptr<StructuredLoop> integer_history_plan() {
+  auto plan = std::make_shared<StructuredLoop>();
+  const int theta = plan->body.add_slot(1, false);
+  const int lower = scalar(*plan, -1);
+  const int upper = scalar(*plan, 1);
+  const int iterator = plan->body.add_slot(1, false);
+  const int two = scalar(*plan, 2);
+  const int integer_result = plan->body.add_slot(1, false);
+  const int zero = scalar(*plan, 0);
+  const int result = plan->body.add_slot(1, false);
+  const int term = plan->body.add_slot(1, false);
+  const int next = plan->body.add_slot(1, false);
+  plan->imports = {{theta, 0, 0}};
+  Node arithmetic = call(*plan, OP_INT_ARITH, {iterator, two}, integer_result);
+  plan->body.ops[static_cast<size_t>(arithmetic.op)].variant = 2;
+  Node multiply = call(*plan, OP_MUL, {theta, integer_result}, term);
+  const int multiply_op = multiply.op;
+  plan->root =
+      sequence({alias(result, zero),
+                counted(lower, upper, iterator, 3,
+                        sequence({std::move(arithmetic), std::move(multiply),
+                                  call(*plan, OP_ADD, {result, term}, next),
+                                  alias(result, next)}))});
+  plan->outputs = {result};
+  plan->prepare(1 << 20);
+  plan->dynamic_history = true;
+  check(set_forward(plan->root, multiply_op, trace_iterator_forward),
+        "find integer-result trace forward callback");
+  check(set_backward(plan->root, multiply_op, trace_iterator_backward),
+        "find integer-result trace backward callback");
+  return plan;
+}
+
+static std::shared_ptr<StructuredLoop> comparison_target_plan() {
+  auto plan = std::make_shared<StructuredLoop>();
+  const int lower = scalar(*plan, -1);
+  const int upper = scalar(*plan, 1);
+  const int iterator = plan->body.add_slot(1, false);
+  const int zero = scalar(*plan, 0);
+  const int compared = plan->body.add_slot(1, false);
+  Node comparison = call(*plan, OP_COMPARE, {iterator, zero}, compared);
+  plan->body.ops[static_cast<size_t>(comparison.op)].variant = 0;
+  Node target;
+  target.kind = Node::Target;
+  target.src = compared;
+  plan->root = counted(lower, upper, iterator, 3,
+                       sequence({std::move(comparison), std::move(target)}));
+  plan->has_target = true;
+  plan->prepare(1 << 20);
+  plan->dynamic_history = true;
+  return plan;
+}
+
+static std::shared_ptr<StructuredLoop> computed_nested_bound_plan() {
+  auto plan = std::make_shared<StructuredLoop>();
+  const int one = scalar(*plan, 1);
+  const int two = scalar(*plan, 2);
+  const int outer_iterator = plan->body.add_slot(1, false);
+  const int inner_iterator = plan->body.add_slot(1, false);
+  const int inner_upper = plan->body.add_slot(1, false);
+  Node arithmetic =
+      call(*plan, OP_INT_ARITH, {outer_iterator, one}, inner_upper);
+  plan->body.ops[static_cast<size_t>(arithmetic.op)].variant = 0;
+  Node target;
+  target.kind = Node::Target;
+  target.src = inner_iterator;
+  plan->root = counted(
+      one, two, outer_iterator, 2,
+      sequence({std::move(arithmetic), counted(one, inner_upper, inner_iterator,
+                                               3, std::move(target))}));
+  plan->has_target = true;
+  plan->prepare(1 << 20);
+  plan->dynamic_history = true;
+  return plan;
+}
+
+static std::shared_ptr<StructuredLoop> integer_output_plan(double a, double b) {
+  auto plan = std::make_shared<StructuredLoop>();
+  const int left = scalar(*plan, a);
+  const int right = scalar(*plan, b);
+  const int integer_result = plan->body.add_slot(1, false);
+  const int result = plan->body.add_slot(1, false);
+  Node arithmetic = call(*plan, OP_INT_ARITH, {left, right}, integer_result);
+  plan->body.ops[static_cast<size_t>(arithmetic.op)].variant = 0;
+  plan->root = sequence({std::move(arithmetic), alias(result, integer_result)});
+  plan->outputs = {result};
+  plan->prepare(1 << 20);
+  plan->dynamic_history = true;
+  return plan;
+}
+
+static std::shared_ptr<StructuredLoop> imported_integer_output_plan(
+    int variant = 0) {
+  auto plan = std::make_shared<StructuredLoop>();
+  const int left = plan->body.add_slot(1, false);
+  const int right = plan->body.add_slot(1, false);
+  const int result = plan->body.add_slot(1, false);
+  plan->imports = {{left, 0, 0}, {right, 1, 0}};
+  Node arithmetic = call(*plan, OP_INT_ARITH, {left, right}, result);
+  plan->body.ops[static_cast<size_t>(arithmetic.op)].variant = variant;
+  plan->root = std::move(arithmetic);
+  plan->outputs = {result};
+  plan->prepare(1 << 20);
+  plan->dynamic_history = true;
+  return plan;
+}
+
+static int custom_integer_calls = 0;
+static void custom_integer_forward(KernelCtx& context) {
+  ++custom_integer_calls;
+  find_kernel(OP_INT_ARITH)->forward(context);
+  context.out.data[0] += 0.5;
+}
+
+static void registered_custom_integer_forward(KernelCtx& context) {
+  ++custom_integer_calls;
+  context.out.data[0] = 5.5;
+}
+
+struct ScopedKernelOverride {
+  uint16_t opcode;
+  Kernel saved;
+
+  ScopedKernelOverride(uint16_t opcode, Kernel replacement)
+      : opcode(opcode), saved(*find_kernel(opcode)) {
+    register_kernel(opcode, replacement);
+  }
+  ~ScopedKernelOverride() { register_kernel(opcode, saved); }
+};
+
+static std::shared_ptr<StructuredLoop> custom_integer_plan() {
+  auto plan = integer_output_plan(2, 3);
+  check(set_forward(plan->root, 0, custom_integer_forward),
+        "find custom integer callback");
+  return plan;
+}
+
+static void compact_integer_result_tests() {
+  iterator_forward_values.clear();
+  iterator_reverse_values.clear();
+  Executor history(outer(integer_history_plan()));
+  const Evaluation traced = evaluate(history, .25, 0);
+  close(traced.value, 0, "inline integer history value");
+  close(traced.gradient[0], 0, "inline integer history theta gradient");
+  check(iterator_forward_values == std::vector<double>({-2, 0, 2}),
+        "inline integer forward values are exact");
+  check(iterator_reverse_values == std::vector<double>({2, 0, -2}),
+        "inline integer reverse values preserve history");
+
+  Executor comparison_target(outer(comparison_target_plan()));
+  const Evaluation compared = evaluate(comparison_target, 0, 0);
+  close(compared.value, 1, "inline comparison target keeps reached values");
+  close(compared.gradient[0], 0, "inline comparison target theta gradient");
+  close(compared.gradient[1], 0, "inline comparison target beta gradient");
+
+  Executor nested_bound(outer(computed_nested_bound_plan()));
+  const Evaluation nested = evaluate(nested_bound, 0, 0);
+  close(nested.value, 9, "inline integer supplies nested loop bound");
+  close(nested.gradient[0], 0, "inline integer bound theta gradient");
+  close(nested.gradient[1], 0, "inline integer bound beta gradient");
+
+  for (const auto& point : std::vector<std::pair<double, double>>{
+           {static_cast<double>(std::numeric_limits<int32_t>::min()), 0},
+           {static_cast<double>(std::numeric_limits<int32_t>::max()) - 1, 1}}) {
+    Executor boundary(outer(integer_output_plan(point.first, point.second)));
+    const Evaluation result = evaluate(boundary, 0, 0);
+    close(result.value, point.first + point.second,
+          "inline integer boundary escapes through output alias");
+    close(result.gradient[0], 0, "inline integer boundary theta gradient");
+    close(result.gradient[1], 0, "inline integer boundary beta gradient");
+  }
+
+  Executor retry(outer(imported_integer_output_plan()));
+  bool threw = false;
+  try {
+    (void)evaluate(retry,
+                   static_cast<double>(std::numeric_limits<int32_t>::max()), 1);
+  } catch (const std::domain_error& error) {
+    threw = std::string(error.what()) ==
+            "integer arithmetic exceeds Stan integer range";
+  }
+  check(threw, "inline integer preserves arithmetic exception");
+  const Evaluation retried = evaluate(retry, 2, 3);
+  close(retried.value, 5, "inline integer retry value");
+  close(retried.gradient[0], 0, "inline integer retry theta gradient");
+  close(retried.gradient[1], 0, "inline integer retry beta gradient");
+
+  Executor division_retry(outer(imported_integer_output_plan(3)));
+  threw = false;
+  try {
+    (void)evaluate(division_retry, 4, 0);
+  } catch (const std::domain_error& error) {
+    threw = std::string(error.what()) == "integer division by zero";
+  }
+  check(threw, "inline integer preserves division exception");
+  const Evaluation divided = evaluate(division_retry, 4, 2);
+  close(divided.value, 2, "inline integer division retry value");
+  close(divided.gradient[0], 0,
+        "inline integer division retry theta gradient");
+  close(divided.gradient[1], 0,
+        "inline integer division retry beta gradient");
+
+  custom_integer_calls = 0;
+  Executor custom(outer(custom_integer_plan()));
+  const Evaluation custom_result = evaluate(custom, 0, 0);
+  close(custom_result.value, 5.5,
+        "custom integer callback keeps ordinary result semantics");
+  check(custom_integer_calls == 1,
+        "custom integer callback uses ordinary retained path");
+
+  custom_integer_calls = 0;
+  {
+    Kernel replacement = *find_kernel(OP_INT_ARITH);
+    replacement.forward = registered_custom_integer_forward;
+    ScopedKernelOverride overridden(OP_INT_ARITH, replacement);
+    Executor registered_custom(outer(integer_output_plan(2, 3)));
+    const Evaluation registered_result = evaluate(registered_custom, 0, 0);
+    close(registered_result.value, 5.5,
+          "registered custom integer callback is not inlined");
+  }
+  check(custom_integer_calls == 1,
+        "pre-prepare custom integer callback keeps ordinary path");
 }
 
 static std::atomic<int> invariant_first_calls{0};
@@ -1427,6 +1652,7 @@ int main() {
   forced_control_tests();
   dynamic_history_tests();
   compact_iterator_history_tests();
+  compact_integer_result_tests();
   loop_invariant_reuse_tests();
   inactive_control_tests();
   dynamic_history_concurrency_tests();

--- a/tests/test_structured_loop_production.cpp
+++ b/tests/test_structured_loop_production.cpp
@@ -521,6 +521,7 @@ static std::vector<const double*> range_update_forward_addresses;
 static bool iterator_throw_once = false;
 static int ordinary_update_forward_calls = 0;
 static int ordinary_update_backward_calls = 0;
+static int duplicate_site_backward_calls = 0;
 
 static void trace_iterator_forward(KernelCtx& context) {
   iterator_forward_values.push_back(context.in[1].data[0]);
@@ -554,6 +555,11 @@ static void ordinary_update_forward(KernelCtx& context) {
 static void ordinary_update_backward(KernelCtx& context) {
   ++ordinary_update_backward_calls;
   find_kernel(OP_SET_INDEX_DYNAMIC)->backward(context);
+}
+
+static void duplicate_site_backward(KernelCtx& context) {
+  ++duplicate_site_backward_calls;
+  find_kernel(OP_MUL)->backward(context);
 }
 
 static void trace_range_sum_backward(KernelCtx& context) {
@@ -973,6 +979,81 @@ static std::shared_ptr<StructuredLoop> loop_aliased_update_plan(
   return plan;
 }
 
+static std::shared_ptr<StructuredLoop> retained_scalar_update_plan(
+    bool force_ordinary) {
+  auto plan = std::make_shared<StructuredLoop>();
+  const int theta = plan->body.add_slot(1, false);
+  const int one = scalar(*plan, 1);
+  const int two = scalar(*plan, 2);
+  const int inactive_rhs = scalar(*plan, 7);
+  const int base = plan->body.add_slot(3, false);
+  plan->fills.push_back({base, {10, 20, 30}});
+  const int current = plan->body.add_slot(3, false);
+  const int updated1_slot = plan->body.add_slot(3, false);
+  const int updated2_slot = plan->body.add_slot(3, false);
+  const int observed1 = plan->body.add_slot(1, false);
+  const int observed2 = plan->body.add_slot(1, false);
+  const int result = plan->body.add_slot(1, false);
+  plan->imports = {{theta, 0, 0}};
+
+  auto spec = std::make_shared<DynamicIndexSpec>();
+  spec->axes = {{DynamicIndexSpec::Axis::Single, 3, 1, 1, 0}};
+  spec->selected_size = 1;
+  Node update1 = call(*plan, OP_SET_INDEX_DYNAMIC,
+                      {current, one, inactive_rhs}, updated1_slot);
+  Node update2 =
+      call(*plan, OP_SET_INDEX_DYNAMIC, {current, two, theta}, updated2_slot);
+  const int update_ops[] = {update1.op, update2.op};
+  for (int op : update_ops)
+    plan->body.ops[static_cast<size_t>(op)].udata = spec.get();
+  plan->body.udata_pool.push_back(spec);
+  Node observe1 = call(*plan, OP_SUM_VEC, {current}, observed1);
+  Node observe2 = call(*plan, OP_SUM_VEC, {current}, observed2);
+  const int observer_ops[] = {observe1.op, observe2.op};
+  plan->root = sequence(
+      {alias(current, base), std::move(update1),
+       alias(current, updated1_slot), std::move(observe1), std::move(update2),
+       alias(current, updated2_slot), std::move(observe2),
+       call(*plan, OP_SUM_VEC, {current}, result)});
+  plan->outputs = {result};
+  plan->prepare(1 << 20);
+  plan->dynamic_history = true;
+  check(plan->compact_update_sites == 2,
+        "retained scalar plan selects compact update sites");
+  for (int op : observer_ops)
+    check(set_forward(plan->root, op, trace_range_sum_forward),
+          "find retained scalar address observer");
+  if (force_ordinary) {
+    for (int op : update_ops) {
+      check(set_forward(plan->root, op, ordinary_update_forward),
+            "find retained scalar forward callback");
+      check(set_backward(plan->root, op, ordinary_update_backward),
+            "find retained scalar backward callback");
+    }
+  }
+  return plan;
+}
+
+static std::shared_ptr<StructuredLoop> duplicate_record_site_plan() {
+  auto plan = std::make_shared<StructuredLoop>();
+  const int theta = plan->body.add_slot(1, false);
+  const int beta = plan->body.add_slot(1, false);
+  const int product = plan->body.add_slot(1, false);
+  plan->imports = {{theta, 0, 0}, {beta, 1, 0}};
+  Node first = call(*plan, OP_MUL, {theta, beta}, product);
+  Node second = first;
+  plan->root = sequence({std::move(first), std::move(second)});
+  plan->outputs = {product};
+  plan->prepare(1 << 20);
+  plan->dynamic_history = true;
+  check(plan->record_node_count == 2 &&
+            plan->root.children[0].record_site !=
+                plan->root.children[1].record_site,
+        "duplicate operation nodes receive distinct record sites");
+  plan->root.children[1].backward = duplicate_site_backward;
+  return plan;
+}
+
 static void compact_iterator_history_tests() {
   iterator_forward_values.clear();
   iterator_reverse_values.clear();
@@ -1181,6 +1262,40 @@ static void compact_iterator_history_tests() {
         "loop-backedge alias preserves snapshot value");
   close(loop_aliased.gradient[0], 7,
         "loop-backedge alias preserves snapshot gradient");
+
+  ordinary_update_forward_calls = ordinary_update_backward_calls = 0;
+  Executor retained_compact(outer(retained_scalar_update_plan(false)));
+  Executor retained_ordinary(outer(retained_scalar_update_plan(true)));
+  range_update_forward_addresses.clear();
+  const Evaluation retained_result = evaluate(retained_compact, .25, 0);
+  const auto retained_compact_addresses = range_update_forward_addresses;
+  range_update_forward_addresses.clear();
+  const Evaluation retained_reference = evaluate(retained_ordinary, .25, 0);
+  const auto retained_ordinary_addresses = range_update_forward_addresses;
+  check(std::memcmp(&retained_result, &retained_reference,
+                    sizeof(Evaluation)) == 0 &&
+            ordinary_update_forward_calls == 2 &&
+            ordinary_update_backward_calls == 1,
+        "retained scalar record has bitwise ordinary-path parity");
+  check(retained_compact_addresses.size() == 2 &&
+            retained_compact_addresses[0] == retained_compact_addresses[1] &&
+            retained_ordinary_addresses.size() == 2 &&
+            retained_ordinary_addresses[0] != retained_ordinary_addresses[1],
+        "unshared active scalar update uses retained compact history");
+  close(retained_result.value, 37.25, "retained scalar record value");
+  close(retained_result.gradient[0], 1,
+        "retained scalar record gradient");
+
+  duplicate_site_backward_calls = 0;
+  Executor duplicate_sites(outer(duplicate_record_site_plan()));
+  const Evaluation duplicate = evaluate(duplicate_sites, 2, 3);
+  close(duplicate.value, 6, "duplicate operation record-site value");
+  close(duplicate.gradient[0], 3,
+        "duplicate operation record-site theta gradient");
+  close(duplicate.gradient[1], 2,
+        "duplicate operation record-site beta gradient");
+  check(duplicate_site_backward_calls == 1,
+        "reverse resolves the exact duplicate operation node");
 }
 
 static std::shared_ptr<StructuredLoop> integer_history_plan() {

--- a/tests/test_structured_loop_production.cpp
+++ b/tests/test_structured_loop_production.cpp
@@ -916,6 +916,105 @@ static std::shared_ptr<StructuredLoop> inactive_zero_output_plan() {
   return plan;
 }
 
+static void redirect_inactive_output(KernelCtx& context) {
+  context.out.data = context.in[0].data;
+}
+
+static std::shared_ptr<StructuredLoop> redirected_inactive_output_plan() {
+  auto plan = std::make_shared<StructuredLoop>();
+  const int source = scalar(*plan, 42);
+  const int zero = scalar(*plan, 0);
+  const int result = plan->body.add_slot(1, false);
+  Node redirected = call(*plan, OP_ADD, {source, zero}, result);
+  const int redirected_op = redirected.op;
+  plan->root = std::move(redirected);
+  plan->outputs = {result};
+  plan->prepare(1 << 20);
+  plan->dynamic_history = true;
+  check(set_forward(plan->root, redirected_op, redirect_inactive_output),
+        "find redirected inactive callback");
+  return plan;
+}
+
+static std::shared_ptr<StructuredLoop> inactive_location_target_plan() {
+  auto plan = std::make_shared<StructuredLoop>();
+  const int two = scalar(*plan, 2);
+  const int three = scalar(*plan, 3);
+  const int result = plan->body.add_slot(1, false);
+  Node target;
+  target.kind = Node::Target;
+  target.src = result;
+  plan->root =
+      sequence({call(*plan, OP_ADD, {two, three}, result), std::move(target)});
+  plan->has_target = true;
+  plan->prepare(1 << 20);
+  plan->dynamic_history = true;
+  return plan;
+}
+
+static std::shared_ptr<StructuredLoop> inactive_location_bound_plan() {
+  auto plan = std::make_shared<StructuredLoop>();
+  const int one = scalar(*plan, 1);
+  const int two = scalar(*plan, 2);
+  const int upper = plan->body.add_slot(1, false);
+  const int iterator = plan->body.add_slot(1, false);
+  const int result = plan->body.add_slot(1, false);
+  plan->root =
+      sequence({call(*plan, OP_ADD, {one, two}, upper),
+                counted(one, upper, iterator, 3, alias(result, iterator))});
+  plan->outputs = {result};
+  plan->prepare(1 << 20);
+  plan->dynamic_history = true;
+  return plan;
+}
+
+static std::shared_ptr<StructuredLoop> inactive_location_reverse_plan() {
+  auto plan = std::make_shared<StructuredLoop>();
+  const int theta = plan->body.add_slot(1, false);
+  const int two = scalar(*plan, 2);
+  const int three = scalar(*plan, 3);
+  const int inactive = plan->body.add_slot(1, false);
+  const int result = plan->body.add_slot(1, false);
+  plan->imports = {{theta, 0, 0}};
+  plan->root = sequence({call(*plan, OP_ADD, {two, three}, inactive),
+                         call(*plan, OP_MUL, {theta, inactive}, result)});
+  plan->outputs = {result};
+  plan->prepare(1 << 20);
+  plan->dynamic_history = true;
+  return plan;
+}
+
+static std::shared_ptr<StructuredLoop> inactive_location_update_plan() {
+  auto plan = std::make_shared<StructuredLoop>();
+  const int lower = scalar(*plan, 1);
+  const int upper = scalar(*plan, 3);
+  const int iterator = plan->body.add_slot(1, false);
+  const int base = plan->body.add_slot(3, false);
+  plan->fills.push_back({base, {10, 20, 30}});
+  const int current = plan->body.add_slot(3, false);
+  const int rhs = scalar(*plan, 7);
+  const int updated = plan->body.add_slot(3, false);
+  const int result = plan->body.add_slot(1, false);
+  auto spec = std::make_shared<DynamicIndexSpec>();
+  spec->axes = {{DynamicIndexSpec::Axis::Single, 3, 1, 1, 0}};
+  spec->selected_size = 1;
+  Node update =
+      call(*plan, OP_SET_INDEX_DYNAMIC, {current, iterator, rhs}, updated);
+  plan->body.ops[static_cast<size_t>(update.op)].udata = spec.get();
+  plan->body.udata_pool.push_back(spec);
+  plan->root =
+      sequence({alias(current, base),
+                counted(lower, upper, iterator, 3,
+                        sequence({std::move(update), alias(current, updated)})),
+                call(*plan, OP_SUM_VEC, {current}, result)});
+  plan->outputs = {result};
+  plan->prepare(1 << 20);
+  plan->dynamic_history = true;
+  check(plan->compact_update_sites == 1,
+        "inactive location update selects compact history");
+  return plan;
+}
+
 static int active_workspace_forward_calls = 0;
 static int active_workspace_backward_calls = 0;
 static double* active_workspace_address = nullptr;
@@ -1110,6 +1209,33 @@ static void compact_integer_result_tests() {
         "inactive zero-output callbacks execute without arena anchors");
   check(inactive_workspace_stable && inactive_workspace_disjoint,
         "inactive zero-output workspace remains stable and disjoint");
+
+  Executor redirected(outer(redirected_inactive_output_plan()));
+  const Evaluation redirected_result = evaluate(redirected, 0, 0);
+  close(redirected_result.value, 42,
+        "redirected inactive output keeps ordinary reference fallback");
+
+  Executor inactive_target(outer(inactive_location_target_plan()));
+  const Evaluation targeted = evaluate(inactive_target, 0, 0);
+  close(targeted.value, 5, "inactive arena handle reaches target reduction");
+
+  Executor inactive_bound(outer(inactive_location_bound_plan()));
+  const Evaluation bounded = evaluate(inactive_bound, 0, 0);
+  close(bounded.value, 3, "inactive arena handle supplies counted-loop bound");
+
+  Executor inactive_reverse(outer(inactive_location_reverse_plan()));
+  const Evaluation reversed = evaluate(inactive_reverse, 4, 0);
+  close(reversed.value, 20,
+        "active operation reads inactive arena-handle primal");
+  close(reversed.gradient[0], 5,
+        "reverse operation reads inactive arena-handle primal");
+  close(reversed.gradient[1], 0,
+        "inactive arena-handle input has no adjoint storage");
+
+  Executor inactive_update(outer(inactive_location_update_plan()));
+  const Evaluation updated = evaluate(inactive_update, 0, 0);
+  close(updated.value, 21,
+        "inactive arena handle supplies compact-update base");
 
   active_workspace_forward_calls = 0;
   active_workspace_backward_calls = 0;

--- a/tests/test_structured_loop_production.cpp
+++ b/tests/test_structured_loop_production.cpp
@@ -569,6 +569,10 @@ static void ordinary_index_backward(KernelCtx& context) {
   find_kernel(OP_INDEX_DYNAMIC)->backward(context);
 }
 
+static void redirect_first_input(KernelCtx& context) {
+  context.out.data = context.in[0].data;
+}
+
 static void duplicate_site_backward(KernelCtx& context) {
   ++duplicate_site_backward_calls;
   find_kernel(OP_MUL)->backward(context);
@@ -1229,6 +1233,144 @@ static Graph scalar_index_after_updates_outer(
   return graph;
 }
 
+static std::shared_ptr<StructuredLoop> scalar_index_redirect_plan(
+    bool active_redirect) {
+  auto plan = std::make_shared<StructuredLoop>();
+  const int base = plan->body.add_slot(32, false);
+  const int one = scalar(*plan, 1);
+  const int upper = scalar(*plan, 32);
+  const int zero = scalar(*plan, 0);
+  const int iterator = plan->body.add_slot(1, false);
+  const int selected = plan->body.add_slot(1, false);
+  const int redirected = plan->body.add_slot(1, false);
+  const int later = plan->body.add_slot(1, false);
+  plan->imports = {{base, 0, 0}};
+
+  auto first_spec = std::make_shared<DynamicIndexSpec>();
+  first_spec->axes = {{DynamicIndexSpec::Axis::Single, 32, 1, 1, 0}};
+  first_spec->selected_size = 1;
+  Node first = call(*plan, OP_INDEX_DYNAMIC, {base, one}, selected);
+  plan->body.ops[static_cast<size_t>(first.op)].udata = first_spec.get();
+  plan->body.udata_pool.push_back(first_spec);
+
+  Node redirect = call(*plan, active_redirect ? OP_ADD : OP_COMPARE,
+                       {selected, zero}, redirected);
+  const int redirect_op = redirect.op;
+  auto later_spec = std::make_shared<DynamicIndexSpec>();
+  later_spec->axes = {{DynamicIndexSpec::Axis::Single, 32, 1, 1, 0}};
+  later_spec->selected_size = 1;
+  Node later_index = call(*plan, OP_INDEX_DYNAMIC, {base, iterator}, later);
+  plan->body.ops[static_cast<size_t>(later_index.op)].udata = later_spec.get();
+  plan->body.udata_pool.push_back(later_spec);
+  plan->root =
+      sequence({std::move(first), std::move(redirect),
+                counted(one, upper, iterator, 32, std::move(later_index))});
+  plan->outputs = {redirected};
+  plan->prepare(1 << 20);
+  plan->dynamic_history = true;
+  check(set_forward(plan->root, redirect_op, redirect_first_input),
+        "find record-scalar redirect callback");
+  if (!active_redirect)
+    check(set_backward(plan->root, redirect_op, nullptr),
+          "disable record-scalar redirect backward callback");
+  return plan;
+}
+
+static Graph scalar_index_redirect_outer(std::shared_ptr<StructuredLoop> plan) {
+  Graph graph;
+  graph.add_slot(32, true);
+  const int output = graph.add_slot(1, false);
+  const int op = graph.add_op(OP_LOOP, {0}, output);
+  graph.ops[op].udata = plan.get();
+  graph.udata_pool.push_back(std::move(plan));
+  graph.result_slot = output;
+  return graph;
+}
+
+static std::shared_ptr<StructuredLoop> scalar_index_target_plan() {
+  auto plan = std::make_shared<StructuredLoop>();
+  const int base = plan->body.add_slot(3, false);
+  const int one = scalar(*plan, 1);
+  const int selected = plan->body.add_slot(1, false);
+  plan->imports = {{base, 0, 0}};
+  auto spec = std::make_shared<DynamicIndexSpec>();
+  spec->axes = {{DynamicIndexSpec::Axis::Single, 3, 1, 1, 0}};
+  spec->selected_size = 1;
+  Node index = call(*plan, OP_INDEX_DYNAMIC, {base, one}, selected);
+  plan->body.ops[static_cast<size_t>(index.op)].udata = spec.get();
+  plan->body.udata_pool.push_back(spec);
+  Node target;
+  target.kind = Node::Target;
+  target.src = selected;
+  plan->root = sequence({std::move(index), std::move(target)});
+  plan->has_target = true;
+  plan->prepare(1 << 20);
+  plan->dynamic_history = true;
+  return plan;
+}
+
+static Graph scalar_index_three_parameter_outer(
+    std::shared_ptr<StructuredLoop> plan) {
+  Graph graph;
+  graph.add_slot(3, true);
+  const int output = graph.add_slot(1, false);
+  const int op = graph.add_op(OP_LOOP, {0}, output);
+  graph.ops[op].udata = plan.get();
+  graph.udata_pool.push_back(std::move(plan));
+  graph.result_slot = output;
+  return graph;
+}
+
+static std::shared_ptr<StructuredLoop> scalar_index_update_rhs_plan(
+    bool force_ordinary_index) {
+  auto plan = std::make_shared<StructuredLoop>();
+  const int base = plan->body.add_slot(3, false);
+  const int one = scalar(*plan, 1);
+  const int two = scalar(*plan, 2);
+  const int iterator = plan->body.add_slot(1, false);
+  const int current = plan->body.add_slot(3, false);
+  const int updated = plan->body.add_slot(3, false);
+  const int selected = plan->body.add_slot(1, false);
+  const int result = plan->body.add_slot(1, false);
+  plan->imports = {{base, 0, 0}};
+
+  auto update_spec = std::make_shared<DynamicIndexSpec>();
+  update_spec->axes = {{DynamicIndexSpec::Axis::Single, 3, 1, 1, 0}};
+  update_spec->selected_size = 1;
+  Node update =
+      call(*plan, OP_SET_INDEX_DYNAMIC, {current, iterator, selected}, updated);
+  plan->body.ops[static_cast<size_t>(update.op)].udata = update_spec.get();
+  plan->body.udata_pool.push_back(update_spec);
+
+  auto index_spec = std::make_shared<DynamicIndexSpec>();
+  index_spec->axes = {{DynamicIndexSpec::Axis::Single, 3, 1, 1, 0}};
+  index_spec->selected_size = 1;
+  Node index = call(*plan, OP_INDEX_DYNAMIC, {base, one}, selected);
+  const int index_op = index.op;
+  plan->body.ops[static_cast<size_t>(index.op)].udata = index_spec.get();
+  plan->body.udata_pool.push_back(index_spec);
+  plan->root =
+      sequence({std::move(index), alias(current, base),
+                counted(one, two, iterator, 2,
+                        sequence({std::move(update), alias(current, updated)})),
+                call(*plan, OP_SUM_VEC, {current}, result)});
+  plan->outputs = {result};
+  plan->prepare(1 << 20);
+  plan->dynamic_history = true;
+  check(
+      plan->compact_update_sites == 1 &&
+          plan->root.children[2].children[0].children[0].compact_update_cell >=
+              0,
+      "record-scalar RHS update selects compact history");
+  if (force_ordinary_index) {
+    check(set_forward(plan->root, index_op, ordinary_index_forward),
+          "find record-scalar RHS index forward callback");
+    check(set_backward(plan->root, index_op, ordinary_index_backward),
+          "find record-scalar RHS index backward callback");
+  }
+  return plan;
+}
+
 static void compact_scalar_index_tests() {
   const double point[] = {7, 1e16, -1e16, 1, 9, .25};
   const double expected_gradient[] = {0, .25, .25, .25, 0, 0};
@@ -1297,6 +1439,64 @@ static void compact_scalar_index_tests() {
   for (size_t i = 0; i < std::size(expected_updated_gradient); ++i)
     close(updated_gradient[i], expected_updated_gradient[i],
           "scalar index routes through a shared update adjoint");
+
+  std::array<double, 32> redirect_point{};
+  for (size_t i = 0; i < redirect_point.size(); ++i)
+    redirect_point[i] = static_cast<double>(i + 1);
+  for (bool active_redirect : {false, true}) {
+    Executor redirected(scalar_index_redirect_outer(
+        scalar_index_redirect_plan(active_redirect)));
+    std::copy(redirect_point.begin(), redirect_point.end(),
+              redirected.params_data());
+    std::array<double, 32> redirect_gradient{};
+    close(redirected.gradient(redirect_gradient.data()), 1,
+          "record scalar survives redirected output and record relocation");
+    for (size_t i = 0; i < redirect_gradient.size(); ++i)
+      close(redirect_gradient[i], active_redirect && i == 0 ? 1 : 0,
+            "redirected record scalar gradient follows callback contract");
+  }
+
+  Executor targeted(
+      scalar_index_three_parameter_outer(scalar_index_target_plan()));
+  const double target_point[] = {2, 3, 4};
+  std::copy(std::begin(target_point), std::end(target_point),
+            targeted.params_data());
+  double target_gradient[3] = {};
+  close(targeted.gradient(target_gradient), 2,
+        "record scalar contributes a target leaf");
+  close(target_gradient[0], 1,
+        "record scalar receives and scatters a target adjoint");
+  close(target_gradient[1], 0,
+        "record scalar target leaves unselected input unchanged");
+  close(target_gradient[2], 0,
+        "record scalar target leaves final input unchanged");
+
+  ordinary_index_forward_calls = ordinary_index_backward_calls = 0;
+  Executor update_rhs(
+      scalar_index_three_parameter_outer(scalar_index_update_rhs_plan(false)));
+  Executor ordinary_update_rhs(
+      scalar_index_three_parameter_outer(scalar_index_update_rhs_plan(true)));
+  std::copy(std::begin(target_point), std::end(target_point),
+            update_rhs.params_data());
+  std::copy(std::begin(target_point), std::end(target_point),
+            ordinary_update_rhs.params_data());
+  double update_rhs_gradient[3] = {};
+  double ordinary_update_rhs_gradient[3] = {};
+  const double update_rhs_value = update_rhs.gradient(update_rhs_gradient);
+  const double ordinary_update_rhs_value =
+      ordinary_update_rhs.gradient(ordinary_update_rhs_gradient);
+  check(std::memcmp(&update_rhs_value, &ordinary_update_rhs_value,
+                    sizeof(double)) == 0 &&
+            std::memcmp(update_rhs_gradient, ordinary_update_rhs_gradient,
+                        sizeof(update_rhs_gradient)) == 0,
+        "record scalar RHS has bitwise ordinary-path parity");
+  close(update_rhs_value, 8, "record scalar RHS update value");
+  const double expected_rhs_gradient[] = {2, 0, 1};
+  for (size_t i = 0; i < std::size(expected_rhs_gradient); ++i)
+    close(update_rhs_gradient[i], expected_rhs_gradient[i],
+          "record scalar RHS update gradient");
+  check(ordinary_index_forward_calls == 1 && ordinary_index_backward_calls == 1,
+        "record scalar RHS ordinary comparison replays its callback");
 }
 
 static void compact_iterator_history_tests() {
@@ -2862,6 +3062,7 @@ int main() {
   test_unsetenv("STANLI_NO_STRUCTURED_INVARIANT_REUSE");
   test_unsetenv("STANLI_NO_STRUCTURED_INACTIVE_CONTROL");
   test_unsetenv("STANLI_NO_STRUCTURED_DIRECT_INDEX_INPUTS");
+  test_unsetenv("STANLI_NO_STRUCTURED_RECORD_SCALARS");
   if (failures == 0) std::printf("test_structured_loop_production OK\n");
   return failures != 0;
 }

--- a/tests/test_structured_loop_production.cpp
+++ b/tests/test_structured_loop_production.cpp
@@ -181,6 +181,44 @@ static void runtime_trip_tests() {
   }
 }
 
+static void compact_import_reference_tests() {
+  auto plan = std::make_shared<StructuredLoop>();
+  const int left = plan->body.add_slot(1, false);
+  const int right = plan->body.add_slot(1, false);
+  const int repeated = plan->body.add_slot(1, false);
+  const int product = plan->body.add_slot(1, false);
+  const int result = plan->body.add_slot(1, false);
+  // Import ordinals deliberately differ from slot order. Two imports also
+  // name the same nonzero outer offset, so reverse must accumulate through
+  // distinct compact Ref entries into one graph adjoint cell.
+  plan->imports = {{repeated, 0, 1}, {left, 1, 2}, {right, 0, 1}};
+  plan->root = sequence({call(*plan, OP_MUL, {left, right}, product),
+                         call(*plan, OP_ADD, {product, repeated}, result)});
+  plan->outputs = {result};
+  plan->prepare(1 << 20);
+  plan->dynamic_history = true;
+
+  Graph graph;
+  graph.add_slot(3, true);
+  graph.add_slot(3, true);
+  const int output = graph.add_slot(1, false);
+  const int op = graph.add_op(OP_LOOP, {0, 1}, output);
+  graph.ops[op].udata = plan.get();
+  graph.udata_pool.push_back(std::move(plan));
+  graph.result_slot = output;
+
+  Executor executor(graph);
+  const double point[] = {1, 2, 3, 4, 5, 6};
+  std::copy(std::begin(point), std::end(point), executor.params_data());
+  double gradient[6] = {};
+  close(executor.gradient(gradient), 14,
+        "compact import ordinals preserve value");
+  const double expected[] = {0, 7, 0, 0, 0, 2};
+  for (size_t i = 0; i < std::size(expected); ++i)
+    close(gradient[i], expected[i],
+          "compact import ordinals preserve outer gradient");
+}
+
 static void direct_index_kernel_tests() {
   const Kernel* dynamic_index = find_kernel(OP_INDEX_DYNAMIC);
   check(dynamic_index && dynamic_index->forward && dynamic_index->backward,
@@ -1997,6 +2035,7 @@ static void direct_index_lowering_tests() {
 int main() {
   test_unsetenv("STANLI_STRUCTURED_LOOP_DIAGNOSTICS");
   runtime_trip_tests();
+  compact_import_reference_tests();
   direct_index_kernel_tests();
   forced_control_tests();
   dynamic_history_tests();

--- a/tests/test_structured_loop_production.cpp
+++ b/tests/test_structured_loop_production.cpp
@@ -436,12 +436,255 @@ static void dynamic_history_tests() {
   compare_gradients(dynamic, legacy, {{.1, .7}, {-.2, .3}, {0, .5}},
                     "dynamic-history target parity",
                     "dynamic-history gradient parity");
+
+  // This fixture feeds the counted iterator directly to an active multiply.
+  // Reverse must therefore recover every historical iterator value from the
+  // retained input handles rather than from one mutable loop cell.
+  test_setenv("STANLI_STRUCTURED_HISTORY_BYTES", "1");
+  const auto counted_dynamic =
+      compile_fixture("structured_counted", 4, Mode::Force);
+  test_unsetenv("STANLI_STRUCTURED_HISTORY_BYTES");
+  const auto counted_legacy =
+      compile_fixture("structured_counted", 4, Mode::Off);
+  check(retained(counted_dynamic) && retained(counted_dynamic)->dynamic_history,
+        "counted iterator test exercises dynamic history");
+  compare_gradients(counted_dynamic, counted_legacy,
+                    {{.1, .7}, {-.2, .3}, {0, .5}},
+                    "dynamic counted-iterator target parity",
+                    "dynamic counted-iterator gradient parity");
+
+  // Exercise iterator-driven nested branches, break, and continue on the
+  // reached-frame tape as well as on the ordinary small fixed-history path.
+  test_setenv("STANLI_STRUCTURED_HISTORY_BYTES", "1");
+  const auto exits_dynamic =
+      compile_fixture("structured_exits", 6, Mode::Force);
+  test_unsetenv("STANLI_STRUCTURED_HISTORY_BYTES");
+  const auto exits_legacy = compile_fixture("structured_exits", 6, Mode::Off);
+  check(retained(exits_dynamic) && retained(exits_dynamic)->dynamic_history,
+        "iterator exit test exercises dynamic history");
+  compare_gradients(exits_dynamic, exits_legacy, {{.1, .7}, {-.2, .3}},
+                    "dynamic iterator-exit target parity",
+                    "dynamic iterator-exit gradient parity");
 }
 
 struct Evaluation {
   double value = 0;
   double gradient[2] = {0, 0};
 };
+
+static Evaluation evaluate(Executor& executor, double theta, double beta);
+
+static std::vector<double> iterator_forward_values;
+static std::vector<double> iterator_reverse_values;
+static bool iterator_throw_once = false;
+
+static void trace_iterator_forward(KernelCtx& context) {
+  iterator_forward_values.push_back(context.in[1].data[0]);
+  if (iterator_throw_once && context.in[1].data[0] == 0) {
+    iterator_throw_once = false;
+    throw std::runtime_error("injected iterator callback failure");
+  }
+  find_kernel(OP_MUL)->forward(context);
+}
+
+static void trace_iterator_backward(KernelCtx& context) {
+  iterator_reverse_values.push_back(context.in[1].data[0]);
+  find_kernel(OP_MUL)->backward(context);
+}
+
+static std::shared_ptr<StructuredLoop> iterator_history_plan() {
+  auto plan = std::make_shared<StructuredLoop>();
+  const int theta = plan->body.add_slot(1, false);
+  const int lower = scalar(*plan, -1);
+  const int upper = scalar(*plan, 1);
+  const int iterator = plan->body.add_slot(1, false);
+  const int zero = scalar(*plan, 0);
+  const int result = plan->body.add_slot(1, false);
+  const int term = plan->body.add_slot(1, false);
+  const int next = plan->body.add_slot(1, false);
+  plan->imports = {{theta, 0, 0}};
+  Node multiply = call(*plan, OP_MUL, {theta, iterator}, term);
+  const int multiply_op = multiply.op;
+  plan->root =
+      sequence({alias(result, zero),
+                counted(lower, upper, iterator, 3,
+                        sequence({std::move(multiply),
+                                  call(*plan, OP_ADD, {result, term}, next),
+                                  alias(result, next)}))});
+  plan->outputs = {result};
+  plan->prepare(1 << 20);
+  plan->dynamic_history = true;
+  check(set_forward(plan->root, multiply_op, trace_iterator_forward),
+        "find iterator trace forward callback");
+  check(set_backward(plan->root, multiply_op, trace_iterator_backward),
+        "find iterator trace backward callback");
+  return plan;
+}
+
+static std::shared_ptr<StructuredLoop> iterator_escape_plan(
+    int32_t lower_value, int32_t upper_value) {
+  auto plan = std::make_shared<StructuredLoop>();
+  const int lower = scalar(*plan, lower_value);
+  const int upper = scalar(*plan, upper_value);
+  const int iterator = plan->body.add_slot(1, false);
+  const int initial = scalar(*plan, 7);
+  const int result = plan->body.add_slot(1, false);
+  const int64_t capacity =
+      upper_value >= lower_value
+          ? static_cast<int64_t>(upper_value) - lower_value + 1
+          : 0;
+  plan->root = sequence(
+      {alias(result, initial),
+       counted(lower, upper, iterator, capacity, alias(result, iterator))});
+  plan->outputs = {result};
+  plan->prepare(1 << 20);
+  plan->dynamic_history = true;
+  return plan;
+}
+
+static std::shared_ptr<StructuredLoop> iterator_target_plan() {
+  auto plan = std::make_shared<StructuredLoop>();
+  const int lower = scalar(*plan, 1);
+  const int upper = scalar(*plan, 3);
+  const int iterator = plan->body.add_slot(1, false);
+  Node target;
+  target.kind = Node::Target;
+  target.src = iterator;
+  plan->root = counted(lower, upper, iterator, 3, std::move(target));
+  plan->has_target = true;
+  plan->prepare(1 << 20);
+  plan->dynamic_history = true;
+  return plan;
+}
+
+static std::shared_ptr<StructuredLoop> nested_iterator_plan() {
+  auto plan = std::make_shared<StructuredLoop>();
+  const int theta = plan->body.add_slot(1, false);
+  const int zero = scalar(*plan, 0);
+  const int two = scalar(*plan, 2);
+  const int outer_iterator = plan->body.add_slot(1, false);
+  const int inner_iterator = plan->body.add_slot(1, false);
+  const int sum = plan->body.add_slot(1, false);
+  const int term = plan->body.add_slot(1, false);
+  const int result = plan->body.add_slot(1, false);
+  const int next = plan->body.add_slot(1, false);
+  plan->imports = {{theta, 0, 0}};
+  plan->root = sequence(
+      {alias(result, zero),
+       counted(zero, two, outer_iterator, 3,
+               counted(zero, outer_iterator, inner_iterator, 3,
+                       sequence({call(*plan, OP_ADD,
+                                      {outer_iterator, inner_iterator}, sum),
+                                 call(*plan, OP_MUL, {theta, sum}, term),
+                                 call(*plan, OP_ADD, {result, term}, next),
+                                 alias(result, next)})))});
+  plan->outputs = {result};
+  plan->prepare(1 << 20);
+  plan->dynamic_history = true;
+  return plan;
+}
+
+static std::shared_ptr<StructuredLoop> iterator_update_plan() {
+  auto plan = std::make_shared<StructuredLoop>();
+  const int theta = plan->body.add_slot(1, false);
+  const int lower = scalar(*plan, 1);
+  const int upper = scalar(*plan, 3);
+  const int iterator = plan->body.add_slot(1, false);
+  const int base = plan->body.add_slot(3, false);
+  plan->fills.push_back({base, {10, 20, 30}});
+  const int current = plan->body.add_slot(3, false);
+  const int rhs = plan->body.add_slot(1, false);
+  const int updated = plan->body.add_slot(3, false);
+  const int result = plan->body.add_slot(1, false);
+  plan->imports = {{theta, 0, 0}};
+
+  auto spec = std::make_shared<DynamicIndexSpec>();
+  spec->axes = {{DynamicIndexSpec::Axis::Single, 3, 1, 1, 0}};
+  spec->selected_size = 1;
+  Node update =
+      call(*plan, OP_SET_INDEX_DYNAMIC, {current, iterator, rhs}, updated);
+  plan->body.ops[static_cast<size_t>(update.op)].udata = spec.get();
+  plan->body.udata_pool.push_back(spec);
+  plan->root =
+      sequence({alias(current, base),
+                counted(lower, upper, iterator, 3,
+                        sequence({call(*plan, OP_MUL, {theta, iterator}, rhs),
+                                  std::move(update), alias(current, updated)})),
+                call(*plan, OP_SUM_VEC, {current}, result)});
+  plan->outputs = {result};
+  plan->prepare(1 << 20);
+  plan->dynamic_history = true;
+  check(plan->compact_update_sites == 1,
+        "iterator update plan selects compact history");
+  return plan;
+}
+
+static void compact_iterator_history_tests() {
+  iterator_forward_values.clear();
+  iterator_reverse_values.clear();
+  Executor history(outer(iterator_history_plan()));
+  const Evaluation traced = evaluate(history, .25, 0);
+  close(traced.value, 0, "inline iterator history value");
+  close(traced.gradient[0], 0, "inline iterator history theta gradient");
+  check(iterator_forward_values == std::vector<double>({-1, 0, 1}),
+        "inline iterator forward values are exact");
+  check(iterator_reverse_values == std::vector<double>({1, 0, -1}),
+        "inline iterator reverse values preserve history");
+
+  Executor retry(outer(iterator_history_plan()));
+  iterator_throw_once = true;
+  bool threw = false;
+  try {
+    (void)evaluate(retry, .25, 0);
+  } catch (const std::runtime_error& error) {
+    threw = std::string(error.what()) == "injected iterator callback failure";
+  }
+  check(threw, "inline iterator preserves callback exception");
+  iterator_forward_values.clear();
+  iterator_reverse_values.clear();
+  const Evaluation retried = evaluate(retry, .25, 0);
+  close(retried.value, traced.value, "inline iterator retry value");
+  close(retried.gradient[0], traced.gradient[0],
+        "inline iterator retry theta gradient");
+  check(iterator_forward_values == std::vector<double>({-1, 0, 1}) &&
+            iterator_reverse_values == std::vector<double>({1, 0, -1}),
+        "inline iterator retry rebuilds historical values");
+
+  for (const auto& bounds : std::vector<std::pair<int32_t, int32_t>>{
+           {std::numeric_limits<int32_t>::min(),
+            std::numeric_limits<int32_t>::min() + 1},
+           {std::numeric_limits<int32_t>::max() - 1,
+            std::numeric_limits<int32_t>::max()},
+           {1, 0}}) {
+    Executor escaped(outer(iterator_escape_plan(bounds.first, bounds.second)));
+    const Evaluation result = evaluate(escaped, 0, 0);
+    const double expected = bounds.second >= bounds.first ? bounds.second : 7;
+    close(result.value, expected, "inline iterator boundary escape value");
+    close(result.gradient[0], 0,
+          "inline iterator boundary escape theta gradient");
+    close(result.gradient[1], 0,
+          "inline iterator boundary escape beta gradient");
+  }
+
+  Executor target(outer(iterator_target_plan()));
+  const Evaluation targeted = evaluate(target, 0, 0);
+  close(targeted.value, 6, "inline iterator target keeps reached values");
+  close(targeted.gradient[0], 0, "inline iterator target theta gradient");
+  close(targeted.gradient[1], 0, "inline iterator target beta gradient");
+
+  Executor nested(outer(nested_iterator_plan()));
+  const Evaluation nested_result = evaluate(nested, .25, 0);
+  close(nested_result.value, 3, "nested inline iterator value");
+  close(nested_result.gradient[0], 12, "nested inline iterator theta gradient");
+  close(nested_result.gradient[1], 0, "nested inline iterator beta gradient");
+
+  Executor update(outer(iterator_update_plan()));
+  const Evaluation updated = evaluate(update, .25, 0);
+  close(updated.value, 1.5, "inline iterator compact-update value");
+  close(updated.gradient[0], 6,
+        "inline iterator compact-update theta gradient");
+  close(updated.gradient[1], 0, "inline iterator compact-update beta gradient");
+}
 
 static std::atomic<int> invariant_first_calls{0};
 static std::atomic<int> invariant_second_calls{0};
@@ -1183,6 +1426,7 @@ int main() {
   direct_index_kernel_tests();
   forced_control_tests();
   dynamic_history_tests();
+  compact_iterator_history_tests();
   loop_invariant_reuse_tests();
   inactive_control_tests();
   dynamic_history_concurrency_tests();

--- a/tests/test_structured_loop_production.cpp
+++ b/tests/test_structured_loop_production.cpp
@@ -538,6 +538,10 @@ static void trace_update_backward(KernelCtx& context) {
   find_kernel(OP_SET_INDEX_DYNAMIC)->backward(context);
 }
 
+static void retained_update_backward(KernelCtx& context) {
+  find_kernel(OP_SET_INDEX_DYNAMIC)->backward(context);
+}
+
 static std::shared_ptr<StructuredLoop> iterator_history_plan() {
   auto plan = std::make_shared<StructuredLoop>();
   const int theta = plan->body.add_slot(1, false);
@@ -630,7 +634,8 @@ static std::shared_ptr<StructuredLoop> nested_iterator_plan() {
   return plan;
 }
 
-static std::shared_ptr<StructuredLoop> iterator_update_plan() {
+static std::shared_ptr<StructuredLoop> iterator_update_plan(
+    void (*backward)(KernelCtx&) = trace_update_backward) {
   auto plan = std::make_shared<StructuredLoop>();
   const int theta = plan->body.add_slot(1, false);
   const int lower = scalar(*plan, 1);
@@ -663,8 +668,9 @@ static std::shared_ptr<StructuredLoop> iterator_update_plan() {
   plan->dynamic_history = true;
   check(plan->compact_update_sites == 1,
         "iterator update plan selects compact history");
-  check(set_backward(plan->root, update_op, trace_update_backward),
-        "find compact-update trace backward callback");
+  if (backward)
+    check(set_backward(plan->root, update_op, backward),
+          "find compact-update replacement backward callback");
   return plan;
 }
 
@@ -738,6 +744,16 @@ static void compact_iterator_history_tests() {
             std::vector<std::array<double, 3>>(
                 {{{.25, .5, .75}}, {{.25, .5, 30}}, {{10, 20, 30}}}),
         "compact-update reverse restores overwritten values in LIFO order");
+
+  Executor frame_free(outer(iterator_update_plan(nullptr)));
+  Executor retained(outer(iterator_update_plan(retained_update_backward)));
+  const Evaluation compact = evaluate(frame_free, .25, 0);
+  const Evaluation reference = evaluate(retained, .25, 0);
+  check(std::memcmp(&compact, &reference, sizeof(Evaluation)) == 0,
+        "frame-free compact reverse has bitwise retained-frame parity");
+  const Evaluation repeated = evaluate(frame_free, .25, 0);
+  check(std::memcmp(&compact, &repeated, sizeof(Evaluation)) == 0,
+        "frame-free compact reverse resets between evaluations");
 }
 
 static std::shared_ptr<StructuredLoop> integer_history_plan() {


### PR DESCRIPTION
# Reduce dynamic structured-loop history and memory

## Why

Retaining large runtime loops avoids the compilation-time and graph-size cost
of unrolling, but the first production dynamic tape stored several generic
values, references, and reverse payloads for work whose shape and lifetime are
already known. On ctsem N=400, the initial retained implementation reached
about 7.38 GB peak RSS even though the loop body itself is compact.

## What this changes

This PR makes the existing `OP_LOOP` dynamic structured executor store the
information that reverse mode actually needs:

- encode counted-loop iterators and exact data-only integer results directly
  in private handles;
- keep inactive callback scratch transient and reuse proven forward-only
  inactive output workspaces;
- encode inactive arena locations without a separate reference entry and keep
  untouched arena capacity unpaged;
- shrink dynamic references and reverse records;
- retain scalar indexed updates without redundant input frames, retain larger
  ordered updates as sparse deltas, and detach at reached alias boundaries;
- embed active scalar indexed-read history in its reverse record;
- pass fixed-capacity indexed-read and indexed-update selectors directly
  instead of materializing packed concatenations; and
- reuse the base reference for frame-free compact updates when the existing
  ownership and shared-adjoint proofs show that the output reference would be
  physically identical.

The alias path remains copy-on-write: a reached alias revokes compact ownership
and the next update produces a separate value before mutation resumes. Every
optional representation has a same-binary environment ablation and falls back
to the established retained path when its proof does not hold.

This PR does not broaden automatic structured-loop selection. The existing
selector still requires the narrow large outer-counted-loop plus transitive
runtime-while hazard. Models that stay on the ordinary graph or unrolled path
do not execute this code.

## Results

For ctsem N=400 at the same point and with the same MIR/data inputs, the
research baseline before these changes measured 7,375,175,680 bytes peak RSS,
5.089 s first gradient, and 4.833 s warm gradient. The final branch measures a
404,062,208-byte median peak RSS, 4.530 s first gradient, and 4.504 s warm
gradient. Preparation remains effectively unchanged (11.726 s to 11.716 s).
The end-to-end figures summarize the accepted sequence; each optimization was
also measured against its immediate same-input predecessor.

The final reference-reuse change alone removes exactly 1,296,148 reference
entries (20,738,368 used bytes), moves reference capacity from 32 MiB to
16 MiB, and reduces median RSS from 438,108,160 to 404,062,208 bytes (7.77%).
Arena storage, reverse records, conceptual adjoints, and physical adjoints are
unchanged. Its three-pair median first and warm gradient changes are +1.40%
and +0.66%; there is no added reverse work, so these small movements are
reported conservatively rather than claimed as a speedup.

All profile and timing comparisons preserve the LP and all 580 gradient values
bitwise.

## Validation

- Clean Release build on current `origin/main` with `-j24`.
- 118/118 tests pass on the production-only branch.
- The pinned 130-model CmdStan-reference corpus passes at all three points: 803,962 values checked, with the same documented worst deviation as `main`.
- The repository auto-vs-off corpus gate reports 119 unchanged successful graphs, zero changed graphs, zero numerical deviation, and one identical known failure. No current corpus benchmark selects `OP_LOOP`, so it cannot enter the changed runtime path.
- A nine-pair counterbalanced `bench_opcost` comparison against a matched `origin/main` build is within measurement noise: density gradient -0.29%, density forward +0.74%, and trivial graph gradient -0.59%.
- Optimized ASan+UBSan structured-loop production test passes with leak
  checking disabled.
- N=400 allocation accounting reconciles arena, reference, and record counts
  exactly with no overflow.
- Three counterbalanced same-binary N=400 pairs have bitwise LP/gradient
  parity.
- Regression tests cover zero/one/many trips, nested for/while/if control,
  direct and packed selectors, scalar and sparse-delta reverse history,
  record-resident scalars, logical extents, duplicate updates, alias snapshots,
  copy-on-write detachment, failure/retry, concurrency, and the interaction
  between shared compact handles and lazy invariant reuse.

The production branch intentionally excludes the research log and raw
measurement artifacts. They remain on the research branch and in the frozen
local evidence directories.
