### PR TITLE
Write generated quantities on each chain's thread as it samples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+Generated quantities and transformed parameters are now written by each
+chain as it samples. The work happens on the chain's own thread as each
+draw is stored, so it runs in parallel across chains and inside the
+sampling progress the user already sees. R and Python no longer constrain
+the stored draws after the run finishes, a phase that showed no progress
+and could take a long time on a model with tens of thousands of output
+columns.
+
 The runtime can now be built with `STANLI_NO_STDIO` defined, for R
 packaging: the object library then contains no stdout, stderr, abort, or
 assert-failure symbols. Debug traces that used to write directly to stderr

--- a/python/stanli/__init__.py
+++ b/python/stanli/__init__.py
@@ -179,6 +179,14 @@ def _load_lib():
         _SampleProgressCallback, ctypes.c_void_p, _SamplePollCallback,
         ctypes.c_void_p, ctypes.POINTER(ctypes.c_int),
         ctypes.POINTER(_SampleReport), ctypes.c_char_p, ctypes.c_size_t]
+    lib.stanli_sample_multi_write_array.restype = ctypes.c_int
+    lib.stanli_sample_multi_write_array.argtypes = [
+        ctypes.c_void_p, ctypes.POINTER(_SampleOpts), ctypes.c_int,
+        ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double),
+        ctypes.POINTER(ctypes.c_double),
+        _SampleProgressCallback, ctypes.c_void_p, _SamplePollCallback,
+        ctypes.c_void_p, ctypes.POINTER(ctypes.c_int),
+        ctypes.POINTER(_SampleReport), ctypes.c_char_p, ctypes.c_size_t]
     lib.stanli_pathfinder_inits.restype = ctypes.c_int
     lib.stanli_pathfinder_inits.argtypes = [
         ctypes.c_void_p, ctypes.c_uint32, ctypes.c_int, ctypes.c_int,
@@ -1139,6 +1147,8 @@ class Model:
         n_stored = _lib.stanli_n_stored_draws(ctypes.byref(opts))
         raw = np.empty((opts.chains, n_stored, self.n_unconstrained))
         stats = np.empty((opts.chains, n_stored, _N_SAMPLER_COLS))
+        names, _ = self._column_names()
+        out = np.empty((opts.chains, n_stored, len(names)))
         reports = (_SampleReport * opts.chains)()
         err = ctypes.create_string_buffer(4096)
         callback_errors = []
@@ -1163,9 +1173,9 @@ class Model:
         interrupted = ctypes.c_int(0)
         watch = _InterruptWatch()
         with watch:
-            failed = _lib.stanli_sample_multi_interruptible(
+            failed = _lib.stanli_sample_multi_write_array(
                 self._m, ctypes.byref(opts), refresh, _dptr(raw),
-                _dptr(stats), progress_cb, None, watch.poll, None,
+                _dptr(stats), _dptr(out), progress_cb, None, watch.poll, None,
                 ctypes.byref(interrupted), reports, err, len(err))
         del init_arr
         if interrupted.value:
@@ -1177,26 +1187,7 @@ class Model:
         if callback_errors:
             raise callback_errors[0]
 
-        names, have_wa = self._column_names()
-        out = np.empty((opts.chains, n_stored, len(names)))
-        row = np.empty(len(names))
         first_chain = opts.chain_id if opts.chain_id > 0 else 1
-        for c in range(opts.chains):
-            if have_wa:
-                # Generated quantities draw from an RNG stream; give each
-                # chain its own, or every chain would produce identical
-                # posterior-predictive draws from its own parameters.
-                _lib.stanli_wa_seed_chain(
-                    self._m, seed & 0xFFFFFFFF, first_chain + c)
-            for s in range(n_stored):
-                q = np.ascontiguousarray(raw[c, s])
-                if have_wa:
-                    if _lib.stanli_wa_row(self._m, _dptr(q), _dptr(row)) != 0:
-                        raise RuntimeError(
-                            f"write_array failed on chain {c}, draw {s}")
-                else:
-                    _lib.stanli_constrain(self._m, _dptr(q), _dptr(row))
-                out[c, s] = row
         fit = Fit(names, out, stats, opts.max_depth, seed, reports)
         if refresh:
             _print_sample_reports(reports, first_chain, opts.samples,

--- a/r/src/bridge.c
+++ b/r/src/bridge.c
@@ -141,6 +141,11 @@ static int (*p_sample_multi_interruptible)(void*, const stanli_sample_opts*,
                                            stanli_sample_poll_cb, void*, int*,
                                            stanli_sample_report*, char*,
                                            size_t);
+static int (*p_sample_multi_write_array)(void*, const stanli_sample_opts*, int,
+                                         double*, double*, double*,
+                                         stanli_sample_progress_cb, void*,
+                                         stanli_sample_poll_cb, void*, int*,
+                                         stanli_sample_report*, char*, size_t);
 static int (*p_pathfinder_inits)(void*, uint32_t, int, int, int, int, int,
                                  double, double*, stanli_path_cb, void*, char*,
                                  size_t);
@@ -225,6 +230,8 @@ SEXP stanli_bridge_load(SEXP path) {
       dl_sym(g_lib, "stanli_sample_multi_progress");
   *(void**)(&p_sample_multi_interruptible) =
       dl_sym(g_lib, "stanli_sample_multi_interruptible");
+  *(void**)(&p_sample_multi_write_array) =
+      dl_sym(g_lib, "stanli_sample_multi_write_array");
   /* Pathfinder initialization is also additive. Only callers that request it
    * require a runtime new enough to provide the symbol. */
   *(void**)(&p_pathfinder_inits) = dl_sym(g_lib, "stanli_pathfinder_inits");
@@ -501,9 +508,14 @@ SEXP stanli_r_sample(SEXP m, SEXP optlist, SEXP inits, SEXP refresh) {
 
   SEXP raw = PROTECT(allocVector(REALSXP, (R_xlen_t)(nchain * rows * n)));
   SEXP stats = PROTECT(allocVector(REALSXP, (R_xlen_t)(nchain * rows * 7)));
+  int64_t ncol = p_wa_n_columns(mm);
+  const int wa = ncol > 0;
+  if (!wa) ncol = p_n_constrained(mm);
+  SEXP vals = PROTECT(allocVector(REALSXP, (R_xlen_t)(nchain * rows * ncol)));
   char err[4096];
   err[0] = '\0';
   const int have_reports = p_sample_multi_progress != NULL;
+  const int in_worker = p_sample_multi_write_array != NULL;
   if (!have_reports && refresh_rate > 0) {
     Rprintf(
         "Sampling progress is unavailable with this older stanli runtime; "
@@ -513,7 +525,11 @@ SEXP stanli_r_sample(SEXP m, SEXP optlist, SEXP inits, SEXP refresh) {
   }
   int interrupted = 0;
   const int failed =
-      p_sample_multi_interruptible != NULL
+      in_worker ? p_sample_multi_write_array(
+                      mm, &o, refresh_rate, REAL(raw), REAL(stats), REAL(vals),
+                      refresh_rate > 0 ? sample_progress : NULL, NULL,
+                      sample_poll, NULL, &interrupted, reports, err, sizeof err)
+      : p_sample_multi_interruptible != NULL
           ? p_sample_multi_interruptible(
                 mm, &o, refresh_rate, REAL(raw), REAL(stats),
                 refresh_rate > 0 ? sample_progress : NULL, NULL, sample_poll,
@@ -525,7 +541,7 @@ SEXP stanli_r_sample(SEXP m, SEXP optlist, SEXP inits, SEXP refresh) {
                                     NULL, reports, err, sizeof err)
           : p_sample_multi(mm, &o, REAL(raw), REAL(stats), err, sizeof err);
   if (failed) {
-    UNPROTECT(2);
+    UNPROTECT(3);
     error("%d of %d chains failed; first: %s", failed, (int)nchain,
           err[0] ? err : "(no message)");
   }
@@ -533,34 +549,37 @@ SEXP stanli_r_sample(SEXP m, SEXP optlist, SEXP inits, SEXP refresh) {
     const char* names[] = {"interrupted", ""};
     SEXP out = PROTECT(mkNamed(VECSXP, names));
     SET_VECTOR_ELT(out, 0, ScalarLogical(1));
-    UNPROTECT(3);
+    UNPROTECT(4);
     return out;
   }
   if (have_reports && refresh_rate > 0)
     print_sample_reports(&o, nchain, reports);
 
-  /* Constrain every stored draw into the CSV columns, per chain, so the
-   * RNG stream in generated quantities differs by chain the way CmdStan's
-   * does. */
-  int64_t ncol = p_wa_n_columns(mm);
-  const int wa = ncol > 0;
-  if (!wa) ncol = p_n_constrained(mm);
-  SEXP vals = PROTECT(allocVector(REALSXP, (R_xlen_t)(nchain * rows * ncol)));
-  double* vp = REAL(vals);
-  double* rp = REAL(raw);
-  double* row = (double*)R_alloc((size_t)ncol, sizeof(double));
-  const uint32_t first_chain = (uint32_t)(o.chain_id > 0 ? o.chain_id : 1);
-  for (int64_t c = 0; c < nchain; ++c) {
-    if (wa) p_wa_seed_chain(mm, o.seed, first_chain + (uint32_t)c);
-    for (int64_t i = 0; i < rows; ++i) {
-      const double* q = rp + (c * rows + i) * n;
-      const int rc = wa ? p_wa_row(mm, q, row) : p_constrain(mm, q, row);
-      if (rc != 0) {
-        UNPROTECT(3);
-        error("failed to write draw %lld of chain %lld", (long long)i,
-              (long long)c);
+  /* Older runtimes write nothing during sampling: constrain every stored
+   * draw here, per chain, so the RNG stream in generated quantities differs
+   * by chain the way CmdStan's does. */
+  if (!in_worker) {
+    double* vp = REAL(vals);
+    double* rp = REAL(raw);
+    double* row = (double*)R_alloc((size_t)ncol, sizeof(double));
+    const uint32_t first_chain = (uint32_t)(o.chain_id > 0 ? o.chain_id : 1);
+    for (int64_t c = 0; c < nchain; ++c) {
+      if (wa) p_wa_seed_chain(mm, o.seed, first_chain + (uint32_t)c);
+      if (refresh_rate > 0) {
+        Rprintf("Chain [%d] Writing %lld draws\n", first_chain + (int)c,
+                (long long)rows);
+        R_FlushConsole();
       }
-      memcpy(vp + (c * rows + i) * ncol, row, sizeof(double) * (size_t)ncol);
+      for (int64_t i = 0; i < rows; ++i) {
+        const double* q = rp + (c * rows + i) * n;
+        const int rc = wa ? p_wa_row(mm, q, row) : p_constrain(mm, q, row);
+        if (rc != 0) {
+          UNPROTECT(3);
+          error("failed to write draw %lld of chain %lld", (long long)i,
+                (long long)c);
+        }
+        memcpy(vp + (c * rows + i) * ncol, row, sizeof(double) * (size_t)ncol);
+      }
     }
   }
 

--- a/r/tests/testthat/test-sampling.R
+++ b/r/tests/testthat/test-sampling.R
@@ -319,3 +319,14 @@ test_that("a part with no compiled path warns, or errors when refused", {
   on.exit(Sys.unsetenv("STANLI_NO_INTERPRETER"), add = TRUE)
   expect_error(stanli_model(code = code), "STANLI_NO_INTERPRETER")
 })
+
+test_that("a draw whose generated quantities fail names the draw", {
+  skip_without_runtime()
+  m <- stanli_model(code = "
+    parameters { real mu; }
+    model { mu ~ normal(0, 1); }
+    generated quantities { int k = categorical_rng([mu, 1 - mu]'); }")
+  expect_error(
+    sample_model(m, chains = 1, warmup = 20, samples = 20, refresh = 0),
+    "write_array failed on draw")
+})

--- a/runtime/include/stanli/capi.h
+++ b/runtime/include/stanli/capi.h
@@ -215,6 +215,28 @@ int stanli_sample_multi_interruptible(
     stanli_sample_poll_cb poll, void* poll_user, int* interrupted,
     stanli_sample_report* reports, char* err, size_t err_len);
 
+/* stanli_sample_multi_interruptible, with each chain also writing its stored
+ * draws through write_array on its own thread as they are stored, so the work
+ * runs in parallel across chains, inside the sampling progress.
+ *
+ * `values` receives chains * stanli_n_stored_draws(opts) rows of W doubles,
+ * chain-major exactly like `draws`, where W is stanli_wa_n_columns(m) when
+ * that is positive and stanli_n_constrained(m) otherwise. Chain c draws its
+ * generated quantities from the stream (opts->seed, chain_id + c), the one
+ * stanli_wa_seed_chain names, so the rows equal a post-hoc
+ * stanli_wa_seed_chain plus stanli_wa_row loop over `draws` byte for byte.
+ * The model's own stanli_wa_seed stream is untouched. A null `values` makes
+ * this identical to stanli_sample_multi_interruptible.
+ *
+ * A draw whose row cannot be produced fails its chain: it counts in the
+ * return value and err names the chain and the draw. Additive, like the
+ * progress and interruptible entry points. */
+int stanli_sample_multi_write_array(
+    stanli_model* m, const stanli_sample_opts* opts, int refresh, double* draws,
+    double* stats, double* values, stanli_sample_progress_cb progress,
+    void* progress_user, stanli_sample_poll_cb poll, void* poll_user,
+    int* interrupted, stanli_sample_report* reports, char* err, size_t err_len);
+
 /* The seven sampler columns, in order: lp__, accept_stat__, stepsize__,
  * treedepth__, n_leapfrog__, divergent__, energy__. */
 #define STANLI_N_SAMPLER_COLS 7

--- a/runtime/include/stanli/nuts.hpp
+++ b/runtime/include/stanli/nuts.hpp
@@ -52,6 +52,10 @@ struct NutsConfig {
   // `stop` and ends the run.
   std::atomic<bool>* stop = nullptr;
   std::function<bool()> poll;
+  // Called on the chain's own thread right after a draw is stored, with the
+  // zero-based stored row index and the unconstrained point. A throw fails
+  // the chain.
+  std::function<void(int64_t row, const double* q)> on_stored;
 };
 
 // One row per stored draw, in CmdStan's column order:
@@ -115,6 +119,10 @@ struct ChainResult {
 using ChainProgressObserver =
     std::function<void(int chain, int64_t i, bool warmup)>;
 
+// Called on the chain's OWN thread as each draw is stored, for every chain.
+using StoredDrawWriter =
+    std::function<void(int chain, int64_t row, const double* q)>;
+
 // CmdStan-style refresh selection. `i` is zero-based within the phase. The
 // first transition, every `refresh`-th transition within the phase, and the
 // phase's final transition are reported.
@@ -144,7 +152,7 @@ std::vector<ChainResult> run_nuts_chains(
     const std::vector<Executor*>& execs, const NutsConfig& cfg,
     int n_threads = 1, const DrawObserver& observe = {},
     const ChainProgressObserver& progress = {}, int progress_refresh = 1,
-    const std::function<bool()>& poll = {});
+    const std::function<bool()>& poll = {}, const StoredDrawWriter& write = {});
 
 // Build `n` executors over the same compiled graph, copying it out of an
 // already-bound one. The caller keeps ownership; `src` is not modified.

--- a/runtime/src/capi.cpp
+++ b/runtime/src/capi.cpp
@@ -516,6 +516,17 @@ int stanli_sample_multi_interruptible(
     double* stats, stanli_sample_progress_cb progress, void* progress_user,
     stanli_sample_poll_cb poll, void* poll_user, int* interrupted,
     stanli_sample_report* reports, char* err, size_t err_len) {
+  return stanli_sample_multi_write_array(
+      m, opts, refresh, draws, stats, nullptr, progress, progress_user, poll,
+      poll_user, interrupted, reports, err, err_len);
+}
+
+int stanli_sample_multi_write_array(
+    stanli_model* m, const stanli_sample_opts* opts, int refresh, double* draws,
+    double* stats, double* values, stanli_sample_progress_cb progress,
+    void* progress_user, stanli_sample_poll_cb poll, void* poll_user,
+    int* interrupted, stanli_sample_report* reports, char* err,
+    size_t err_len) {
   try {
     if (interrupted != nullptr) *interrupted = 0;
     if (opts == nullptr) {
@@ -565,10 +576,75 @@ int stanli_sample_multi_interruptible(
     if (poll != nullptr)
       poll_fn = [poll, poll_user] { return poll(poll_user) != 0; };
 
+    const int64_t width = m->wa_n > 0 ? m->wa_n : m->n_con;
+    std::vector<stanli::WaRng> wa_rngs;
+    std::vector<std::unique_ptr<stanli::Executor>> wa_clones;
+    std::vector<stanli::Executor*> wa_execs;
+    if (values != nullptr) {
+      wa_rngs.reserve((size_t)n_chains);
+      for (int c = 0; c < n_chains; ++c)
+        wa_rngs.emplace_back((unsigned)opts->seed,
+                             (unsigned)(cfg.chain_id + c));
+      if (m->wa_ex) {
+        wa_execs.push_back(m->wa_ex.get());
+        for (int c = 1; c < n_chains; ++c) {
+          wa_clones.push_back(std::make_unique<stanli::Executor>(*m->wa_ex));
+          wa_execs.push_back(wa_clones.back().get());
+        }
+      }
+    }
+
+    stanli::StoredDrawWriter writer;
+    if (values != nullptr)
+      writer = [&](int c, int64_t row, const double* q) {
+        if (row >= n_stored) return;
+        double* out = values + ((int64_t)c * n_stored + row) * width;
+        stanli::Executor& main_ex = *execs[(size_t)c];
+        stanli::WaRng& rng = wa_rngs[(size_t)c];
+        try {
+          if (m->wa_interp) {
+            std::memcpy(main_ex.params_data(), q,
+                        sizeof(double) * (size_t)main_ex.n_params());
+            main_ex.run_forward_only();
+            const auto r =
+                m->wa_interp->eval(m->cm.constrained_env(main_ex), rng);
+            if ((int64_t)r.size() != width)
+              throw std::runtime_error(
+                  "write_array produced " + std::to_string(r.size()) +
+                  " columns, expected " + std::to_string(width));
+            std::memcpy(out, r.data(), sizeof(double) * (size_t)width);
+          } else if (m->wa_ex) {
+            stanli::Executor& wa_ex = *wa_execs[(size_t)c];
+            std::memcpy(wa_ex.params_data(), q,
+                        sizeof(double) * (size_t)wa_ex.n_params());
+            wa_ex.run_forward_only(stanli::EvalState{&rng});
+            int64_t at = 0;
+            for (const auto& col : m->wa_cols) {
+              const double* p = wa_ex.value_ptr(col.slot);
+              for (int64_t i = 0; i < col.len; ++i) out[at++] = p[i];
+            }
+          } else {
+            std::memcpy(main_ex.params_data(), q,
+                        sizeof(double) * (size_t)main_ex.n_params());
+            main_ex.run_forward_only();
+            int64_t at = 0;
+            for (const auto& v : m->cm.views) {
+              const double* p = main_ex.value_ptr(v.slot);
+              for (int64_t i = 0; i < v.len; ++i)
+                out[at++] = p[v.storage_index(i)];
+            }
+          }
+        } catch (const std::exception& e) {
+          throw std::runtime_error("write_array failed on draw " +
+                                   std::to_string(row) + ": " + e.what());
+        }
+      };
+
     std::vector<stanli::ChainResult> res;
     if (opts->inits == nullptr) {
-      res = stanli::run_nuts_chains(execs, cfg, opts->num_threads, {},
-                                    progress_observer, refresh, poll_fn);
+      res =
+          stanli::run_nuts_chains(execs, cfg, opts->num_threads, {},
+                                  progress_observer, refresh, poll_fn, writer);
     } else {
       std::atomic<bool> stop{false};
       // Per-chain inits mean per-chain configs, which run_nuts_chains
@@ -582,6 +658,10 @@ int stanli_sample_multi_interruptible(
         cc.init = opts->inits + (int64_t)c * n;
         cc.stop = &stop;
         cc.poll = poll_fn;
+        if (writer)
+          cc.on_stored = [&writer, c](int64_t row, const double* q) {
+            writer(c, row, q);
+          };
         try {
           stanli::ProgressObserver one_progress;
           if (progress_observer)

--- a/runtime/src/nuts.cpp
+++ b/runtime/src/nuts.cpp
@@ -106,6 +106,7 @@ std::vector<std::vector<double>> run_nuts(Executor& ex, const NutsConfig& cfg,
              sp.size() > 1 ? sp[1] : 0.0, sp.size() > 2 ? sp[2] : 0.0,
              sp.size() > 3 ? sp[3] : 0.0, sp.size() > 4 ? sp[4] : 0.0});
       }
+      if (cfg.on_stored) cfg.on_stored((int64_t)draws.size() - 1, qd.data());
     }
     if (!warmup && report) {
       if (sp.size() > 3 && sp[3] != 0.0) ++report->n_divergent;
@@ -199,7 +200,8 @@ std::vector<ChainResult> run_nuts_chains(const std::vector<Executor*>& execs,
                                          const DrawObserver& observe,
                                          const ChainProgressObserver& progress,
                                          int progress_refresh,
-                                         const std::function<bool()>& poll) {
+                                         const std::function<bool()>& poll,
+                                         const StoredDrawWriter& write) {
   const size_t n_chains = execs.size();
   std::vector<ChainResult> out(n_chains);
   std::atomic<bool> local_stop{false};
@@ -215,6 +217,10 @@ std::vector<ChainResult> run_nuts_chains(const std::vector<Executor*>& execs,
     cc.chain_id = cfg.chain_id + (int)c;
     cc.stop = stop;
     cc.poll = chain_poll;
+    if (write)
+      cc.on_stored = [&write, c](int64_t row, const double* q) {
+        write((int)c, row, q);
+      };
     try {
       out[c].draws = run_nuts(*execs[c], cc, &out[c].stats,
                               n_chains == 1 ? observe : DrawObserver{},

--- a/runtime/src/wa_interp.cpp
+++ b/runtime/src/wa_interp.cpp
@@ -188,8 +188,8 @@ std::vector<double> WaInterp::eval(
     // ordered backwards.
     if (!saw_gq_) n_gq_start_ = cols_.size();
     if (!saw_tp_) n_tp_start_ = n_gq_start_;
+    have_cols_ = true;
   }
-  have_cols_ = true;
   return row;
 }
 

--- a/tests/fixtures/gq_row_reject.stan
+++ b/tests/fixtures/gq_row_reject.stan
@@ -1,0 +1,11 @@
+// Generated quantities that fail on most draws: [mu, 1 - mu] is a simplex
+// only while mu stays in [0, 1].
+parameters {
+  real mu;
+}
+model {
+  mu ~ normal(0, 1);
+}
+generated quantities {
+  int k = categorical_rng([mu, 1 - mu]');
+}

--- a/tests/test_capi.cpp
+++ b/tests/test_capi.cpp
@@ -737,6 +737,137 @@ void expect_interruptible_sampling() {
   stanli_model_free(model);
 }
 
+// Writing the CSV columns on each chain's own thread as the draws land must
+// produce exactly what the post-hoc loop over the same draws produces, and
+// must leave the sampler's own output alone.
+void expect_in_worker_write_array_on(const char* label, stanli_model* model) {
+  stanli_sample_opts opts;
+  stanli_sample_opts_init(&opts);
+  opts.seed = 7;
+  opts.chains = 2;
+  opts.warmup = 20;
+  opts.samples = 20;
+  const int64_t n = stanli_n_unconstrained(model);
+  const int64_t rows = stanli_n_stored_draws(&opts);
+  const int64_t wa = stanli_wa_n_columns(model);
+  const int64_t width = wa > 0 ? wa : stanli_n_constrained(model);
+  const size_t n_draws = (size_t)(opts.chains * rows * n);
+  const size_t n_stats = (size_t)(opts.chains * rows * STANLI_N_SAMPLER_COLS);
+  const size_t n_values = (size_t)(opts.chains * rows * width);
+  char err[8192]{};
+  for (int threads : {1, 2}) {
+    opts.num_threads = threads;
+    const std::string mode = std::string(" [") + label +
+                             (threads == 1 ? " sequential]" : " threaded]");
+
+    std::vector<double> want_draws(n_draws), want_stats(n_stats);
+    stanli_sample_report want_reports[2];
+    err[0] = '\0';
+    int rc = stanli_sample_multi_interruptible(
+        model, &opts, 0, want_draws.data(), want_stats.data(), nullptr, nullptr,
+        nullptr, nullptr, nullptr, want_reports, err, sizeof err);
+    expect_true("post-hoc reference run succeeds" + mode, rc == 0);
+
+    std::vector<double> want_values(n_values);
+    std::vector<double> row((size_t)width);
+    bool reference_ok = true;
+    for (int64_t c = 0; c < opts.chains; ++c) {
+      if (wa > 0) stanli_wa_seed_chain(model, opts.seed, (uint32_t)(1 + c));
+      for (int64_t i = 0; i < rows; ++i) {
+        const double* q = want_draws.data() + (c * rows + i) * n;
+        const int wrc = wa > 0 ? stanli_wa_row(model, q, row.data())
+                               : stanli_constrain(model, q, row.data());
+        if (wrc != 0) reference_ok = false;
+        std::copy(row.begin(), row.end(),
+                  want_values.begin() + (size_t)((c * rows + i) * width));
+      }
+    }
+    expect_true("post-hoc write_array succeeds" + mode, reference_ok);
+
+    std::vector<double> draws(n_draws, -1.0), stats(n_stats, -1.0);
+    std::vector<double> values(n_values, -1.0);
+    stanli_sample_report reports[2];
+    int interrupted = -1;
+    err[0] = '\0';
+    rc = stanli_sample_multi_write_array(
+        model, &opts, 0, draws.data(), stats.data(), values.data(), nullptr,
+        nullptr, nullptr, nullptr, &interrupted, reports, err, sizeof err);
+    expect_true("in-worker write_array sampling succeeds" + mode,
+                rc == 0 && interrupted == 0);
+    expect_true("in-worker write_array leaves the sampler alone" + mode,
+                draws == want_draws && stats == want_stats);
+    expect_true("in-worker write_array matches the post-hoc loop" + mode,
+                values == want_values);
+
+    std::vector<double> null_draws(n_draws, -1.0), null_stats(n_stats, -1.0);
+    err[0] = '\0';
+    rc = stanli_sample_multi_write_array(
+        model, &opts, 0, null_draws.data(), null_stats.data(), nullptr, nullptr,
+        nullptr, nullptr, nullptr, nullptr, reports, err, sizeof err);
+    expect_true(
+        "a null values buffer is the interruptible entry" + mode,
+        rc == 0 && null_draws == want_draws && null_stats == want_stats);
+  }
+}
+
+void expect_in_worker_write_array() {
+  char err[8192]{};
+  stanli_model* graph = stanli_model_new(
+      slurp("tests/fixtures/gqconst.tmir.sexp").c_str(),
+      R"({"rectangular":[[1,4],[2,5],[3,6]]})", err, sizeof err);
+  expect_true("in-worker write_array graph model builds", graph != nullptr);
+  if (graph != nullptr) {
+    expect_in_worker_write_array_on("graph", graph);
+    stanli_model_free(graph);
+  }
+
+  const std::string interp_mir = categorical_write_array_mir(
+      slurp("tests/fixtures/cat.tmir.sexp"), "categorical_lpmf", false, false,
+      false, true);
+  err[0] = '\0';
+  stanli_model* interp = stanli_model_new(
+      interp_mir.c_str(), R"({"K":3,"y":2,"ys":[3,1,3]})", err, sizeof err);
+  expect_true("in-worker write_array interpreted model builds",
+              interp != nullptr);
+  if (interp != nullptr) {
+    expect_in_worker_write_array_on("interpreted", interp);
+    stanli_model_free(interp);
+  }
+
+  err[0] = '\0';
+  stanli_model* reject =
+      stanli_model_new(slurp("tests/fixtures/gq_row_reject.tmir.sexp").c_str(),
+                       "{}", err, sizeof err);
+  expect_true("in-worker write_array reject model builds", reject != nullptr);
+  if (reject == nullptr) return;
+  expect_true("in-worker write_array reject model has columns",
+              stanli_wa_n_columns(reject) > 0);
+  stanli_sample_opts opts;
+  stanli_sample_opts_init(&opts);
+  opts.seed = 7;
+  opts.chains = 1;
+  opts.warmup = 20;
+  opts.samples = 20;
+  const int64_t n = stanli_n_unconstrained(reject);
+  const int64_t rows = stanli_n_stored_draws(&opts);
+  const int64_t width = stanli_wa_n_columns(reject);
+  std::vector<double> draws((size_t)(rows * n));
+  std::vector<double> stats((size_t)(rows * STANLI_N_SAMPLER_COLS));
+  std::vector<double> values((size_t)(rows * width));
+  stanli_sample_report reports[1];
+  int interrupted = -1;
+  err[0] = '\0';
+  const int rc = stanli_sample_multi_write_array(
+      reject, &opts, 0, draws.data(), stats.data(), values.data(), nullptr,
+      nullptr, nullptr, nullptr, &interrupted, reports, err, sizeof err);
+  const std::string message(err);
+  expect_true("a rejected row fails its chain",
+              rc == 1 && interrupted == 0 &&
+                  message.find("chain 1") != std::string::npos &&
+                  message.find("draw") != std::string::npos);
+  stanli_model_free(reject);
+}
+
 // The additive progress entry point must be the old sampler plus observation:
 // same bytes, caller-thread callbacks, exact refresh schedule and reports.
 void expect_sampling_progress() {
@@ -992,6 +1123,7 @@ int main() {
   expect_pathfinder();
   expect_sampling_progress();
   expect_interruptible_sampling();
+  expect_in_worker_write_array();
   expect_streaming_stats();
 
   if (failures == 0) std::printf("test_capi OK\n");

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -1063,6 +1063,20 @@ def test_embedded_stanc_from_concurrent_python_threads():
         assert bool(error) == (worker == 0)
 
 
+def test_failing_generated_quantities_name_the_draw():
+    m = stanli.Model(stan_code="""
+        parameters { real mu; }
+        model { mu ~ normal(0, 1); }
+        generated quantities { int k = categorical_rng([mu, 1 - mu]'); }
+    """)
+    try:
+        m.sample(chains=1, warmup=20, samples=20, refresh=0)
+    except RuntimeError as e:
+        assert "write_array failed on draw" in str(e), e
+    else:
+        raise AssertionError("a rejected generated quantity did not fail")
+
+
 def test_build_id_is_stable_and_specific():
     # Identifies the runtime binary. Anything caching artifacts keyed to a
     # build (a compiled MIR next to the library that produced it) needs a

--- a/tools/exported_symbols.def
+++ b/tools/exported_symbols.def
@@ -48,6 +48,7 @@ EXPORTS
   stanli_sample_multi
   stanli_sample_multi_progress
   stanli_sample_multi_interruptible
+  stanli_sample_multi_write_array
   stanli_sampler_column_name
   stanli_summary_stats
   stanli_diagnose_text


### PR DESCRIPTION
Every stored draw was constrained through write_array after the run, serially on the calling thread. On a model with 90k output columns that phase took about an hour with nothing to watch. Each chain now writes its rows on its own thread as the draws are stored, so the work runs in parallel and inside the progress output.

- `NutsConfig::on_stored`, plus a chain-indexed writer on `run_nuts_chains`.
- `stanli_sample_multi_write_array`, additive. One RNG per chain on the stream `stanli_wa_seed_chain` names and one write_array executor per chain, so the rows equal the old loop element for element. test_capi checks that on the graph and interpreted paths, threaded and sequential, and that the sampler's draws are unchanged.
- `WaInterp::eval` stored its discovery flag on every call; that store now only happens during discovery.
- R and Python drop their post-run loops. R keeps the loop for a runtime without the symbol and prints one line per chain there.
- `stanli_run` and the browser worker are unchanged.