### PR TITLE
Explicit runtime storage lifetimes, pooled autodiff tapes, and a Windows stanr check

### DIFF
--- a/.github/workflows/stanr.yml
+++ b/.github/workflows/stanr.yml
@@ -8,28 +8,54 @@
 # its pinned revision predates the lower.cpp split, so the job reports but
 # does not block until stanr can take a current runtime. Keep
 # workflow_dispatch as an on-demand compatibility check.
+#
+# The Windows row exists because stanr compiles the runtime into its own
+# package DLL with Rtools (UCRT64 GCC), where thread_local objects live in
+# emulated TLS and are torn down differently from Linux and macOS. A
+# dispatch can point at another stanr revision and widen the test filter:
+# `stanr_ref=b08398fa test_filter=show-exceptions` reproduces the worker
+# crash andrjohns reported on his full-suite branch (stanli#349).
 name: stanr downstream
 
 on:
   workflow_call:
   workflow_dispatch:
+    inputs:
+      stanr_ref:
+        description: stanr git revision to build against (default: the pin)
+        required: false
+        default: ''
+      test_filter:
+        description: testthat filter regex over stanr's test files
+        required: false
+        default: stanli-backend
+      parallel:
+        description: run testthat in parallel worker processes (TRUE/FALSE)
+        required: false
+        default: 'TRUE'
 
 permissions:
   contents: read
 
 jobs:
   backend:
-    name: current runtime in stanr
-    runs-on: ubuntu-24.04
+    name: current runtime in stanr (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
     continue-on-error: true
-    timeout-minutes: 60
+    timeout-minutes: 90
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-24.04, windows-latest]
     env:
       # Pin the downstream source so unrelated upstream changes cannot make a
       # Stanli release fail. Refresh this together with the test if stanr
       # changes its vendoring or backend contract.
-      STANR_REF: da5de850718ca62ad752365d5467566eea22a0c5
-      MAKEFLAGS: -j2
-      TESTTHAT_CPUS: 2
+      STANR_REF: ${{ inputs.stanr_ref || 'da5de850718ca62ad752365d5467566eea22a0c5' }}
+      STANR_TEST_FILTER: ${{ inputs.test_filter || 'stanli-backend' }}
+      TESTTHAT_PARALLEL: ${{ inputs.parallel || 'TRUE' }}
+      MAKEFLAGS: -j4
+      TESTTHAT_CPUS: 4
     steps:
       - uses: actions/checkout@v4
 
@@ -46,4 +72,5 @@ jobs:
             any::R6, any::QuickJSR, any::posterior, any::withr, any::testthat
 
       - name: Build and test stanr's Stanli backend
+        shell: bash
         run: ./tests/test_stanr.sh "$STANR_REF"

--- a/.github/workflows/stanr.yml
+++ b/.github/workflows/stanr.yml
@@ -22,7 +22,7 @@ on:
   workflow_dispatch:
     inputs:
       stanr_ref:
-        description: stanr git revision to build against (default: the pin)
+        description: 'stanr git revision to build against (default: the pin)'
         required: false
         default: ''
       test_filter:
@@ -30,7 +30,7 @@ on:
         required: false
         default: stanli-backend
       parallel:
-        description: run testthat in parallel worker processes (TRUE/FALSE)
+        description: 'run testthat in parallel worker processes (TRUE/FALSE)'
         required: false
         default: 'TRUE'
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -825,6 +825,12 @@ target_link_libraries(bench_executor_clone PRIVATE stanli)
 add_test(NAME test_bench_opcost_smoke COMMAND bench_opcost --smoke)
 set_tests_properties(test_bench_opcost_smoke PROPERTIES
   PASS_REGULAR_EXPRESSION "sink=")
+# Developer-only: one pool lease + gradient from the three thread states a
+# caller can be in, for judging what the pool's autodiff-tape policy costs.
+add_executable(bench_pool EXCLUDE_FROM_ALL
+  tools/bench_pool.cpp tests/tbb_stub.cpp)
+target_link_libraries(bench_pool PRIVATE stanli)
+add_dependencies(bench_pool stanli_mir_fixtures)
 # Developer-only ODE RHS generated-adjoint spike.  Not a test and not installed.
 add_executable(bench_rhs_adjoint EXCLUDE_FROM_ALL
   tools/bench_rhs_adjoint.cpp tests/tbb_stub.cpp)

