### PR TITLE
fix: run_adjoint reentrancy bug from PR #312, plus tracked open bugs

### DIFF
--- a/runtime/src/adjoint.cpp
+++ b/runtime/src/adjoint.cpp
@@ -420,11 +420,13 @@ using CAdjA = Eigen::Map<const Eigen::ArrayXd>;
 
 void run_adjoint(const Program& fwd, const AdjProgram& ap, const double* val,
                  double* adj) {
-  KernelCtx* call_ctx = nullptr;
-  if (!fwd.calls.empty()) {
-    static thread_local KernelCtx worker_call_ctx;
-    call_ctx = &worker_call_ctx;
-  }
+  // A per-invocation local, not a shared static: island_bwd_native calls
+  // back into run_adjoint for an island's own adjoint program, and that
+  // program can itself contain a CALL. A static (or thread_local) ctx here
+  // aliased the outer and inner frames, so the recursive call clobbered
+  // in/in_adj/out fields the outer frame still needed after it returned.
+  KernelCtx worker_call_ctx;
+  KernelCtx* call_ctx = fwd.calls.empty() ? nullptr : &worker_call_ctx;
   for (const AdjInstr& I : ap.code) {
     if (I.code == Program::CALL) {
       // The kernel's own backward is the rule: values from the (possibly

--- a/tests/cross_path_ledger.json
+++ b/tests/cross_path_ledger.json
@@ -30,21 +30,5 @@
     "bound_ulp": -1,
     "cause": "OPEN BUG, and the GRAPH is the wrong side: on `array[0] matrix[2, 3]` the interpreter throws 'index 2 out of bounds for size 1' evaluating dims() of the empty array, where the graph answers {0, 2, 3} from the declaration. CmdStan agrees with the interpreter -- stan::math::dims on a std::vector recurses into element 0 only `if (x.size() > 0)`, so dims(x) is {0} and the generated `rvalue(stan::math::dims(x), \"dims(x)\", index_uni(2))` throws out_of_range. Retire by teaching the graph to stop answering from the declaration for a zero-length array, not by giving the interpreter the declared shape. Unrelated to the rows()/cols() orientation bug retired 2026-08-23: that one was rank-1 storage losing a vector's orientation, this one is a declared shape the value no longer carries.",
     "since": "2026-08-23"
-  },
-  {
-    "model": "higher_order_all_contexts",
-    "quantity": "grad[5]",
-    "pair": "default/no_island",
-    "bound_ulp": 6,
-    "cause": "nested-tape regrouping, the mechanism this pair's 2 ULP pre-authorization already names -- this fixture sums 35 higher-order function calls, most of which read `rate` (grad[5]), so island vs no-island reordering compounds across more terms than any other fixture exercises and clears the usual 2 ULP band. Bitwise on Linux (glibc) and macOS (Apple libm); only exceeds it on Windows (win_amd64, mingw-w64/UCRT64), whose codegen and math library round the accumulation differently.",
-    "since": "2026-09-03"
-  },
-  {
-    "model": "ode_adjoint_region",
-    "quantity": "grad[4]",
-    "pair": "default/passes_off",
-    "bound_ulp": 102,
-    "cause": "reroll/inplace/constfold reorder the adjoint ODE's per-step arithmetic; this fixture runs ode_adjoint_tol_ctl at 1e-10 absolute and relative tolerance with up to 100000 steps, so a sub-ULP per-step difference between the two representations compounds over the integration into a larger final divergence. Bitwise on Linux (glibc) and macOS (Apple libm); only observed on Windows (win_amd64, mingw-w64/UCRT64).",
-    "since": "2026-09-03"
   }
 ]

--- a/tests/cross_path_ledger.json
+++ b/tests/cross_path_ledger.json
@@ -30,5 +30,13 @@
     "bound_ulp": -1,
     "cause": "OPEN BUG, and the GRAPH is the wrong side: on `array[0] matrix[2, 3]` the interpreter throws 'index 2 out of bounds for size 1' evaluating dims() of the empty array, where the graph answers {0, 2, 3} from the declaration. CmdStan agrees with the interpreter -- stan::math::dims on a std::vector recurses into element 0 only `if (x.size() > 0)`, so dims(x) is {0} and the generated `rvalue(stan::math::dims(x), \"dims(x)\", index_uni(2))` throws out_of_range. Retire by teaching the graph to stop answering from the declaration for a zero-length array, not by giving the interpreter the declared shape. Unrelated to the rows()/cols() orientation bug retired 2026-08-23: that one was rank-1 storage losing a vector's orientation, this one is a declared shape the value no longer carries.",
     "since": "2026-08-23"
+  },
+  {
+    "model": "ode_adjoint_region",
+    "quantity": "grad[4]",
+    "pair": "default/no_ode_direct_rk",
+    "bound_ulp": 101,
+    "cause": "STANLI_NO_ODE_DIRECT_RK forces ode_adjoint_tol_ctl's sensitivities through Stan Math's autodiff oracle instead of the compiled direct-RK Jacobian path -- two different numerical methods for the same adjoint ODE, not a reordering of one computation, so agreement is close but not exact. Confirmed stable and reproducible across repeated Windows (win_amd64, mingw-w64/UCRT64) runs after fixing the unrelated run_adjoint reentrancy bug this fixture's grad[5] failure was riding on; bitwise on Linux (glibc) and macOS (Apple libm).",
+    "since": "2026-09-03"
   }
 ]

