### PR TITLE
Route the interpreter's reductions, matrix algebra and discrete densities through the kernel table

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -812,7 +812,8 @@ set(STANLI_TESTS
   test_reroll test_profile test_inplace test_pass_safety test_sampling
   test_ode_prog test_mir_program_conformance test_mir_checks
   test_structured_checks test_structured_loop
-  test_mir_unary_fallback test_mir_binary_fallback test_constfold test_cse
+  test_mir_unary_fallback test_mir_binary_fallback test_mir_reduction_fallback
+  test_constfold test_cse
   test_partition
   test_solve test_cross_path
   test_write_array test_pool test_bridgestan test_mixture test_island

--- a/runtime/include/stanli/mir_interp.hpp
+++ b/runtime/include/stanli/mir_interp.hpp
@@ -2833,19 +2833,62 @@ class MirInterp {
       return r;
     }
 
-    // The continuous scalar ones come from the shared list, so this can
-    // never be narrower than what the register-machine compiler accepts
-    // -- the compiled path falls back here when compilation fails, and a
-    // narrower fallback turns a slow path into an error. The discrete
-    // ones are the interpreter's alone: the register file has nowhere to
-    // put an integer outcome.
+    {
+      struct DiscreteSpec {
+        uint16_t opcode;
+        int n_real;
+        bool two_int_groups;
+      };
+      static const std::map<std::string, DiscreteSpec> kDiscrete = {
+          {"bernoulli_lpmf", {OP_BERNOULLI_LPMF, 1, false}},
+          {"bernoulli_logit_lpmf", {OP_BERNOULLI_LOGIT_LPMF, 1, false}},
+          {"poisson_lpmf", {OP_POISSON_LPMF, 1, false}},
+          {"poisson_log_lpmf", {OP_POISSON_LOG_LPMF, 1, false}},
+          {"neg_binomial_2_lpmf", {OP_NEG_BINOMIAL_2_LPMF, 2, false}},
+          {"neg_binomial_2_log_lpmf", {OP_NEG_BINOMIAL_2_LOG_LPMF, 2, false}},
+          {"binomial_lpmf", {OP_BINOMIAL_LPMF, 1, true}},
+          {"binomial_logit_lpmf", {OP_BINOMIAL_LOGIT_LPMF, 1, true}},
+      };
+      const auto spec = kDiscrete.find(e.name);
+      if (spec != kDiscrete.end()) {
+        const int n_int = spec->second.two_int_groups ? 2 : 1;
+        if (e.args.size() != (size_t)(n_int + spec->second.n_real))
+          fail(e.name + ": wrong arity in the interpreter", e.raw);
+        std::vector<Value> av;
+        av.reserve(e.args.size());
+        for (const auto& a : e.args) av.push_back(eval(a));
+        const auto int_group = [&](const Value& a) {
+          std::vector<int> vals;
+          if (a.is_int && a.i.size() == a.r.size()) {
+            vals.assign(a.i.begin(), a.i.end());
+          } else {
+            vals.reserve(a.r.size());
+            for (const T& x : a.r) vals.push_back((int)val(x));
+          }
+          return vals;
+        };
+        std::vector<int> idata;
+        if (spec->second.two_int_groups) {
+          for (size_t k = 0; k < 2; ++k) {
+            const std::vector<int> vals = int_group(av[k]);
+            idata.push_back(is_scalar(av[k]) ? -1 : (int)vals.size());
+            idata.insert(idata.end(), vals.begin(), vals.end());
+          }
+        } else {
+          idata = int_group(av[0]);
+        }
+        std::vector<const std::vector<T>*> in;
+        for (size_t k = (size_t)n_int; k < av.size(); ++k)
+          in.push_back(&av[k].r);
+        Value o;
+        o.r.resize(1);
+        call_kernel<T>(spec->second.opcode, 0, 0x3f, idata, in, o.r);
+        return o;
+      }
+    }
     const int shared_id = program_density_id_by_name(e.name);
-    if (shared_id >= 0 || e.name == "bernoulli_lpmf" ||
-        e.name == "binomial_lpmf" || e.name == "poisson_lpmf" ||
-        e.name == "poisson_log_lpmf" || e.name == "bernoulli_logit_lpmf" ||
-        e.name == "binomial_logit_lpmf" || e.name == "hypergeometric_lpmf" ||
-        e.name == "discrete_range_lpmf" || e.name == "neg_binomial_2_lpmf" ||
-        e.name == "neg_binomial_2_log_lpmf") {
+    if (shared_id >= 0 || e.name == "hypergeometric_lpmf" ||
+        e.name == "discrete_range_lpmf") {
       if (shared_id >= 0 &&
           e.args.size() != (size_t)program_density_arity(shared_id))
         fail(e.name + " takes " +
@@ -2878,31 +2921,11 @@ class MirInterp {
           acc += program_density<T>(shared_id, argbuf);
           continue;
         }
-        if (e.name == "bernoulli_lpmf")
-          acc += stan::math::bernoulli_lpmf(ic(0, i), sc(1, i));
-        else if (e.name == "bernoulli_logit_lpmf")
-          acc += stan::math::bernoulli_logit_lpmf(ic(0, i), sc(1, i));
-        else if (e.name == "binomial_lpmf")
-          acc += stan::math::binomial_lpmf(ic(0, i), ic(1, i), sc(2, i));
-        else if (e.name == "binomial_logit_lpmf")
-          acc += stan::math::binomial_logit_lpmf(ic(0, i), ic(1, i), sc(2, i));
-        else if (e.name == "poisson_lpmf")
-          acc += stan::math::poisson_lpmf(ic(0, i), sc(1, i));
-        else if (e.name == "poisson_log_lpmf")
-          acc += stan::math::poisson_log_lpmf(ic(0, i), sc(1, i));
-        else if (e.name == "hypergeometric_lpmf")
+        if (e.name == "hypergeometric_lpmf")
           acc += stan::math::hypergeometric_lpmf(ic(0, i), ic(1, i), ic(2, i),
                                                  ic(3, i));
         else if (e.name == "discrete_range_lpmf")
           acc += stan::math::discrete_range_lpmf(ic(0, i), ic(1, i), ic(2, i));
-        else if (e.name == "neg_binomial_2_lpmf")
-          acc += stan::math::neg_binomial_2_lpmf(ic(0, i), sc(1, i), sc(2, i));
-        else if (e.name == "neg_binomial_2_log_lpmf")
-          acc +=
-              stan::math::neg_binomial_2_log_lpmf(ic(0, i), sc(1, i), sc(2, i));
-        else if (e.name == "student_t_lpdf")
-          acc += stan::math::student_t_lpdf(sc(0, i), sc(1, i), sc(2, i),
-                                            sc(3, i));
         else
           fail("unsupported density " + e.name, e.raw);
       }

--- a/runtime/include/stanli/mir_interp.hpp
+++ b/runtime/include/stanli/mir_interp.hpp
@@ -1483,19 +1483,23 @@ class MirInterp {
           r.dims = {Ra, Cb};
           return r;
         }
-        // Col-major storage on both sides.
-        r.r.assign((size_t)(Ra * Cb), T(0.0));
-        for (int64_t j = 0; j < Cb; ++j)
-          for (int64_t k = 0; k < Ca; ++k) {
-            const T& bv = b.r.at((size_t)(j * Rb + k));
-            for (int64_t i = 0; i < Ra; ++i)
-              r.r[(size_t)(j * Ra + i)] +=
-                  a.r.at((size_t)(a_mat ? k * Ra + i : k)) * bv;
+        if (a_mat) {
+          Value o;
+          o.dims = {Ra};
+          o.r.resize((size_t)Ra);
+          const std::vector<const std::vector<T>*> in{&a.r, &b.r};
+          if constexpr (std::is_same_v<T, double>) {
+            call_kernel<T>(OP_MATVEC, 0, 0x3f, {(int)Ra, (int)Ca}, in, o.r);
+          } else {
+            call_kernel<T>(OP_GEMM, 0, 0x3f, {(int)Ra, (int)Ca, 1}, in, o.r);
           }
-        if (a_mat && b_mat)
-          r.dims = {Ra, Cb};
-        else
-          r.dims = {(int64_t)r.r.size()};
+          return o;
+        }
+        r.r.assign((size_t)Cb, T(0.0));
+        for (int64_t j = 0; j < Cb; ++j)
+          for (int64_t k = 0; k < Ca; ++k)
+            r.r[(size_t)j] += a.r.at((size_t)k) * b.r.at((size_t)(j * Rb + k));
+        r.dims = {(int64_t)r.r.size()};
         return r;
       }
       if (!is_scalar(a) && !is_scalar(b) && !a_mat && !b_mat) {
@@ -1695,10 +1699,8 @@ class MirInterp {
         have_container = true;
       }
       o.r.resize(n);
-      for (size_t i = 0; i < n; ++i)
-        o.r[i] = stan::math::fma(a.r[a.r.size() == 1 ? 0 : i],
-                                 b.r[b.r.size() == 1 ? 0 : i],
-                                 c.r[c.r.size() == 1 ? 0 : i]);
+      const std::vector<const std::vector<T>*> in{&a.r, &b.r, &c.r};
+      call_kernel<T>(OP_FMA, 0, 0x3f, {}, in, o.r);
       return o;
     }
     // Callable transforms share their name/arity dispatch and their typed
@@ -1833,7 +1835,6 @@ class MirInterp {
       return o;
     }
     if (e.name == "matrix_exp" && e.args.size() == 1) {
-      using Mat = Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>;
       Value a = eval(e.args[0]);
       if (a.dims.size() != 2 || a.dims[0] != a.dims[1])
         fail("matrix_exp: needs a square matrix", e.raw);
@@ -1841,148 +1842,110 @@ class MirInterp {
       if (n < 0 || (n != 0 && n > std::numeric_limits<int64_t>::max() / n) ||
           n * n != static_cast<int64_t>(a.r.size()))
         fail("matrix_exp: matrix shape does not match storage", e.raw);
-      Mat A(n, n);
-      for (int64_t j = 0; j < n; ++j)
-        for (int64_t i = 0; i < n; ++i) A(i, j) = a.r[(size_t)(j * n + i)];
-      const Mat c = stan::math::matrix_exp(A);
       Value o;
       o.dims = {n, n};
       o.r.resize((size_t)(n * n));
-      for (int64_t j = 0; j < n; ++j)
-        for (int64_t i = 0; i < n; ++i) o.r[(size_t)(j * n + i)] = c(i, j);
+      const std::vector<const std::vector<T>*> in{&a.r};
+      call_kernel<T>(OP_MATRIX_EXP, 0, 0x3f, {(int)n}, in, o.r);
       return o;
     }
     if ((e.name == "inverse" || e.name == "inverse_spd") &&
         e.args.size() == 1) {
-      using Mat = Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>;
       Value a = eval(e.args[0]);
       if (a.dims.size() != 2 || a.dims[0] != a.dims[1])
         fail(e.name + ": needs a square matrix", e.raw);
       const int64_t n = a.dims[0];
-      Mat A(n, n);
-      for (int64_t j = 0; j < n; ++j)
-        for (int64_t i = 0; i < n; ++i) A(i, j) = a.r.at((size_t)(j * n + i));
-      const Mat c = e.name == "inverse" ? stan::math::inverse(A)
-                                        : stan::math::inverse_spd(A);
       Value o;
       o.dims = {n, n};
       o.r.resize((size_t)(n * n));
-      for (int64_t j = 0; j < n; ++j)
-        for (int64_t i = 0; i < n; ++i) o.r[(size_t)(j * n + i)] = c(i, j);
+      const std::vector<const std::vector<T>*> in{&a.r};
+      const uint8_t variant =
+          e.name == "inverse_spd" && std::is_same_v<T, stan::math::var> ? 1u
+                                                                        : 0u;
+      call_kernel<T>(e.name == "inverse" ? OP_INVERSE : OP_INVERSE_SPD, variant,
+                     0x3f, {(int)n}, in, o.r);
       return o;
     }
     if (e.name == "log_determinant" && e.args.size() == 1) {
-      using Mat = Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>;
       Value a = eval(e.args[0]);
       if (a.dims.size() != 2 || a.dims[0] != a.dims[1])
         fail("log_determinant: needs a square matrix", e.raw);
       const int64_t n = a.dims[0];
-      Mat A(n, n);
-      for (int64_t j = 0; j < n; ++j)
-        for (int64_t i = 0; i < n; ++i) A(i, j) = a.r.at((size_t)(j * n + i));
-      r.r = {stan::math::log_determinant(A)};
-      return r;
+      Value o;
+      o.r.resize(1);
+      const std::vector<const std::vector<T>*> in{&a.r};
+      call_kernel<T>(OP_LOG_DETERMINANT, 0, 0x3f, {(int)n}, in, o.r);
+      return o;
     }
     if (e.name == "quad_form" && e.args.size() == 2) {
-      using Mat = Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>;
       Value a = eval(e.args[0]);
       Value b = eval(e.args[1]);
       if (a.dims.size() != 2 || a.dims[0] != a.dims[1])
         fail("quad_form: needs a square matrix", e.raw);
       const int64_t n = a.dims[0];
-      Mat A(n, n);
-      for (int64_t j = 0; j < n; ++j)
-        for (int64_t i = 0; i < n; ++i) A(i, j) = a.r.at((size_t)(j * n + i));
+      const bool b_matrix = b.dims.size() == 2;
+      const int64_t m = b_matrix ? b.dims[1] : 1;
       Value o;
-      if (b.dims.size() != 2) {
-        Eigen::Matrix<T, Eigen::Dynamic, 1> B((Eigen::Index)b.r.size());
-        for (size_t i = 0; i < b.r.size(); ++i) B((Eigen::Index)i) = b.r[i];
-        o.r = {stan::math::quad_form(A, B)};
-        return o;
-      }
-      const int64_t rb = b.dims[0], m = b.dims[1];
-      Mat B(rb, m);
-      for (int64_t j = 0; j < m; ++j)
-        for (int64_t i = 0; i < rb; ++i) B(i, j) = b.r.at((size_t)(j * rb + i));
-      const Mat c = stan::math::quad_form(A, B);
-      o.dims = {m, m};
-      o.r.resize((size_t)(m * m));
-      for (int64_t j = 0; j < m; ++j)
-        for (int64_t i = 0; i < m; ++i) o.r[(size_t)(j * m + i)] = c(i, j);
+      o.r.resize(b_matrix ? (size_t)(m * m) : 1);
+      if (b_matrix) o.dims = {m, m};
+      const std::vector<const std::vector<T>*> in{&a.r, &b.r};
+      const bool active = std::is_same_v<T, stan::math::var>;
+      const uint8_t variant =
+          (uint8_t)((b_matrix ? 0u : 1u) | (active ? 2u : 0u));
+      call_kernel<T>(OP_QUAD_FORM, variant, 0x3f, {(int)n, (int)m}, in, o.r);
       return o;
     }
     if (e.name == "add_diag" && e.args.size() == 2) {
-      using Mat = Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>;
       Value a = eval(e.args[0]);
       Value d = eval(e.args[1]);
       if (a.dims.size() != 2) fail("add_diag: needs a matrix", e.raw);
       const int64_t rows = a.dims[0], cols = a.dims[1];
-      Mat A(rows, cols);
-      for (int64_t j = 0; j < cols; ++j)
-        for (int64_t i = 0; i < rows; ++i)
-          A(i, j) = a.r.at((size_t)(j * rows + i));
-      Mat c;
-      if (d.r.size() == 1 && d.dims.empty()) {
-        c = stan::math::add_diag(A, d.r[0]);
-      } else {
-        Eigen::Matrix<T, Eigen::Dynamic, 1> D((Eigen::Index)d.r.size());
-        for (size_t i = 0; i < d.r.size(); ++i) D((Eigen::Index)i) = d.r[i];
-        c = stan::math::add_diag(A, D);
-      }
+      const bool scalar = d.r.size() == 1 && d.dims.empty();
       Value o;
       o.dims = {rows, cols};
       o.r.resize((size_t)(rows * cols));
-      for (int64_t j = 0; j < cols; ++j)
-        for (int64_t i = 0; i < rows; ++i)
-          o.r[(size_t)(j * rows + i)] = c(i, j);
+      const std::vector<const std::vector<T>*> in{&a.r, &d.r};
+      call_kernel<T>(OP_ADD_DIAG, scalar ? 1u : 0u, 0x3f,
+                     {(int)rows, (int)cols}, in, o.r);
       return o;
     }
     if (e.name == "quad_form_sym" && e.args.size() == 2) {
-      // B' A B, symmetrised. Overload resolution on T reaches the same
-      // stan-math call the graph kernel makes -- prim's B.dot(A * B) at
-      // double, quad_form_vari's B' * A * B at var -- so the two paths
-      // group the arithmetic the same way. stan-math checks A for symmetry
-      // and throws the std::domain_error CmdStan would.
-      using Mat = Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>;
       Value a = eval(e.args[0]);
       Value b = eval(e.args[1]);
       if (a.dims.size() != 2 || a.dims[0] != a.dims[1])
         fail("quad_form_sym: needs a square matrix", e.raw);
       const int64_t n = a.dims[0];
-      Mat A(n, n);
-      for (int64_t j = 0; j < n; ++j)
-        for (int64_t i = 0; i < n; ++i) A(i, j) = a.r.at((size_t)(j * n + i));
+      const bool b_matrix = b.dims.size() == 2;
+      const int64_t m = b_matrix ? b.dims[1] : 1;
       Value o;
-      if (b.dims.size() != 2) {
-        // A vector goes in as a vector: the one-column matrix would take
-        // Eigen's matrix paths and associate the product differently.
-        Eigen::Matrix<T, Eigen::Dynamic, 1> B((Eigen::Index)b.r.size());
-        for (size_t i = 0; i < b.r.size(); ++i) B((Eigen::Index)i) = b.r[i];
-        o.r = {stan::math::quad_form_sym(A, B)};
-        return o;
-      }
-      const int64_t rb = b.dims[0], m = b.dims[1];
-      Mat B(rb, m);
-      for (int64_t j = 0; j < m; ++j)
-        for (int64_t i = 0; i < rb; ++i) B(i, j) = b.r.at((size_t)(j * rb + i));
-      const Mat c = stan::math::quad_form_sym(A, B);
-      o.dims = {m, m};
-      o.r.resize((size_t)(m * m));
-      for (int64_t j = 0; j < m; ++j)
-        for (int64_t i = 0; i < m; ++i) o.r[(size_t)(j * m + i)] = c(i, j);
+      o.r.resize(b_matrix ? (size_t)(m * m) : 1);
+      if (b_matrix) o.dims = {m, m};
+      const std::vector<const std::vector<T>*> in{&a.r, &b.r};
+      const bool active = std::is_same_v<T, stan::math::var>;
+      const uint8_t variant =
+          (uint8_t)((b_matrix ? 0u : 1u) | (active ? 2u : 0u));
+      call_kernel<T>(OP_QUAD_FORM_SYM, variant, 0x3f, {(int)n, (int)m}, in,
+                     o.r);
       return o;
     }
     if (e.name == "gp_exp_quad_cov" && e.args.size() == 3) {
       // K(i,j) = alpha^2 exp(-|x_i - x_j|^2 / (2 rho^2)); x is array[N]
       // real or array[N] vector[D] in Fortran storage.
       Value x = eval(e.args[0]);
-      const T alpha = eval(e.args[1]).r.at(0);
-      const T rho = eval(e.args[2]).r.at(0);
-      const int64_t N = x.dims.size() == 2 ? x.dims[0] : (int64_t)x.r.size();
-      const int64_t D = x.dims.size() == 2 ? x.dims[1] : 1;
-      const T a2 = alpha * alpha;
-      const T inv2r2 = T(1.0) / (T(2.0) * rho * rho);
+      Value alpha = eval(e.args[1]);
+      Value rho = eval(e.args[2]);
       Value o;
+      if (x.dims.size() != 2) {
+        const int64_t N = (int64_t)x.r.size();
+        o.dims = {N, N};
+        o.r.resize((size_t)(N * N));
+        const std::vector<const std::vector<T>*> in{&x.r, &alpha.r, &rho.r};
+        call_kernel<T>(OP_GP_EXP_QUAD_COV, 0, 0x3f, {(int)N, 1}, in, o.r);
+        return o;
+      }
+      const int64_t N = x.dims[0], D = x.dims[1];
+      const T a2 = alpha.r[0] * alpha.r[0];
+      const T inv2r2 = T(1.0) / (T(2.0) * rho.r[0] * rho.r[0]);
       o.dims = {N, N};
       o.r.resize((size_t)(N * N));
       for (int64_t j = 0; j < N; ++j)
@@ -2159,20 +2122,25 @@ class MirInterp {
       Value a = eval(e.args[0]);
       if (a.dims.size() != 2) fail("tcrossprod: needs a matrix", e.raw);
       const int64_t rows = a.dims[0], cols = a.dims[1];
-      r.dims = {rows, rows};
-      r.r.assign((size_t)(rows * rows), T(0.0));
-      for (int64_t j = 0; j < rows; ++j)
-        for (int64_t k = 0; k < cols; ++k) {
-          const T& rhs = a.r.at((size_t)(k * rows + j));
-          for (int64_t i = 0; i < rows; ++i)
-            r.r[(size_t)(j * rows + i)] += a.r.at((size_t)(k * rows + i)) * rhs;
-        }
-      return r;
+      Value transpose;
+      transpose.dims = {cols, rows};
+      transpose.r.resize((size_t)(rows * cols));
+      {
+        const std::vector<const std::vector<T>*> in{&a.r};
+        call_kernel<T>(OP_TRANSPOSE, 0, 0x3f, {(int)rows, (int)cols}, in,
+                       transpose.r);
+      }
+      Value o;
+      o.dims = {rows, rows};
+      o.r.resize((size_t)(rows * rows));
+      const std::vector<const std::vector<T>*> in{&a.r, &transpose.r};
+      call_kernel<T>(OP_GEMM, 0, 0x3f, {(int)rows, (int)cols, (int)rows}, in,
+                     o.r);
+      return o;
     }
     if ((e.name == "crossprod" ||
          e.name == "multiply_lower_tri_self_transpose") &&
         e.args.size() == 1) {
-      using Mat = Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>;
       Value a = eval(e.args[0]);
       if (a.dims.size() != 2) fail(e.name + ": needs a matrix", e.raw);
       const int64_t rows = a.dims[0], cols = a.dims[1];
@@ -2180,32 +2148,28 @@ class MirInterp {
           (rows != 0 && cols > std::numeric_limits<int64_t>::max() / rows) ||
           rows * cols != static_cast<int64_t>(a.r.size()))
         fail(e.name + ": matrix shape does not match storage", e.raw);
-      Mat matrix(rows, cols);
-      for (int64_t j = 0; j < cols; ++j)
-        for (int64_t i = 0; i < rows; ++i)
-          matrix(i, j) = a.r[(size_t)(j * rows + i)];
       // crossprod is A' A (cols x cols); multiply_lower_tri_self_transpose
       // takes the lower triangle of A and forms L L' (rows x rows).
-      const Mat product =
-          e.name == "crossprod"
-              ? Mat(stan::math::crossprod(matrix))
-              : Mat(stan::math::multiply_lower_tri_self_transpose(matrix));
       const int64_t out = e.name == "crossprod" ? cols : rows;
-      r.dims = {out, out};
-      r.r.resize((size_t)(out * out));
-      for (int64_t j = 0; j < out; ++j)
-        for (int64_t i = 0; i < out; ++i)
-          r.r[(size_t)(j * out + i)] = product(i, j);
-      return r;
+      Value o;
+      o.dims = {out, out};
+      o.r.resize((size_t)(out * out));
+      const std::vector<const std::vector<T>*> in{&a.r};
+      const uint8_t variant = std::is_same_v<T, stan::math::var> ? 1u : 0u;
+      call_kernel<T>(e.name == "crossprod" ? OP_CROSSPROD
+                                           : OP_MULT_LOWER_TRI_SELF_TRANSPOSE,
+                     variant, 0x3f, {(int)rows, (int)cols}, in, o.r);
+      return o;
     }
     if (e.name == "diag_matrix" && e.args.size() == 1) {
       Value diagonal = eval(e.args[0]);
       const int64_t n = (int64_t)diagonal.r.size();
-      r.dims = {n, n};
-      r.r.assign((size_t)(n * n), T(0.0));
-      for (int64_t i = 0; i < n; ++i)
-        r.r[(size_t)(i * n + i)] = diagonal.r[(size_t)i];
-      return r;
+      Value o;
+      o.dims = {n, n};
+      o.r.resize((size_t)(n * n));
+      const std::vector<const std::vector<T>*> in{&diagonal.r};
+      call_kernel<T>(OP_DIAG_MATRIX, 0, 0x3f, {}, in, o.r);
+      return o;
     }
     if (e.name == "diagonal") {
       if (e.args.size() != 1)
@@ -2222,31 +2186,15 @@ class MirInterp {
       return r;
     }
     if (e.name == "cholesky_decompose" && e.args.size() == 1) {
-      // Standard column-oriented Cholesky on the templated scalar.
       Value a = eval(e.args[0]);
       if (a.dims.size() != 2 || a.dims[0] != a.dims[1])
         fail("cholesky_decompose: needs a square matrix", e.raw);
       const int64_t K = a.dims[0];
       Value o;
       o.dims = {K, K};
-      o.r.assign((size_t)(K * K), T(0.0));
-      for (int64_t j = 0; j < K; ++j) {
-        T d = a.r.at((size_t)(j * K + j));
-        for (int64_t k = 0; k < j; ++k) {
-          const T& l = o.r[(size_t)(k * K + j)];
-          d -= l * l;
-        }
-        if (!(val(d) > 0.0))
-          fail("cholesky_decompose: matrix is not positive definite", e.raw);
-        const T dj = stan::math::sqrt(d);
-        o.r[(size_t)(j * K + j)] = dj;
-        for (int64_t i = j + 1; i < K; ++i) {
-          T s = a.r.at((size_t)(j * K + i));
-          for (int64_t k = 0; k < j; ++k)
-            s -= o.r[(size_t)(k * K + i)] * o.r[(size_t)(k * K + j)];
-          o.r[(size_t)(j * K + i)] = s / dj;
-        }
-      }
+      o.r.resize((size_t)(K * K));
+      const std::vector<const std::vector<T>*> in{&a.r};
+      call_kernel<T>(OP_CHOLESKY, 0, 0x3f, {(int)K}, in, o.r);
       return o;
     }
     if (e.name == "prod") {

--- a/runtime/include/stanli/mir_interp.hpp
+++ b/runtime/include/stanli/mir_interp.hpp
@@ -908,18 +908,6 @@ class MirInterp {
     }
   }
 
-  // max-shifted log-sum-exp over a buffer; -inf on an empty or all
-  // -inf input rather than NaN.
-  static T lse(const std::vector<T>& xs) {
-    T m = T(-std::numeric_limits<double>::infinity());
-    for (const T& x : xs)
-      if (val(x) > val(m)) m = x;
-    if (!(val(m) > -std::numeric_limits<double>::infinity())) return m;
-    T s = T(0.0);
-    for (const T& x : xs) s += stan::math::exp(x - m);
-    return m + stan::math::log(s);
-  }
-
   static Value from_entry(const DataMap::Entry& d) {
     if constexpr (std::is_same_v<T, double>) {
       return d;
@@ -2011,40 +1999,22 @@ class MirInterp {
     }
     if (e.name == "mean") {
       Value a = eval(e.args[0]);
-      T m = T(0.0);
-      for (const T& v : a.r) m += v;
-      r.r = {m / (double)a.r.size()};
-      return r;
+      Value o;
+      o.r.resize(1);
+      const std::vector<const std::vector<T>*> in{&a.r};
+      call_kernel<T>(OP_MEAN, 0, 0x3f, {}, in, o.r);
+      return o;
     }
-    if (e.name == "sd") {
+    if (e.name == "sd" || e.name == "variance") {
       Value a = eval(e.args[0]);
-      if (a.r.empty()) fail("sd: input must have a positive size", e.raw);
-      if (a.r.size() == 1) {
-        r.r = {T(0.0)};
-        return r;
-      }
-      T m = T(0.0);
-      for (const T& v : a.r) m += v;
-      m /= (double)a.r.size();
-      T s2 = T(0.0);
-      for (const T& v : a.r) s2 += (v - m) * (v - m);
-      r.r = {stan::math::sqrt(s2 / (double)(a.r.size() - 1))};
-      return r;
-    }
-    if (e.name == "variance") {
-      Value a = eval(e.args[0]);
-      if (a.r.empty()) fail("variance: input must have a positive size", e.raw);
-      if (a.r.size() == 1) {
-        r.r = {T(0.0)};
-        return r;
-      }
-      T m = T(0.0);
-      for (const T& v : a.r) m += v;
-      m /= (double)a.r.size();
-      T s2 = T(0.0);
-      for (const T& v : a.r) s2 += (v - m) * (v - m);
-      r.r = {s2 / (double)(a.r.size() - 1)};
-      return r;
+      if (a.r.empty())
+        fail(e.name + ": input must have a positive size", e.raw);
+      Value o;
+      o.r.resize(1);
+      const std::vector<const std::vector<T>*> in{&a.r};
+      call_kernel<T>(e.name == "sd" ? OP_SD : OP_VARIANCE, 0, 0x3f, {}, in,
+                     o.r);
+      return o;
     }
     if (e.name == "sum") {
       Value a = eval(e.args[0]);
@@ -2054,12 +2024,39 @@ class MirInterp {
         r.is_int = true;
         r.i = {total};
         r.r = {T((double)total)};
-      } else {
-        T total = T(0.0);
-        for (const T& x : a.r) total += x;
-        r.r = {total};
+        return r;
       }
-      return r;
+      Value o;
+      o.r.resize(1);
+      const std::vector<const std::vector<T>*> in{&a.r};
+      call_kernel<T>(OP_SUM_VEC, 0, 0x3f, {}, in, o.r);
+      return o;
+    }
+    if (e.name == "squared_distance" && e.args.size() == 2) {
+      Value a = eval(e.args[0]), b = eval(e.args[1]);
+      if (a.r.size() != b.r.size())
+        fail("squared_distance: length mismatch", e.raw);
+      Value diff;
+      diff.r.resize(a.r.size());
+      {
+        const std::vector<const std::vector<T>*> in{&a.r, &b.r};
+        call_kernel<T>(OP_SUB, 0, 0x3f, {}, in, diff.r);
+      }
+      Value o;
+      o.r.resize(1);
+      const std::vector<const std::vector<T>*> in{&diff.r, &diff.r};
+      call_kernel<T>(OP_DOT, 0, 0x3f, {}, in, o.r);
+      return o;
+    }
+    if ((e.name == "dot_product" || e.name == "dot_self")) {
+      Value a = eval(e.args[0]);
+      Value b = e.name == "dot_self" ? a : eval(e.args[1]);
+      if (a.r.size() != b.r.size()) fail("dot_product: length mismatch", e.raw);
+      Value o;
+      o.r.resize(1);
+      const std::vector<const std::vector<T>*> in{&a.r, &b.r};
+      call_kernel<T>(OP_DOT, 0, 0x3f, {}, in, o.r);
+      return o;
     }
     // The matrix slice family, all on col-major storage.
     if (e.name == "sub_col" && e.args.size() == 4) {
@@ -2156,33 +2153,6 @@ class MirInterp {
       };
       reverse_outer(&r.r);
       if (r.is_int) reverse_outer(&r.i);
-      return r;
-    }
-    // squared_distance is dot_self of the difference, which is how the
-    // graph lowers it too (lower.cpp); the two spellings agreeing keeps
-    // transformed data and the log density on the same summation order.
-    // A vector may be paired with a row_vector, and neither view carries
-    // anything but a length, so there is nothing to reorder. No
-    // broadcasting: the language has no scalar-against-container overload.
-    if (e.name == "squared_distance" && e.args.size() == 2) {
-      Value a = eval(e.args[0]), b = eval(e.args[1]);
-      if (a.r.size() != b.r.size())
-        fail("squared_distance: length mismatch", e.raw);
-      T s = T(0.0);
-      for (size_t i = 0; i < a.r.size(); ++i) {
-        const T d = a.r[i] - b.r[i];
-        s += d * d;
-      }
-      r.r = {s};
-      return r;
-    }
-    if ((e.name == "dot_product" || e.name == "dot_self")) {
-      Value a = eval(e.args[0]);
-      Value b = e.name == "dot_self" ? a : eval(e.args[1]);
-      if (a.r.size() != b.r.size()) fail("dot_product: length mismatch", e.raw);
-      T s = T(0.0);
-      for (size_t i = 0; i < a.r.size(); ++i) s += a.r[i] * b.r[i];
-      r.r = {s};
       return r;
     }
     if (e.name == "tcrossprod" && e.args.size() == 1) {
@@ -2290,41 +2260,25 @@ class MirInterp {
           (e.args[0].unsized.leaf == mir::UnsizedLeaf::Vector ||
            e.args[0].unsized.leaf == mir::UnsizedLeaf::RowVector);
       const ExpressionLayout layout =
-          udf_depth_ == 0 ? mir::source_expression_layout(e.args[0])
-                          : ExpressionLayout::unknown();
-      if (!eigen_container || !layout.known()) {
-        T product = T(1.0);
-        for (const T& value : a.r) product *= value;
-        r.r = {product};
-        return r;
+          udf_depth_ == 0 && eigen_container
+              ? mir::source_expression_layout(e.args[0])
+              : ExpressionLayout::unknown();
+      const bool active = std::is_same_v<T, stan::math::var>;
+      uint8_t variant = 0;
+      std::vector<int> idata;
+      if (active || !layout.known() ||
+          layout.kind == ExpressionLayout::Kind::Scalar) {
+        variant = active ? 2u : 1u;
+      } else if (layout.kind == ExpressionLayout::Kind::Direct &&
+                 layout.element_offset != 0) {
+        variant = 4u;
+        idata = {(int)layout.element_offset};
       }
-      if (layout.kind == ExpressionLayout::Kind::Scalar) {
-        T product = a.r[0];
-        for (size_t i = 1; i < a.r.size(); ++i) product *= a.r[i];
-        r.r = {product};
-        return r;
-      }
-      if (layout.kind == ExpressionLayout::Kind::Direct &&
-          layout.element_offset != 0) {
-        if constexpr (std::is_same_v<T, double>) {
-          r.r = {prod_phased(a.r.data(), static_cast<int64_t>(a.r.size()),
-                             layout.element_offset)};
-          return r;
-        }
-        T product = T(1.0);
-        for (const T& value : a.r) product *= value;
-        r.r = {product};
-        return r;
-      }
-      // Match the address-independent packet grouping used by the compiled
-      // generated-quantities kernel.  A direct Map (including the Map used
-      // by stan::math::prod(std::vector)) can pick a different alignedStart
-      // when this vector's allocation is shifted under AVX.
-      using Vec = Eigen::Matrix<T, Eigen::Dynamic, 1>;
-      const Eigen::Map<const Vec> input(a.r.data(), a.r.size());
-      r.r = {stan::math::prod(
-          input.unaryExpr(Eigen::internal::core_cast_op<T, T>()))};
-      return r;
+      Value o;
+      o.r.resize(1);
+      const std::vector<const std::vector<T>*> in{&a.r};
+      call_kernel<T>(OP_PROD_VEC, variant, 0x3f, idata, in, o.r);
+      return o;
     }
     if ((e.name == "columns_dot_product" || e.name == "rows_dot_product") &&
         e.args.size() == 2) {
@@ -2364,8 +2318,11 @@ class MirInterp {
     }
     if (e.name == "log_sum_exp") {
       Value a = eval(e.args[0]);
-      r.r = {lse(a.r)};
-      return r;
+      Value o;
+      o.r.resize(1);
+      const std::vector<const std::vector<T>*> in{&a.r};
+      call_kernel<T>(OP_LOG_SUM_EXP, 0, 0x3f, {}, in, o.r);
+      return o;
     }
     if ((e.name == "diag_pre_multiply" || e.name == "diag_post_multiply") &&
         e.args.size() == 2) {

--- a/tests/test_mir_reduction_fallback.cpp
+++ b/tests/test_mir_reduction_fallback.cpp
@@ -177,32 +177,6 @@ void check(const std::string& name, std::vector<Arg> args, Expected expected) {
   }
 }
 
-// idata is the outcome (lpmf1) or outcome-and-trials (lpmf2) int group(s).
-auto lpmf1(uint16_t opcode) {
-  return [opcode](auto& a) {
-    using T = typename decltype(a[0].r)::value_type;
-    auto r = out_like(a, {}, 1);
-    std::vector<const std::vector<T>*> in;
-    for (size_t k = 1; k < a.size(); ++k) in.push_back(&a[k].r);
-    const std::vector<int> idata(a[0].i.begin(), a[0].i.end());
-    stanli::call_kernel<T>(opcode, 0, 0x3f, idata, in, r.r);
-    return r;
-  };
-}
-auto lpmf2(uint16_t opcode) {
-  return [opcode](auto& a) {
-    using T = typename decltype(a[0].r)::value_type;
-    auto r = out_like(a, {}, 1);
-    std::vector<int> idata{(int)a[0].i.size()};
-    idata.insert(idata.end(), a[0].i.begin(), a[0].i.end());
-    idata.push_back((int)a[1].i.size());
-    idata.insert(idata.end(), a[1].i.begin(), a[1].i.end());
-    const std::vector<const std::vector<T>*> in{&a[2].r};
-    stanli::call_kernel<T>(opcode, 0, 0x3f, idata, in, r.r);
-    return r;
-  };
-}
-
 }  // namespace
 
 int main() {
@@ -245,6 +219,84 @@ int main() {
     const std::vector<const std::vector<T>*> dot_in{&diff.r, &diff.r};
     call_kernel<T>(OP_DOT, 0, 0x3f, {}, dot_in, r.r);
     return r;
+  });
+
+  // spd: symmetric positive definite 3x3. gen: general invertible 3x3.
+  const std::vector<double> spd{4, 1, 0, 1, 3, 1, 0, 1, 2};
+  const std::vector<double> gen{2, 1, 0, 0, 3, 1, 1, 0, 2};
+  const std::vector<double> rect{1, 2, 3, 0, 1, 1};
+  const std::vector<double> v3{0.5, -0.3, 0.8};
+  const std::vector<double> d2{0.3, -0.2};
+
+  check("crossprod", {mat(rect, 3, 2)}, [](auto& a) {
+    using T = typename decltype(a[0].r)::value_type;
+    const uint8_t variant = std::is_same_v<T, stan::math::var> ? 1u : 0u;
+    return kernel(a, 1, OP_CROSSPROD, variant, {3, 2}, {2, 2}, 4);
+  });
+  check("multiply_lower_tri_self_transpose", {mat(rect, 3, 2)}, [](auto& a) {
+    using T = typename decltype(a[0].r)::value_type;
+    const uint8_t variant = std::is_same_v<T, stan::math::var> ? 1u : 0u;
+    return kernel(a, 1, OP_MULT_LOWER_TRI_SELF_TRANSPOSE, variant, {3, 2},
+                  {3, 3}, 9);
+  });
+  check("tcrossprod", {mat(rect, 3, 2)}, [](auto& a) {
+    using T = typename decltype(a[0].r)::value_type;
+    auto transpose = out_like(a, {2, 3}, 6);
+    const std::vector<const std::vector<T>*> t_in{&a[0].r};
+    call_kernel<T>(OP_TRANSPOSE, 0, 0x3f, {3, 2}, t_in, transpose.r);
+    auto r = out_like(a, {3, 3}, 9);
+    const std::vector<const std::vector<T>*> g_in{&a[0].r, &transpose.r};
+    call_kernel<T>(OP_GEMM, 0, 0x3f, {3, 2, 3}, g_in, r.r);
+    return r;
+  });
+  check("cholesky_decompose", {mat(spd, 3, 3)},
+        [](auto& a) { return kernel(a, 1, OP_CHOLESKY, 0, {3}, {3, 3}, 9); });
+  check("inverse", {mat(gen, 3, 3)},
+        [](auto& a) { return kernel(a, 1, OP_INVERSE, 0, {3}, {3, 3}, 9); });
+  check("inverse_spd", {mat(spd, 3, 3)}, [](auto& a) {
+    using T = typename decltype(a[0].r)::value_type;
+    const uint8_t variant = std::is_same_v<T, stan::math::var> ? 1u : 0u;
+    return kernel(a, 1, OP_INVERSE_SPD, variant, {3}, {3, 3}, 9);
+  });
+  check("log_determinant", {mat(gen, 3, 3)}, [](auto& a) {
+    return kernel(a, 1, OP_LOG_DETERMINANT, 0, {3}, {}, 1);
+  });
+  check("matrix_exp", {mat(gen, 3, 3)},
+        [](auto& a) { return kernel(a, 1, OP_MATRIX_EXP, 0, {3}, {3, 3}, 9); });
+  check("diag_matrix", {real(v3)},
+        [](auto& a) { return kernel(a, 1, OP_DIAG_MATRIX, 0, {}, {3, 3}, 9); });
+  check("quad_form", {mat(spd, 3, 3), real(v3)}, [](auto& a) {
+    using T = typename decltype(a[0].r)::value_type;
+    const uint8_t variant =
+        (uint8_t)(1u | (std::is_same_v<T, stan::math::var> ? 2u : 0u));
+    return kernel(a, 2, OP_QUAD_FORM, variant, {3, 1}, {}, 1);
+  });
+  check("quad_form_sym", {mat(spd, 3, 3), real(v3)}, [](auto& a) {
+    using T = typename decltype(a[0].r)::value_type;
+    const uint8_t variant =
+        (uint8_t)(1u | (std::is_same_v<T, stan::math::var> ? 2u : 0u));
+    return kernel(a, 2, OP_QUAD_FORM_SYM, variant, {3, 1}, {}, 1);
+  });
+  check("add_diag", {mat(rect, 3, 2), real(d2)}, [](auto& a) {
+    return kernel(a, 2, OP_ADD_DIAG, 0, {3, 2}, {3, 2}, 6);
+  });
+  check("multiply", {mat(rect, 3, 2), real(d2)}, [](auto& a) {
+    using T = typename decltype(a[0].r)::value_type;
+    auto r = out_like(a, {3}, 3);
+    const std::vector<const std::vector<T>*> in{&a[0].r, &a[1].r};
+    if constexpr (std::is_same_v<T, double>) {
+      call_kernel<T>(OP_MATVEC, 0, 0x3f, {3, 2}, in, r.r);
+    } else {
+      call_kernel<T>(OP_GEMM, 0, 0x3f, {3, 2, 1}, in, r.r);
+    }
+    return r;
+  });
+  check("fma", {real(as), real(bs), real(xs)},
+        [](auto& a) { return kernel(a, 3, OP_FMA, 0, {}, {}, a[0].r.size()); });
+  check("gp_exp_quad_cov", {real(xs), real({1.3}), real({0.9})}, [](auto& a) {
+    const int64_t n = (int64_t)a[0].r.size();
+    return kernel(a, 3, OP_GP_EXP_QUAD_COV, 0, {(int)n, 1}, {n, n},
+                  (size_t)(n * n));
   });
 
   if (failures == 0)

--- a/tests/test_mir_reduction_fallback.cpp
+++ b/tests/test_mir_reduction_fallback.cpp
@@ -177,6 +177,32 @@ void check(const std::string& name, std::vector<Arg> args, Expected expected) {
   }
 }
 
+// idata is the outcome (lpmf1) or outcome-and-trials (lpmf2) int group(s).
+auto lpmf1(uint16_t opcode) {
+  return [opcode](auto& a) {
+    using T = typename decltype(a[0].r)::value_type;
+    auto r = out_like(a, {}, 1);
+    std::vector<const std::vector<T>*> in;
+    for (size_t k = 1; k < a.size(); ++k) in.push_back(&a[k].r);
+    const std::vector<int> idata(a[0].i.begin(), a[0].i.end());
+    stanli::call_kernel<T>(opcode, 0, 0x3f, idata, in, r.r);
+    return r;
+  };
+}
+auto lpmf2(uint16_t opcode) {
+  return [opcode](auto& a) {
+    using T = typename decltype(a[0].r)::value_type;
+    auto r = out_like(a, {}, 1);
+    std::vector<int> idata{(int)a[0].i.size()};
+    idata.insert(idata.end(), a[0].i.begin(), a[0].i.end());
+    idata.push_back((int)a[1].i.size());
+    idata.insert(idata.end(), a[1].i.begin(), a[1].i.end());
+    const std::vector<const std::vector<T>*> in{&a[2].r};
+    stanli::call_kernel<T>(opcode, 0, 0x3f, idata, in, r.r);
+    return r;
+  };
+}
+
 }  // namespace
 
 int main() {
@@ -298,6 +324,35 @@ int main() {
     return kernel(a, 3, OP_GP_EXP_QUAD_COV, 0, {(int)n, 1}, {n, n},
                   (size_t)(n * n));
   });
+
+  check("bernoulli_lpmf",
+        {ints({0, 1, 1, 0, 1}), real({0.3, 0.6, 0.7, 0.4, 0.5})},
+        lpmf1(OP_BERNOULLI_LPMF));
+  check("bernoulli_logit_lpmf",
+        {ints({0, 1, 1, 0, 1}), real({0.2, -0.5, 1.1, -0.3, 0.7})},
+        lpmf1(OP_BERNOULLI_LOGIT_LPMF));
+  check("poisson_lpmf",
+        {ints({0, 2, 1, 3, 0}), real({1.2, 0.5, 2.0, 0.8, 1.5})},
+        lpmf1(OP_POISSON_LPMF));
+  check("poisson_log_lpmf",
+        {ints({0, 2, 1, 3, 0}), real({0.1, -0.2, 0.3, 0.05, -0.1})},
+        lpmf1(OP_POISSON_LOG_LPMF));
+  check("neg_binomial_2_lpmf",
+        {ints({0, 2, 1, 3, 0}), real({1.1, 0.7, 2.0, 0.9, 1.3}),
+         real({2.0, 1.5, 3.0, 1.0, 2.5})},
+        lpmf1(OP_NEG_BINOMIAL_2_LPMF));
+  check("neg_binomial_2_log_lpmf",
+        {ints({0, 2, 1, 3, 0}), real({0.2, -0.1, 0.4, 0.1, -0.2}),
+         real({2.0, 1.5, 3.0, 1.0, 2.5})},
+        lpmf1(OP_NEG_BINOMIAL_2_LOG_LPMF));
+  check("binomial_lpmf",
+        {ints({1, 0, 2, 1, 3}), ints({3, 2, 4, 2, 5}),
+         real({0.3, 0.4, 0.5, 0.6, 0.35})},
+        lpmf2(OP_BINOMIAL_LPMF));
+  check("binomial_logit_lpmf",
+        {ints({1, 0, 2, 1, 3}), ints({3, 2, 4, 2, 5}),
+         real({-0.2, 0.1, 0.4, 0.3, -0.1})},
+        lpmf2(OP_BINOMIAL_LOGIT_LPMF));
 
   if (failures == 0)
     std::printf("test_mir_reduction_fallback: all cases passed\n");

--- a/tests/test_mir_reduction_fallback.cpp
+++ b/tests/test_mir_reduction_fallback.cpp
@@ -1,0 +1,253 @@
+// MIR<double>/MIR<var> reductions, matrix algebra and discrete densities vs the
+// graph kernel table.
+#include <stanli/kernel_bridge.hpp>
+#include <stanli/mir.hpp>
+#include <stanli/mir_interp.hpp>
+#include <stanli/optable.hpp>
+
+#include <stan/math.hpp>
+
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <map>
+#include <string>
+#include <type_traits>
+#include <vector>
+
+namespace {
+
+using stanli::MirInterp;
+using stanli::mir::Expr;
+using stanli::mir::FunDef;
+using stanli::mir::Stmt;
+
+int failures = 0;
+
+template <typename T>
+using Val = typename MirInterp<T>::Value;
+
+// One test argument: a real/int scalar, vector or (with explicit dims) matrix.
+struct Arg {
+  bool is_int = false;
+  std::vector<double> vals;
+  std::vector<int64_t> dims;
+};
+Arg real(std::vector<double> v) {
+  std::vector<int64_t> dims;
+  if (v.size() != 1) dims = {(int64_t)v.size()};
+  return {false, std::move(v), std::move(dims)};
+}
+Arg mat(std::vector<double> v, int64_t rows, int64_t cols) {
+  return {false, std::move(v), {rows, cols}};
+}
+Arg ints(std::vector<int> v) {
+  std::vector<int64_t> dims;
+  if (v.size() != 1) dims = {(int64_t)v.size()};
+  return {true, std::vector<double>(v.begin(), v.end()), std::move(dims)};
+}
+
+template <typename T>
+Val<T> to_val(const Arg& a) {
+  Val<T> v;
+  v.r.assign(a.vals.begin(), a.vals.end());
+  v.dims = a.dims;
+  v.is_int = a.is_int;
+  if (a.is_int) v.i.assign(a.vals.begin(), a.vals.end());
+  return v;
+}
+
+// A fresh output Value of the same T as `a`'s elements, shaped as given.
+template <typename VecOfVal>
+auto out_like(VecOfVal& a, std::vector<int64_t> dims, size_t len) {
+  std::decay_t<decltype(a[0])> r;
+  r.dims = std::move(dims);
+  r.r.resize(len);
+  return r;
+}
+
+// Dispatches through call_kernel over the first n_in entries of `a`.
+template <typename VecOfVal>
+auto kernel(VecOfVal& a, size_t n_in, uint16_t opcode, uint8_t variant,
+            std::vector<int> idata, std::vector<int64_t> out_dims,
+            size_t out_len) {
+  using T = typename decltype(a[0].r)::value_type;
+  auto r = out_like(a, std::move(out_dims), out_len);
+  std::vector<const std::vector<T>*> in;
+  for (size_t k = 0; k < n_in; ++k) in.push_back(&a[k].r);
+  stanli::call_kernel<T>(opcode, variant, 0x3f, idata, in, r.r);
+  return r;
+}
+
+uint64_t ordered(double x) {
+  uint64_t b;
+  std::memcpy(&b, &x, sizeof(b));
+  return (b >> 63) ? ~b : (b | (uint64_t(1) << 63));
+}
+bool close(double got, double want) {
+  if (std::isnan(want)) return std::isnan(got);
+  if (!std::isfinite(want) || !std::isfinite(got)) return got == want;
+  const uint64_t g = ordered(got), w = ordered(want);
+  return (g > w ? g - w : w - g) <= 2;
+}
+void expect_close(const std::string& what, double got, double want) {
+  if (close(got, want)) return;
+  ++failures;
+  std::printf("FAIL %-40s got %.17g want %.17g\n", what.c_str(), got, want);
+}
+double sum_r(const std::vector<double>& r) {
+  double s = 0;
+  for (double x : r) s += x;
+  return s;
+}
+
+// Runs MIR<double>/MIR<var> on name(args...) and compares value and gradient
+// against expected(vals), a generic (std::vector<Val<T>>&) -> Val<T> lambda.
+template <typename Expected>
+void check(const std::string& name, std::vector<Arg> args, Expected expected) {
+  FunDef f;
+  f.name = "rhs";
+  Expr call;
+  call.kind = Expr::FunApp;
+  call.name = name;
+  call.type_ = "UReal";
+  call.fn_lib = Expr::Lib::StanLib;
+  for (size_t i = 0; i < args.size(); ++i) {
+    const std::string nm = "a" + std::to_string(i);
+    f.arg_names.push_back(nm);
+    Expr v;
+    v.kind = Expr::Var;
+    v.name = nm;
+    v.type_ = "UReal";
+    call.args.push_back(v);
+  }
+  Stmt ret;
+  ret.kind = Stmt::Return;
+  ret.has_init = true;
+  ret.rhs = std::move(call);
+  f.body = {std::move(ret)};
+  const std::map<std::string, const FunDef*> defs{{f.name, &f}};
+
+  {
+    std::vector<Val<double>> vals;
+    for (auto& a : args) vals.push_back(to_val<double>(a));
+    Val<double> ref = expected(vals);
+    MirInterp<double> interp(defs, name + " double");
+    auto out = interp.call(f, vals);
+    expect_close(name + " MIR<double>", sum_r(out.r), sum_r(ref.r));
+  }
+  // Two independent nested scopes: grad() sweeps every vari created since
+  // the scope began, so a leftover ref vari still on a shared stack would
+  // get re-chained (and its adjoint re-accumulated) by the second grad().
+  double ref_val;
+  std::vector<std::vector<double>> ref_grad(args.size());
+  {
+    stan::math::nested_rev_autodiff nested;
+    std::vector<Val<stan::math::var>> ref_vals;
+    for (auto& a : args) ref_vals.push_back(to_val<stan::math::var>(a));
+    Val<stan::math::var> ref = expected(ref_vals);
+    stan::math::var ref_sum = 0;
+    for (auto& x : ref.r) ref_sum += x;
+    stan::math::grad(ref_sum.vi_);
+    ref_val = ref_sum.val();
+    for (size_t k = 0; k < args.size(); ++k) {
+      ref_grad[k].resize(args[k].vals.size());
+      for (size_t i = 0; i < args[k].vals.size(); ++i)
+        ref_grad[k][i] = ref_vals[k].r[i].adj();
+    }
+  }
+  {
+    stan::math::nested_rev_autodiff nested;
+    std::vector<Val<stan::math::var>> mir_vals;
+    for (auto& a : args) mir_vals.push_back(to_val<stan::math::var>(a));
+    MirInterp<stan::math::var> interp(defs, name + " var");
+    auto out = interp.call(f, mir_vals);
+    stan::math::var sum = 0;
+    for (auto& x : out.r) sum += x;
+    stan::math::grad(sum.vi_);
+    expect_close(name + " MIR<var> value", sum.val(), ref_val);
+    for (size_t k = 0; k < args.size(); ++k) {
+      if (args[k].is_int) continue;
+      for (size_t i = 0; i < args[k].vals.size(); ++i)
+        expect_close(
+            name + " MIR<var> g" + std::to_string(k) + "_" + std::to_string(i),
+            mir_vals[k].r[i].adj(), ref_grad[k][i]);
+    }
+  }
+}
+
+// idata is the outcome (lpmf1) or outcome-and-trials (lpmf2) int group(s).
+auto lpmf1(uint16_t opcode) {
+  return [opcode](auto& a) {
+    using T = typename decltype(a[0].r)::value_type;
+    auto r = out_like(a, {}, 1);
+    std::vector<const std::vector<T>*> in;
+    for (size_t k = 1; k < a.size(); ++k) in.push_back(&a[k].r);
+    const std::vector<int> idata(a[0].i.begin(), a[0].i.end());
+    stanli::call_kernel<T>(opcode, 0, 0x3f, idata, in, r.r);
+    return r;
+  };
+}
+auto lpmf2(uint16_t opcode) {
+  return [opcode](auto& a) {
+    using T = typename decltype(a[0].r)::value_type;
+    auto r = out_like(a, {}, 1);
+    std::vector<int> idata{(int)a[0].i.size()};
+    idata.insert(idata.end(), a[0].i.begin(), a[0].i.end());
+    idata.push_back((int)a[1].i.size());
+    idata.insert(idata.end(), a[1].i.begin(), a[1].i.end());
+    const std::vector<const std::vector<T>*> in{&a[2].r};
+    stanli::call_kernel<T>(opcode, 0, 0x3f, idata, in, r.r);
+    return r;
+  };
+}
+
+}  // namespace
+
+int main() {
+  using namespace stanli;
+
+  const std::vector<double> xs{0.7, -1.3, 2.1, 0.4, -0.6};
+  const std::vector<double> as{0.5, -1.2, 2.0, 0.3, 1.1};
+  const std::vector<double> bs{1.5, 0.7, -0.4, 2.2, -0.8};
+
+  check("sum", {real(xs)},
+        [](auto& a) { return kernel(a, 1, OP_SUM_VEC, 0, {}, {}, 1); });
+  check("mean", {real(xs)},
+        [](auto& a) { return kernel(a, 1, OP_MEAN, 0, {}, {}, 1); });
+  check("sd", {real(xs)},
+        [](auto& a) { return kernel(a, 1, OP_SD, 0, {}, {}, 1); });
+  check("variance", {real(xs)},
+        [](auto& a) { return kernel(a, 1, OP_VARIANCE, 0, {}, {}, 1); });
+  check("prod", {real(xs)}, [](auto& a) {
+    using T = typename decltype(a[0].r)::value_type;
+    const uint8_t variant = std::is_same_v<T, stan::math::var> ? 2u : 1u;
+    return kernel(a, 1, OP_PROD_VEC, variant, {}, {}, 1);
+  });
+  check("log_sum_exp", {real(xs)},
+        [](auto& a) { return kernel(a, 1, OP_LOG_SUM_EXP, 0, {}, {}, 1); });
+  check("dot_product", {real(as), real(bs)},
+        [](auto& a) { return kernel(a, 2, OP_DOT, 0, {}, {}, 1); });
+  check("dot_self", {real(as)}, [](auto& a) {
+    using T = typename decltype(a[0].r)::value_type;
+    auto r = out_like(a, {}, 1);
+    const std::vector<const std::vector<T>*> in{&a[0].r, &a[0].r};
+    call_kernel<T>(OP_DOT, 0, 0x3f, {}, in, r.r);
+    return r;
+  });
+  check("squared_distance", {real(as), real(bs)}, [](auto& a) {
+    using T = typename decltype(a[0].r)::value_type;
+    auto diff = out_like(a, {}, a[0].r.size());
+    const std::vector<const std::vector<T>*> sub_in{&a[0].r, &a[1].r};
+    call_kernel<T>(OP_SUB, 0, 0x3f, {}, sub_in, diff.r);
+    auto r = out_like(a, {}, 1);
+    const std::vector<const std::vector<T>*> dot_in{&diff.r, &diff.r};
+    call_kernel<T>(OP_DOT, 0, 0x3f, {}, dot_in, r.r);
+    return r;
+  });
+
+  if (failures == 0)
+    std::printf("test_mir_reduction_fallback: all cases passed\n");
+  return failures == 0 ? 0 : 1;
+}


### PR DESCRIPTION
Follows #321, which moved the interpreter's scalar builtins onto the graph's kernel table through `call_kernel<T>`. This moves the rest that has a kernel: reductions (sum, mean, sd, variance, prod, log_sum_exp, dot_product, dot_self, squared_distance), matrix algebra (crossprod, tcrossprod, multiply_lower_tri_self_transpose, cholesky_decompose, inverse, inverse_spd, log_determinant, matrix_exp, quad_form, quad_form_sym, add_diag, diag_matrix, fma, matrix*vector, flat gp_exp_quad_cov) and the discrete lpmfs (bernoulli, poisson, neg_binomial_2, binomial and their logit/log forms). The idata and variant recipes come from lower_funapp.cpp. Left hand-written: hypergeometric and discrete_range (no kernel), gp_exp_quad_cov on array[] vector (layout differs), matrix*matrix and scalar*container.

Found along the way: the interpreter's student_t_lpdf branch was unreachable, and its hand-written sd gradient was 2-3 ULP off the kernel's.

mir_interp.hpp 3201 -> 3129. New test_mir_reduction_fallback checks MIR<double> and MIR<var> value and gradient against the same kernel at 2 ULP. ctest 122/122; corpus replay 130/130, diamonds goes from 45450 ulp to bitwise because its transformed data now reduces in the graph's order.
