### PR TITLE
Fix the main-only CI jobs: aarch64 density ULP and Windows manifests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -996,6 +996,9 @@ if(Python3_Interpreter_FOUND)
                    --stanc ${STANLI_STANC_EXECUTABLE}
                    --registry $<TARGET_FILE:dump_function_specs> --check
            WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+  add_test(NAME test_signature_manifests
+           COMMAND ${Python3_EXECUTABLE} tests/test_signature_manifests.py
+           WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
   add_test(NAME test_function_model_harness
            COMMAND ${Python3_EXECUTABLE} tests/test_function_models.py
            WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})

--- a/tests/function_coverage/builtin_signatures_manifest.json
+++ b/tests/function_coverage/builtin_signatures_manifest.json
@@ -10864,6 +10864,6 @@
   ],
   "registry_name_count": 209,
   "signature_dump_sha256": "06e94846cf9530eb88549fc86ac3f6b7ac9291f9d3085f5c7424f6268f08f692",
-  "stanc_build_id": "stanc3 v2.39.0-174-g8e154ac (Unix)",
+  "stanc_build_id": "stanc3 v2.39.0-174-g8e154ac",
   "tested_signature_count": 7128
 }

--- a/tests/function_coverage/density_signatures_manifest.json
+++ b/tests/function_coverage/density_signatures_manifest.json
@@ -12548,7 +12548,7 @@
   ],
   "registry_name_count": 173,
   "signature_dump_sha256": "06e94846cf9530eb88549fc86ac3f6b7ac9291f9d3085f5c7424f6268f08f692",