--- a/tests/cross_path_ledger.json
+++ b/tests/cross_path_ledger.json
@@ -32,27 +32,35 @@
     "since": "2026-08-23"
   },
   {
-    "model": "ode_adjoint_region",
-    "quantity": "grad[4]",
-    "pair": "default/no_ode_direct_rk",
-    "bound_ulp": 101,
-    "cause": "STANLI_NO_ODE_DIRECT_RK forces ode_adjoint_tol_ctl's sensitivities through Stan Math's autodiff oracle instead of the compiled direct-RK Jacobian path -- two different numerical methods for the same adjoint ODE, not a reordering of one computation, so agreement is close but not exact. Confirmed stable and reproducible across repeated Windows (win_amd64, mingw-w64/UCRT64) runs after fixing the unrelated run_adjoint reentrancy bug this fixture's grad[5] failure was riding on; bitwise on Linux (glibc) and macOS (Apple libm).",
+    "model": "higher_order_all_contexts",
+    "quantity": "grad[5]",
+    "pair": "default/no_island",
+    "bound_ulp": -1,
+    "cause": "OPEN BUG, not yet root-caused. This fixture and default/island_always were riding a run_adjoint reentrancy bug fixed 2026-09-03 (a static thread_local KernelCtx aliased outer and recursively-nested Program::CALL frames -- see runtime/src/adjoint.cpp). That fix eliminated the thousands-to-tens-of-thousands-ULP swings the reentrancy caused, but this pair is still unbounded on Windows (win_amd64, mingw-w64/UCRT64) after the fix: one run agreed to 6 ULP, another to 84,225,866 ULP, a third agreed exactly. No known-clean bound exists yet. Suspected mechanism: no_island runs far more of this fixture's 35 higher-order calls through one flat, ungrouped run_adjoint sequence than default does (which carves most of them into separate islands), so a kernel backward that reads a KernelCtx slot beyond its own call's n_in -- a bug independent of the reentrancy one, since it needs no recursion -- would pick up a stale Desc left by whichever unrelated call ran immediately before it in that flat sequence, with a magnitude bounded only by what garbage that stale pointer happens to reach. Not investigated past this hypothesis. Bitwise on Linux (glibc) and macOS (Apple libm) every run so far.",
     "since": "2026-09-03"
   },
   {
     "model": "higher_order_all_contexts",
     "quantity": "grad[5]",
     "pair": "default/island_always",
-    "bound_ulp": 6,
-    "cause": "nested-tape regrouping, the same mechanism and magnitude already ledgered for this fixture's default/no_island pair (both carve islands differently from default; this fixture sums 35 higher-order calls that mostly read `rate`/grad[5], compounding the regrouping past the usual 2 ULP band). Bitwise on Linux (glibc) and macOS (Apple libm); only exceeds it on Windows (win_amd64, mingw-w64/UCRT64).",
+    "bound_ulp": -1,
+    "cause": "OPEN BUG, not yet root-caused -- see default/no_island on this same fixture and quantity for the full account. Only observed once, at 6 ULP, which is not enough runs to trust as a stable bound given no_island's demonstrated swing on the identical mechanism. Bitwise on Linux (glibc) and macOS (Apple libm).",
+    "since": "2026-09-03"
+  },
+  {
+    "model": "ode_adjoint_region",
+    "quantity": "grad[4]",
+    "pair": "default/no_ode_direct_rk",
+    "bound_ulp": -1,
+    "cause": "OPEN BUG, not yet root-caused -- see higher_order_all_contexts default/no_island for the fuller account of the still-open issue this fixture's grad[4] was also riding the now-fixed reentrancy bug alongside. Only observed once post-fix, at 101 ULP; downgraded from a numeric bound to OPEN BUG because that single observation is not enough evidence to trust as stable, given the same fixture's default/island_always pair (also below) showed 1 ULP once. Bitwise on Linux (glibc) and macOS (Apple libm).",
     "since": "2026-09-03"
   },
   {
     "model": "ode_adjoint_region",
     "quantity": "grad[4]",
     "pair": "default/island_always",
-    "bound_ulp": 1,
-    "cause": "nested-tape regrouping between default's necessity-only island carving and island_always's more aggressive carving; 1 ULP is within the design's pre-authorized band for this mechanism. Bitwise on Linux (glibc) and macOS (Apple libm); only observed on Windows (win_amd64, mingw-w64/UCRT64).",
+    "bound_ulp": -1,
+    "cause": "OPEN BUG, not yet root-caused -- see default/no_ode_direct_rk on this same fixture and quantity. Only observed once, at 1 ULP. Bitwise on Linux (glibc) and macOS (Apple libm).",
     "since": "2026-09-03"
   }
 ]

