### PR TITLE
Build the runtime without stdio for R packaging

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -156,6 +156,34 @@ jobs:
           node --check "$inline"
           node --check web/index.mjs
 
+  # Any runtime file can regress this, so it runs unconditionally rather
+  # than behind the `changes` classification.
+  no-stdio:
+    name: runtime without stdio
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Restore the vendored dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            deps/math
+            deps/stan
+          key: deps-${{ runner.os }}-sources3-${{ hashFiles('deps/fetch.sh') }}
+      - run: ./deps/fetch.sh
+      - run: which ccache || sudo apt-get install -y ccache
+      - name: Restore the compiler cache
+        uses: actions/cache@v4
+        with:
+          path: .ccache
+          key: >-
+            ccache-no-stdio-${{ hashFiles('CMakeLists.txt', 'runtime/**', 'tools/check_no_stdio.sh', 'deps/fetch.sh') }}
+          restore-keys: ccache-no-stdio-
+      - name: Build stanli_runtime_objects under STANLI_NO_STDIO
+        run: |
+          export CCACHE_DIR="$PWD/.ccache" CCACHE_COMPRESS=1 CCACHE_MAXSIZE=300M
+          ./tools/check_no_stdio.sh
+
   build:
     name: build (${{ matrix.plat }})
     needs: changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## Unreleased
+
+The runtime can now be built with `STANLI_NO_STDIO` defined, for R
+packaging: the object library then contains no stdout, stderr, abort, or
+assert-failure symbols. Debug traces that used to write directly to stderr
+(island carving, structured-loop diagnostics, the preparation profiler) now
+go through `emit_diagnostic`, a sink-backed channel parallel to `print()`'s
+existing `emit_message`. The preparation profiler no longer aborts if a
+model exceeds its previous fixed row count; it grows instead.
+
 ## 0.12.0
 
 ### Sampling can be interrupted

--- a/TESTING.md
+++ b/TESTING.md
@@ -634,6 +634,18 @@ counter in a regression test for maximum tree depth: `ar1` must average more
 than 40 leapfrog steps per iteration, which cannot occur with a depth-5 limit
 of 31.
 
+## Building without stdio
+
+The R package stanr vendors this repository's runtime sources into a
+CRAN-style package, and `R CMD check` rejects compiled code that references
+stdout, stderr, `printf`, `puts`, `abort`, `exit`, or the assert failure
+path. [`tools/check_no_stdio.sh`](tools/check_no_stdio.sh) configures the
+runtime object library with `-DSTANLI_NO_STDIO`, builds it, and scans every
+object file's undefined symbols for that list, failing with the offending
+file and symbol if any appear. The `no-stdio` job in
+[`.github/workflows/wheels.yml`](.github/workflows/wheels.yml) runs it on
+every pull request.
+
 ## Memory safety
 
 Memory errors do not always terminate the process; they can also produce

--- a/runtime/include/stanli/message_sink.hpp
+++ b/runtime/include/stanli/message_sink.hpp
@@ -38,6 +38,14 @@ void set_message_sink(MessageSink sink);
 // One print() line, from either path.
 void emit_message(const std::string& text);
 
+// Install a sink for emit_diagnostic, or pass nullptr to restore the
+// stderr default.
+void set_diagnostic_sink(MessageSink sink);
+
+// One operator-facing trace line: STANLI_DEBUG_* traces, the preparation
+// profiler, and structured-loop diagnostics.
+void emit_diagnostic(const std::string& text);
+
 }  // namespace stanli
 
 #endif

--- a/runtime/src/island.cpp
+++ b/runtime/src/island.cpp
@@ -22,13 +22,14 @@
 #include <stanli/island.hpp>
 
 #include <stanli/graph.hpp>
+#include <stanli/message_sink.hpp>
 #include <stanli/optable.hpp>
 #include <stanli/program_density.hpp>
 
-#include <cstdio>
 #include <cstdlib>
 #include <limits>
 #include <memory>
