### PR TITLE
Rewind memo-node storage while recording and fix the zero-length adjoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### Fixes
+
+The generated reverse pass no longer reads out of bounds when an island
+contains a zero-length range copy.
+
 ### Retained loops store one version per write
 
 The structured loop executor (`STANLI_STRUCTURED_LOOPS`) decides every body

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,11 @@ kernels run as one register program with a generated reverse pass, so a
 scalar recurrence costs one tape record per iteration instead of one per
 kernel (`STANLI_NO_STRUCTURED_SEGMENTS=1` keeps every kernel its own node).
 
+The recording evaluation hands back the storage of a data-only subtree whose
+values nothing reads once it exits, so the first gradient of a retained loop
+no longer costs several times the steady-state tape. ctsem at 400 rows peaks
+at 0.95 GB instead of 1.24 GB.
+
 By default a loop is retained when it is an outermost `while`, or an
 outermost `for` of at least 32 iterations whose body contains a `while` or a
 branch chosen by a parameter; every other loop unrolls as before.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,11 @@ values nothing reads once it exits, so the first gradient of a retained loop
 no longer costs several times the steady-state tape. ctsem at 400 rows peaks
 at 0.95 GB instead of 1.24 GB.
 
+A retained loop's dynamic index kernels resolve their selector once per call
+instead of once per selected element, and their validation no longer carries
+message building in the path that takes no error. ctsem is 14% faster per
+gradient and radon_county's retained loop 20%.
+
 By default a loop is retained when it is an outermost `while`, or an
 outermost `for` of at least 32 iterations whose body contains a `while` or a
 branch chosen by a parameter; every other loop unrolls as before.

--- a/docs/superpowers/plans/2026-09-03-structured-loop-static-storage.md
+++ b/docs/superpowers/plans/2026-09-03-structured-loop-static-storage.md
@@ -785,3 +785,51 @@ few ns, so about 15 ns per iteration against the flat executor's 40. That
 gain applies to loops that are flat, which today excludes ctsem (nested
 loops), the corpus recurrences with in-place element updates (hmm, garch,
 arma) and any body with an active loop-invariant kernel.
+
+## Addendum: the recording evaluation gives silent subtrees their storage back
+
+Date: 2026-09-03. Branch `feat/loop-next`.
+
+Measured on ctsem N=400 before the change: the recording evaluation allocates
+21.8M arena doubles and 15.8M versions against the replayed evaluation's 10.2M
+and 5.3M. The whole difference is inside memo nodes, and 10.2M of it is one
+iterator cell plus one version per iteration of a data-only `for` whose
+iterator some kernel reads by name. Peak RSS is 1.24 GB against a 0.53 GB
+steady-state tape.
+
+A memo node with no live-outs is skipped entirely on replay, so what it
+allocates while recording has no reader once it exits. Such a node
+(`Node::memo_silent`) takes an arena mark and a version count at entry and
+rewinds to them at exit. `BlockArena` keeps a cursor and the blocks past it,
+so a rewind never frees a block the next visit would have to buy back.
+
+Two things make the release safe:
+
+- A traced `If` or `For` reads its condition or bounds while recording even
+  though replay takes the decision from the trace, and `number()` discounts
+  exactly those reads when it decides live-outs. Those slots
+  (`Node::memo_keep`) move to fixed cells in the state with one version each
+  made per evaluation, the way a Transient result does: the reader takes the
+  value before the node runs again. Copying them into fresh arena versions
+  instead was measured and costs more than the release recovers -- 11.0M kept
+  versions against 10.2M freed.
+- A node whose subtree contains an active call puts records, handles and
+  adjoints on the tape that point into the region; those nodes are not
+  released. Cached results of loop-invariant calls inside a released node have
+  their generation invalidated.
+
+Result on ctsem: recording arena 21.8M -> 11.5M doubles, versions 15.8M ->
+5.6M. Peak RSS at N=400 1.24 GB -> 0.95 GB, at N=33 168 MB -> 142 MB.
+Gradient time 307.4 -> 306.0 ms at N=400 and 26.34 -> 26.13 ms at N=33; lp and
+gradients are bitwise identical at two points and the 130-model census is
+unchanged. The tape diagnostic gained `record_arena` and `record_versions`,
+the recording evaluation's peaks.
+
+Not done: releasing memo nodes that do have live-outs. Their live-outs are
+already copied to the memo tape, so a release would have to re-materialize
+them; measured, that is 1.18M versions freed against 1.97M tape doubles
+re-materialized per evaluation, which is a loss.
+
+`BlockArena::grow` is `noinline`. Inlined into `allocate` it cost m1 14% and
+ctsem 1%, by displacing the register program interpreter in the same
+translation unit.

--- a/docs/superpowers/plans/2026-09-03-structured-loop-static-storage.md
+++ b/docs/superpowers/plans/2026-09-03-structured-loop-static-storage.md
@@ -833,3 +833,149 @@ re-materialized per evaluation, which is a loss.
 `BlockArena::grow` is `noinline`. Inlined into `allocate` it cost m1 14% and
 ctsem 1%, by displacing the register program interpreter in the same
 translation unit.
