### PR TITLE
Reduce loop preparation and retained primal storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,12 @@ NUTS (stan::mcmc::adapt_diag_e_nuts) -> draws
    become gathers, and N scalar density terms fuse into one summed
    vector density. `radon_pooled` goes from 27,670 ops to 8. Anything a
    pass cannot prove safe it leaves alone. `STANLI_NO_REROLL=1` disables
-   the main pass.
+   the main pass. A proven subset of terminal scalar loops (one indexed
+   real-data read, parameter addition/multiplication or FMA, then an
+   optional `exp`/`square` chain) is priced before expanding its iterations.
+   When profitable, lowering emits the same vector kernels directly.
+   `STANLI_SYMBOLIC_LANES=0` disables this shortcut; unset or `1` enables
+   automatic selection. Other values conservatively disable it.
 
 4. **Execution** (`runtime/src/executor.cpp`). The op graph is the AD
    tape. The forward sweep computes the log density and stashes each

--- a/runtime/include/stanli/island.hpp
+++ b/runtime/include/stanli/island.hpp
@@ -84,8 +84,9 @@ struct Softmax3IslandProg : IslandProg {
 // IslandProg violates the tagged payload contract; the graph carver is the
 // only production producer. Its
 // forward must leave outputs and scratch bitwise-identical to OP_ISLAND's
-// canonical forward: the profiled executor and direct kernel-table callers
-// use that path, and the generated adjoint consumes either register file.
+// canonical forward: direct kernel-table callers use that path, and the
+// generated adjoint consumes either register file. Both executor modes use
+// the same bound specialized forward.
 // test_softmax3_double_exact enforces this contract.
 constexpr uint8_t kIslandSoftmax3Variant = 1;
 // Generic variant for a canonical IslandProg whose forward bytecode contains

--- a/runtime/include/stanli/optable.hpp
+++ b/runtime/include/stanli/optable.hpp
@@ -754,6 +754,41 @@ enum Opcode : uint16_t {
       OP_COUNT_
 };
 
+// Value buffers a registered kernel's backward may read.  This is separate
+// from adjoint activity: a backward can route an adjoint through an input
+// without reading that input's primal value.  Unknown opcodes deliberately
+// claim every input and both outputs, so consumers may only discard a value
+// after recognizing the exact registered backward function as well.
+struct BackwardPrimalReads {
+  static constexpr uint8_t kAllInputs = 0x3fu;
+  static constexpr uint8_t kAllOutputs = 0x03u;
+  uint8_t input_mask = kAllInputs;
+  uint8_t output_mask = kAllOutputs;
+
+  constexpr bool input(int i) const {
+    return i < 0 || i >= 6 || (input_mask & (uint8_t)(1u << i)) != 0;
+  }
+  constexpr bool output(int i = 0) const {
+    return i < 0 || i >= 2 || (output_mask & (uint8_t)(1u << i)) != 0;
+  }
+  constexpr bool none() const { return input_mask == 0 && output_mask == 0; }
+};
+
+using BackwardPrimalReadFn = BackwardPrimalReads (*)(uint8_t variant);
+
+// Contracts are registered beside the implementation they describe. These
+// callbacks accept the variant even where today's implementation has one
+// rule for every variant.
+constexpr BackwardPrimalReads backward_reads_none(uint8_t variant) {
+  (void)variant;
+  return BackwardPrimalReads{0, 0};
+}
+
+constexpr BackwardPrimalReads backward_reads_inputs_only(uint8_t variant) {
+  (void)variant;
+  return BackwardPrimalReads{BackwardPrimalReads::kAllInputs, 0};
+}
+
 // OP_NONE_ is the graph's unregistered sentinel. A specialized Program::CALL
 // temporarily claims that otherwise-unused table slot for its fixed-size,
 // allocation-free three-lane softmax; ordinary graph ops never carry either
@@ -918,7 +953,17 @@ struct Kernel {
   // Optional mutable state, created once per bound Executor/op. Graph udata
   // remains immutable and safely shared by executor copies.
   KernelState* (*make_state)(const Op&, const Slot* slots) = nullptr;
+  // Null is the conservative default: backward may read every primal. The
+  // callback lives on the registered implementation so replacing a kernel
+  // cannot accidentally inherit an opcode-only promise.
+  BackwardPrimalReadFn primal_reads = nullptr;
 };
+
+inline BackwardPrimalReads backward_primal_reads(const Kernel* kernel,
+                                                 uint8_t variant) {
+  return kernel && kernel->primal_reads ? kernel->primal_reads(variant)
+                                        : BackwardPrimalReads{};
+}
 
 // The most common Kernel::scratch_size shape: one scratch double per
 // element of every input.

--- a/runtime/include/stanli/structured_loop.hpp
+++ b/runtime/include/stanli/structured_loop.hpp
@@ -59,6 +59,13 @@ struct StructuredLoop {
     } kind = Sequence;
     enum Storage { Retained, Transient, InPlace } storage = Retained;
     bool active = false;
+    // The active call still records handles and owns an adjoint, but its
+    // historical output primal may live in one per-site workspace cell.
+    bool reuse_primal_output = false;
+    // Snapshot of the variant whose registered backward contract was used
+    // during prepare. Runtime mutation fails closed to ordinary retention.
+    uint8_t primal_contract_variant = 0;
+    BackwardPrimalReadFn primal_contract = nullptr;
     bool memo = false;
     // A memo node whose values are read by nothing once it exits, so the
     // recording evaluation gives its storage back.

--- a/runtime/kernels/eltwise_expr.cpp
+++ b/runtime/kernels/eltwise_expr.cpp
@@ -598,7 +598,8 @@ void register_eltwise_kernels() {
   register_kernel(code, Kernel{name##_ufwd, name##_ubwd, nullptr});
   STANLI_SCALAR_UNARY_LIST(STANLI_REGISTER_UNARY)
 #undef STANLI_REGISTER_UNARY
-  register_kernel(OP_ADD, Kernel{add_fwd, add_bwd, nullptr});
+  register_kernel(
+      OP_ADD, Kernel{add_fwd, add_bwd, nullptr, nullptr, backward_reads_none});
   register_kernel(OP_SUB, Kernel{sub_fwd, sub_bwd, nullptr});
   register_kernel(OP_MUL, Kernel{mul_fwd, mul_bwd, nullptr});
   register_kernel(OP_FMA, Kernel{fma_fwd, fma_bwd, nullptr});

--- a/runtime/src/adjoint.cpp
+++ b/runtime/src/adjoint.cpp
@@ -312,21 +312,30 @@ bool gen_adjoint(IslandProg& p) {
   for (int i = 0; i < (int)orig.size(); ++i) {
     const Program::Instr& I = orig[i];
     if (I.code == Program::CALL) {
-      // The kernel's backward may read its input VALUES, not just its
-      // scratch (backward_ignores_values is a whitelist, not a
-      // guarantee), and some read their output values too -- so both are
-      // checkpointed whenever a later instruction overwrites them.
       Program::Call call = fwd.calls[(size_t)I.a];
+      // Metadata describes the registered implementation, not an arbitrary
+      // CALL payload.  A private/replaced function therefore keeps the old
+      // save-everything behavior even when it borrows a known opcode.
+      const Kernel* registered = find_kernel(call.opcode);
+      const bool canonical = registered && registered->backward &&
+                             call.backward == registered->backward &&
+                             registered->primal_reads;
+      const BackwardPrimalReads reads =
+          canonical ? backward_primal_reads(registered, call.variant)
+                    : BackwardPrimalReads{};
       for (int j = 0; j < call.n_in; ++j) {
         call.bwd_adj_in[j] = mapn(call.in[j], call.in_len[j]);
-        call.bwd_value_in[j] = save_range(call.in[j], call.in_len[j], i);
+        call.bwd_value_in[j] = reads.input(j)
+                                   ? save_range(call.in[j], call.in_len[j], i)
+                                   : call.in[j];
       }
       call.bwd_adj_out = mapn(call.out, call.out_len);
       if (!mapped_ranges_ok) return false;
       Program::Instr F = I;
       F.a = static_cast<int32_t>(bound_calls.size());
       ncode.push_back(F);
-      call.bwd_value_out = save_range(call.out, call.out_len, i);
+      call.bwd_value_out =
+          reads.output() ? save_range(call.out, call.out_len, i) : call.out;
       AdjInstr A;
       A.code = Program::CALL;
       A.a = static_cast<int32_t>(bound_calls.size());

--- a/runtime/src/executor.cpp
+++ b/runtime/src/executor.cpp
@@ -629,17 +629,16 @@ void Executor::run_forward_only(EvalState state) {
   } restore{eval_state_, eval_state_};
   eval_state_ = state;
   // The profiled path keeps the opcode-keyed loop (attribution needs the
-  // opcode anyway, and the timing calls dwarf dispatch cost). This bypasses
-  // resolve_forward_fn, so a variant-specialized op is timed through its
-  // canonical kernel. island.hpp requires the two forwards to leave bitwise-
-  // identical outputs and scratch; switch this loop to fwd_fn_ only when the
-  // executor's layout is next re-gated.
+  // opcode anyway, and the timing calls dwarf dispatch cost), but it must
+  // invoke the same bound function pointer as the fast path. The registry is
+  // mutable for extension kernels; consulting it here would make profiling
+  // change both variant specialization and post-bind kernel overrides.
   if (profile_) {
     const size_t np = graph_.ops.size();
     for (size_t i = 0; i < np; ++i) {
       const uint16_t op = graph_.ops[i].opcode;
       const auto t0 = std::chrono::steady_clock::now();
-      kernel(op).forward(ctx_[i]);
+      fwd_fn_[i](ctx_[i]);
       const auto t1 = std::chrono::steady_clock::now();
       ProfEntry& e = prof_[op];
       ++e.calls;
@@ -687,14 +686,17 @@ double Executor::gradient(double* grad_out) {
   assert(result_adjoint_offset_ >= 0);
   adjoints_[result_adjoint_offset_] = 1.0;
   if (profile_) {
-    for (size_t pi = graph_.ops.size(); pi-- > 0;) {
-      const Kernel& k = kernel(graph_.ops[pi].opcode);
-      if (!k.backward) continue;
-      KernelCtx& ctx = ctx_[pi];
+    // Profile the exact bound backward plan. Each context belongs to ctx_,
+    // so its index supplies opcode attribution without a second graph walk
+    // or extra fields in the fast-path BwdStep layout.
+    for (const BwdStep& step : bwd_) {
+      KernelCtx& ctx = *step.ctx;
+      const size_t pi = static_cast<size_t>(step.ctx - ctx_.data());
+      assert(pi < graph_.ops.size());
       if (ctx.out_adj_vec.len == 1) ctx.out_adj = ctx.out_adj_vec.data[0];
-      if (out2_adj_ptr_[pi]) ctx.out2_adj = *out2_adj_ptr_[pi];
+      if (step.out2_adj) ctx.out2_adj = *step.out2_adj;
       const auto t0 = std::chrono::steady_clock::now();
-      k.backward(ctx);
+      step.fn(ctx);
       prof_[graph_.ops[pi].opcode].bwd_ns +=
           std::chrono::duration_cast<std::chrono::nanoseconds>(
               std::chrono::steady_clock::now() - t0)

--- a/runtime/src/lower.cpp
+++ b/runtime/src/lower.cpp
@@ -24,6 +24,39 @@ Lowering::Lowering(const DataMap& d, PrepTrace& p, PassDumper& dump_to,
       dumper(dump_to),
       prep_graph(graph_name),
       td_rng(std::move(stream)) {}
+Lowering::Lowering(const DataMap& d, PrepTrace& p, PassDumper& dump_to,
+                   const char* graph_name,
+                   const PreparedContext& prepared_context)
+    : Lowering(d, p, dump_to, graph_name, prepared_context.rng,
+               prepared_context.shapes) {
+  const auto env_copy_time = prep.start();
+  td.env() = prepared_context.environment;
+  int_env = prepared_context.integers;
+  decls = prepared_context.declarations;
+  prep.plain(prep_graph, "env_copy", env_copy_time);
+}
+Lowering::Lowering(Lowering& parent, RegionTrialTag)
+    : Lowering(parent.data, parent.prep, parent.dumper, parent.prep_graph,
+               parent.td_rng,
+               std::make_shared<ShapeInterner>(*parent.shape_pool)) {
+  fun_defs = parent.fun_defs;
+  decls = parent.decls;
+  td.env() = parent.td.env();
+  int_env = parent.int_env;
+  int_locals = parent.int_locals;
+  propto_ctx = parent.propto_ctx;
+  udf_depth = parent.udf_depth;
+  udf_autodiff_ctx = parent.udf_autodiff_ctx;
+  udf_formal_autodiff = parent.udf_formal_autodiff;
+}
+PreparedContext Lowering::prepared_context() {
+  if (!data_prepared)
+    throw std::logic_error("lowering has not prepared model data");
+  return {td_rng, shape_pool, td.env(), int_env_data, decls};
+}
+Lowering Lowering::fork_region_trial() {
+  return Lowering(*this, RegionTrialTag{});
+}
 void Lowering::dump_named(const std::string& label, const std::string& name,
                           const std::vector<int>& roots, bool unfiltered) {
   GraphPrintInfo info;
@@ -284,6 +317,7 @@ void Lowering::bind_data(const mir::Program& p) {
     if (e.is_int && e.i.size() == 1 && e.dims.empty()) int_env[name] = e.i[0];
   }
   int_env_data = int_env;
+  data_prepared = true;
 }
 // ---- statements -----------------------------------------------------------
 CompiledModel::ParamView Lowering::parameter_view(const mir::Stmt& s, int slot,
@@ -775,6 +809,23 @@ CompiledModel Lowering::run(const mir::Program& p) {
              target_terms.size(), out.views.size());
   dump("bind_data", {});
   const auto lower_time = prep.start();
+  const char* symbolic_lanes = std::getenv("STANLI_SYMBOLIC_LANES");
+  if (!symbolic_lanes || std::string_view(symbolic_lanes) == "1") {
+    const auto terminal =
+        [&](const auto& self,
+            const std::vector<mir::Stmt>& body) -> const mir::Stmt* {
+      for (auto it = body.rbegin(); it != body.rend(); ++it) {
+        if (it->kind == mir::Stmt::Skip) continue;
+        if (it->kind == mir::Stmt::Block || it->kind == mir::Stmt::SList) {
+          if (const auto* tail = self(self, it->body)) return tail;
+          continue;
+        }
+        return &*it;
+      }
+      return nullptr;
+    };
+    symbolic_lane_tail = terminal(terminal, p.log_prob);
+  }
   for (const auto& s : p.log_prob) lower_stmt(s);
   prep.graph(prep_graph, "lower", lower_time, g, out.fills, target_terms.size(),
              out.views.size());
@@ -848,15 +899,8 @@ CompiledModel compile_model(const std::string& mir_text, const DataMap& data,
     // A second lowering, over the transformed data the first one already
     // interpreted: re-running prepare_data would double preparation time on
     // the models where preparation is the cost (nn_rbm1bJ100, 20.7 s).
-    Lowering wa(data, prep, dumper, "write_array", lo.td_rng, lo.shape_pool);
-    const auto env_copy_time = prep.start();
-    wa.td.env() = lo.td.env();
-    wa.int_env = lo.int_env_data;
-    // bind_data owns immutable declaration shape and physical-layout facts;
-    // write_array skips that expensive pass, so its fresh lexical lowering
-    // receives the facts together with the already-prepared environment.
-    wa.decls = lo.decls;
-    prep.plain("write_array", "env_copy", env_copy_time);
+    const PreparedContext prepared = lo.prepared_context();
+    Lowering wa(data, prep, dumper, "write_array", prepared);
     CompiledModel::WriteArray w = wa.run_write_array(*prog);
     for (const std::string& note : wa.out.interpreter_fallbacks)
       add_interpreter_fallback(cm, note);
@@ -884,7 +928,7 @@ CompiledModel compile_model(const std::string& mir_text, const DataMap& data,
       // The graph could not express the whole section; hand the model the
       // per-draw interpreter, seeded with data + transformed data and the
       // emission flags the guard blocks test.
-      auto env = lo.td.env();
+      auto env = prepared.environment;
       for (const char* flag :
            {"emit_transformed_parameters__", "emit_generated_quantities__"}) {
         DataMap::Entry one;

--- a/runtime/src/lower_internal.hpp
+++ b/runtime/src/lower_internal.hpp
@@ -467,6 +467,27 @@ inline std::vector<double> graph_order(const DataMap::Entry& en,
   return graph_container_order(en.r, en.dims, outer_rank);
 }
 
+struct DeclView {
+  int64_t len = 0;
+  bool autodiff = false;
+  SlotInfo si;
+  bool int_array = false;
+  bool deferred_shape = false;
+  std::vector<int> runtime_dims;
+};
+
+// A lifetime-bound view of the prepared facts handed from the completed
+// log-probability lowering to write_array. The integer map is the one snapshot
+// bind_data retains; the other references preserve the established handoff
+// timing without another O(data bytes) copy.
+struct PreparedContext {
+  const WaRng& rng;
+  const std::shared_ptr<ShapeInterner>& shapes;
+  const std::map<std::string, DataMap::Entry>& environment;
+  const std::map<std::string, long>& integers;
+  const std::map<std::string, DeclView>& declarations;
+};
+
 struct Lowering {
   struct Val {
     int slot;
@@ -835,6 +856,7 @@ struct Lowering {
   // int_env as bind_data left it, before either section's locals and loop
   // variables were folded in; the write_array lowering starts from this.
   std::map<std::string, long> int_env_data;
+  bool data_prepared = false;
   // Lowering generate_quantities rather than log_prob: parameters are columns
   // to emit, not values to differentiate.
   bool in_write_array = false;
@@ -859,6 +881,11 @@ struct Lowering {
   // its collapsed trip counts. TargetPE consumes the product at the edge,
   // so nested invariant loops still emit one scale rather than a MUL chain.
   double target_scale = 1.0;
+  // Automatic symbolic-lane probe: only the terminal unconditional model loop.
+  // False leaves ordinary lowering untouched; true handles the whole loop.
+  const mir::Stmt* symbolic_lane_tail = nullptr;
+  bool try_lower_symbolic_lane_tail(const mir::Stmt& s, int64_t first,
+                                    int64_t last);
   // OR of the actual real/container scalar types for the current inlined
   // UDF. Generic AutoDiffable locals and returns instantiate to this type.
   bool udf_autodiff_ctx = false;
@@ -875,6 +902,13 @@ struct Lowering {
       const DataMap& d, PrepTrace& p, PassDumper& dump_to,
       const char* graph_name, WaRng stream,
       std::shared_ptr<ShapeInterner> pool = std::make_shared<ShapeInterner>());
+  Lowering(const DataMap& d, PrepTrace& p, PassDumper& dump_to,
+           const char* graph_name, const PreparedContext& prepared_context);
+  struct RegionTrialTag {};
+  Lowering(Lowering& parent, RegionTrialTag);
+
+  PreparedContext prepared_context();
+  Lowering fork_region_trial();
 
   void dump_named(const std::string& label, const std::string& name,
                   const std::vector<int>& roots, bool unfiltered);
@@ -1883,14 +1917,6 @@ struct Lowering {
 
   void lower_read_param(const mir::Stmt& s);
 
-  struct DeclView {
-    int64_t len = 0;
-    bool autodiff = false;
-    SlotInfo si;
-    bool int_array = false;
-    bool deferred_shape = false;
-    std::vector<int> runtime_dims;
-  };
   // The only name-keyed declaration protocol. Runtime values carry the same
   // static scalar type and SlotInfo in `scope`; this registry is needed only
   // before first binding.

--- a/runtime/src/lower_stmt.cpp
+++ b/runtime/src/lower_stmt.cpp
@@ -1,4 +1,5 @@
 #include "lower_internal.hpp"
+#include "reroll_plan.hpp"
 
 namespace stanli {
 namespace lower_detail {
@@ -6,6 +7,8 @@ namespace lower_detail {
 // A guard that stays decidable and never false is the model's own
 // nontermination. Stop unrolling and let it compile as a loop.
 constexpr long kWhileUnrollLimit = 1L << 16;
+
+#include "lower_symbolic_lane.inc"
 
 bool Lowering::expr_has_jacobian(const mir::Expr& e) {
   if (e.kind == mir::Expr::FunApp) {
@@ -1410,6 +1413,8 @@ void Lowering::lower_stmt_impl(const mir::Stmt& s) {
         int_env.erase(s.loopvar);
         return;
       }
+      if (&s == symbolic_lane_tail && try_lower_symbolic_lane_tail(s, lo, hi))
+        return;
       // Both the pre-control target fold and the ordinary path ask the same
       // structural question.  A nonselected automatic candidate reaches
       // both sites, so retain the answer for this lowering encounter rather

--- a/runtime/src/lower_structured_loop.inc
+++ b/runtime/src/lower_structured_loop.inc
@@ -1995,17 +1995,10 @@ bool try_lower_region(
   {
     bool candidate_ready = false;
     try {
-      Lowering trial(data, prep, dumper, prep_graph, td_rng,
-                     std::make_shared<ShapeInterner>(*shape_pool));
-      trial.fun_defs = fun_defs;
-      trial.decls = decls;
-      trial.td.env() = td.env();
-      trial.int_env = int_env;
-      trial.int_locals = int_locals;
-      trial.propto_ctx = propto_ctx;
-      trial.udf_depth = udf_depth;
-      trial.udf_autodiff_ctx = udf_autodiff_ctx;
-      trial.udf_formal_autodiff = udf_formal_autodiff;
+      // Keep the complete trial seed in one audited helper. The candidate owns
+      // its mutable interpreter and shape state until every refusal point has
+      // passed; only the shape interner is published below.
+      Lowering trial = fork_region_trial();
       auto p = std::make_shared<StructuredLoop>();
       trial.region_current = &p->root;
       std::map<int, int> imported;

--- a/runtime/src/lower_symbolic_lane.inc
+++ b/runtime/src/lower_symbolic_lane.inc
@@ -1,0 +1,319 @@
+// Included inside lower_detail. Prove the whole source family before ordinary
+// typed lowering supplies a scalar seed; refusals retain that ordinary work.
+namespace {
+struct SymbolicLaneProof {
+  Lowering& lo;
+  const mir::Stmt& loop;
+  int64_t first, last;
+  enum class Kind { Bad, Parameter, Read, Chain };
+  struct Local {
+    Kind value = Kind::Bad;
+    bool consumed = false;
+  };
+  std::map<std::string, Local> locals;
+  int remaining = 128;
+  int reads = 0, anchors = 0;
+  uint16_t anchor_opcode = OP_NONE_;
+  int anchor_arity = 0;
+  bool target = false;
+  int64_t offset = 0;
+
+  std::optional<int64_t> index_offset(const mir::Expr& e) {
+    if (e.kind == mir::Expr::Var && e.name == loop.loopvar) return 0;
+    if (e.kind != mir::Expr::FunApp || e.fn_lib != mir::Expr::Lib::StanLib ||
+        e.args.size() != 2 || e.args[1].kind != mir::Expr::LitInt)
+      return std::nullopt;
+    // A single fixed shift only; checked in the range of graph immediates.
+    if (e.args[0].kind != mir::Expr::Var || e.args[0].name != loop.loopvar)
+      return std::nullopt;
+    const int64_t n = e.args[1].lit_i;
+    if (n < 0 || n > INT_MAX) return std::nullopt;
+    if (e.name == "Plus__" || e.name == "add") return n;
+    if (e.name == "Minus__" || e.name == "subtract") return -n;
+    return std::nullopt;
+  }
+
+  Kind expression(const mir::Expr& e) {
+    if (--remaining < 0 || e.type_ != "UReal") return Kind::Bad;
+    if (e.kind == mir::Expr::Var) {
+      auto local = locals.find(e.name);
+      if (local != locals.end()) {
+        if (local->second.consumed) return Kind::Bad;
+        local->second.consumed = true;
+        return local->second.value;
+      }
+      auto v = lo.scope.find(e.name);
+      return v != lo.scope.end() && v->second.autodiff &&
+                     lo.g.slots[v->second.slot].is_param &&
+                     lo.g.slots[v->second.slot].len == 1
+                 ? Kind::Parameter
+                 : Kind::Bad;
+    }
+    if (e.kind == mir::Expr::Indexed && e.args.size() == 2 &&
+        e.args[0].kind == mir::Expr::Var && !locals.count(e.args[0].name) &&
+        e.args[1].name == "IndexSingle" && e.args[1].args.size() == 1) {
+      if (++reads != 1 || lo.scope.count(e.args[0].name)) return Kind::Bad;
+      const auto delta = index_offset(e.args[1].args[0]);
+      const auto view = lo.try_static_view(e.args[0]);
+      const auto* value = lo.td.find(e.args[0].name);
+      if (!delta || view.state != Lowering::StaticProbeState::Known || !value ||
+          value->is_int)
+        return Kind::Bad;
+      const auto& si = view.value.si;
+      const bool flat_real =
+          is_vector(si) || is_row_vector(si) ||
+          (is_array(si) && lo.array_shape(si).dims.size() == 1 &&
+           lo.array_shape(si).leaf == ViewKind::Flat &&
+           e.args[0].unsized.leaf == mir::UnsizedLeaf::Real);
+      if (!flat_real || first + *delta < 1 || last + *delta > view.value.len ||
+          view.value.len != static_cast<int64_t>(value->r.size()))
+        return Kind::Bad;
+      offset = first + *delta - 1;
+      return Kind::Read;
+    }
+    if (e.kind != mir::Expr::FunApp || e.fn_lib != mir::Expr::Lib::StanLib ||
+        e.fn_propto)
+      return Kind::Bad;
+    // Recognize the registered family, then require the ordinary typed seed
+    // below to produce the corresponding scalar operation. A Product descriptor
+    // is only scalar multiplication here because every argument must be UReal.
+    uint16_t opcode = OP_NONE_;
+    if (e.name == "fma" && e.args.size() == 3) opcode = OP_FMA;
+    if (e.args.size() == 2) {
+      const auto* spec = function_spec(e);
+      const auto* builtin = spec ? spec->builtin() : nullptr;
+      if (builtin && builtin->shape == BuiltinShapePolicy::Product)
+        opcode = OP_MUL;
+      else if (builtin && builtin->shape == BuiltinShapePolicy::Elementwise &&
+               (builtin->opcode == OP_ADD || builtin->opcode == OP_MUL))
+        opcode = builtin->opcode;
+    }
+    if (opcode != OP_NONE_) {
+      if (++anchors != 1) return Kind::Bad;
+      anchor_opcode = opcode;
+      anchor_arity = static_cast<int>(e.args.size());
+      int params = 0, varying = 0;
+      for (const auto& arg : e.args) {
+        const Kind kind = expression(arg);
+        params += kind == Kind::Parameter;
+        varying += kind == Kind::Read;
+      }
+      return params == anchor_arity - 1 && varying == 1 ? Kind::Chain
+                                                        : Kind::Bad;
+    }
+    if ((e.name == "exp" || e.name == "square") && e.args.size() == 1 &&
+        expression(e.args[0]) == Kind::Chain)
+      return Kind::Chain;
+    return Kind::Bad;
+  }
+
+  bool statement(const mir::Stmt& s) {
+    if (--remaining < 0) return false;
+    if (s.kind == mir::Stmt::Skip) return true;
+    if (s.kind == mir::Stmt::Block || s.kind == mir::Stmt::SList) {
+      for (const auto& child : s.body)
+        if (!statement(child)) return false;
+      return true;
+    }
+    if (target) return false;
+    if (s.kind == mir::Stmt::Decl) {
+      if (s.decl_type.base != "SReal" || s.read_transform ||
+          s.decl_id == loop.loopvar || locals.count(s.decl_id) ||
+          lo.scope.count(s.decl_id) || lo.decls.count(s.decl_id) ||
+          lo.int_locals.count(s.decl_id) || lo.int_env.count(s.decl_id) ||
+          lo.td.find(s.decl_id))
+        return false;
+      Local local;
+      if (s.has_init) {
+        local.value = expression(s.init);
+        if (local.value == Kind::Bad) return false;
+      }
+      locals.emplace(s.decl_id, local);
+      return true;
+    }
+    if (s.kind == mir::Stmt::Assignment) {
+      auto local = locals.find(s.lhs);
+      if (!s.lhs_idx.empty() || local == locals.end() ||
+          local->second.value != Kind::Bad || local->second.consumed)
+        return false;
+      local->second.value = expression(s.rhs);
+      return local->second.value != Kind::Bad;
+    }
+    if (s.kind == mir::Stmt::TargetPE) {
+      target = expression(s.target) == Kind::Chain;
+      return target;
+    }
+    return false;
+  }
+};
+
+struct SymbolicLaneSource {
+  // The proof below permits exactly one varying hashed field: the data-read
+  // identity in the first FMA/ADD/MUL. Other operands are fixed parameter IDs
+  // or lane-local sentinel -1, with no idata. XOR and odd multiplication are
+  // bijections modulo 2^64, so fresh checked identities give L distinct hashes.
+  // Broader source families must re-prove this property or use actual hashing.
+  static constexpr bool kDistinctLaneHashes = true;
+  std::vector<Op> lane;
+  int first_fresh = 0, stride = 0;
+  Op at(int position, int64_t l) const {
+    Op op = lane[position];
+    for (int j = 0; j < op.n_in; ++j)
+      if (op.in[j] >= first_fresh) op.in[j] += static_cast<int>(l * stride);
+    op.out += static_cast<int>(l * stride);
+    return op;
+  }
+  void replace_terms(int, int64_t, int term, std::vector<int>& targets,
+                     std::unordered_set<int>& terms) const {
+    // The proof admits only this terminal region and no preceding targets.
+    assert(targets.empty() && terms.empty());
+    targets.push_back(term);
+    terms.insert(term);
+  }
+};
+}  // namespace
+
+bool Lowering::try_lower_symbolic_lane_tail(const mir::Stmt& s, int64_t first,
+                                            int64_t last) {
+  namespace rp = detail::reroll_plan;
+  if (in_write_array || region_current || udf_depth || target_scale != 1.0 ||
+      first < 1 || last > INT_MAX || last - first + 1 < detail::kMinLanes ||
+      !g.ops.empty() || !target_terms.empty() || !jac_slots.empty() ||
+      !extra_roots.empty() || !out.fills.empty() || !const_cache.empty() ||
+      std::getenv("STANLI_NO_REROLL") || std::getenv("STANLI_NO_CONSTFOLD") ||
+      structured_policy == StructuredMode::Prefer ||
+      structured_policy == StructuredMode::Force)
+    return false;
+  for (const auto& slot : g.slots)
+    if (!slot.is_param || slot.len != 1) return false;
+  SymbolicLaneProof proof{*this, s, first, last};
+  for (const auto& child : s.body)
+    if (!proof.statement(child)) return false;
+  if (!proof.target || proof.reads != 1 || proof.anchors != 1) return false;
+  for (const auto& local : proof.locals)
+    if (!local.second.consumed) return false;
+
+  // This is ordinary lowering, not a speculative compiler/environment copy.
+  // The proof excludes effects and control, so a typed or pricing refusal can
+  // retain iteration one and lower the remainder without replaying any work.
+  const size_t parameter_slots = g.slots.size();
+  int_env[s.loopvar] = first;
+  for (const auto& child : s.body) lower_stmt(child);
+  const auto continue_ordinary = [&] {
+    for (int64_t lane = first + 1; lane <= last; ++lane) {
+      int_env[s.loopvar] = lane;
+      for (const auto& child : s.body) lower_stmt(child);
+    }
+    int_env.erase(s.loopvar);
+    return true;
+  };
+  if (g.ops.size() < 2 || g.ops.size() > detail::kMaxPeriod + 1 ||
+      target_terms.size() != 1 || !jac_slots.empty())
+    return continue_ordinary();
+  const Op read = g.ops.front();
+  if (read.opcode != OP_INDEX || read.n_in != 1 || read.n_idata != 1 ||
+      read.idata[0] != proof.offset || g.slots[read.out].len != 1)
+    return continue_ordinary();
+  const int P = static_cast<int>(g.ops.size()) - 1;
+  const int64_t lanes = last - first + 1;
+  // Preserve the ordinary fresh-slot identity arithmetic without allocating
+  // any of its later slots. One INDEX plus P active outputs per iteration.
+  if (g.slots.size() != static_cast<size_t>(read.out + P + 1) ||
+      lanes > (INT_MAX - read.out) / (P + 1))
+    return continue_ordinary();
+  std::vector<double> values;
+  for (const auto& fill : out.fills)
+    if (fill.first == read.in[0]) {
+      if (proof.offset + lanes > static_cast<int64_t>(fill.second.size()))
+        return continue_ordinary();
+      values.assign(fill.second.begin() + proof.offset,
+                    fill.second.begin() + proof.offset + lanes);
+    }
+  if (static_cast<int64_t>(values.size()) != lanes) return continue_ordinary();
+
+  rp::CandidatePlan plan;
+  plan.lanes = lanes;
+  plan.positions.resize(P);
+  int previous = read.out;
+  for (int p = 0; p < P; ++p) {
+    const Op& op = g.ops[p + 1];
+    if (op.opcode != (p == 0 ? proof.anchor_opcode : OP_EXPV) &&
+        !(p > 0 && op.opcode == OP_SQUARE))
+      return continue_ordinary();
+    if (!has_op_trait(op.opcode, op_trait::kRerollWidenable) ||
+        op.n_in != (p == 0 ? proof.anchor_arity : 1) ||
+        op.out != read.out + p + 1 || op.out2 >= 0 || op.n_idata || op.udata ||
+        op.dyn_lengths || op.dyn_extent_in >= 0 || g.slots[op.out].len != 1)
+      return continue_ordinary();
+    auto& pos = plan.positions[p];
+    pos.ins.resize(op.n_in);
+    int chain_reads = 0;
+    for (int j = 0; j < op.n_in; ++j) {
+      auto& in = pos.ins[j];
+      if (op.in[j] == previous) {
+        ++chain_reads;
+        if (p == 0) {
+          in.kind = rp::InKind::kConstLanes;
+          in.values = std::move(values);
+        } else {
+          in.kind = rp::InKind::kLaneLocal;
+          in.producer_pos = p - 1;
+        }
+      } else {
+        if (p != 0 || op.in[j] >= read.out || !g.slots[op.in[j]].is_param)
+          return continue_ordinary();
+        in.kind = rp::InKind::kInvariant;
+      }
+    }
+    if (chain_reads != 1) return continue_ordinary();
+    previous = op.out;
+  }
+  if (target_terms[0] != previous) return continue_ordinary();
+  plan.positions.back().term_widen = true;
+  // The proven INDEX is an exact slice of the existing fill. Its scalar
+  // result is dead after widening; do not execute a speculative constant-fold
+  // pass (which would materialize its full backing array) just to discard it.
+  SymbolicLaneSource source{{g.ops.begin() + 1, g.ops.end()}, read.out, P + 1};
+  auto selected = rp::SelectedPlan<SymbolicLaneSource>::select(g, plan, source);
+  if (!selected) return continue_ordinary();
+  std::vector<Op> result;
+  std::vector<int> targets;
+  std::unordered_set<int> terms;
+  std::unordered_map<int, int> renamed;
+  std::move(*selected).emit(g, out.fills, targets, terms, result, renamed);
+  // Selection commits to this representation. An internal emitter invariant
+  // failure must fail compilation, never continue from a partly mutated graph.
+  for (const auto& op : result) {
+    if (op.out < 0 || static_cast<size_t>(op.out) >= g.slots.size())
+      fail("invalid symbolic lane output", s.raw);
+    for (int j = 0; j < op.n_in; ++j)
+      if (op.in[j] < 0 || static_cast<size_t>(op.in[j]) >= g.slots.size())
+        fail("invalid symbolic lane input", s.raw);
+  }
+  for (size_t slot = parameter_slots; slot < g.slots.size(); ++slot)
+    if (g.slots[slot].is_param) fail("invalid symbolic lane parameter", s.raw);
+  g.ops = std::move(result);
+  target_terms = std::move(targets);
+  // Nothing declared inside the terminal loop escapes. Drop seed bindings and
+  // observations (including the full source-array observation) just as the old
+  // isolated trial did. Keep the original data environment and emitted fills.
+  for (const auto& local : proof.locals) {
+    scope.erase(local.first);
+    decls.erase(local.first);
+    td.env().erase(local.first);
+  }
+  for (auto it = scope.begin(); it != scope.end();) {
+    if (it->second.slot >= static_cast<int>(parameter_slots))
+      it = scope.erase(it);
+    else
+      ++it;
+  }
+  for (auto it = observations.begin(); it != observations.end();) {
+    if (it->first.slot >= static_cast<int>(parameter_slots))
+      it = observations.erase(it);
+    else
+      ++it;
+  }
+  int_env.erase(s.loopvar);
+  return true;
+}

--- a/runtime/src/reroll.cpp
+++ b/runtime/src/reroll.cpp
@@ -52,6 +52,7 @@
 
 #include "pass_util.hpp"
 #include "reroll_profile.hpp"
+#include "reroll_plan.hpp"
 
 #include <algorithm>
 #include <cstdlib>
@@ -67,59 +68,10 @@ constexpr int64_t kMinLanes = detail::kMinLanes;
 constexpr int kMaxPeriod = detail::kMaxPeriod;
 constexpr int kMaxClassifyAttempts = 6;
 
-enum class InKind { kInvariant, kConstLanes, kLaneLocal, kBad };
-
-struct PosIn {
-  InKind kind = InKind::kBad;
-  int producer_pos = -1;       // LANE_LOCAL: template position of producer
-  std::vector<double> values;  // CONST_LANES: `width` values per lane
-  int64_t width = 1;
-  bool tile_wide = false;  // INVARIANT, len == the position's own width:
-                           //   tile via OP_REP_MAT instead of rejecting
-};
-
-// How L lanes of C elements sit in one L*C vector: element k of lane l is
-// at flat position `lane_stride*l + elem_stride*k`. Row-major rows
-// (lane_stride=C, elem_stride=1) and column-major rows (lane_stride=1,
-// elem_stride=L) are the two conventions a region may commit to; every
-// wide row op in one region must agree on which. A position's own read
-// of the base is either an elision (the fused consumer reads the base
-// directly, no op) or a slice (one OP_SLICE at `offset`, a window that
-// does not cover the whole base); `kNone` means neither applies.
-struct LaneLayout {
-  int64_t lane_stride = 0;
-  int64_t elem_stride = 1;
-  enum class Kind { kNone, kElide, kSlice } kind = Kind::kNone;
-  int64_t offset = 0;  // meaningful only for kSlice
-
-  int64_t flat_at(int64_t l, int64_t k) const {
-    return lane_stride * l + elem_stride * k;
-  }
-};
-
-struct Pos {
-  std::vector<PosIn> ins;
-  int64_t width = 1;            // elements per lane through this position
-  LaneLayout read;              // OP_INDEX/row elision or slice of the base
-  bool row_store = false;       // SET_SLICE of row `lane`, lanes cover it
-  int store_src = -1;           // the store's base at lane 0
-  bool hoist = false;           // all inputs + idata invariant: emit once
-  bool term_density = false;    // density, every lane's out a target term
-  bool elt_density = false;     // density, every lane's out consumed only
-                                //   inside its own lane -> variant bit 6,
-                                //   out[n] = lane n's lp
-  int64_t rows = 1;             // elt_density with ap.width > 1: outcome
-                                //   elements reduced back per lane by
-                                //   OP_SUM_ROWS; ap.width becomes 1 after
-  bool term_widen = false;      // widenable, every lane's out a target term
-                                //   -> widen + OP_SUM_VEC, swap the terms
-  std::vector<int> gather_idx;  // OP_INDEX with a data-driven index
-  int store_vec = -1;           // element write filling a window of this
-  int store_start = 0;          //   vector, starting here,
-  int store_stride = 1;         //   advancing by this much per lane
-  bool store_written_after = false;  // someone writes the vector later
-  std::vector<int> outcome_idata;    // lpmf: per-lane integer outcomes
-};
+using detail::reroll_plan::InKind;
+using detail::reroll_plan::LaneLayout;
+using detail::reroll_plan::Pos;
+using detail::reroll_plan::PosIn;
 
 bool is_row_read(const Op& op) {
   return op.n_in == 1 && ((op.opcode == OP_SLICE && op.n_idata == 1) ||
@@ -743,8 +695,7 @@ static RerollStats reroll_impl(
   // replacement each time keeps lookups single-step.
   std::unordered_map<int, int> renamed;
   const auto resolve = [&renamed](int s) {
-    const auto it = renamed.find(s);
-    return it == renamed.end() ? s : it->second;
+    return detail::reroll_plan::resolve_slot(renamed, s);
   };
 
   // Slots read from outside the op graph (jacobian terms, constrained
@@ -845,11 +796,14 @@ static RerollStats reroll_impl(
       const bool doomed_next = doomed && L > kMinLanes && rigid_diverges(1);
 
       // ---- classify, shrinking to the reported prefix on failure ----
-      std::vector<Pos> pos;
-      bool layout_set = false;   // has the region committed to a convention
-      bool layout_cols = false;  // column-major, once committed
+      detail::reroll_plan::CandidatePlan plan;
+      std::vector<Pos>& pos = plan.positions;
+      bool layout_set = false;  // has the region committed to a convention
+      bool& layout_cols = plan.column_major;  // column-major, once committed
       int64_t Luse = doomed ? 0 : L;
-      bool classified = false;
+      using SelectedPlan =
+          detail::reroll_plan::SelectedPlan<detail::reroll_plan::GraphSource>;
+      std::optional<SelectedPlan> selected;
       for (int attempt = 0;
            !doomed && attempt < kMaxClassifyAttempts && Luse >= kMinLanes;
            ++attempt) {
@@ -1407,82 +1361,10 @@ static RerollStats reroll_impl(
           // the same per-element work in Luse separate calls, so only the
           // eliminated dispatches and the genuine copies are the region's
           // net win.
-          int64_t ops_out = 0, added = 0, lane_elems = 0;
-          for (int p = 0; p < P; ++p) {
-            const Pos& ap = pos[(size_t)p];
-            const int64_t tile_width = ap.rows > 1 ? ap.rows : ap.width;
-            for (const PosIn& in : ap.ins)
-              if (in.tile_wide) {
-                ++ops_out;
-                added += Luse * tile_width;
-              }
-            if (ap.read.kind == LaneLayout::Kind::kElide) {
-              continue;
-            } else if (ap.hoist) {
-              ++ops_out;
-            } else if (ap.read.kind == LaneLayout::Kind::kSlice) {
-              ++ops_out;
-              added += Luse * ap.width;
-              lane_elems += 2 * ap.width;
-            } else if (!ap.gather_idx.empty()) {
-              ++ops_out;
-              added += 2 * Luse * ap.width;
-              lane_elems += 2 * ap.width;
-            } else if (ap.term_density) {
-              ++ops_out;
-              lane_elems += ap.width * kLaneDensityElem;
-            } else if (ap.elt_density) {
-              const uint16_t opcode = op_at(p, 0).opcode;
-              ops_out += ap.rows > 1 ? 2 : 1;
-              lane_elems += ap.rows * kLaneDensityElem;
-              if (ap.rows > 1 && lane_elt_costs_per_element(opcode))
-                added += Luse * ap.rows * kLaneDensityElem;
-              if (ap.rows > 1 && layout_cols) {
-                // The column-major repack ahead of OP_SUM_ROWS: one gather,
-                // priced like any other.
-                ++ops_out;
-                added += 2 * Luse * ap.rows;
-                lane_elems += 2 * ap.rows;
-              }
-            } else if (ap.term_widen) {
-              ops_out += 2;
-              lane_elems += 2 * ap.width;
-            } else if (ap.store_vec >= 0) {
-              const bool whole = ap.row_store ||
-                                 (ap.store_stride == 1 && ap.store_start == 0 &&
-                                  Luse == g.slots[(size_t)ap.store_vec].len);
-              if (!whole || ap.store_written_after) {
-                ++ops_out;
-                lane_elems += 2 * ap.width;
-              }
-            } else {
-              ++ops_out;
-              lane_elems += 2 * ap.width;
-            }
-          }
-          std::unordered_set<uint64_t> lane_hash;
-          for (int64_t l = 0; l < Luse; ++l) {
-            uint64_t h = 1469598103934665603ull;
-            const auto mix = [&h](int64_t v) {
-              h = (h ^ (uint64_t)v) * 1099511628211ull;
-            };
-            for (int p = 0; p < P; ++p) {
-              const Op& o = op_at(p, l);
-              const Pos& ap = pos[(size_t)p];
-              for (int j = 0; j < o.n_in; ++j)
-                mix(ap.ins[(size_t)j].kind == InKind::kLaneLocal ? -1
-                                                                 : o.in[j]);
-              for (int64_t m = 0; m < o.n_idata; ++m) mix(o.idata[m]);
-            }
-            lane_hash.insert(h);
-          }
-          const int64_t distinct = (int64_t)lane_hash.size();
-          added += ops_out * kLaneOpCost + (Luse - distinct) * lane_elems;
-          if (distinct * (int64_t)P * kLaneOpCost >
-              added + kLanePartitionMargin) {
-            classified = true;
-            break;
-          }
+          plan.lanes = Luse;
+          selected = SelectedPlan::select(
+              g, plan, detail::reroll_plan::GraphSource{g.ops.data() + i, P});
+          if (selected) break;
           ok = false;
         }
         if (ok) prefix = 0;                     // classifiable but useless
@@ -1490,7 +1372,7 @@ static RerollStats reroll_impl(
         Luse = prefix;
       }
 
-      if (!classified) {
+      if (!selected) {
         // Bookkeeping. Soft failures (positive prefix) re-attempt at the
         // reported boundary; hard failures (prefix 0) get one second
         // chance one lane in, then the whole run is skipped.
@@ -1512,316 +1394,14 @@ static RerollStats reroll_impl(
         continue;
       }
 
-      // ---- rewrite the classified prefix [i, i + P*Luse) ----
-      std::vector<int> pos_out((size_t)P, -1);
-      const auto packed_const = [&](const PosIn& in, int64_t w) {
-        // Element k of lane l in a vector of `w`-wide lanes, per the
-        // region's committed convention.
-        const LaneLayout lay =
-            layout_cols ? LaneLayout{1, Luse} : LaneLayout{w, 1};
-        std::vector<double> packed((size_t)(Luse * w));
-        for (int64_t l = 0; l < Luse; ++l)
-          for (int64_t k = 0; k < w; ++k)
-            packed[(size_t)lay.flat_at(l, k)] =
-                in.values[(size_t)(l * in.width + (in.width == 1 ? 0 : k))];
-        const int cs = g.add_slot(Luse * w, false);
-        fills.emplace_back(cs, std::move(packed));
-        return cs;
-      };
-      for (int p = 0; p < P; ++p) {
-        const Op& t = op_at(p, 0);
-        Pos& ap = pos[(size_t)p];
-        if (ap.read.kind == LaneLayout::Kind::kElide) {
-          pos_out[(size_t)p] = resolve(t.in[0]);
-          continue;
-        }
-        if (ap.hoist) {
-          Op h = t;
-          for (int j = 0; j < h.n_in; ++j) h.in[j] = resolve(h.in[j]);
-          result.push_back(h);
-          pos_out[(size_t)p] = h.out;
-          continue;
-        }
-        if (ap.store_vec >= 0) {
-          // The lanes' values, as one vector.
-          int W = -1;
-          if (ap.ins[1].kind == InKind::kLaneLocal) {
-            W = pos_out[(size_t)ap.ins[1].producer_pos];
-          } else {
-            W = packed_const(ap.ins[1], ap.width);
-          }
-          // Every lane writing the same scalar (the value chain stayed
-          // scalar because all its inputs were lane-invariant): the store
-          // wants a vector, so broadcast it into one.
-          if (g.slots[W].len == 1 && Luse > 1) {
-            Op rv;
-            rv.opcode = OP_REP_VEC;
-            rv.n_in = 1;
-            rv.in[0] = W;
-            rv.out = g.add_slot(Luse, false);
-            result.push_back(rv);
-            W = rv.out;
-          }
-          const int vec = ap.store_vec;
-          int replacement = W;
-          const bool whole =
-              ap.row_store || (ap.store_stride == 1 && ap.store_start == 0 &&
-                               Luse == g.slots[vec].len);
-          if (ap.store_written_after || !whole) {
-            // A window (or a comb) rather than the whole vector: the
-            // untouched elements still have to come from somewhere, so this
-            // is a real store.
-            Op sv;
-            sv.opcode =
-                ap.store_stride == 1 ? OP_SET_SLICE : OP_SET_SLICE_STRIDED;
-            sv.n_in = 2;
-            sv.in[0] = resolve(ap.store_src);
-            sv.in[1] = W;
-            sv.out = g.add_slot(g.slots[vec].len, false);
-            std::vector<int> sidata{ap.store_start};
-            if (ap.store_stride != 1) sidata.push_back(ap.store_stride);
-            g.idata_pool.push_back(std::move(sidata));
-            sv.idata = g.idata_pool.back().data();
-            sv.n_idata = (int64_t)g.idata_pool.back().size();
-            result.push_back(sv);
-            replacement = sv.out;
-          }
-          // Every later reference to the vector -- read or write -- now
-          // means the fused value: recorded here, applied when those ops
-          // are emitted. Renaming the writes too is what lets interleaved
-          // runs chain: the next block's element writes still NAME the
-          // original vector, resolve to this block's store output when
-          // that block fuses in its turn, and repeat the process on a
-          // fresh slot. Ops before the region were emitted already; they
-          // saw the pre-write contents and still do.
-          renamed[vec] = replacement;
-          pos_out[(size_t)p] = replacement;
-          continue;
-        }
-        const bool is_slice = ap.read.kind == LaneLayout::Kind::kSlice;
-        if (is_slice || !ap.gather_idx.empty()) {
-          // One vector read replaces the lanes' scalar reads. Both kernels
-          // scatter their adjoints back into the base, gather in ascending
-          // lane order so repeated indices accumulate like the var path.
-          Op rd;
-          rd.opcode = is_slice ? OP_SLICE : OP_GATHER;
-          rd.n_in = 1;
-          rd.in[0] = resolve(t.in[0]);
-          rd.out = g.add_slot(Luse * ap.width, false);
-          std::vector<int> idata;
-          if (is_slice)
-            idata.push_back((int)ap.read.offset);
-          else
-            idata = std::move(ap.gather_idx);
-          g.idata_pool.push_back(std::move(idata));
-          rd.idata = g.idata_pool.back().data();
-          rd.n_idata = (int64_t)g.idata_pool.back().size();
-          pos_out[(size_t)p] = rd.out;
-          result.push_back(rd);
-          continue;
-        }
-        Op op = t;  // opcode, variant, idata carry over
-        // elt_density with ap.rows > 1 sets ap.width to 1 for downstream
-        // consumers (its own output is one lp per lane, after OP_SUM_ROWS);
-        // its own operands still pack at the row width.
-        const int64_t eff_width = ap.rows > 1 ? ap.rows : ap.width;
-        if (eff_width > 1 && !ap.outcome_idata.empty()) {
-          const LaneLayout lay =
-              layout_cols ? LaneLayout{1, Luse} : LaneLayout{eff_width, 1};
-          std::vector<int> packed(ap.outcome_idata.size());
-          for (int64_t l = 0; l < Luse; ++l)
-            for (int64_t k = 0; k < eff_width; ++k)
-              packed[(size_t)lay.flat_at(l, k)] =
-                  ap.outcome_idata[(size_t)(l * eff_width + k)];
-          ap.outcome_idata = std::move(packed);
-        }
-        // A wide shared operand tiled to the region's packing order: mode
-        // {width, count, 1} tail-to-tail (row-major) or {count, width, 2}
-        // each element repeated (column-major), matching the same
-        // LaneLayout convention.
-        const auto tile_wide_op = [&](int base) {
-          Op rep;
-          rep.opcode = OP_REP_MAT;
-          rep.n_in = 1;
-          rep.in[0] = base;
-          rep.out = g.add_slot(Luse * eff_width, false);
-          std::vector<int> ridata =
-              layout_cols ? std::vector<int>{(int)Luse, (int)eff_width, 2}
-                          : std::vector<int>{(int)eff_width, (int)Luse, 1};
-          g.idata_pool.push_back(std::move(ridata));
-          rep.idata = g.idata_pool.back().data();
-          rep.n_idata = (int64_t)g.idata_pool.back().size();
-          result.push_back(rep);
-          return rep.out;
-        };
-        bool all_scalar = true;
-        for (int j = 0; j < t.n_in; ++j) {
-          switch (ap.ins[j].kind) {
-            case InKind::kInvariant:
-              op.in[j] = ap.ins[j].tile_wide ? tile_wide_op(resolve(t.in[j]))
-                                             : resolve(t.in[j]);
-              if (g.slots[t.in[j]].len != 1) all_scalar = false;
-              break;
-            case InKind::kLaneLocal:
-              op.in[j] = pos_out[(size_t)ap.ins[j].producer_pos];
-              if (ap.ins[j].tile_wide) op.in[j] = tile_wide_op(op.in[j]);
-              if (g.slots[op.in[j]].len != 1) all_scalar = false;
-              break;
-            case InKind::kConstLanes:
-              op.in[j] = packed_const(ap.ins[j], eff_width);
-              all_scalar = false;
-              break;
-            case InKind::kBad:
-              break;  // unreachable: classification succeeded
-          }
-        }
-        // Swap the Luse lane terms for one replacement, at the first
-        // lane's position (term_density and term_widen both end here).
-        const auto swap_terms = [&](int new_term) {
-          std::unordered_set<int> dead;
-          for (int64_t l = 0; l < Luse; ++l) dead.insert(op_at(p, l).out);
-          std::vector<int> next_terms;
-          next_terms.reserve(target_terms.size());
-          bool placed = false;
-          for (int s : target_terms) {
-            if (dead.count(s)) {
-              if (!placed) {
-                next_terms.push_back(new_term);
-                placed = true;
-              }
-            } else {
-              next_terms.push_back(s);
-            }
-          }
-          target_terms = std::move(next_terms);
-          for (int s : dead) term_set.erase(s);
-          term_set.insert(new_term);
-        };
-        // The fused lpmf's outcome vector is the lanes' immediates.
-        const auto attach_idata = [&](Op& o, std::vector<int> outcome) {
-          if (outcome.empty()) return;
-          g.idata_pool.push_back(std::move(outcome));
-          o.idata = g.idata_pool.back().data();
-          o.n_idata = (int64_t)g.idata_pool.back().size();
-        };
-        // Every lane computes the same scalar: emit it once and multiply by
-        // L. Both callers are all-scalar term dispositions, whose positions
-        // have no op consumers at all (the classifier refuses otherwise), so
-        // pos_out here is bookkeeping nobody reads. Returns the new term.
-        const auto scalar_times_lanes = [&](const Op& scalar) {
-          result.push_back(scalar);  // scalar op, out = t.out
-          Op mul;
-          mul.opcode = OP_MUL;
-          mul.n_in = 2;
-          mul.in[0] = scalar.out;
-          const int lc = g.add_slot(1, false);
-          fills.emplace_back(lc, std::vector<double>{(double)Luse});
-          mul.in[1] = lc;
-          mul.out = g.add_slot(1, false);
-          result.push_back(mul);
-          pos_out[(size_t)p] = scalar.out;
-          return mul.out;
-        };
-        if (ap.elt_density) {
-          // One density op with variant bit 6: out[n] is lane n's lp (or,
-          // when ap.rows > 1, out holds Luse*rows per-element lps that
-          // OP_SUM_ROWS folds back to one lp per lane), read by the lanes'
-          // (widened) consumers. An all-scalar real-arg density classified
-          // as hoist instead, so a vector input or a per-lane outcome
-          // exists here.
-          op.variant = (uint8_t)(op.variant | 0x40u);
-          op.out = g.add_slot(Luse * ap.rows, false);
-          attach_idata(op, std::move(ap.outcome_idata));
-          int result_slot = op.out;
-          result.push_back(op);
-          if (ap.rows > 1) {
-            // The density's real args pack in the region's committed order.
-            // OP_SUM_ROWS needs lane l's `rows` elements contiguous
-            // (l*rows+k); row-major packing already has that, but
-            // column-major (l + Luse*k) does not, so repack it first.
-            if (layout_cols) {
-              Op perm;
-              perm.opcode = OP_GATHER;
-              perm.n_in = 1;
-              perm.in[0] = result_slot;
-              perm.out = g.add_slot(Luse * ap.rows, false);
-              std::vector<int> idx;
-              idx.reserve((size_t)(Luse * ap.rows));
-              for (int64_t l = 0; l < Luse; ++l)
-                for (int64_t k = 0; k < ap.rows; ++k)
-                  idx.push_back((int)(l + Luse * k));
-              g.idata_pool.push_back(std::move(idx));
-              perm.idata = g.idata_pool.back().data();
-              perm.n_idata = (int64_t)g.idata_pool.back().size();
-              result.push_back(perm);
-              result_slot = perm.out;
-            }
-            Op rows;
-            rows.opcode = OP_SUM_ROWS;
-            rows.n_in = 1;
-            rows.in[0] = result_slot;
-            rows.out = g.add_slot(Luse, false);
-            attach_idata(rows, std::vector<int>{(int)ap.rows});
-            result.push_back(rows);
-            result_slot = rows.out;
-          }
-          pos_out[(size_t)p] = result_slot;
-          continue;
-        }
-        if (ap.term_widen) {
-          int term_slot;
-          if (all_scalar) {
-            // Every lane's term is the same scalar: one op, times L.
-            term_slot = scalar_times_lanes(op);
-          } else {
-            op.out = g.add_slot(Luse, false);
-            result.push_back(op);
-            Op sum;
-            sum.opcode = OP_SUM_VEC;
-            sum.n_in = 1;
-            sum.in[0] = op.out;
-            sum.out = g.add_slot(1, false);
-            result.push_back(sum);
-            term_slot = sum.out;
-            pos_out[(size_t)p] = op.out;
-          }
-          swap_terms(term_slot);
-          continue;
-        }
-        // A widened op whose mapped inputs are all len-1 computes the same
-        // value in every lane -- its lane-varying inputs came from HOISTED
-        // producers, which are scalars. Widening it anyway hands the kernels
-        // scalar inputs with a vector output, and their scalar-x-scalar
-        // paths write element 0 only (found by the corpus A/B on
-        // losscurve_sislob: a cohort's lm window filled with arena zeros).
-        // Keep it scalar; consumers broadcast, and the store materializes.
-        if (!ap.term_density && all_scalar) {
-          pos_out[(size_t)p] = op.out;  // t's own (lane 0) output slot
-          result.push_back(op);
-          continue;
-        }
-        if (ap.term_density) {
-          if (all_scalar && ap.outcome_idata.empty()) {
-            // Every lane's density is the same scalar (lane-varying inputs
-            // all came from hoisted producers): the target owes L copies of
-            // it, and L times one lane is that, exactly -- the density
-            // backward sees out_adj = L and scales its partials to match.
-            swap_terms(scalar_times_lanes(op));
-            continue;
-          }
-          op.out = g.add_slot(1, false);
-          attach_idata(op, std::move(ap.outcome_idata));
-          swap_terms(op.out);
-        } else {
-          op.out = g.add_slot(Luse * ap.width, false);
-        }
-        pos_out[(size_t)p] = op.out;
-        result.push_back(op);
-      }
+      // Emit only the accepted plan; classification and pricing above have
+      // not changed graph storage, targets or lazy renaming.
+      std::move(*selected).emit(g, fills, target_terms, term_set, result,
+                                renamed);
       i += (size_t)P * (size_t)Luse;
       ++st.regions;
       if (dispositions) {
-        for (const Pos& committed : pos) {
+        for (const Pos& committed : selected->description().positions) {
           dispositions->term_density += committed.term_density;
           dispositions->element_density += committed.elt_density;
           dispositions->term_widen += committed.term_widen;

--- a/runtime/src/reroll_plan.hpp
+++ b/runtime/src/reroll_plan.hpp
@@ -1,0 +1,552 @@
+// Private lane plan shared by reroll selection and emission. Not installed.
+#ifndef STANLI_REROLL_PLAN_HPP
+#define STANLI_REROLL_PLAN_HPP
+
+#include "pass_util.hpp"
+
+#include <optional>
+#include <unordered_set>
+
+namespace stanli {
+namespace detail {
+namespace reroll_plan {
+
+enum class InKind { kInvariant, kConstLanes, kLaneLocal, kBad };
+
+struct PosIn {
+  InKind kind = InKind::kBad;
+  int producer_pos = -1;       // LANE_LOCAL: template position of producer
+  std::vector<double> values;  // CONST_LANES: `width` values per lane
+  int64_t width = 1;
+  bool tile_wide = false;  // INVARIANT, len == the position's own width:
+                           //   tile via OP_REP_MAT instead of rejecting
+};
+
+// How L lanes of C elements sit in one L*C vector: element k of lane l is
+// at flat position `lane_stride*l + elem_stride*k`. Row-major rows
+// (lane_stride=C, elem_stride=1) and column-major rows (lane_stride=1,
+// elem_stride=L) are the two conventions a region may commit to; every
+// wide row op in one region must agree on which. A position's own read
+// of the base is either an elision (the fused consumer reads the base
+// directly, no op) or a slice (one OP_SLICE at `offset`, a window that
+// does not cover the whole base); `kNone` means neither applies.
+struct LaneLayout {
+  int64_t lane_stride = 0;
+  int64_t elem_stride = 1;
+  enum class Kind { kNone, kElide, kSlice } kind = Kind::kNone;
+  int64_t offset = 0;  // meaningful only for kSlice
+
+  int64_t flat_at(int64_t l, int64_t k) const {
+    return lane_stride * l + elem_stride * k;
+  }
+};
+
+struct Pos {
+  std::vector<PosIn> ins;
+  int64_t width = 1;            // elements per lane through this position
+  LaneLayout read;              // OP_INDEX/row elision or slice of the base
+  bool row_store = false;       // SET_SLICE of row `lane`, lanes cover it
+  int store_src = -1;           // the store's base at lane 0
+  bool hoist = false;           // all inputs + idata invariant: emit once
+  bool term_density = false;    // density, every lane's out a target term
+  bool elt_density = false;     // density, every lane's out consumed only
+                                //   inside its own lane -> variant bit 6,
+                                //   out[n] = lane n's lp
+  int64_t rows = 1;             // elt_density with ap.width > 1: outcome
+                                //   elements reduced back per lane by
+                                //   OP_SUM_ROWS; ap.width becomes 1 after
+  bool term_widen = false;      // widenable, every lane's out a target term
+                                //   -> widen + OP_SUM_VEC, swap the terms
+  std::vector<int> gather_idx;  // OP_INDEX with a data-driven index
+  int store_vec = -1;           // element write filling a window of this
+  int store_start = 0;          //   vector, starting here,
+  int store_stride = 1;         //   advancing by this much per lane
+  bool store_written_after = false;  // someone writes the vector later
+  std::vector<int> outcome_idata;    // lpmf: per-lane integer outcomes
+};
+
+// Classification fills positions without publishing graph mutations. Pricing
+// reads the same plan. After acceptance emit consumes the packing payloads;
+// the flags remain available for preparation diagnostics. This is a one-use
+// preparation object, not an executor/AD record or an eligibility proof.
+struct CandidatePlan {
+  int64_t lanes = 0;
+  bool column_major = false;
+  std::vector<Pos> positions;
+};
+
+// Adapter over the immutable input op sequence. Graph slot/idata allocations
+// during emission cannot invalidate it: the driver publishes g.ops only after
+// the entire scan. Target replacement preserves the original first-leaf
+// position, including surrounding terms and lazy region-to-region renaming.
+struct GraphSource {
+  static constexpr bool kDistinctLaneHashes = false;
+  const Op* ops;
+  int period;
+  const Op& at(int p, int64_t lane) const {
+    return ops[(size_t)lane * (size_t)period + (size_t)p];
+  }
+  void replace_terms(int p, int64_t Luse, int new_term,
+                     std::vector<int>& target_terms,
+                     std::unordered_set<int>& term_set) const {
+    std::unordered_set<int> dead;
+    for (int64_t l = 0; l < Luse; ++l) dead.insert(at(p, l).out);
+    std::vector<int> next_terms;
+    next_terms.reserve(target_terms.size());
+    bool placed = false;
+    for (int s : target_terms) {
+      if (dead.count(s)) {
+        if (!placed) {
+          next_terms.push_back(new_term);
+          placed = true;
+        }
+      } else {
+        next_terms.push_back(s);
+      }
+    }
+    target_terms = std::move(next_terms);
+    for (int s : dead) term_set.erase(s);
+    term_set.insert(new_term);
+  }
+};
+
+// Existing cost model, including CSE's distinct-input-lane discount. Geometry
+// alone must not select a vector plan: choosing this form changes reductions
+// and broadcast-adjoint accumulation order. Source::at must describe every
+// lane; a few observed iterations are not an affine/control proof.
+template <class Source>
+bool profitable(const Graph& g, const CandidatePlan& plan,
+                const Source& source) {
+  const auto& pos = plan.positions;
+  const int P = static_cast<int>(pos.size());
+  const int64_t Luse = plan.lanes;
+  const bool layout_cols = plan.column_major;
+  int64_t ops_out = 0, added = 0, lane_elems = 0;
+  for (int p = 0; p < P; ++p) {
+    const Pos& ap = pos[(size_t)p];
+    const int64_t tile_width = ap.rows > 1 ? ap.rows : ap.width;
+    for (const PosIn& in : ap.ins)
+      if (in.tile_wide) {
+        ++ops_out;
+        added += Luse * tile_width;
+      }
+    if (ap.read.kind == LaneLayout::Kind::kElide) {
+      continue;
+    } else if (ap.hoist) {
+      ++ops_out;
+    } else if (ap.read.kind == LaneLayout::Kind::kSlice) {
+      ++ops_out;
+      added += Luse * ap.width;
+      lane_elems += 2 * ap.width;
+    } else if (!ap.gather_idx.empty()) {
+      ++ops_out;
+      added += 2 * Luse * ap.width;
+      lane_elems += 2 * ap.width;
+    } else if (ap.term_density) {
+      ++ops_out;
+      lane_elems += ap.width * kLaneDensityElem;
+    } else if (ap.elt_density) {
+      const uint16_t opcode = source.at(p, 0).opcode;
+      ops_out += ap.rows > 1 ? 2 : 1;
+      lane_elems += ap.rows * kLaneDensityElem;
+      if (ap.rows > 1 && lane_elt_costs_per_element(opcode))
+        added += Luse * ap.rows * kLaneDensityElem;
+      if (ap.rows > 1 && layout_cols) {
+        // The column-major repack ahead of OP_SUM_ROWS: one gather,
+        // priced like any other.
+        ++ops_out;
+        added += 2 * Luse * ap.rows;
+        lane_elems += 2 * ap.rows;
+      }
+    } else if (ap.term_widen) {
+      ops_out += 2;
+      lane_elems += 2 * ap.width;
+    } else if (ap.store_vec >= 0) {
+      const bool whole =
+          ap.row_store || (ap.store_stride == 1 && ap.store_start == 0 &&
+                           Luse == g.slots[(size_t)ap.store_vec].len);
+      if (!whole || ap.store_written_after) {
+        ++ops_out;
+        lane_elems += 2 * ap.width;
+      }
+    } else {
+      ++ops_out;
+      lane_elems += 2 * ap.width;
+    }
+  }
+  // A source may prove these exact hashes distinct without constructing
+  // them. This is stronger than distinct data values or distinct input tuples:
+  // multiple varying fields can collide. Arbitrary graph sources still hash.
+  // Retain the graph path's original container lifetime through the return;
+  // the proved specialization leaves it empty and the compiler removes it.
+  std::unordered_set<uint64_t> lane_hash;
+  int64_t distinct = Luse;
+  if constexpr (!Source::kDistinctLaneHashes) {
+    for (int64_t l = 0; l < Luse; ++l) {
+      uint64_t h = 1469598103934665603ull;
+      const auto mix = [&h](int64_t v) {
+        h = (h ^ (uint64_t)v) * 1099511628211ull;
+      };
+      for (int p = 0; p < P; ++p) {
+        const Op& o = source.at(p, l);
+        const Pos& ap = pos[(size_t)p];
+        for (int j = 0; j < o.n_in; ++j)
+          mix(ap.ins[(size_t)j].kind == InKind::kLaneLocal ? -1 : o.in[j]);
+        for (int64_t m = 0; m < o.n_idata; ++m) mix(o.idata[m]);
+      }
+      lane_hash.insert(h);
+    }
+    distinct = (int64_t)lane_hash.size();
+  }
+  added += ops_out * kLaneOpCost + (Luse - distinct) * lane_elems;
+  return distinct * (int64_t)P * kLaneOpCost > added + kLanePartitionMargin;
+}
+
+// The classifier supplies the structural proof. This move-only boundary
+// additionally enforces the unchanged cost gate and binds the source used
+// for pricing to the source used for emission. A rejection leaves candidate
+// storage intact for the driver's prefix retry; acceptance transfers it once.
+// Source must have immutable value semantics (or be a stable borrowed view):
+// copying it must preserve all lane identities and target-publication facts.
+// Call emit once; its rvalue qualification expresses the consumption contract,
+// but does not by itself prevent a caller from reusing a moved-from object.
+template <class Source>
+class SelectedPlan {
+ public:
+  SelectedPlan(const SelectedPlan&) = delete;
+  SelectedPlan& operator=(const SelectedPlan&) = delete;
+  SelectedPlan(SelectedPlan&&) = default;
+  SelectedPlan& operator=(SelectedPlan&&) = default;
+
+  static std::optional<SelectedPlan> select(const Graph& g,
+                                            CandidatePlan& candidate,
+                                            const Source& source) {
+    if (!profitable(g, candidate, source)) return std::nullopt;
+    return SelectedPlan(std::move(candidate), source);
+  }
+  const CandidatePlan& description() const { return plan_; }
+
+  // Consumes packing payloads, emitting existing kernels in their original
+  // order. Target/rename state stays live across regions; it is not captured
+  // in the plan. The caller publishes the completed op sequence afterward.
+  void emit(Graph& g, Fills& fills, std::vector<int>& target_terms,
+            std::unordered_set<int>& term_set, std::vector<Op>& result,
+            std::unordered_map<int, int>& renamed) &&;
+
+ private:
+  SelectedPlan(CandidatePlan&& plan, const Source& source)
+      : plan_(std::move(plan)), source_(source) {}
+  CandidatePlan plan_;
+  Source source_;
+};
+
+inline int resolve_slot(const std::unordered_map<int, int>& renamed, int slot) {
+  const auto it = renamed.find(slot);
+  return it == renamed.end() ? slot : it->second;
+}
+
+template <class Source>
+void SelectedPlan<Source>::emit(Graph& g, Fills& fills,
+                                std::vector<int>& target_terms,
+                                std::unordered_set<int>& term_set,
+                                std::vector<Op>& result,
+                                std::unordered_map<int, int>& renamed) && {
+  CandidatePlan& plan = plan_;
+  const Source& source = source_;
+  const auto resolve = [&](int slot) { return resolve_slot(renamed, slot); };
+  auto& pos = plan.positions;
+  const int P = static_cast<int>(pos.size());
+  const int64_t Luse = plan.lanes;
+  const bool layout_cols = plan.column_major;
+  std::vector<int> pos_out((size_t)P, -1);
+  const auto packed_const = [&](const PosIn& in, int64_t w) {
+    // Element k of lane l in a vector of `w`-wide lanes, per the
+    // region's committed convention.
+    const LaneLayout lay = layout_cols ? LaneLayout{1, Luse} : LaneLayout{w, 1};
+    std::vector<double> packed((size_t)(Luse * w));
+    for (int64_t l = 0; l < Luse; ++l)
+      for (int64_t k = 0; k < w; ++k)
+        packed[(size_t)lay.flat_at(l, k)] =
+            in.values[(size_t)(l * in.width + (in.width == 1 ? 0 : k))];
+    const int cs = g.add_slot(Luse * w, false);
+    fills.emplace_back(cs, std::move(packed));
+    return cs;
+  };
+  for (int p = 0; p < P; ++p) {
+    const Op& t = source.at(p, 0);
+    Pos& ap = pos[(size_t)p];
+    if (ap.read.kind == LaneLayout::Kind::kElide) {
+      pos_out[(size_t)p] = resolve(t.in[0]);
+      continue;
+    }
+    if (ap.hoist) {
+      Op h = t;
+      for (int j = 0; j < h.n_in; ++j) h.in[j] = resolve(h.in[j]);
+      result.push_back(h);
+      pos_out[(size_t)p] = h.out;
+      continue;
+    }
+    if (ap.store_vec >= 0) {
+      // The lanes' values, as one vector.
+      int W = -1;
+      if (ap.ins[1].kind == InKind::kLaneLocal) {
+        W = pos_out[(size_t)ap.ins[1].producer_pos];
+      } else {
+        W = packed_const(ap.ins[1], ap.width);
+      }
+      // Every lane writing the same scalar (the value chain stayed
+      // scalar because all its inputs were lane-invariant): the store
+      // wants a vector, so broadcast it into one.
+      if (g.slots[W].len == 1 && Luse > 1) {
+        Op rv;
+        rv.opcode = OP_REP_VEC;
+        rv.n_in = 1;
+        rv.in[0] = W;
+        rv.out = g.add_slot(Luse, false);
+        result.push_back(rv);
+        W = rv.out;
+      }
+      const int vec = ap.store_vec;
+      int replacement = W;
+      const bool whole =
+          ap.row_store || (ap.store_stride == 1 && ap.store_start == 0 &&
+                           Luse == g.slots[vec].len);
+      if (ap.store_written_after || !whole) {
+        // A window (or a comb) rather than the whole vector: the
+        // untouched elements still have to come from somewhere, so this
+        // is a real store.
+        Op sv;
+        sv.opcode = ap.store_stride == 1 ? OP_SET_SLICE : OP_SET_SLICE_STRIDED;
+        sv.n_in = 2;
+        sv.in[0] = resolve(ap.store_src);
+        sv.in[1] = W;
+        sv.out = g.add_slot(g.slots[vec].len, false);
+        std::vector<int> sidata{ap.store_start};
+        if (ap.store_stride != 1) sidata.push_back(ap.store_stride);
+        g.idata_pool.push_back(std::move(sidata));
+        sv.idata = g.idata_pool.back().data();
+        sv.n_idata = (int64_t)g.idata_pool.back().size();
+        result.push_back(sv);
+        replacement = sv.out;
+      }
+      // Every later reference to the vector -- read or write -- now
+      // means the fused value: recorded here, applied when those ops
+      // are emitted. Renaming the writes too is what lets interleaved
+      // runs chain: the next block's element writes still NAME the
+      // original vector, resolve to this block's store output when
+      // that block fuses in its turn, and repeat the process on a
+      // fresh slot. Ops before the region were emitted already; they
+      // saw the pre-write contents and still do.
+      renamed[vec] = replacement;
+      pos_out[(size_t)p] = replacement;
+      continue;
+    }
+    const bool is_slice = ap.read.kind == LaneLayout::Kind::kSlice;
+    if (is_slice || !ap.gather_idx.empty()) {
+      // One vector read replaces the lanes' scalar reads. Both kernels
+      // scatter their adjoints back into the base, gather in ascending
+      // lane order so repeated indices accumulate like the var path.
+      Op rd;
+      rd.opcode = is_slice ? OP_SLICE : OP_GATHER;
+      rd.n_in = 1;
+      rd.in[0] = resolve(t.in[0]);
+      rd.out = g.add_slot(Luse * ap.width, false);
+      std::vector<int> idata;
+      if (is_slice)
+        idata.push_back((int)ap.read.offset);
+      else
+        idata = std::move(ap.gather_idx);
+      g.idata_pool.push_back(std::move(idata));
+      rd.idata = g.idata_pool.back().data();
+      rd.n_idata = (int64_t)g.idata_pool.back().size();
+      pos_out[(size_t)p] = rd.out;
+      result.push_back(rd);
+      continue;
+    }
+    Op op = t;  // opcode, variant, idata carry over
+    // elt_density with ap.rows > 1 sets ap.width to 1 for downstream
+    // consumers (its own output is one lp per lane, after OP_SUM_ROWS);
+    // its own operands still pack at the row width.
+    const int64_t eff_width = ap.rows > 1 ? ap.rows : ap.width;
+    if (eff_width > 1 && !ap.outcome_idata.empty()) {
+      const LaneLayout lay =
+          layout_cols ? LaneLayout{1, Luse} : LaneLayout{eff_width, 1};
+      std::vector<int> packed(ap.outcome_idata.size());
+      for (int64_t l = 0; l < Luse; ++l)
+        for (int64_t k = 0; k < eff_width; ++k)
+          packed[(size_t)lay.flat_at(l, k)] =
+              ap.outcome_idata[(size_t)(l * eff_width + k)];
+      ap.outcome_idata = std::move(packed);
+    }
+    // A wide shared operand tiled to the region's packing order: mode
+    // {width, count, 1} tail-to-tail (row-major) or {count, width, 2}
+    // each element repeated (column-major), matching the same
+    // LaneLayout convention.
+    const auto tile_wide_op = [&](int base) {
+      Op rep;
+      rep.opcode = OP_REP_MAT;
+      rep.n_in = 1;
+      rep.in[0] = base;
+      rep.out = g.add_slot(Luse * eff_width, false);
+      std::vector<int> ridata =
+          layout_cols ? std::vector<int>{(int)Luse, (int)eff_width, 2}
+                      : std::vector<int>{(int)eff_width, (int)Luse, 1};
+      g.idata_pool.push_back(std::move(ridata));
+      rep.idata = g.idata_pool.back().data();
+      rep.n_idata = (int64_t)g.idata_pool.back().size();
+      result.push_back(rep);
+      return rep.out;
+    };
+    bool all_scalar = true;
+    for (int j = 0; j < t.n_in; ++j) {
+      switch (ap.ins[j].kind) {
+        case InKind::kInvariant:
+          op.in[j] = ap.ins[j].tile_wide ? tile_wide_op(resolve(t.in[j]))
+                                         : resolve(t.in[j]);
+          if (g.slots[t.in[j]].len != 1) all_scalar = false;
+          break;
+        case InKind::kLaneLocal:
+          op.in[j] = pos_out[(size_t)ap.ins[j].producer_pos];
+          if (ap.ins[j].tile_wide) op.in[j] = tile_wide_op(op.in[j]);
+          if (g.slots[op.in[j]].len != 1) all_scalar = false;
+          break;
+        case InKind::kConstLanes:
+          op.in[j] = packed_const(ap.ins[j], eff_width);
+          all_scalar = false;
+          break;
+        case InKind::kBad:
+          break;  // unreachable: classification succeeded
+      }
+    }
+    // Swap the Luse lane terms for one replacement, at the first
+    // lane's position (term_density and term_widen both end here).
+    const auto swap_terms = [&](int new_term) {
+      source.replace_terms(p, Luse, new_term, target_terms, term_set);
+    };
+    // The fused lpmf's outcome vector is the lanes' immediates.
+    const auto attach_idata = [&](Op& o, std::vector<int> outcome) {
+      if (outcome.empty()) return;
+      g.idata_pool.push_back(std::move(outcome));
+      o.idata = g.idata_pool.back().data();
+      o.n_idata = (int64_t)g.idata_pool.back().size();
+    };
+    // Every lane computes the same scalar: emit it once and multiply by
+    // L. Both callers are all-scalar term dispositions, whose positions
+    // have no op consumers at all (the classifier refuses otherwise), so
+    // pos_out here is bookkeeping nobody reads. Returns the new term.
+    const auto scalar_times_lanes = [&](const Op& scalar) {
+      result.push_back(scalar);  // scalar op, out = t.out
+      Op mul;
+      mul.opcode = OP_MUL;
+      mul.n_in = 2;
+      mul.in[0] = scalar.out;
+      const int lc = g.add_slot(1, false);
+      fills.emplace_back(lc, std::vector<double>{(double)Luse});
+      mul.in[1] = lc;
+      mul.out = g.add_slot(1, false);
+      result.push_back(mul);
+      pos_out[(size_t)p] = scalar.out;
+      return mul.out;
+    };
+    if (ap.elt_density) {
+      // One density op with variant bit 6: out[n] is lane n's lp (or,
+      // when ap.rows > 1, out holds Luse*rows per-element lps that
+      // OP_SUM_ROWS folds back to one lp per lane), read by the lanes'
+      // (widened) consumers. An all-scalar real-arg density classified
+      // as hoist instead, so a vector input or a per-lane outcome
+      // exists here.
+      op.variant = (uint8_t)(op.variant | 0x40u);
+      op.out = g.add_slot(Luse * ap.rows, false);
+      attach_idata(op, std::move(ap.outcome_idata));
+      int result_slot = op.out;
+      result.push_back(op);
+      if (ap.rows > 1) {
+        // The density's real args pack in the region's committed order.
+        // OP_SUM_ROWS needs lane l's `rows` elements contiguous
+        // (l*rows+k); row-major packing already has that, but
+        // column-major (l + Luse*k) does not, so repack it first.
+        if (layout_cols) {
+          Op perm;
+          perm.opcode = OP_GATHER;
+          perm.n_in = 1;
+          perm.in[0] = result_slot;
+          perm.out = g.add_slot(Luse * ap.rows, false);
+          std::vector<int> idx;
+          idx.reserve((size_t)(Luse * ap.rows));
+          for (int64_t l = 0; l < Luse; ++l)
+            for (int64_t k = 0; k < ap.rows; ++k)
+              idx.push_back((int)(l + Luse * k));
+          g.idata_pool.push_back(std::move(idx));
+          perm.idata = g.idata_pool.back().data();
+          perm.n_idata = (int64_t)g.idata_pool.back().size();
+          result.push_back(perm);
+          result_slot = perm.out;
+        }
+        Op rows;
+        rows.opcode = OP_SUM_ROWS;
+        rows.n_in = 1;
+        rows.in[0] = result_slot;
+        rows.out = g.add_slot(Luse, false);
+        attach_idata(rows, std::vector<int>{(int)ap.rows});
+        result.push_back(rows);
+        result_slot = rows.out;
+      }
+      pos_out[(size_t)p] = result_slot;
+      continue;
+    }
+    if (ap.term_widen) {
+      int term_slot;
+      if (all_scalar) {
+        // Every lane's term is the same scalar: one op, times L.
+        term_slot = scalar_times_lanes(op);
+      } else {
+        op.out = g.add_slot(Luse, false);
+        result.push_back(op);
+        Op sum;
+        sum.opcode = OP_SUM_VEC;
+        sum.n_in = 1;
+        sum.in[0] = op.out;
+        sum.out = g.add_slot(1, false);
+        result.push_back(sum);
+        term_slot = sum.out;
+        pos_out[(size_t)p] = op.out;
+      }
+      swap_terms(term_slot);
+      continue;
+    }
+    // A widened op whose mapped inputs are all len-1 computes the same
+    // value in every lane -- its lane-varying inputs came from HOISTED
+    // producers, which are scalars. Widening it anyway hands the kernels
+    // scalar inputs with a vector output, and their scalar-x-scalar
+    // paths write element 0 only (found by the corpus A/B on
+    // losscurve_sislob: a cohort's lm window filled with arena zeros).
+    // Keep it scalar; consumers broadcast, and the store materializes.
+    if (!ap.term_density && all_scalar) {
+      pos_out[(size_t)p] = op.out;  // t's own (lane 0) output slot
+      result.push_back(op);
+      continue;
+    }
+    if (ap.term_density) {
+      if (all_scalar && ap.outcome_idata.empty()) {
+        // Every lane's density is the same scalar (lane-varying inputs
+        // all came from hoisted producers): the target owes L copies of
+        // it, and L times one lane is that, exactly -- the density
+        // backward sees out_adj = L and scales its partials to match.
+        swap_terms(scalar_times_lanes(op));
+        continue;
+      }
+      op.out = g.add_slot(1, false);
+      attach_idata(op, std::move(ap.outcome_idata));
+      swap_terms(op.out);
+    } else {
+      op.out = g.add_slot(Luse * ap.width, false);
+    }
+    pos_out[(size_t)p] = op.out;
+    result.push_back(op);
+  }
+}
+
+}  // namespace reroll_plan
+}  // namespace detail
+}  // namespace stanli
+#endif

--- a/runtime/src/structured_loop.cpp
+++ b/runtime/src/structured_loop.cpp
@@ -97,6 +97,9 @@ void prepare_node(StructuredLoop& p, Node& n, unsigned depth,
   ++p.node_count;
   if (n.storage != Node::InPlace) n.storage = Node::Retained;
   n.active = false;
+  n.reuse_primal_output = false;
+  n.primal_contract_variant = 0;
+  n.primal_contract = nullptr;
   n.memo = false;
   n.memo_silent = false;
   n.trace = false;
@@ -792,13 +795,26 @@ void classify(StructuredLoop& p) {
   walk(p.root, loops, renumber);
 
   // Segments read their inputs from their own frame.
-  std::vector<char> inplace_base(slots, 0), active_reader(slots, 0);
+  std::vector<char> inplace_base(slots, 0), active_reader(slots, 0),
+      primal_reader(slots, 0);
   auto mark_readers = [&](Node& n, const std::vector<int>&) {
     if (n.kind != Node::KernelCall) return;
     const Op& op = p.body.ops[n.op];
     if (n.storage == Node::InPlace) inplace_base[op.in[0]] = 1;
-    if (n.active)
-      for (int k = 0; k < op.n_in; ++k) active_reader[op.in[k]] = 1;
+    if (!n.active) return;
+    const Kernel* registered = find_kernel(op.opcode);
+    const bool canonical = registered && registered->backward &&
+                           n.backward == registered->backward &&
+                           registered->primal_reads && !op.dyn_lengths;
+    n.primal_contract_variant = op.variant;
+    n.primal_contract = canonical ? registered->primal_reads : nullptr;
+    const BackwardPrimalReads reads =
+        canonical ? backward_primal_reads(registered, op.variant)
+                  : BackwardPrimalReads{};
+    for (int k = 0; k < op.n_in; ++k) {
+      active_reader[op.in[k]] = 1;
+      if (reads.input(k)) primal_reader[op.in[k]] = 1;
+    }
   };
   walk(p.root, loops, mark_readers);
 
@@ -834,6 +850,29 @@ void classify(StructuredLoop& p) {
             add(add(length(p, op.out), length(p, op.out2)), n.kernel_scratch));
   };
   walk(p.root, loops, classify_transient);
+
+  // This pilot only moves an active primary output when no historical
+  // backward can read it and the call has no adjacent output/scratch whose
+  // tape layout would also have to change.  Aliases and externally visible
+  // values retain their existing stable-address behavior.
+  auto classify_reusable_primal = [&](Node& n, const std::vector<int>&) {
+    if (n.kind != Node::KernelCall || !n.active ||
+        n.storage != Node::Retained || n.kernel_scratch != 0)
+      return;
+    const Op& op = p.body.ops[n.op];
+    if (op.out2 >= 0 || uses.alias[op.out] || uses.target[op.out] ||
+        uses.output[op.out] || inplace_base[op.out] || primal_reader[op.out])
+      return;
+    const Kernel* registered = find_kernel(op.opcode);
+    if (op.dyn_lengths || !registered || !registered->backward ||
+        !registered->primal_reads || n.backward != registered->backward ||
+        backward_primal_reads(registered, op.variant).output())
+      return;
+    n.reuse_primal_output = true;
+    n.workspace = p.workspace_size;
+    p.workspace_size = add(p.workspace_size, length(p, op.out));
+  };
+  walk(p.root, loops, classify_reusable_primal);
 }
 
 void compare_forward(KernelCtx& c) {
@@ -1395,10 +1434,12 @@ struct LoopState : KernelState {
   size_t record_arena = 0, record_versions = 0;
   size_t trace_pos = 0;
   uint64_t effects = 0;
-  size_t memo_restores = 0, visits = 0;
+  size_t memo_restores = 0, visits = 0, reused_primal_cells = 0;
   int64_t adjoint_size = 0;
   bool reverse_ready = false;
   bool memo_ready = false;
+  bool has_reusable_primals = false;
+  bool reuse_primals = false;
   bool report_tape =
       std::getenv("STANLI_STRUCTURED_LOOP_DIAGNOSTICS") != nullptr;
 
@@ -1435,6 +1476,7 @@ struct LoopState : KernelState {
       const Node* n = sites[site];
       if (!n) throw std::logic_error("structured loop site numbering is stale");
       const Op& op = p.body.ops[n->op];
+      has_reusable_primals |= n->reuse_primal_output;
       KernelCtx& c = ctx[site];
       c.n_in = op.n_in;
       c.variant = op.variant;
@@ -1613,8 +1655,13 @@ struct Execution {
     }
     const int64_t out_len = p.body.slots[op.out].len,
                   out2_len = op.out2 >= 0 ? c.out2.len : 0;
+    const bool reuse_primal = n.reuse_primal_output && s.reuse_primals;
+    if (reuse_primal && s.report_tape)
+      s.reused_primal_cells += static_cast<size_t>(out_len);
     double* block =
-        s.arena.allocate(add(add(out_len, out2_len), n.kernel_scratch));
+        reuse_primal
+            ? s.workspace.data() + n.workspace
+            : s.arena.allocate(add(add(out_len, out2_len), n.kernel_scratch));
     c.out.data = block;
     if (op.out2 >= 0) c.out2.data = block + out_len;
     c.scratch = block + out_len + out2_len;
@@ -1914,6 +1961,14 @@ struct Execution {
           double* block = s.versions[static_cast<size_t>(r.out)].value;
           c.out.data = block;
           c.out_adj_vec.data = adj(r.out);
+          const bool reuse_primal = n.reuse_primal_output && s.reuse_primals;
+          if (reuse_primal) {
+            c.scratch = nullptr;
+            if (c.dyn_lengths) apply_dynamic_length(c);
+            if (c.out.len == 1) c.out_adj = c.out_adj_vec.data[0];
+            n.backward(c);
+            break;
+          }
           block += p.body.slots[op.out].len;
           if (op.out2 >= 0) {
             c.out2.data = block;
@@ -2058,6 +2113,26 @@ void structured_loop_forward(KernelCtx& ctx) {
   std::fill(s.memo_ordinal.begin(), s.memo_ordinal.end(), 0);
   s.trace_pos = 0;
   s.visits = 0;
+  s.reused_primal_cells = 0;
+  s.reuse_primals = s.has_reusable_primals;
+  if (s.has_reusable_primals) {
+    for (const Node* n : s.sites) {
+      if (!n || !n->active) continue;
+      // Null was the conservative contract during classification. It cannot
+      // invalidate reuse elsewhere because every one of this call's inputs
+      // was already marked as a historical primal reader.
+      if (!n->primal_contract) continue;
+      const Op& op = p.body.ops[n->op];
+      const Kernel* registered = find_kernel(op.opcode);
+      if (op.dyn_lengths || !registered || !registered->backward ||
+          !registered->primal_reads || n->backward != registered->backward ||
+          n->primal_contract != registered->primal_reads ||
+          n->primal_contract_variant != op.variant) {
+        s.reuse_primals = false;
+        break;
+      }
+    }
+  }
   if (!s.memo_ready) {
     for (auto& tape : s.memo_tape) tape.clear();
     s.trace.clear();
@@ -2123,6 +2198,7 @@ void structured_loop_forward(KernelCtx& ctx) {
         " copies=" + std::to_string(copies) +
         " targets=" + std::to_string(s.target_refs.size()) +
         " workspace=" + std::to_string(s.workspace.size()) +
+        " reused_primal_cells=" + std::to_string(s.reused_primal_cells) +
         " memo_nodes=" + std::to_string(p.memo_count) +
         " memo_restores=" + std::to_string(s.memo_restores) + " memo_tape=" +
         std::to_string(memo_tape) + " traces=" + std::to_string(p.trace_count) +
@@ -2168,7 +2244,8 @@ void register_structured_loop_kernel() {
                             nullptr, make_loop_state});
   register_kernel(OP_COMPARE, {compare_forward, nullptr, nullptr});
   register_kernel(OP_INT_ARITH, {int_forward, nullptr, nullptr});
-  register_kernel(OP_INDEX_DYNAMIC, {index_forward, index_backward, nullptr});
+  register_kernel(OP_INDEX_DYNAMIC, {index_forward, index_backward, nullptr,
+                                     nullptr, backward_reads_inputs_only});
   register_kernel(OP_SET_INDEX_DYNAMIC,
                   {set_index_forward, set_index_backward, set_index_scratch});
 }

--- a/tests/fixtures/symbolic_lane_add.stan
+++ b/tests/fixtures/symbolic_lane_add.stan
@@ -1,0 +1,14 @@
+data {
+  int<lower=0> N;
+  array[N] real y;
+}
+parameters {
+  real a;
+  real b;
+}
+model {
+  for (i in 1:N) {
+    real z = exp(y[i] + b);
+    target += z;
+  }
+}

--- a/tests/fixtures/symbolic_lane_backing.stan
+++ b/tests/fixtures/symbolic_lane_backing.stan
@@ -1,0 +1,16 @@
+data {
+  int<lower=0> N;
+  int<lower=N> M;
+  array[M] real y;
+  array[M] real unused;
+}
+parameters {
+  real a;
+  real b;
+}
+model {
+  for (i in 1:N) {
+    real z = exp(b * y[i]);
+    target += z;
+  }
+}

--- a/tests/fixtures/symbolic_lane_chain.stan
+++ b/tests/fixtures/symbolic_lane_chain.stan
@@ -1,0 +1,14 @@
+data {
+  int<lower=0> N;
+  array[N] real y;
+}
+parameters {
+  real a;
+  real b;
+}
+model {
+  for (i in 1:N) {
+    real z = exp(fma(b, y[i], a));
+    target += z;
+  }
+}

--- a/tests/fixtures/symbolic_lane_multiply.stan
+++ b/tests/fixtures/symbolic_lane_multiply.stan
@@ -1,0 +1,14 @@
+data {
+  int<lower=0> N;
+  array[N] real y;
+}
+parameters {
+  real a;
+  real b;
+}
+model {
+  for (i in 1:N) {
+    real z = exp(b * y[i]);
+    target += z;
+  }
+}

--- a/tests/fixtures/tdintsize.stan
+++ b/tests/fixtures/tdintsize.stan
@@ -12,10 +12,24 @@ transformed data {
   int sumnt2 = 0;
   for (i in 1 : nots)
     sumnt2 += nts[i] * nts[i];
+  // Keep trailing geometry that cannot be recovered from a flattened empty
+  // value. The write-array lowering must receive the declaration facts from
+  // the same prepared handoff as sumnt2.
+  array[0, 2] matrix[3, 4] empty_tensor =
+      rep_array(rep_matrix(0, 3, 4), 0, 2);
+  array[1, 2] matrix[3, 4] shaped_tensor =
+      rep_array(rep_matrix(0, 3, 4), 1, 2);
+  for (j in 1 : 2)
+    shaped_tensor[1, j] = rep_matrix(sumnt2 + j, 3, 4);
 }
 parameters {
   vector[sumnt2] x;
 }
 model {
   x ~ normal(0, 1);
+}
+generated quantities {
+  int prepared_size = sumnt2;
+  array[0, 2] matrix[3, 4] empty_copy = empty_tensor;
+  matrix[3, 4] prepared_leaf = shaped_tensor[1, 2];
 }

--- a/tests/test_adjoint.cpp
+++ b/tests/test_adjoint.cpp
@@ -289,6 +289,92 @@ static void test_call_cached_forward_reverse_aliasing() {
          ulps(adj[(size_t)p.adj.adj_reg[4]], want_c) == 0);
 }
 
+static void test_call_primal_read_contract() {
+  const BackwardPrimalReads add_reads =
+      backward_primal_reads(find_kernel(OP_ADD), 0);
+  expect("ADD backward reads no primals",
+         !add_reads.input(0) && !add_reads.input(1) && !add_reads.output());
+  const BackwardPrimalReads unknown = backward_primal_reads(nullptr, 255);
+  expect("unknown backward retains every primal",
+         unknown.input(0) && unknown.input(5) && unknown.output(0) &&
+             unknown.output(1));
+
+  // Both an input and the output are overwritten after the call.  ADD's
+  // registered backward only routes adjoints, so gen_adjoint need not insert
+  // value checkpoints for either range.
+  IslandProg p;
+  p.n_regs = 5;
+  p.ins = {IslandProg::LiveIn{0, 1}, IslandProg::LiveIn{1, 1},
+           IslandProg::LiveIn{4, 1}};
+  p.out_regs = {3};
+  Program::Call add;
+  add.opcode = OP_ADD;
+  add.n_in = 2;
+  add.in[0] = 0;
+  add.in[1] = 1;
+  add.in_len[0] = add.in_len[1] = 1;
+  add.out = 2;
+  add.out_len = 1;
+  expect("value-free CALL binds", bind_call(add));
+  p.calls.push_back(add);
+  p.code = {{Program::CALL, 0, 0},
+            {Program::MOV, 3, 2},
+            {Program::MOV, 0, 4},
+            {Program::MOV, 2, 4}};
+  expect("value-free CALL adjoint generated", gen_adjoint(p));
+  if (!p.calls.empty()) {
+    expect("value-free CALL keeps original input binding",
+           p.calls[0].bwd_value_in[0] == 0);
+    expect("value-free CALL keeps original output binding",
+           p.calls[0].bwd_value_out == 2);
+  }
+
+  // A private backward carrying the same opcode is not covered by the
+  // registered kernel's metadata and must retain the conservative saves.
+  IslandProg private_call;
+  private_call.n_regs = 5;
+  private_call.ins = p.ins;
+  private_call.out_regs = {3};
+  add.backward = test_call_backward;
+  private_call.calls.push_back(add);
+  private_call.code = {{Program::CALL, 0, 0},
+                       {Program::MOV, 3, 2},
+                       {Program::MOV, 0, 4},
+                       {Program::MOV, 2, 4}};
+  expect("private CALL adjoint generated", gen_adjoint(private_call));
+  if (!private_call.calls.empty()) {
+    expect("private CALL checkpoints overwritten input",
+           private_call.calls[0].bwd_value_in[0] != 0);
+    expect("private CALL checkpoints overwritten output",
+           private_call.calls[0].bwd_value_out != 2);
+  }
+
+  // Registry identity alone is insufficient: a replacement implementation
+  // has no contract unless it explicitly registers one alongside itself.
+  const Kernel saved_add = *find_kernel(OP_ADD);
+  register_kernel(OP_ADD,
+                  Kernel{saved_add.forward, test_call_backward, nullptr});
+  IslandProg replaced;
+  replaced.n_regs = 5;
+  replaced.ins = p.ins;
+  replaced.out_regs = {3};
+  Program::Call rebound = add;
+  expect("replacement CALL binds", bind_call(rebound));
+  replaced.calls.push_back(rebound);
+  replaced.code = {{Program::CALL, 0, 0},
+                   {Program::MOV, 3, 2},
+                   {Program::MOV, 0, 4},
+                   {Program::MOV, 2, 4}};
+  expect("replacement CALL adjoint generated", gen_adjoint(replaced));
+  if (!replaced.calls.empty()) {
+    expect("replacement CALL defaults to input checkpoint",
+           replaced.calls[0].bwd_value_in[0] != 0);
+    expect("replacement CALL defaults to output checkpoint",
+           replaced.calls[0].bwd_value_out != 2);
+  }
+  register_kernel(OP_ADD, saved_add);
+}
+
 // One case, both ways. `tol` is how many ulp of disagreement the case
 // tolerates, and is 0 -- bitwise -- everywhere except the fuzzer.
 //
@@ -1594,6 +1680,7 @@ static void test_fuzz_ranges() {
 int main() {
   test_call_binding_refusal();
   test_call_cached_forward_reverse_aliasing();
+  test_call_primal_read_contract();
   test_binary_ops();
   test_fma();
   test_unary_ops();

--- a/tests/test_lower.cpp
+++ b/tests/test_lower.cpp
@@ -431,11 +431,249 @@ static void reference(const double* q, double* lp_out, double* grad_out) {
   stan::math::recover_memory();
 }
 
+// Keep the planner's small-loop refusal and large-loop vector accumulation
+// decision exact. The cancellation inputs distinguish the two reverse orders.
+static void test_symbolic_lane_chain(const std::string& fixture) {
+  const std::string mir = slurp("tests/fixtures/" + fixture + ".tmir.sexp");
+  for (bool stress : {false, true}) {
+    for (int n : {0, 1, 3, 4, 5, 6, 8, 16, 33, 4096}) {
+      std::ostringstream json;
+      json << "{\"N\":" << n << ",\"y\":[";
+      for (int i = 0; i < n; ++i) {
+        if (i) json << ',';
+        if (!stress) {
+          const char* finite[] = {"-0.3", "0.1", "0.2", "0.0", "-0.0", "0.4"};
+          json << finite[i % 6];
+          continue;
+        }
+        json << (i % 4 == 0   ? "1e8"
+                 : i % 4 == 1 ? "-1e8"
+                 : i % 4 == 2 ? "0.2"
+                              : "0.3");
+      }
+      json << "]}";
+      const auto data = stanli::DataMap::from_json(json.str());
+      test_setenv("STANLI_SYMBOLIC_LANES", "0", 1);
+      auto baseline = stanli::compile_model(mir, data);
+      test_unsetenv("STANLI_SYMBOLIC_LANES");
+      auto candidate = stanli::compile_model(mir, data);
+      test_unsetenv("STANLI_SYMBOLIC_LANES");
+      if (n == 16) {
+        test_setenv("STANLI_SYMBOLIC_LANES", "1", 1);
+        const auto explicit_on = stanli::compile_model(mir, data);
+        test_unsetenv("STANLI_SYMBOLIC_LANES");
+        check(same_graph_structure(candidate, explicit_on) &&
+                  candidate.fills == explicit_on.fills,
+              "automatic symbolic selection matches explicit enablement");
+        check(baseline.graph.slots.size() > candidate.graph.slots.size(),
+              "explicit zero disables the symbolic shortcut");
+        test_setenv("STANLI_SYMBOLIC_LANES", "unknown", 1);
+        const auto unknown = stanli::compile_model(mir, data);
+        test_unsetenv("STANLI_SYMBOLIC_LANES");
+        check(same_graph_structure(baseline, unknown) &&
+                  baseline.fills == unknown.fills,
+              "unknown symbolic policy conservatively disables the shortcut");
+      }
+      check(candidate.n_unconstrained == baseline.n_unconstrained &&
+                candidate.n_unconstrained == 2,
+            "symbolic lanes preserve parameter layout");
+      if (n >= 6) {
+        check(candidate.graph.ops.size() == 3 &&
+                  candidate.graph.slots.size() <= 12,
+              "symbolic lane metadata does not expand with trip count");
+        const auto& ops = candidate.graph.ops;
+        const auto& slots = candidate.graph.slots;
+        const auto anchor = fixture == "symbolic_lane_chain" ? stanli::OP_FMA
+                            : fixture == "symbolic_lane_add" ? stanli::OP_ADD
+                                                             : stanli::OP_MUL;
+        check(ops[0].opcode == anchor && ops[1].opcode == stanli::OP_EXPV &&
+                  ops[2].opcode == stanli::OP_SUM_VEC &&
+                  slots[ops[0].out].len == n && slots[ops[1].out].len == n &&
+                  slots[ops[2].out].len == 1 && ops[1].in[0] == ops[0].out &&
+                  ops[2].in[0] == ops[1].out,
+              "symbolic lanes use the existing ordered vector kernel chain");
+        const int varying = fixture == "symbolic_lane_add" ? 0 : 1;
+        check(slots[ops[0].in[varying]].len == n &&
+                  slots[ops[0].in[1 - varying]].is_param,
+              "symbolic lanes preserve parameter and read operand positions");
+      } else {
+        check(same_graph_structure(candidate, baseline) &&
+                  candidate.fills == baseline.fills,
+              "unprofitable symbolic lanes preserve graph and fills exactly");
+      }
+      stanli::Executor a(std::move(baseline.graph));
+      stanli::Executor b(std::move(candidate.graph));
+      baseline.bind(a);
+      candidate.bind(b);
+      check(a.n_params() == b.n_params() && b.n_params() == 2,
+            "virtual lane identities never become parameters");
+      for (const auto point :
+           {std::pair<double, double>{0.1, 0.0}, {0.0, 1e-9}, {-0.1, -1e-9}}) {
+        a.params_data()[0] = b.params_data()[0] = point.first;
+        a.params_data()[1] = b.params_data()[1] = point.second;
+        for (int repeat = 0; repeat < 2; ++repeat) {
+          double ga[2], gb[2];
+          const double la = a.gradient(ga), lb = b.gradient(gb);
+          check(std::memcmp(&la, &lb, sizeof(double)) == 0 &&
+                    std::memcmp(ga, gb, sizeof(ga)) == 0,
+                "symbolic lane LP/gradient matches existing selection bitwise");
+        }
+      }
+    }
+  }
+  stanli::DataMap data;
+  data.set_int("N", 16);
+  data.set_real_array("y", std::vector<double>(16, 0.2));
+  for (const char* flag :
+       {"STANLI_NO_REROLL", "STANLI_NO_CONSTFOLD", "STANLI_STRUCTURED_LOOPS"}) {
+    test_setenv(flag, "1", 1);
+    test_setenv("STANLI_SYMBOLIC_LANES", "0", 1);
+    const auto baseline = stanli::compile_model(mir, data);
+    test_setenv("STANLI_SYMBOLIC_LANES", "1", 1);
+    const auto candidate = stanli::compile_model(mir, data);
+    test_unsetenv("STANLI_SYMBOLIC_LANES");
+    test_unsetenv(flag);
+    check(same_graph_structure(baseline, candidate) &&
+              baseline.fills == candidate.fills,
+          std::string("symbolic lane source respects ") + flag);
+  }
+}
+
+static void test_symbolic_lane_backing() {
+  const std::string mir =
+      slurp("tests/fixtures/symbolic_lane_backing.tmir.sexp");
+  for (int n : {4, 5, 6, 16}) {
+    stanli::DataMap data;
+    data.set_int("N", n);
+    data.set_int("M", 262144);
+    data.set_real_array("y", std::vector<double>(262144, 0.2));
+    data.set_real_array("unused", std::vector<double>(262144, -0.3));
+    test_setenv("STANLI_SYMBOLIC_LANES", "0", 1);
+    auto baseline = stanli::compile_model(mir, data);
+    test_unsetenv("STANLI_SYMBOLIC_LANES");
+    auto candidate = stanli::compile_model(mir, data);
+    if (n <= 5) {
+      check(
+          same_graph_structure(baseline, candidate) &&
+              baseline.fills == candidate.fills,
+          "seed refusal retains ordinary graph/fills with large backing data");
+    } else {
+      check(
+          candidate.graph.ops.size() == 3 && candidate.graph.slots.size() <= 12,
+          "large backing or unrelated data does not prevent compact lowering");
+    }
+    stanli::Executor a(std::move(baseline.graph));
+    stanli::Executor b(std::move(candidate.graph));
+    baseline.bind(a);
+    candidate.bind(b);
+    for (double value : {-0.3, 0.0, 0.2}) {
+      a.params_data()[0] = b.params_data()[0] = 0.1;
+      a.params_data()[1] = b.params_data()[1] = value;
+      double ga[2], gb[2];
+      const double la = a.gradient(ga), lb = b.gradient(gb);
+      check(
+          std::memcmp(&la, &lb, sizeof(double)) == 0 &&
+              std::memcmp(ga, gb, sizeof(ga)) == 0,
+          "seed continuation and direct slicing preserve LP/gradient exactly");
+    }
+  }
+}
+
+static void test_symbolic_lane_executor_sharing() {
+  const std::string mir = slurp("tests/fixtures/symbolic_lane_chain.tmir.sexp");
+  stanli::DataMap data;
+  data.set_int("N", 16);
+  data.set_real_array("y", {-0.3, 0.1, 0.2, 0.0, -0.0, 0.4, -0.3, 0.1, 0.2, 0.0,
+                            -0.0, 0.4, -0.3, 0.1, 0.2, 0.0});
+
+  test_setenv("STANLI_SYMBOLIC_LANES", "0", 1);
+  auto ordinary = stanli::compile_model(mir, data);
+  test_unsetenv("STANLI_SYMBOLIC_LANES");
+  auto symbolic = stanli::compile_model(mir, data);
+  check(symbolic.graph.ops.size() == 3,
+        "symbolic sharing fixture selects the compact graph");
+  if (symbolic.graph.ops.size() != 3 || ordinary.graph.ops.empty()) return;
+
+  const stanli::Op& anchor = symbolic.graph.ops.front();
+  int packed = -1;
+  for (int j = 0; j < anchor.n_in; ++j) {
+    const auto& slot = symbolic.graph.slots[anchor.in[j]];
+    if (!slot.is_param && slot.len == 16) packed = anchor.in[j];
+  }
+  const auto ordinary_anchor = std::find_if(
+      ordinary.graph.ops.begin(), ordinary.graph.ops.end(),
+      [](const stanli::Op& op) { return op.opcode == stanli::OP_FMA; });
+  int ordinary_packed = -1;
+  if (ordinary_anchor != ordinary.graph.ops.end()) {
+    for (int j = 0; j < ordinary_anchor->n_in; ++j) {
+      const auto& slot = ordinary.graph.slots[ordinary_anchor->in[j]];
+      if (!slot.is_param && slot.len == 16)
+        ordinary_packed = ordinary_anchor->in[j];
+    }
+  }
+  if (packed < 0 || ordinary_packed < 0) {
+    check(false, "symbolic sharing fixture exposes packed ordinary data");
+    return;
+  }
+  const int anchor_out = anchor.out;
+  const int vector_out = symbolic.graph.ops[1].out;
+
+  stanli::Executor reference(std::move(ordinary.graph));
+  stanli::Executor prototype(std::move(symbolic.graph));
+  ordinary.bind(reference);
+  symbolic.bind(prototype);
+  reference.params_data()[0] = prototype.params_data()[0] = 0.1;
+  reference.params_data()[1] = prototype.params_data()[1] = -0.2;
+
+  stanli::Executor clone(prototype);
+  const stanli::Executor& const_prototype = prototype;
+  const stanli::Executor& const_clone = clone;
+  check(const_prototype.value_ptr(packed) == const_clone.value_ptr(packed),
+        "symbolic packed constant data is shared by executor clones");
+  check(const_prototype.value_ptr(anchor_out) !=
+                const_clone.value_ptr(anchor_out) &&
+            const_prototype.value_ptr(vector_out) !=
+                const_clone.value_ptr(vector_out),
+        "symbolic vector outputs remain private to each executor");
+
+  const double original = const_prototype.value_ptr(packed)[0];
+  double* clone_packed = clone.value_ptr(packed);
+  check(clone_packed != const_prototype.value_ptr(packed),
+        "writing a cloned symbolic constant detaches its data");
+  clone_packed[0] = original + 0.5;
+  check(const_prototype.value_ptr(packed)[0] == original,
+        "cloned symbolic data mutation leaves the prototype unchanged");
+
+  stanli::Executor changed_reference(reference);
+  changed_reference.value_ptr(ordinary_packed)[0] = original + 0.5;
+  double reference_grad[2], prototype_grad[2], changed_grad[2], clone_grad[2];
+  const double reference_lp = reference.gradient(reference_grad);
+  const double prototype_lp = prototype.gradient(prototype_grad);
+  const double changed_lp = changed_reference.gradient(changed_grad);
+  check(std::memcmp(&prototype_lp, &reference_lp, sizeof(double)) == 0,
+        "symbolic prototype kernels match the ordinary reference");
+  check(
+      std::memcmp(prototype_grad, reference_grad, sizeof(prototype_grad)) == 0,
+      "symbolic prototype gradients match the ordinary reference");
+  const double clone_lp = clone.gradient(clone_grad);
+  check(std::memcmp(&clone_lp, &changed_lp, sizeof(double)) == 0,
+        "mutated symbolic clone keeps vector kernels correct");
+  check(
+      std::memcmp(clone_grad, changed_grad, sizeof(clone_grad)) == 0 &&
+          std::memcmp(changed_grad, reference_grad, sizeof(changed_grad)) != 0,
+      "mutated symbolic clone observes its private data");
+}
+
 int main() {
   // These fixtures pin ULP-level parity with DEFAULT CmdStan, whose AoS
   // Matrix<var> paths run scalar libm per element; the packet path answers
   // to `stanc --O1` instead and is verified there.
   stanli::set_packet_math(false);
+  test_symbolic_lane_backing();
+  test_symbolic_lane_executor_sharing();
+  for (const char* fixture :
+       {"symbolic_lane_chain", "symbolic_lane_add", "symbolic_lane_multiply"})
+    test_symbolic_lane_chain(fixture);
   using namespace stanli;
 
   // Section A1's five reductions must lower in the autodiff model graph, not
@@ -3752,6 +3990,30 @@ int main() {
     for (int k = 0; k < 14; ++k)
       expect_eq("tdintsize g" + std::to_string(k), grad[k], x(k).adj());
     stan::math::recover_memory();
+
+    check(lm.write_array && lm.write_array->truncated.empty(),
+          "tdintsize prepared write_array compiled");
+    if (lm.write_array && lm.write_array->truncated.empty()) {
+      Executor wx(std::move(lm.write_array->graph));
+      lm.write_array->bind(wx);
+      for (int k = 0; k < 14; ++k) wx.params_data()[k] = 0.1 * (k + 1) - 0.7;
+      wx.run_forward_only();
+      int found = 0;
+      for (const auto& col : lm.write_array->columns) {
+        if (col.name == "prepared_size") {
+          ++found;
+          expect_eq("tdintsize prepared integer", *wx.value_ptr(col.slot), 14);
+        } else if (col.name == "prepared_leaf") {
+          ++found;
+          check(col.len == 12 && col.rows == 3,
+                "tdintsize prepared leaf keeps matrix geometry");
+          for (int k = 0; k < 12; ++k)
+            expect_eq("tdintsize prepared leaf " + std::to_string(k),
+                      wx.value_ptr(col.slot)[col.storage_index(k)], 16);
+        }
+      }
+      check(found == 2, "tdintsize writes prepared integer and shaped leaf");
+    }
   }
 
   // profile("name") { ... } wraps ordinary statements purely for stanc's own

--- a/tests/test_profile.cpp
+++ b/tests/test_profile.cpp
@@ -1,6 +1,7 @@
 // The built-in per-op profiler: opt-in accounting of where gradient time
 // goes, per opcode, without touching the fast path when off.
 #include <stanli/graph.hpp>
+#include <stanli/island.hpp>
 #include <stanli/optable.hpp>
 
 #include <cmath>
@@ -8,6 +9,7 @@
 #include <cstdlib>
 #include <cstring>
 #include <string>
+#include <vector>
 
 static int failures = 0;
 static void expect(const char* what, bool ok) {
@@ -36,6 +38,109 @@ static long long calls_for(const std::string& rep, const char* opcode) {
   return -1;
 }
 
+static void bound_add_forward(stanli::KernelCtx& ctx) {
+  ctx.out.data[0] = ctx.in[0].data[0] + ctx.in[1].data[0] + 3.0;
+}
+
+static void bound_add_backward(stanli::KernelCtx& ctx) {
+  ctx.in_adj[0].data[0] += 4.0 * ctx.out_adj;
+  ctx.in_adj[1].data[0] += 5.0 * ctx.out_adj;
+}
+
+static void replacement_add_forward(stanli::KernelCtx& ctx) {
+  ctx.out.data[0] = ctx.in[0].data[0] + ctx.in[1].data[0] + 30.0;
+}
+
+static void replacement_add_backward(stanli::KernelCtx& ctx) {
+  ctx.in_adj[0].data[0] += 40.0 * ctx.out_adj;
+  ctx.in_adj[1].data[0] += 50.0 * ctx.out_adj;
+}
+
+static std::shared_ptr<stanli::Softmax3IslandProg> make_specialized_softmax() {
+  auto p = std::make_shared<stanli::Softmax3IslandProg>();
+  p->n_regs = 6;
+  p->ins.push_back(stanli::IslandProg::LiveIn{0, 3});
+  p->out_regs = {3, 4, 5};
+  p->code.push_back(
+      stanli::Program::Instr{stanli::Program::SOFTMAX, 3, 0, 0, 0, 3});
+  p->native_adj = true;
+  p->optimized_double = stanli::specialize_softmax3(*p, 1);
+  return p;
+}
+
+static void test_specialized_forward_profile_parity() {
+  using namespace stanli;
+  auto payload = make_specialized_softmax();
+  expect("profile specialized plan",
+         static_cast<bool>(payload->optimized_double));
+
+  Graph g;
+  const int input = g.add_slot(3, true);
+  const int probs = g.add_slot(3, false);
+  const int result = g.add_slot(1, false);
+  g.add_op(OP_ISLAND, {input}, probs);
+  g.ops.back().variant = kIslandSoftmax3Variant;
+  g.ops.back().udata = payload.get();
+  g.udata_pool.push_back(payload);
+  g.add_op(OP_INDEX, {probs}, result, {1});
+  g.result_slot = result;
+
+  Executor ex(std::move(g));
+  ex.param_ptr(input)[0] = 1.2;
+  ex.param_ptr(input)[1] = -0.7;
+  ex.param_ptr(input)[2] = 0.4;
+  ex.run_forward_only();
+  const double ordinary = ex.forward();
+  double ordinary_probs[3];
+  std::memcpy(ordinary_probs, ex.value_ptr(probs), sizeof ordinary_probs);
+
+  ex.set_profile(true);
+  const double profiled = ex.forward();
+  expect("specialized profiled value", profiled == ordinary);
+  expect("specialized profiled lanes",
+         std::memcmp(ordinary_probs, ex.value_ptr(probs),
+                     sizeof ordinary_probs) == 0);
+}
+
+static void test_bound_kernel_survives_post_bind_override() {
+  using namespace stanli;
+  const Kernel saved = *find_kernel(OP_ADD_N);
+  register_kernel(OP_ADD_N,
+                  Kernel{bound_add_forward, bound_add_backward, nullptr});
+
+  Graph g;
+  const int a = g.add_slot(1, true);
+  const int b = g.add_slot(1, true);
+  const int out = g.add_slot(1, false);
+  g.add_op(OP_ADD_N, {a, b}, out);
+  g.result_slot = out;
+  Executor ex(std::move(g));
+  ex.param_ptr(a)[0] = 0.2;
+  ex.param_ptr(b)[0] = -1.0;
+
+  // The executor has already bound the original pair. A later registry write
+  // must not make profiling run a different forward or reverse function.
+  register_kernel(OP_ADD_N, Kernel{replacement_add_forward,
+                                   replacement_add_backward, nullptr});
+  double grad[2];
+  const double unprofiled = ex.gradient(grad);
+  expect("bound forward before profile", unprofiled == 2.2);
+  expect("bound backward before profile", grad[0] == 4.0 && grad[1] == 5.0);
+
+  ex.set_profile(true);
+  // A single tiny call can round to zero at the profiler clock resolution.
+  // The report omits a zero-time sample, so accumulate several executions.
+  for (int i = 0; i < 100; ++i) {
+    const double profiled = ex.gradient(grad);
+    expect("bound forward under profile", profiled == 2.2);
+    expect("bound backward under profile", grad[0] == 4.0 && grad[1] == 5.0);
+  }
+  expect("bound override is profiled",
+         calls_for(ex.profile_report(), "OP_ADD_N") == 100);
+
+  register_kernel(OP_ADD_N, saved);
+}
+
 int main() {
   using namespace stanli;
 
@@ -44,7 +149,9 @@ int main() {
   const int b = g.add_slot(1, /*is_param=*/true);
   const int ea = g.add_slot(1, false);
   const int lp = g.add_slot(1, false);
+  const int control = g.add_slot(1, false);
   g.add_op(OP_EXP, {a}, ea);
+  g.add_op(OP_COMPARE, {a, b}, control);
   g.add_op(OP_ADD_N, {ea, b}, lp);
   g.result_slot = lp;
 
@@ -70,12 +177,23 @@ int main() {
   expect("counts EXP calls", calls_for(rep, "OP_EXP") == 11);
   expect("counts ADD_N calls", calls_for(rep, "OP_ADD_N") == 11);
   expect("report has totals", rep.find("total") != std::string::npos);
+  expect("forward-only gap is profiled", calls_for(rep, "OP_COMPARE") == 11);
+
+  // A copy must attribute its own rebound contexts and preserve reverse order.
+  Executor copied(ex);
+  copied.set_profile(true);
+  expect("copied executor profiled value", copied.gradient(grad) == v_off);
+  expect("copied executor profiled gradient",
+         grad[0] == da_off && grad[1] == 1);
 
   // Toggling off stops accumulation but keeps the collected numbers.
   ex.set_profile(false);
   const std::string before = ex.profile_report();
   ex.gradient(grad);
   expect("no growth when off", ex.profile_report() == before);
+
+  test_specialized_forward_profile_parity();
+  test_bound_kernel_survives_post_bind_override();
 
   if (failures == 0) std::printf("test_profile: all ok\n");
   return failures == 0 ? 0 : 1;

--- a/tests/test_reroll.cpp
+++ b/tests/test_reroll.cpp
@@ -10,6 +10,7 @@
 #include <stanli/reroll.hpp>
 
 #include "../runtime/src/reroll_profile.hpp"
+#include "../runtime/src/reroll_plan.hpp"
 
 #ifndef _WIN32
 #include <sys/resource.h>
@@ -17,6 +18,7 @@
 
 #include <algorithm>
 #include <chrono>
+#include <climits>
 #include <cmath>
 #include <cstdio>
 #include <cstdlib>
@@ -2473,7 +2475,163 @@ static void test_bail_message_ops() {
   }
 }
 
+// Pricing is a read-only gate, not permission inferred from the lane count.
+// In particular, the four-lane cancellation fixture must retain scalar
+// accumulation while a larger distinct-lane region may use the vector plan.
+struct ProvenDistinctHashSource : stanli::detail::reroll_plan::GraphSource {
+  static constexpr bool kDistinctLaneHashes = true;
+};
+
+static void test_proven_lane_pricing() {
+  namespace rp = stanli::detail::reroll_plan;
+  // This synthetic source has the same one-varying-field proof as symbolic
+  // lowering. Virtual slot IDs near INT_MAX stress identity arithmetic without
+  // allocating those graph slots. Pricing must not dereference them.
+  Graph g;
+  g.add_slot(1, true);
+  g.add_slot(1, true);
+  for (uint16_t anchor : {OP_FMA, OP_ADD, OP_MUL}) {
+    const int arity = anchor == OP_FMA ? 3 : 2;
+    for (int lanes : {1, 3, 4, 5, 6, 7, 8, 16, 33, 4096}) {
+      for (int period : {1, 2, 4}) {
+        for (int varying = 0; varying < arity; ++varying) {
+          for (bool near_limit : {false, true}) {
+            const int stride = period + 1;
+            const int first = near_limit ? INT_MAX - lanes * stride : 2;
+            rp::CandidatePlan plan;
+            plan.lanes = lanes;
+            plan.positions.resize(period);
+            for (int p = 0; p < period; ++p) {
+              auto& pos = plan.positions[p];
+              pos.ins.resize(p == 0 ? arity : 1);
+              for (int j = 0; j < (p == 0 ? arity : 1); ++j) {
+                pos.ins[j].kind = p              ? rp::InKind::kLaneLocal
+                                  : j == varying ? rp::InKind::kConstLanes
+                                                 : rp::InKind::kInvariant;
+              }
+            }
+            plan.positions.back().term_widen = true;
+            std::vector<Op> ops;
+            for (int lane = 0; lane < lanes; ++lane) {
+              const int read = first + lane * stride;
+              for (int p = 0; p < period; ++p) {
+                Op op;
+                op.opcode = p ? OP_EXPV : anchor;
+                op.n_in = p ? 1 : arity;
+                for (int j = 0; j < op.n_in; ++j)
+                  op.in[j] = p ? read + p : j == varying ? read : j % 2;
+                op.out = read + p + 1;
+                ops.push_back(op);
+              }
+            }
+            const rp::GraphSource hashed{ops.data(), period};
+            ProvenDistinctHashSource proven;
+            proven.ops = ops.data();
+            proven.period = period;
+            expect("proven unique hashes preserve exact lane selection",
+                   rp::profitable(g, plan, hashed) ==
+                       rp::profitable(g, plan, proven));
+          }
+        }
+      }
+    }
+  }
+}
+
+static void test_lane_plan_boundary() {
+  namespace rp = stanli::detail::reroll_plan;
+  for (int lanes : {4, 8}) {
+    for (bool repeated : {false, true}) {
+      Graph g;
+      Fills fills;
+      const int a = g.add_slot(1, true);
+      const int b = g.add_slot(1, true);
+      const int prefix = g.add_slot(1, false);
+      const int suffix = g.add_slot(1, false);
+      fills.emplace_back(prefix, std::vector<double>{10});
+      fills.emplace_back(suffix, std::vector<double>{20});
+      std::vector<int> terms{prefix};
+      int shared = -1;
+      rp::CandidatePlan plan;
+      plan.lanes = lanes;
+      plan.positions.resize(2);
+      auto& fma = plan.positions[0];
+      fma.ins.resize(3);
+      fma.ins[0].kind = rp::InKind::kInvariant;
+      fma.ins[1].kind = rp::InKind::kConstLanes;
+      fma.ins[2].kind = rp::InKind::kInvariant;
+      auto& exp = plan.positions[1];
+      exp.ins.resize(1);
+      exp.ins[0].kind = rp::InKind::kLaneLocal;
+      exp.ins[0].producer_pos = 0;
+      exp.term_widen = true;
+      for (int lane = 0; lane < lanes; ++lane) {
+        const double value = repeated ? 0.2 : 0.2 + 0.1 * lane;
+        int y = shared;
+        if (!repeated || y < 0) {
+          y = g.add_slot(1, false);
+          fills.emplace_back(y, std::vector<double>{value});
+          shared = y;
+        }
+        fma.ins[1].values.push_back(value);
+        const int x = g.add_slot(1, false);
+        g.add_op(OP_FMA, {b, y, a}, x);
+        const int out = g.add_slot(1, false);
+        g.add_op(OP_EXPV, {x}, out);
+        terms.push_back(out);
+      }
+      terms.push_back(suffix);
+      const Graph before = g;
+      const Fills old_fills = fills;
+      const std::vector<int> old_terms = terms;
+      const rp::GraphSource source{g.ops.data(), 2};
+      const bool selected = rp::profitable(g, plan, source);
+      expect("lane pricing respects margin and CSE",
+             selected == (lanes == 8 && !repeated));
+      expect("lane pricing leaves ops unchanged", graphs_equal(g, before));
+      expect("lane pricing leaves allocation unchanged",
+             g.slots.size() == before.slots.size() &&
+                 g.idata_pool.size() == before.idata_pool.size() &&
+                 g.udata_pool.size() == before.udata_pool.size());
+      expect("lane pricing leaves fills/targets unchanged",
+             fills == old_fills && terms == old_terms);
+      auto accepted =
+          rp::SelectedPlan<rp::GraphSource>::select(g, plan, source);
+      expect("selection follows unchanged price",
+             accepted.has_value() == selected);
+      if (!selected) {
+        expect("rejected selection retains candidate for retry",
+               plan.positions.size() == 2 &&
+                   plan.positions[0].ins[1].values.size() == (size_t)lanes);
+        continue;
+      }
+
+      std::unordered_set<int> term_set(terms.begin(), terms.end());
+      std::unordered_map<int, int> renamed;
+      std::vector<Op> emitted;
+      std::move(*accepted).emit(g, fills, terms, term_set, emitted, renamed);
+      expect("lane emitter keeps operation order",
+             emitted.size() == 3 && emitted[0].opcode == OP_FMA &&
+                 emitted[1].opcode == OP_EXPV &&
+                 emitted[2].opcode == OP_SUM_VEC);
+      expect("lane emitter preserves target boundaries",
+             terms == std::vector<int>({prefix, emitted[2].out, suffix}));
+      expect("lane emitter keeps source stable", graphs_equal(g, before));
+      expect("lane emitter updates target membership",
+             term_set == std::unordered_set<int>(terms.begin(), terms.end()));
+      expect("lane emitter owns packed constants",
+             fills.back().second ==
+                     accepted->description().positions[0].ins[1].values &&
+                 g.slots[emitted[0].out].len == lanes &&
+                 g.slots[emitted[1].out].len == lanes &&
+                 g.slots[emitted[2].out].len == 1);
+    }
+  }
+}
+
 int main() {
+  test_proven_lane_pricing();
+  test_lane_plan_boundary();
   test_scalar_density_traits();
   test_scalar_math_widenable_traits();
   test_radon_shape();

--- a/tests/test_structured_loop.cpp
+++ b/tests/test_structured_loop.cpp
@@ -1535,6 +1535,96 @@ static std::shared_ptr<StructuredLoop> scalar_index_loop_plan(bool direct) {
   return plan;
 }
 
+static void routed_add_backward(KernelCtx& context) {
+  find_kernel(OP_ADD)->backward(context);
+}
+
+// Select the same element on every trip. The alias that refreshes the
+// selector prevents loop-invariant hoisting, and the ADD consumer's backward
+// routes adjoints without rereading the selected primal.
+static std::shared_ptr<StructuredLoop> repeated_index_retention_plan(
+    bool alias_selected = false, bool replace_consumer_after_prepare = false) {
+  auto plan = std::make_shared<StructuredLoop>();
+  const int base = plan->body.add_slot(1, false);
+  const int theta = plan->body.add_slot(1, false);
+  const int one = scalar(*plan, 1);
+  const int eight = scalar(*plan, 8);
+  const int iterator = plan->body.add_slot(1, false);
+  const int selector = plan->body.add_slot(1, false);
+  const int selected = plan->body.add_slot(1, false);
+  const int held = plan->body.add_slot(1, false);
+  const int term = plan->body.add_slot(1, false);
+  plan->imports = {{base, 0, 0, true}, {theta, 1, 0, true}};
+  Node index = call(*plan, OP_INDEX_DYNAMIC, {base, selector}, selected);
+  const int index_op = index.op;
+  attach(*plan, index.op, single_spec(1));
+  Node consume =
+      call(*plan, OP_ADD, {alias_selected ? held : selected, theta}, term);
+  const int consume_op = consume.op;
+  std::vector<Node> body{alias(selector, one), std::move(index)};
+  if (alias_selected) body.push_back(alias(held, selected));
+  body.push_back(std::move(consume));
+  body.push_back(target(term));
+  plan->root = counted(one, eight, iterator, sequence(std::move(body)));
+  plan->has_target = true;
+  prepare_kernels(*plan);
+  Node* indexed = find_call(plan->root, index_op);
+  check(indexed && indexed->reuse_primal_output == !alias_selected,
+        alias_selected ? "alias keeps indexed primal retained"
+                       : "repeated index reuses one primal workspace");
+  if (replace_consumer_after_prepare)
+    check(set_backward(plan->root, consume_op, routed_add_backward),
+          "replace retention consumer backward");
+  return plan;
+}
+
+static void primal_retention_tests() {
+  test_setenv("STANLI_STRUCTURED_LOOP_DIAGNOSTICS", "1");
+  Executor executor(outer(repeated_index_retention_plan(), {1, 1}));
+  test_unsetenv("STANLI_STRUCTURED_LOOP_DIAGNOSTICS");
+  executor.params_data()[0] = 2;
+  executor.params_data()[1] = .5;
+  double gradient[2] = {};
+  stanli_test::StdoutCapture captured(stderr);
+  close(executor.gradient(gradient), 20,
+        "repeated index retained-primal result");
+  executor.params_data()[0] = 3;
+  close(executor.gradient(gradient), 28,
+        "reused primals refresh on next evaluation");
+  const std::string diagnostics = captured.finish();
+  check(diagnostics.find("reused_primal_cells=8") != std::string::npos,
+        "repeated index saves eight arena cells");
+  close(gradient[0], 8, "repeated index scatter accumulation");
+  close(gradient[1], 8, "value-free consumer adjoint accumulation");
+
+  Executor aliased(outer(repeated_index_retention_plan(true), {1, 1}));
+  aliased.params_data()[0] = 2;
+  aliased.params_data()[1] = .5;
+  std::fill(std::begin(gradient), std::end(gradient), 0.0);
+  close(aliased.gradient(gradient), 20, "aliased indexed primal result");
+  close(gradient[0], 8, "aliased indexed primal gradient");
+
+  // The plan was proved with the registered ADD backward, then mutated to a
+  // private callback. Runtime identity validation must disable workspace
+  // reuse while preserving the answer.
+  test_setenv("STANLI_STRUCTURED_LOOP_DIAGNOSTICS", "1");
+  Executor replaced(outer(repeated_index_retention_plan(false, true), {1, 1}));
+  test_unsetenv("STANLI_STRUCTURED_LOOP_DIAGNOSTICS");
+  replaced.params_data()[0] = 2;
+  replaced.params_data()[1] = .5;
+  std::fill(std::begin(gradient), std::end(gradient), 0.0);
+  stanli_test::StdoutCapture fallback_captured(stderr);
+  close(replaced.gradient(gradient), 20,
+        "replaced consumer falls back to retained primals");
+  replaced.params_data()[0] = 3;
+  close(replaced.gradient(gradient), 28,
+        "fallback refreshes on next evaluation");
+  const std::string fallback_diagnostics = fallback_captured.finish();
+  check(fallback_diagnostics.find("reused_primal_cells=0") != std::string::npos,
+        "replaced consumer saves no arena cells");
+  close(gradient[0], 8, "replaced consumer fallback gradient");
+}
+
 static std::shared_ptr<StructuredLoop> zero_scalar_index_plan(bool invalid) {
   auto plan = std::make_shared<StructuredLoop>();
   const int base = plan->body.add_slot(4, false);
@@ -4677,6 +4767,7 @@ int main() {
   direct_index_kernel_tests();
   forced_control_tests();
   iterator_history_tests();
+  primal_retention_tests();
   scalar_index_tests();
   integer_result_tests();
   loop_invariant_reuse_tests();


### PR DESCRIPTION
## Why

Some scalar observation loops expand into thousands of temporary graph operations before reroll reconstructs a small vector graph. A proven subset can reach that same result directly. The previous opt-in experiment also copied the entire compiler data environment to try one iteration, which made even refused short loops slower with large backing arrays.

## Changes

- Share reroll selection and emission behind a private lane-plan interface. Preserve the existing profitability rule, operation order, target reduction, and kernels.
- Lower proven terminal scalar loops directly: one affine real-data read, scalar parameter ADD/MUL/FMA, and an optional EXP/SQUARE chain. Lower iteration one normally; if typed matching or pricing refuses, retain it and continue ordinary lowering. Do not clone the compiler environment or run an unnecessary early constant fold.
- Enable this narrow subset automatically. `STANLI_SYMBOLIC_LANES=0` explicitly disables it; unset/`1` enables automatic selection, other values disable it. Existing structured-loop and optimization switches remain authoritative.
- Make profiling use the executor's already-bound dispatch, and make prepared lowering state an explicit handoff.
- Reuse structured-loop primal outputs only under conservative backward-read contracts. Unspecified contracts retain everything, including #357's GP and Cholesky kernels.
- Add numerical, refusal, shared-pricing, preparation, profiler, retained-storage and executor-clone isolation tests.

This is the curated production delta rebased onto #357 (`e814b81b`): runtime, tests and switch documentation only. Raw research artifacts and experiments are excluded; full history is preserved separately.

## Validation

- Clean Release builds of main and candidate, Apple Clang/arm64, `-O3 -ffp-contract=off`, `-j24`.
- All 241 tests pass on both versions, including sharing/mutation isolation of emitted packed constants.
- 418 targeted cases at three parameter points match main/off/automatic outputs exactly; corresponding graph comparisons pass.
- 254 corpus models at three points match main/off/automatic status, numerical output and diagnostics exactly. No current corpus model selects the symbolic shortcut.
- Five additional canonical graph checks cover 65,536-iteration FMA/add/multiply and short loops with large backing arrays.

## Performance against merged main

All measurements below use the clean post-#357 baseline. Three balanced main/off/automatic blocks across the full corpus, with the production benchmark's elapsed 200 ms warmup and fixed baseline-derived iteration counts. Geometric means of per-model paired medians:

| Metric | Automatic / main | Automatic / off |
|---|---:|---:|
| Warm gradient (251 finite models) | 0.9982 | 1.0015 |
| Forward (251 finite models) | 0.9951 | 1.0011 |
| Preparation (253 successful models) | 0.9954 | 1.0017 |
| Process RSS | 0.9938 | 1.0011 |

The existing `s2_com_poisson` preparation abort is identical in every mode and is not successful timing coverage. RSS above includes its process record; excluding it does not change the rounded conclusion. `dogs_log` and `s2_invgaussian` are preparation-only timing cases. No current corpus model selects symbolic lowering: this measures integration/default-policy overhead, not a corpus speedup claim.

Five models selected by predefined outlier rules received eight balanced main/main-identical-control/off/automatic confirmation blocks. None of their main-versus-automatic gradient/forward/preparation/RSS signals remained above the investigation trigger. The largest confirmed time ratio was 1.0311. Individual timings are noisy; these measurements do not prove every future model cannot regress, and 5% is an investigation trigger, not an allowed slowdown.

Selected long-loop examples, three balanced pairs (median values):

| N=65,536 | Preparation main → automatic | RSS main → automatic |
|---|---:|---:|
| Multiply/exp | 113.83 → 6.09 ms | 115.45 → 13.47 MiB |
| Add/exp | 125.21 → 6.30 ms | 114.89 → 13.48 MiB |
| FMA/exp | 124.00 → 8.60 ms | 122.22 → 15.98 MiB |

The emitted live graphs/kernels remain identical. Five synthetic gradient/forward screen warnings received bounded same-binary and identical-binary controls; none persisted above the trigger. Their preparation and storage savings remained. The initial FMA harness used mismatched data and failed before preparation; only those failed cases were corrected, and raw failures are retained. Three confirmation cases accidentally overlapped an untimed checker; those samples were explicitly invalidated and replaced once in isolation, with both sets retained.

ctsem N=400, three balanced pairs with three timed gradients per process:

| Metric | Main | Candidate |
|---|---:|---:|
| Preparation | 12.912 s | 12.971 s |
| Warm gradient | 285.22 ms | 283.08 ms |
| Forward | 201.56 ms | 197.55 ms |
| RSS | 920.36 MiB | 900.67 MiB |

ctsem also matches main's log density/gradients exactly at three parameter points. It exercises the retained-primal changes, not symbolic acceptance. The approximately 19.7 MiB observed RSS difference is not all attributed to a single allocation mechanism. A separate diagnostic confirms exactly 10.076 MiB less primal storage (after added workspace), with history/record/trace counts unchanged.

The 32 MiB backing-array counterexample is fixed: N=4 seeded refusal is essentially flat (7.567/7.536 ms off/automatic); N=16 acceptance is 7.576/6.296 ms. Neither has an additional whole-array RSS surcharge. These timings include stored-MIR compilation, bind, one verification gradient and destruction; five balanced pairs, three repetitions per process, all hexadecimal LP/gradients exact. They are not pure compile timings.

Local validation and independent code reviews are complete. Merge remains gated on required CI; no checks will be bypassed. Raw evidence, fixed plans, source/binary hashes and all samples are retained in `/Users/xitrium/.codex/stanli-research/2026-09-12-symbolic-auto/postmerge/`; research history is on the preserved `codex/architecture-contracts-research-20260912` ref. Candidate source is `035cde19`; the configuration-time embedded build ID retained the base label, so source content and binary hashes identify the tested artifacts.