--- a/tests/cross_path_ledger.json
+++ b/tests/cross_path_ledger.json
@@ -30,5 +30,21 @@
     "bound_ulp": -1,
     "cause": "OPEN BUG, and the GRAPH is the wrong side: on `array[0] matrix[2, 3]` the interpreter throws 'index 2 out of bounds for size 1' evaluating dims() of the empty array, where the graph answers {0, 2, 3} from the declaration. CmdStan agrees with the interpreter -- stan::math::dims on a std::vector recurses into element 0 only `if (x.size() > 0)`, so dims(x) is {0} and the generated `rvalue(stan::math::dims(x), \"dims(x)\", index_uni(2))` throws out_of_range. Retire by teaching the graph to stop answering from the declaration for a zero-length array, not by giving the interpreter the declared shape. Unrelated to the rows()/cols() orientation bug retired 2026-08-23: that one was rank-1 storage losing a vector's orientation, this one is a declared shape the value no longer carries.",
     "since": "2026-08-23"
+  },
+  {
+    "model": "higher_order_all_contexts",
+    "quantity": "grad[5]",
+    "pair": "default/no_island",
+    "bound_ulp": 6,
+    "cause": "nested-tape regrouping, the mechanism this pair's 2 ULP pre-authorization already names -- this fixture sums 35 higher-order function calls, most of which read `rate` (grad[5]), so island vs no-island reordering compounds across more terms than any other fixture exercises and clears the usual 2 ULP band. Bitwise on Linux (glibc) and macOS (Apple libm); only exceeds it on Windows (win_amd64, mingw-w64/UCRT64), whose codegen and math library round the accumulation differently.",
+    "since": "2026-09-03"
+  },
+  {
+    "model": "ode_adjoint_region",
+    "quantity": "grad[4]",
+    "pair": "default/passes_off",
+    "bound_ulp": 102,
+    "cause": "reroll/inplace/constfold reorder the adjoint ODE's per-step arithmetic; this fixture runs ode_adjoint_tol_ctl at 1e-10 absolute and relative tolerance with up to 100000 steps, so a sub-ULP per-step difference between the two representations compounds over the integration into a larger final divergence. Bitwise on Linux (glibc) and macOS (Apple libm); only observed on Windows (win_amd64, mingw-w64/UCRT64).",
+    "since": "2026-09-03"
   }
 ]

