### PR TITLE
Warn on interpreter fallback, interruptible sampling, bracket names in R

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 ## Unreleased
 
+### A model that leaves the compiled path says so
+
+When the graph could not lower a model's transformed parameters and generated
+quantities, or the register program could not compile an ODE, DAE, algebraic
+or quadrature callback, the MIR interpreter took over that part, around a
+hundred times slower per evaluation, and nothing said so. The model now
+carries a warning that quotes the lowering's reason and asks for a bug report:
+the R package raises it with `warning()`, the Python package as a
+`RuntimeWarning`, `stanli_run` prints it to stderr, and `stanli_warnings`
+returns it from the C ABI. A model whose interpreted section fails at every
+probe point, which used to drop its columns silently, gets the same text.
+Setting `STANLI_NO_INTERPRETER=1` turns the warning into a compile error.
+
+A runtime-control region may now use 2^20 registers rather than 2^16. The
+generated quantities of `hmm_gaussian` and `iohmm_reg`, the two posteriordb
+models that reached the interpreter, lower to the graph within that and match
+the CmdStan references; their write_array row costs the same either way.
+
 ### Fixes
 
 A retained loop no longer answers a reduction from a slice's storage capacity.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ the session down. The C ABI gains `stanli_sample_multi_interruptible`, the
 progress sampler plus a poll callback asked on the calling thread about every
 100 ms; the R package uses it when the runtime provides it. (#327)
 
+### R names indexed values with brackets
+
+`model$columns`, and with it every draw, summary and diagnostic name, now
+spells an indexed value `theta[1,2]`, the form the posterior package and the
+rest of the R Stan tooling read, instead of the CSV header's `theta.1.2`.
+(#328)
+
 ### A model that leaves the compiled path says so
 
 When the graph could not lower a model's transformed parameters and generated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,15 @@ spells an indexed value `theta[1,2]`, the form the posterior package and the
 rest of the R Stan tooling read, instead of the CSV header's `theta.1.2`.
 (#328)
 
+### Python reads variables by shape
+
+The Python package spells indexed values the same way: `Model.constrained_names`,
+`Fit.names`, summaries and `optimize()` results all use bracket names now.
+`Fit` and `OptimizeResult` also index by variable name: `fit["theta"]`
+returns an array with the declared dims rather than one flat column, and
+`to_arviz()` passes those dims through to the posterior group.
+Dot names like `theta.1` are still accepted wherever a name is looked up.
+
 ### A model that leaves the compiled path says so
 
 When the graph could not lower a model's transformed parameters and generated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Unreleased
 
+### Sampling can be interrupted
+
+Ctrl-C in R, or the stop button in RStudio, now stops every chain after its
+current transition and raises the usual interrupt, on every platform. Before,
+the interrupt could only land between chains, and on Windows it could take
+the session down. The C ABI gains `stanli_sample_multi_interruptible`, the
+progress sampler plus a poll callback asked on the calling thread about every
+100 ms; the R package uses it when the runtime provides it. (#327)
+
 ### A model that leaves the compiled path says so
 
 When the graph could not lower a model's transformed parameters and generated

--- a/README.md
+++ b/README.md
@@ -133,9 +133,10 @@ NUTS (stan::mcmc::adapt_diag_e_nuts) -> draws
 
 7. **Writing draws.** A second, forward-only graph lowers the MIR's
    `generate_quantities` section and produces every CSV column CmdStan
-   would write, in CmdStan's order and under CmdStan's naming. Models
-   using unsupported/container-result RNGs or dynamic geometry still have a
-   per-draw interpreter fallback (`runtime/src/wa_interp.cpp`). Fixed-shape
+   would write, in CmdStan's order and under CmdStan's naming. A section the
+   graph cannot lower runs through the per-draw interpreter
+   (`runtime/src/wa_interp.cpp`) with a warning naming the reason;
+   `STANLI_NO_INTERPRETER=1` makes that a compile error. Fixed-shape
    draw-dependent branches, checked one-level runtime indexing, and Viterbi
    backtracking now compile, so all 119 compiling corpus models have complete,
    graph-backed write arrays.

--- a/js/worker.js
+++ b/js/worker.js
@@ -185,6 +185,10 @@ onmessage = async (e) => {
     M._free(mirPtr);
     M._free(dataPtr);
     if (!model) throw new Error(M.UTF8ToString(errPtr));
+    if (M._stanli_warnings) {
+      const note = M.UTF8ToString(M._stanli_warnings(model));
+      if (note) console.warn(note);
+    }
     const tCompile = performance.now();
 
     const n = Number(M._stanli_n_unconstrained(model));

--- a/python/README.md
+++ b/python/README.md
@@ -254,13 +254,14 @@ model = stanli.Model(stan_file="model.stan", data="data.json")
 model = stanli.Model(stan_code=src, data={"J": 8, "y": y, "sigma": sigma})
 
 model.n_unconstrained               # length of the unconstrained vector
-model.constrained_names             # ['mu', 'tau', 'theta.1', ...]
+model.constrained_names             # ['mu', 'tau', 'theta[1]', ...]
 
 lp, grad = model.log_prob_grad(q)   # sampling log density and its gradient
 
 fit = model.sample(seed=1, warmup=1000, samples=1000, delta=0.8,
                    refresh=100)
-fit["theta.1"]                      # ndarray, chains concatenated
+fit["theta"]                        # (chains*draws, 8) ndarray
+fit["theta[1]"]                     # one column, chains concatenated
 ```
 
 Pathfinder can generate one initialization per chain before NUTS. The
@@ -282,9 +283,11 @@ single-path Pathfinder does not perform PSIS resampling.
 `data` accepts a path to a JSON file or a dict of Python scalars,
 lists, and numpy arrays. `sample` returns every column CmdStan's CSV
 would carry (constrained parameters, transformed parameters, generated
-quantities, with RNG draws streamed per chain), named the way CmdStan
-names them, so `theta` declared as `vector[8]` arrives as `theta.1`
-through `theta.8`. Sampler columns (`lp__`, `divergent__`, ...) are
+quantities, with RNG draws streamed per chain); a `theta` declared as
+`vector[8]` gets columns `theta[1]` through `theta[8]`, the way CmdStanPy
+names them. Indexing by the variable name, `fit["theta"]`, returns an
+array with the declared shape; dot names like `theta.1` are still
+accepted when indexing. Sampler columns (`lp__`, `divergent__`, ...) are
 reachable by name too.
 
 ## Platforms

--- a/python/stanli/__init__.py
+++ b/python/stanli/__init__.py
@@ -14,6 +14,7 @@ import os
 import pathlib
 import subprocess
 import sys
+import warnings
 
 import numpy as np
 
@@ -141,6 +142,8 @@ def _load_lib():
     lib.stanli_wa_n_columns.argtypes = [ctypes.c_void_p]
     lib.stanli_wa_column_name.restype = ctypes.c_char_p
     lib.stanli_wa_column_name.argtypes = [ctypes.c_void_p, ctypes.c_int64]
+    lib.stanli_warnings.restype = ctypes.c_char_p
+    lib.stanli_warnings.argtypes = [ctypes.c_void_p]
     lib.stanli_wa_seed.argtypes = [ctypes.c_void_p, ctypes.c_uint32]
     lib.stanli_wa_seed_chain.argtypes = [ctypes.c_void_p, ctypes.c_uint32,
                                          ctypes.c_uint32]
@@ -739,6 +742,9 @@ class Model:
             _lib.stanli_constrained_name(self._m, i).decode()
             for i in range(n_con)
         ]
+        note = _lib.stanli_warnings(self._m)
+        if note:
+            warnings.warn(note.decode(), RuntimeWarning, stacklevel=3)
 
     def __del__(self):
         if getattr(self, "_m", None):

--- a/python/stanli/__init__.py
+++ b/python/stanli/__init__.py
@@ -12,6 +12,7 @@ import math
 import operator
 import os
 import pathlib
+import re
 import subprocess
 import sys
 import warnings
@@ -210,6 +211,70 @@ SAMPLER_COLUMNS = tuple(_lib.stanli_sampler_column_name(i).decode()
 
 def _dptr(a):
     return a.ctypes.data_as(ctypes.POINTER(ctypes.c_double))
+
+
+def _bracket(name):
+    """CmdStan's dot form to CmdStanPy's bracket form: theta.1.2 -> theta[1,2]."""
+    if "[" in name:
+        return name
+    parts = name.split(".")
+    if len(parts) < 2 or not all(p.isdigit() for p in parts[1:]):
+        return name
+    return parts[0] + "[" + ",".join(parts[1:]) + "]"
+
+
+_VARIABLE_INDEX_RE = re.compile(r"^(.+?)\[(\d+(?:,\d+)*)\]$")
+
+
+def _group_variables(names):
+    """{variable: (dims, index_array)} from bracket-form flat names.
+
+    First-appearance order. A column with no bracket suffix is a scalar
+    variable under its own name.
+    """
+    groups = {}
+    for col, name in enumerate(names):
+        m = _VARIABLE_INDEX_RE.match(name)
+        if m is None:
+            base, idx = name, ()
+        else:
+            base = m.group(1)
+            idx = tuple(int(i) - 1 for i in m.group(2).split(","))
+        groups.setdefault(base, []).append((idx, col))
+
+    out = {}
+    for base, entries in groups.items():
+        ndim = len(entries[0][0])
+        if ndim == 0:
+            out[base] = ((), np.array(entries[0][1], dtype=np.int64))
+            continue
+        if any(len(idx) != ndim for idx, _ in entries):
+            for _, col in entries:
+                out[names[col]] = ((), np.array(col, dtype=np.int64))
+            continue
+        dims = tuple(max(idx[d] for idx, _ in entries) + 1
+                     for d in range(ndim))
+        arr = np.full(dims, -1, dtype=np.int64)
+        for idx, col in entries:
+            arr[idx] = col
+        if (arr >= 0).all() and arr.size == len(entries):
+            out[base] = (dims, arr)
+        else:
+            for _, col in entries:
+                out[names[col]] = ((), np.array(col, dtype=np.int64))
+    return out
+
+
+def _resolve(name, variables, columns):
+    """(dims, index_array) for a variable, flat bracket, or dot name."""
+    if name in variables:
+        return variables[name]
+    bracketed = _bracket(name)
+    if bracketed in variables:
+        return variables[bracketed]
+    if bracketed in columns:
+        return (), np.array(columns[bracketed], dtype=np.int64)
+    raise ValueError(f"{name!r} is not a column or variable of this fit")
 
 
 _PATHFINDER_INIT_DEFAULTS = {
@@ -505,7 +570,9 @@ class Summary:
         return len(self.names)
 
     def __getitem__(self, name):
-        """The row for one parameter, as a dict."""
+        """The row for one parameter, as a dict. Dot names are also accepted."""
+        if name not in self.names:
+            name = _bracket(name)
         i = self.names.index(name)
         return {k: self.stats[i, j] for j, k in enumerate(_SUMMARY_STATS)}
 
@@ -534,11 +601,13 @@ class Summary:
 class Fit:
     """Draws from one sampling run, plus the sampler's own diagnostics.
 
-    Indexing by name gives every draw of that column with the chains
-    concatenated, which is what an estimate wants and what ``sample()``
-    returned before it grew chains::
+    Indexing by name gives every draw with the chains concatenated, which
+    is what an estimate wants and what ``sample()`` returned before it grew
+    chains::
 
         fit["mu"].mean()
+        fit["theta"]        # (chains*draws, 8), the declared shape
+        fit["theta[1]"]     # (chains*draws,), one column
 
     ``fit.draws("mu")`` keeps the chain axis -- shape (chains, draws) --
     which is what a trace plot or a per-chain check wants.
@@ -547,6 +616,8 @@ class Fit:
     def __init__(self, names, draws, sampler_stats, max_depth, seed,
                  reports=None):
         self.names = list(names)
+        self._columns = {n: i for i, n in enumerate(self.names)}
+        self._variables = _group_variables(self.names)
         self._draws = draws               # (chains, draws, cols)
         self.sampler_stats = sampler_stats  # (chains, draws, 7)
         self.max_depth = max_depth
@@ -567,23 +638,35 @@ class Fit:
     def n_draws(self):
         return self._draws.shape[1]
 
+    @property
+    def variables(self):
+        """{name: dims} for every declared variable, in declaration order."""
+        return {name: dims for name, (dims, idx) in self._variables.items()}
+
     def draws(self, name=None):
-        """(chains, draws) for one column, or (chains, draws, cols) for all."""
+        """(chains, draws, *dims) for one variable, or all columns if None.
+
+        A scalar variable, or a flat or dot column name, keeps the plain
+        (chains, draws) shape.
+        """
         if name is None:
             return self._draws
-        return self._draws[:, :, self.names.index(name)]
+        _, idx = _resolve(name, self._variables, self._columns)
+        return self._draws[:, :, idx]
 
     def __getitem__(self, name):
-        """Every draw of one column, chains concatenated.
+        """Every draw of one variable or column, chains concatenated.
 
-        Sampler columns (lp__, divergent__, ...) are reachable by name
-        here too, so `fit["lp__"]` works the way a CSV reader would
+        A variable name keeps its declared shape; a flat or dot name gives
+        one column. Sampler columns (lp__, divergent__, ...) are reachable
+        by name here too, so `fit["lp__"]` works the way a CSV reader would
         expect even though they are not posterior columns.
         """
         if name in SAMPLER_COLUMNS:
             col = SAMPLER_COLUMNS.index(name)
             return self.sampler_stats[:, :, col].reshape(-1)
-        return self._draws[:, :, self.names.index(name)].reshape(-1)
+        dims, idx = _resolve(name, self._variables, self._columns)
+        return self._draws[:, :, idx].reshape(-1, *dims)
 
     # The dict protocol the pre-chains API returned, so `fit["mu"]` and
     # `for k, v in fit.items()` keep working unchanged.
@@ -603,7 +686,11 @@ class Fit:
         return len(self.names)
 
     def __contains__(self, name):
-        return name in self.names
+        try:
+            _resolve(name, self._variables, self._columns)
+        except ValueError:
+            return False
+        return True
 
     @property
     def divergences(self):
@@ -644,9 +731,18 @@ class Fit:
             return np.where(den > 0, num / den, np.nan)
 
     def summary(self, params=None):
-        """Per-parameter summary. `params` selects columns by name."""
-        cols = (list(range(len(self.names))) if params is None
-                else [self.names.index(p) for p in params])
+        """Per-parameter summary. `params` selects columns by name.
+
+        Each entry in `params` may be a variable, flat, or dot name; a
+        variable name expands to all of its columns in column order.
+        """
+        if params is None:
+            cols = list(range(len(self.names)))
+        else:
+            cols = []
+            for p in params:
+                _, idx = _resolve(p, self._variables, self._columns)
+                cols.extend(int(c) for c in np.atleast_1d(idx).flatten("F"))
         sub = np.ascontiguousarray(self._draws[:, :, cols], dtype=np.float64)
         n_chains, n_draws, n_cols = sub.shape
         out = np.empty((n_cols, _N_SUMMARY_STATS))
@@ -682,7 +778,7 @@ class Fit:
         arviz is not a dependency; this raises ImportError without it.
         """
         import arviz as az
-        posterior = {n: self._draws[:, :, i] for i, n in enumerate(self.names)}
+        posterior = {var: self.draws(var) for var in self.variables}
         stats = {n.rstrip("_"): self.sampler_stats[:, :, i]
                  for i, n in enumerate(SAMPLER_COLUMNS)}
         return az.from_dict(posterior=posterior, sample_stats=stats)
@@ -697,9 +793,43 @@ class OptimizeResult(dict):
 
     A dict so `result["mu"]` reads the way a draw does, with the
     unconstrained point and lp attached for handing to `sample(inits=)`.
+    A variable name instead returns an array with its declared shape, e.g.
+    `result["theta"]` for a `vector[8]`; flat and dot names still give a
+    single float.
     """
     unconstrained = None
     lp = None
+
+    def __init__(self, data):
+        super().__init__(data)
+        self._names = list(data)
+        self._columns = {n: i for i, n in enumerate(self._names)}
+        self._variables = _group_variables(self._names)
+
+    @property
+    def variables(self):
+        """{name: dims} for every declared variable, in declaration order."""
+        return {name: dims for name, (dims, idx) in self._variables.items()}
+
+    def __missing__(self, key):
+        try:
+            dims, idx = _resolve(key, self._variables, self._columns)
+        except ValueError:
+            raise KeyError(key) from None
+        if dims == ():
+            return self[self._names[int(idx)]]
+        cols = idx.flatten("F")
+        return np.array([self[self._names[int(c)]] for c in cols]) \
+            .reshape(dims)
+
+    def __contains__(self, key):
+        if super().__contains__(key):
+            return True
+        try:
+            _resolve(key, self._variables, self._columns)
+        except ValueError:
+            return False
+        return True
 
 
 class Model:
@@ -739,7 +869,7 @@ class Model:
         self.n_unconstrained = _lib.stanli_n_unconstrained(self._m)
         n_con = _lib.stanli_n_constrained(self._m)
         self.constrained_names = [
-            _lib.stanli_constrained_name(self._m, i).decode()
+            _bracket(_lib.stanli_constrained_name(self._m, i).decode())
             for i in range(n_con)
         ]
         note = _lib.stanli_warnings(self._m)
@@ -801,7 +931,7 @@ class Model:
         """
         n_wa = _lib.stanli_wa_n_columns(self._m)
         if n_wa > 0:
-            return [_lib.stanli_wa_column_name(self._m, i).decode()
+            return [_bracket(_lib.stanli_wa_column_name(self._m, i).decode())
                     for i in range(n_wa)], True
         return list(self.constrained_names), False
 

--- a/r/R/stanli.R
+++ b/r/R/stanli.R
@@ -50,7 +50,11 @@ read_utf8_file <- function(path) {
 #' @param data A named list of data, or a path to a JSON data file.
 #' @param mir Transformed MIR text, for a build without the embedded
 #'   compiler. Rarely needed.
-#' @return An object of class `stanli_model`.
+#' @return An object of class `stanli_model`. Warns, naming the part and the
+#'   reason, when part of the model has no compiled path and runs through
+#'   the much slower MIR interpreter; with the environment variable
+#'   `STANLI_NO_INTERPRETER` set that is an error instead. Either message is
+#'   what to include in a bug report.
 #' @export
 stanli_model <- function(file = NULL, code = NULL, data = NULL, mir = NULL) {
   load_runtime()
@@ -77,6 +81,8 @@ stanli_model <- function(file = NULL, code = NULL, data = NULL, mir = NULL) {
   }
   ptr <- .Call("stanli_r_model_new", if (is_mir) mir else code, data_json,
                is_mir)
+  note <- .Call("stanli_r_warnings", ptr)
+  if (nzchar(note)) warning(note, call. = FALSE)
   structure(list(ptr = ptr,
                  n_unconstrained = .Call("stanli_r_n_unconstrained", ptr),
                  columns = .Call("stanli_r_column_names", ptr)),

--- a/r/R/stanli.R
+++ b/r/R/stanli.R
@@ -50,7 +50,9 @@ read_utf8_file <- function(path) {
 #' @param data A named list of data, or a path to a JSON data file.
 #' @param mir Transformed MIR text, for a build without the embedded
 #'   compiler. Rarely needed.
-#' @return An object of class `stanli_model`. Warns, naming the part and the
+#' @return An object of class `stanli_model` whose `columns` name every
+#'   output the way the posterior package reads them, `theta[1,2]` for an
+#'   indexed value. Warns, naming the part and the
 #'   reason, when part of the model has no compiled path and runs through
 #'   the much slower MIR interpreter; with the environment variable
 #'   `STANLI_NO_INTERPRETER` set that is an error instead. Either message is
@@ -85,8 +87,18 @@ stanli_model <- function(file = NULL, code = NULL, data = NULL, mir = NULL) {
   if (nzchar(note)) warning(note, call. = FALSE)
   structure(list(ptr = ptr,
                  n_unconstrained = .Call("stanli_r_n_unconstrained", ptr),
-                 columns = .Call("stanli_r_column_names", ptr)),
+                 columns = stan_variable_names(
+                   .Call("stanli_r_column_names", ptr))),
             class = "stanli_model")
+}
+
+stan_variable_names <- function(x) {
+  vapply(strsplit(x, ".", fixed = TRUE), function(parts) {
+    if (length(parts) > 1L && all(grepl("^[0-9]+$", parts[-1L])))
+      paste0(parts[1L], "[", paste(parts[-1L], collapse = ","), "]")
+    else
+      paste(parts, collapse = ".")
+  }, character(1))
 }
 
 #' @export

--- a/r/R/stanli.R
+++ b/r/R/stanli.R
@@ -160,6 +160,9 @@ unconstrain <- function(model, values) {
 #' @param refresh Print a progress update every `refresh` transitions within
 #'   each phase, plus the first and last transition of the phase. Set to 0 to
 #'   suppress all automatic sampling output.
+#' @details Interrupting R (Ctrl-C, or the stop button in RStudio) stops
+#'   every chain after its current transition and raises the usual
+#'   interrupt; no fit is returned.
 #' @return An object of class `stanli_fit`. Its `report` element contains
 #'   per-chain warmup and sampling times plus exact divergence and
 #'   maximum-treedepth counts. With a compatible older runtime that predates
@@ -208,6 +211,12 @@ sample_model <- function(model, chains = 4, seed = 1, warmup = 1000,
                as.integer(max_depth), isTRUE(save_warmup),
                as.double(init_radius), as.integer(parallel_chains))
   res <- .Call("stanli_r_sample", model$ptr, opts, init_vec, refresh)
+  if (isTRUE(res$interrupted)) {
+    signalCondition(structure(class = c("interrupt", "condition"),
+                              list(message = "sampling interrupted",
+                                   call = NULL)))
+    invokeRestart("abort")
+  }
 
   nchain <- res$chains
   ndraw <- res$draws

--- a/r/man/sample_model.Rd
+++ b/r/man/sample_model.Rd
@@ -66,3 +66,8 @@ Four chains by default, run in parallel: R-hat needs more than one
 chain, and a single-chain run cannot be checked for convergence at
 all. Chain `c` uses CmdStan's stream for `(seed, chain id c + 1)`.
 }
+\details{
+Interrupting R (Ctrl-C, or the stop button in RStudio) stops
+  every chain after its current transition and raises the usual
+  interrupt; no fit is returned.
+}

--- a/r/man/stanli_model.Rd
+++ b/r/man/stanli_model.Rd
@@ -17,7 +17,11 @@ stanli_model(file = NULL, code = NULL, data = NULL, mir = NULL)
 compiler. Rarely needed.}
 }
 \value{
-An object of class `stanli_model`.
+An object of class `stanli_model`. Warns, naming the part and the
+  reason, when part of the model has no compiled path and runs through
+  the much slower MIR interpreter; with the environment variable
+  `STANLI_NO_INTERPRETER` set that is an error instead. Either message is
+  what to include in a bug report.
 }
 \description{
 Compile a Stan model

--- a/r/man/stanli_model.Rd
+++ b/r/man/stanli_model.Rd
@@ -17,7 +17,9 @@ stanli_model(file = NULL, code = NULL, data = NULL, mir = NULL)
 compiler. Rarely needed.}
 }
 \value{
-An object of class `stanli_model`. Warns, naming the part and the
+An object of class `stanli_model` whose `columns` name every
+  output the way the posterior package reads them, `theta[1,2]` for an
+  indexed value. Warns, naming the part and the
   reason, when part of the model has no compiled path and runs through
   the much slower MIR interpreter; with the environment variable
   `STANLI_NO_INTERPRETER` set that is an error instead. Either message is

--- a/r/src/bridge.c
+++ b/r/src/bridge.c
@@ -93,6 +93,7 @@ typedef struct {
 typedef void (*stanli_sample_progress_cb)(int32_t, int64_t, int64_t, int32_t,
                                           void*);
 typedef void (*stanli_path_cb)(int32_t, double, void*);
+typedef int (*stanli_sample_poll_cb)(void*);
 
 typedef struct {
   uint32_t seed;
@@ -134,6 +135,12 @@ static int (*p_sample_multi_progress)(void*, const stanli_sample_opts*, int,
                                       double*, double*,
                                       stanli_sample_progress_cb, void*,
                                       stanli_sample_report*, char*, size_t);
+static int (*p_sample_multi_interruptible)(void*, const stanli_sample_opts*,
+                                           int, double*, double*,
+                                           stanli_sample_progress_cb, void*,
+                                           stanli_sample_poll_cb, void*, int*,
+                                           stanli_sample_report*, char*,
+                                           size_t);
 static int (*p_pathfinder_inits)(void*, uint32_t, int, int, int, int, int,
                                  double, double*, stanli_path_cb, void*, char*,
                                  size_t);
@@ -216,6 +223,8 @@ SEXP stanli_bridge_load(SEXP path) {
    * than making an optional feature prevent the library loading. */
   *(void**)(&p_sample_multi_progress) =
       dl_sym(g_lib, "stanli_sample_multi_progress");
+  *(void**)(&p_sample_multi_interruptible) =
+      dl_sym(g_lib, "stanli_sample_multi_interruptible");
   /* Pathfinder initialization is also additive. Only callers that request it
    * require a runtime new enough to provide the symbol. */
   *(void**)(&p_pathfinder_inits) = dl_sym(g_lib, "stanli_pathfinder_inits");
@@ -398,6 +407,20 @@ static void sample_progress(int32_t chain_id, int64_t iteration, int64_t total,
   R_FlushConsole();
 }
 
+static void check_interrupt(void* unused) {
+  (void)unused;
+  R_CheckUserInterrupt();
+}
+
+/* A pending interrupt would longjmp straight through the runtime's C++
+ * frames. R_ToplevelExec catches it instead and answers FALSE, which the
+ * runtime turns into a stop; the R side raises the interrupt again once the
+ * sampler has returned. */
+static int sample_poll(void* user) {
+  (void)user;
+  return R_ToplevelExec(check_interrupt, NULL) ? 0 : 1;
+}
+
 static void print_sample_reports(const stanli_sample_opts* o, int64_t nchain,
                                  const stanli_sample_report* reports) {
   int64_t n_divergent = 0;
@@ -488,8 +511,14 @@ SEXP stanli_r_sample(SEXP m, SEXP optlist, SEXP inits, SEXP refresh) {
         "stanli_install(overwrite = TRUE) to update.\n");
     R_FlushConsole();
   }
+  int interrupted = 0;
   const int failed =
-      have_reports
+      p_sample_multi_interruptible != NULL
+          ? p_sample_multi_interruptible(
+                mm, &o, refresh_rate, REAL(raw), REAL(stats),
+                refresh_rate > 0 ? sample_progress : NULL, NULL, sample_poll,
+                NULL, &interrupted, reports, err, sizeof err)
+      : have_reports
           ? p_sample_multi_progress(mm, &o, refresh_rate, REAL(raw),
                                     REAL(stats),
                                     refresh_rate > 0 ? sample_progress : NULL,
@@ -499,6 +528,13 @@ SEXP stanli_r_sample(SEXP m, SEXP optlist, SEXP inits, SEXP refresh) {
     UNPROTECT(2);
     error("%d of %d chains failed; first: %s", failed, (int)nchain,
           err[0] ? err : "(no message)");
+  }
+  if (interrupted) {
+    const char* names[] = {"interrupted", ""};
+    SEXP out = PROTECT(mkNamed(VECSXP, names));
+    SET_VECTOR_ELT(out, 0, ScalarLogical(1));
+    UNPROTECT(3);
+    return out;
   }
   if (have_reports && refresh_rate > 0)
     print_sample_reports(&o, nchain, reports);

--- a/r/src/bridge.c
+++ b/r/src/bridge.c
@@ -147,6 +147,7 @@ static int64_t (*p_wa_n_columns)(const void*);
 static const char* (*p_wa_column_name)(const void*, int64_t);
 static void (*p_wa_seed_chain)(void*, uint32_t, uint32_t);
 static int (*p_wa_row)(void*, const double*, double*);
+static const char* (*p_warnings)(const void*);
 static void (*p_optimize_opts_init)(stanli_optimize_opts*);
 static int (*p_optimize)(void*, const stanli_optimize_opts*, double*, double*,
                          double*, char*, size_t);
@@ -225,6 +226,7 @@ SEXP stanli_bridge_load(SEXP path) {
   BIND("stanli_wa_column_name", p_wa_column_name);
   BIND("stanli_wa_seed_chain", p_wa_seed_chain);
   BIND("stanli_wa_row", p_wa_row);
+  *(void**)(&p_warnings) = dl_sym(g_lib, "stanli_warnings");
   BIND("stanli_optimize_opts_init", p_optimize_opts_init);
   BIND("stanli_optimize", p_optimize);
   return mkString("");
@@ -308,6 +310,13 @@ SEXP stanli_r_column_names(SEXP m) {
   }
   UNPROTECT(1);
   return out;
+}
+
+SEXP stanli_r_warnings(SEXP m) {
+  require_loaded();
+  if (p_warnings == NULL) return mkString("");
+  const char* s = p_warnings(model_ptr(m));
+  return mkString(s ? s : "");
 }
 
 SEXP stanli_r_unconstrain_inits(SEXP m, SEXP json) {

--- a/r/src/init.c
+++ b/r/src/init.c
@@ -12,6 +12,7 @@ extern SEXP stanli_r_exact_lp(void);
 extern SEXP stanli_r_thread_safe(void);
 extern SEXP stanli_r_n_unconstrained(SEXP);
 extern SEXP stanli_r_column_names(SEXP);
+extern SEXP stanli_r_warnings(SEXP);
 extern SEXP stanli_r_grad(SEXP, SEXP);
 extern SEXP stanli_r_unconstrain_inits(SEXP, SEXP);
 extern SEXP stanli_r_pathfinder_inits(SEXP, SEXP, SEXP, SEXP);
@@ -30,6 +31,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"stanli_r_thread_safe", (DL_FUNC)&stanli_r_thread_safe, 0},
     {"stanli_r_n_unconstrained", (DL_FUNC)&stanli_r_n_unconstrained, 1},
     {"stanli_r_column_names", (DL_FUNC)&stanli_r_column_names, 1},
+    {"stanli_r_warnings", (DL_FUNC)&stanli_r_warnings, 1},
     {"stanli_r_grad", (DL_FUNC)&stanli_r_grad, 2},
     {"stanli_r_unconstrain_inits", (DL_FUNC)&stanli_r_unconstrain_inits, 2},
     {"stanli_r_pathfinder_inits", (DL_FUNC)&stanli_r_pathfinder_inits, 4},

--- a/r/tests/testthat/test-sampling.R
+++ b/r/tests/testthat/test-sampling.R
@@ -30,7 +30,22 @@ test_that("a model compiles and reports its shape", {
   m <- es_model()
   expect_s3_class(m, "stanli_model")
   expect_equal(m$n_unconstrained, 10L)
-  expect_true(all(c("mu", "tau", "theta.1") %in% m$columns))
+  expect_true(all(c("mu", "tau", "theta[1]") %in% m$columns))
+})
+
+test_that("columns index with brackets the way posterior reads them", {
+  skip_without_runtime()
+  m <- stanli_model(code = "
+    parameters { real s; vector[2] v; matrix[2, 3] M; }
+    model { s ~ std_normal(); v ~ std_normal(); to_vector(M) ~ std_normal(); }")
+  expect_equal(m$columns, c("s", "v[1]", "v[2]", "M[1,1]", "M[2,1]",
+                            "M[1,2]", "M[2,2]", "M[1,3]", "M[2,3]"))
+  fit <- sample_model(m, chains = 1, warmup = 20, samples = 5, refresh = 0)
+  expect_equal(dimnames(fit$draws)[[3]], m$columns)
+  skip_if_not_installed("posterior")
+  rv <- posterior::as_draws_rvars(as_draws_array(fit))
+  expect_equal(dim(rv$M), c(2L, 3L))
+  expect_equal(length(rv$v), 2L)
 })
 
 test_that("log_prob_grad returns lp and a gradient of the right length", {

--- a/r/tests/testthat/test-sampling.R
+++ b/r/tests/testthat/test-sampling.R
@@ -285,3 +285,22 @@ test_that("data reaches the model in the right shape", {
   g <- log_prob_grad(m, c(0.1, 0.2, 0.3))
   expect_true(is.finite(g$lp))
 })
+
+test_that("a part with no compiled path warns, or errors when refused", {
+  skip_without_runtime()
+  code <- "
+    parameters { real mu; }
+    model { mu ~ normal(0, 1); }
+    generated quantities {
+      real s = 0;
+      if (mu > 0) {
+        matrix[1100, 1000] big = rep_matrix(mu, 1100, 1000);
+        s = big[1, 1];
+      }
+    }"
+  expect_warning(stanli_model(code = code), "interpreter")
+  expect_warning(es_model(), NA)
+  Sys.setenv(STANLI_NO_INTERPRETER = "1")
+  on.exit(Sys.unsetenv("STANLI_NO_INTERPRETER"), add = TRUE)
+  expect_error(stanli_model(code = code), "STANLI_NO_INTERPRETER")
+})

--- a/runtime/include/stanli/capi.h
+++ b/runtime/include/stanli/capi.h
@@ -201,6 +201,20 @@ int stanli_sample_multi_progress(
     double* stats, stanli_sample_progress_cb progress, void* progress_user,
     stanli_sample_report* reports, char* err, size_t err_len);
 
+/* Asked on the calling thread about every 100 ms while chains run. A nonzero
+ * answer stops every chain after its current transition. */
+typedef int (*stanli_sample_poll_cb)(void* user);
+
+/* stanli_sample_multi_progress plus cooperative interruption. A stopped run
+ * returns 0 with `*interrupted` set to 1 and only the rows stored before the
+ * stop written; the binding raises its language's interrupt from that. `poll`
+ * and `interrupted` may be null. Additive, like the progress entry point. */
+int stanli_sample_multi_interruptible(
+    stanli_model* m, const stanli_sample_opts* opts, int refresh, double* draws,
+    double* stats, stanli_sample_progress_cb progress, void* progress_user,
+    stanli_sample_poll_cb poll, void* poll_user, int* interrupted,
+    stanli_sample_report* reports, char* err, size_t err_len);
+
 /* The seven sampler columns, in order: lp__, accept_stat__, stepsize__,
  * treedepth__, n_leapfrog__, divergent__, energy__. */
 #define STANLI_N_SAMPLER_COLS 7

--- a/runtime/include/stanli/capi.h
+++ b/runtime/include/stanli/capi.h
@@ -398,6 +398,10 @@ const char* stanli_wa_column_name(const stanli_model* m, int64_t i);
 void stanli_wa_seed(stanli_model* m, uint32_t seed);
 void stanli_wa_seed_chain(stanli_model* m, uint32_t seed, uint32_t chain);
 int stanli_wa_row(stanli_model* m, const double* q, double* out);
+/* Empty unless parts of the model have no compiled path and run through
+ * the MIR interpreter. Then a message to show once per model: which parts,
+ * why, and where to report it. Owned by the model. */
+const char* stanli_warnings(const stanli_model* m);
 
 #ifdef __cplusplus
 }

--- a/runtime/include/stanli/compile.hpp
+++ b/runtime/include/stanli/compile.hpp
@@ -209,9 +209,19 @@ struct CompiledModel {
     std::string truncated;
   };
   std::optional<TransformInits> transform_inits;
+  // Each part of the model that has no compiled path and would run through
+  // the MIR interpreter, with the lowering's reason.
+  std::vector<std::string> interpreter_fallbacks;
 };
 
 CompiledModel compile_model(const std::string& mir_text, const DataMap& data);
+
+// The warning a host shows once per model with interpreter_fallbacks, and
+// the compile error STANLI_NO_INTERPRETER turns it into. `probe_failure` is
+// what the interpreter threw when a host probed it.
+std::string interpreter_error(const CompiledModel& cm);
+std::string interpreter_warning(const CompiledModel& cm,
+                                const std::string& probe_failure = "");
 
 }  // namespace stanli
 

--- a/runtime/include/stanli/mir_prog.hpp
+++ b/runtime/include/stanli/mir_prog.hpp
@@ -217,11 +217,10 @@ struct ProgramCompiler {
     int_decl_at.erase(name);
   }
 
-  // Registers are never recycled. Right-hand sides are a few lines over a
-  // handful of states, so the count stays in the dozens; the cap is a
-  // backstop against a pathological unroll, and trips into the interpreter
-  // rather than into a huge allocation.
-  static constexpr int kMaxRegs = 1 << 16;
+  // Registers are never recycled, so an unrolled generated-quantities
+  // region over a long series (hmm_gaussian, T=500) needs well over 2^16.
+  // The cap is a backstop against a pathological unroll.
+  static constexpr int kMaxRegs = 1 << 20;
 
   [[noreturn]] void bail(const std::string& why) { throw Bail{why}; }
 

--- a/runtime/include/stanli/nuts.hpp
+++ b/runtime/include/stanli/nuts.hpp
@@ -4,6 +4,7 @@
 #include <stanli/graph.hpp>
 
 #include <array>
+#include <atomic>
 #include <cstdint>
 #include <functional>
 #include <memory>
@@ -45,6 +46,12 @@ struct NutsConfig {
   // (CompiledModel::transform_inits), rather than teaching every sampler
   // entry point a second kind of start.
   const double* init = nullptr;
+  // Cooperative interruption. A chain reads `stop` before every transition
+  // and returns the draws it has once it is set. `poll`, when present, is
+  // asked on the chain's own thread about every 100 ms; a true answer sets
+  // `stop` and ends the run.
+  std::atomic<bool>* stop = nullptr;
+  std::function<bool()> poll;
 };
 
 // One row per stored draw, in CmdStan's column order:
@@ -67,6 +74,7 @@ struct SamplingReport {
   double sampling_seconds = 0;
   int64_t n_divergent = 0;
   int64_t n_max_treedepth = 0;
+  bool interrupted = false;
 };
 
 // Optional per-transition observer for streaming consumers (the browser
@@ -129,10 +137,14 @@ bool thread_safe_build();
 // n_threads <= 1 runs sequentially. Larger values are honoured only on a
 // thread_safe_build(); elsewhere they are clamped to 1, because the
 // alternative is a wrong answer rather than a slow one.
+//
+// `poll` is asked on the calling thread about every 100 ms; a true answer
+// stops every chain after its current transition.
 std::vector<ChainResult> run_nuts_chains(
     const std::vector<Executor*>& execs, const NutsConfig& cfg,
     int n_threads = 1, const DrawObserver& observe = {},
-    const ChainProgressObserver& progress = {}, int progress_refresh = 1);
+    const ChainProgressObserver& progress = {}, int progress_refresh = 1,
+    const std::function<bool()>& poll = {});
 
 // Build `n` executors over the same compiled graph, copying it out of an
 // already-bound one. The caller keeps ownership; `src` is not modified.

--- a/runtime/src/bridgestan_abi.cpp
+++ b/runtime/src/bridgestan_abi.cpp
@@ -330,6 +330,7 @@ bs_model* bs_model_from_mir(const char* mir, const char* data,
     m->cm.bind(*m->ex);
     m->pool.reset(new stanli::ExecutorPool(*m->ex));
 
+    std::string probe_failure;
     if (m->cm.write_array) {
       auto& wa = *m->cm.write_array;
       if (wa.interp) {
@@ -352,10 +353,12 @@ bs_model* bs_model_from_mir(const char* mir, const char* data,
             lease->run_forward_only();
             (void)m->wa_interp->eval(m->cm.constrained_env(*lease), probe);
             found = true;
-          } catch (const std::exception&) {
+          } catch (const std::exception& e) {
+            probe_failure = e.what();
           }
         }
         if (found) {
+          probe_failure.clear();
           m->cols = m->wa_interp->columns();
           m->n_tp_start = m->wa_interp->n_tp_start();
           m->n_gq_start = m->wa_interp->n_gq_start();
@@ -370,6 +373,11 @@ bs_model* bs_model_from_mir(const char* mir, const char* data,
         m->n_tp_start = wa.n_tp_start;
         m->n_gq_start = wa.n_gq_start;
       }
+    }
+    {
+      const std::string note =
+          stanli::interpreter_warning(m->cm, probe_failure);
+      if (!note.empty()) stanli::emit_message(note);
     }
     if (m->cols.empty()) {
       // No write_array (or none that could be evaluated): the constrained

--- a/runtime/src/capi.cpp
+++ b/runtime/src/capi.cpp
@@ -60,6 +60,7 @@ struct stanli_model {
   // Seeded rather than default-constructed so a caller who never calls
   // stanli_wa_seed still gets the same rows every run.
   stanli::WaRng wa_rng{1};
+  std::string warnings;
 };
 
 namespace {
@@ -88,6 +89,7 @@ stanli_model* stanli_model_new(const char* tmir_sexp, const char* data_json,
     m->cm.bind(*m->ex);
     for (const auto& v : m->cm.views) m->n_con += v.len;
     m->flat_names = stanli::CompiledModel::csv_names(m->cm.views);
+    std::string probe_failure;
     if (m->cm.write_array) {
       auto& wa = *m->cm.write_array;
       if (wa.interp) {
@@ -111,10 +113,14 @@ stanli_model* stanli_model_new(const char* tmir_sexp, const char* data_json,
             m->wa_gq_start = scalar_column_start(m->wa_interp->columns(),
                                                  m->wa_interp->n_gq_start());
             found = true;
-          } catch (const std::exception&) {
+          } catch (const std::exception& e) {
+            probe_failure = e.what();
           }
         }
-        if (!found) m->wa_interp.reset();
+        if (found)
+          probe_failure.clear();
+        else
+          m->wa_interp.reset();
       } else if (!wa.columns.empty()) {
         m->wa_ex = std::make_unique<stanli::Executor>(std::move(wa.graph));
         wa.bind(*m->wa_ex);
@@ -124,6 +130,7 @@ stanli_model* stanli_model_new(const char* tmir_sexp, const char* data_json,
         m->wa_gq_start = scalar_column_start(wa.columns, wa.n_gq_start);
       }
     }
+    m->warnings = stanli::interpreter_warning(m->cm, probe_failure);
     return m.release();
   } catch (const std::exception& e) {
     put_err(err, err_len, e.what());
@@ -739,6 +746,10 @@ const char* stanli_constrained_name(const stanli_model* m, int64_t i) {
 }
 
 int64_t stanli_wa_n_columns(const stanli_model* m) { return m->wa_n; }
+
+const char* stanli_warnings(const stanli_model* m) {
+  return m->warnings.c_str();
+}
 
 int64_t stanli_wa_n_generated_start(const stanli_model* m) {
   return m->wa_n > 0 ? m->wa_gq_start : 0;

--- a/runtime/src/capi.cpp
+++ b/runtime/src/capi.cpp
@@ -12,6 +12,7 @@
 #include "build_id.hpp"
 
 #include <algorithm>
+#include <atomic>
 #include <cmath>
 #include <cstdlib>
 #include <cstring>
@@ -505,7 +506,18 @@ int stanli_sample_multi_progress(
     stanli_model* m, const stanli_sample_opts* opts, int refresh, double* draws,
     double* stats, stanli_sample_progress_cb progress, void* progress_user,
     stanli_sample_report* reports, char* err, size_t err_len) {
+  return stanli_sample_multi_interruptible(
+      m, opts, refresh, draws, stats, progress, progress_user, nullptr, nullptr,
+      nullptr, reports, err, err_len);
+}
+
+int stanli_sample_multi_interruptible(
+    stanli_model* m, const stanli_sample_opts* opts, int refresh, double* draws,
+    double* stats, stanli_sample_progress_cb progress, void* progress_user,
+    stanli_sample_poll_cb poll, void* poll_user, int* interrupted,
+    stanli_sample_report* reports, char* err, size_t err_len) {
   try {
+    if (interrupted != nullptr) *interrupted = 0;
     if (opts == nullptr) {
       put_err(err, err_len, "null options");
       return 1;
@@ -549,11 +561,16 @@ int stanli_sample_multi_progress(
       };
     }
 
+    std::function<bool()> poll_fn;
+    if (poll != nullptr)
+      poll_fn = [poll, poll_user] { return poll(poll_user) != 0; };
+
     std::vector<stanli::ChainResult> res;
     if (opts->inits == nullptr) {
       res = stanli::run_nuts_chains(execs, cfg, opts->num_threads, {},
-                                    progress_observer, refresh);
+                                    progress_observer, refresh, poll_fn);
     } else {
+      std::atomic<bool> stop{false};
       // Per-chain inits mean per-chain configs, which run_nuts_chains
       // does not take (it varies only the chain id). Run them one at a
       // time; explicit inits are a debugging and Pathfinder-handoff path,
@@ -563,6 +580,8 @@ int stanli_sample_multi_progress(
         stanli::NutsConfig cc = cfg;
         cc.chain_id = cfg.chain_id + c;
         cc.init = opts->inits + (int64_t)c * n;
+        cc.stop = &stop;
+        cc.poll = poll_fn;
         try {
           stanli::ProgressObserver one_progress;
           if (progress_observer)
@@ -589,6 +608,7 @@ int stanli_sample_multi_progress(
         reports[c].n_divergent = r.report.n_divergent;
         reports[c].n_max_treedepth = r.report.n_max_treedepth;
       }
+      if (interrupted != nullptr && r.report.interrupted) *interrupted = 1;
       if (!r.error.empty()) {
         if (failed++ == 0)
           first_error =

--- a/runtime/src/lower.cpp
+++ b/runtime/src/lower.cpp
@@ -1,5 +1,7 @@
 #include "lower_internal.hpp"
 
+#include "build_id.hpp"
+
 namespace stanli {
 namespace lower_detail {
 
@@ -783,6 +785,28 @@ CompiledModel Lowering::run(const mir::Program& p) {
 
 using namespace lower_detail;
 
+namespace {
+
+void add_interpreter_fallback(CompiledModel& cm, const std::string& note) {
+  auto& all = cm.interpreter_fallbacks;
+  if (std::find(all.begin(), all.end(), note) == all.end()) all.push_back(note);
+}
+
+std::string fallback_items(const CompiledModel& cm) {
+  std::string items;
+  for (const std::string& note : cm.interpreter_fallbacks)
+    items += (items.empty() ? "" : "; ") + note;
+  return items;
+}
+
+std::string report_request() {
+  return "Please report this at https://github.com/seantalts/stanli/issues "
+         "with this message and the model. stanli build " +
+         std::string(runtime_build_id()) + ".";
+}
+
+}  // namespace
+
 CompiledModel compile_model(const std::string& mir_text, const DataMap& data) {
   const char* prep_env = std::getenv("STANLI_PROFILE_PREP");
   PrepTrace prep(prep_env && prep_env[0] != '0');
@@ -813,6 +837,8 @@ CompiledModel compile_model(const std::string& mir_text, const DataMap& data) {
     wa.decls = lo.decls;
     prep.plain("write_array", "env_copy", env_copy_time);
     CompiledModel::WriteArray w = wa.run_write_array(*prog);
+    for (const std::string& note : wa.out.interpreter_fallbacks)
+      add_interpreter_fallback(cm, note);
     if (w.n_unconstrained != cm.n_unconstrained) {
       // The two graphs read the same draw; if they disagree on its length the
       // write_array cannot be driven at all. Keep the model, drop the columns,
@@ -849,6 +875,11 @@ CompiledModel compile_model(const std::string& mir_text, const DataMap& data) {
       w.interp = std::make_shared<WaInterp>(prog, std::move(env));
     }
     cm.write_array = std::move(w);
+    if (!cm.write_array->truncated.empty())
+      add_interpreter_fallback(cm,
+                               "transformed parameters and generated "
+                               "quantities (" +
+                                   cm.write_array->truncated + ")");
   }
   if (prog->has_transform_inits) {
     // The inverse parameter transforms. Nothing is interpreted here: the
@@ -901,9 +932,36 @@ CompiledModel compile_model(const std::string& mir_text, const DataMap& data) {
           std::make_shared<InitInterp>(prog, lo.td.env(), std::move(params));
     cm.transform_inits = std::move(ti);
   }
+  if (!cm.interpreter_fallbacks.empty() && std::getenv("STANLI_NO_INTERPRETER"))
+    throw CompileError(interpreter_error(cm));
   prep.plain("compile", "total", compile_time);
   prep.report();
   return cm;
+}
+
+std::string interpreter_error(const CompiledModel& cm) {
+  return "stanli: STANLI_NO_INTERPRETER is set and parts of this model have "
+         "no compiled path: " +
+         fallback_items(cm) +
+         ". Unset it to run them through the MIR interpreter, which is far "
+         "slower. " +
+         report_request();
+}
+
+std::string interpreter_warning(const CompiledModel& cm,
+                                const std::string& probe_failure) {
+  if (cm.interpreter_fallbacks.empty()) return "";
+  std::string text =
+      "stanli: parts of this model have no compiled path and run through the "
+      "MIR interpreter, which is far slower: " +
+      fallback_items(cm) + ".";
+  if (!probe_failure.empty())
+    text += " The interpreter also failed at every probe point (" +
+            probe_failure +
+            "), so transformed parameters and generated quantities are "
+            "unavailable and draws carry only the constrained parameters.";
+  return text + " " + report_request() +
+         " Set STANLI_NO_INTERPRETER=1 to refuse such models.";
 }
 
 }  // namespace stanli

--- a/runtime/src/lower_higher_order.cpp
+++ b/runtime/src/lower_higher_order.cpp
@@ -94,6 +94,9 @@ bool Lowering::lower_program_variadic_algebra(ProgramCompiler& c,
     c.bail(e.name + ": initial guess must be a vector");
   spec->prog = compile_rhs_args(with_leading_time(*spec->system()),
                                 *spec->funs(), x.len, spec->args);
+  if (!spec->prog.ok)
+    note_interpreter_fallback("the algebraic system " + spec->system_name,
+                              spec->prog.why);
 
   Range result{0, x.len};
   result.kind = ViewKind::Vector;
@@ -152,6 +155,9 @@ bool Lowering::lower_program_quadrature(ProgramCompiler& c, const mir::Expr& e,
                              *spec, &spec->parameter_count);
   spec->prog =
       compile_rhs_args(*spec->callback(), *spec->funs(), 1, spec->args);
+  if (!spec->prog.ok)
+    note_interpreter_fallback("the quadrature integrand " + spec->callback_name,
+                              spec->prog.why);
 
   const Range a = c.expr(e.args[1]);
   const Range b = c.expr(e.args[2]);
@@ -239,6 +245,9 @@ bool Lowering::lower_program_ode(ProgramCompiler& c, const mir::Expr& e,
                                    e.args.size(), *spec, &parameter_count);
     theta_active = parameter_count != 0;
     spec->prog = compile_rhs_args(*spec->rhs(), *spec->funs(), S, spec->args);
+    if (!spec->prog.ok)
+      note_interpreter_fallback("the ODE right-hand side " + spec->rhs_name,
+                                spec->prog.why);
   }
 
   Range result{0, (int)(N * S)};
@@ -319,6 +328,9 @@ bool Lowering::lower_program_ode_adjoint(ProgramCompiler& c, const mir::Expr& e,
   const Range theta = program_callback_theta(
       c, e, call->callback_args_begin, e.args.size(), *spec, &parameter_count);
   spec->prog = compile_rhs_args(*spec->rhs(), *spec->funs(), S, spec->args);
+  if (!spec->prog.ok)
+    note_interpreter_fallback(
+        "the adjoint ODE right-hand side " + spec->rhs_name, spec->prog.why);
 
   Range result{0, N * S};
   result.kind = ViewKind::Array;
@@ -370,6 +382,9 @@ bool Lowering::lower_program_dae(ProgramCompiler& c, const mir::Expr& e,
       c, e, call->callback_args_begin, e.args.size(), *spec, &parameter_count);
   spec->prog =
       compile_dae_args(*spec->residual(), *spec->funs(), S, spec->args);
+  if (!spec->prog.ok)
+    note_interpreter_fallback("the DAE residual " + spec->residual_name,
+                              spec->prog.why);
 
   Range result{0, (int)(N * S)};
   result.kind = ViewKind::Array;
@@ -451,6 +466,9 @@ bool Lowering::lower_program_higher_order(ProgramCompiler& c,
   args[2].ints = spec->x_i;
   spec->prog = compile_rhs_args(with_leading_time(*spec->system()),
                                 *spec->funs(), x.len, args);
+  if (!spec->prog.ok)
+    note_interpreter_fallback("the algebraic system " + spec->system_name,
+                              spec->prog.why);
 
   Range result{0, x.len};
   result.kind = ViewKind::Vector;
@@ -768,6 +786,9 @@ Lowering::Val Lowering::lower_quadrature_fn(const mir::Expr& e,
   }
   spec->prog =
       compile_rhs_args(*spec->callback(), *spec->funs(), 1, spec->args);
+  if (!spec->prog.ok)
+    note_interpreter_fallback("the quadrature integrand " + spec->callback_name,
+                              spec->prog.why);
 
   Val a = actuals.at(1).value();
   Val b = actuals.at(2).value();
@@ -857,6 +878,9 @@ Lowering::Val Lowering::lower_algebra_fn(const mir::Expr& e,
   args[2].ints = spec->x_i;
   spec->prog = compile_rhs_args(with_leading_time(*spec->system()),
                                 *spec->funs(), (int)n, args);
+  if (!spec->prog.ok)
+    note_interpreter_fallback("the algebraic system " + spec->system_name,
+                              spec->prog.why);
   if (!spec->prog.ok && std::getenv("STANLI_DEBUG_ALGEBRA"))
     std::fprintf(stderr,
                  "stanli: algebraic system %s falls back to the "
@@ -1045,6 +1069,9 @@ std::optional<Lowering::Val> Lowering::lower_ode_variadic(
 
   spec->args = rargs;
   spec->prog = compile_rhs_args(*spec->rhs(), *spec->funs(), (int)S, rargs);
+  if (!spec->prog.ok)
+    note_interpreter_fallback("the ODE right-hand side " + spec->rhs_name,
+                              spec->prog.why);
   if (runtime_times)
     return emit_ode(std::move(spec), z0, theta, N, S, ode_result_view(e, N, S),
                     t0, ts);

--- a/runtime/src/lower_internal.hpp
+++ b/runtime/src/lower_internal.hpp
@@ -912,6 +912,13 @@ struct Lowering {
   }
   void forget_observation(const Val& v) { observations.erase({v.slot, v.si}); }
   int add_slot(int64_t len, bool is_param) { return g.add_slot(len, is_param); }
+  void note_interpreter_fallback(const std::string& what,
+                                 const std::string& why) {
+    const std::string note = what + " (" + why + ")";
+    auto& all = out.interpreter_fallbacks;
+    if (std::find(all.begin(), all.end(), note) == all.end())
+      all.push_back(note);
+  }
   [[noreturn]] void fail(const std::string& msg, const std::string& raw = "") {
     throw CompileError("stanli compile: " + msg +
                        (raw.empty() ? "" : " | in: " + raw));

--- a/runtime/src/nuts.cpp
+++ b/runtime/src/nuts.cpp
@@ -119,19 +119,44 @@ std::vector<std::vector<double>> run_nuts(Executor& ex, const NutsConfig& cfg,
   // Match Stan's timing boundary: initialization and stepsize search are
   // setup, not warmup transitions. In particular, warmup=0 should not report
   // model initialization as warmup time.
+  constexpr auto poll_period = std::chrono::milliseconds(100);
+  auto last_poll = Clock::now() - poll_period;
+  const auto stopping = [&]() {
+    if (cfg.stop && cfg.stop->load()) return true;
+    if (!cfg.poll) return false;
+    const auto now = Clock::now();
+    if (now - last_poll < poll_period) return false;
+    last_poll = now;
+    if (!cfg.poll()) return false;
+    if (cfg.stop) cfg.stop->store(true);
+    return true;
+  };
+  bool interrupted = false;
+
   const auto warmup_started = Clock::now();
-  for (int i = 0; i < cfg.warmup; ++i)
-    step(i, true, cfg.save_warmup && (i % thin == 0));
+  for (int i = 0; i < cfg.warmup && !interrupted; ++i) {
+    if (stopping())
+      interrupted = true;
+    else
+      step(i, true, cfg.save_warmup && (i % thin == 0));
+  }
   const auto warmup_finished = Clock::now();
   if (report)
     report->warmup_seconds =
         std::chrono::duration<double>(warmup_finished - warmup_started).count();
   sampler.disengage_adaptation();
   const auto sampling_started = Clock::now();
-  for (int i = 0; i < cfg.samples; ++i) step(i, false, i % thin == 0);
-  if (report)
+  for (int i = 0; i < cfg.samples && !interrupted; ++i) {
+    if (stopping())
+      interrupted = true;
+    else
+      step(i, false, i % thin == 0);
+  }
+  if (report) {
     report->sampling_seconds =
         std::chrono::duration<double>(Clock::now() - sampling_started).count();
+    report->interrupted = interrupted;
+  }
   return draws;
 }
 
@@ -173,17 +198,23 @@ std::vector<ChainResult> run_nuts_chains(const std::vector<Executor*>& execs,
                                          const NutsConfig& cfg, int n_threads,
                                          const DrawObserver& observe,
                                          const ChainProgressObserver& progress,
-                                         int progress_refresh) {
+                                         int progress_refresh,
+                                         const std::function<bool()>& poll) {
   const size_t n_chains = execs.size();
   std::vector<ChainResult> out(n_chains);
+  std::atomic<bool> local_stop{false};
+  std::atomic<bool>* const stop = cfg.stop ? cfg.stop : &local_stop;
 
   // One chain's work, by index. A chain that throws records its message
   // and leaves its draws empty rather than taking the run down: CmdStan
   // reports a failed chain and keeps the others, and a three-of-four run
   // is something the caller can decide about.
-  const auto run_one = [&](size_t c, const ProgressObserver& one_progress) {
+  const auto run_one = [&](size_t c, const ProgressObserver& one_progress,
+                           const std::function<bool()>& chain_poll) {
     NutsConfig cc = cfg;
     cc.chain_id = cfg.chain_id + (int)c;
+    cc.stop = stop;
+    cc.poll = chain_poll;
     try {
       out[c].draws = run_nuts(*execs[c], cc, &out[c].stats,
                               n_chains == 1 ? observe : DrawObserver{},
@@ -216,7 +247,7 @@ std::vector<ChainResult> run_nuts_chains(const std::vector<Executor*>& execs,
             progress_error = std::current_exception();
           }
         };
-      run_one(c, one_progress);
+      run_one(c, one_progress, poll);
     }
     if (progress_error) std::rethrow_exception(progress_error);
     return out;
@@ -266,7 +297,7 @@ std::vector<ChainResult> run_nuts_chains(const std::vector<Executor*>& execs,
             }
             progress_ready.notify_one();
           };
-        run_one(c, one_progress);
+        run_one(c, one_progress, {});
       }
       {
         // Completion is part of the condition-variable predicate, so mutate
@@ -279,15 +310,31 @@ std::vector<ChainResult> run_nuts_chains(const std::vector<Executor*>& execs,
     });
 
   std::exception_ptr progress_error;
-  if (progress) {
+  // The caller's poll runs here, between events, so a busy progress stream
+  // and a silent one both see it about every period.
+  using Clock = std::chrono::steady_clock;
+  constexpr auto poll_period = std::chrono::milliseconds(100);
+  auto last_poll = Clock::now() - poll_period;
+  const auto maybe_poll = [&] {
+    if (!poll || stop->load()) return;
+    const auto now = Clock::now();
+    if (now - last_poll < poll_period) return;
+    last_poll = now;
+    if (poll()) stop->store(true);
+  };
+  if (progress || poll) {
     for (;;) {
+      maybe_poll();
       ProgressEvent event{};
       {
         std::unique_lock<std::mutex> lock(progress_mutex);
-        progress_ready.wait(lock, [&] {
+        progress_ready.wait_for(lock, poll_period, [&] {
           return !progress_events.empty() || live_workers == 0;
         });
-        if (progress_events.empty()) break;
+        if (progress_events.empty()) {
+          if (live_workers == 0) break;
+          continue;
+        }
         event = progress_events.front();
         progress_events.pop_front();
       }

--- a/tests/fixtures/interp_fallback_ode.stan
+++ b/tests/fixtures/interp_fallback_ode.stan
@@ -1,0 +1,18 @@
+functions {
+  vector rhs(real t, vector y, real k) {
+    matrix[1100, 1000] big = rep_matrix(k, 1100, 1000);
+    return -big[1, 1] * y;
+  }
+}
+transformed data {
+  array[3] real ts = {0.5, 1.0, 1.5};
+}
+parameters {
+  real<lower=0> k;
+}
+transformed parameters {
+  array[3] vector[1] sol = ode_rk45(rhs, [1.0]', 0.0, ts, k);
+}
+model {
+  k ~ lognormal(0, 1);
+}

--- a/tests/fixtures/interp_fallback_region.stan
+++ b/tests/fixtures/interp_fallback_region.stan
@@ -1,0 +1,13 @@
+parameters {
+  real mu;
+}
+model {
+  mu ~ normal(0, 1);
+}
+generated quantities {
+  real s = 0;
+  if (mu > 0) {
+    matrix[1100, 1000] big = rep_matrix(mu, 1100, 1000);
+    s = big[1, 1];
+  }
+}

--- a/tests/fixtures/wa_literal_write.stan
+++ b/tests/fixtures/wa_literal_write.stan
@@ -1,0 +1,9 @@
+parameters {
+  real mu;
+}
+model {
+  mu ~ normal(0, 1);
+}
+generated quantities {
+  real two = 2;
+}

--- a/tests/test_capi.cpp
+++ b/tests/test_capi.cpp
@@ -13,6 +13,7 @@
 #include <array>
 #include <cmath>
 #include <cstdio>
+#include <cstdlib>
 #include <fstream>
 #include <limits>
 #include <map>
@@ -820,7 +821,58 @@ void expect_streaming_stats() {
 
 }  // namespace
 
+void expect_interpreter_policy(const char* fixture,
+                               const char* expected_reason) {
+  const std::string mir = slurp(fixture);
+  const std::string tag(fixture);
+  char err[8192]{};
+  setenv("STANLI_NO_INTERPRETER", "1", 1);
+  stanli_model* model = stanli_model_new(mir.c_str(), "{}", err, sizeof err);
+  unsetenv("STANLI_NO_INTERPRETER");
+  if (expected_reason == nullptr) {
+    if (model == nullptr) {
+      ++failures;
+      std::printf("FAIL model construction for %s: %s\n", fixture, err);
+      return;
+    }
+    expect_eq((tag + " no warning").c_str(), stanli_warnings(model), "");
+    stanli_model_free(model);
+    return;
+  }
+  const std::string error(err);
+  expect_true(tag + " refused under STANLI_NO_INTERPRETER: " + error,
+              model == nullptr);
+  if (model != nullptr) stanli_model_free(model);
+  expect_true(tag + " error carries the reason: " + error,
+              error.find(expected_reason) != std::string::npos);
+  expect_true(tag + " error names the variable: " + error,
+              error.find("STANLI_NO_INTERPRETER") != std::string::npos);
+  expect_true(
+      tag + " error points at the issue tracker: " + error,
+      error.find("github.com/seantalts/stanli/issues") != std::string::npos);
+
+  model = stanli_model_new(mir.c_str(), "{}", err, sizeof err);
+  if (model == nullptr) {
+    ++failures;
+    std::printf("FAIL default model construction for %s: %s\n", fixture, err);
+    return;
+  }
+  const std::string text = stanli_warnings(model);
+  expect_true(tag + " warning carries the reason: " + text,
+              text.find(expected_reason) != std::string::npos);
+  expect_true(tag + " warning names the build: " + text,
+              text.find(stanli_build_id()) != std::string::npos);
+  stanli_model_free(model);
+}
+
 int main() {
+  expect_interpreter_policy("tests/fixtures/wanames.tmir.sexp", nullptr);
+  expect_interpreter_policy("tests/fixtures/wa_literal_write.tmir.sexp",
+                            nullptr);
+  expect_interpreter_policy("tests/fixtures/interp_fallback_region.tmir.sexp",
+                            "oversized shape");
+  expect_interpreter_policy("tests/fixtures/interp_fallback_ode.tmir.sexp",
+                            "the ODE right-hand side rhs");
   expect_unconstrain_inits_round_trip();
   expect_parameterless_unconstrain();
 

--- a/tests/test_capi.cpp
+++ b/tests/test_capi.cpp
@@ -661,6 +661,75 @@ void capture_progress(int32_t chain_id, int64_t iteration, int64_t total,
   capture->events.push_back({chain_id, iteration, total, warmup});
 }
 
+int poll_stop_at_once(void* user) {
+  ++*static_cast<int*>(user);
+  return 1;
+}
+
+int poll_keep_going(void* user) {
+  ++*static_cast<int*>(user);
+  return 0;
+}
+
+// The interruptible entry point is the progress sampler plus a poll: a stop
+// answer ends the run cleanly with the flag set, and a run whose poll never
+// stops it produces the same bytes as the plain sampler.
+void expect_interruptible_sampling() {
+  const std::string mir = slurp("tests/fixtures/gqconst.tmir.sexp");
+  const char* data = R"({"rectangular":[[1,4],[2,5],[3,6]]})";
+  char err[8192]{};
+  stanli_model* model = stanli_model_new(mir.c_str(), data, err, sizeof err);
+  expect_true("interruptible sampling model builds", model != nullptr);
+  if (model == nullptr) return;
+  stanli_sample_opts opts;
+  stanli_sample_opts_init(&opts);
+  opts.seed = 7;
+  opts.chains = 2;
+  opts.warmup = 40;
+  opts.samples = 40;
+  const int64_t n = stanli_n_unconstrained(model);
+  const int64_t rows = stanli_n_stored_draws(&opts);
+  const size_t n_draws = (size_t)(opts.chains * rows * n);
+  const size_t n_stats = (size_t)(opts.chains * rows * STANLI_N_SAMPLER_COLS);
+  for (int threads : {1, 2}) {
+    opts.num_threads = threads;
+    const std::string mode = threads == 1 ? " (sequential)" : " (threaded)";
+    std::vector<double> draws(n_draws, -1.0);
+    std::vector<double> stats(n_stats, -1.0);
+    stanli_sample_report reports[2];
+    int polls = 0;
+    int interrupted = -1;
+    err[0] = '\0';
+    int rc = stanli_sample_multi_interruptible(
+        model, &opts, 0, draws.data(), stats.data(), nullptr, nullptr,
+        poll_stop_at_once, &polls, &interrupted, reports, err, sizeof err);
+    expect_true("a stop answer ends sampling cleanly" + mode,
+                rc == 0 && interrupted == 1 && polls >= 1);
+    if (threads == 1)
+      expect_true("a stop before the first transition stores nothing" + mode,
+                  draws[0] == -1.0 && stats[0] == -1.0);
+
+    std::vector<double> plain_draws(n_draws), plain_stats(n_stats);
+    stanli_sample_report plain_reports[2];
+    rc = stanli_sample_multi_progress(model, &opts, 0, plain_draws.data(),
+                                      plain_stats.data(), nullptr, nullptr,
+                                      plain_reports, err, sizeof err);
+    expect_true("plain sampling succeeds" + mode, rc == 0);
+    polls = 0;
+    interrupted = -1;
+    rc = stanli_sample_multi_interruptible(
+        model, &opts, 0, draws.data(), stats.data(), nullptr, nullptr,
+        poll_keep_going, &polls, &interrupted, reports, err, sizeof err);
+    expect_true(
+        "a poll that never stops is observational" + mode,
+        rc == 0 && interrupted == 0 && polls >= 1 && draws == plain_draws &&
+            stats == plain_stats &&
+            reports[0].n_divergent == plain_reports[0].n_divergent &&
+            reports[1].n_max_treedepth == plain_reports[1].n_max_treedepth);
+  }
+  stanli_model_free(model);
+}
+
 // The additive progress entry point must be the old sampler plus observation:
 // same bytes, caller-thread callbacks, exact refresh schedule and reports.
 void expect_sampling_progress() {
@@ -915,6 +984,7 @@ int main() {
   expect_necessity_effects();
   expect_pathfinder();
   expect_sampling_progress();
+  expect_interruptible_sampling();
   expect_streaming_stats();
 
   if (failures == 0) std::printf("test_capi OK\n");

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -304,7 +304,7 @@ def test_unconstrain_round_trip():
 
     values = {}
     for name, value in zip(names, row):
-        values.setdefault(name.split(".")[0], []).append(float(value))
+        values.setdefault(name.split("[")[0], []).append(float(value))
     values = {k: (v[0] if len(v) == 1 else v) for k, v in values.items()}
 
     back = m.unconstrain(values)
@@ -571,6 +571,82 @@ def test_summary_and_diagnostics():
     assert one["mu"]["mean"] == s["mu"]["mean"]
 
 
+SHAPES_SOURCE = """
+parameters {
+  real s;
+  vector[3] v;
+  matrix[2,3] M;
+  array[2] vector[3] a;
+  array[2,2] real r;
+  array[2] matrix[2,2] Q;
+}
+model {
+  s ~ std_normal();
+  v ~ std_normal();
+  to_vector(M) ~ std_normal();
+  for (i in 1:2) {
+    a[i] ~ std_normal();
+    to_vector(Q[i]) ~ std_normal();
+  }
+  for (i in 1:2) {
+    for (j in 1:2) {
+      r[i, j] ~ std_normal();
+    }
+  }
+}
+generated quantities {
+  real g = s;
+  array[2] vector[2] ag = a[:, 1:2];
+}
+"""
+
+
+def test_variables_are_shaped():
+    m = stanli.Model(stan_code=SHAPES_SOURCE)
+    fit = m.sample(chains=2, seed=1, warmup=100, samples=50, refresh=0)
+
+    assert fit.names[:6] == ["s", "v[1]", "v[2]", "v[3]", "M[1,1]", "M[2,1]"]
+    assert "Q[1,1,1]" in fit.names and "ag[1,1]" in fit.names
+    assert fit.variables == {
+        "s": (), "v": (3,), "M": (2, 3), "a": (2, 3), "r": (2, 2),
+        "Q": (2, 2, 2), "g": (), "ag": (2, 2),
+    }
+
+    assert fit["M"].shape == (100, 2, 3)
+    assert np.array_equal(fit["M"][:, 0, 1], fit["M[1,2]"])
+    assert np.array_equal(fit["M[1,2]"], fit["M.1.2"])
+
+    assert fit.draws("Q").shape == (2, 50, 2, 2, 2)
+    assert np.array_equal(fit.draws("Q")[:, :, 1, 0, 1], fit.draws("Q[2,1,2]"))
+
+    assert fit["s"].shape == (100,)
+    assert "M" in fit and "M[1,2]" in fit and "M.1.2" in fit
+
+    assert fit.summary(params=["M"]).names == [
+        "M[1,1]", "M[2,1]", "M[1,2]", "M[2,2]", "M[1,3]", "M[2,3]"]
+    assert fit.summary()["M.1.2"] == fit.summary()["M[1,2]"]
+
+
+def test_to_arviz_keeps_dims():
+    try:
+        import arviz  # noqa: F401
+    except ImportError:
+        return
+    m = stanli.Model(stan_code=SHAPES_SOURCE)
+    fit = m.sample(chains=2, seed=1, warmup=100, samples=50, refresh=0)
+    assert fit.to_arviz().posterior["M"].shape == (2, 50, 2, 3)
+
+
+def test_group_variables_incomplete_and_non_numeric():
+    variables = stanli._group_variables(["x[1]", "x[3]"])
+    assert set(variables) == {"x[1]", "x[3]"}
+    assert variables["x[1]"][0] == () and variables["x[3]"][0] == ()
+
+    variables = stanli._group_variables(["z.real"])
+    assert set(variables) == {"z.real"}
+    assert variables["z.real"][0] == ()
+
+
 def test_diagnostics_report_a_broken_fit():
     # A funnel sampled with a loose target and short warmup diverges
     # reliably. The point is not the model, it is that the checks come
@@ -690,7 +766,9 @@ def test_optimize_finds_a_mode_and_feeds_sample():
     m = _es()
     r = m.optimize(seed=1)
     # Every CSV column, the way one draw of sample() comes back.
-    assert "mu" in r and "tau" in r and "theta.1" in r
+    assert "mu" in r and "tau" in r and "theta[1]" in r
+    assert r["theta"].shape == (8,)
+    assert r["theta.1"] == r["theta[1]"]
     assert r.unconstrained.shape == (m.n_unconstrained,)
     # The reported lp must be the model's lp at that point, not the
     # objective the optimizer minimizes -- that sign slip is silent.

--- a/tools/exported_symbols.def
+++ b/tools/exported_symbols.def
@@ -47,6 +47,7 @@ EXPORTS
   stanli_thread_safe
   stanli_sample_multi
   stanli_sample_multi_progress
+  stanli_sample_multi_interruptible
   stanli_sampler_column_name
   stanli_summary_stats
   stanli_diagnose_text

--- a/tools/exported_symbols.def
+++ b/tools/exported_symbols.def
@@ -41,6 +41,7 @@ EXPORTS
   stanli_wa_seed
   stanli_wa_seed_chain
   stanli_wa_row
+  stanli_warnings
   stanli_sample_opts_init
   stanli_n_stored_draws
   stanli_thread_safe

--- a/tools/stanli_check.cpp
+++ b/tools/stanli_check.cpp
@@ -215,6 +215,10 @@ int main(int argc, char** argv) {
   try {
     stanli::DataMap data = stanli::DataMap::from_json_file(argv[2]);
     cm = stanli::compile_model(mir, data);
+    {
+      const std::string note = stanli::interpreter_warning(cm);
+      if (!note.empty()) std::fprintf(stderr, "INTERP %s\n", note.c_str());
+    }
   } catch (const std::exception& e) {
     std::string what = e.what();
     const size_t nl = what.find('\n');

--- a/tools/stanli_run.cpp
+++ b/tools/stanli_run.cpp
@@ -214,10 +214,10 @@ int main(int argc, char** argv) {
                                : nullptr;
     const bool have_wa =
         !wi && cm.write_array && !cm.write_array->columns.empty();
-    if (cm.write_array && !cm.write_array->truncated.empty())
-      std::fprintf(stderr, "stanli_run: write_array %s: %s\n",
-                   wi ? "interpreted (graph could not express)" : "truncated",
-                   cm.write_array->truncated.c_str());
+    {
+      const std::string note = stanli::interpreter_warning(cm);
+      if (!note.empty()) std::fprintf(stderr, "%s\n", note.c_str());
+    }
     std::unique_ptr<stanli::Executor> wex;
     if (have_wa) {
       wex =


### PR DESCRIPTION
Four changes, each with its CHANGELOG entry.

A model whose transformed parameters, generated quantities, or higher-order callback could not be lowered used to run through the MIR interpreter silently, around a hundred times slower per evaluation. It now warns with the lowering's reason and asks for a bug report: R `warning()`, Python `RuntimeWarning`, `stanli_run` stderr, and `stanli_warnings` in the C ABI. `STANLI_NO_INTERPRETER=1` turns the warning into a compile error. Runtime-control regions get 2^20 registers, which brings hmm_gaussian and iohmm_reg onto the graph.

Sampling can be interrupted. Chains read a stop flag before every transition and the calling thread polls the host about every 100 ms through the new `stanli_sample_multi_interruptible`. In R, Ctrl-C or the RStudio stop button now stops the run and raises the usual interrupt.

R names indexed values `theta[1,2]` rather than `theta.1.2`, so posterior reads them as arrays.

Python uses the same bracket names and reads variables by shape: `fit["theta"]` returns an array with the declared dims, `to_arviz()` passes those dims through, and dot names still resolve when indexing.

Fixes #327
Fixes #328
