### PR TITLE
release: 0.13.0

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -945,7 +945,7 @@ jobs:
       - name: Fetch the previous release and the legacy anchor
         run: |
           mkdir -p previous-release/runtime legacy-release
-          previous=https://github.com/seantalts/stanli/releases/download/v0.11.1
+          previous=https://github.com/seantalts/stanli/releases/download/v0.12.0
           legacy=https://github.com/seantalts/stanli/releases/download/v0.9.3
           # A GitHub asset redirect reset the connection once and failed this
           # whole job. Plain --retry does not include curl error 35, so keep
@@ -954,13 +954,13 @@ jobs:
             "$previous/stanli-runtime-linux-x86_64.tar.gz" \
             -o previous-release/runtime.tar.gz
           curl -fsSL --retry 5 --retry-all-errors --retry-delay 2 \
-            "$previous/stanli_0.11.1.tar.gz" \
-            -o previous-release/stanli_0.11.1.tar.gz
+            "$previous/stanli_0.12.0.tar.gz" \
+            -o previous-release/stanli_0.12.0.tar.gz
           curl -fsSL --retry 5 --retry-all-errors --retry-delay 2 \
             "$legacy/stanli_0.9.3.tar.gz" \
             -o legacy-release/stanli_0.9.3.tar.gz
-          echo 'b3902d4044f522f5feb0d08bfea6de0c4510c81d37609577f9ccb454c55f7817  previous-release/runtime.tar.gz' | sha256sum -c -
-          echo '40f72e86f911a717c41f70eaea84758b3b9db7c36fbda9bad47d0760c307d245  previous-release/stanli_0.11.1.tar.gz' | sha256sum -c -
+          echo '614ff7b39c243b15f71f6257d5ad16128726be396a87a6208fc91978806e3418  previous-release/runtime.tar.gz' | sha256sum -c -
+          echo '5595cb3fd2fb51a97ad1288a8ca77719b9b484b3d7b3b51f7e9d6e391260a906  previous-release/stanli_0.12.0.tar.gz' | sha256sum -c -
           echo '1acbe821c58115678a69451c553a9b23c141d009f53c142492cee94599430495  legacy-release/stanli_0.9.3.tar.gz' | sha256sum -c -
           tar xzf previous-release/runtime.tar.gz \
             -C previous-release/runtime
@@ -1012,7 +1012,7 @@ jobs:
         working-directory: r
         run: |
           current_library="$PWD/../r-current-library"
-          previous_library="$PWD/../r-v0.11.1-library"
+          previous_library="$PWD/../r-v0.12.0-library"
           legacy_library="$PWD/../r-v0.9.3-library"
           previous_runtime="$PWD/../previous-release/runtime/libstanli.so"
           current_runtime="$STANLI_RUNTIME"
@@ -1023,7 +1023,7 @@ jobs:
 
           mkdir -p "$previous_library"
           R CMD INSTALL --library="$previous_library" \
-            ../previous-release/stanli_0.11.1.tar.gz
+            ../previous-release/stanli_0.12.0.tar.gz
           STANLI_RUNTIME="$current_runtime" \
             R_LIBS_USER="$previous_library${R_LIBS_USER:+:$R_LIBS_USER}" \
             Rscript ../tests/test_r_portable_compiler.R

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.13.0
 
 ### The upstream loop vectorizer's new shapes lower without regressions
 
@@ -92,6 +92,31 @@ about as much there, CmdStan by its one-term-at-a-time sum and stanli by
 Eigen's packet reduction, so the gap is a difference in rounding rather
 than an error on one side, and `tools/corpus.py` records it as such.
 
