### PR TITLE
Give the loop test graphs a scalar result slot

### DIFF
--- a/tests/test_structured_loop.cpp
+++ b/tests/test_structured_loop.cpp
@@ -162,6 +162,10 @@ static Graph outer(std::shared_ptr<StructuredLoop> plan,
   graph.ops.push_back(op);
   graph.udata_pool.push_back(std::move(plan));
   graph.result_slot = output;
+  if (output_len != 1) {
+    graph.result_slot = graph.add_slot(1, false);
+    graph.add_op(OP_INDEX, {output}, graph.result_slot, {0});
+  }
   return graph;
 }
 


### PR DESCRIPTION
The hand-built graphs in test_structured_loop used the loop's packed output slot as the graph result. Executor::forward asserts a scalar result, so the assert-enabled ASan configuration (BUILD_TYPE=None) aborts while Release never checked it; the post-submit ASan job would fail on main. The result is now an OP_INDEX of element 0, which is what the Release build was reading and seeding anyway, so no expectations change. test_structured_loop passes under ASan+UBSan.