--- a/runtime/include/stanli/executor_pool.hpp
+++ b/runtime/include/stanli/executor_pool.hpp
@@ -32,6 +32,8 @@
 namespace stanli {
 
 class ExecutorPool {
+  struct Tape;
+
  public:
   // The prototype is cloned on demand and must outlive the pool. It is
   // never handed out itself, so the caller keeps using it if it wants.
@@ -42,12 +44,9 @@ class ExecutorPool {
 
   class Lease {
    public:
-    Lease(ExecutorPool& pool, std::unique_ptr<Executor> ex)
-        : pool_(&pool), ex_(std::move(ex)) {}
-    ~Lease() {
-      if (ex_) pool_->give_back(std::move(ex_));
-    }
-    Lease(Lease&& o) noexcept : pool_(o.pool_), ex_(std::move(o.ex_)) {}
+    Lease(ExecutorPool& pool, std::unique_ptr<Executor> ex);
+    ~Lease();
+    Lease(Lease&& o) noexcept;
     Lease& operator=(Lease&&) = delete;
     Lease(const Lease&) = delete;
     Lease& operator=(const Lease&) = delete;
@@ -58,6 +57,7 @@ class ExecutorPool {
    private:
     ExecutorPool* pool_;
     std::unique_ptr<Executor> ex_;
+    Tape* tape_;
   };
 
   // An executor for the duration of one evaluation. Also makes sure the

--- a/runtime/include/stanli/executor_pool.hpp
+++ b/runtime/include/stanli/executor_pool.hpp
@@ -37,7 +37,9 @@ class ExecutorPool {
  public:
   // The prototype is cloned on demand and must outlive the pool. It is
   // never handed out itself, so the caller keeps using it if it wants.
-  explicit ExecutorPool(const Executor& proto) : proto_(&proto) {}
+  // Both out of line: the pooled tapes are an incomplete type here.
+  explicit ExecutorPool(const Executor& proto);
+  ~ExecutorPool();
 
   ExecutorPool(const ExecutorPool&) = delete;
   ExecutorPool& operator=(const ExecutorPool&) = delete;
@@ -62,7 +64,9 @@ class ExecutorPool {
 
   // An executor for the duration of one evaluation. Also makes sure the
   // calling thread has an autodiff stack, which stan-math requires of
-  // every thread that builds a nested tape and does not create by itself.
+  // every thread that builds a nested tape and does not create by itself:
+  // a thread without one borrows a pooled tape for as long as it holds any
+  // lease, and must release every lease on the thread that acquired it.
   Lease acquire();
 
   // Clones currently in the free list, for tests and diagnostics.
@@ -77,8 +81,14 @@ class ExecutorPool {
     free_.push_back(std::move(ex));
   }
 
+  Tape* take_tape();
+  void give_back_tape(Tape* tape);
+
   mutable std::mutex mu_;
   std::vector<std::unique_ptr<Executor>> free_;
+  // Autodiff stacks for threads that arrive without one, pooled like the
+  // executors so a lease never allocates one after a thread's first.
+  std::vector<std::unique_ptr<Tape>> free_tapes_;
   const Executor* proto_;
 };
 

--- a/runtime/include/stanli/island.hpp
+++ b/runtime/include/stanli/island.hpp
@@ -127,12 +127,10 @@ std::shared_ptr<const Program> specialize_softmax3(const IslandProg& p,
 
 // Evaluate on T = double (forward) or stan::math::var (backward replay,
 // inside the caller's nested_rev_autodiff). The register file is reused
-// between calls. Not reentrant; islands cannot contain islands.
+// by the caller, which owns its lifetime.
 template <typename T>
-void run_island(const IslandProg& p, const T* const* in, T* out,
+void run_island(const IslandProg& p, const T* const* in, T* out, T* reg,
                 EvalState* state = nullptr) {
-  static thread_local std::vector<T> reg;
-  if ((int64_t)reg.size() < p.n_regs) reg.resize((size_t)p.n_regs);
   for (size_t k = 0; k < p.ins.size(); ++k) {
     const int input = p.ins[k].input >= 0 ? p.ins[k].input : (int)k;
     for (int i = 0; i < p.ins[k].len; ++i)

--- a/runtime/include/stanli/ode_prog.hpp
+++ b/runtime/include/stanli/ode_prog.hpp
@@ -28,6 +28,7 @@
 #include <map>
 #include <memory>
 #include <string>
+#include <tuple>
 #include <vector>
 
 namespace stanli {
@@ -87,23 +88,16 @@ RhsProgram compile_rhs(const mir::FunDef& f,
 std::shared_ptr<const IslandProg> make_rhs_adjoint_program(
     const RhsProgram& rhs, std::string* refusal = nullptr);
 
-// Evaluate. The register file is reused between calls (one per result scalar
-// type), which keeps the register-machine body allocation-free after first
-// use; the compiler guarantees every register is written before it is read,
-// so leftovers are never observed. y and theta may have different scalar
-// types: seed them straight into the result-typed registers instead of
-// allocating promoted vectors for every integrator callback.
-//
-// Promotions deliberately retain the old order: y, every source theta
-// (including an unused lowering placeholder), t, then x_r. Besides keeping
-// values identical, this preserves stan-math's var/nochain node creation order
-// from when y and theta were staged in vectors before the call.
-// Not reentrant, which is fine: an ODE right-hand side cannot solve an ODE.
-template <typename T>
-std::vector<T>& rhs_regs() {
-  static thread_local std::vector<T> reg;
-  return reg;
-}
+// A callback owns its registers for the solve, including deferred adjoint
+// callbacks. Copies own independent buffers; no storage survives thread exit.
+struct RhsWorkspace {
+  std::tuple<std::vector<double>, std::vector<stan::math::var>> registers;
+
+  template <typename T>
+  std::vector<T>& get() {
+    return std::get<std::vector<T>>(registers);
+  }
+};
 
 namespace detail {
 
@@ -141,8 +135,8 @@ template <typename T, typename T_time, typename T_y, typename T_yp,
           typename T_theta>
 std::vector<T>& eval_dae_regs(const RhsProgram& p, const T_time& t,
                               const T_y* y, const T_yp* yp, const T_theta* th,
-                              size_t n_th_source, const double* xr) {
-  std::vector<T>& reg = rhs_regs<T>();
+                              size_t n_th_source, const double* xr,
+                              std::vector<T>& reg) {
   seed_dae_regs<T>(p, t, y, yp, th, n_th_source, xr, reg);
   run_program(p, reg);
   return reg;
@@ -151,8 +145,8 @@ std::vector<T>& eval_dae_regs(const RhsProgram& p, const T_time& t,
 template <typename T, typename T_time, typename T_y, typename T_theta>
 std::vector<T>& eval_rhs_regs(const RhsProgram& p, const T_time& t,
                               const T_y* y, const T_theta* th,
-                              size_t n_th_source, const double* xr) {
-  std::vector<T>& reg = rhs_regs<T>();
+                              size_t n_th_source, const double* xr,
+                              std::vector<T>& reg) {
   seed_rhs_regs<T>(p, t, y, th, n_th_source, xr, reg);
 
   run_program(p, reg);
@@ -165,9 +159,9 @@ template <typename T, typename T_time, typename T_y, typename T_yp,
           typename T_theta>
 void run_dae_into(const RhsProgram& p, const T_time& t, const T_y* y,
                   const T_yp* yp, const T_theta* th, size_t n_th_source,
-                  const double* xr, T* out) {
+                  const double* xr, T* out, std::vector<T>& registers) {
   const std::vector<T>& reg =
-      detail::eval_dae_regs<T>(p, t, y, yp, th, n_th_source, xr);
+      detail::eval_dae_regs<T>(p, t, y, yp, th, n_th_source, xr, registers);
   for (size_t i = 0; i < p.out_regs.size(); ++i)
     out[i] = reg[(size_t)p.out_regs[i]];
 }
@@ -178,9 +172,9 @@ void run_dae_into(const RhsProgram& p, const T_time& t, const T_y* y,
 template <typename T, typename T_time, typename T_y, typename T_theta>
 void run_rhs_into(const RhsProgram& p, const T_time& t, const T_y* y,
                   const T_theta* th, size_t n_th_source, const double* xr,
-                  T* out) {
+                  T* out, std::vector<T>& registers) {
   const std::vector<T>& reg =
-      detail::eval_rhs_regs<T>(p, t, y, th, n_th_source, xr);
+      detail::eval_rhs_regs<T>(p, t, y, th, n_th_source, xr, registers);
   for (size_t i = 0; i < p.out_regs.size(); ++i)
     out[i] = reg[(size_t)p.out_regs[i]];
 }
@@ -188,9 +182,9 @@ void run_rhs_into(const RhsProgram& p, const T_time& t, const T_y* y,
 template <typename T, typename T_time, typename T_y, typename T_theta>
 void run_rhs(const RhsProgram& p, const T_time& t, const T_y* y,
              const T_theta* th, size_t n_th_source, const double* xr,
-             std::vector<T>& out) {
+             std::vector<T>& out, std::vector<T>& registers) {
   const std::vector<T>& reg =
-      detail::eval_rhs_regs<T>(p, t, y, th, n_th_source, xr);
+      detail::eval_rhs_regs<T>(p, t, y, th, n_th_source, xr, registers);
 
   // Keep resize after the program replay, as in the original adapter. Besides
   // retaining allocation behavior for existing callers, this leaves the
@@ -205,14 +199,16 @@ void run_rhs(const RhsProgram& p, const T_time& t, const T_y* y,
 // overload when lowering supplied an extra, deliberately unread placeholder.
 template <typename T, typename T_time, typename T_y, typename T_theta>
 void run_rhs(const RhsProgram& p, const T_time& t, const T_y* y,
-             const T_theta* th, const double* xr, std::vector<T>& out) {
-  run_rhs<T>(p, t, y, th, (size_t)p.n_th, xr, out);
+             const T_theta* th, const double* xr, std::vector<T>& out,
+             std::vector<T>& registers) {
+  run_rhs<T>(p, t, y, th, (size_t)p.n_th, xr, out, registers);
 }
 
 template <typename T, typename T_time, typename T_y, typename T_theta>
 void run_rhs_into(const RhsProgram& p, const T_time& t, const T_y* y,
-                  const T_theta* th, const double* xr, T* out) {
-  run_rhs_into<T>(p, t, y, th, (size_t)p.n_th, xr, out);
+                  const T_theta* th, const double* xr, T* out,
+                  std::vector<T>& registers) {
+  run_rhs_into<T>(p, t, y, th, (size_t)p.n_th, xr, out, registers);
 }
 
 }  // namespace stanli

--- a/runtime/kernels/algebra.cpp
+++ b/runtime/kernels/algebra.cpp
@@ -26,6 +26,7 @@ namespace {
 
 struct MirSystem {
   const AlgebraSpec* spec;
+  mutable RhsWorkspace workspace;
 
   template <typename T_x, typename T_y>
   Eigen::Matrix<stan::return_type_t<typename T_x::Scalar, typename T_y::Scalar>,
@@ -39,7 +40,7 @@ struct MirSystem {
       // installed by lowering.  The remaining regions are exactly unknown,
       // parameters, and real data.
       run_rhs<T>(spec->prog, 0.0, x.data(), y.data(), (size_t)y.size(),
-                 x_r.data(), result);
+                 x_r.data(), result, workspace.get<T>());
     } else {
       const mir::FunDef* system = spec->system();
       if (!system)
@@ -63,6 +64,7 @@ struct MirSystem {
 
 struct MirVariadicSystem {
   const AlgebraSpec* spec;
+  mutable RhsWorkspace workspace;
 
   template <typename T_x, typename T_theta>
   Eigen::Matrix<
@@ -74,7 +76,7 @@ struct MirVariadicSystem {
     std::vector<T> result;
     if (spec->prog.ok) {
       run_rhs<T>(spec->prog, 0.0, x.data(), theta.data(), (size_t)theta.size(),
-                 spec->x_r.data(), result);
+                 spec->x_r.data(), result, workspace.get<T>());
     } else {
       const mir::FunDef* system = spec->system();
       if (!system) throw std::runtime_error("solve: missing algebraic system");

--- a/runtime/kernels/dae.cpp
+++ b/runtime/kernels/dae.cpp
@@ -19,6 +19,7 @@ using stan::math::var;
 
 struct DaeResidual {
   const DaeSpec* spec;
+  mutable RhsWorkspace workspace;
 
   template <typename T_y, typename T_yp, typename T_param>
   Eigen::Matrix<stan::return_type_t<T_y, T_yp, T_param>, Eigen::Dynamic, 1>
@@ -31,7 +32,7 @@ struct DaeResidual {
     Eigen::Matrix<T, Eigen::Dynamic, 1> out(y.size());
     if (spec->prog.ok) {
       run_dae_into<T>(spec->prog, t, y.data(), yp.data(), theta.data(),
-                      theta.size(), x_r.data(), out.data());
+                      theta.size(), x_r.data(), out.data(), workspace.get<T>());
       return out;
     }
 

--- a/runtime/kernels/island.cpp
+++ b/runtime/kernels/island.cpp
@@ -36,9 +36,10 @@ int64_t island_scratch(const Op& op, const Slot* slots) {
   const auto& p = *static_cast<const IslandProg*>(op.udata);
   // The generated backward reads the whole register file, so the forward
   // runs in scratch and leaves it there. n_regs covers the live-ins, which
-  // occupy registers of their own. The replay only needs their snapshot.
-  if (p.native_adj) return p.n_regs;
-  return sum_in_lens(op, slots);
+  // occupy registers of their own. Backward has a separate adjoint region;
+  // replay uses an input snapshot followed by its forward registers.
+  if (p.native_adj) return (int64_t)p.n_regs + p.adj.n_regs;
+  return sum_in_lens(op, slots) + p.n_regs;
 }
 
 template <bool ReuseCallCtx>
@@ -66,16 +67,15 @@ void island_fwd_impl(KernelCtx& ctx) {
     in[k] = ctx.scratch + off;
     off += ctx.in[k].len;
   }
-  run_island<double>(p, in, ctx.out.data, ctx.eval_state);
+  run_island<double>(p, in, ctx.out.data, ctx.scratch + off, ctx.eval_state);
 }
 
 void island_fwd(KernelCtx& ctx) { island_fwd_impl<false>(ctx); }
 
 // The generated backward: seed the live-outs, sweep, harvest the live-ins.
 void island_bwd_native(const IslandProg& p, KernelCtx& ctx) {
-  static thread_local std::vector<double> adj;
-  if ((int64_t)adj.size() < p.adj.n_regs) adj.resize((size_t)p.adj.n_regs);
-  std::fill(adj.begin(), adj.begin() + p.adj.n_regs, 0.0);
+  double* adj = ctx.scratch + p.n_regs;
+  std::fill_n(adj, p.adj.n_regs, 0.0);
   // Through the sharing map, since a live-out register need not own its
   // adjoint cell. Descending, because two live-out slots can share a
   // register range (the carver aliases a dead copy-then-modify chain onto
@@ -83,7 +83,7 @@ void island_bwd_native(const IslandProg& p, KernelCtx& ctx) {
   const auto& map = p.adj.adj_reg;
   for (size_t m = p.out_regs.size(); m-- > 0;)
     adj[(size_t)map[(size_t)p.out_regs[m]]] += ctx.out_adj_vec.data[m];
-  run_adjoint(p, p.adj, ctx.scratch, adj.data());
+  run_adjoint(p, p.adj, ctx.scratch, adj);
   for (size_t k = 0; k < p.ins.size(); ++k) {
     const auto& li = p.ins[k];
     const int input = li.input >= 0 ? li.input : (int)k;
@@ -114,7 +114,8 @@ void island_bwd(KernelCtx& ctx) {
     off += ctx.in[k].len;
   }
   std::vector<var> vout(p.out_regs.size());
-  run_island<var>(p, in, vout.data());
+  std::vector<var> reg((size_t)p.n_regs);
+  run_island<var>(p, in, vout.data(), reg.data());
   var j = 0.0;
   for (size_t m = 0; m < vout.size(); ++m)
     j += vout[m] * ctx.out_adj_vec.data[m];

--- a/runtime/kernels/ode.cpp
+++ b/runtime/kernels/ode.cpp
@@ -49,6 +49,7 @@ using stan::math::var;
 // one, the MIR interpreter when there is not.
 struct MirRhs {
   const OdeSpec* spec;
+  mutable RhsWorkspace workspace;
 
   template <typename T_y, typename T_param>
   std::vector<stan::return_type_t<T_y, T_param>> eval(
@@ -61,7 +62,8 @@ struct MirRhs {
       // theta.size(), rather than prog.n_th, retains promotion of lowering's
       // unread no-parameter placeholder in the old tape position.
       std::vector<T> out;
-      run_rhs<T>(spec->prog, t, y, theta.data(), theta.size(), x_r.data(), out);
+      run_rhs<T>(spec->prog, t, y, theta.data(), theta.size(), x_r.data(), out,
+                 workspace.get<T>());
       return out;
     }
     // Preserve the interpreter adapter exactly. The modern caller used to
@@ -117,6 +119,7 @@ struct MirRhs {
 // into the right-hand side's declared parameters.
 struct VarRhs {
   const OdeSpec* spec;
+  mutable RhsWorkspace workspace;
 
   template <typename T_y, typename T_param>
   Eigen::Matrix<stan::return_type_t<T_y, T_param>, Eigen::Dynamic, 1>
@@ -132,7 +135,7 @@ struct VarRhs {
       // return object. The vector-returning MirRhs entry remains the exact
       // interpreter fallback and compatibility path.
       run_rhs_into<T>(spec->prog, t, y.data(), theta.data(), theta.size(),
-                      x_r.data(), out.data());
+                      x_r.data(), out.data(), workspace.get<T>());
       return out;
     }
     const std::vector<T> dy =
@@ -218,10 +221,8 @@ std::vector<std::vector<stan::return_type_t<T_y0, T_theta, T_t0, T_ts>>> solve(
   return out;
 }
 
-// Mutable storage for the direct RK callback. It is deliberately per thread,
-// not part of OdeSpec: executors share the immutable spec and may run in
-// parallel. An ODE RHS cannot itself solve an ODE, so the same non-reentrant
-// contract as rhs_regs<T>() lets successive solves reuse every allocation.
+// Mutable storage owned by one direct solve and reused by its RK callbacks.
+// OdeSpec stays immutable and can be shared by concurrent solves.
 struct DirectRkWorkspace {
   std::vector<double> values;
   std::vector<double> adjoints;
@@ -231,11 +232,6 @@ struct DirectRkWorkspace {
   std::vector<double> state;
   std::vector<double> times;
 };
-
-DirectRkWorkspace& direct_rk_workspace() {
-  static thread_local DirectRkWorkspace workspace;
-  return workspace;
-}
 
 // Evaluate f, J_y and (when needed) J_theta without constructing a nested
 // autodiff tape. The immutable payload is a clone of the canonical RHS with
@@ -440,7 +436,7 @@ void solve_direct_rk(KernelCtx& ctx, const OdeSpec& spec) {
   if ((size_t)ctx.out.len != spec.ts.size() * states)
     throw std::runtime_error("OP_ODE output shape does not match solve times");
 
-  DirectRkWorkspace& workspace = direct_rk_workspace();
+  DirectRkWorkspace workspace;
   workspace.state.assign(coupled_size, 0.0);
   for (size_t i = 0; i < states; ++i) workspace.state[i] = ctx.in[0].data[i];
   if constexpr (YAutodiff)

--- a/runtime/kernels/ode_adjoint.cpp
+++ b/runtime/kernels/ode_adjoint.cpp
@@ -19,6 +19,7 @@ using stan::math::var;
 
 struct AdjointRhs {
   const OdeAdjointSpec* spec;
+  mutable RhsWorkspace workspace;
 
   template <typename T_time, typename T_y, typename T_param>
   Eigen::Matrix<
@@ -34,7 +35,7 @@ struct AdjointRhs {
     Eigen::Matrix<T, Eigen::Dynamic, 1> out(state.size());
     if (spec->prog.ok) {
       run_rhs_into<T>(spec->prog, t, state.data(), theta.data(), theta.size(),
-                      x_r.data(), out.data());
+                      x_r.data(), out.data(), workspace.get<T>());
       return out;
     }
 

--- a/runtime/kernels/quadrature.cpp
+++ b/runtime/kernels/quadrature.cpp
@@ -17,6 +17,7 @@ namespace {
 
 struct MirIntegrand {
   const QuadratureSpec* spec;
+  mutable RhsWorkspace workspace;
 
   template <typename Theta>
   auto operator()(double x, double xc, std::ostream*,
@@ -29,7 +30,7 @@ struct MirIntegrand {
     if (spec->prog.ok) {
       run_rhs<T>(spec->prog, x, &xc, theta.data(),
                  static_cast<size_t>(spec->parameter_count), spec->x_r.data(),
-                 result);
+                 result, workspace.get<T>());
     } else {
       const mir::FunDef* callback = spec->callback();
       if (!callback)

--- a/runtime/src/executor_pool.cpp
+++ b/runtime/src/executor_pool.cpp
@@ -4,22 +4,67 @@
 
 namespace stanli {
 
-// Only the non-owning pointer is TLS. The last lease destroys the tape while
-// its calling thread is still running, including when leases overlap or move.
+// A tape a thread borrows for the span of its leases. The pool owns every
+// tape. A thread that arrives without an autodiff stack -- a caller's own
+// worker thread under STAN_THREADS, where stan-math's pointer starts null
+// -- installs one from the free list on its first lease and returns it on
+// its last, so overlapping and moved leases share it and after the first
+// evaluation on a thread no lease allocates. A thread that already has a
+// stack (the main thread, which stan-math's static scheduler observer
+// registers; a chain thread nuts.cpp equipped) installs nothing.
+//
+// Only the non-owning pointer is thread_local. Nothing with a destructor
+// lives in TLS: under MinGW's emulated TLS such destructors run after the
+// DLL that owns them may be gone, which is what crashed R worker processes
+// at exit on Windows.
 struct ExecutorPool::Tape {
-  stan::math::ChainableStack stack;
+  stan::math::ChainableStack::AutodiffStackStorage storage;
   size_t leases = 0;
 
   static Tape*& current() {
     static thread_local Tape* tape = nullptr;
     return tape;
   }
+
+  // What stan::math::recover_memory() does, on this storage rather than on
+  // the thread's current one, so a tape goes back to the free list empty.
+  void recover() {
+    storage.var_stack_.clear();
+    storage.var_nochain_stack_.clear();
+    for (auto* x : storage.var_alloc_stack_) delete x;
+    storage.var_alloc_stack_.clear();
+    storage.memalloc_.recover_all();
+  }
 };
+
+ExecutorPool::ExecutorPool(const Executor& proto) : proto_(&proto) {}
+ExecutorPool::~ExecutorPool() = default;
+
+ExecutorPool::Tape* ExecutorPool::take_tape() {
+  {
+    std::lock_guard<std::mutex> lock(mu_);
+    if (!free_tapes_.empty()) {
+      Tape* t = free_tapes_.back().release();
+      free_tapes_.pop_back();
+      return t;
+    }
+  }
+  return new Tape;
+}
+
+void ExecutorPool::give_back_tape(Tape* tape) {
+  std::lock_guard<std::mutex> lock(mu_);
+  free_tapes_.emplace_back(tape);
+}
 
 ExecutorPool::Lease::Lease(ExecutorPool& pool, std::unique_ptr<Executor> ex)
     : pool_(&pool), ex_(std::move(ex)), tape_(Tape::current()) {
-  if (!tape_) Tape::current() = tape_ = new Tape;
-  ++tape_->leases;
+  if (!tape_ && stan::math::ChainableStack::instance_ == nullptr) {
+    tape_ = pool.take_tape();
+    stan::math::ChainableStack::instance_ = &tape_->storage;
+    Tape::current() = tape_;
+  }
+  if (tape_) ++tape_->leases;
 }
 
 ExecutorPool::Lease::Lease(Lease&& other) noexcept
@@ -27,11 +72,18 @@ ExecutorPool::Lease::Lease(Lease&& other) noexcept
   other.tape_ = nullptr;
 }
 
+// Must run on the thread that acquired the lease: the tape is that thread's
+// stan-math stack, and both TLS pointers are reset here.
 ExecutorPool::Lease::~Lease() {
   if (ex_) pool_->give_back(std::move(ex_));
   if (tape_ && --tape_->leases == 0) {
     Tape::current() = nullptr;
-    delete tape_;
+    stan::math::ChainableStack::instance_ = nullptr;
+    tape_->recover();
+    // Whichever pool the last lease came from keeps the tape; tapes carry
+    // no model state, so one migrating between the pools of one model is
+    // harmless.
+    pool_->give_back_tape(tape_);
   }
 }
 

--- a/runtime/src/executor_pool.cpp
+++ b/runtime/src/executor_pool.cpp
@@ -4,23 +4,38 @@
 
 namespace stanli {
 
-ExecutorPool::Lease ExecutorPool::acquire() {
-  // stan-math REQUIRES an autodiff stack on every thread that builds a
-  // nested tape, and under STAN_THREADS the pointer to it is thread_local
-  // and starts null. CmdStan never writes this because TBB's
-  // scheduler-entry hook does it for every worker, and this build stubs
-  // TBB out; nuts.cpp does it explicitly for the chain threads it starts
-  // itself. Here the threads belong to the CALLER -- a sampler embedding
-  // the runtime -- so the pool is the only place that can.
-  //
-  // Constructing one on a thread that already has a stack is a no-op:
-  // AutodiffStackSingleton::init() hands ownership to the first
-  // constructor on the thread and returns false to every later one, whose
-  // destructor then leaves the stack alone. So this is safe on the main
-  // thread too. Destroyed when the thread exits, which is the only point
-  // at which freeing the tape is correct.
-  static thread_local stan::math::ChainableStack ad_tape_for_this_thread;
+// Only the non-owning pointer is TLS. The last lease destroys the tape while
+// its calling thread is still running, including when leases overlap or move.
+struct ExecutorPool::Tape {
+  stan::math::ChainableStack stack;
+  size_t leases = 0;
 
+  static Tape*& current() {
+    static thread_local Tape* tape = nullptr;
+    return tape;
+  }
+};
+
+ExecutorPool::Lease::Lease(ExecutorPool& pool, std::unique_ptr<Executor> ex)
+    : pool_(&pool), ex_(std::move(ex)), tape_(Tape::current()) {
+  if (!tape_) Tape::current() = tape_ = new Tape;
+  ++tape_->leases;
+}
+
+ExecutorPool::Lease::Lease(Lease&& other) noexcept
+    : pool_(other.pool_), ex_(std::move(other.ex_)), tape_(other.tape_) {
+  other.tape_ = nullptr;
+}
+
+ExecutorPool::Lease::~Lease() {
+  if (ex_) pool_->give_back(std::move(ex_));
+  if (tape_ && --tape_->leases == 0) {
+    Tape::current() = nullptr;
+    delete tape_;
+  }
+}
+
+ExecutorPool::Lease ExecutorPool::acquire() {
   std::unique_ptr<Executor> ex;
   {
     std::lock_guard<std::mutex> lock(mu_);

--- a/tests/test_island.cpp
+++ b/tests/test_island.cpp
@@ -16,6 +16,7 @@
 #include <sstream>
 #include <stdexcept>
 #include <string>
+#include <thread>
 #include <utility>
 #include <vector>
 
@@ -49,7 +50,7 @@ static std::vector<double> run_grad(Graph g, const Fills& fills) {
   return testutil::run_grad(std::move(g), fills, fill_at);
 }
 
-// The island kernel reuses its thread-local compact adjoint file. Running the
+// The island kernel reuses its executor-owned compact adjoint file. Running the
 // same executor twice catches a stale cell beyond the shortened zeroed range.
 static std::vector<double> run_grad_twice(Graph g, const Fills& fills) {
   Executor ex(std::move(g));
@@ -83,9 +84,7 @@ static std::string slurp(const std::string& path) {
 // not run -- and the live-out harvest reads them regardless. Before the
 // prologue fill (mir_prog.hpp) the backward's var replay read a register
 // file no one had written and dereferenced a null vari: SIGSEGV, not a
-// wrong number. Runs first so the replay's thread_local register file is
-// still empty, which is the state that makes that a null rather than a
-// vari from an already-recovered nested tape.
+// wrong number. Each replay now starts with an empty register file.
 static void test_branch_bound_live_out() {
   CompiledModel cm =
       compile_model(slurp("tests/fixtures/branchudf.tmir.sexp"), DataMap());
@@ -1479,7 +1478,34 @@ static void test_while_lpmf_region_matches_flat() {
   }
 }
 
+// Exercise both island buffer paths on short-lived workers, sharing graph
+// payloads while each executor owns its scratch and each replay owns its vars.
+static void test_worker_lifetimes() {
+  for (bool native : {false, true}) {
+    const Graph graph = build_packed_live_ins(native);
+    std::vector<int> ok(4, 1);
+    std::vector<std::thread> workers;
+    for (int t = 0; t < 4; ++t) {
+      workers.emplace_back([&, t] {
+        stan::math::ChainableStack tape;
+        Executor ex(graph);
+        for (int repeat = 0; repeat < 6; ++repeat) {
+          for (int64_t i = 0; i < ex.n_params(); ++i)
+            ex.params_data()[i] = t + repeat + 1;
+          std::vector<double> grad((size_t)ex.n_params());
+          const double value = ex.gradient(grad.data());
+          ok[t] &= value == 7.0 * (t + repeat + 1);
+          for (double derivative : grad) ok[t] &= derivative == 1.0;
+        }
+      });
+    }
+    for (auto& worker : workers) worker.join();
+    for (int result : ok) expect("island worker values and gradients", result);
+  }
+}
+
 int main() {
+  test_worker_lifetimes();
   // What the compiler does with a region, on graphs small enough to
   // reason about. The cost estimate would refuse most of them -- it is
   // policy, tested separately below, and these are about correctness.

--- a/tests/test_lower_array_contract.cpp
+++ b/tests/test_lower_array_contract.cpp
@@ -162,7 +162,8 @@ void test_register_array_boundary() {
     const double theta[4] = {4.0, 5.0, 6.0, 7.0};
     const double xr[1] = {1.5};
     std::vector<double> out;
-    run_rhs<double>(flat, 0.0, y, theta, xr, out);
+    std::vector<double> rhs_registers;
+    run_rhs<double>(flat, 0.0, y, theta, xr, out, rhs_registers);
     check(out.size() == 1, "register scalar-array output width");
     if (out.size() == 1) eq("register scalar-array value", out[0], 15.5);
   }

--- a/tests/test_mir_program_conformance.cpp
+++ b/tests/test_mir_program_conformance.cpp
@@ -311,7 +311,9 @@ ProgramObservation observe_program(
   Observation accepted{Stage::Compile, OutcomeKind::Accepted, {}, {}, {}};
   return {std::move(accepted), observe_execution([&] {
             std::vector<double> value;
-            run_rhs<double>(p, t, y.data(), theta.data(), x_r.data(), value);
+            std::vector<double> rhs_registers;
+            run_rhs<double>(p, t, y.data(), theta.data(), x_r.data(), value,
+                            rhs_registers);
             return value;
           }),
           false};

--- a/tests/test_mir_unary_fallback.cpp
+++ b/tests/test_mir_unary_fallback.cpp
@@ -223,7 +223,8 @@ Observation program(const std::string& name, double x, double seed) {
     stan::math::var t = 0, y = 1, theta = x;
     const double x_r = 1.25;
     std::vector<stan::math::var> out;
-    stanli::run_rhs(p, t, &y, &theta, &x_r, out);
+    std::vector<stan::math::var> rhs_registers;
+    stanli::run_rhs(p, t, &y, &theta, &x_r, out, rhs_registers);
     stan::math::grad(out.at(0).vi_);
     return std::pair{out[0].val(), theta.adj()};
   });

--- a/tests/test_ode_prog.cpp
+++ b/tests/test_ode_prog.cpp
@@ -71,9 +71,10 @@ void check_generated_local(const std::string& name, const stanli::RhsProgram& p,
     std::vector<stan::math::var> y_vars(y.begin(), y.end());
     std::vector<stan::math::var> theta_vars(theta.begin(), theta.end());
     std::vector<stan::math::var> outputs(p.out_regs.size());
+    std::vector<stan::math::var> registers;
     run_rhs_into<stan::math::var>(p, t, y_vars.data(), theta_vars.data(),
-                                  theta_vars.size(), x_r.data(),
-                                  outputs.data());
+                                  theta_vars.size(), x_r.data(), outputs.data(),
+                                  registers);
     for (size_t output = 0; output < outputs.size(); ++output)
       want_values[output] = outputs[output].val();
     for (size_t output = 0; output < outputs.size(); ++output) {
@@ -235,10 +236,11 @@ void check(const std::string& name, const stanli::mir::FunDef& f,
     for (int i = 0; i < n_th; ++i) th[(size_t)i] = probe(trial * 11 + i) + 0.2;
 
     std::vector<double> got;
-    run_rhs<double>(p, t, y.data(), th.data(), x_r.data(), got);
+    std::vector<double> registers;
+    run_rhs<double>(p, t, y.data(), th.data(), x_r.data(), got, registers);
     std::vector<double> got_into(p.out_regs.size());
-    run_rhs_into<double>(p, t, y.data(), th.data(), x_r.data(),
-                         got_into.data());
+    run_rhs_into<double>(p, t, y.data(), th.data(), x_r.data(), got_into.data(),
+                         registers);
     if (got_into != got) {
       ++failures;
       std::printf("FAIL %s: caller-owned output differs\n", name.c_str());
@@ -313,19 +315,20 @@ MixedRun mixed_run(const stanli::RhsProgram& p, double t,
   const size_t nochain_first = stack->var_nochain_stack_.size();
 
   std::vector<T> out;
+  std::vector<T> registers;
   if constexpr (Into) {
     out.resize(p.out_regs.size());
     stanli::run_rhs_into<T>(p, t, y.data(), theta.data(), theta.size(),
-                            x_r.data(), out.data());
+                            x_r.data(), out.data(), registers);
   } else if constexpr (Staged) {
     std::vector<T> staged_y(y.begin(), y.end());
     std::vector<T> staged_theta(theta.begin(), theta.end());
     const T staged_t(t);
     stanli::run_rhs<T>(p, staged_t, staged_y.data(), staged_theta.data(),
-                       staged_theta.size(), x_r.data(), out);
+                       staged_theta.size(), x_r.data(), out, registers);
   } else {
     stanli::run_rhs<T>(p, t, y.data(), theta.data(), theta.size(), x_r.data(),
-                       out);
+                       out, registers);
   }
 
   MixedRun run;

--- a/tests/test_odevariadic.cpp
+++ b/tests/test_odevariadic.cpp
@@ -298,12 +298,13 @@ static void check_error_parity(
 }
 
 // OdeSpec and its generated derivative payload are graph-owned and shared by
-// executor copies. The mutable direct-RK register/Jacobian buffers must remain
-// thread-local: otherwise two chains can agree in a serial test and corrupt
+// executor copies. The mutable register/Jacobian buffers must remain private
+// to each solve: otherwise two chains can agree in a serial test and corrupt
 // each other as soon as multiple chains evaluate the same model concurrently.
-static void check_shared_spec_threads(const stanli::OdeSpec& spec) {
+static void check_shared_spec_threads(const stanli::OdeSpec& spec,
+                                      bool use_direct) {
   stanli::OdeSpec direct_spec = spec;
-  direct_spec.direct_rk_enabled = true;
+  direct_spec.direct_rk_enabled = use_direct;
 
   constexpr int kThreads = 4;
   constexpr int kRepeats = 6;
@@ -327,6 +328,7 @@ static void check_shared_spec_threads(const stanli::OdeSpec& spec) {
   threads.reserve(kThreads);
   for (int thread = 0; thread < kThreads; ++thread) {
     threads.emplace_back([&, thread] {
+      stan::math::ChainableStack tape;
       ready.fetch_add(1, std::memory_order_release);
       while (!start.load(std::memory_order_acquire)) std::this_thread::yield();
       try {
@@ -474,7 +476,8 @@ int main() {
     check_activity_case<false, true>(*rk45_spec, "data y/active theta");
     check_activity_case<true, true>(*rk45_spec, "active y/active theta");
     check_activity_case<false, false>(*rk45_spec, "data y/data theta");
-    check_shared_spec_threads(*rk45_spec);
+    check_shared_spec_threads(*rk45_spec, true);
+    check_shared_spec_threads(*rk45_spec, false);
 
     OdeSpec invalid = *rk45_spec;
     invalid.rtol = 0.0;

--- a/tests/test_pool.cpp
+++ b/tests/test_pool.cpp
@@ -13,6 +13,7 @@
 // iterations to lose a race if there is one.
 #include <stanli/compile.hpp>
 #include <stanli/executor_pool.hpp>
+#include <stan/math/rev/core/chainablestack.hpp>
 
 #include <cstdio>
 #include <fstream>
@@ -64,11 +65,26 @@ int main() {
   const int kThreads = 8;
   std::vector<std::vector<double>> got_lp((size_t)kThreads);
   std::vector<std::vector<std::vector<double>>> got_g((size_t)kThreads);
+  std::vector<int> tape_lifetime_ok(kThreads, 0);
   std::vector<std::thread> ts;
   for (int t = 0; t < kThreads; ++t) {
     got_lp[(size_t)t].resize((size_t)kIters);
     got_g[(size_t)t].resize((size_t)kIters);
     ts.emplace_back([&, t] {
+      auto* initial_tape = stan::math::ChainableStack::instance_;
+      {
+        ExecutorPool scope_pool(proto);
+        auto first =
+            std::make_unique<ExecutorPool::Lease>(scope_pool.acquire());
+        auto second = scope_pool.acquire();
+        auto moved = std::move(second);
+        auto* tape = stan::math::ChainableStack::instance_;
+        first.reset();
+        tape_lifetime_ok[t] =
+            tape && stan::math::ChainableStack::instance_ == tape;
+      }
+      tape_lifetime_ok[t] &=
+          stan::math::ChainableStack::instance_ == initial_tape;
       for (int k = 0; k < kIters; ++k) {
         auto lease = pool.acquire();
         for (int64_t i = 0; i < n; ++i) lease->params_data()[i] = point(i, k);
@@ -76,9 +92,20 @@ int main() {
         got_lp[(size_t)t][(size_t)k] =
             lease->gradient(got_g[(size_t)t][(size_t)k].data());
       }
+      tape_lifetime_ok[t] &=
+          stan::math::ChainableStack::instance_ == initial_tape;
     });
   }
   for (auto& th : ts) th.join();
+
+  for (int t = 0; t < kThreads; ++t) {
+    if (!tape_lifetime_ok[t]) {
+      ++failures;
+      std::printf(
+          "FAIL thread %d: autodiff tape outlived or died before its leases\n",
+          t);
+    }
+  }
 
   for (int t = 0; t < kThreads; ++t)
     for (int k = 0; k < kIters; ++k) {

--- a/tests/test_stanr.sh
+++ b/tests/test_stanr.sh
@@ -50,6 +50,13 @@ grep -Fqx 'STANLI_REF="current-checkout"' \
 )
 
 mkdir -p "$r_library"
-R CMD INSTALL --library="$r_library" "$stanr_dir"
-R_LIBS_USER="$r_library${R_LIBS_USER:+:$R_LIBS_USER}" \
+# R is a native program: under Rtools bash on Windows it needs Windows-style
+# paths (bash converts arguments, not environment variables) and a `;`
+# library-path separator.
+native_path() { if command -v cygpath >/dev/null 2>&1; then cygpath -m "$1"; else printf '%s' "$1"; fi; }
+lib_sep=:
+case "$(uname -s)" in MINGW*|MSYS*|CYGWIN*) lib_sep=';' ;; esac
+r_library_native=$(native_path "$r_library")
+R CMD INSTALL --library="$r_library_native" "$stanr_dir"
+R_LIBS_USER="$r_library_native${R_LIBS_USER:+$lib_sep$R_LIBS_USER}" \
   Rscript --vanilla "$repo_root/tests/test_stanr_backend.R" "$stanr_dir"

--- a/tests/test_stanr_backend.R
+++ b/tests/test_stanr_backend.R
@@ -11,9 +11,19 @@ suppressPackageStartupMessages({
   library(testthat)
 })
 
+# stanr's suite runs in full under either backend and reads the choice from
+# STANR_BACKEND (tests/testthat/helpers.R, "Backend selection"). The default
+# filter keeps the contract file, which names its backend itself; a wider
+# STANR_TEST_FILTER runs other files under the stanli backend too.
+# TESTTHAT_PARALLEL is honored by testthat and, with the installed package
+# named here, runs each file in its own worker process, which is where a
+# teardown crash surfaces as "R session crashed" rather than as a failure.
+Sys.setenv(STANR_BACKEND = "stanli")
 testthat::test_dir(
   file.path(args[[1L]], "tests", "testthat"),
-  filter = "stanli-backend",
+  filter = Sys.getenv("STANR_TEST_FILTER", "stanli-backend"),
+  package = "stanr",
+  load_package = "installed",
   reporter = "summary",
   stop_on_failure = TRUE
 )

--- a/tools/bench_ode_ceiling.cpp
+++ b/tools/bench_ode_ceiling.cpp
@@ -328,6 +328,7 @@ template <bool Diagnostic>
 struct OracleRhs {
   const OdeSpec* spec;
   Breakdown* breakdown;
+  mutable stanli::RhsWorkspace workspace;
 
   template <typename T_y, typename T_param>
   Eigen::Matrix<stan::return_type_t<T_y, T_param>, Eigen::Dynamic, 1>
@@ -343,7 +344,7 @@ struct OracleRhs {
 
     Eigen::Matrix<T, Eigen::Dynamic, 1> out(
         static_cast<Eigen::Index>(spec->prog.out_regs.size()));
-    std::vector<T>& registers = stanli::rhs_regs<T>();
+    std::vector<T>& registers = workspace.get<T>();
 
     TimePoint phase;
     if constexpr (Diagnostic) phase = Clock::now();
@@ -920,8 +921,9 @@ LocalResult local_oracle(const RhsProgram& rhs, double t,
   for (double value : y_values) y.emplace_back(value);
   for (double value : theta_values) theta.emplace_back(value);
   std::vector<var> outputs(rhs.out_regs.size());
+  std::vector<var> rhs_registers;
   stanli::run_rhs_into<var>(rhs, t, y.data(), theta.data(), theta.size(),
-                            x_r.data(), outputs.data());
+                            x_r.data(), outputs.data(), rhs_registers);
 
   LocalResult result;
   result.values.resize(outputs.size());

--- a/tools/bench_ode_cvodes_ceiling.cpp
+++ b/tools/bench_ode_cvodes_ceiling.cpp
@@ -722,6 +722,7 @@ template <bool Profile>
 struct OracleRhs {
   const BenchCase* benchmark;
   OracleCallbackProfile* profile;
+  mutable stanli::RhsWorkspace workspace;
 
   template <typename T_y, typename T_theta>
   Eigen::Matrix<stan::return_type_t<T_y, T_theta>, Eigen::Dynamic, 1>
@@ -734,7 +735,8 @@ struct OracleRhs {
     Eigen::Matrix<T, Eigen::Dynamic, 1> out(
         static_cast<Eigen::Index>(benchmark->ode.prog.out_regs.size()));
     stanli::run_rhs_into<T>(benchmark->ode.prog, t, y.data(), theta.data(),
-                            theta.size(), x_r.data(), out.data());
+                            theta.size(), x_r.data(), out.data(),
+                            workspace.get<T>());
     if constexpr (Profile) {
       if constexpr (std::is_same_v<T, double>) {
         ++profile->double_calls;
@@ -942,9 +944,10 @@ LocalRhsResult local_reverse_result(const BenchCase& benchmark, double t) {
   for (double value : benchmark.theta) theta.emplace_back(value);
 
   std::vector<var> output(benchmark.ode.prog.out_regs.size());
+  std::vector<var> rhs_registers;
   stanli::run_rhs_into<var>(benchmark.ode.prog, t, y.data(), theta.data(),
                             theta.size(), benchmark.ode.x_r.data(),
-                            output.data());
+                            output.data(), rhs_registers);
   LocalRhsResult result;
   result.values.resize(output.size());
   const size_t width = y.size() + theta.size();

--- a/tools/bench_pool.cpp
+++ b/tools/bench_pool.cpp
@@ -1,0 +1,66 @@
+// Cost of one pool lease + gradient on eight schools, from threads in the
+// three states a caller can be in: no stan-math stack (a BridgeStan
+// caller's own worker under STAN_THREADS), its own ChainableStack (what
+// nuts.cpp gives chain threads), and the main thread (registered by
+// stan-math's static scheduler observer). Build: cmake --build build-rel
+// --target bench_pool; run from the repo root.
+#include <stanli/compile.hpp>
+#include <stanli/executor_pool.hpp>
+
+#include <stan/math/rev/core/chainablestack.hpp>
+
+#include <chrono>
+#include <cstdio>
+#include <fstream>
+#include <memory>
+#include <sstream>
+#include <string>
+#include <thread>
+#include <vector>
+
+using namespace stanli;
+
+static std::string slurp(const std::string& path) {
+  std::ifstream in(path);
+  std::stringstream ss;
+  ss << in.rdbuf();
+  return ss.str();
+}
+
+int main() {
+  DataMap data = DataMap::from_json_file("tests/fixtures/eight_schools.json");
+  CompiledModel cm = compile_model(slurp("tests/fixtures/es.tmir.sexp"), data);
+  Executor ex(std::move(cm.graph));
+  cm.bind(ex);
+  ExecutorPool pool(ex);
+  const int64_t n = ex.n_params();
+
+  auto body = [&](const char* label) {
+    std::vector<double> g((size_t)n);
+    volatile double sink = 0;
+    const auto once = [&] {
+      auto lease = pool.acquire();
+      for (int64_t i = 0; i < n; ++i)
+        lease->params_data()[i] = 0.05 * (double)i;
+      sink = sink + lease->gradient(g.data());
+    };
+    for (int i = 0; i < 20000; ++i) once();
+    const int N = 300000;
+    const auto t0 = std::chrono::steady_clock::now();
+    for (int i = 0; i < N; ++i) once();
+    const auto t1 = std::chrono::steady_clock::now();
+    const double ns =
+        std::chrono::duration<double, std::nano>(t1 - t0).count() / N;
+    std::printf(
+        "%-58s %7.1f ns per lease+gradient (instance_ null before: %d)\n",
+        label, ns, stan::math::ChainableStack::instance_ == nullptr);
+  };
+
+  body("main thread");
+  std::thread([&] { body("worker thread, no stack of its own"); }).join();
+  std::thread([&] {
+    stan::math::ChainableStack own;
+    body("worker thread with its own ChainableStack");
+  }).join();
+  return 0;
+}

--- a/tools/bench_rhs_adjoint.cpp
+++ b/tools/bench_rhs_adjoint.cpp
@@ -186,6 +186,7 @@ struct Observation {
 };
 
 struct OldWorkspace {
+  std::vector<var> registers;
   std::vector<var> y;
   std::vector<var> outputs;
   std::vector<double> harvested;
@@ -265,7 +266,7 @@ double old_callback(const Prototype& p, double t,
   refill_vars(ws.y, y_values);
 
   stanli::run_rhs<var>(p.rhs, t, ws.y.data(), theta.data(), theta.size(),
-                       x_r.data(), ws.outputs);
+                       x_r.data(), ws.outputs, ws.registers);
   const size_t n_out = ws.outputs.size();
   sweep_and_harvest(ws.outputs, ws.y, theta, nested, ws.harvested);
 


### PR DESCRIPTION
The runtime half of #349, plus a way to reproduce the crash it fixes and a cheaper tape policy for the pool. Three commits from @andrjohns' work and ours, kept separate.

**Andrew's commit (authored by him):** no `thread_local` object with a destructor anywhere in the runtime. Island registers and native adjoints move into executor scratch, solver callbacks own their register workspaces, the direct RK workspace belongs to each solve, and the executor pool's thread-local autodiff stack becomes a lease-counted tape with only a non-owning pointer in TLS. Under MinGW's emulated TLS, thread-local destructors run after the DLL that owns them may be gone, which crashed R worker processes on x64 Windows in stanr's test suite.

**Pooled tape:** same constraint, but the tape comes from a free list the pool owns, like the executors, and goes back empty when a thread's last lease ends. After a thread's first evaluation no lease allocates a stack. On the pool path, per lease + eight-schools gradient (`tools/bench_pool`, added here):

| thread state | per-lease tape | pooled tape |
|---|---|---|
| main thread | 244–306 ns | 227–306 ns |
| worker with no stack of its own | 414–451 ns | 238–268 ns |
| worker with its own ChainableStack | 248–282 ns | 226–261 ns |

The stack-less worker is the BridgeStan-from-your-own-threads case; the other two are unaffected either way.

**Reproduction:** the stanr downstream workflow gets a windows-latest row and dispatch inputs (`stanr_ref`, `test_filter`, `parallel`). stanr compiles this runtime into its own package DLL with Rtools and links real TBB, which is where the crash lives. Dispatched with Andrew's full-suite stanr branch and `test_filter=show-exceptions`:

- main's runtime: Linux passes 10/10, [Windows R process dies at the first sampling call](https://github.com/seantalts/stanli/actions/runs/34600743348)
- Andrew's commit alone: [passes both](https://github.com/seantalts/stanli/actions/runs/34601095467)
- with the pooled tape: [passes both](https://github.com/seantalts/stanli/actions/runs/34601097332)

That job is dispatch-only (and called by the release workflow), so it isn't in this PR's checks. Full ctest passes locally on macOS for both runtime variants.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