-  "stanc_build_id": "stanc3 v2.39.0-174-g8e154ac (Unix)",
+  "stanc_build_id": "stanc3 v2.39.0-174-g8e154ac",
   "tested_registry_name_count": 173,
   "tested_registry_names": [
     "bernoulli_cdf",

--- a/tests/test_mir_program_conformance.cpp
+++ b/tests/test_mir_program_conformance.cpp
@@ -324,7 +324,17 @@ bool same_observation(const Observation& a, const Observation& b) {
   return a.bits == b.bits;
 }
 
-bool satisfies_semantics(const Observation& got, const Observation& want) {
+int64_t ulp_distance(double a, double b) {
+  int64_t ia, ib;
+  std::memcpy(&ia, &a, sizeof ia);
+  std::memcpy(&ib, &b, sizeof ib);
+  if ((ia < 0) != (ib < 0)) return std::numeric_limits<int64_t>::max();
+  const int64_t d = ia - ib;
+  return d < 0 ? -d : d;
+}
+
+bool satisfies_semantics(const Observation& got, const Observation& want,
+                         int64_t ulps) {
   if (got.stage != want.stage || got.kind != want.kind ||
       got.value.size() != want.value.size() ||
       got.stdout_text != want.stdout_text)
@@ -337,7 +347,8 @@ bool satisfies_semantics(const Observation& got, const Observation& want) {
   for (size_t i = 0; i < want.value.size(); ++i) {
     if (std::isnan(want.value[i])) {
       if (!std::isnan(got.value[i])) return false;
-    } else if (got.bits[i] != want.bits[i]) {
+    } else if (got.bits[i] != want.bits[i] &&
+               ulp_distance(got.value[i], want.value[i]) > ulps) {
       return false;
     }
   }
@@ -345,8 +356,9 @@ bool satisfies_semantics(const Observation& got, const Observation& want) {
 }
 
 void expect_observation(const std::string& case_name, const char* path,
-                        const Observation& got, const Observation& want) {
-  if (satisfies_semantics(got, want)) return;
+                        const Observation& got, const Observation& want,
+                        int64_t ulps) {
+  if (satisfies_semantics(got, want, ulps)) return;
   ++failures;
   std::printf("FAIL %-24s %-11s got %s; Stan semantics require %s\n",
               case_name.c_str(), path, describe(got).c_str(),
@@ -357,7 +369,7 @@ void run_observation_case(const std::string& name, const char* semantics,
                           std::vector<FunDef> functions, double t,
                           Observation want,
                           const char* required_refusal = nullptr,
-                          bool required_acceptance = false) {
+                          bool required_acceptance = false, int64_t ulps = 0) {
   std::map<std::string, const FunDef*> table;
   for (const FunDef& f : functions) table[f.name] = &f;
   const FunDef& entry = functions.front();
@@ -382,8 +394,8 @@ void run_observation_case(const std::string& name, const char* semantics,
         "FAIL %-24s expected a cleared Program refusal naming %s; got %s\n",
         name.c_str(), required_refusal, describe(program.compile).c_str());
   }
-  expect_observation(name, "Program", program.outcome, want);
-  expect_observation(name, "MirInterp", interpreter, want);
+  expect_observation(name, "Program", program.outcome, want, ulps);
+  expect_observation(name, "MirInterp", interpreter, want, ulps);
   if (!same_observation(program.outcome, interpreter)) {
     ++failures;
     std::printf("FAIL %-24s path parity Program=%s; MirInterp=%s\n",
@@ -406,9 +418,10 @@ void run_case(const std::string& name, const char* semantics,
 // allowed to decline: a refusal here is a failure, not a fallback.
 void run_program_case(const std::string& name, const char* semantics,
                       std::vector<FunDef> functions, double t,
-                      std::vector<double> expected) {
+                      std::vector<double> expected, int64_t ulps = 0) {
   run_observation_case(name, semantics, std::move(functions), t,
-                       observed_values(std::move(expected)), nullptr, true);
+                       observed_values(std::move(expected)), nullptr, true,
+                       ulps);
 }
 
 void run_domain_error_case(const std::string& name, const char* semantics,
@@ -562,13 +575,14 @@ void test_discrete_densities() {
   // on an argument register, so both routes reach the graph kernel and the
   // oracle is Stan Math's own propto-OFF value.
   const Expr rate = var("t", "UReal");
+  const int64_t library_ulps = 2;
   const auto check = [&](const std::string& name, std::vector<Expr> args,
                          double expected) {
     FunDef entry = rhs_function(
         name + "_rhs",
         {return_value(make_array({fun(name, std::move(args), "UReal")}))});
     run_program_case(name, "an integer outcome reaches the same kernel",
-                     {std::move(entry)}, 0.25, {expected});
+                     {std::move(entry)}, 0.25, {expected}, library_ulps);
   };
   check("poisson_lpmf", {lit_int(3), rate},
         stan::math::poisson_lpmf<false>(3, 0.25));

--- a/tests/test_signature_manifests.py
+++ b/tests/test_signature_manifests.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+"""The committed signature manifests must regenerate identically anywhere."""
+import json
+import pathlib
+import unittest
+
+REPO = pathlib.Path(__file__).resolve().parents[1]
+MANIFESTS = ("tests/function_coverage/builtin_signatures_manifest.json",
+             "tests/function_coverage/density_signatures_manifest.json")
+
+
+def manifests():
+    for name in MANIFESTS:
+        yield name, json.loads((REPO / name).read_text())
+
+
+class SignatureManifestPortabilityTest(unittest.TestCase):
+    def test_model_paths_are_posix(self):
+        for name, manifest in manifests():
+            for model in manifest["models"]:
+                self.assertNotIn("\\", model["file"], name)
+
+    def test_build_id_names_no_host(self):
+        for name, manifest in manifests():
+            self.assertNotIn("(", manifest["stanc_build_id"], name)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/function_signature_common.py
+++ b/tools/function_signature_common.py
@@ -7,6 +7,7 @@ import json
 import os
 import math
 import pathlib
+import re
 import subprocess
 from typing import Sequence, TypeVar
 
@@ -178,15 +179,23 @@ def write_or_check(path: pathlib.Path, content: str, check: bool,
         if touch_unchanged:
             os.utime(path, None)
         return True
-    path.write_text(content)
+    with path.open("w", newline="\n") as handle:
+        handle.write(content)
     return True
 
 
 def display_path(path: pathlib.Path, root: pathlib.Path) -> str:
     try:
-        return str(path.resolve().relative_to(root.resolve()))
+        return path.resolve().relative_to(root.resolve()).as_posix()
     except ValueError:
-        return str(path.resolve())
+        return path.resolve().as_posix()
+
+
+HOST_TAG = re.compile(r" \((?:Unix|Win32|Cygwin)\)$")
+
+
+def portable_build_id(build_id: str) -> str:
+    return HOST_TAG.sub("", build_id)
 
 
 def generated_model_record(path: pathlib.Path, source: str,

--- a/tools/generate_builtin_signature_models.py
+++ b/tools/generate_builtin_signature_models.py
@@ -40,6 +40,7 @@ from function_signature_common import (  # noqa: E402
     balanced_partitions,
     generated_model_record,
     numeric_leaf_kind,
+    portable_build_id,
     registry_by_name,
     resolve_registry_spec,
     unwrap_data,
@@ -270,7 +271,7 @@ def generate(stanc: pathlib.Path, registry: pathlib.Path,
         models.append(generated_model_record(path, source, ids, ROOT))
     manifest = {
         "generator": "tools/generate_builtin_signature_models.py",
-        "stanc_build_id": inventory.stanc_build_id,
+        "stanc_build_id": portable_build_id(inventory.stanc_build_id),
         "signature_dump_sha256": inventory.raw_sha256,
         "registry_name_count": len(descriptors),
         "dumped_registry_name_count": len(dumped_names),

--- a/tools/generate_density_signature_model.py
+++ b/tools/generate_density_signature_model.py
@@ -30,6 +30,7 @@ from function_signature_common import (  # noqa: E402
     balanced_partitions,
     generated_model_record,
     numeric_leaf_kind,
+    portable_build_id,
     registry_by_name,
     resolve_registry_spec,
     unwrap_data,
@@ -443,7 +444,7 @@ def main() -> int:
     manifest = {
         "generator": "tools/generate_density_signature_model.py",
         "partial": partial,
-        "stanc_build_id": inventory.stanc_build_id,
+        "stanc_build_id": portable_build_id(inventory.stanc_build_id),
         "signature_dump_sha256": inventory.raw_sha256,
         "registry_name_count": len(registered_names),
         "tested_registry_name_count": len(tested_names),


### PR DESCRIPTION
Two jobs the pull-request matrix does not run were red on main.

On manylinux aarch64 the discrete-density conformance cases added in #326 held the Program and the interpreter to bitwise agreement with a direct stan-math call, and neg_binomial_2_lpmf lands one ulp away on that libm. The two engines still agree bitwise with each other; the oracle comparison now has the two-ulp allowance TESTING.md documents.

On win_amd64 the signature-model generation tests reported the committed manifests stale since #324. The manifests carried two platform-dependent fields: stanc3's build id, which ends in (Win32) or (Unix) from Sys.os_type, and model paths written with the native separator. Both are normalized at manifest construction and the files are written with a fixed newline. A test pins both, and the manifests changed by one line each.

The full wheels matrix ran green on this branch through workflow_dispatch: https://github.com/seantalts/stanli/actions/runs/33993903337