+
+## Addendum: the dynamic index kernels, measured
+
+Date: 2026-09-03. Branch `feat/loop-next`.
+
+Sampled profile of a ctsem gradient at 400 rows, after the release above
+(9,059 samples over 12 s of steady-state evaluation):
+
+| | share |
+| --- | --- |
+| `validate_index` | 22.1% |
+| `Execution::run` | 22.7% |
+| `selected_position` | 8.8% |
+| `Execution::forward` | 8.5% |
+| `run_retained` | 5.0% |
+| `index_input` | 4.7% |
+| `run_in_place` | 4.4% |
+| `structured_loop_backward` | 3.2% |
+| `make_version` | 3.1% |
+| Eigen | 2.5% |
+
+The index machinery is 41%, not the 17% the earlier profile suggested, and
+the tree walk 31%. Two things were wrong with the index path, both fixed:
+
+- `selected_position` called `index_input` once per axis per selected element
+  to bounds-check a descriptor index `validate_index` had already checked.
+  The selector pointer now rides in `IndexRuntime`, which became one struct
+  per axis (extent, count, stride, selector) instead of three parallel runs
+  in one block.
+- Every check built its message inline. `index_input` was too large to inline
+  because of the `std::string` concatenation on its throw path, and
+  `validate_index` carried string construction through its whole body. The
+  throws moved to `[[noreturn]] noinline` helpers with the same messages.
+
+Together: ctsem 26.4 -> 22.6 ms per gradient at 33 rows and 307 -> 265 ms at
+400, radon_county retained 1.02 -> 0.82 ms, m2 1.08 -> 0.95 ms, arK 85 -> 76
+us, everything else neutral, all results bitwise identical.
+
+### Flattening nested sequences: measured, not kept
+
+A pass in `classify` that splices a sequence's sequence children into it and
+collapses lone-child sequences dropped ctsem's node visits per gradient from
+22.38M to 21.77M (2.7%) and moved the gradient not at all (265.6 vs 264.8 ms,
+inside the noise). ctsem's tree is already nearly flat after specialization;
+the visits are kernel calls and traced control, not sequence nodes. The pass
+was dropped. It would have to run before `form_segments` to be worth
+anything, and that changes which runs become register programs, which changes
+the last bit of a reduction.
+
+### What is left in validate_index
+
+Stubbing out every check in `validate_index` that depends only on the
+descriptor and the input lengths -- the input layout, the selector-input
+range checks, the shape check, the stride checks, the capacity comparison --
+leaves ctsem at 21.4 ms at 33 rows and 251 ms at 400: 5.3% of a gradient.
+Those checks are static per site, because the loop executor binds one
+`KernelCtx` per site at state construction and the lengths come from the
+plan's slots.
+
+Collecting it needs a split of `validate_index` into a shape check over the
+lengths and a value check, the first run once at `prepare` against a
+length-only context, plus lean kernel entry points chosen per node so the
+flat executor keeps checking. The risk is not the plumbing but the partition:
+a check on the wrong side either runs never or runs always, and the wrong
+side of "never" is a descriptor bug that reaches a kernel. It also moves
+descriptor errors from the first forward to `prepare`. Not done here.
+
+## Addendum: candidate coverage, diagnosed
+
+Date: 2026-09-03.
+
+### The corpus refusals are mode-1 only
+
+Under `STANLI_STRUCTURED_LOOPS=1` the 130-model corpus produces 226 candidate
+refusals over 20 models, concentrated in seven: dogs and its three variants
+(31 each), covid19imperial v2 and v3 (30 each), multi_occupancy (29). Under
+the shipping selector (auto) the same corpus produces **zero** refusals: every
+loop the selector picks lowers. The refusals are an A/B-mode coverage gap,
+not a shipped one.
+
+They are three messages and one cause:
+
+- `prepare_data: unknown variable j (type UInt)` (162): a data expression
+  inside the region names an enclosing loop's iterator. The lowering folds
+  data expressions with the `prepare_data` MIR interpreter, whose unknown
+  variables resolve through `int_env`, the unrolled-loop counter environment.
+  A retained loop's iterator is a runtime slot and is not there.
+- `size expression needs unknown int i` (58, lower.cpp:1108): a declaration
+  inside the region is sized by an expression that needs a loop iterator.
+- `runtime-sized structured declaration ... needs a finite capacity` and
+  `structured slice needs a fixed lower bound and finite capacity` (1 each).
+
+All three are one gap: **a region cell's capacity has to be a compile-time
+constant**, so a local whose size varies per iteration cannot live in one.
+Closing it means capacities that are the maximum over the iteration space
+(which needs a bound the compiler does not have today) or slots with a
+runtime length, and a runtime-int path for data expressions that name an
+iterator. That is a large change with no effect on the default selector.
+
+### ctsem's O1 MIR
+
+`ctsem.stanli.mir` (stanc3 `--O1`) refuses the candidate with `structured
+assignment changes logical shape: inline_whichequals_inline_vecequals_return_
+sym23___sym1104__`: an inlined `which_equal` returns a runtime-sized integer
+array, and `region_assign`'s `same_view` requires the cell and the value to
+have the same logical shape and slot length. Same gap as above.
+
+The second failure is independent of retained loops. With
+`STANLI_STRUCTURED_LOOPS=0` the same MIR fails identically with
+`runtime-control region: integer inline_sdcovsqrt2cov_inline_constraincorsqrt1
+_d_sym28___sym1405__ is not known at compile time`, from the island region
+compiler in lower.cpp:3510. Fixing the candidate would not make ctsem's O1
+MIR compile; the O1-budget fallback to O0 MIR is what makes the model work
+and it stays necessary until that one is fixed too.
+
+## Addendum: write_array and forward-only regions
+
+Date: 2026-09-03. Status: assessed, not implemented.
+
+ctsem's `write_array` falls back to the MIR interpreter per draw with
+`runtime-control region: right-hand side needs too many registers` -- the
+island region compiler, not the loop. `try_lower_region` never runs there:
+`in_write_array` returns false at its first line, and four more guards in the
+region helpers (`lower_structured_loop.inc:1054, 1057, 1080, 1092`) turn off
+the runtime-value path, the runtime scalar form, the runtime-value rescue in
+call lowering, and `param_free` inside write_array.
+
+A forward-only region is the same tree with no tape: every `Import.active` is
+false, `has_target` is false, no adjoint is ever reserved and
+`structured_loop_backward` is never called, so the executor needs nothing new.
+The memo and trace machinery is a good fit for write_array, which runs the
+same data-only work once per draw.
+
+What is not free:
+
+- The four helper guards exist because write_array treats every value as
+  parameter-dependent (`si.param_free = false` at 1092) and refuses the
+  runtime-value path. Each has to be re-derived for a region rather than
+  removed.
+- ctsem's transformed parameters are assigned inside the Kalman loop, and
+  some of them are the runtime-sized locals the addendum above describes. The
+  region would refuse them for the same reason the log_prob candidate refuses
+  ctsem's O1 MIR.
+
+So the write_array path depends on the runtime-sized-cell work, and is worth
+starting only after it. Left for that change.

