### PR TITLE
Run ctest on every core instead of the compile-phase job limit

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -422,10 +422,16 @@ jobs:
           fi
           ccache -s
 
+      # Every core, not matrix.build_jobs. That number is a memory ceiling
+      # for the compile phase (one densities shard peaks near 3 GB); the
+      # tests are 200-odd small processes with no such constraint. The
+      # generated signature models alone are ~280 s of work, which -j2
+      # served in 150 s on a 4-core runner.
       - name: Tests
-        run: >-
-          ctest --test-dir build-rel
-          --parallel ${{ matrix.build_jobs }} --output-on-failure
+        run: |
+          cores=$(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 2)
+          echo "runner: $cores cores, testing -j$cores"
+          ctest --test-dir build-rel --parallel "$cores" --output-on-failure
 
       # The models and data the corpus check reads: ~24 MB out of
       # posteriordb's 2 GB, via sparse checkout, cached on the pinned SHA.


### PR DESCRIPTION
## Why

`matrix.build_jobs` is a memory ceiling for the compile phase: one `densities` shard peaks near 3 GB, so the manylinux jobs build at `-j2`. The `Tests` step reused that number, so the whole CTest suite ran at `--parallel 2` on a 4-core runner.

That was invisible while the suite was 10 s. Since #324 the generated builtin and density signature models are 81 lit cases at 2.5–4 s each (about 280 s of work), and on the last main run ([33998623605](https://github.com/seantalts/stanli/actions/runs/33998623605)):

| job | Tests step before #324 | after #324 |
|---|---|---|
| manylinux x86_64 | 10 s | **150 s** |
| manylinux aarch64 | — | **9m41s** |

298.6 s of work in 149.96 s wall is `--parallel 2` doing exactly what it says.

## What

Detect the core count in the `Tests` step the same way the build step already prints it (`nproc`, falling back to `sysctl -n hw.ncpu`), and pass that to `ctest --parallel`. Running tests has no per-job memory constraint, so there is no reason to inherit the compile phase's limit.

Expected: ~75 s on x86_64. A dispatch run of this branch is at [34034106538](https://github.com/seantalts/stanli/actions/runs/34034106538); I'll post the measured before/after numbers here when it finishes.

Not in this PR: whether the two generated signature families should gate every PR push at all. That is a coverage-vs-latency call worth a separate conversation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GdbwLBhXDbGtnpKu3XKZJU

---
_Generated by [Claude Code](https://claude.ai/code/session_01GdbwLBhXDbGtnpKu3XKZJU)_