### PR TITLE
Add per-pass IR dumps for the lowering pipeline

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -321,6 +321,7 @@ set(STANLI_RUNTIME_SOURCES
   runtime/src/inplace.cpp
   runtime/src/constfold.cpp
   runtime/src/cse.cpp
+  runtime/src/graph_print.cpp
   runtime/src/partition.cpp
   runtime/src/data.cpp
   runtime/src/data_var_context.cpp
@@ -928,7 +929,7 @@ set(STANLI_TESTS
   test_ode_prog test_mir_program_conformance test_mir_checks
   test_structured_checks test_structured_loop
   test_mir_unary_fallback test_mir_binary_fallback test_mir_reduction_fallback
-  test_constfold test_cse
+  test_constfold test_cse test_graph_print test_pass_dump
   test_function_registry test_function_shape
   test_partition
   test_solve test_cross_path

--- a/docs/hacking.md
+++ b/docs/hacking.md
@@ -208,6 +208,34 @@ The tools you will reach for most:
   call also includes emitting the buffered profile rows.
 - [`dump_ops`](../tools/dump_ops.cpp): print the op list a model
   lowered to. Usually the first thing to look at.
+- `STANLI_DUMP_PASSES=<dir>`: an environment variable read by anything that
+  compiles a model. It writes the graph after every lowering pass to
+  `<dir>/NN-<graph>-<stage>.txt`, numbered so `ls` sorts in pass order, plus
+  the input MIR as `00-mir.sexp`. Diff two consecutive files to see exactly
+  what one pass did. A pass that throws still leaves
+  `NN-<graph>-FAILED-after-<stage>.txt` with the graph it died on.
+
+  ```
+  STANLI_DUMP_PASSES=/tmp/d ./build/stanli_check model.stan data.json
+  diff /tmp/d/05-log_prob-constfold.txt /tmp/d/06-log_prob-reroll.txt
+  ```
+
+  `STANLI_DUMP_PASSES=-` writes to stdout instead, each dump bracketed by
+  `;; <graph>:<stage>` and `;; end <graph>:<stage>`. No printed op or header
+  line can begin with `;`, so a consumer can slice one stage back out.
+
+  `STANLI_DUMP_STAGES=<list>` narrows the selection to a comma-separated set;
+  unset or `all` is every stage. An entry is a bare stage name, which matches
+  that stage in every graph, or `graph:stage`, which matches one. The input
+  MIR is the stage `mir`. Sequence numbers still count the stages the filter
+  dropped, so `05-log_prob-constfold.txt` is `05` under any selection.
+  `stanli_check` takes the same two as `--dump-passes=<list>` and
+  `--dump-dir=<dir>`; without a directory it dumps to stdout.
+
+  ```
+  ./build/stanli_check model.stan data.json --dump-passes=log_prob:reroll
+  ```
+
 - [`dump_islands`](../tools/dump_islands.cpp): print every island's
   forward and adjoint programs, instruction by instruction.
 - [`verify_refs.py`](../tools/verify_refs.py): replay the whole model
@@ -632,7 +660,9 @@ For a live CmdStan column-name comparison, use `--wa-headers deps/cmdstan`.
 Both modes default to `build-rel/stanli_check`. For any
 performance claim, measure with `STANLI_PROFILE=1` before and after for
 evaluation work, or `STANLI_PROFILE_PREP=1` for compilation and binding;
-[`docs/benchmarks.md`](benchmarks.md) has the harnesses.
+[`docs/benchmarks.md`](benchmarks.md) has the harnesses. When the question is
+what a pass did rather than what it cost, `STANLI_DUMP_PASSES=<dir>` writes
+one graph dump per stage for diffing.
 
 ## Landing a change
 

--- a/runtime/include/stanli/graph_print.hpp
+++ b/runtime/include/stanli/graph_print.hpp
@@ -1,0 +1,30 @@
+// Deterministic text rendering of the op graph. Output is diffed between
+// passes, so op lines are keyed on the destination slot, never an op index.
+#ifndef STANLI_GRAPH_PRINT_HPP
+#define STANLI_GRAPH_PRINT_HPP
+
+#include <stanli/graph.hpp>
+
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace stanli {
+
+struct GraphPrintInfo {
+  std::vector<int> roots;
+  std::vector<int> target_terms;
+  std::vector<int> jac_slots;
+  std::vector<std::pair<std::string, int>> views;
+  const std::vector<std::pair<int, std::vector<double>>>* fills = nullptr;
+  bool print_islands = true;
+};
+
+void print_graph(std::string& out, const Graph& g,
+                 const GraphPrintInfo& info = {});
+
+void print_islands(std::string& out, const Graph& g);
+
+}  // namespace stanli
+
+#endif

--- a/runtime/src/graph_print.cpp
+++ b/runtime/src/graph_print.cpp
@@ -1,0 +1,209 @@
+#include <stanli/graph_print.hpp>
+
+#include <stanli/adjoint.hpp>
+#include <stanli/island.hpp>
+#include <stanli/optable.hpp>
+#include <stanli/program.hpp>
+#include <stanli/program_density.hpp>
+
+#include <algorithm>
+#include <cstdarg>
+#include <cstdio>
+#include <string>
+#include <vector>
+
+namespace stanli {
+namespace {
+
+void appendf(std::string& out, const char* fmt, ...) {
+  char buf[512];
+  va_list ap;
+  va_start(ap, fmt);
+  const int n = std::vsnprintf(buf, sizeof(buf), fmt, ap);
+  va_end(ap);
+  if (n < 0) return;
+  if ((size_t)n < sizeof(buf)) {
+    out.append(buf, (size_t)n);
+    return;
+  }
+  std::vector<char> big((size_t)n + 1);
+  va_start(ap, fmt);
+  std::vsnprintf(big.data(), big.size(), fmt, ap);
+  va_end(ap);
+  out.append(big.data(), (size_t)n);
+}
+
+const char* shortname(uint16_t oc) {
+  const char* n = opcode_name(oc);
+  return n[0] == 'O' && n[1] == 'P' && n[2] == '_' ? n + 3 : n;
+}
+
+void append_slot_ref(std::string& out, const Graph& g, int slot) {
+  if (slot < 0 || (size_t)slot >= g.slots.size()) {
+    appendf(out, "s%d[?]", slot);
+    return;
+  }
+  const Slot& s = g.slots[(size_t)slot];
+  appendf(out, "s%d[%lld%s]", slot, (long long)s.len, s.is_param ? ",P" : "");
+}
+
+void append_slot_list(std::string& out, const char* label,
+                      const std::vector<int>& slots) {
+  if (slots.empty()) return;
+  appendf(out, "%s:", label);
+  for (size_t i = 0; i < slots.size(); ++i) {
+    if (i && i % 16 == 0) appendf(out, "\n %s:", label);
+    appendf(out, " s%d", slots[i]);
+  }
+  out += '\n';
+}
+
+void print_instr(std::string& out, const Program& p, size_t i,
+                 const Program::Instr& I) {
+  appendf(out, "  %3zu  %-9s", i, program_code_spec(I.code).name);
+  switch (I.code) {
+    case Program::CONST:
+      appendf(out, " r%d <- pool[%d] (=%g)", I.dst, I.a, p.pool[(size_t)I.a]);
+      break;
+    case Program::CONSTR:
+      appendf(out, " r%d..r%d <- pool[%d..] (=", I.dst, I.dst + I.len - 1, I.a);
+      for (int k = 0; k < I.len; ++k)
+        appendf(out, "%s%g", k ? "," : "", p.pool[(size_t)(I.a + k)]);
+      appendf(out, ")");
+      break;
+    case Program::JZ:
+      appendf(out, " if r%d == 0 goto %d", I.a, I.dst);
+      break;
+    case Program::JMP:
+      appendf(out, " goto %d", I.dst);
+      break;
+    case Program::MOVR:
+      appendf(out, " r%d..r%d <- r%d..r%d", I.dst, I.dst + I.len - 1, I.a,
+              I.a + I.len - 1);
+      break;
+    case Program::DOT:
+      appendf(out, " r%d <- dot(r%d.., r%d.., len %d)", I.dst, I.a, I.b, I.len);
+      break;
+    case Program::DENSITY:
+      appendf(out, " r%d <- %s(r%d, r%d, r%d)", I.dst,
+              program_density_name(I.len), I.a, I.b, I.c);
+      break;
+    case Program::CALL: {
+      const Program::Call& c = p.calls[(size_t)I.a];
+      appendf(out, " %s(", opcode_name(c.opcode));
+      for (int k = 0; k < c.n_in; ++k)
+        appendf(out, "%sr%d[len %d]", k ? ", " : "", c.in[k], c.in_len[k]);
+      appendf(out, ") -> r%d[len %d]", c.out, c.out_len);
+      if (c.scratch_len)
+        appendf(out, ", scratch r%d[len %d]", c.scratch, c.scratch_len);
+      else
+        appendf(out, ", no scratch");
+      break;
+    }
+    default:
+      appendf(out, " r%d <- r%d", I.dst, I.a);
+      const bool ternary = I.code == Program::LOG_MIX || I.code == Program::FMA;
+      if ((I.code >= Program::ADD && I.code <= Program::FMIN) ||
+          (I.code >= Program::GT && I.code <= Program::NE) ||
+          I.code == Program::LSE2 || ternary)
+        appendf(out, ", r%d", I.b);
+      if (ternary) appendf(out, ", r%d", I.c);
+      if (I.len) appendf(out, " (len %d)", I.len);
+  }
+  out += '\n';
+}
+
+void print_island_body(std::string& out, const Graph& g, size_t u, int n) {
+  const Op& op = g.ops[u];
+  const auto& p = *static_cast<const IslandProg*>(op.udata);
+  appendf(out,
+          "\n== island %d (graph op %zu): %zu instrs, %d regs, "
+          "%zu calls, adjoint %zu instrs, native_adj=%d, softmax3=%d\n",
+          n, u, p.code.size(), p.n_regs, p.calls.size(), p.adj.code.size(),
+          (int)p.native_adj, (int)(op.variant == kIslandSoftmax3Variant));
+  appendf(out, "  live-ins:");
+  for (size_t k = 0; k < p.ins.size(); ++k)
+    appendf(out, " slot%d->r%d[len %d]", op.in[k], p.ins[k].reg, p.ins[k].len);
+  appendf(out, "\n  live-outs (out_regs):");
+  for (int r : p.out_regs) appendf(out, " r%d", r);
+  appendf(out, "\n\n  FORWARD:\n");
+  for (size_t i = 0; i < p.code.size(); ++i) print_instr(out, p, i, p.code[i]);
+  if (p.adj.code.empty()) return;
+  appendf(out,
+          "\n  ADJOINT (reverse order; dst/a/b/c are adjoint cells, "
+          "va/vb/vc/vd are value registers):\n");
+  for (size_t i = 0; i < p.adj.code.size(); ++i) {
+    const AdjInstr& A = p.adj.code[i];
+    appendf(out,
+            "  %3zu  %-9s dst=%d a=%d b=%d c=%d | va=%d vb=%d vc=%d "
+            "vd=%d\n",
+            i, program_code_spec(A.code).name, A.dst, A.a, A.b, A.c, A.va, A.vb,
+            A.vc, A.vd);
+  }
+}
+
+}  // namespace
+
+void print_graph(std::string& out, const Graph& g, const GraphPrintInfo& info) {
+  appendf(out, "ops=%zu slots=%zu result=s%d\n", g.ops.size(), g.slots.size(),
+          g.result_slot);
+  append_slot_list(out, "roots", info.roots);
+  append_slot_list(out, "target_terms", info.target_terms);
+  append_slot_list(out, "jac_slots", info.jac_slots);
+  if (!info.views.empty()) {
+    std::vector<std::pair<std::string, int>> views = info.views;
+    std::sort(views.begin(), views.end());
+    appendf(out, "views:");
+    for (size_t i = 0; i < views.size(); ++i) {
+      if (i && i % 8 == 0) appendf(out, "\nviews:");
+      appendf(out, " %s=s%d", views[i].first.c_str(), views[i].second);
+    }
+    out += '\n';
+  }
+  if (info.fills && !info.fills->empty()) {
+    appendf(out, "fills:");
+    for (size_t i = 0; i < info.fills->size(); ++i) {
+      if (i && i % 8 == 0) appendf(out, "\nfills:");
+      const auto& f = (*info.fills)[i];
+      appendf(out, " s%d[%zu]=", f.first, f.second.size());
+      for (size_t k = 0; k < f.second.size() && k < 4; ++k)
+        appendf(out, "%s%.17g", k ? "," : "", f.second[k]);
+      if (f.second.size() > 4) appendf(out, ",...");
+    }
+    out += '\n';
+  }
+
+  int island = 0;
+  for (size_t u = 0; u < g.ops.size(); ++u) {
+    const Op& op = g.ops[u];
+    append_slot_ref(out, g, op.out);
+    appendf(out, " = %s", shortname(op.opcode));
+    if (op.variant) appendf(out, ".v=0x%02x", op.variant);
+    for (int k = 0; k < op.n_in; ++k) {
+      out += ' ';
+      append_slot_ref(out, g, op.in[k]);
+    }
+    if (op.out2 != -1) appendf(out, " out2=s%d", op.out2);
+    if (op.n_idata) {
+      appendf(out, " idata=[");
+      for (int64_t k = 0; k < op.n_idata && k < 8; ++k)
+        appendf(out, "%s%d", k ? "," : "", op.idata[k]);
+      if (op.n_idata > 8) appendf(out, ",...x%lld", (long long)op.n_idata);
+      appendf(out, "]");
+    }
+    out += '\n';
+    if (info.print_islands && op.opcode == OP_ISLAND)
+      print_island_body(out, g, u, island++);
+  }
+}
+
+void print_islands(std::string& out, const Graph& g) {
+  appendf(out, "graph: %zu ops, %zu slots\n", g.ops.size(), g.slots.size());
+  int n = 0;
+  for (size_t u = 0; u < g.ops.size(); ++u) {
+    if (g.ops[u].opcode != OP_ISLAND) continue;
+    print_island_body(out, g, u, n++);
+  }
+}
+
+}  // namespace stanli

--- a/runtime/src/lower.cpp
+++ b/runtime/src/lower.cpp
@@ -13,9 +13,26 @@ StructuredMode read_structured_mode() {
   // An unrecognized policy must preserve the established representation.
   return StructuredMode::Off;
 }
-Lowering::Lowering(const DataMap& d, PrepTrace& p, const char* graph_name,
-                   std::shared_ptr<ShapeInterner> pool)
-    : data(d), shape_pool(std::move(pool)), prep(p), prep_graph(graph_name) {}
+Lowering::Lowering(const DataMap& d, PrepTrace& p, PassDumper& dump_to,
+                   const char* graph_name, std::shared_ptr<ShapeInterner> pool)
+    : data(d),
+      shape_pool(std::move(pool)),
+      prep(p),
+      dumper(dump_to),
+      prep_graph(graph_name) {}
+void Lowering::dump_named(const std::string& label, const std::string& name,
+                          const std::vector<int>& roots, bool unfiltered) {
+  GraphPrintInfo info;
+  info.roots = roots;
+  info.target_terms = target_terms;
+  info.jac_slots = jac_slots;
+  for (const CompiledModel::ParamView& v : out.views)
+    info.views.emplace_back(v.name, v.slot);
+  info.fills = &out.fills;
+  std::string text;
+  print_graph(text, g, info);
+  dumper.write(label, name, text, unfiltered);
+}
 void Lowering::sync_data_local(const std::string& name, const mir::Expr& rhs,
                                const Val& v) {
   if (!v.si.param_free) {
@@ -560,12 +577,14 @@ int Lowering::reduce_terms(std::vector<int> terms) {
 // that do run are noted where each stage starts.
 void Lowering::run_passes(const std::vector<int>& roots, const PassPlan& plan) {
   const auto trace = [&](const char* stage, PrepTrace::Time from,
+                         const std::vector<int>& stage_roots,
                          PrepTrace::Extra extra = PrepTrace::Extra::None,
                          int64_t a = 0, int64_t b = 0, bool deep = false,
                          int64_t params = 0, int64_t c = 0, int64_t d = 0,
                          const detail::RerollDispositionStats* disp = nullptr) {
     prep.graph(prep_graph, stage, from, g, out.fills, target_terms.size(),
                out.views.size(), extra, a, b, deep, params, c, d, disp);
+    dump(stage, stage_roots);
   };
 
   // Target terms have no consuming op yet either: reduce_terms (log_prob)
@@ -576,20 +595,23 @@ void Lowering::run_passes(const std::vector<int>& roots, const PassPlan& plan) {
   const auto inplace_time = prep.start();
   const int inplace =
       make_inplace_updates(g, update_roots);  // off under STANLI_NO_INPLACE
-  trace("inplace", inplace_time, PrepTrace::Extra::Rewrites, inplace);
+  trace("inplace", inplace_time, update_roots, PrepTrace::Extra::Rewrites,
+        inplace);
   // Deleting the write/read-back pairs first is what leaves a plain
   // arithmetic lane for reroll to vectorize.
   const auto forward_time = prep.start();
   const int forwarded = forward_stores_to_loads(g, update_roots);
-  trace("store_forward", forward_time, PrepTrace::Extra::Removed, forwarded);
+  trace("store_forward", forward_time, update_roots, PrepTrace::Extra::Removed,
+        forwarded);
   if (plan.constfold) {
     // After the update chains collapse, so a data-only chain is one slot
     // rather than N; before reroll, so the lanes it sees have data
     // operands.
     const auto constfold_time = prep.start();
     const ConstFoldStats constfolded = const_fold(g, out.fills, update_roots);
-    trace("constfold", constfold_time, PrepTrace::Extra::ConstFold,
-          constfolded.ops_removed, constfolded.slots_folded);
+    trace("constfold", constfold_time, update_roots,
+          PrepTrace::Extra::ConstFold, constfolded.ops_removed,
+          constfolded.slots_folded);
   }
   const auto reroll_time = prep.start();
   RerollStats rerolled;
@@ -602,9 +624,9 @@ void Lowering::run_passes(const std::vector<int>& roots, const PassPlan& plan) {
   } else {
     rerolled = reroll(g, out.fills, target_terms, roots);  // STANLI_NO_REROLL
   }
-  trace("reroll", reroll_time, PrepTrace::Extra::Reroll, rerolled.regions,
-        rerolled.list_steps, false, 0, rerolled.candidate_steps,
-        rerolled.row_steps, &reroll_dispositions);
+  trace("reroll", reroll_time, roots, PrepTrace::Extra::Reroll,
+        rerolled.regions, rerolled.list_steps, false, 0,
+        rerolled.candidate_steps, rerolled.row_steps, &reroll_dispositions);
   // Re-roll can replace many element writes with copying slice stores, and
   // may have replaced target terms with vector reductions: rebuild the
   // implicit-root set before giving those new ops the same last-use proof
@@ -615,7 +637,7 @@ void Lowering::run_passes(const std::vector<int>& roots, const PassPlan& plan) {
   const auto post_reroll_inplace_time = prep.start();
   const int post_reroll_inplace =
       rerolled.regions ? make_inplace_updates(g, post_reroll_roots) : 0;
-  trace("post_reroll_inplace", post_reroll_inplace_time,
+  trace("post_reroll_inplace", post_reroll_inplace_time, post_reroll_roots,
         PrepTrace::Extra::Rewrites, post_reroll_inplace);
   std::vector<int> current_roots = post_reroll_roots;
   if (plan.partition) {
@@ -625,7 +647,7 @@ void Lowering::run_passes(const std::vector<int>& roots, const PassPlan& plan) {
     const auto partition_time = prep.start();
     const PartitionStats parted =
         partition_lanes(g, out.fills, target_terms, roots);
-    trace("partition", partition_time, PrepTrace::Extra::Partition,
+    trace("partition", partition_time, roots, PrepTrace::Extra::Partition,
           parted.groups, parted.lanes, false, 0, parted.declined,
           parted.list_steps);
     // Same proof the slice stores re-roll makes get: rebuilt from the
@@ -637,7 +659,8 @@ void Lowering::run_passes(const std::vector<int>& roots, const PassPlan& plan) {
     const int post_partition_inplace =
         parted.groups ? make_inplace_updates(g, post_partition_roots) : 0;
     trace("post_partition_inplace", post_partition_inplace_time,
-          PrepTrace::Extra::Rewrites, post_partition_inplace);
+          post_partition_roots, PrepTrace::Extra::Rewrites,
+          post_partition_inplace);
     current_roots = post_partition_roots;
   }
   if (plan.elide_stores) {
@@ -646,7 +669,8 @@ void Lowering::run_passes(const std::vector<int>& roots, const PassPlan& plan) {
     // reach.
     const auto elide_time = prep.start();
     const int elided = elide_full_extent_stores(g, current_roots);
-    trace("elide_stores", elide_time, PrepTrace::Extra::Removed, elided);
+    trace("elide_stores", elide_time, current_roots, PrepTrace::Extra::Removed,
+          elided);
   }
   if (plan.cse) {
     // After reroll, whose lane matching needs the repeated ops it hoists
@@ -654,7 +678,8 @@ void Lowering::run_passes(const std::vector<int>& roots, const PassPlan& plan) {
     // residue.
     const auto cse_time = prep.start();
     const CseStats cse_st = cse(g, out.fills, target_terms, roots);
-    trace("cse", cse_time, PrepTrace::Extra::Removed, cse_st.ops_removed);
+    trace("cse", cse_time, roots, PrepTrace::Extra::Removed,
+          cse_st.ops_removed);
   }
   if (plan.island) {
     // LAST, after every other pass has had first crack: compile whatever
@@ -662,7 +687,7 @@ void Lowering::run_passes(const std::vector<int>& roots, const PassPlan& plan) {
     // into island ops. Off under STANLI_NO_ISLAND.
     const auto island_time = prep.start();
     const int islands = carve_islands(g, out.fills, target_terms, roots);
-    trace("island", island_time, PrepTrace::Extra::Regions, islands);
+    trace("island", island_time, roots, PrepTrace::Extra::Regions, islands);
   }
 }
 CompiledModel::WriteArray Lowering::run_write_array(const mir::Program& p) {
@@ -674,6 +699,7 @@ CompiledModel::WriteArray Lowering::run_write_array(const mir::Program& p) {
   int_env["emit_transformed_parameters__"] = 1;
   int_env["emit_generated_quantities__"] = 1;
   CompiledModel::WriteArray wa;
+  DumpOnThrow guard{*this};
   const auto lower_time = prep.start();
   try {
     for (const auto& s : p.generate_quantities) lower_stmt(s);
@@ -689,6 +715,7 @@ CompiledModel::WriteArray Lowering::run_write_array(const mir::Program& p) {
   prep.graph(prep_graph, "lower", lower_time, g, out.fills, target_terms.size(),
              out.views.size(), PrepTrace::Extra::Truncated,
              !wa.truncated.empty());
+  dump("lower", roots);
 
   run_passes(roots, PassPlan{true, false, false, true, false});
 
@@ -699,9 +726,11 @@ CompiledModel::WriteArray Lowering::run_write_array(const mir::Program& p) {
   wa.n_unconstrained = out.n_unconstrained;
   prep.graph(prep_graph, "finalize", finalize_time, g, out.fills,
              target_terms.size(), out.views.size());
+  dump("finalize", roots);
   prep.graph(prep_graph, "total", total_time, g, out.fills, target_terms.size(),
              out.views.size(), PrepTrace::Extra::None, 0, 0, true,
              out.n_unconstrained);
+  guard.done = true;
   wa.graph = std::move(g);
   // A section stanc did not emit a guard for (or one lowering stopped
   // short of) has no columns of its own: it starts where the CSV ends.
@@ -715,16 +744,19 @@ CompiledModel::WriteArray Lowering::run_write_array(const mir::Program& p) {
   return wa;
 }
 CompiledModel Lowering::run(const mir::Program& p) {
+  DumpOnThrow guard{*this};
   const auto total_time = prep.start();
   for (const auto& f : p.fun_defs) fun_defs[f.name] = &f;
   const auto bind_time = prep.start();
   bind_data(p);
   prep.graph(prep_graph, "bind_data", bind_time, g, out.fills,
              target_terms.size(), out.views.size());
+  dump("bind_data", {});
   const auto lower_time = prep.start();
   for (const auto& s : p.log_prob) lower_stmt(s);
   prep.graph(prep_graph, "lower", lower_time, g, out.fills, target_terms.size(),
              out.views.size());
+  dump("lower", {});
   // Jacobian terms and constrained-parameter views are read straight out
   // of the arena, so no op consumes them and the pass cannot infer them.
   std::vector<int> roots = jac_slots;
@@ -738,9 +770,11 @@ CompiledModel Lowering::run(const mir::Program& p) {
   g.result_slot = reduce_terms(all);
   prep.graph(prep_graph, "reduce", reduce_time, g, out.fills,
              target_terms.size(), out.views.size());
+  dump("reduce", roots);
   prep.graph(prep_graph, "total", total_time, g, out.fills, target_terms.size(),
              out.views.size(), PrepTrace::Extra::None, 0, 0, true,
              out.n_unconstrained);
+  guard.done = true;
   out.graph = std::move(g);
   return std::move(out);
 }
@@ -751,6 +785,9 @@ using namespace lower_detail;
 CompiledModel compile_model(const std::string& mir_text, const DataMap& data) {
   const char* prep_env = std::getenv("STANLI_PROFILE_PREP");
   PrepTrace prep(prep_env && prep_env[0] != '0');
+  PassDumper dumper(std::getenv("STANLI_DUMP_PASSES"),
+                    std::getenv("STANLI_DUMP_STAGES"));
+  if (dumper.enabled()) dumper.write("mir", "mir.sexp", mir_text);
   const auto compile_time = prep.start();
   // Shared because the interpreted write_array fallback, when needed,
   // keeps the generate_quantities statements and UDF bodies alive for the
@@ -759,13 +796,13 @@ CompiledModel compile_model(const std::string& mir_text, const DataMap& data) {
   auto prog = std::make_shared<mir::Program>(decode_program(mir_text));
   prep.plain("compile", "parse_mir", parse_time, PrepTrace::Extra::MirBytes,
              static_cast<int64_t>(mir_text.size()));
-  Lowering lo(data, prep, "log_prob");
+  Lowering lo(data, prep, dumper, "log_prob");
   CompiledModel cm = lo.run(*prog);
   if (!prog->generate_quantities.empty()) {
     // A second lowering, over the transformed data the first one already
     // interpreted: re-running prepare_data would double preparation time on
     // the models where preparation is the cost (nn_rbm1bJ100, 20.7 s).
-    Lowering wa(data, prep, "write_array", lo.shape_pool);
+    Lowering wa(data, prep, dumper, "write_array", lo.shape_pool);
     const auto env_copy_time = prep.start();
     wa.td.env() = lo.td.env();
     wa.int_env = lo.int_env_data;

--- a/runtime/src/lower_internal.hpp
+++ b/runtime/src/lower_internal.hpp
@@ -13,6 +13,7 @@
 #include <stanli/function_view_shape.hpp>
 #include <stanli/higher_order_eval.hpp>
 #include <stanli/expression_layout.hpp>
+#include <stanli/graph_print.hpp>
 #include <stanli/inplace.hpp>
 #include <stanli/mir_message.hpp>
 #include <stanli/mir_prog.hpp>
@@ -36,6 +37,11 @@
 #include <algorithm>
 #include <cstdio>
 #include <cstdlib>
+#ifdef _WIN32
+#include <direct.h>
+#else
+#include <sys/stat.h>
+#endif
 #include <array>
 #include <chrono>
 #include <functional>
@@ -253,6 +259,78 @@ struct PrepTrace {
     if (size_ >= rows_.size()) std::abort();
     return rows_[size_++];
   }
+};
+
+// STANLI_DUMP_PASSES=<dir>|-: one graph dump per lowering stage, to files or
+// to stdout. STANLI_DUMP_STAGES selects stages by bare name or graph:stage.
+// Separate from PrepTrace, which selects a different reroll implementation
+// when it is on.
+struct PassDumper {
+  PassDumper(const char* dir, const char* stages) : dir_(dir ? dir : "") {
+    if (stages && *stages) {
+      std::string_view rest(stages);
+      while (!rest.empty()) {
+        const size_t comma = rest.find(',');
+        const std::string_view one = rest.substr(0, comma);
+        if (!one.empty()) stages_.emplace_back(one);
+        rest = comma == std::string_view::npos ? std::string_view()
+                                               : rest.substr(comma + 1);
+      }
+    }
+    if (stages_.size() == 1 && stages_[0] == "all") stages_.clear();
+    if (dir_.empty() || to_stdout()) return;
+    for (size_t i = 1; i <= dir_.size(); ++i) {
+      if (i < dir_.size() && dir_[i] != '/' && dir_[i] != '\\') continue;
+      const std::string part = dir_.substr(0, i);
+#ifdef _WIN32
+      _mkdir(part.c_str());
+#else
+      ::mkdir(part.c_str(), 0777);
+#endif
+    }
+  }
+
+  bool enabled() const { return !dir_.empty(); }
+
+  bool selects(const std::string& label) const {
+    if (stages_.empty()) return true;
+    const size_t colon = label.find(':');
+    const std::string stage =
+        colon == std::string::npos ? label : label.substr(colon + 1);
+    for (const std::string& want : stages_)
+      if (want == label || want == stage) return true;
+    return false;
+  }
+
+  // The sequence number advances for every stage the lowering reaches, so a
+  // filtered run keeps the numbers an unfiltered one would have given.
+  void write(const std::string& label, const std::string& name,
+             const std::string& text, bool unfiltered = false) {
+    const int n = n_++;
+    if (!unfiltered && !selects(label)) return;
+    if (to_stdout()) {
+      std::printf(";; %s\n", label.c_str());
+      std::fwrite(text.data(), 1, text.size(), stdout);
+      if (!text.empty() && text.back() != '\n') std::fputc('\n', stdout);
+      std::printf(";; end %s\n", label.c_str());
+      std::fflush(stdout);
+      return;
+    }
+    char prefix[8];
+    std::snprintf(prefix, sizeof(prefix), "%02d-", n);
+    const std::string path = dir_ + "/" + prefix + name;
+    std::FILE* f = std::fopen(path.c_str(), "wb");
+    if (!f) return;
+    std::fwrite(text.data(), 1, text.size(), f);
+    std::fclose(f);
+  }
+
+ private:
+  bool to_stdout() const { return dir_ == "-"; }
+
+  std::string dir_;
+  std::vector<std::string> stages_;
+  int n_ = 0;
 };
 
 struct SlotInfo {
@@ -677,7 +755,10 @@ struct Lowering {
   const DataMap& data;
   std::shared_ptr<ShapeInterner> shape_pool;
   PrepTrace& prep;
+  PassDumper& dumper;
   const char* prep_graph;
+  const char* last_stage = "start";
+  std::vector<int> last_roots;
   // The MIR interpreter instance for everything DataOnly: prepare_data,
   // data-only conditions, size expressions. Its environment doubles as the
   // lowering's view of transformed data. Hooks route FnReadData to the
@@ -773,8 +854,36 @@ struct Lowering {
   bool expression_autodiff(const mir::Expr& e) const;
 
   explicit Lowering(
-      const DataMap& d, PrepTrace& p, const char* graph_name,
+      const DataMap& d, PrepTrace& p, PassDumper& dump_to,
+      const char* graph_name,
       std::shared_ptr<ShapeInterner> pool = std::make_shared<ShapeInterner>());
+
+  void dump_named(const std::string& label, const std::string& name,
+                  const std::vector<int>& roots, bool unfiltered);
+
+  void dump(const char* stage, const std::vector<int>& roots) {
+    if (!dumper.enabled()) return;
+    dump_named(std::string(prep_graph) + ":" + stage,
+               std::string(prep_graph) + "-" + stage + ".txt", roots, false);
+    last_stage = stage;
+    last_roots = roots;
+  }
+
+  struct DumpOnThrow {
+    Lowering& lo;
+    bool done = false;
+    ~DumpOnThrow() {
+      if (done || !lo.dumper.enabled()) return;
+      try {
+        lo.dump_named(
+            std::string(lo.prep_graph) + ":FAILED-after-" + lo.last_stage,
+            std::string(lo.prep_graph) + "-FAILED-after-" + lo.last_stage +
+                ".txt",
+            lo.last_roots, true);
+      } catch (...) {
+      }
+    }
+  };
 
   void observe(const Val& v, DataMap::Entry en) {
     const int64_t len = g.slots[v.slot].len;

--- a/runtime/src/lower_structured_loop.inc
+++ b/runtime/src/lower_structured_loop.inc
@@ -1982,7 +1982,7 @@ bool try_lower_region(
   {
     bool candidate_ready = false;
     try {
-      Lowering trial(data, prep, prep_graph,
+      Lowering trial(data, prep, dumper, prep_graph,
                      std::make_shared<ShapeInterner>(*shape_pool));
       trial.fun_defs = fun_defs;
       trial.decls = decls;

--- a/tests/lit/README.md
+++ b/tests/lit/README.md
@@ -26,6 +26,34 @@ also how a silently accepted invalid model is recorded: `XFAIL` plus `OK`.
 XFAIL cases also carry the CTest label `broken`, so the known-gap inventory is
 directly runnable with `ctest --test-dir build -L broken`.
 
+## Checking a lowering pass
+
+A case can additionally assert the shape of one pass dump. `STANLI-LIT-DUMP`
+names the stage; the runner asks `stanli_check` for it on stdout and matches
+the `CHECK` directives against that stage's dump alone. The ordinary result
+expectation still applies.
+
+```stan
+// STANLI-LIT: PASS
+// STANLI-LIT-EXPECT: OK
+// STANLI-LIT-DUMP: log_prob:reroll
+// STANLI-LIT-CHECK: s{{[0-9]+}}[1] = INDEX s{{[0-9]+}}[5,P] idata=[4]
+// STANLI-LIT-CHECK-NEXT: s{{[0-9]+}}[15] = FMA s{{[0-9]+}}[1] s{{[0-9]+}}[15] s{{[0-9]+}}[15]
+// STANLI-LIT-CHECK-NEXT: s{{[0-9]+}}[1] = NORMAL_LPDF.v=0x86 s{{[0-9]+}}[15] s{{[0-9]+}}[15] s{{[0-9]+}}[1]
+```
+
+- `CHECK` searches forward from the line after the previous match.
+- `CHECK-NEXT` must match the immediately following line.
+- `CHECK-NOT` must match nothing between the checks surrounding it, or
+  nothing in the rest of the dump when no check follows it.
+- A pattern is matched literally except inside `{{...}}`, whose contents are
+  a regular expression. Slot numbers are model-dependent, so write them as
+  `{{[0-9]+}}` rather than pinning them.
+- Matching is a search within a line, not a whole-line match.
+
+Write the checks from real output rather than from expectation: `--discover`
+prints the sliced dump for the named stage.
+
 The runner copies each source into a temporary directory before invoking
 `stanli_check`, because its pinned stanc writes a sibling `.hpp` even when MIR
 is sent to stdout. The ordinary developer setup provisions that compiler. A

--- a/tests/lit/passes/ark_reroll_fma.stan
+++ b/tests/lit/passes/ark_reroll_fma.stan
@@ -1,0 +1,31 @@
+// STANLI-LIT: PASS
+// STANLI-LIT-EXPECT: OK
+// STANLI-LIT-DATA: {"K": 5, "T": 20, "y": [0.0, 0.744218, 1.18545, 1.163209, 0.734988, 0.149217, -0.271576, -0.282453, 0.168733, 0.916814, 0.656987, 1.088168, 1.054599, 0.619098, 0.033521, -0.379696, -0.379178, 0.081863, 0.833623, 1.56957]}
+// STANLI-LIT-DUMP: log_prob:reroll
+// STANLI-LIT-CHECK: s{{[0-9]+}}[1] = INDEX s{{[0-9]+}}[5,P] idata=[0]
+// STANLI-LIT-CHECK-NEXT: s{{[0-9]+}}[15] = FMA s{{[0-9]+}}[1] s{{[0-9]+}}[15] s{{[0-9]+}}[1,P]
+// STANLI-LIT-CHECK: s{{[0-9]+}}[1] = INDEX s{{[0-9]+}}[5,P] idata=[4]
+// STANLI-LIT-CHECK-NEXT: s{{[0-9]+}}[15] = FMA s{{[0-9]+}}[1] s{{[0-9]+}}[15] s{{[0-9]+}}[15]
+// STANLI-LIT-CHECK-NEXT: s{{[0-9]+}}[1] = NORMAL_LPDF.v=0x86 s{{[0-9]+}}[15] s{{[0-9]+}}[15] s{{[0-9]+}}[1]
+data {
+  int<lower=0> K;
+  int<lower=0> T;
+  array[T] real y;
+}
+parameters {
+  real alpha;
+  array[K] real beta;
+  real<lower=0> sigma;
+}
+model {
+  alpha ~ normal(0, 10);
+  beta ~ normal(0, 10);
+  sigma ~ cauchy(0, 2.5);
+  for (t in (K + 1) : T) {
+    real mu = alpha;
+    for (k in 1 : K) {
+      mu = mu + beta[k] * y[t - k];
+    }
+    y[t] ~ normal(mu, sigma);
+  }
+}

--- a/tests/lit/passes/scalar_loop_reroll_collapse.stan
+++ b/tests/lit/passes/scalar_loop_reroll_collapse.stan
@@ -1,0 +1,19 @@
+// STANLI-LIT: PASS
+// STANLI-LIT-EXPECT: OK
+// STANLI-LIT-DATA: {"N": 8, "y": [0.4, -1.1, 0.7, 2.0, -0.3, 1.4, 0.1, -0.9]}
+// STANLI-LIT-DUMP: log_prob:reroll
+// STANLI-LIT-CHECK-NOT: NORMAL_LPDF.v=0x86 s{{[0-9]+}}[1] s
+// STANLI-LIT-CHECK: s{{[0-9]+}}[1] = NORMAL_LPDF.v=0x86 s{{[0-9]+}}[8] s{{[0-9]+}}[1,P] s{{[0-9]+}}[1]
+data {
+  int<lower=0> N;
+  array[N] real y;
+}
+parameters {
+  real mu;
+  real<lower=0> sigma;
+}
+model {
+  for (n in 1 : N) {
+    y[n] ~ normal(mu, sigma);
+  }
+}

--- a/tests/lit/run.py
+++ b/tests/lit/run.py
@@ -10,6 +10,13 @@ comments:
 
 Known gaps use ``XFAIL``.  Matching XFAILs pass the CTest invocation; a changed
 result fails it so the case must be reviewed and promoted when the gap closes.
+
+A case can also assert the shape of one lowering-pass dump:
+
+    // STANLI-LIT-DUMP: log_prob:reroll
+    // STANLI-LIT-CHECK: s{{[0-9]+}}[195] = FMA
+    // STANLI-LIT-CHECK-NEXT: s{{[0-9]+}}[1] = INDEX
+    // STANLI-LIT-CHECK-NOT: SUM_VEC
 """
 
 from __future__ import annotations
@@ -17,6 +24,7 @@ from __future__ import annotations
 import argparse
 import json
 import pathlib
+import re
 import subprocess
 import tempfile
 
@@ -25,6 +33,12 @@ PREFIX = "// STANLI-LIT: "
 EXPECT_PREFIX = "// STANLI-LIT-EXPECT: "
 DATA_PREFIX = "// STANLI-LIT-DATA: "
 TIMEOUT_PREFIX = "// STANLI-LIT-TIMEOUT: "
+DUMP_PREFIX = "// STANLI-LIT-DUMP: "
+CHECK_PREFIXES = {
+    "// STANLI-LIT-CHECK: ": "CHECK",
+    "// STANLI-LIT-CHECK-NEXT: ": "CHECK-NEXT",
+    "// STANLI-LIT-CHECK-NOT: ": "CHECK-NOT",
+}
 
 
 def directive(lines: list[str], prefix: str) -> str | None:
@@ -33,6 +47,58 @@ def directive(lines: list[str], prefix: str) -> str | None:
     if len(values) > 1:
         raise ValueError(f"duplicate {prefix.strip()} directive")
     return values[0] if values else None
+
+
+def checks(lines: list[str]) -> list[tuple[str, str]]:
+    found = []
+    for line in lines:
+        for prefix, kind in CHECK_PREFIXES.items():
+            if line.startswith(prefix):
+                found.append((kind, line[len(prefix):].strip()))
+    return found
+
+
+def compile_pattern(pattern: str) -> re.Pattern[str]:
+    parts = re.split(r"\{\{(.*?)\}\}", pattern)
+    return re.compile("".join(part if i % 2 else re.escape(part)
+                              for i, part in enumerate(parts)))
+
+
+def slice_region(stdout: str, stage: str) -> list[str] | None:
+    begin, end = f";; {stage}", f";; end {stage}"
+    lines = stdout.splitlines()
+    try:
+        first = lines.index(begin)
+        last = lines.index(end, first)
+    except ValueError:
+        return None
+    return lines[first + 1:last]
+
+
+def run_checks(region: list[str],
+               directives: list[tuple[str, str]]) -> str | None:
+    """Return a failure message, or None when every directive is satisfied."""
+    pos = 0
+    pending_not = []
+    for kind, pattern in directives:
+        rx = compile_pattern(pattern)
+        if kind == "CHECK-NOT":
+            pending_not.append((pattern, rx))
+            continue
+        end = pos + 1 if kind == "CHECK-NEXT" else len(region)
+        hit = next((i for i in range(pos, min(end, len(region)))
+                    if rx.search(region[i])), None)
+        if hit is None:
+            return f"{kind}: {pattern}"
+        for not_pattern, not_rx in pending_not:
+            if any(not_rx.search(line) for line in region[pos:hit]):
+                return f"CHECK-NOT: {not_pattern}"
+        pending_not = []
+        pos = hit + 1
+    for not_pattern, not_rx in pending_not:
+        if any(not_rx.search(line) for line in region[pos:]):
+            return f"CHECK-NOT: {not_pattern}"
+    return None
 
 
 def result_line(completed: subprocess.CompletedProcess[str]) -> str:
@@ -70,6 +136,10 @@ def main() -> int:
         expect = directive(lines, EXPECT_PREFIX)
         data_text = directive(lines, DATA_PREFIX) or "{}"
         timeout_text = directive(lines, TIMEOUT_PREFIX) or "30"
+        dump_stage = directive(lines, DUMP_PREFIX)
+        check_directives = checks(lines)
+        if check_directives and not dump_stage:
+            raise ValueError("CHECK directives need a STANLI-LIT-DUMP stage")
         if status not in {"PASS", "XFAIL"}:
             raise ValueError("STANLI-LIT must be PASS or XFAIL")
         if not expect:
@@ -94,13 +164,12 @@ def main() -> int:
         data_path = root / f"{args.case.stem}.json"
         source.write_text(source_text, encoding="utf-8")
         data_path.write_text(json.dumps(data), encoding="utf-8")
+        command = [str(args.stanli_check), str(source), str(data_path)]
+        if dump_stage:
+            command.append(f"--dump-passes={dump_stage}")
         try:
             completed = subprocess.run(
-                [
-                    str(args.stanli_check),
-                    str(source),
-                    str(data_path),
-                ],
+                command,
                 text=True,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
@@ -112,9 +181,29 @@ def main() -> int:
             return 1
 
     result = result_line(completed)
+    region = slice_region(completed.stdout, dump_stage) if dump_stage else None
+
     if args.discover:
+        if dump_stage:
+            if region is None:
+                print(f"{args.case}: no ';; {dump_stage}' region in:")
+                print(completed.stdout)
+            else:
+                print("\n".join(region))
         print(f"{args.case}: {result}")
         return 0
+
+    if dump_stage and region is None:
+        print(f"FAIL {args.case}: no ';; {dump_stage}' region in stdout")
+        print(completed.stdout)
+        return 1
+
+    if check_directives:
+        failed = run_checks(region, check_directives)
+        if failed:
+            print(f"FAIL {args.case}: unmatched {failed}")
+            print("\n".join(region))
+            return 1
 
     if matches(expect, result, completed.returncode):
         print(f"{status} {args.case}: {result}")

--- a/tests/test_graph_print.cpp
+++ b/tests/test_graph_print.cpp
@@ -1,0 +1,131 @@
+// Text rendering of the graph: exact layout, determinism, and the property
+// the pass dumps depend on -- deleting an op perturbs no other op line.
+#include <stanli/graph.hpp>
+#include <stanli/graph_print.hpp>
+#include <stanli/optable.hpp>
+
+#include <cstdio>
+#include <string>
+#include <utility>
+#include <vector>
+
+static int failures = 0;
+static void expect(const char* what, bool ok) {
+  if (!ok) {
+    ++failures;
+    std::printf("FAIL %s\n", what);
+  }
+}
+
+using namespace stanli;
+
+static Graph build_graph() {
+  Graph g;
+  const int p = g.add_slot(1, true);   // s0
+  const int d = g.add_slot(3, false);  // s1
+  const int e = g.add_slot(1, false);  // s2
+  const int m = g.add_slot(3, false);  // s3
+  const int s = g.add_slot(1, false);  // s4
+  const int r = g.add_slot(1, false);  // s5
+  const int j = g.add_slot(1, false);  // s6
+  g.add_op(OP_EXP, {p}, e);
+  g.add_op(OP_MUL, {d, e}, m, {7, 8, 9});
+  g.ops.back().variant = 0x03;
+  g.add_op(OP_SUM_VEC, {m}, s);
+  g.add_op(OP_ADD, {s, e}, r);
+  g.ops.back().out2 = j;
+  g.result_slot = r;
+  return g;
+}
+
+static GraphPrintInfo build_info(
+    const std::vector<std::pair<int, std::vector<double>>>& fills) {
+  GraphPrintInfo info;
+  info.roots = {2};
+  info.target_terms = {4, 5};
+  info.jac_slots = {6};
+  info.views = {{"y", 1}, {"mu", 3}};
+  info.fills = &fills;
+  return info;
+}
+
+static const char* kGolden =
+    "ops=4 slots=7 result=s5\n"
+    "roots: s2\n"
+    "target_terms: s4 s5\n"
+    "jac_slots: s6\n"
+    "views: mu=s3 y=s1\n"
+    "fills: s1[3]=0.5,1.5,2.5\n"
+    "s2[1] = EXP s0[1,P]\n"
+    "s3[3] = MUL.v=0x03 s1[3] s2[1] idata=[7,8,9]\n"
+    "s4[1] = SUM_VEC s3[3]\n"
+    "s5[1] = ADD s4[1] s2[1] out2=s6\n";
+
+static void test_exact_text() {
+  const std::vector<std::pair<int, std::vector<double>>> fills = {
+      {1, {0.5, 1.5, 2.5}}};
+  std::string out;
+  print_graph(out, build_graph(), build_info(fills));
+  expect("exact text", out == kGolden);
+  if (out != kGolden) std::printf("--- got ---\n%s--- end ---\n", out.c_str());
+}
+
+static void test_deterministic() {
+  const std::vector<std::pair<int, std::vector<double>>> fills = {
+      {1, {0.5, 1.5, 2.5}}};
+  const Graph g = build_graph();
+  std::string a, b;
+  print_graph(a, g, build_info(fills));
+  print_graph(b, g, build_info(fills));
+  expect("deterministic", a == b && !a.empty());
+}
+
+static std::vector<std::string> op_lines(const std::string& text) {
+  std::vector<std::string> lines;
+  size_t pos = 0;
+  while (pos < text.size()) {
+    const size_t nl = text.find('\n', pos);
+    lines.push_back(text.substr(pos, nl - pos));
+    pos = nl + 1;
+  }
+  std::vector<std::string> ops;
+  for (const std::string& l : lines)
+    if (!l.empty() && l[0] == 's' && l.find(" = ") != std::string::npos)
+      ops.push_back(l);
+  return ops;
+}
+
+static void test_removal_is_one_line() {
+  Graph g = build_graph();
+  std::string before;
+  print_graph(before, g);
+  const std::vector<std::string> a = op_lines(before);
+
+  g.ops.erase(g.ops.begin() + 2);
+  std::string after;
+  print_graph(after, g);
+  const std::vector<std::string> b = op_lines(after);
+
+  expect("one op removed", a.size() == b.size() + 1);
+  size_t i = 0, k = 0, dropped = 0;
+  for (; i < a.size(); ++i) {
+    if (k < b.size() && a[i] == b[k]) {
+      ++k;
+      continue;
+    }
+    ++dropped;
+  }
+  expect("survivors byte-identical and in order",
+         dropped == 1 && k == b.size());
+  if (dropped != 1 || k != b.size())
+    std::printf("--- before ---\n%s--- after ---\n%s", before.c_str(),
+                after.c_str());
+}
+
+int main() {
+  test_exact_text();
+  test_deterministic();
+  test_removal_is_one_line();
+  if (failures == 0) std::printf("test_graph_print OK\n");
+  return failures == 0 ? 0 : 1;
+}

--- a/tests/test_pass_dump.cpp
+++ b/tests/test_pass_dump.cpp
@@ -1,0 +1,188 @@
+// STANLI_DUMP_PASSES: one graph dump per lowering pass, so consecutive
+// stages can be diffed. The dumps are a debugging aid, so the property that
+// matters most is that turning them on does not change what is compiled.
+#include "env_helpers.hpp"
+#include <stanli/compile.hpp>
+#include <stanli/graph_print.hpp>
+
+#include <algorithm>
+#include <cstdio>
+#include <filesystem>
+#include <fstream>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#ifdef _WIN32
+#include <fcntl.h>
+#include <io.h>
+#include <sys/stat.h>
+#define test_dup _dup
+#define test_dup2 _dup2
+#define test_close _close
+static int test_open_for_write(const char* path) {
+  return _open(path, _O_WRONLY | _O_CREAT | _O_TRUNC, _S_IWRITE);
+}
+#else
+#include <fcntl.h>
+#include <unistd.h>
+#define test_dup dup
+#define test_dup2 dup2
+#define test_close close
+static int test_open_for_write(const char* path) {
+  return ::open(path, O_WRONLY | O_CREAT | O_TRUNC, 0666);
+}
+#endif
+
+static int failures = 0;
+static void expect(const std::string& what, bool ok) {
+  if (!ok) {
+    ++failures;
+    std::printf("FAIL %s\n", what.c_str());
+  }
+}
+
+static std::string slurp(const std::filesystem::path& p) {
+  std::ifstream f(p, std::ios::binary);
+  std::ostringstream ss;
+  ss << f.rdbuf();
+  return ss.str();
+}
+
+static std::vector<std::string> listing(const std::filesystem::path& dir) {
+  std::vector<std::string> names;
+  if (!std::filesystem::exists(dir)) return names;
+  for (const auto& e : std::filesystem::directory_iterator(dir))
+    names.push_back(e.path().filename().string());
+  std::sort(names.begin(), names.end());
+  return names;
+}
+
+static const char* kExpected[] = {"00-mir.sexp",
+                                  "01-log_prob-bind_data.txt",
+                                  "02-log_prob-lower.txt",
+                                  "03-log_prob-inplace.txt",
+                                  "04-log_prob-store_forward.txt",
+                                  "05-log_prob-constfold.txt",
+                                  "06-log_prob-reroll.txt",
+                                  "07-log_prob-post_reroll_inplace.txt",
+                                  "08-log_prob-partition.txt",
+                                  "09-log_prob-post_partition_inplace.txt",
+                                  "10-log_prob-elide_stores.txt",
+                                  "11-log_prob-cse.txt",
+                                  "12-log_prob-island.txt",
+                                  "13-log_prob-reduce.txt",
+                                  "14-write_array-lower.txt",
+                                  "15-write_array-inplace.txt",
+                                  "16-write_array-store_forward.txt",
+                                  "17-write_array-constfold.txt",
+                                  "18-write_array-reroll.txt",
+                                  "19-write_array-post_reroll_inplace.txt",
+                                  "20-write_array-cse.txt",
+                                  "21-write_array-finalize.txt"};
+
+int main() {
+  using namespace stanli;
+
+  // Constant folding removes nine of this model's sixteen ops, so the
+  // store_forward and constfold dumps differ in the graph itself.
+  const DataMap data =
+      DataMap::from_json_file("tests/fixtures/arr2d_rowrange.json");
+  const std::string mir = slurp("tests/fixtures/arr2d_rowrange.tmir.sexp");
+
+  const std::filesystem::path root =
+      std::filesystem::temp_directory_path() / "stanli_pass_dump_test";
+  std::filesystem::remove_all(root);
+
+  test_unsetenv("STANLI_DUMP_PASSES");
+  CompiledModel plain = compile_model(mir, data);
+
+  const std::filesystem::path on_dir = root / "on";
+  test_setenv("STANLI_DUMP_PASSES", on_dir.string().c_str(), 1);
+  CompiledModel dumped = compile_model(mir, data);
+  test_unsetenv("STANLI_DUMP_PASSES");
+
+  const std::vector<std::string> got = listing(on_dir);
+  const std::vector<std::string> want(std::begin(kExpected),
+                                      std::end(kExpected));
+  expect("stage file names", got == want);
+  if (got != want)
+    for (const std::string& n : got) std::printf("  got %s\n", n.c_str());
+
+  for (const std::string& n : got)
+    expect("non-empty " + n, !slurp(on_dir / n).empty());
+
+  expect("00-mir.sexp is the input mir", slurp(on_dir / "00-mir.sexp") == mir);
+
+  const std::string before = slurp(on_dir / "04-log_prob-store_forward.txt");
+  const std::string after = slurp(on_dir / "05-log_prob-constfold.txt");
+  expect("constfold changes the graph", before.substr(0, before.find('\n')) !=
+                                            after.substr(0, after.find('\n')));
+
+  compile_model(mir, data);
+  expect("no dumps once unset", listing(on_dir) == want);
+
+  const auto listing_with = [&](const char* stages, const char* name) {
+    const std::filesystem::path dir = root / name;
+    test_setenv("STANLI_DUMP_PASSES", dir.string().c_str(), 1);
+    test_setenv("STANLI_DUMP_STAGES", stages, 1);
+    compile_model(mir, data);
+    test_unsetenv("STANLI_DUMP_PASSES");
+    test_unsetenv("STANLI_DUMP_STAGES");
+    return listing(dir);
+  };
+
+  // Numbering counts the stages the filter dropped, so a documented
+  // `diff 05 06` keeps naming the same two passes under any selection.
+  expect("one stage keeps its unfiltered number",
+         listing_with("constfold", "constfold") ==
+             std::vector<std::string>{"05-log_prob-constfold.txt",
+                                      "17-write_array-constfold.txt"});
+  expect("bare stage name matches every graph",
+         listing_with("reroll", "reroll") ==
+             std::vector<std::string>{"06-log_prob-reroll.txt",
+                                      "18-write_array-reroll.txt"});
+  expect("qualified stage name matches one graph",
+         listing_with("log_prob:reroll", "qualified") ==
+             std::vector<std::string>{"06-log_prob-reroll.txt"});
+  expect(
+      "mir is selectable",
+      listing_with("mir,constfold", "mir") ==
+          std::vector<std::string>{"00-mir.sexp", "05-log_prob-constfold.txt",
+                                   "17-write_array-constfold.txt"});
+  expect("all selects every stage", listing_with("all", "all") == want);
+
+  const std::filesystem::path captured = root / "stdout.txt";
+  std::fflush(stdout);
+  const int saved = test_dup(1);
+  const int sink = test_open_for_write(captured.string().c_str());
+  test_dup2(sink, 1);
+  test_setenv("STANLI_DUMP_PASSES", "-", 1);
+  test_setenv("STANLI_DUMP_STAGES", "reroll", 1);
+  compile_model(mir, data);
+  test_unsetenv("STANLI_DUMP_PASSES");
+  test_unsetenv("STANLI_DUMP_STAGES");
+  std::fflush(stdout);
+  test_dup2(saved, 1);
+  test_close(sink);
+  test_close(saved);
+
+  std::vector<std::string> banners;
+  std::istringstream lines(slurp(captured));
+  for (std::string line; std::getline(lines, line);)
+    if (line.rfind(";; ", 0) == 0) banners.push_back(line);
+  expect("stdout banners are balanced",
+         banners == std::vector<std::string>{
+                        ";; log_prob:reroll", ";; end log_prob:reroll",
+                        ";; write_array:reroll", ";; end write_array:reroll"});
+  expect("stdout mode makes no directory", !std::filesystem::exists("-"));
+
+  std::string a, b;
+  print_graph(a, plain.graph);
+  print_graph(b, dumped.graph);
+  expect("dumping does not change the compiled graph", a == b && !a.empty());
+
+  std::filesystem::remove_all(root);
+  if (failures == 0) std::printf("test_pass_dump OK\n");
+  return failures == 0 ? 0 : 1;
+}

--- a/tests/test_pass_dump.cpp
+++ b/tests/test_pass_dump.cpp
@@ -2,6 +2,7 @@
 // stages can be diffed. The dumps are a debugging aid, so the property that
 // matters most is that turning them on does not change what is compiled.
 #include "env_helpers.hpp"
+#include "stdout_capture.hpp"
 #include <stanli/compile.hpp>
 #include <stanli/graph_print.hpp>
 
@@ -12,27 +13,6 @@
 #include <sstream>
 #include <string>
 #include <vector>
-
-#ifdef _WIN32
-#include <fcntl.h>
-#include <io.h>
-#include <sys/stat.h>
-#define test_dup _dup
-#define test_dup2 _dup2
-#define test_close _close
-static int test_open_for_write(const char* path) {
-  return _open(path, _O_WRONLY | _O_CREAT | _O_TRUNC, _S_IWRITE);
-}
-#else
-#include <fcntl.h>
-#include <unistd.h>
-#define test_dup dup
-#define test_dup2 dup2
-#define test_close close
-static int test_open_for_write(const char* path) {
-  return ::open(path, O_WRONLY | O_CREAT | O_TRUNC, 0666);
-}
-#endif
 
 static int failures = 0;
 static void expect(const std::string& what, bool ok) {
@@ -152,23 +132,19 @@ int main() {
                                    "17-write_array-constfold.txt"});
   expect("all selects every stage", listing_with("all", "all") == want);
 
-  const std::filesystem::path captured = root / "stdout.txt";
-  std::fflush(stdout);
-  const int saved = test_dup(1);
-  const int sink = test_open_for_write(captured.string().c_str());
-  test_dup2(sink, 1);
-  test_setenv("STANLI_DUMP_PASSES", "-", 1);
-  test_setenv("STANLI_DUMP_STAGES", "reroll", 1);
-  compile_model(mir, data);
-  test_unsetenv("STANLI_DUMP_PASSES");
-  test_unsetenv("STANLI_DUMP_STAGES");
-  std::fflush(stdout);
-  test_dup2(saved, 1);
-  test_close(sink);
-  test_close(saved);
+  std::string captured;
+  {
+    stanli_test::StdoutCapture capture;
+    test_setenv("STANLI_DUMP_PASSES", "-", 1);
+    test_setenv("STANLI_DUMP_STAGES", "reroll", 1);
+    compile_model(mir, data);
+    test_unsetenv("STANLI_DUMP_PASSES");
+    test_unsetenv("STANLI_DUMP_STAGES");
+    captured = capture.finish();
+  }
 
   std::vector<std::string> banners;
-  std::istringstream lines(slurp(captured));
+  std::istringstream lines(captured);
   for (std::string line; std::getline(lines, line);)
     if (line.rfind(";; ", 0) == 0) banners.push_back(line);
   expect("stdout banners are balanced",

--- a/tools/dump_islands.cpp
+++ b/tools/dump_islands.cpp
@@ -2,12 +2,8 @@
 // program (checkpoint saves included), the CALL payloads, and the generated
 // adjoint program. What dump_ops is for the graph, this is for the layer
 // below it.
-#include <stanli/adjoint.hpp>
 #include <stanli/compile.hpp>
-#include <stanli/graph.hpp>
-#include <stanli/island.hpp>
-#include <stanli/optable.hpp>
-#include <stanli/program_density.hpp>
+#include <stanli/graph_print.hpp>
 
 #include <cstdio>
 #include <fstream>
@@ -23,60 +19,6 @@ static std::string slurp(const char* p) {
   return ss.str();
 }
 
-static void print_instr(const Program& p, size_t i, const Program::Instr& I) {
-  std::printf("  %3zu  %-9s", i, program_code_spec(I.code).name);
-  switch (I.code) {
-    case Program::CONST:
-      std::printf(" r%d <- pool[%d] (=%g)", I.dst, I.a, p.pool[(size_t)I.a]);
-      break;
-    case Program::CONSTR:
-      std::printf(" r%d..r%d <- pool[%d..] (=", I.dst, I.dst + I.len - 1, I.a);
-      for (int k = 0; k < I.len; ++k)
-        std::printf("%s%g", k ? "," : "", p.pool[(size_t)(I.a + k)]);
-      std::printf(")");
-      break;
-    case Program::JZ:
-      std::printf(" if r%d == 0 goto %d", I.a, I.dst);
-      break;
-    case Program::JMP:
-      std::printf(" goto %d", I.dst);
-      break;
-    case Program::MOVR:
-      std::printf(" r%d..r%d <- r%d..r%d", I.dst, I.dst + I.len - 1, I.a,
-                  I.a + I.len - 1);
-      break;
-    case Program::DOT:
-      std::printf(" r%d <- dot(r%d.., r%d.., len %d)", I.dst, I.a, I.b, I.len);
-      break;
-    case Program::DENSITY:
-      std::printf(" r%d <- %s(r%d, r%d, r%d)", I.dst,
-                  program_density_name(I.len), I.a, I.b, I.c);
-      break;
-    case Program::CALL: {
-      const Program::Call& c = p.calls[(size_t)I.a];
-      std::printf(" %s(", opcode_name(c.opcode));
-      for (int k = 0; k < c.n_in; ++k)
-        std::printf("%sr%d[len %d]", k ? ", " : "", c.in[k], c.in_len[k]);
-      std::printf(") -> r%d[len %d]", c.out, c.out_len);
-      if (c.scratch_len)
-        std::printf(", scratch r%d[len %d]", c.scratch, c.scratch_len);
-      else
-        std::printf(", no scratch");
-      break;
-    }
-    default:
-      std::printf(" r%d <- r%d", I.dst, I.a);
-      const bool ternary = I.code == Program::LOG_MIX || I.code == Program::FMA;
-      if ((I.code >= Program::ADD && I.code <= Program::FMIN) ||
-          (I.code >= Program::GT && I.code <= Program::NE) ||
-          I.code == Program::LSE2 || ternary)
-        std::printf(", r%d", I.b);
-      if (ternary) std::printf(", r%d", I.c);
-      if (I.len) std::printf(" (len %d)", I.len);
-  }
-  std::printf("\n");
-}
-
 int main(int argc, char** argv) {
   if (argc < 3) {
     std::fprintf(stderr, "usage: dump_islands mir.sexp data.json\n");
@@ -84,39 +26,8 @@ int main(int argc, char** argv) {
   }
   DataMap data = DataMap::from_json(slurp(argv[2]));
   CompiledModel cm = compile_model(slurp(argv[1]), data);
-  const Graph& g = cm.graph;
-
-  std::printf("graph: %zu ops, %zu slots\n", g.ops.size(), g.slots.size());
-  int n = 0;
-  for (size_t u = 0; u < g.ops.size(); ++u) {
-    const Op& op = g.ops[u];
-    if (op.opcode != OP_ISLAND) continue;
-    const auto& p = *static_cast<const IslandProg*>(op.udata);
-    std::printf(
-        "\n== island %d (graph op %zu): %zu instrs, %d regs, "
-        "%zu calls, adjoint %zu instrs, native_adj=%d, softmax3=%d\n",
-        n++, u, p.code.size(), p.n_regs, p.calls.size(), p.adj.code.size(),
-        (int)p.native_adj, (int)(op.variant == kIslandSoftmax3Variant));
-    std::printf("  live-ins:");
-    for (size_t k = 0; k < p.ins.size(); ++k)
-      std::printf(" slot%d->r%d[len %d]", op.in[k], p.ins[k].reg, p.ins[k].len);
-    std::printf("\n  live-outs (out_regs):");
-    for (int r : p.out_regs) std::printf(" r%d", r);
-    std::printf("\n\n  FORWARD:\n");
-    for (size_t i = 0; i < p.code.size(); ++i) print_instr(p, i, p.code[i]);
-    if (!p.adj.code.empty()) {
-      std::printf(
-          "\n  ADJOINT (reverse order; dst/a/b/c are adjoint cells, "
-          "va/vb/vc/vd are value registers):\n");
-      for (size_t i = 0; i < p.adj.code.size(); ++i) {
-        const AdjInstr& A = p.adj.code[i];
-        std::printf(
-            "  %3zu  %-9s dst=%d a=%d b=%d c=%d | va=%d vb=%d vc=%d "
-            "vd=%d\n",
-            i, program_code_spec(A.code).name, A.dst, A.a, A.b, A.c, A.va, A.vb,
-            A.vc, A.vd);
-      }
-    }
-  }
+  std::string out;
+  print_islands(out, cm.graph);
+  std::fputs(out.c_str(), stdout);
   return 0;
 }

--- a/tools/stanli_check.cpp
+++ b/tools/stanli_check.cpp
@@ -70,7 +70,8 @@ int main(int argc, char** argv) {
                  "usage: stanli_check model.stan data.json "
                  "[--stanc PATH | --mir PATH] [--point N] [--columns]\n"
                  "       [--paths] [--cross [--cross-one lp|grad|wa] "
-                 "[--draw-variant N] [--ledger PATH]]\n");
+                 "[--draw-variant N] [--ledger PATH]]\n"
+                 "       [--dump-passes=STAGES] [--dump-dir=DIR]\n");
     return 2;
   }
 #ifdef _WIN32
@@ -88,9 +89,14 @@ int main(int argc, char** argv) {
   std::string cross_one;
   std::string ledger_path = "tests/cross_path_ledger.json";
   int draw_variant = -1;
+  std::string dump_stages, dump_dir;
   for (int i = 3; i < argc; ++i) {
     const std::string a = argv[i];
-    if (a == "--columns")
+    if (a.rfind("--dump-passes=", 0) == 0)
+      dump_stages = a.substr(sizeof("--dump-passes=") - 1);
+    else if (a.rfind("--dump-dir=", 0) == 0)
+      dump_dir = a.substr(sizeof("--dump-dir=") - 1);
+    else if (a == "--columns")
       columns_only = true;
     else if (a == "--wa-values")
       wa_values = true;
@@ -118,6 +124,18 @@ int main(int argc, char** argv) {
     return 2;
   }
   if (const char* env = std::getenv("STANC")) stanc = env;
+  if (!dump_stages.empty() || !dump_dir.empty()) {
+    const std::string sink = dump_dir.empty() ? "-" : dump_dir;
+#ifdef _WIN32
+    _putenv_s("STANLI_DUMP_PASSES", sink.c_str());
+    if (!dump_stages.empty())
+      _putenv_s("STANLI_DUMP_STAGES", dump_stages.c_str());
+#else
+    setenv("STANLI_DUMP_PASSES", sink.c_str(), 1);
+    if (!dump_stages.empty())
+      setenv("STANLI_DUMP_STAGES", dump_stages.c_str(), 1);
+#endif
+  }
 
   std::string mir;
   try {


### PR DESCRIPTION
Seeing what one lowering pass did used to mean adding prints and rebuilding. STANLI_DUMP_PASSES=<dir> (or `-` for stdout) now writes the graph after every stage of both Lowering::run and Lowering::run_write_array, numbered so ls sorts in pass order. Diff two consecutive files and you see exactly what one pass changed. A pass that throws still leaves a FAILED-after-<stage> dump of the graph it died on. stanli_check gets --dump-passes and --dump-dir wrapping the same two environment variables, and the lit harness gets STANLI-LIT-DUMP/-CHECK/-CHECK-NEXT/-CHECK-NOT directives that assert against one stage's dump. It could previously only assert PASS/XFAIL and a result line, never the IR shape.

The hook itself is a single trace lambda plugged into Lowering::run_passes, the unified stage runner main picked up since this branch last synced, rather than a call at each pass site. write_array picks up constfold and cse dumps for free because run_passes now runs those stages there too.

The printer itself (graph_print.hpp/.cpp) keys op lines on the destination slot rather than an op index, so a pass that deletes one op removes exactly one line and leaves the rest byte-identical. That's what makes the dumps diffable. It replaces the printer that lived in dump_islands.cpp, which shrinks from 97 lines to 33 with byte-identical output on all 146 fixtures.

Two new lit cases (ark_reroll_fma, scalar_loop_reroll_collapse) use the new directives to assert the re-roll collapse; both fail under STANLI_NO_REROLL=1.

Tests: ctest 130/130 passing.
