### PR TITLE
Keep Boost's long double promotion on x86

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,8 +37,9 @@ transition instead of racing the worker threads.
 on aarch64 Linux. Boost's default policy evaluates double special
 functions in long double, which there is software binary128, and its
 epsilon set the length of the hypergeometric series. The build now turns
-that promotion off, so every platform evaluates in double, as macOS on
-Apple silicon already did.
+that promotion off on non-x86 targets, so those platforms evaluate in
+double instead. x86 keeps the promotion, since there long double is the
+hardware 80-bit type and matches CmdStan's reference results.
 
 `bernoulli_logit_glm`, `poisson_log_glm` and `neg_binomial_2_log_glm`
 dropped the gradient of a parameter design matrix: the log density was

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,10 +106,13 @@ target_include_directories(stanmath INTERFACE
   ${_sundials}/include
   ${_tbb}/include)
 target_compile_definitions(stanmath INTERFACE _REENTRANT BOOST_DISABLE_ASSERTS)
-# Boost's default policy evaluates double in long double, which on aarch64
-# Linux is software binary128: its epsilon then sets the series length in
-# hypergeometric_pFq, so beta_neg_binomial's CDFs take a second per call.
-target_compile_definitions(stanmath INTERFACE BOOST_MATH_PROMOTE_DOUBLE_POLICY=false)
+# Boost's default policy evaluates double in long double. On x86 that's the
+# hardware 80-bit type, which is what CmdStan's reference results are
+# computed with. Elsewhere long double is software binary128, whose epsilon
+# sets the series length in hypergeometric_pFq and makes it slow.
+if(NOT CMAKE_SYSTEM_PROCESSOR MATCHES "^(x86_64|AMD64|i[3-6]86)$")
+  target_compile_definitions(stanmath INTERFACE BOOST_MATH_PROMOTE_DOUBLE_POLICY=false)
+endif()
 # Pin FP contraction off: clang otherwise forms FMAs differently across
 # template instantiations of the same math, which breaks bitwise parity
 # between the kernels and the var-path references (measured: 2 ULP on


### PR DESCRIPTION
The nightly conformance run on main reports mismatches against CmdStan on the Boost-backed CDFs (beta_neg_binomial, neg_binomial_2_cdf, poisson_lcdf, inv_chi_square_lcdf) since #341 turned off Boost's double-to-long-double promotion everywhere. On x86 that promotion is the hardware 80-bit type CmdStan itself computes with, so stanli diverged from the reference. This limits the define to non-x86 targets, where long double is software emulated and the aarch64 timeouts came from.

Dispatched on the branch: conformance nightly https://github.com/seantalts/stanli/actions/runs/34234361214 and full wheels matrix https://github.com/seantalts/stanli/actions/runs/34234364476.