### PR TITLE
Poll for a stop before the chain pool starts

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -1533,6 +1533,52 @@ jobs:
           # a local run needs nothing.
           ASAN_OPTIONS: detect_leaks=0
 
+  # The tests that run chains on worker threads, under ThreadSanitizer.
+  # Three binaries rather than the suite: the instrumentation is only
+  # informative where a second thread exists, and building just those
+  # keeps the job to minutes without a compiler cache.
+  tsan:
+    name: threaded tests under ThreadSanitizer
+    needs: build
+    if: >-
+      github.event_name != 'pull_request' &&
+      startsWith(github.ref, 'refs/tags/') == false
+    runs-on: ubuntu-24.04
+    env:
+      CC: clang
+      CXX: clang++
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install the Clang C/C++ compiler
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang
+      - name: Fetch pinned dependencies
+        run: ./deps/fetch.sh
+      - name: Install the pinned compiler from the native build
+        uses: actions/download-artifact@v4
+        with:
+          name: stanc-linux-x86_64
+          path: deps/stanc3
+      - name: Check compiler provenance
+        run: |
+          test "$(cat deps/stanc3/stanc.src)" = "$STANC3_SRC_SHA"
+          chmod +x deps/stanc3/stanc
+          ./deps/stanc3/stanc --version
+      - name: Build with -fsanitize=thread
+        run: |
+          cmake -B build-tsan -DCMAKE_BUILD_TYPE=None \
+            -DCMAKE_C_FLAGS="-O1 -g1" -DCMAKE_CXX_FLAGS="-O1 -g1" \
+            -DSTANLI_SANITIZE=thread \
+            -DCMAKE_C_COMPILER="$CC" -DCMAKE_CXX_COMPILER="$CXX"
+          cmake --build build-tsan -j2 \
+            --target test_capi test_pool test_multichain
+      - name: ctest
+        run: >-
+          ctest --test-dir build-tsan --output-on-failure
+          -R '^(test_capi|test_pool|test_multichain)$'
+
   # Pull requests compile the complete runtime for wasm32, catching portable
   # ABI and type-width failures without paying for the final Emscripten link.
   # Pushes and tags finish the module and publish the artifact used by the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,10 @@ is re-recorded. The sweep found the three fixes below.
 
 ### Fixes
 
+A threaded run now polls its interrupt callback once before starting the
+chains, so a stop that is already pending ends the run before the first
+transition instead of racing the worker threads.
+
 `beta_neg_binomial_cdf`, `_lcdf` and `_lccdf` took about a second per call
 on aarch64 Linux. Boost's default policy evaluates double special
 functions in long double, which there is software binary128, and its

--- a/runtime/src/nuts.cpp
+++ b/runtime/src/nuts.cpp
@@ -260,6 +260,22 @@ std::vector<ChainResult> run_nuts_chains(const std::vector<Executor*>& execs,
   std::vector<std::thread> pool;
   pool.reserve((size_t)threads);
 
+  // The caller's poll runs on this thread, between progress events, so a
+  // busy progress stream and a silent one both see it about every period.
+  // It runs once before the pool starts as well: a stop that is already
+  // pending is then seen by every chain ahead of its first transition.
+  using Clock = std::chrono::steady_clock;
+  constexpr auto poll_period = std::chrono::milliseconds(100);
+  auto last_poll = Clock::now() - poll_period;
+  const auto maybe_poll = [&] {
+    if (!poll || stop->load()) return;
+    const auto now = Clock::now();
+    if (now - last_poll < poll_period) return;
+    last_poll = now;
+    if (poll()) stop->store(true);
+  };
+  maybe_poll();
+
   // R's console API is main-thread-only, and a Python callback from a new
   // native thread has avoidable interpreter overhead. Workers therefore
   // enqueue only the three small fields; this calling thread drains them and
@@ -310,18 +326,6 @@ std::vector<ChainResult> run_nuts_chains(const std::vector<Executor*>& execs,
     });
 
   std::exception_ptr progress_error;
-  // The caller's poll runs here, between events, so a busy progress stream
-  // and a silent one both see it about every period.
-  using Clock = std::chrono::steady_clock;
-  constexpr auto poll_period = std::chrono::milliseconds(100);
-  auto last_poll = Clock::now() - poll_period;
-  const auto maybe_poll = [&] {
-    if (!poll || stop->load()) return;
-    const auto now = Clock::now();
-    if (now - last_poll < poll_period) return;
-    last_poll = now;
-    if (poll()) stop->store(true);
-  };
   if (progress || poll) {
     for (;;) {
       maybe_poll();

--- a/tests/test_capi.cpp
+++ b/tests/test_capi.cpp
@@ -12,6 +12,7 @@
 
 #include <algorithm>
 #include <array>
+#include <chrono>
 #include <cmath>
 #include <cstdio>
 #include <cstdlib>
@@ -662,8 +663,11 @@ void capture_progress(int32_t chain_id, int64_t iteration, int64_t total,
   capture->events.push_back({chain_id, iteration, total, warmup});
 }
 
-int poll_stop_at_once(void* user) {
+// Answers stop only after the chains have had time to finish: a sampler
+// that starts them before asking has nothing left to interrupt.
+int poll_stop_after_pause(void* user) {
   ++*static_cast<int*>(user);
+  std::this_thread::sleep_for(std::chrono::milliseconds(100));
   return 1;
 }
 
@@ -703,12 +707,14 @@ void expect_interruptible_sampling() {
     err[0] = '\0';
     int rc = stanli_sample_multi_interruptible(
         model, &opts, 0, draws.data(), stats.data(), nullptr, nullptr,
-        poll_stop_at_once, &polls, &interrupted, reports, err, sizeof err);
+        poll_stop_after_pause, &polls, &interrupted, reports, err, sizeof err);
     expect_true("a stop answer ends sampling cleanly" + mode,
                 rc == 0 && interrupted == 1 && polls >= 1);
-    if (threads == 1)
-      expect_true("a stop before the first transition stores nothing" + mode,
-                  draws[0] == -1.0 && stats[0] == -1.0);
+    expect_true("a stop before the first transition stores nothing" + mode,
+                std::all_of(draws.begin(), draws.end(),
+                            [](double x) { return x == -1.0; }) &&
+                    std::all_of(stats.begin(), stats.end(),
+                                [](double x) { return x == -1.0; }));
 
     std::vector<double> plain_draws(n_draws), plain_stats(n_stats);
     stanli_sample_report plain_reports[2];


### PR DESCRIPTION
The macOS x86 post-submit job failed test_capi's threaded interrupt test. run_nuts_chains spawned the workers before running the caller's poll, so a poll that stops at once could lose to two short chains and the run reported no interruption. The poll now runs once before the pool starts.

The test's poll pauses before answering, so a sampler that starts chains first fails every time rather than only on a loaded runner, and the no-draws-stored check now covers the threaded run.

A post-submit ThreadSanitizer job runs the three threaded test binaries, beside the ASan job.