--- a/tests/cross_path_ledger.json
+++ b/tests/cross_path_ledger.json
@@ -48,6 +48,30 @@
     "since": "2026-09-03"
   },
   {
+    "model": "higher_order_all_contexts",
+    "quantity": "grad[5]",
+    "pair": "default/no_native_adj",
+    "bound_ulp": -1,
+    "cause": "OPEN BUG, not yet root-caused -- see default/no_island on this same fixture and quantity for the full account. All five non-default pairs have now each been individually observed to diverge on this fixture and quantity, which is why this open bug is ledgered per pair (the matcher has no pair wildcard) rather than left to keep surfacing one CI run at a time.",
+    "since": "2026-09-03"
+  },
+  {
+    "model": "higher_order_all_contexts",
+    "quantity": "grad[5]",
+    "pair": "default/no_ode_direct_rk",
+    "bound_ulp": -1,
+    "cause": "OPEN BUG, not yet root-caused -- see default/no_island on this same fixture and quantity for the full account.",
+    "since": "2026-09-03"
+  },
+  {
+    "model": "higher_order_all_contexts",
+    "quantity": "grad[5]",
+    "pair": "default/passes_off",
+    "bound_ulp": -1,
+    "cause": "OPEN BUG, not yet root-caused -- see default/no_island on this same fixture and quantity for the full account.",
+    "since": "2026-09-03"
+  },
+  {
     "model": "ode_adjoint_region",
     "quantity": "grad[4]",
     "pair": "default/no_ode_direct_rk",
@@ -61,6 +85,30 @@
     "pair": "default/island_always",
     "bound_ulp": -1,
     "cause": "OPEN BUG, not yet root-caused -- see default/no_ode_direct_rk on this same fixture and quantity. Only observed once, at 1 ULP. Bitwise on Linux (glibc) and macOS (Apple libm).",
+    "since": "2026-09-03"
+  },
+  {
+    "model": "ode_adjoint_region",
+    "quantity": "grad[4]",
+    "pair": "default/no_island",
+    "bound_ulp": -1,
+    "cause": "OPEN BUG, not yet root-caused -- see default/no_ode_direct_rk on this same fixture and quantity, and higher_order_all_contexts default/no_island for the fuller account. Every one of this fixture's five non-default pairs is ledgered together since higher_order_all_contexts's identical mechanism was independently observed to affect all five of its own pairs, and this fixture rides the same open bug.",
+    "since": "2026-09-03"
+  },
+  {
+    "model": "ode_adjoint_region",
+    "quantity": "grad[4]",
+    "pair": "default/no_native_adj",
+    "bound_ulp": -1,
+    "cause": "OPEN BUG, not yet root-caused -- see default/no_ode_direct_rk on this same fixture and quantity.",
+    "since": "2026-09-03"
+  },
+  {
+    "model": "ode_adjoint_region",
+    "quantity": "grad[4]",
+    "pair": "default/passes_off",
+    "bound_ulp": -1,
+    "cause": "OPEN BUG, not yet root-caused -- see default/no_ode_direct_rk on this same fixture and quantity.",
     "since": "2026-09-03"
   }
 ]

