### PR TITLE
release: 0.12.0

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -890,7 +890,7 @@ jobs:
       - name: Fetch the previous release and the legacy anchor
         run: |
           mkdir -p previous-release/runtime legacy-release
-          previous=https://github.com/seantalts/stanli/releases/download/v0.11.0
+          previous=https://github.com/seantalts/stanli/releases/download/v0.11.1
           legacy=https://github.com/seantalts/stanli/releases/download/v0.9.3
           # A GitHub asset redirect reset the connection once and failed this
           # whole job. Plain --retry does not include curl error 35, so keep
@@ -899,13 +899,13 @@ jobs:
             "$previous/stanli-runtime-linux-x86_64.tar.gz" \
             -o previous-release/runtime.tar.gz
           curl -fsSL --retry 5 --retry-all-errors --retry-delay 2 \
-            "$previous/stanli_0.11.0.tar.gz" \
-            -o previous-release/stanli_0.11.0.tar.gz
+            "$previous/stanli_0.11.1.tar.gz" \
+            -o previous-release/stanli_0.11.1.tar.gz
           curl -fsSL --retry 5 --retry-all-errors --retry-delay 2 \
             "$legacy/stanli_0.9.3.tar.gz" \
             -o legacy-release/stanli_0.9.3.tar.gz
-          echo 'f602a5b0985f208962cf2b42bc9c7b06e22482a6a5fadba7a1e29ae23131f828  previous-release/runtime.tar.gz' | sha256sum -c -
-          echo 'b7a0174ddc15a91be6f5bdb9973792f38522b4308f8463915ea85ab4936469ab  previous-release/stanli_0.11.0.tar.gz' | sha256sum -c -
+          echo 'b3902d4044f522f5feb0d08bfea6de0c4510c81d37609577f9ccb454c55f7817  previous-release/runtime.tar.gz' | sha256sum -c -
+          echo '40f72e86f911a717c41f70eaea84758b3b9db7c36fbda9bad47d0760c307d245  previous-release/stanli_0.11.1.tar.gz' | sha256sum -c -
           echo '1acbe821c58115678a69451c553a9b23c141d009f53c142492cee94599430495  legacy-release/stanli_0.9.3.tar.gz' | sha256sum -c -
           tar xzf previous-release/runtime.tar.gz \
             -C previous-release/runtime
@@ -957,7 +957,7 @@ jobs:
         working-directory: r
         run: |
           current_library="$PWD/../r-current-library"
-          previous_library="$PWD/../r-v0.11.0-library"
+          previous_library="$PWD/../r-v0.11.1-library"
           legacy_library="$PWD/../r-v0.9.3-library"
           previous_runtime="$PWD/../previous-release/runtime/libstanli.so"
           current_runtime="$STANLI_RUNTIME"
@@ -968,7 +968,7 @@ jobs:
 
           mkdir -p "$previous_library"
           R CMD INSTALL --library="$previous_library" \
-            ../previous-release/stanli_0.11.0.tar.gz
+            ../previous-release/stanli_0.11.1.tar.gz
           STANLI_RUNTIME="$current_runtime" \
             R_LIBS_USER="$previous_library${R_LIBS_USER:+:$R_LIBS_USER}" \
             Rscript ../tests/test_r_portable_compiler.R

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.12.0
 
 ### Sampling can be interrupted
 

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@seantalts/stanli",
-  "version": "0.11.1",
+  "version": "0.12.0",
   "description": "Full Stan in the browser: stanc3 compiles the model in JS, a WASM runtime lowers it to an op graph and runs NUTS. No server, no C++ toolchain.",
   "type": "module",
   "main": "index.mjs",

--- a/python/stanli/__init__.py
+++ b/python/stanli/__init__.py
@@ -27,7 +27,7 @@ __all__ = ["Model", "Function", "Fit", "Summary", "OptimizeResult",
            "SAMPLER_COLUMNS", "__version__"]
 # The one place the version lives. setup.py and the release workflow both
 # read it from here.
-__version__ = "0.11.1"
+__version__ = "0.12.0"
 
 _BIN = pathlib.Path(__file__).parent / "_bin"
 

--- a/r/DESCRIPTION
+++ b/r/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: stanli
 Type: Package
 Title: The Stan Language Interpreter
-Version: 0.11.1
+Version: 0.12.0
 Authors@R: person("Sean", "Talts", email = "xitrium@gmail.com",
                   role = c("aut", "cre"))
 Description: Compile and sample Stan models without a C++ toolchain. Stan

--- a/r/R/install.R
+++ b/r/R/install.R
@@ -14,7 +14,7 @@
 # and a default of "latest" would silently pair a pinned binding with a runtime
 # that has moved. The release workflow asserts this equals the tag being cut,
 # so bumping one without the other fails there rather than at a user's install.
-stanli_runtime_release <- "v0.11.1"
+stanli_runtime_release <- "v0.12.0"
 
 runtime_filename <- function() {
   switch(Sys.info()[["sysname"]],


### PR DESCRIPTION
Version bumps, CHANGELOG heading, and the R cross-release pin moved to v0.11.1. Tag v0.12.0 goes on the merge commit.