### PR TITLE
Assign the adjoint ODE quadrature vector before stan-math accumulates into it

### DIFF
--- a/deps/fetch.sh
+++ b/deps/fetch.sh
@@ -15,11 +15,28 @@ fetch() { # name url sha sparse-paths...
   fi
   git -C "$name" sparse-checkout set "$@"
   git -C "$name" fetch -q origin "$sha"
-  git -C "$name" checkout -q "$sha"
+  git -C "$name" checkout -q -f "$sha"
 }
 
 fetch math https://github.com/stan-dev/math.git "$MATH_SHA" stan lib
 fetch stan https://github.com/stan-dev/stan.git "$STAN_SHA" src/stan
+
+# The adjoint ODE's backward quadrature callback accumulates into the CVODES
+# output vector without assigning it first, so it inherits whatever the
+# vector held: uninitialized memory on the first call, the previous step's
+# correction after that.
+git -C math apply <<'EOF'
+--- a/stan/math/rev/functor/cvodes_integrator_adjoint.hpp
++++ b/stan/math/rev/functor/cvodes_integrator_adjoint.hpp
+@@ -641,6 +641,7 @@ class cvodes_integrator_adjoint_vari : public vari_base {
+                      f_y_t_vars.size(), "states", N_);
+     f_y_t_vars.adj() = -Eigen::Map<Eigen::VectorXd>(NV_DATA_S(yB), N_);
+     grad();
++    Eigen::Map<Eigen::VectorXd>(NV_DATA_S(qBdot), num_args_vars_).setZero();
+     math::apply(
+         [&qBdot](auto&&... args) {
+           accumulate_adjoints(NV_DATA_S(qBdot), args...);
+EOF
 
 # Do not fetch stanc3's moving `nightly` release here. It is replaced in
 # place, so its URL cannot identify the compiler bytes a release used.


### PR DESCRIPTION
main's post-submit win_amd64 job failed test_lower on 3b743045 with a CVODES backward-solve error on a binary ccache served almost entirely from the green run before it. Filling fresh heap allocations with NaN bytes reproduces it deterministically on macOS; bisecting by allocation size and call site lands on the quadrature vector CVODES hands to stan-math's `quad_rhs_adj` uninitialized on the first step. That callback accumulates into the vector without assigning it first, and upstream develop has the same body.

`deps/fetch.sh` now patches the header after checkout to zero the vector, with a forced checkout so re-runs restore the pristine file before re-applying. Every deps cache keys on the script's hash. Dispatched run 34657669610 on this branch is fully green, including win_amd64 and ASan.