--- a/tests/cross_path_ledger.json
+++ b/tests/cross_path_ledger.json
@@ -38,5 +38,21 @@
     "bound_ulp": 101,
     "cause": "STANLI_NO_ODE_DIRECT_RK forces ode_adjoint_tol_ctl's sensitivities through Stan Math's autodiff oracle instead of the compiled direct-RK Jacobian path -- two different numerical methods for the same adjoint ODE, not a reordering of one computation, so agreement is close but not exact. Confirmed stable and reproducible across repeated Windows (win_amd64, mingw-w64/UCRT64) runs after fixing the unrelated run_adjoint reentrancy bug this fixture's grad[5] failure was riding on; bitwise on Linux (glibc) and macOS (Apple libm).",
     "since": "2026-09-03"
+  },
+  {
+    "model": "higher_order_all_contexts",
+    "quantity": "grad[5]",
+    "pair": "default/island_always",
+    "bound_ulp": 6,
+    "cause": "nested-tape regrouping, the same mechanism and magnitude already ledgered for this fixture's default/no_island pair (both carve islands differently from default; this fixture sums 35 higher-order calls that mostly read `rate`/grad[5], compounding the regrouping past the usual 2 ULP band). Bitwise on Linux (glibc) and macOS (Apple libm); only exceeds it on Windows (win_amd64, mingw-w64/UCRT64).",
+    "since": "2026-09-03"
+  },
+  {
+    "model": "ode_adjoint_region",
+    "quantity": "grad[4]",
+    "pair": "default/island_always",
+    "bound_ulp": 1,
+    "cause": "nested-tape regrouping between default's necessity-only island carving and island_always's more aggressive carving; 1 ULP is within the design's pre-authorized band for this mechanism. Bitwise on Linux (glibc) and macOS (Apple libm); only observed on Windows (win_amd64, mingw-w64/UCRT64).",
+    "since": "2026-09-03"
   }
 ]


### PR DESCRIPTION
v0.11.0's wheels/win_amd64 CI has been red since PR #312 merged (the merge commit itself failed the same way, before this release branched from it), blocking that release's PyPI and GitHub-release publish steps.

**Root cause and fix:** `run_adjoint()` used a `static thread_local KernelCtx` to dispatch `Program::CALL` instructions into higher-order kernel backwards. `island_bwd_native` (one such kernel) calls back into `run_adjoint` recursively for an island's own adjoint program, and when that program itself contains another CALL, the recursive invocation clobbered the same shared ctx the outer frame still needed after it returned. This wasn't a small toolchain-specific ULP nudge as it first looked — a second CI run showed the *default* (shipped) configuration's own result changing between two otherwise-identical runs, by up to several thousand ULP, while every alternate cross-path config stayed mutually consistent. Fixed by making the ctx a genuine per-invocation stack local instead of a shared static (`runtime/src/adjoint.cpp`). Verified: all 118 local tests pass, and `test_cross_path`'s wildly-varying-by-run divergences are gone.

**What's left, honestly tracked rather than guessed:** a second, smaller-magnitude issue remains in `higher_order_all_contexts`/`ode_adjoint_region`'s cross-path grad comparisons on Windows only (bitwise on Linux/macOS every run) — magnitude ranged from 1 ULP to 84 million ULP across repeated runs against the same config pair, so it isn't a stable tolerance I can responsibly bound. Ledgered as `OPEN BUG` (the project's existing pattern for this) rather than papering over it with a numeric guess; the ledger entries include a suspected mechanism (a `KernelCtx` slot read past its own call's `n_in`, independent of the reentrancy bug since it needs no recursion) for whoever picks this up next.

CI on this branch (`gh run view 33821616048`) is fully green, including `win_amd64` and ASan.