--- a/runtime/include/stanli/structured_loop.hpp
+++ b/runtime/include/stanli/structured_loop.hpp
@@ -60,6 +60,9 @@ struct StructuredLoop {
     enum Storage { Retained, Transient, InPlace } storage = Retained;
     bool active = false;
     bool memo = false;
+    // A memo node whose values are read by nothing once it exits, so the
+    // recording evaluation gives its storage back.
+    bool memo_silent = false;
     // If/For/While whose data-only decisions are recorded once and replayed.
     bool trace = false;
     int invariant_loop = -1;
@@ -74,6 +77,8 @@ struct StructuredLoop {
     // only read in place and share one version whose pointer moves.
     std::vector<int> memo_outs;
     size_t memo_fresh = 0;
+    // Silent nodes only: slots a traced reader still reads while recording.
+    std::vector<int> memo_keep;
     std::vector<Node> children;
     int op = -1;
     int dst = -1, src = -1;

--- a/runtime/src/adjoint.cpp
+++ b/runtime/src/adjoint.cpp
@@ -376,6 +376,10 @@ bool gen_adjoint(IslandProg& p) {
 
     ncode.push_back(I);
 
+    // Nothing is written, and compact_program leaves such an instruction's
+    // `dst` in the numbering it had before compaction.
+    if (wl == 0) continue;
+
     // An output value is needed as this instruction LEFT it, so only a
     // later overwrite can lose it.
     if (spec.has(kProgramSaveOut)) A.vd = save_range(I.dst, wl, i);

--- a/runtime/src/structured_loop.cpp
+++ b/runtime/src/structured_loop.cpp
@@ -98,11 +98,13 @@ void prepare_node(StructuredLoop& p, Node& n, unsigned depth,
   if (n.storage != Node::InPlace) n.storage = Node::Retained;
   n.active = false;
   n.memo = false;
+  n.memo_silent = false;
   n.trace = false;
   n.invariant_loop = -1;
   n.memo_index = -1;
   n.memo_outs.clear();
   n.memo_fresh = 0;
+  n.memo_keep.clear();
   n.site = ~uint32_t{0};
   n.workspace = -1;
   n.loop_index = -1;
@@ -491,6 +493,12 @@ struct Memoizer {
       for (int s : written)
         if (uses.output[s] || outside(s, inside) > traced[s])
           n.memo_outs.push_back(s);
+      // A traced reader takes the recorded decision on replay but still reads
+      // the value while recording, so a silent node hands those slots on.
+      n.memo_silent = n.memo_outs.empty();
+      if (n.memo_silent)
+        for (int s : written)
+          if (traced[s]) n.memo_keep.push_back(s);
       return;
     }
     for (auto& c : n.children) number(c);
@@ -1232,11 +1240,17 @@ struct BlockArena {
   struct Block {
     std::unique_ptr<double[]> data;
     size_t capacity = 0;
+  };
+  struct Mark {
+    size_t block = 0;
     size_t used = 0;
+    size_t live = 0;
   };
   static constexpr size_t min_block = size_t{1} << 16;
   std::vector<Block> blocks;
-  size_t total = 0;
+  double* next = nullptr;
+  double* limit = nullptr;
+  size_t cursor = 0, closed = 0;
 
   static Block make(size_t capacity) {
     Block block;
@@ -1253,47 +1267,77 @@ struct BlockArena {
         static_cast<uint64_t>(count) > std::numeric_limits<size_t>::max() / 2)
       throw std::length_error("structured loop storage overflow");
     const size_t n = static_cast<size_t>(count);
-    if (blocks.empty() || n > blocks.back().capacity - blocks.back().used) {
-      const size_t grown = blocks.empty() ? 0 : blocks.back().capacity * 2;
-      const size_t capacity = std::max({n, min_block, grown});
-      blocks.push_back(make(capacity));
-      total += capacity;
-    }
-    Block& block = blocks.back();
-    double* result = block.data.get() + block.used;
-    block.used += n;
+    if (n > static_cast<size_t>(limit - next)) grow(n);
+    double* result = next;
+    next += n;
     return result;
   }
-  size_t used() const {
-    size_t n = 0;
-    for (const auto& block : blocks) n += block.used;
-    return n;
+  // Blocks past the cursor stay allocated: freeing them on a rewind would
+  // make the next one cost a fresh block twice the size.
+  __attribute__((noinline)) void grow(size_t n) {
+    if (blocks.empty()) {
+      blocks.push_back(make(std::max(n, min_block)));
+      cursor = 0;
+    } else {
+      closed += used_here();
+      if (cursor + 1 < blocks.size() && n <= blocks[cursor + 1].capacity) {
+        ++cursor;
+      } else {
+        blocks.resize(cursor + 1);
+        blocks.push_back(
+            make(std::max({n, min_block, blocks[cursor].capacity * 2})));
+        cursor = blocks.size() - 1;
+      }
+    }
+    open(0);
+  }
+  void open(size_t at) {
+    next = blocks[cursor].data.get() + at;
+    limit = blocks[cursor].data.get() + blocks[cursor].capacity;
+  }
+  size_t used_here() const {
+    return blocks.empty()
+               ? 0
+               : static_cast<size_t>(next - blocks[cursor].data.get());
+  }
+  size_t used() const { return closed + used_here(); }
+  Mark mark() const { return Mark{cursor, used_here(), used()}; }
+  void rewind(const Mark& at) {
+    cursor = at.block;
+    if (!blocks.empty()) open(at.used);
+    closed = at.live - at.used;
   }
   // One block sized for the evaluation just finished, so a steady-state
   // evaluation never pays block growth and never keeps the first
   // evaluation's larger recording footprint.
   void clear() {
-    const size_t want = std::max(min_block, used() + used() / 8);
-    if (blocks.size() != 1 || blocks.back().capacity > 2 * want ||
-        blocks.back().capacity < want) {
+    const size_t high = used();
+    const size_t want = std::max(min_block, high + high / 8);
+    if (blocks.size() != 1 || blocks[0].capacity > 2 * want ||
+        blocks[0].capacity < want) {
       blocks.clear();
       blocks.push_back(make(want));
-      total = want;
     }
-    blocks.back().used = 0;
+    cursor = closed = 0;
+    open(0);
   }
 };
 
 template <class T>
-void right_size(std::vector<T>& v) {
-  if (v.empty()) return;
-  const size_t want = v.size() + v.size() / 8;
+void right_size(std::vector<T>& v, size_t used) {
+  if (used == 0) return;
+  const size_t want = used + used / 8;
   if (v.capacity() > 2 * want || v.capacity() < want) {
     std::vector<T> fresh;
     fresh.reserve(want);
     v.swap(fresh);
   }
   v.clear();
+}
+
+template <class T>
+void right_size(std::vector<T>& v) {
+  right_size(v, v.size());
 }
 
 struct Version {
@@ -1336,7 +1380,14 @@ struct LoopState : KernelState {
   std::vector<int64_t> memo_entries, memo_stride, memo_ordinal;
   std::vector<const Node*> memo_nodes;
   std::vector<int64_t> memo_shared_base, memo_shared;
+  std::vector<std::vector<uint32_t>> memo_invariant;
+  std::vector<char> memo_release;
+  std::vector<double> keep_store;
+  std::vector<int64_t> keep_version, keep_offset;
+  std::vector<int64_t> keep_store_base, keep_version_base;
   std::vector<int64_t> trace;
+  size_t version_peak = 0;
+  size_t record_arena = 0, record_versions = 0;
   size_t trace_pos = 0;
   uint64_t effects = 0;
   size_t memo_restores = 0, visits = 0;
@@ -1361,8 +1412,12 @@ struct LoopState : KernelState {
         memo_stride(plan.memo_count, 0),
         memo_ordinal(plan.memo_count, 0),
         memo_nodes(plan.memo_count, nullptr),
-        memo_shared_base(plan.memo_count, 0) {
-    collect(plan.root);
+        memo_shared_base(plan.memo_count, 0),
+        memo_invariant(plan.memo_count),
+        memo_release(plan.memo_count, 0),
+        keep_store_base(plan.memo_count, 0),
+        keep_version_base(plan.memo_count, 0) {
+    collect(plan.root, -1);
     int64_t shared = 0;
     for (size_t m = 0; m < memo_nodes.size(); ++m) {
       const Node* n = memo_nodes[m];
@@ -1394,29 +1449,61 @@ struct LoopState : KernelState {
     }
   }
 
-  void collect(const Node& n) {
+  // A subtree that leaves no value behind can give its storage back when it
+  // exits, unless a call inside it put something on the tape.
+  static bool releasable(const Node& n, bool& allocates) {
+    if (n.kind == Node::KernelCall) {
+      if (n.active) return false;
+      if (n.storage == Node::Retained) allocates = true;
+    }
+    if (n.kind == Node::For && n.storage != Node::Transient) allocates = true;
+    for (const auto& c : n.children)
+      if (!releasable(c, allocates)) return false;
+    return true;
+  }
+
+  void collect(const Node& n, int memo) {
     if (n.kind == Node::KernelCall) {
       if (n.site >= sites.size())
         throw std::logic_error("structured loop site numbering is stale");
       sites[n.site] = &n;
+      if (memo >= 0 && n.invariant_loop >= 0 && n.storage != Node::Transient)
+        memo_invariant[static_cast<size_t>(memo)].push_back(n.site);
     }
     if (n.memo) {
       if (n.memo_index < 0 ||
           static_cast<size_t>(n.memo_index) >= memo_stride.size())
         throw std::logic_error("structured loop memo numbering is stale");
+      if (n.memo_silent) {
+        bool allocates = false;
+        const size_t m = static_cast<size_t>(n.memo_index);
+        memo_release[m] = releasable(n, allocates) && allocates;
+        if (memo_release[m]) {
+          keep_store_base[m] = static_cast<int64_t>(keep_store.size());
+          keep_version_base[m] = static_cast<int64_t>(keep_version.size());
+          for (int slot : n.memo_keep) {
+            keep_version.push_back(-1);
+            keep_offset.push_back(static_cast<int64_t>(keep_store.size()));
+            keep_store.resize(keep_store.size() +
+                              static_cast<size_t>(p.body.slots[slot].len));
+          }
+        }
+      }
       memo_nodes[static_cast<size_t>(n.memo_index)] = &n;
       int64_t& stride = memo_stride[static_cast<size_t>(n.memo_index)];
       for (int slot : n.memo_outs) stride = add(stride, p.body.slots[slot].len);
     }
     if (n.kind == Node::For && n.storage == Node::Transient)
       transient_loops.push_back(&n);
-    for (const auto& c : n.children) collect(c);
+    for (const auto& c : n.children) collect(c, n.memo ? n.memo_index : memo);
   }
 
   void release() {
     arena.clear();
-    right_size(versions);
-    right_size(owner);
+    version_peak = std::max(version_peak, versions.size());
+    right_size(versions, version_peak);
+    right_size(owner, version_peak);
+    version_peak = 0;
     right_size(handles);
     right_size(undo);
     right_size(records);
@@ -1455,6 +1542,34 @@ struct Execution {
     s.owner.push_back(-1);
     return static_cast<int64_t>(s.versions.size()) - 1;
   }
+  struct Snapshot {
+    BlockArena::Mark arena;
+    size_t versions = 0;
+  };
+  Snapshot snapshot() const {
+    return Snapshot{s.arena.mark(), s.versions.size()};
+  }
+  // The kept slots move to fixed cells, the way a Transient result does: the
+  // reader takes the value before this node runs again.
+  void rewind(const Snapshot& at, const Node& n) {
+    const size_t m = static_cast<size_t>(n.memo_index);
+    s.record_arena = std::max(s.record_arena, s.arena.used());
+    double* store = s.keep_store.data() + s.keep_store_base[m];
+    for (int slot : n.memo_keep) {
+      const int64_t len = p.body.slots[slot].len;
+      std::copy_n(value(slot), len, store);
+      store += len;
+    }
+    s.arena.rewind(at.arena);
+    s.version_peak = std::max(s.version_peak, s.versions.size());
+    s.versions.resize(at.versions);
+    s.owner.resize(at.versions);
+    const int64_t* kept = s.keep_version.data() + s.keep_version_base[m];
+    for (size_t k = 0; k < n.memo_keep.size(); ++k)
+      s.bindings[n.memo_keep[k]] = kept[k];
+    for (uint32_t site : s.memo_invariant[m]) s.node_generation[site] = -1;
+  }
+
   int64_t reserve_adjoint(int64_t len) {
     const int64_t at = s.adjoint_size;
     s.adjoint_size = add(s.adjoint_size, len);
@@ -1561,14 +1676,25 @@ struct Execution {
     s.bindings[n.iterator] = make_version(cell, -1);
   }
 
-  Flow forward(const Node& n) {
-    if (!n.memo) return run(n);
-    if (n.memo_outs.empty()) {
-      if (s.memo_ready) return Normal;
-      const uint64_t effects = s.effects;
+  __attribute__((noinline)) Flow record_silent(const Node& n) {
+    const uint64_t effects = s.effects;
+    if (!s.memo_release[static_cast<size_t>(n.memo_index)]) {
       const Flow flow = run(n);
       s.effects = effects;
       return flow;
+    }
+    const Snapshot at = snapshot();
+    const Flow flow = run(n);
+    s.effects = effects;
+    rewind(at, n);
+    return flow;
+  }
+
+  Flow forward(const Node& n) {
+    if (!n.memo) return run(n);
+    if (n.memo_silent) {
+      if (s.memo_ready) return Normal;
+      return record_silent(n);
     }
     ++s.effects;
     const size_t m = static_cast<size_t>(n.memo_index);
@@ -1913,6 +2039,9 @@ void structured_loop_forward(KernelCtx& ctx) {
   for (const Node* n : s.transient_loops)
     s.loop_version[n->loop_index] =
         e.make_version(s.workspace.data() + n->workspace, -1);
+  for (size_t k = 0; k < s.keep_version.size(); ++k)
+    s.keep_version[k] =
+        e.make_version(s.keep_store.data() + s.keep_offset[k], -1);
   std::fill(s.node_generation.begin(), s.node_generation.end(), -1);
   std::fill(s.loop_generation.begin(), s.loop_generation.end(), 0);
   std::fill(s.memo_ordinal.begin(), s.memo_ordinal.end(), 0);
@@ -1957,10 +2086,13 @@ void structured_loop_forward(KernelCtx& ctx) {
     }
     ctx.out.data[pos++] = count ? s.target_work[0] : 0.0;
   }
+  if (!replaying) {
+    s.record_arena = std::max(s.record_arena, s.arena.used());
+    s.record_versions = std::max(s.version_peak, s.versions.size());
+  }
   if (s.report_tape && (replaying || p.memo_count == 0)) {
     s.report_tape = false;
-    size_t arena_used = 0;
-    for (const auto& block : s.arena.blocks) arena_used += block.used;
+    const size_t arena_used = s.arena.used();
     size_t kernel_records = 0, copies = 0, updates = 0, memo_tape = 0,
            segment_records = 0;
     for (const auto& r : s.records) {
@@ -1975,13 +2107,14 @@ void structured_loop_forward(KernelCtx& ctx) {
                  "handles=%zu kernel_records=%zu updates=%zu undo=%zu "
                  "copies=%zu targets=%zu workspace=%zu memo_nodes=%zu "
                  "memo_restores=%zu memo_tape=%zu traces=%zu trace=%zu "
-                 "visits=%zu segments=%zu segment_records=%zu\n",
+                 "visits=%zu segments=%zu segment_records=%zu "
+                 "record_arena=%zu record_versions=%zu\n",
                  arena_used, static_cast<long long>(s.adjoint_size),
                  s.versions.size(), s.handles.size(), kernel_records, updates,
                  s.undo.size() / 2, copies, s.target_refs.size(),
                  s.workspace.size(), p.memo_count, s.memo_restores, memo_tape,
                  p.trace_count, s.trace.size(), s.visits, p.segments.size(),
-                 segment_records);
+                 segment_records, s.record_arena, s.record_versions);
   }
   s.memo_ready = true;
   s.reverse_ready = true;

--- a/runtime/src/structured_loop.cpp
+++ b/runtime/src/structured_loop.cpp
@@ -908,21 +908,37 @@ void int_forward(KernelCtx& c) {
   c.out.data[0] = static_cast<double>(integer(static_cast<double>(v)));
 }
 
+[[noreturn]] __attribute__((noinline)) void index_fault(const char* message) {
+  throw std::logic_error(message);
+}
+
+[[noreturn]] __attribute__((noinline)) void index_fault(const char* what,
+                                                        const char* suffix) {
+  throw std::logic_error(std::string("invalid ") + what + suffix);
+}
+
+[[noreturn]] __attribute__((noinline)) void index_over_capacity(
+    const char* what) {
+  throw std::out_of_range(std::string(what) + " exceeds capacity");
+}
+
+[[noreturn]] __attribute__((noinline)) void index_out_of_range() {
+  throw std::out_of_range("structured index out of range");
+}
+
 const Desc& index_input(const KernelCtx& c, int input, const char* what) {
-  if (input < 0 || input >= c.n_in)
-    throw std::logic_error(std::string("invalid ") + what + " input");
+  if (input < 0 || input >= c.n_in) index_fault(what, " input");
   return c.in[input];
 }
 
 int64_t index_integer(const KernelCtx& c, int input, int64_t offset,
                       int64_t upper, const char* what) {
   const Desc& values = index_input(c, input, what);
-  if (offset < 0 || offset >= values.len)
-    throw std::logic_error(std::string("invalid ") + what + " offset");
+  if (offset < 0 || offset >= values.len) index_fault(what, " offset");
   const double raw = values.data[offset];
   if (!std::isfinite(raw) || std::trunc(raw) != raw || raw < 0 ||
       raw > static_cast<double>(upper))
-    throw std::out_of_range(std::string(what) + " exceeds capacity");
+    index_over_capacity(what);
   return static_cast<int64_t>(raw);
 }
 
@@ -946,7 +962,7 @@ int64_t dynamic_axis_count(const DynamicIndexSpec::Axis& axis,
     const Desc& selector =
         index_input(c, axis.selector_input, "dynamic range start");
     if (axis.input_offset < 0 || axis.input_offset >= selector.len)
-      throw std::logic_error("invalid dynamic range start offset");
+      index_fault("invalid dynamic range start offset");
     const double first = selector.data[axis.input_offset];
     if (!std::isfinite(first) || std::trunc(first) != first || first < 1 ||
         first > std::numeric_limits<int32_t>::max())
@@ -960,86 +976,71 @@ int64_t dynamic_axis_count(const DynamicIndexSpec::Axis& axis,
 }
 
 struct IndexRuntime {
+  struct Axis {
+    int64_t extent = 0;
+    int64_t count = 0;
+    int64_t stride = 0;
+    const double* selector = nullptr;
+  };
   // Stan indices are normally low-dimensional. Keep their validation state
-  // inline, while retaining arbitrary-rank support with one contiguous heap
-  // block instead of one allocation for each field.
+  // inline, while retaining arbitrary-rank support with one heap block.
   static constexpr size_t inline_dimensions = 8;
 
-  explicit IndexRuntime(size_t dimensions) : dimensions_(dimensions) {
-    if (dimensions_ > inline_dimensions) {
-      if (dimensions_ > std::numeric_limits<size_t>::max() / 3)
-        throw std::length_error("dynamic index rank exceeds storage limit");
-      heap_storage_.reset(new int64_t[3 * dimensions_]);
-      storage_ = heap_storage_.get();
+  explicit IndexRuntime(size_t dimensions) {
+    if (dimensions > inline_dimensions) {
+      heap_.reset(new Axis[dimensions]);
+      axes = heap_.get();
     } else {
-      storage_ = inline_storage_.data();
+      axes = inline_.data();
     }
   }
   IndexRuntime(const IndexRuntime&) = delete;
   IndexRuntime& operator=(const IndexRuntime&) = delete;
   IndexRuntime(IndexRuntime&& other) noexcept
-      : heap_storage_(std::move(other.heap_storage_)),
-        dimensions_(other.dimensions_),
+      : inline_(other.inline_),
+        heap_(std::move(other.heap_)),
         selected(other.selected) {
-    if (heap_storage_) {
-      storage_ = heap_storage_.get();
-    } else {
-      std::copy_n(other.inline_storage_.data(), 3 * dimensions_,
-                  inline_storage_.data());
-      storage_ = inline_storage_.data();
-    }
+    axes = heap_ ? heap_.get() : inline_.data();
   }
 
-  int64_t& extent(size_t dim) { return storage_[dim]; }
-  int64_t extent(size_t dim) const { return storage_[dim]; }
-  int64_t& count(size_t dim) { return storage_[dimensions_ + dim]; }
-  int64_t count(size_t dim) const { return storage_[dimensions_ + dim]; }
-  int64_t& stride(size_t dim) { return storage_[2 * dimensions_ + dim]; }
-  int64_t stride(size_t dim) const { return storage_[2 * dimensions_ + dim]; }
-
  private:
-  std::array<int64_t, 3 * inline_dimensions> inline_storage_;
-  std::unique_ptr<int64_t[]> heap_storage_;
-  int64_t* storage_ = nullptr;
-  size_t dimensions_;
+  std::array<Axis, inline_dimensions> inline_;
+  std::unique_ptr<Axis[]> heap_;
 
  public:
+  Axis* axes = nullptr;
   int64_t selected = 1;
 };
 
-int64_t selected_position(const DynamicIndexSpec& p, const KernelCtx& c,
+int64_t selected_position(const DynamicIndexSpec& p,
                           const IndexRuntime& runtime, int64_t linear) {
   int64_t result = 0;
   const auto consume = [&](size_t dim, int64_t& q) {
     const auto& axis = p.axes[dim];
-    const int64_t count = runtime.count(dim);
-    const int64_t ordinal = q % count;
-    q /= count;
+    const IndexRuntime::Axis& state = runtime.axes[dim];
+    const int64_t ordinal = q % state.count;
+    q /= state.count;
     double raw;
     switch (axis.kind) {
       case DynamicIndexSpec::Axis::All:
         raw = static_cast<double>(ordinal + 1);
         break;
       case DynamicIndexSpec::Axis::Single:
-        raw = index_input(c, axis.selector_input, "structured selector")
-                  .data[axis.input_offset];
+        raw = state.selector[axis.input_offset];
         break;
       case DynamicIndexSpec::Axis::Multi:
-        raw = index_input(c, axis.selector_input, "structured selector")
-                  .data[axis.input_offset + ordinal];
+        raw = state.selector[axis.input_offset + ordinal];
         break;
       case DynamicIndexSpec::Axis::Range:
-        raw = index_input(c, axis.selector_input, "structured selector")
-                  .data[axis.input_offset] +
-              static_cast<double>(ordinal);
+        raw = state.selector[axis.input_offset] + static_cast<double>(ordinal);
         break;
       default:
-        throw std::logic_error("invalid index selector");
+        index_fault("invalid index selector");
     }
     if (!std::isfinite(raw) || std::trunc(raw) != raw || raw < 1 ||
-        raw > static_cast<double>(runtime.extent(dim)))
-      throw std::out_of_range("structured index out of range");
-    result += (static_cast<int64_t>(raw) - 1) * runtime.stride(dim);
+        raw > static_cast<double>(state.extent))
+      index_out_of_range();
+    result += (static_cast<int64_t>(raw) - 1) * state.stride;
   };
   const size_t outer = p.axes.size() - (p.matrix_leaf ? 2 : 0);
   if (p.matrix_leaf) {
@@ -1053,10 +1054,9 @@ IndexRuntime validate_index(const DynamicIndexSpec& p, const KernelCtx& c,
                             bool update) {
   const IndexInputLayout layout = require_index_input_layout(p, update);
   if (c.n_in != layout.expected || (p.matrix_leaf && p.axes.size() < 2))
-    throw std::logic_error("invalid structured index descriptor");
+    index_fault("invalid structured index descriptor");
   const auto validate_selector_input = [&](int input, const char* what) {
-    if (input < 1 || input >= layout.selector_end)
-      throw std::logic_error(std::string("invalid ") + what + " input");
+    if (input < 1 || input >= layout.selector_end) index_fault(what, " input");
   };
   IndexRuntime runtime(p.axes.size());
   int64_t capacity = 1, logical_size = 1;
@@ -1070,15 +1070,15 @@ IndexRuntime validate_index(const DynamicIndexSpec& p, const KernelCtx& c,
       validate_selector_input(axis.extent_input,
                               "dynamic index logical extent");
     const int64_t logical_extent = logical_axis_extent(axis, c);
-    runtime.extent(dim) = logical_extent;
+    runtime.axes[dim].extent = logical_extent;
     const int64_t count = dynamic_axis_count(axis, c);
-    runtime.count(dim) = count;
+    runtime.axes[dim].count = count;
     runtime.selected = mul(runtime.selected, count);
     capacity = mul(capacity, axis.extent);
     logical_size = mul(logical_size, logical_extent);
     if (axis.stride < 0 ||
         (axis.kind != DynamicIndexSpec::Axis::All && axis.input_offset < 0))
-      throw std::logic_error("invalid structured index offset");
+      index_fault("invalid structured index offset");
     const int64_t width =
         axis.kind == DynamicIndexSpec::Axis::All     ? 0
         : axis.kind == DynamicIndexSpec::Axis::Multi ? axis.count
@@ -1092,6 +1092,7 @@ IndexRuntime validate_index(const DynamicIndexSpec& p, const KernelCtx& c,
         axis.kind == DynamicIndexSpec::Axis::All
             ? nullptr
             : &index_input(c, axis.selector_input, "structured selector");
+    runtime.axes[dim].selector = selector ? selector->data : nullptr;
     if ((selector && (axis.input_offset > selector->len ||
                       width > selector->len - axis.input_offset)) ||
         (axis.count_input_offset >= 0 &&
@@ -1103,7 +1104,7 @@ IndexRuntime validate_index(const DynamicIndexSpec& p, const KernelCtx& c,
                  .len) ||
         (axis.kind == DynamicIndexSpec::Axis::Single && axis.count != 1) ||
         (axis.kind == DynamicIndexSpec::Axis::All && axis.count != axis.extent))
-      throw std::logic_error("invalid structured index shape");
+      index_fault("invalid structured index shape");
     // Validate selectors even when a different axis makes the result empty.
     if (axis.kind == DynamicIndexSpec::Axis::All ||
         (axis.kind == DynamicIndexSpec::Axis::Range && count == 0))
@@ -1117,7 +1118,7 @@ IndexRuntime validate_index(const DynamicIndexSpec& p, const KernelCtx& c,
                               : raw;
       if (!std::isfinite(raw) || std::trunc(raw) != raw || raw < 1 ||
           last > logical_extent)
-        throw std::out_of_range("structured index out of range");
+        index_out_of_range();
     }
   }
   const size_t outer = p.axes.size() - (p.matrix_leaf ? 2 : 0);
@@ -1126,33 +1127,34 @@ IndexRuntime validate_index(const DynamicIndexSpec& p, const KernelCtx& c,
   if (p.matrix_leaf) {
     if (p.axes[outer].stride != 1 ||
         p.axes[outer + 1].stride != p.axes[outer].extent)
-      throw std::logic_error("invalid structured matrix stride");
-    runtime.stride(outer) = 1;
-    runtime.stride(outer + 1) = runtime.extent(outer);
+      index_fault("invalid structured matrix stride");
+    runtime.axes[outer].stride = 1;
+    runtime.axes[outer + 1].stride = runtime.axes[outer].extent;
     capacity_stride = mul(p.axes[outer].extent, p.axes[outer + 1].extent);
-    logical_stride = mul(runtime.extent(outer), runtime.extent(outer + 1));
+    logical_stride =
+        mul(runtime.axes[outer].extent, runtime.axes[outer + 1].extent);
   }
   for (size_t d = outer; d-- > 0;) {
     if (p.axes[d].stride != capacity_stride)
-      throw std::logic_error("invalid structured array stride");
-    runtime.stride(d) = logical_stride;
+      index_fault("invalid structured array stride");
+    runtime.axes[d].stride = logical_stride;
     capacity_stride = mul(capacity_stride, p.axes[d].extent);
-    logical_stride = mul(logical_stride, runtime.extent(d));
+    logical_stride = mul(logical_stride, runtime.axes[d].extent);
   }
   if (capacity != c.in[0].len || logical_size > capacity ||
       runtime.selected > p.selected_size ||
       (update
            ? (c.out.len != capacity || c.in[layout.rhs].len != p.selected_size)
            : c.out.len != p.selected_size))
-    throw std::logic_error("invalid structured index storage");
+    index_fault("invalid structured index storage");
   return runtime;
 }
 
 template <class F>
-void selected_positions(const DynamicIndexSpec& p, const KernelCtx& c,
-                        const IndexRuntime& runtime, F&& f) {
+void selected_positions(const DynamicIndexSpec& p, const IndexRuntime& runtime,
+                        F&& f) {
   for (int64_t i = 0; i < runtime.selected; ++i)
-    f(i, selected_position(p, c, runtime, i));
+    f(i, selected_position(p, runtime, i));
 }
 int64_t scalar_index_forward(KernelCtx& c) {
   const auto& p = *static_cast<const DynamicIndexSpec*>(c.udata);
@@ -1161,7 +1163,7 @@ int64_t scalar_index_forward(KernelCtx& c) {
     throw std::logic_error("invalid compact scalar index shape");
   c.out.data[0] = 0.0;
   if (runtime.selected == 0) return -1;
-  const int64_t position = selected_position(p, c, runtime, 0);
+  const int64_t position = selected_position(p, runtime, 0);
   c.out.data[0] = c.in[0].data[position];
   return position;
 }
@@ -1173,7 +1175,7 @@ void index_forward(KernelCtx& c) {
   }
   const IndexRuntime runtime = validate_index(p, c, false);
   std::fill(c.out.data, c.out.data + c.out.len, 0.0);
-  selected_positions(p, c, runtime, [&](int64_t i, int64_t at) {
+  selected_positions(p, runtime, [&](int64_t i, int64_t at) {
     c.out.data[i] = c.in[0].data[at];
   });
 }
@@ -1181,7 +1183,7 @@ void index_backward(KernelCtx& c) {
   if (!c.in_adj[0].data) return;
   const auto& p = *static_cast<const DynamicIndexSpec*>(c.udata);
   const IndexRuntime runtime = validate_index(p, c, false);
-  selected_positions(p, c, runtime, [&](int64_t i, int64_t at) {
+  selected_positions(p, runtime, [&](int64_t i, int64_t at) {
     c.in_adj[0].data[at] += c.out_adj_vec.data[i];
   });
 }
@@ -1192,7 +1194,7 @@ void set_index_forward(KernelCtx& c) {
   std::copy_n(c.in[0].data, c.in[0].len, c.out.data);
   const bool may_repeat = !index_selection_is_ordered_unique(p);
   if (may_repeat) std::fill(c.scratch, c.scratch + c.in[0].len, -1.0);
-  selected_positions(p, c, runtime, [&](int64_t i, int64_t at) {
+  selected_positions(p, runtime, [&](int64_t i, int64_t at) {
     c.out.data[at] = c.in[layout.rhs].data[i];
     if (may_repeat) c.scratch[at] = static_cast<double>(i);
   });
@@ -1206,14 +1208,14 @@ void set_index_backward(KernelCtx& c) {
     const IndexRuntime runtime = validate_index(p, c, true);
     int64_t selected = 0;
     int64_t selected_at =
-        runtime.selected > 0 ? selected_position(p, c, runtime, 0) : -1;
+        runtime.selected > 0 ? selected_position(p, runtime, 0) : -1;
     for (int64_t i = 0; i < c.out.len; ++i) {
       if (selected < runtime.selected && i == selected_at) {
         if (c.in_adj[layout.rhs].data)
           c.in_adj[layout.rhs].data[selected] += c.out_adj_vec.data[i];
         ++selected;
         if (selected < runtime.selected)
-          selected_at = selected_position(p, c, runtime, selected);
+          selected_at = selected_position(p, runtime, selected);
       } else if (c.in_adj[0].data) {
         c.in_adj[0].data[i] += c.out_adj_vec.data[i];
       }
@@ -1650,7 +1652,7 @@ struct Execution {
     const IndexRuntime runtime = validate_index(spec, c, true);
     const double* source = c.in[layout.rhs].data;
     const int64_t undo = static_cast<int64_t>(s.undo.size());
-    selected_positions(spec, c, runtime, [&](int64_t i, int64_t at) {
+    selected_positions(spec, runtime, [&](int64_t i, int64_t at) {
       s.undo.push_back(static_cast<double>(at));
       s.undo.push_back(values[at]);
       values[at] = source[i];

--- a/tests/test_adjoint.cpp
+++ b/tests/test_adjoint.cpp
@@ -720,6 +720,29 @@ static void test_ranged() {
   }
 }
 
+// compact_program renumbers `dst` only when the instruction writes something,
+// so a zero-length range copy keeps a destination from the old numbering.
+static void test_zero_length_output() {
+  IslandProg p;
+  p.n_regs = 3;
+  p.ins = {IslandProg::LiveIn{0, 1}, IslandProg::LiveIn{1, 1}};
+  p.out_regs = {2};
+  p.code.push_back(Program::Instr{Program::MOVR, 5000, 0, 0, 0, 0});
+  p.code.push_back(Program::Instr{Program::MUL, 2, 0, 1, 0, 0});
+
+  expect("zero-length output adjoint generated", gen_adjoint(p));
+  bool in_range = true;
+  for (const AdjInstr& A : p.adj.code)
+    if (A.dst < 0 || A.dst >= p.adj.n_regs) in_range = false;
+  expect("zero-length output keeps adjoint registers in range", in_range);
+
+  std::vector<double> out_vals;
+  const std::vector<double> got =
+      native_adjoints(p, {1.25, 3.5}, {1.0}, &out_vals);
+  expect("zero-length output gradient",
+         got.size() == 2 && got[0] == 3.5 && got[1] == 1.25);
+}
+
 // The double interpreter has a stack-backed SOFTMAX(3) result.  Compare it
 // directly with the owning Stan Math expression it replaces, including every
 // legal overlap between the three-lane source and destination ranges.  Full
@@ -1438,6 +1461,7 @@ int main() {
   test_ranged_saveout_partial_later_write_refuses();
   test_accumulate_into_one_register();
   test_ranged();
+  test_zero_length_output();
   test_softmax3_activation();
   test_softmax3_double_exact();
   test_in_place_ranges();

--- a/tests/test_structured_loop.cpp
+++ b/tests/test_structured_loop.cpp
@@ -618,14 +618,18 @@ static void direct_index_kernel_tests() {
   try {
     dynamic_index->forward(direct);
     check(false, "direct index validates selectors");
-  } catch (const std::out_of_range&) {
+  } catch (const std::out_of_range& error) {
+    check(std::string(error.what()) == "structured index out of range",
+          "direct index selector message");
   }
   lower = 1;
   direct.n_in = 3;
   try {
     dynamic_index->forward(direct);
     check(false, "direct index validates input arity");
-  } catch (const std::logic_error&) {
+  } catch (const std::logic_error& error) {
+    check(std::string(error.what()) == "invalid structured index descriptor",
+          "direct index arity message");
   }
   direct.n_in = 4;
   lower = 1;

--- a/tests/test_structured_loop.cpp
+++ b/tests/test_structured_loop.cpp
@@ -3921,10 +3921,16 @@ static std::vector<double> sparse_rows(int rows, std::vector<int> positive) {
   return table;
 }
 
+static size_t reported_field(const std::string& diagnostics,
+                             const std::string& name) {
+  const size_t at = diagnostics.find(name);
+  return at == std::string::npos
+             ? std::numeric_limits<size_t>::max()
+             : std::stoul(diagnostics.substr(at + name.size()));
+}
+
 static size_t reported_visits(const std::string& diagnostics) {
-  const size_t at = diagnostics.find("visits=");
-  return at == std::string::npos ? std::numeric_limits<size_t>::max()
-                                 : std::stoul(diagnostics.substr(at + 7));
+  return reported_field(diagnostics, "visits=");
 }
 
 // Replays under STANLI_STRUCTURED_LOOP_DIAGNOSTICS and returns the node
@@ -3941,6 +3947,59 @@ static Executor diagnosed_executor(Graph graph) {
   Executor executor(std::move(graph));
   test_unsetenv("STANLI_STRUCTURED_LOOP_DIAGNOSTICS");
   return executor;
+}
+
+// A data-only scan whose values leave nothing behind runs once, during the
+// recording evaluation, and is skipped afterwards. What it allocated has no
+// reader once it exits.
+static void memo_release_tests() {
+  auto plan = std::make_shared<StructuredLoop>();
+  const int theta = plan->body.add_slot(1, false);
+  const int one = scalar(*plan, 1);
+  const int rows = scalar(*plan, 200);
+  const int columns = scalar(*plan, 50);
+  const int row = plan->body.add_slot(1, false);
+  const int column = plan->body.add_slot(1, false);
+  const int seen = plan->body.add_slot(1, false);
+  const int acc = plan->body.add_slot(1, false);
+  plan->fills.push_back({acc, {0}});
+  const int next = plan->body.add_slot(1, false);
+  plan->imports = {{theta, 0, 0, true, false}};
+  const int half = scalar(*plan, 100);
+  const int guard = plan->body.add_slot(1, false);
+  Node scan = counted(one, columns, column, sequence({alias(seen, column)}));
+  Node compare = call(*plan, OP_COMPARE, {row, half}, guard);
+  plan->body.ops[static_cast<size_t>(compare.op)].variant = 2;
+  plan->root = counted(
+      one, rows, row,
+      sequence({std::move(scan), std::move(compare),
+                branch(guard,
+                       sequence({call(*plan, OP_ADD, {acc, theta}, next),
+                                 alias(acc, next)}),
+                       sequence({}))}));
+  plan->outputs = {acc};
+  prepare_kernels(*plan);
+  check(plan->memo_count == 1, "the data-only scan is one memo node");
+  check(plan->root.children[0].children[0].memo_keep.size() == 1,
+        "the guard the traced branch reads survives the scan");
+
+  Executor executor = diagnosed_executor(outer(plan, {1, 1}));
+  const Evaluation first = evaluate(executor, .25, 0);
+  close(first.value, 25, "scan recording value");
+  close(first.gradient[0], 100, "scan recording gradient");
+  Evaluation second;
+  std::string diagnostics;
+  {
+    stanli_test::StdoutCapture captured(stderr);
+    second = evaluate(executor, .5, 0);
+    diagnostics = captured.finish();
+  }
+  close(second.value, 50, "scan replayed value");
+  close(second.gradient[0], 100, "scan replayed gradient");
+  check(reported_field(diagnostics, "record_versions=") < 500,
+        "the recording evaluation keeps one scan of versions");
+  check(reported_field(diagnostics, "record_arena=") < 500,
+        "the recording evaluation keeps one scan of storage");
 }
 
 static void for_trace_tests() {
@@ -4456,6 +4515,7 @@ int main() {
   memo_tests();
   trace_tests();
   for_trace_tests();
+  memo_release_tests();
   test_unsetenv("STANLI_STRUCTURED_LOOPS");
   test_unsetenv("STANLI_NO_STRUCTURED_DIRECT_INDEX_INPUTS");
   if (failures == 0) std::printf("test_structured_loop OK\n");


### PR DESCRIPTION
Follows #314.

gen_adjoint was walking the adjoint of a zero-length output, which was a pre-existing heap overflow visible under ASan; it now skips those. Memo nodes that turn out silent while recording now give back their arena and version storage instead of holding onto it for the rest of the recording pass, which cut ctsem N=400 peak RSS from 1.24 GB to 0.95 GB and ms/grad from 308 to 266 on the earlier measurement (this run: 0.264 s/grad, peak RSS 0.95 GB). Dynamic index error message building moved off the hot path so it's not paid on every bounds check. The plan doc records the index profile, the corpus refusals, and the write_array cost that motivated this work.

Tests: ctest 118/118 passing.
