### PR TITLE
Stop Python sampling on Ctrl-C

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,9 @@ current transition and raises the usual interrupt, on every platform. Before,
 the interrupt could only land between chains, and on Windows it could take
 the session down. The C ABI gains `stanli_sample_multi_interruptible`, the
 progress sampler plus a poll callback asked on the calling thread about every
-100 ms; the R package uses it when the runtime provides it. (#327)
+100 ms; the R package uses it when the runtime provides it. The Python
+package does the same: Ctrl-C during `sample()` stops the chains and raises
+`KeyboardInterrupt`. (#327)
 
 ### R names indexed values with brackets
 

--- a/python/README.md
+++ b/python/README.md
@@ -264,6 +264,9 @@ fit["theta"]                        # (chains*draws, 8) ndarray
 fit["theta[1]"]                     # one column, chains concatenated
 ```
 
+Ctrl-C while `sample()` runs stops every chain after its current
+transition and raises `KeyboardInterrupt`.
+
 Pathfinder can generate one initialization per chain before NUTS. The
 sampling seed controls both stages; an empty options object uses CmdStan's
 single-path defaults:

--- a/python/stanli/__init__.py
+++ b/python/stanli/__init__.py
@@ -13,8 +13,10 @@ import operator
 import os
 import pathlib
 import re
+import signal
 import subprocess
 import sys
+import threading
 import warnings
 
 import numpy as np
@@ -95,6 +97,7 @@ class _SampleReport(ctypes.Structure):
 _SampleProgressCallback = ctypes.CFUNCTYPE(
     None, ctypes.c_int32, ctypes.c_int64, ctypes.c_int64, ctypes.c_int32,
     ctypes.c_void_p)
+_SamplePollCallback = ctypes.CFUNCTYPE(ctypes.c_int, ctypes.c_void_p)
 
 
 def _load_lib():
@@ -168,6 +171,13 @@ def _load_lib():
         ctypes.c_void_p, ctypes.POINTER(_SampleOpts), ctypes.c_int,
         ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double),
         _SampleProgressCallback, ctypes.c_void_p,
+        ctypes.POINTER(_SampleReport), ctypes.c_char_p, ctypes.c_size_t]
+    lib.stanli_sample_multi_interruptible.restype = ctypes.c_int
+    lib.stanli_sample_multi_interruptible.argtypes = [
+        ctypes.c_void_p, ctypes.POINTER(_SampleOpts), ctypes.c_int,
+        ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double),
+        _SampleProgressCallback, ctypes.c_void_p, _SamplePollCallback,
+        ctypes.c_void_p, ctypes.POINTER(ctypes.c_int),
         ctypes.POINTER(_SampleReport), ctypes.c_char_p, ctypes.c_size_t]
     lib.stanli_pathfinder_inits.restype = ctypes.c_int
     lib.stanli_pathfinder_inits.argtypes = [
@@ -275,6 +285,42 @@ def _resolve(name, variables, columns):
     if bracketed in columns:
         return (), np.array(columns[bracketed], dtype=np.int64)
     raise ValueError(f"{name!r} is not a column or variable of this fit")
+
+
+class _InterruptWatch:
+    """Turns Ctrl-C during a native call into a stop the sampler polls.
+
+    Python only runs its SIGINT handler when the main thread executes
+    bytecode, which during a foreign call is exactly the poll callback. A
+    handler that raised there would be swallowed by ctypes, so this one
+    records the signal and the poll answers it; the caller raises once the
+    sampler has returned. Off the main thread no handler can be installed
+    and the poll simply never fires.
+    """
+
+    def __init__(self):
+        self.tripped = False
+        self.previous = None
+        self.poll = _SamplePollCallback(lambda _user: 1 if self.tripped else 0)
+
+    def _handle(self, _signum, _frame):
+        self.tripped = True
+
+    def __enter__(self):
+        if threading.current_thread() is threading.main_thread():
+            self.previous = signal.signal(signal.SIGINT, self._handle)
+        return self
+
+    def __exit__(self, *_exc):
+        if self.previous is not None:
+            signal.signal(signal.SIGINT, self.previous)
+        return False
+
+    def raise_interrupt(self):
+        previous = self.previous
+        if callable(previous) and previous is not signal.default_int_handler:
+            previous(signal.SIGINT, None)
+        raise KeyboardInterrupt
 
 
 _PATHFINDER_INIT_DEFAULTS = {
@@ -1114,10 +1160,16 @@ class Model:
             # leave the sampler calling freed memory.
             progress_cb = _SampleProgressCallback(progress)
 
-        failed = _lib.stanli_sample_multi_progress(
-            self._m, ctypes.byref(opts), refresh, _dptr(raw), _dptr(stats),
-            progress_cb, None, reports, err, len(err))
+        interrupted = ctypes.c_int(0)
+        watch = _InterruptWatch()
+        with watch:
+            failed = _lib.stanli_sample_multi_interruptible(
+                self._m, ctypes.byref(opts), refresh, _dptr(raw),
+                _dptr(stats), progress_cb, None, watch.poll, None,
+                ctypes.byref(interrupted), reports, err, len(err))
         del init_arr
+        if interrupted.value:
+            watch.raise_interrupt()
         if failed:
             raise RuntimeError(
                 f"{failed} of {opts.chains} chains failed; first: "

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -14,11 +14,13 @@ import pathlib
 import pickle
 import re
 import shutil
+import signal
 import struct
 import subprocess
 import sys
 import tempfile
 import threading
+import time
 from unittest import mock
 
 import numpy as np
@@ -523,6 +525,32 @@ def test_multichain_shapes_and_dict_protocol():
     # Sampler columns are reachable by name too.
     assert fit["lp__"].shape == (600,)
     assert fit.sampler_stats.shape == (3, 200, len(stanli.SAMPLER_COLUMNS))
+
+
+def test_ctrl_c_stops_sampling():
+    m = _es()
+    timer = threading.Timer(0.5, lambda: signal.raise_signal(signal.SIGINT))
+    timer.start()
+    started = time.perf_counter()
+    try:
+        m.sample(chains=2, seed=1, warmup=500000, samples=500000, refresh=0)
+    except KeyboardInterrupt:
+        pass
+    else:
+        raise AssertionError("sampling ran to completion through a SIGINT")
+    finally:
+        timer.cancel()
+    assert time.perf_counter() - started < 60, "the stop took too long"
+    assert signal.getsignal(signal.SIGINT) is signal.default_int_handler, \
+        "the SIGINT handler was not restored"
+
+
+def test_sampling_off_the_main_thread_still_works():
+    m = _es()
+    with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
+        fit = pool.submit(m.sample, chains=1, seed=1, warmup=50, samples=20,
+                          refresh=0).result()
+    assert fit.n_draws == 20
 
 
 def test_chains_are_different_streams_and_seeds_reproduce():


### PR DESCRIPTION
Python counterpart of #331's interrupt support. While ctypes holds the sampler call the interpreter runs no bytecode, so a SIGINT sat pending until every chain finished. `sample()` now goes through `stanli_sample_multi_interruptible` with a poll callback, and a SIGINT handler installed for the duration of the call sets the flag the poll answers from. Once the sampler returns the previous handler is restored, called if it was a custom one, and `KeyboardInterrupt` is raised. Off the main thread nothing is installed and sampling behaves as before.

Two tests: a scheduled SIGINT ends a long run with `KeyboardInterrupt` and restores the default handler, and sampling from a worker thread still works.