+#include <string>
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
@@ -633,10 +634,9 @@ int carve_islands(Graph& g,
       // difference between a region that is fast and one that merely
       // works, and nothing else about the model would show it.
       if (!priced_gen && std::getenv("STANLI_DEBUG_ISLAND"))
-        std::fprintf(stderr,
-                     "island: no adjoint generated for a %zu-op region; "
-                     "it will replay under var\n",
-                     j - i);
+        emit_diagnostic("island: no adjoint generated for a " +
+                        std::to_string(j - i) +
+                        "-op region; it will replay under var");
     }
     // Is the island cheaper than the ops it replaces? The graph's side is
     // what its ops move (an in-place element update moves one element, not
@@ -683,8 +683,9 @@ int carve_islands(Graph& g,
           adj_regs + (int64_t)cc.prog.code.size() +
           (int64_t)cc.prog.adj.code.size() + (kOpCost - 1) * 2 * n_calls;
       if (std::getenv("STANLI_DEBUG_ISLAND"))
-        std::fprintf(stderr, "island? ops=%zu graph=%lld island=%lld\n", j - i,
-                     (long long)graph_cost, (long long)island_cost);
+        emit_diagnostic("island? ops=" + std::to_string(j - i) +
+                        " graph=" + std::to_string(graph_cost) +
+                        " island=" + std::to_string(island_cost));
       if (graph_cost < island_cost) compiled = false;
     }
     if (compiled && destination_source && priced_gen) {
@@ -701,9 +702,9 @@ int carve_islands(Graph& g,
         if (usable) {
           cc.prog = std::move(optimized);
         } else if (std::getenv("STANLI_DEBUG_ISLAND")) {
-          std::fprintf(stderr,
-                       "island: destination forwarding kept the priced "
-                       "program because its optimized adjoint was refused\n");
+          emit_diagnostic(
+              "island: destination forwarding kept the priced program "
+              "because its optimized adjoint was refused");
         }
       }
     }
@@ -771,22 +772,25 @@ int carve_islands(Graph& g,
       }
       if (std::getenv("STANLI_DEBUG_ISLAND")) {
         const IslandProg& p = *static_cast<const IslandProg*>(is.udata);
-        std::fprintf(stderr,
-                     "island: ops=%zu instr=%zu regs=%d ins=%zu outs=%zu "
-                     "adj=%zu adj_regs=%d\n",
-                     j - i, p.code.size(), p.n_regs, p.ins.size(),
-                     p.out_regs.size(), p.adj.code.size(), p.adj.n_regs);
+        emit_diagnostic("island: ops=" + std::to_string(j - i) +
+                        " instr=" + std::to_string(p.code.size()) +
+                        " regs=" + std::to_string(p.n_regs) +
+                        " ins=" + std::to_string(p.ins.size()) +
+                        " outs=" + std::to_string(p.out_regs.size()) +
+                        " adj=" + std::to_string(p.adj.code.size()) +
+                        " adj_regs=" + std::to_string(p.adj.n_regs));
         // Which instructions the region is made of, so a disagreement
         // with the replay can be attributed to an opcode rather than
         // guessed at.
         std::vector<int> hist(64, 0);
         for (const auto& I : p.code)
           if ((int)I.code < 64) ++hist[(size_t)I.code];
-        std::fprintf(stderr, "island opcodes:");
+        std::string opcodes = "island opcodes:";
         for (int c = 0; c < 64; ++c)
           if (hist[(size_t)c])
-            std::fprintf(stderr, " %d:%d", c, hist[(size_t)c]);
-        std::fprintf(stderr, "\n");
+            opcodes +=
+                " " + std::to_string(c) + ":" + std::to_string(hist[(size_t)c]);
+        emit_diagnostic(opcodes);
       }
       ++carved;
       i = j;

