### PR TITLE
Evaluate Boost special functions in double

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,13 @@ is re-recorded. The sweep found the three fixes below.
 
 ### Fixes
 
+`beta_neg_binomial_cdf`, `_lcdf` and `_lccdf` took about a second per call
+on aarch64 Linux. Boost's default policy evaluates double special
+functions in long double, which there is software binary128, and its
+epsilon set the length of the hypergeometric series. The build now turns
+that promotion off, so every platform evaluates in double, as macOS on
+Apple silicon already did.
+
 `bernoulli_logit_glm`, `poisson_log_glm` and `neg_binomial_2_log_glm`
 dropped the gradient of a parameter design matrix: the log density was
 right and `x`'s adjoint came back zero.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,6 +106,10 @@ target_include_directories(stanmath INTERFACE
   ${_sundials}/include
   ${_tbb}/include)
 target_compile_definitions(stanmath INTERFACE _REENTRANT BOOST_DISABLE_ASSERTS)
+# Boost's default policy evaluates double in long double, which on aarch64
+# Linux is software binary128: its epsilon then sets the series length in
+# hypergeometric_pFq, so beta_neg_binomial's CDFs take a second per call.
+target_compile_definitions(stanmath INTERFACE BOOST_MATH_PROMOTE_DOUBLE_POLICY=false)
 # Pin FP contraction off: clang otherwise forms FMAs differently across
 # template instantiations of the same math, which breaks bitwise parity
 # between the kernels and the var-path references (measured: 2 ULP on


### PR DESCRIPTION
The post-submit aarch64 job on main timed out in the beta_neg_binomial CDF signature partitions. stan-math calls Boost's hypergeometric_pFq under the default policy, which promotes double to long double. On aarch64 Linux that is software binary128, and Boost's series then runs until its terms fall below an epsilon of 1e-34. For the CDF's 3F2 at z = 1 that is tens of thousands of software-float terms per call.

This sets BOOST_MATH_PROMOTE_DOUBLE_POLICY=false for everything built against stan-math, so all platforms evaluate in double. macOS on Apple silicon already did, since long double is double there, and the references were recorded on it.

PR CI does not build aarch64, so I have dispatched the full matrix on this branch by hand.