+### RNG functions in transformed data
+
+Transformed data can now call `_rng` functions. Draws come from the
+construction seed the way CmdStan's generated constructor seeds them, so a
+matched seed reproduces CmdStan's transformed data bit for bit. Python
+`Model(seed=1)`, R `stanli_model(seed = 1)`, `stanli_run --seed` and the C
+API's `stanli_model_new_seeded` set that seed; the unseeded constructors use
+1, and BridgeStan passes its construction seed through. One seed governs a
+run, as in CmdStan: Python `sample` and `optimize` and R `sample_model` and
+`optimize_model` rebuild the model under their own seed when transformed
+data drew and the seed differs. Models without transformed-data draws are
+never rebuilt. An `_rng` call inside a user-defined `_rng` function failed
+with "unknown variable" in the interpreted write_array; it works now.
+
+### Executors share model data
+
+Model data is shared across executor copies. Parameters, written outputs,
+adjoints and scratch stay private, and taking a writable pointer detaches
+that executor's copy. Eight MNIST executors peak at 4.8 GB of memory where
+they peaked at 10.3 GB. Parsed JSON arrays move straight into the data map,
+and the exponentiated-quadratic GP kernel with fixed coordinates and
+Cholesky decompositions reuse their saved forward results in the backward
+pass in place of a nested autodiff tape, so gp_regr's gradient takes 2.6 µs
+where it took 6.7.
+
 ### Every stanc signature replays against CmdStan
 
 The generated builtin and density signature models used to prove only that
@@ -156,6 +181,22 @@ so the compiler's 64-bit integer constants were undefined and the first
 compile threw. The build now joins those lines and fails if any remain.
 The reporter also fixed the printer upstream in ocsigen/js_of_ocaml#2421
 (#342).
+
+The runtime no longer keeps a `thread_local` object with a destructor.
+Island registers, native adjoints and solver workspaces live in executor
+scratch, and the executor pool's autodiff tape is leased from a free list
+the pool owns and returned empty when a thread's last lease ends. Under
+MinGW's emulated thread-local storage those destructors ran after the DLL
+that owned them was unloaded, which crashed R worker processes on Windows.
+A worker thread with no autodiff stack of its own, the case when BridgeStan
+is driven from the caller's threads, now takes a gradient about as fast as
+the main thread.
+
+The adjoint ODE solver handed stan-math an uninitialized quadrature vector
+on the first backward step, and stan-math accumulates into it without
+assigning it first, so a backward solve could fail depending on what the
+allocator returned. The pinned stan-math is patched at checkout to zero the
+vector.
 
 ## 0.12.0
 

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@seantalts/stanli",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "Full Stan in the browser: stanc3 compiles the model in JS, a WASM runtime lowers it to an op graph and runs NUTS. No server, no C++ toolchain.",
   "type": "module",
   "main": "index.mjs",

--- a/python/stanli/__init__.py
+++ b/python/stanli/__init__.py
@@ -27,7 +27,7 @@ __all__ = ["Model", "Function", "Fit", "Summary", "OptimizeResult",
            "SAMPLER_COLUMNS", "__version__"]
 # The one place the version lives. setup.py and the release workflow both
 # read it from here.
-__version__ = "0.12.0"
+__version__ = "0.13.0"
 
 _BIN = pathlib.Path(__file__).parent / "_bin"
 

--- a/r/DESCRIPTION
+++ b/r/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: stanli
 Type: Package
 Title: The Stan Language Interpreter
-Version: 0.12.0
+Version: 0.13.0
 Authors@R: person("Sean", "Talts", email = "xitrium@gmail.com",
                   role = c("aut", "cre"))
 Description: Compile and sample Stan models without a C++ toolchain. Stan

--- a/r/R/install.R
+++ b/r/R/install.R
@@ -14,7 +14,7 @@
 # and a default of "latest" would silently pair a pinned binding with a runtime
 # that has moved. The release workflow asserts this equals the tag being cut,
 # so bumping one without the other fails there rather than at a user's install.
-stanli_runtime_release <- "v0.12.0"
+stanli_runtime_release <- "v0.13.0"
 
 runtime_filename <- function() {
   switch(Sys.info()[["sysname"]],


### PR DESCRIPTION
Version bump to 0.13.0 across Python, npm, R and the R runtime pin, the changelog heading, and the r-tests job's previous-release anchor moved to the v0.12.0 assets. Also adds the changelog entries that #348, #352, #356 and #357 landed without.