--- a/runtime/src/lower_higher_order.cpp
+++ b/runtime/src/lower_higher_order.cpp
@@ -882,10 +882,8 @@ Lowering::Val Lowering::lower_algebra_fn(const mir::Expr& e,
     note_interpreter_fallback("the algebraic system " + spec->system_name,
                               spec->prog.why);
   if (!spec->prog.ok && std::getenv("STANLI_DEBUG_ALGEBRA"))
-    std::fprintf(stderr,
-                 "stanli: algebraic system %s falls back to the "
-                 "interpreter: %s\n",
-                 spec->system_name.c_str(), spec->prog.why.c_str());
+    emit_diagnostic("stanli: algebraic system " + spec->system_name +
+                    " falls back to the interpreter: " + spec->prog.why);
 
   SlotInfo si = view_of(e.type_);
   si.param_free = x.si.param_free && y.si.param_free;
@@ -905,10 +903,8 @@ Lowering::Val Lowering::emit_ode(std::shared_ptr<OdeSpec> spec, const Val& z0,
   // Falling back to the interpreter is correct but ~30x slower, so make
   // it findable rather than silent.
   if (!spec->prog.ok && std::getenv("STANLI_DEBUG_ODE"))
-    std::fprintf(stderr,
-                 "stanli: ODE right-hand side %s falls back to the "
-                 "interpreter: %s\n",
-                 spec->rhs_name.c_str(), spec->prog.why.c_str());
+    emit_diagnostic("stanli: ODE right-hand side " + spec->rhs_name +
+                    " falls back to the interpreter: " + spec->prog.why);
   if (spec->prog.ok &&
       (spec->solver == OdeSpec::RK45 || spec->solver == OdeSpec::CKRK)) {
     spec->direct_rk =
@@ -920,14 +916,12 @@ Lowering::Val Lowering::emit_ode(std::shared_ptr<OdeSpec> spec, const Val& z0,
       (spec->solver == OdeSpec::RK45 || spec->solver == OdeSpec::CKRK) &&
       std::getenv("STANLI_DEBUG_ODE")) {
     if (spec->direct_rk)
-      std::fprintf(stderr,
-                   "stanli: ODE right-hand side %s is direct-RK eligible%s\n",
-                   spec->rhs_name.c_str(),
-                   spec->direct_rk_enabled ? "" : " (oracle selected)");
+      emit_diagnostic("stanli: ODE right-hand side " + spec->rhs_name +
+                      " is direct-RK eligible" +
+                      (spec->direct_rk_enabled ? "" : " (oracle selected)"));
     else
-      std::fprintf(stderr,
-                   "stanli: ODE right-hand side %s keeps the RK oracle: %s\n",
-                   spec->rhs_name.c_str(), spec->direct_rk_why.c_str());
+      emit_diagnostic("stanli: ODE right-hand side " + spec->rhs_name +
+                      " keeps the RK oracle: " + spec->direct_rk_why);
   }
   Val v = t0 && ts ? emit_value(OP_ODE, {z0, theta, *t0, *ts}, N * S, result_si,
                                 {(int)N, (int)S})

--- a/runtime/src/lower_internal.hpp
+++ b/runtime/src/lower_internal.hpp
@@ -19,6 +19,7 @@
 #include <stanli/mir_prog.hpp>
 #include <stanli/mir.hpp>
 #include <stanli/mir_decode.hpp>
+#include <stanli/message_sink.hpp>
 #include <stanli/mir_interp.hpp>
 #include <stanli/ode.hpp>
 #include <stanli/ode_adjoint.hpp>
@@ -36,7 +37,6 @@
 
 #include <algorithm>
 #include <cstdio>
-#include <cstdlib>
 #ifdef _WIN32
 #include <direct.h>
 #else
@@ -111,7 +111,9 @@ struct PrepTrace {
     int64_t udata = 0;
   };
 
-  explicit PrepTrace(bool enabled) : enabled_(enabled) {}
+  explicit PrepTrace(bool enabled) : enabled_(enabled) {
+    if (enabled_) rows_.reserve(32);
+  }
 
   bool enabled() const { return enabled_; }
 
@@ -173,8 +175,7 @@ struct PrepTrace {
 
   void report() const {
     if (!enabled_) return;
-    for (size_t i = 0; i < size_; ++i) {
-      const Row& r = rows_[i];
+    for (const Row& r : rows_) {
       std::string line = "stanli_prep graph=" + std::string(r.graph) +
                          " stage=" + r.stage + " ns=" + std::to_string(r.ns);
       const auto field = [&](const char* name, int64_t value) {
@@ -238,14 +239,13 @@ struct PrepTrace {
         field("idata_elems", r.idata_elems);
         field("udata", r.udata);
       }
-      std::fprintf(stderr, "%s\n", line.c_str());
+      emit_diagnostic(line);
     }
   }
 
  private:
   bool enabled_ = false;
-  std::array<Row, 32> rows_{};
-  size_t size_ = 0;
+  std::vector<Row> rows_;
 
   int64_t elapsed(Time from) const {
     return std::chrono::duration_cast<std::chrono::nanoseconds>(Clock::now() -
@@ -254,10 +254,8 @@ struct PrepTrace {
   }
 
   Row& next() {
-    // There are currently 20 rows with a write_array graph. Keep this a fixed
-    // buffer so the profiler itself cannot show up as allocator work.
-    if (size_ >= rows_.size()) std::abort();
-    return rows_[size_++];
+    rows_.emplace_back();
+    return rows_.back();
   }
 };
 
@@ -309,11 +307,10 @@ struct PassDumper {
     const int n = n_++;
     if (!unfiltered && !selects(label)) return;
     if (to_stdout()) {
-      std::printf(";; %s\n", label.c_str());
-      std::fwrite(text.data(), 1, text.size(), stdout);
-      if (!text.empty() && text.back() != '\n') std::fputc('\n', stdout);
-      std::printf(";; end %s\n", label.c_str());
-      std::fflush(stdout);
+      std::string dump = ";; " + label + "\n" + text;
+      if (!text.empty() && text.back() != '\n') dump += '\n';
+      dump += ";; end " + label;
+      emit_message(dump);
       return;
     }
     char prefix[8];

--- a/runtime/src/lower_structured_loop.inc
+++ b/runtime/src/lower_structured_loop.inc
@@ -9,6 +9,13 @@ int region_control_depth = 0;
 bool region_control_active = false;
 unsigned structured_outer_depth = 0;
 
+// Matches ostream's default floating-point formatting.
+static std::string fmt_g(double v) {
+  char buf[32];
+  std::snprintf(buf, sizeof(buf), "%g", v);
+  return buf;
+}
+
 void region_flush() {
   while (region_emitted < g.ops.size()) {
     RegionNode n;
@@ -1179,24 +1186,26 @@ std::optional<int64_t> region_while_capacity(const mir::Stmt& s,
   auto real_end = region_real_range(guard->args[1]);
   if (integer_counter ? (!int_start || !int_end) : (!real_start || !real_end)) {
     if (std::getenv("STANLI_STRUCTURED_LOOP_DIAGNOSTICS")) {
-      std::cerr << "stanli_structured while capacity ranges counter=" << counter
-                << " integer=" << integer_counter << " start="
-                << bool(integer_counter ? bool(int_start) : bool(real_start))
-                << " end="
-                << bool(integer_counter ? bool(int_end) : bool(real_end))
-                << " real_slots=" << real_ranges.size() << "\n";
+      emit_diagnostic(
+          "stanli_structured while capacity ranges counter=" + counter +
+          " integer=" + std::to_string(integer_counter) + " start=" +
+          std::to_string(integer_counter ? bool(int_start) : bool(real_start)) +
+          " end=" +
+          std::to_string(integer_counter ? bool(int_end) : bool(real_end)) +
+          " real_slots=" + std::to_string(real_ranges.size()));
       std::function<void(const mir::Expr&)> show = [&](const mir::Expr& x) {
         if (x.kind == mir::Expr::Var) {
           auto sv = scope.find(x.name);
-          std::cerr << "  var " << x.name
-                    << " slot=" << (sv == scope.end() ? -1 : sv->second.slot);
+          std::string line =
+              "  var " + x.name +
+              " slot=" + std::to_string(sv == scope.end() ? -1 : sv->second.slot);
           if (sv != scope.end()) {
             auto rr = real_ranges.find(sv->second.slot);
             if (rr != real_ranges.end())
-              std::cerr << " range=[" << rr->second.lo << "," << rr->second.hi
-                        << "]";
+              line += " range=[" + fmt_g(rr->second.lo) + "," +
+                      fmt_g(rr->second.hi) + "]";
           }
-          std::cerr << "\n";
+          emit_diagnostic(line);
         }
         for (const auto& a : x.args) show(a);
       };
@@ -1268,8 +1277,9 @@ std::optional<int64_t> region_while_capacity(const mir::Stmt& s,
   for (const auto& st : s.body) advances(st, true);
   if (!valid) {
     if (std::getenv("STANLI_STRUCTURED_LOOP_DIAGNOSTICS"))
-      std::cerr << "stanli_structured while capacity invalid update counter="
-                << counter << "\n";
+      emit_diagnostic(
+          "stanli_structured while capacity invalid update counter=" +
+          counter);
     return {};
   }
   int64_t count = 0;
@@ -1302,11 +1312,12 @@ std::optional<int64_t> region_while_capacity(const mir::Stmt& s,
           real_start->lo,
           std::max(real_start->hi, real_end->hi + real_step_hi)};
     if (std::getenv("STANLI_STRUCTURED_LOOP_DIAGNOSTICS"))
-      std::cerr << "stanli_structured real while counter=" << counter
-                << " start=[" << real_start->lo << "," << real_start->hi
-                << "] end=[" << real_end->lo << "," << real_end->hi
-                << "] step=[" << real_step_lo << "," << real_step_hi
-                << "] capacity=" << count << "\n";
+      emit_diagnostic(
+          "stanli_structured real while counter=" + counter + " start=[" +
+          fmt_g(real_start->lo) + "," + fmt_g(real_start->hi) + "] end=[" +
+          fmt_g(real_end->lo) + "," + fmt_g(real_end->hi) + "] step=[" +
+          fmt_g(real_step_lo) + "," + fmt_g(real_step_hi) +
+          "] capacity=" + std::to_string(count));
   }
   *proven_counter = counter;
   return count;
@@ -1964,7 +1975,7 @@ bool try_lower_region(
   if (!force && profitable_unroll) return false;
   const auto refuse = [&](const std::string& reason) {
     if (std::getenv("STANLI_STRUCTURED_LOOP_DIAGNOSTICS"))
-      std::fprintf(stderr, "stanli_structured refused: %s\n", reason.c_str());
+      emit_diagnostic("stanli_structured refused: " + reason);
     if (force)
       fail("compact loop lowering unavailable: " + reason +
            "; forced structured lowering cannot use the legacy path");
@@ -2147,8 +2158,8 @@ bool try_lower_region(
     }
     if (!candidate_ready) native_refusal = refusal;
     if (!candidate_ready && std::getenv("STANLI_STRUCTURED_LOOP_DIAGNOSTICS"))
-      std::fprintf(stderr, "stanli_structured native candidate (%s): %s\n",
-                   s.loopvar.c_str(), refusal.c_str());
+      emit_diagnostic("stanli_structured native candidate (" + s.loopvar +
+                      "): " + refusal);
   }
   const bool diagnostics = std::getenv("STANLI_STRUCTURED_LOOP_DIAGNOSTICS") ||
                            std::getenv("STANLI_PROFILE_PREP");
@@ -2225,7 +2236,8 @@ bool try_lower_region(
             .slot);
   }
   if (diagnostics)
-    std::fprintf(stderr, "stanli_structured selected nodes=%zu kernels=%zu\n",
-                 plan->node_count, plan->body.ops.size());
+    emit_diagnostic("stanli_structured selected nodes=" +
+                    std::to_string(plan->node_count) +
+                    " kernels=" + std::to_string(plan->body.ops.size()));
   return true;
 }

--- a/runtime/src/message_sink.cpp
+++ b/runtime/src/message_sink.cpp
@@ -13,7 +13,17 @@ std::mutex& sink_mutex() {
   return m;
 }
 
-MessageSink& sink() {
+MessageSink& current_sink() {
+  static MessageSink s;
+  return s;
+}
+
+std::mutex& diagnostic_mutex() {
+  static std::mutex m;
+  return m;
+}
+
+MessageSink& current_diagnostic_sink() {
   static MessageSink s;
   return s;
 }
@@ -22,21 +32,41 @@ MessageSink& sink() {
 
 void set_message_sink(MessageSink s) {
   std::lock_guard<std::mutex> lock(sink_mutex());
-  sink() = std::move(s);
+  current_sink() = std::move(s);
 }
 
 void emit_message(const std::string& text) {
   std::lock_guard<std::mutex> lock(sink_mutex());
-  if (sink()) {
-    sink()(text.data(), text.size());
+  if (current_sink()) {
+    current_sink()(text.data(), text.size());
     return;
   }
+#ifndef STANLI_NO_STDIO
   // The default, and what both paths did before there was a sink: the
   // line and its newline to stdout. One fwrite per call rather than two,
   // so a line cannot be split by another thread's output.
   std::string line = text;
   line += '\n';
   std::fwrite(line.data(), 1, line.size(), stdout);
+#endif
+}
+
+void set_diagnostic_sink(MessageSink s) {
+  std::lock_guard<std::mutex> lock(diagnostic_mutex());
+  current_diagnostic_sink() = std::move(s);
+}
+
+void emit_diagnostic(const std::string& text) {
+  std::lock_guard<std::mutex> lock(diagnostic_mutex());
+  if (current_diagnostic_sink()) {
+    current_diagnostic_sink()(text.data(), text.size());
+    return;
+  }
+#ifndef STANLI_NO_STDIO
+  std::string line = text;
+  line += '\n';
+  std::fwrite(line.data(), 1, line.size(), stderr);
+#endif
 }
 
 }  // namespace stanli

--- a/runtime/src/structured_loop.cpp
+++ b/runtime/src/structured_loop.cpp
@@ -1,10 +1,10 @@
 #include <stanli/structured_loop.hpp>
+#include <stanli/message_sink.hpp>
 #include <stanli/optable.hpp>
 
 #include <algorithm>
 #include <array>
 #include <cmath>
-#include <cstdio>
 #include <cstdlib>
 #include <limits>
 #include <memory>
@@ -606,14 +606,16 @@ struct Segmenter {
         std::any_of(segment.program.ins.begin(), segment.program.ins.end(),
                     [](const IslandProg::LiveIn& in) { return in.active; });
     if (std::getenv("STANLI_STRUCTURED_LOOP_DIAGNOSTICS"))
-      std::fprintf(stderr,
-                   "stanli_structured segment: items=%zu instr=%zu calls=%zu "
-                   "regs=%d ins=%zu outs=%zu adj=%zu adj_regs=%d active=%d\n",
-                   items.size(), segment.program.code.size(),
-                   segment.program.calls.size(), segment.program.n_regs,
-                   segment.ins.size(), segment.outs.size(),
-                   segment.program.adj.code.size(), segment.program.adj.n_regs,
-                   result.active ? 1 : 0);
+      emit_diagnostic(
+          "stanli_structured segment: items=" + std::to_string(items.size()) +
+          " instr=" + std::to_string(segment.program.code.size()) +
+          " calls=" + std::to_string(segment.program.calls.size()) +
+          " regs=" + std::to_string(segment.program.n_regs) +
+          " ins=" + std::to_string(segment.ins.size()) +
+          " outs=" + std::to_string(segment.outs.size()) +
+          " adj=" + std::to_string(segment.program.adj.code.size()) +
+          " adj_regs=" + std::to_string(segment.program.adj.n_regs) +
+          " active=" + std::to_string(result.active ? 1 : 0));
     p.segments.push_back(std::move(segment));
     return true;
   }
@@ -2111,19 +2113,25 @@ void structured_loop_forward(KernelCtx& ctx) {
       segment_records += r.kind == Record::Segment;
     }
     for (const auto& tape : s.memo_tape) memo_tape += tape.size();
-    std::fprintf(stderr,
-                 "stanli_structured tape: arena=%zu adjoints=%lld versions=%zu "
-                 "handles=%zu kernel_records=%zu updates=%zu undo=%zu "
-                 "copies=%zu targets=%zu workspace=%zu memo_nodes=%zu "
-                 "memo_restores=%zu memo_tape=%zu traces=%zu trace=%zu "
-                 "visits=%zu segments=%zu segment_records=%zu "
-                 "record_arena=%zu record_versions=%zu\n",
-                 arena_used, static_cast<long long>(s.adjoint_size),
-                 s.versions.size(), s.handles.size(), kernel_records, updates,
-                 s.undo.size() / 2, copies, s.target_refs.size(),
-                 s.workspace.size(), p.memo_count, s.memo_restores, memo_tape,
-                 p.trace_count, s.trace.size(), s.visits, p.segments.size(),
-                 segment_records, s.record_arena, s.record_versions);
+    emit_diagnostic(
+        "stanli_structured tape: arena=" + std::to_string(arena_used) +
+        " adjoints=" + std::to_string(s.adjoint_size) +
+        " versions=" + std::to_string(s.versions.size()) +
+        " handles=" + std::to_string(s.handles.size()) + " kernel_records=" +
+        std::to_string(kernel_records) + " updates=" + std::to_string(updates) +
+        " undo=" + std::to_string(s.undo.size() / 2) +
+        " copies=" + std::to_string(copies) +
+        " targets=" + std::to_string(s.target_refs.size()) +
+        " workspace=" + std::to_string(s.workspace.size()) +
+        " memo_nodes=" + std::to_string(p.memo_count) +
+        " memo_restores=" + std::to_string(s.memo_restores) + " memo_tape=" +
+        std::to_string(memo_tape) + " traces=" + std::to_string(p.trace_count) +
+        " trace=" + std::to_string(s.trace.size()) +
+        " visits=" + std::to_string(s.visits) +
+        " segments=" + std::to_string(p.segments.size()) +
+        " segment_records=" + std::to_string(segment_records) +
+        " record_arena=" + std::to_string(s.record_arena) +
+        " record_versions=" + std::to_string(s.record_versions));
   }
   s.memo_ready = true;
   s.reverse_ready = true;

--- a/tools/check_no_stdio.sh
+++ b/tools/check_no_stdio.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# Builds stanli_runtime_objects with STANLI_NO_STDIO defined and fails if any
+# of its object files (other than the ones stanr's tools/upgrade_stanli.sh
+# deletes before packaging) reference an entry point R CMD check forbids in
+# compiled code: the standard streams, abort/exit, or the assert failure path.
+#
+#   tools/check_no_stdio.sh [build-dir]     (default build-dir: build-no-stdio)
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+BUILD_DIR=${1:-build-no-stdio}
+
+# stanr deletes these source files before vendoring the runtime; their
+# object files are not part of what ships and may still reference the
+# symbols below.
+EXEMPT_STEMS=(
+  capi bridgestan_abi stanc_embed_c nuts estimate diagnose walnuts
+  pathfinder data
+)
+
+# The entry points R CMD check rejects in compiled code (tools/sotools.R):
+# the stdout/stderr objects and the functions that imply them, process
+# exit, the assert failure path, and the C rand family. Writes to a FILE*
+# the code opened itself are allowed.
+FORBIDDEN=(
+  stdout stderr __stdoutp __stderrp printf vprintf puts putchar
+  abort exit _exit _Exit __assert_fail __assert_rtn
+  rand srand random srandom
+)
+
+LAUNCHER_FLAG=()
+if command -v ccache >/dev/null 2>&1; then
+  LAUNCHER_FLAG=(-DCMAKE_CXX_COMPILER_LAUNCHER=ccache)
+fi
+
+cmake -B "$BUILD_DIR" -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_CXX_FLAGS="-DSTANLI_NO_STDIO -DNDEBUG" \
+  "${LAUNCHER_FLAG[@]}"
+cmake --build "$BUILD_DIR" --target stanli_runtime_objects \
+  --parallel "$(tools/build_jobs.sh)"
+
+is_exempt() {
+  local stem=$1 e
+  for e in "${EXEMPT_STEMS[@]}"; do
+    [ "$stem" = "$e" ] && return 0
+  done
+  return 1
+}
+
+# A symbol is forbidden if either the raw nm name or that name with one
+# leading underscore stripped (the Mach-O C-symbol prefix; Linux ELF adds
+# none) equals an entry verbatim, or if it demangles to std::cout/std::cerr
+# (with or without libc++'s inline ABI namespace).
+is_forbidden_symbol() {
+  local raw=$1 demangled=$2 stripped f
+  raw=${raw%%@@*}
+  stripped=${raw#_}
+  for f in "${FORBIDDEN[@]}"; do
+    [ "$raw" = "$f" ] && return 0
+    [ "$stripped" = "$f" ] && return 0
+  done
+  case "$demangled" in
+    std::cout | std::__*::cout | std::cerr | std::__*::cerr) return 0 ;;
+  esac
+  return 1
+}
+
+found=0
+while IFS= read -r -d '' obj; do
+  stem=$(basename "$obj" .cpp.o)
+  is_exempt "$stem" && continue
+
+  raw_file=$(mktemp)
+  demangled_file=$(mktemp)
+  nm -uP "$obj" 2>/dev/null | awk '{print $1}' > "$raw_file"
+  c++filt < "$raw_file" > "$demangled_file"
+
+  while IFS=$'\t' read -r raw demangled; do
+    [ -z "$raw" ] && continue
+    if is_forbidden_symbol "$raw" "$demangled"; then
+      echo "forbidden symbol in $obj: $demangled ($raw)" >&2
+      found=1
+    fi
+  done < <(paste "$raw_file" "$demangled_file")
+  rm -f "$raw_file" "$demangled_file"
+done < <(find "$BUILD_DIR/CMakeFiles/stanli_runtime_objects.dir" -name '*.o' -print0)
+
+if [ "$found" -ne 0 ]; then
+  echo "check_no_stdio: forbidden symbols found under STANLI_NO_STDIO" >&2
+  exit 1
+fi
+echo "check_no_stdio: stanli_runtime_objects has no forbidden symbols"

--- a/tools/check_no_stdio.sh
+++ b/tools/check_no_stdio.sh
@@ -28,14 +28,19 @@ FORBIDDEN=(
   rand srand random srandom
 )
 
-LAUNCHER_FLAG=()
+EXTRA_FLAGS=()
 if command -v ccache >/dev/null 2>&1; then
-  LAUNCHER_FLAG=(-DCMAKE_CXX_COMPILER_LAUNCHER=ccache)
+  EXTRA_FLAGS+=(-DCMAKE_CXX_COMPILER_LAUNCHER=ccache)
+fi
+# Configuration insists on the pinned compiler, but the runtime objects never
+# run it; a stub keeps this check independent of the OCaml build.
+if [ ! -x deps/stanc3/stanc ]; then
+  EXTRA_FLAGS+=(-DSTANLI_STANC_EXECUTABLE=/usr/bin/true)
 fi
 
 cmake -B "$BUILD_DIR" -DCMAKE_BUILD_TYPE=Release \
   -DCMAKE_CXX_FLAGS="-DSTANLI_NO_STDIO -DNDEBUG" \
-  "${LAUNCHER_FLAG[@]}"
+  "${EXTRA_FLAGS[@]}"
 cmake --build "$BUILD_DIR" --target stanli_runtime_objects \
   --parallel "$(tools/build_jobs.sh)"
 


### PR DESCRIPTION
stanr vendors runtime/ into a CRAN-style package and R CMD check rejects compiled code that references the standard streams, abort, exit or the assert path. Its upgrade script edits our sources by exact string match to get there, which broke when lower.cpp was split.

With `STANLI_NO_STDIO` defined the runtime object library carries none of those symbols: the STANLI_DEBUG_* traces, the preparation profiler and the structured-loop diagnostics go through a new `emit_diagnostic` channel (stderr by default, sink-installable), the stdout pass dump goes through `emit_message`, and PrepTrace grows a vector instead of aborting at 32 rows. `tools/check_no_stdio.sh` builds the objects under the macro and scans them; a new PR job runs it.

A stanr PR follows that drops the anchored patches and pins this revision.